### PR TITLE
Use "context" to contain run details

### DIFF
--- a/benches/my_benchmark.rs
+++ b/benches/my_benchmark.rs
@@ -5,17 +5,17 @@ use criterion::Criterion;
 
 use clap::{App, Arg};
 use starship::modules;
-use std::path::Path;
+use starship::context::Context;
 
 fn char_segment(c: &mut Criterion) {
     let args = App::new("starship")
         .arg(Arg::with_name("status_code"))
         .get_matches_from(vec!["starship", "0"]);
-
-    let path = Path::new("~");
-
+    
+    let context = Context::new_with_dir(args, "~");
+    
     c.bench_function("char segment", move |b| {
-        b.iter(|| modules::handle("char", &path, &args))
+        b.iter(|| modules::handle("char", &context))
     });
 }
 
@@ -24,10 +24,10 @@ fn dir_segment(c: &mut Criterion) {
         .arg(Arg::with_name("status_code"))
         .get_matches_from(vec!["starship", "0"]);
 
-    let path = Path::new("~");
+    let context = Context::new_with_dir(args, "~");
 
     c.bench_function("dir segment", move |b| {
-        b.iter(|| modules::handle("dir", &path, &args))
+        b.iter(|| modules::handle("dir", &context))
     });
 }
 
@@ -36,10 +36,10 @@ fn line_break_segment(c: &mut Criterion) {
         .arg(Arg::with_name("status_code"))
         .get_matches_from(vec!["starship", "0"]);
 
-    let path = Path::new("~");
+    let context = Context::new_with_dir(args, "~");
 
     c.bench_function("line break segment", move |b| {
-        b.iter(|| modules::handle("line_break", &path, &args))
+        b.iter(|| modules::handle("line_break", &context))
     });
 }
 

--- a/benches/my_benchmark.rs
+++ b/benches/my_benchmark.rs
@@ -4,16 +4,15 @@ extern crate criterion;
 use criterion::Criterion;
 
 use clap::{App, Arg};
-use starship::modules;
 use starship::context::Context;
+use starship::modules;
 
 fn char_segment(c: &mut Criterion) {
     let args = App::new("starship")
         .arg(Arg::with_name("status_code"))
         .get_matches_from(vec!["starship", "0"]);
-    
     let context = Context::new_with_dir(args, "~");
-    
+
     c.bench_function("char segment", move |b| {
         b.iter(|| modules::handle("char", &context))
     });
@@ -23,7 +22,6 @@ fn dir_segment(c: &mut Criterion) {
     let args = App::new("starship")
         .arg(Arg::with_name("status_code"))
         .get_matches_from(vec!["starship", "0"]);
-
     let context = Context::new_with_dir(args, "~");
 
     c.bench_function("dir segment", move |b| {
@@ -35,7 +33,6 @@ fn line_break_segment(c: &mut Criterion) {
     let args = App::new("starship")
         .arg(Arg::with_name("status_code"))
         .get_matches_from(vec!["starship", "0"]);
-
     let context = Context::new_with_dir(args, "~");
 
     c.bench_function("line break segment", move |b| {

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,0 +1,27 @@
+use clap::ArgMatches;
+use std::env;
+use std::path::PathBuf;
+
+pub struct Context<'a> {
+    pub current_dir: PathBuf,
+    pub arguments: ArgMatches<'a>,
+}
+
+impl<'a> Context<'a> {
+    pub fn new(arguments: ArgMatches) -> Context {
+        // TODO: Currently gets the physical directory. Get the logical directory.
+        let current_dir = env::current_dir().expect("Unable to identify current directory.");
+
+        Context {
+            current_dir,
+            arguments,
+        }
+    }
+
+    pub fn new_with_dir<T>(arguments: ArgMatches, dir: T) -> Context where T: Into<PathBuf> {
+        Context {
+            current_dir: dir.into(),
+            arguments,
+        }
+    }
+}

--- a/src/context.rs
+++ b/src/context.rs
@@ -18,7 +18,10 @@ impl<'a> Context<'a> {
         }
     }
 
-    pub fn new_with_dir<T>(arguments: ArgMatches, dir: T) -> Context where T: Into<PathBuf> {
+    pub fn new_with_dir<T>(arguments: ArgMatches, dir: T) -> Context
+    where
+        T: Into<PathBuf>,
+    {
         Context {
             current_dir: dir.into(),
             arguments,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 // Lib is present to allow for benchmarking
+pub mod context;
 pub mod modules;
 pub mod print;
 pub mod segment;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ extern crate ansi_term;
 extern crate dirs;
 extern crate git2;
 
+mod context;
 mod modules;
 mod print;
 mod segment;

--- a/src/modules/character.rs
+++ b/src/modules/character.rs
@@ -1,7 +1,7 @@
-use super::Segment;
 use ansi_term::Color;
-use clap::ArgMatches;
-use std::path::Path;
+
+use super::Segment;
+use crate::context::Context;
 
 /// Creates a segment for the prompt character
 ///
@@ -11,14 +11,15 @@ use std::path::Path;
 /// (green by default)
 /// - If the exit-code was anything else, the arrow will be formatted with
 /// `COLOR_FAILURE` (red by default)
-pub fn segment(_current_dir: &Path, args: &ArgMatches) -> Option<Segment> {
+pub fn segment(context: &Context) -> Option<Segment> {
     const PROMPT_CHAR: &str = "➜";
     const COLOR_SUCCESS: Color = Color::Green;
     const COLOR_FAILURE: Color = Color::Red;
 
     let mut segment = Segment::new("char");
+    let arguments = &context.arguments;
 
-    if args.value_of("status_code").unwrap() == "0" {
+    if arguments.value_of("status_code").unwrap() == "0" {
         segment.set_style(COLOR_SUCCESS);
     } else {
         segment.set_style(COLOR_FAILURE);

--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -1,9 +1,9 @@
-use super::Segment;
 use ansi_term::Color;
-use clap::ArgMatches;
-use dirs;
 use git2::Repository;
 use std::path::Path;
+
+use super::Segment;
+use crate::context::Context;
 
 /// Creates a segment with the current directory
 ///
@@ -14,12 +14,13 @@ use std::path::Path;
 ///
 /// **Truncation**
 /// Paths will be limited in length to `3` path components by default.
-pub fn segment(current_dir: &Path, _args: &ArgMatches) -> Option<Segment> {
+pub fn segment(context: &Context) -> Option<Segment> {
     const HOME_SYMBOL: &str = "~";
     const DIR_TRUNCATION_LENGTH: usize = 3;
     const SECTION_COLOR: Color = Color::Cyan;
 
     let mut segment = Segment::new("dir");
+    let current_dir = &context.current_dir;
 
     let dir_string;
     if let Ok(repo) = git2::Repository::discover(current_dir) {

--- a/src/modules/line_break.rs
+++ b/src/modules/line_break.rs
@@ -1,9 +1,8 @@
 use super::Segment;
-use clap::ArgMatches;
-use std::path::Path;
+use crate::context::Context;
 
 /// Creates a segment for the line break
-pub fn segment(_current_dir: &Path, _args: &ArgMatches) -> Option<Segment> {
+pub fn segment(_context: &Context) -> Option<Segment> {
     const LINE_ENDING: &str = "\n";
 
     let mut segment = Segment::new("line_break");

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -3,16 +3,15 @@ mod directory;
 mod line_break;
 mod nodejs;
 
+use crate::context::Context;
 use crate::segment::Segment;
-use clap::ArgMatches;
-use std::path::Path;
 
-pub fn handle(module: &str, current_dir: &Path, args: &ArgMatches) -> Option<Segment> {
+pub fn handle(module: &str, context: &Context) -> Option<Segment> {
     match module {
-        "dir" | "directory" => directory::segment(current_dir, args),
-        "char" | "character" => character::segment(current_dir, args),
-        "node" | "nodejs" => nodejs::segment(current_dir, args),
-        "line_break" => line_break::segment(current_dir, args),
+        "dir" | "directory" => directory::segment(context),
+        "char" | "character" => character::segment(context),
+        "node" | "nodejs" => nodejs::segment(context),
+        "line_break" => line_break::segment(context),
 
         _ => panic!("Unknown module: {}", module),
     }

--- a/src/modules/nodejs.rs
+++ b/src/modules/nodejs.rs
@@ -19,7 +19,6 @@ pub fn segment(context: &Context) -> Option<Segment> {
     let current_dir = &context.current_dir;
     let files = fs::read_dir(current_dir).unwrap();
 
-
     // Early return if there are no JS project files
     let is_js_project = files.filter_map(Result::ok).any(has_js_files);
     if !is_js_project {

--- a/src/modules/nodejs.rs
+++ b/src/modules/nodejs.rs
@@ -1,9 +1,9 @@
-use super::Segment;
 use ansi_term::Color;
-use clap::ArgMatches;
 use std::fs::{self, DirEntry};
-use std::path::Path;
 use std::process::Command;
+
+use super::Segment;
+use crate::context::Context;
 
 /// Creates a segment with the current Node.js version
 ///
@@ -11,12 +11,14 @@ use std::process::Command;
 ///     - Current directory contains a `.js` file
 ///     - Current directory contains a `node_modules` directory
 ///     - Current directory contains a `package.json` file
-pub fn segment(current_dir: &Path, _args: &ArgMatches) -> Option<Segment> {
+pub fn segment(context: &Context) -> Option<Segment> {
     const NODE_CHAR: &str = "⬢";
     const SECTION_COLOR: Color = Color::Green;
 
     let mut segment = Segment::new("node");
+    let current_dir = &context.current_dir;
     let files = fs::read_dir(current_dir).unwrap();
+
 
     // Early return if there are no JS project files
     let is_js_project = files.filter_map(Result::ok).any(has_js_files);

--- a/src/print.rs
+++ b/src/print.rs
@@ -1,14 +1,12 @@
 use clap::ArgMatches;
-use std::env;
 use std::io::{self, Write};
 
+use crate::context::Context;
 use crate::modules;
 
 pub fn prompt(args: ArgMatches) {
-    let default_prompt = vec!["directory", "nodejs", "line_break", "character"];
-
-    // TODO: Currently gets the physical directory. Get the logical directory.
-    let current_path = env::current_dir().expect("Unable to identify current directory.");
+    let prompt_order = vec!["directory", "nodejs", "line_break", "character"];
+    let context = Context::new(args);
 
     // TODO:
     // - List files in directory
@@ -20,9 +18,9 @@ pub fn prompt(args: ArgMatches) {
     // Write a new line before the prompt
     writeln!(handle).unwrap();
 
-    default_prompt
+    prompt_order
         .iter()
-        .map(|module| modules::handle(module, &current_path, &args)) // Compute segments
+        .map(|module| modules::handle(module, &context)) // Compute segments
         .flatten() // Remove segments set to `None`
         .enumerate() // Turn segment into tuple with index
         .map(|(index, segment)| segment.output_index(index)) // Generate string outputs

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,18 +1,26 @@
 use clap::{App, Arg};
+use starship::context::Context;
 use starship::modules;
-use std::path::Path;
+use std::path::PathBuf;
 
-pub fn render_segment(module: &str, path: &Path) -> String {
-    render_segment_with_status(module, path, "0")
+pub fn render_segment<T>(module: &str, path: T) -> String
+where
+    T: Into<PathBuf>,
+{
+    render_segment_with_status(module, &path.into(), "0")
 }
 
-pub fn render_segment_with_status(module: &str, path: &Path, status: &str) -> String {
+pub fn render_segment_with_status<T>(module: &str, path: T, status: &str) -> String
+where
+    T: Into<PathBuf>,
+{
     // Create an `Arg` with status_code of "0"
     let args = App::new("starship")
         .arg(Arg::with_name("status_code"))
         .get_matches_from(vec!["starship", status]);
+    let context = Context::new_with_dir(args, path.into());
 
-    let segment = modules::handle(module, path, &args);
+    let segment = modules::handle(module, &context);
 
     segment.unwrap().output()
 }


### PR DESCRIPTION
I noticed we were passing around a whole lot of arguments with the details of the particular run. I did a little refactoring to contain that data in a `context` struct.

In the future, this will contain other details such as:
- A list of files in `PWD`
- A list of binaries in `PATH`
- Configuration parsed from the config file
- Maybe cached values from previous runs? 🤔 