### PR TITLE
fix: Don't check extensions of directories

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -186,7 +186,7 @@ mod tests {
     }
 
     #[test]
-    fn test_criteria_scan() {
+    fn test_criteria_scan_fails() {
         let mut failing_criteria = ScanDir {
             dir_files: &vec![PathBuf::new()],
             files: &["package.json"],
@@ -197,6 +197,19 @@ mod tests {
         // fails if buffer does not match any criteria
         assert_eq!(failing_criteria.scan(), false);
 
+        let mut failing_dir_criteria = ScanDir {
+            dir_files: &vec![PathBuf::from("/package.js/dog.go")],
+            files: &["package.json"],
+            extensions: &["js"],
+            folders: &["node_modules"],
+        };
+
+        // fails when passed a pathbuf dir matches extension path
+        assert_eq!(failing_dir_criteria.scan(), false);
+    }
+
+    #[test]
+    fn test_criteria_scan_passes() {
         let mut passing_criteria = ScanDir {
             dir_files: &vec![PathBuf::from("package.json")],
             files: &["package.json"],

--- a/src/context.rs
+++ b/src/context.rs
@@ -105,9 +105,11 @@ impl<'a> ScanDir<'a> {
     /// if any of this criteria match or exist and returning a boolean
     pub fn scan(&mut self) -> bool {
         self.dir_files.iter().any(|path| {
-            path_has_name(&path, &self.folders)
-                || path_has_name(&path, &self.files)
-                || has_extension(&path, &self.extensions)
+            if path.is_dir() {
+                return path_has_name(&path, &self.folders);
+            } else {
+                return path_has_name(&path, &self.files) || has_extension(&path, &self.extensions);
+            }
         })
     }
 }
@@ -142,6 +144,13 @@ pub fn has_extension<'a>(dir_entry: &PathBuf, extensions: &'a [&'a str]) -> bool
         Some(extension) => !extension.is_empty(),
         None => false,
     }
+}
+
+fn get_current_branch(repository: &Repository) -> Option<String> {
+    let head = repository.head().ok()?;
+    let shorthand = head.shorthand();
+
+    shorthand.map(|branch| branch.to_string())
 }
 
 #[cfg(test)]
@@ -197,11 +206,4 @@ mod tests {
 
         assert_eq!(passing_criteria.scan(), true);
     }
-}
-
-fn get_current_branch(repository: &Repository) -> Option<String> {
-    let head = repository.head().ok()?;
-    let shorthand = head.shorthand();
-
-    shorthand.map(|branch| branch.to_string())
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
As per YoussefHabri in the discord chat:
```There's a minor issue with the has_extension function. It acts as if it found a match when dealing with folders with an extension at the end e.g. a folder named test.js```

Added a quick check to make sure we are only scanning paths based on their type ie a file vs a dir.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

https://github.com/starship/starship/issues/52

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [X] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
