### PR TITLE
feat: Add Rust version segment

### DIFF
--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -12,7 +12,7 @@ pub fn handle(module: &str, context: &Context) -> Option<Segment> {
         "dir" | "directory" => directory::segment(context),
         "char" | "character" => character::segment(context),
         "node" | "nodejs" => nodejs::segment(context),
-        "rust" => rust::segment(context),
+        "rust" | "rustlang" => rust::segment(context),
         "line_break" => line_break::segment(context),
 
         _ => panic!("Unknown module: {}", module),

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -2,6 +2,7 @@ mod character;
 mod directory;
 mod line_break;
 mod nodejs;
+mod rust;
 
 use crate::context::Context;
 use crate::segment::Segment;
@@ -11,6 +12,7 @@ pub fn handle(module: &str, context: &Context) -> Option<Segment> {
         "dir" | "directory" => directory::segment(context),
         "char" | "character" => character::segment(context),
         "node" | "nodejs" => nodejs::segment(context),
+        "rust" => rust::segment(context),
         "line_break" => line_break::segment(context),
 
         _ => panic!("Unknown module: {}", module),

--- a/src/modules/rust.rs
+++ b/src/modules/rust.rs
@@ -1,7 +1,7 @@
 use super::Segment;
+use crate::context::Context;
 use ansi_term::Color;
 use std::fs::{self, DirEntry};
-use crate::context::Context;
 use std::process::Command;
 
 /// Creates a segment with the current Rust version
@@ -26,9 +26,9 @@ pub fn segment(context: &Context) -> Option<Segment> {
             let formated_version = format_rustc_version(rust_version);
             segment.set_value(format!("{} {}", RUST_LOGO, formated_version));
 
-            return Some(segment)
-        },
-        None => return None
+            return Some(segment);
+        }
+        None => return None,
     };
 }
 
@@ -46,17 +46,16 @@ fn has_rs_files(dir_entry: DirEntry) -> bool {
 fn get_rust_version() -> Option<String> {
     match Command::new("rustc").arg("-V").output() {
         Ok(output) => Some(String::from_utf8(output.stdout).unwrap()),
-        Err(_) => None
+        Err(_) => None,
     }
 }
 
 fn format_rustc_version(mut rustc_stdout: String) -> String {
-   let offset = &rustc_stdout.find('(').unwrap();
-   let formated_version: String = rustc_stdout.drain(..offset).collect();
+    let offset = &rustc_stdout.find('(').unwrap();
+    let formated_version: String = rustc_stdout.drain(..offset).collect();
 
-   format!(" v{}", formated_version.replace("rustc", "").trim())
+    format!(" v{}", formated_version.replace("rustc", "").trim())
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/src/modules/rust.rs
+++ b/src/modules/rust.rs
@@ -24,12 +24,12 @@ pub fn segment(context: &Context) -> Option<Segment> {
             segment.set_style(SECTION_COLOR);
 
             let formatted_version = format_rustc_version(rust_version);
-            segment.set_value(format!("{} {}", RUST_LOGO, formated_version));
+            segment.set_value(format!("{} {}", RUST_LOGO, formatted_version));
 
-            return Some(segment);
+            Some(segment)
         }
-        None => return None,
-    };
+        None => None,
+    }
 }
 
 fn has_rs_files(dir_entry: DirEntry) -> bool {
@@ -52,9 +52,9 @@ fn get_rust_version() -> Option<String> {
 
 fn format_rustc_version(mut rustc_stdout: String) -> String {
     let offset = &rustc_stdout.find('(').unwrap();
-    let formated_version: String = rustc_stdout.drain(..offset).collect();
+    let formatted_version: String = rustc_stdout.drain(..offset).collect();
 
-    format!(" v{}", formated_version.replace("rustc", "").trim())
+    format!("v{}", formatted_version.replace("rustc", "").trim())
 }
 
 #[cfg(test)]
@@ -64,12 +64,12 @@ mod tests {
     #[test]
     fn test_format_rustc_version() {
         let nightly_input = String::from("rustc 1.34.0-nightly (b139669f3 2019-04-10)");
-        assert_eq!(format_rustc_version(nightly_input), " v1.34.0-nightly");
+        assert_eq!(format_rustc_version(nightly_input), "v1.34.0-nightly");
 
         let beta_input = String::from("rustc 1.34.0-beta.1 (2bc1d406d 2019-04-10)");
-        assert_eq!(format_rustc_version(beta_input), " v1.34.0-beta.1");
+        assert_eq!(format_rustc_version(beta_input), "v1.34.0-beta.1");
 
         let stable_input = String::from("rustc 1.34.0 (91856ed52 2019-04-10)");
-        assert_eq!(format_rustc_version(stable_input), " v1.34.0");
+        assert_eq!(format_rustc_version(stable_input), "v1.34.0");
     }
 }

--- a/src/modules/rust.rs
+++ b/src/modules/rust.rs
@@ -23,7 +23,7 @@ pub fn segment(context: &Context) -> Option<Segment> {
             let mut segment = Segment::new("rust");
             segment.set_style(SECTION_COLOR);
 
-            let formated_version = format_rustc_version(rust_version);
+            let formatted_version = format_rustc_version(rust_version);
             segment.set_value(format!("{} {}", RUST_LOGO, formated_version));
 
             return Some(segment);

--- a/src/modules/rust.rs
+++ b/src/modules/rust.rs
@@ -1,0 +1,49 @@
+use super::Segment;
+use ansi_term::Color;
+use std::fs::{self, DirEntry};
+use crate::context::Context;
+use std::process::Command;
+
+/// Creates a segment with the current Node.js version
+///
+/// Will display the Node.js version if any of the following criteria are met:
+///     - Current directory contains a `.js` file
+///     - Current directory contains a `node_modules` directory
+///     - Current directory contains a `package.json` file
+pub fn segment(context: &Context) -> Option<Segment> {
+    const RUST_LOGO: &str = "🦀";
+    const SECTION_COLOR: Color = Color::Red;
+
+    let mut segment = Segment::new("node");
+    let files = fs::read_dir(&context.current_dir).unwrap();
+
+    // Early return if there are no JS project files
+    let is_rs_project = files.filter_map(Result::ok).any(has_rs_files);
+    if !is_rs_project {
+        return None;
+    }
+
+    match Command::new("rustc").arg("-V").output() {
+        Ok(output) => {
+            let version = String::from_utf8(output.stdout).unwrap();
+            segment.set_value(format!("{}  {}", RUST_LOGO, version.trim()))
+        }
+        Err(_) => {
+            return None;
+        }
+    };
+
+    segment.set_style(SECTION_COLOR);
+    Some(segment)
+}
+
+fn has_rs_files(dir_entry: DirEntry) -> bool {
+    let is_rs_file = |d: &DirEntry| -> bool {
+        d.path().is_file() && d.path().extension().unwrap_or_default() == "rs"
+    };
+    let is_package_json = |d: &DirEntry| -> bool {
+        d.path().is_file() && d.path().file_name().unwrap_or_default() == "Cargo.toml"
+    };
+
+    is_rs_file(&dir_entry) || is_package_json(&dir_entry)
+}

--- a/src/modules/rust.rs
+++ b/src/modules/rust.rs
@@ -4,46 +4,73 @@ use std::fs::{self, DirEntry};
 use crate::context::Context;
 use std::process::Command;
 
-/// Creates a segment with the current Node.js version
+/// Creates a segment with the current Rust version
 ///
-/// Will display the Node.js version if any of the following criteria are met:
-///     - Current directory contains a `.js` file
-///     - Current directory contains a `node_modules` directory
-///     - Current directory contains a `package.json` file
+/// Will display the Rust version if any of the following criteria are met:
+///     - Current directory contains a `.rs` or 'Cargo.toml' file
 pub fn segment(context: &Context) -> Option<Segment> {
-    const RUST_LOGO: &str = "🦀";
-    const SECTION_COLOR: Color = Color::Red;
-
-    let mut segment = Segment::new("node");
     let files = fs::read_dir(&context.current_dir).unwrap();
-
-    // Early return if there are no JS project files
     let is_rs_project = files.filter_map(Result::ok).any(has_rs_files);
     if !is_rs_project {
         return None;
     }
 
-    match Command::new("rustc").arg("-V").output() {
-        Ok(output) => {
-            let version = String::from_utf8(output.stdout).unwrap();
-            segment.set_value(format!("{}  {}", RUST_LOGO, version.trim()))
-        }
-        Err(_) => {
-            return None;
-        }
-    };
+    match get_rust_version() {
+        Some(rust_version) => {
+            const RUST_LOGO: &str = "🦀";
+            const SECTION_COLOR: Color = Color::Red;
 
-    segment.set_style(SECTION_COLOR);
-    Some(segment)
+            let mut segment = Segment::new("rust");
+            segment.set_style(SECTION_COLOR);
+
+            let formated_version = format_rustc_version(rust_version);
+            segment.set_value(format!("{} {}", RUST_LOGO, formated_version));
+
+            return Some(segment)
+        },
+        None => return None
+    };
 }
 
 fn has_rs_files(dir_entry: DirEntry) -> bool {
     let is_rs_file = |d: &DirEntry| -> bool {
         d.path().is_file() && d.path().extension().unwrap_or_default() == "rs"
     };
-    let is_package_json = |d: &DirEntry| -> bool {
+    let is_cargo_toml = |d: &DirEntry| -> bool {
         d.path().is_file() && d.path().file_name().unwrap_or_default() == "Cargo.toml"
     };
 
-    is_rs_file(&dir_entry) || is_package_json(&dir_entry)
+    is_rs_file(&dir_entry) || is_cargo_toml(&dir_entry)
+}
+
+fn get_rust_version() -> Option<String> {
+    match Command::new("rustc").arg("-V").output() {
+        Ok(output) => Some(String::from_utf8(output.stdout).unwrap()),
+        Err(_) => None
+    }
+}
+
+fn format_rustc_version(mut rustc_stdout: String) -> String {
+   let offset = &rustc_stdout.find('(').unwrap();
+   let formated_version: String = rustc_stdout.drain(..offset).collect();
+
+   format!(" v{}", formated_version.replace("rustc", "").trim())
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_rustc_version() {
+        let nightly_input = String::from("rustc 1.34.0-nightly (b139669f3 2019-04-10)");
+        assert_eq!(format_rustc_version(nightly_input), " v1.34.0-nightly");
+
+        let beta_input = String::from("rustc 1.34.0-beta.1 (2bc1d406d 2019-04-10)");
+        assert_eq!(format_rustc_version(beta_input), " v1.34.0-beta.1");
+
+        let stable_input = String::from("rustc 1.34.0 (91856ed52 2019-04-10)");
+        assert_eq!(format_rustc_version(stable_input), " v1.34.0");
+    }
 }

--- a/src/print.rs
+++ b/src/print.rs
@@ -5,7 +5,7 @@ use crate::context::Context;
 use crate::modules;
 
 pub fn prompt(args: ArgMatches) {
-    let prompt_order = vec!["directory", "nodejs", "line_break", "character"];
+    let prompt_order = vec!["directory", "nodejs", "rust", "line_break", "character"];
     let context = Context::new(args);
 
     // TODO:


### PR DESCRIPTION
Heya!

I started with a very naive implementation:

- It will still display the `-nightly` or `-beta.1` postfix if the user is using that toolchain currently. Not sure what the best default would be, please let me know your thoughts!

- I also did not include the `cargo` version etc but I can if you guys think its a good idea atm.

I think there is some potential refactoring with regards to how the commands work, maybe wrapping them in a struct so we can use dependancy injection to test them might be a good idea? 
was also thinking of doing a more reusable function for the `is_<insert_lang_here>_project()`?

I moved things around in this file but I can make it mirror the node file if you guys think thats a good idea.

Closes #12