### PR TITLE
Install a fixed version of rust for CI integration tests

### DIFF
--- a/.build/install-rust.yml
+++ b/.build/install-rust.yml
@@ -1,19 +1,12 @@
-parameters:
-  versionSpec: ''
-
 steps:
- - bash: |
-     TOOLCHAIN="${{parameters['versionSpec']}}"
-     echo "##vso[task.setvariable variable=TOOLCHAIN;]$TOOLCHAIN"
-   displayName: Set rust toolchain
  - script: |
      curl -sSf -o rustup-init.exe https://win.rustup.rs
-     rustup-init.exe -y --default-toolchain %TOOLCHAIN%
+     rustup-init.exe -y --default-toolchain %RUSTUP_TOOLCHAIN%
      echo "##vso[task.setvariable variable=PATH;]%PATH%;%USERPROFILE%\.cargo\bin"
    displayName: Windows install rust
    condition: eq( variables['Agent.OS'], 'Windows_NT' )
  - script: |
-     curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $TOOLCHAIN
+     curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $RUSTUP_TOOLCHAIN
      echo "##vso[task.setvariable variable=PATH;]$PATH:$HOME/.cargo/bin"
    displayName: Install rust
    condition: ne( variables['Agent.OS'], 'Windows_NT' )

--- a/.build/install-rust.yml
+++ b/.build/install-rust.yml
@@ -1,0 +1,19 @@
+parameters:
+  versionSpec: ''
+
+steps:
+ - bash: |
+     TOOLCHAIN="${{parameters['versionSpec']}}"
+     echo "##vso[task.setvariable variable=TOOLCHAIN;]$TOOLCHAIN"
+   displayName: Set rust toolchain
+ - script: |
+     curl -sSf -o rustup-init.exe https://win.rustup.rs
+     rustup-init.exe -y --default-toolchain %TOOLCHAIN%
+     echo "##vso[task.setvariable variable=PATH;]%PATH%;%USERPROFILE%\.cargo\bin"
+   displayName: Windows install rust
+   condition: eq( variables['Agent.OS'], 'Windows_NT' )
+ - script: |
+     curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $TOOLCHAIN
+     echo "##vso[task.setvariable variable=PATH;]$PATH:$HOME/.cargo/bin"
+   displayName: Install rust
+   condition: ne( variables['Agent.OS'], 'Windows_NT' )

--- a/.build/install-rust.yml
+++ b/.build/install-rust.yml
@@ -7,13 +7,14 @@ steps:
      curl -sSf -o rustup-init.exe https://win.rustup.rs
      rustup-init.exe -y --default-toolchain ${{ parameters.versionSpec }}
      echo "##vso[task.setvariable variable=PATH;]%PATH%;%USERPROFILE%\.cargo\bin"
-   displayName: Windows install rust
+   displayName: Windows install Rust
    condition: eq( variables['Agent.OS'], 'Windows_NT' )
  - script: |
      curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain ${{ parameters.versionSpec }}
      echo "##vso[task.setvariable variable=PATH;]$PATH:$HOME/.cargo/bin"
-   displayName: Install rust
+   displayName: Install a fixed version of Rust
    condition: ne( variables['Agent.OS'], 'Windows_NT' )
 
   # Install the version of Rust used for testing with
  - script: rustup install $RUSTUP_TOOLCHAIN
+   displayName: Install Rust used for CI

--- a/.build/install-rust.yml
+++ b/.build/install-rust.yml
@@ -1,12 +1,15 @@
+parameters:
+  versionSpec: ""
+
 steps:
  - script: |
      curl -sSf -o rustup-init.exe https://win.rustup.rs
-     rustup-init.exe -y --default-toolchain %RUSTUP_TOOLCHAIN%
+     rustup-init.exe -y --default-toolchain ${{ parameters.versionSpec }}
      echo "##vso[task.setvariable variable=PATH;]%PATH%;%USERPROFILE%\.cargo\bin"
    displayName: Windows install rust
    condition: eq( variables['Agent.OS'], 'Windows_NT' )
  - script: |
-     curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $RUSTUP_TOOLCHAIN
+     curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain ${{ parameters.versionSpec }}
      echo "##vso[task.setvariable variable=PATH;]$PATH:$HOME/.cargo/bin"
    displayName: Install rust
    condition: ne( variables['Agent.OS'], 'Windows_NT' )

--- a/.build/install-rust.yml
+++ b/.build/install-rust.yml
@@ -2,6 +2,7 @@ parameters:
   versionSpec: ""
 
 steps:
+  # Install Rust at a fixed version for integration tests to pass
  - script: |
      curl -sSf -o rustup-init.exe https://win.rustup.rs
      rustup-init.exe -y --default-toolchain ${{ parameters.versionSpec }}
@@ -13,3 +14,6 @@ steps:
      echo "##vso[task.setvariable variable=PATH;]$PATH:$HOME/.cargo/bin"
    displayName: Install rust
    condition: ne( variables['Agent.OS'], 'Windows_NT' )
+
+  # Install the version of Rust used for testing with
+ - script: rustup install $RUSTUP_TOOLCHAIN

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,4 +1,5 @@
 jobs:
+  # Run the Rust linter
   - job: "Clippy"
     pool:
       vmImage: "ubuntu-16.04"
@@ -9,6 +10,7 @@ jobs:
       - script: cargo clippy --all
         displayName: Run clippy
 
+  # Run the Rust formatter
   - job: "Rustfmt"
     pool:
       vmImage: "ubuntu-16.04"
@@ -20,13 +22,15 @@ jobs:
       - script: cargo fmt --all -- --check
         displayName: Run Rustfmt
 
-  - job: "Dockerized tests"
+  # Run the integration tests in a Docker container
+  - job: "Docker_tests"
     pool:
       vmImage: "ubuntu-16.04"
     steps:
       - script: ./integration_test
         displayName: Dockerized tests
 
+  # Run the integration tests on virtual machines
   - job: "Test"
     strategy:
       matrix:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,3 +55,10 @@ jobs:
         displayName: Cargo build
       - script: rustup run $RUSTUP_TOOLCHAIN cargo test -- --ignored
         displayName: Cargo test
+
+  - job: "Dockerized tests"
+    pool:
+      vmImage: "ubuntu-16.04"
+    steps:
+      - script: ./integration_test
+        displayName: Dockerized tests

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,7 +45,7 @@ jobs:
       - task: NodeTool@0
         inputs:
           versionSpec: "12.0.0"
-      # Install Rust
+      # Install Rust at a fixed version for integration tests
       - template: ".build/install-rust.yml"
         parameters:
           versionSpec: "1.34.0"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,21 +41,17 @@ jobs:
     pool:
       vmImage: "ubuntu-16.04"
     steps:
-      - task: NodeTool@0 
+      # Install Node.js
+      - task: NodeTool@0
         inputs:
           versionSpec: '12.0.0'
-      - script: |
-          curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $RUSTUP_TOOLCHAIN
-          echo "##vso[task.setvariable variable=PATH;]$PATH:$HOME/.cargo/bin"
-        displayName: Install rust
-        condition: ne( variables['Agent.OS'], 'Windows_NT' )
-      - script: |
-          curl -sSf -o rustup-init.exe https://win.rustup.rs
-          rustup-init.exe -y --default-toolchain %RUSTUP_TOOLCHAIN%
-          echo "##vso[task.setvariable variable=PATH;]%PATH%;%USERPROFILE%\.cargo\bin"
-        displayName: Windows install rust
-        condition: eq( variables['Agent.OS'], 'Windows_NT' )
-      - script: cargo build --all
+      # Install Rust
+      - template: '.build/install-rust.yml'
+        inputs:
+          versionSpec: '1.34.0'
+
+      # Because integration tests rely on a fixed Rust version, we must use rustup to run with the intended toolkit
+      - script: rustup run $RUSTUP_TOOLCHAIN cargo build --all
         displayName: Cargo build
-      - script: cargo test -- --ignored
+      - script: rustup run $RUSTUP_TOOLCHAIN cargo test -- --ignored
         displayName: Cargo test

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,6 +47,8 @@ jobs:
           versionSpec: "12.0.0"
       # Install Rust
       - template: ".build/install-rust.yml"
+        parameters:
+          versionSpec: "1.34.0"
 
       # Because integration tests rely on a fixed Rust version, we must use rustup to run with the intended toolkit
       - script: rustup run $RUSTUP_TOOLCHAIN cargo build --all

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,6 +20,13 @@ jobs:
       - script: cargo fmt --all -- --check
         displayName: Run Rustfmt
 
+  - job: "Dockerized tests"
+    pool:
+      vmImage: "ubuntu-16.04"
+    steps:
+      - script: ./integration_test
+        displayName: Dockerized tests
+
   - job: "Test"
     strategy:
       matrix:
@@ -55,10 +62,3 @@ jobs:
         displayName: Cargo build
       - script: rustup run $RUSTUP_TOOLCHAIN cargo test -- --ignored
         displayName: Cargo test
-
-  - job: "Dockerized tests"
-    pool:
-      vmImage: "ubuntu-16.04"
-    steps:
-      - script: ./integration_test
-        displayName: Dockerized tests

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,7 +23,7 @@ jobs:
         displayName: Run Rustfmt
 
   # Run the integration tests in a Docker container
-  - job: "Docker_tests"
+  - job: "Docker"
     pool:
       vmImage: "ubuntu-16.04"
     steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,11 +44,9 @@ jobs:
       # Install Node.js
       - task: NodeTool@0
         inputs:
-          versionSpec: '12.0.0'
+          versionSpec: "12.0.0"
       # Install Rust
-      - template: '.build/install-rust.yml'
-        inputs:
-          versionSpec: '1.34.0'
+      - template: ".build/install-rust.yml"
 
       # Because integration tests rely on a fixed Rust version, we must use rustup to run with the intended toolkit
       - script: rustup run $RUSTUP_TOOLCHAIN cargo build --all

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:latest
+FROM rust:1.34.0
 
 # Install Node.js
 ENV NODE_VERSION 12.0.0
@@ -24,7 +24,8 @@ RUN mkdir benches
 RUN touch benches/my_benchmark.rs
 
 # This is a dummy build to get dependencies cached
-RUN cargo build --release
+RUN rustup install stable
+RUN rustup run stable cargo build --release
 
 # Delete the dummy build
 RUN rm -rf /starship
@@ -33,4 +34,5 @@ RUN rm -rf /starship
 RUN mkdir starship
 WORKDIR /starship
 
-CMD [ "cargo", "test", "--", "--ignored"]
+# Run with rustup to use stable instead of the Rust default
+CMD [ "rustup", "run", "stable", "cargo", "test", "--", "--ignored"]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Make `rustup` install a specific version of Rust along with the required Rust toolchain to run the build and tests.

- Split out the Rust installation logic from within `azure-pipelines.yml`
- Define a fixed version to be installed within Azure Pipelines
- Run tests with `rustup run` using the required toolkit
- Make the same changes in the Dockerfile


#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In order to be able to have integration tests that run `rust --version`, we need the locally used Rust to be a fixed version, while running tests and builds with the current stable/beta/nightly.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
