### PR TITLE
Correct the Rust version symbol in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ I'm very new to Rust, so any help is appreciated when it comes to improving deve
 
 - [x] Prompt character turns red if the last command exits with non-zero code.
 - [x] Current Node.js version(`⬢`).
-- [x] Current Rust version (`𝗥`).
+- [x] Current Rust version (`🦀`).
 - [ ] Package version of package in current directory (`📦`).
 - [ ] Current battery level and status
 - [ ] Current Git branch and rich repo status.


### PR DESCRIPTION
According to #12, the Rust version symbol is `🦀` instead of `𝗥`.