### PR TITLE
Parallelize prompt modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,6 +689,7 @@ dependencies = [
  "criterion 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "git2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ dirs = "1.0.5"
 git2 = "0.8.0"
 toml = "0.5.0"
 serde_json = "1.0.39"
+rayon = "1.0.3"
 
 [dev-dependencies]
 tempfile = "3.0.7"

--- a/benches/my_benchmark.rs
+++ b/benches/my_benchmark.rs
@@ -6,8 +6,8 @@ use criterion::Criterion;
 use clap::{App, Arg};
 use starship::context::Context;
 use starship::modules;
-use tempfile::TempDir;
 use std::fs;
+use tempfile::TempDir;
 
 fn char_segment(c: &mut Criterion) {
     let args = App::new("starship")
@@ -59,5 +59,11 @@ fn git_branch_segment(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, char_segment, dir_segment, line_break_segment, git_branch_segment);
+criterion_group!(
+    benches,
+    char_segment,
+    dir_segment,
+    line_break_segment,
+    git_branch_segment
+);
 criterion_main!(benches);

--- a/benches/my_benchmark.rs
+++ b/benches/my_benchmark.rs
@@ -6,6 +6,8 @@ use criterion::Criterion;
 use clap::{App, Arg};
 use starship::context::Context;
 use starship::modules;
+use tempfile::TempDir;
+use std::fs;
 
 fn char_segment(c: &mut Criterion) {
     let args = App::new("starship")
@@ -40,5 +42,22 @@ fn line_break_segment(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, dir_segment, char_segment, line_break_segment);
+fn git_branch_segment(c: &mut Criterion) {
+    let tmp_dir = TempDir::new().unwrap();
+    let repo_dir = tmp_dir.path().join("rocket-controls");
+    fs::create_dir(&repo_dir).unwrap();
+
+    git2::Repository::init(&repo_dir).unwrap();
+
+    let args = App::new("starship")
+        .arg(Arg::with_name("status_code"))
+        .get_matches_from(vec!["starship", "0"]);
+    let context = Context::new_with_dir(args, "~");
+
+    c.bench_function("git_branch segment", move |b| {
+        b.iter(|| modules::handle("git_branch", &context))
+    });
+}
+
+criterion_group!(benches, char_segment, dir_segment, line_break_segment, git_branch_segment);
 criterion_main!(benches);

--- a/src/context.rs
+++ b/src/context.rs
@@ -8,7 +8,7 @@ pub struct Context<'a> {
     pub current_dir: PathBuf,
     pub dir_files: Vec<PathBuf>,
     pub arguments: ArgMatches<'a>,
-    pub repository: Option<Repository>,
+    pub repo_root: Option<PathBuf>,
 }
 
 impl<'a> Context<'a> {
@@ -36,13 +36,15 @@ impl<'a> Context<'a> {
             .map(|entry| entry.path())
             .collect::<Vec<PathBuf>>();
 
-        let repository: Option<Repository> = Repository::discover(&current_dir).ok();
+        let repo_root: Option<PathBuf> = Repository::discover(&current_dir)
+            .ok()
+            .and_then(|repo| repo.workdir().map(|repo| repo.to_path_buf()));
 
         Context {
             arguments,
             current_dir,
             dir_files,
-            repository,
+            repo_root,
         }
     }
 

--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -23,9 +23,8 @@ pub fn segment(context: &Context) -> Option<Module> {
     let current_dir = &context.current_dir;
 
     let dir_string;
-    if let Some(repo) = &context.repository {
+    if let Some(repo_root) = &context.repo_root {
         // Contract the path to the git repo root
-        let repo_root = repo.workdir().unwrap();
         let repo_folder_name = repo_root.file_name().unwrap().to_str().unwrap();
 
         dir_string = contract_path(&current_dir, repo_root, repo_folder_name);

--- a/src/modules/git_branch.rs
+++ b/src/modules/git_branch.rs
@@ -7,12 +7,10 @@ use super::{Context, Module};
 ///
 /// Will display the branch name if the current directory is a git repo
 pub fn segment(context: &Context) -> Option<Module> {
-    if context.repository.is_none() {
-        return None;
-    }
+    let repo_root = context.repo_root.as_ref()?;
+    let repository = Repository::open(repo_root).ok()?;
 
-    let repository = context.repository.as_ref().unwrap();
-    match get_current_branch(repository) {
+    match get_current_branch(&repository) {
         Ok(branch_name) => {
             const GIT_BRANCH_CHAR: &str = " ";
             let segment_color = Color::Purple.bold();

--- a/src/print.rs
+++ b/src/print.rs
@@ -1,4 +1,5 @@
 use clap::ArgMatches;
+use rayon::prelude::*;
 use std::io::{self, Write};
 
 use crate::context::Context;
@@ -29,7 +30,7 @@ pub fn prompt(args: ArgMatches) {
     writeln!(handle).unwrap();
 
     let modules = prompt_order
-        .iter()
+        .par_iter()
         .map(|module| modules::handle(module, &context)) // Compute modules
         .flatten()
         .collect::<Vec<Module>>(); // Remove segments set to `None`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Add Rayon as a dependency
- Parallelize the handling of modules
- Replace `repository` with `repo_root` in `Context`

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Initially surfaced as a comment in #45 by @mehcode, it appears git2-rs is not thread safe, which botched future plans to add Rayon to the project. This PR adds Rayon so that we can safely identify thread safety issues moving forward.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
