### PR TITLE
Fix python version bug

### DIFF
--- a/src/modules/python.rs
+++ b/src/modules/python.rs
@@ -46,7 +46,14 @@ pub fn segment(context: &Context) -> Option<Module> {
 
 fn get_python_version() -> Option<String> {
     match Command::new("python").arg("--version").output() {
-        Ok(output) => Some(String::from_utf8(output.stdout).unwrap()),
+        Ok(output) => {
+            let temp_version = String::from_utf8(output.stdout).unwrap();
+            if temp_version == "" {
+                Some(String::from_utf8(output.stderr).unwrap())
+            } else {
+                Some(temp_version)
+            }
+        }
         Err(_) => None,
     }
 }

--- a/src/modules/python.rs
+++ b/src/modules/python.rs
@@ -47,11 +47,15 @@ pub fn segment(context: &Context) -> Option<Module> {
 fn get_python_version() -> Option<String> {
     match Command::new("python").arg("--version").output() {
         Ok(output) => {
-            let temp_version = String::from_utf8(output.stdout).unwrap();
-            if temp_version == "" {
-                Some(String::from_utf8(output.stderr).unwrap())
+            // We have to check both stdout and stderr since for Python versions
+            // < 3.4, Python reports to stderr and for Python version >= 3.5,
+            // Python reports to stdout
+            if output.stdout.is_empty() {
+                let stderr_string = String::from_utf8(output.stderr).unwrap();
+                Some(stderr_string)
             } else {
-                Some(temp_version)
+                let stdout_string = String::from_utf8(output.stdout).unwrap();
+                Some(stdout_string)
             }
         }
         Err(_) => None,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
The Python version wasn't showing for versions < 3.4 (reported by @youssefhabri). The problem was that `python --version` for < 3.4 is outputting to stderr, but we were only checking stdout since for versions >= 3.4, that's where it outputs. I have fixed this bug.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #53 

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.