### PR TITLE
fix: handle path to shell in starship init

### DIFF
--- a/src/init.rs
+++ b/src/init.rs
@@ -4,9 +4,9 @@ use std::path::Path;
 pub fn init(shell_name: &str) {
     log::debug!("Shell name: {}", shell_name);
 
-    let shell_basename = Path::new(OsStr::new(shell_name))
+    let shell_basename = Path::new(shell_name)
         .file_stem()
-        .and_then(|path| path.to_str());
+        .and_then(OsStr::to_str);
 
     let setup_script = match shell_basename {
         Some("bash") => {
@@ -22,11 +22,10 @@ pub fn init(shell_name: &str) {
             Some(script)
         }
         None => {
-            println!(
-                "printf \"Starship cannot understand the name: {0}\\n\
-                 If you have not made weird changes to your shell, this\\n\
-                 probably indicates a bug in Starship. Please file a bug at\\n\
-                 https://github.com/starship/starship/issues/new\\n\"",
+            println!("Invalid shell name provided: {}\\n\
+                    If this issue persists, please open an \
+                    issue in the starship repo: \\n\
+                    https://github.com/starship/starship/issues/new\\n\"",
                 shell_name
             );
             None

--- a/src/init.rs
+++ b/src/init.rs
@@ -1,25 +1,45 @@
+use std::ffi::OsStr;
+use std::path::Path;
+
 pub fn init(shell_name: &str) {
     log::debug!("Shell name: {}", shell_name);
-    let setup_script = match shell_name {
-        "bash" => {
+
+    let shell_basename = Path::new(OsStr::new(shell_name))
+        .file_stem()
+        .and_then(|path| path.to_str());
+
+    let setup_script = match shell_basename {
+        Some("bash") => {
             let script = "PS1=\"$(starship prompt --status=$?)\"";
             Some(script)
         }
-        "zsh" => {
+        Some("zsh") => {
             let script = "PROMPT=\"$(starship prompt --status=$?)\"";
             Some(script)
         }
-        "fish" => {
+        Some("fish") => {
             let script = "function fish_prompt; starship prompt --status=$status; end";
             Some(script)
         }
+        None => {
+            println!(
+                "printf \"Starship cannot understand the name: {0}\\n\
+                 If you have not made weird changes to your shell, this\\n\
+                 probably indicates a bug in Starship. Please file a bug at\\n\
+                 https://github.com/starship/starship/issues/new\\n\"",
+                shell_name
+            );
+            None
+        }
         _ => {
+            /* Calling unwrap() here is fine because the None case will have
+            already matched on the previous arm */
             println!(
                 "printf \"\\n{0} is not yet supported by starship.\\n\
                  For the time being, we support bash, zsh, and fish.\\n\
                  Please open an issue in the starship repo if you would like to \
                  see support for {0}:\\nhttps://github.com/starship/starship/issues/new\"\\n\\n",
-                shell_name
+                shell_basename.unwrap()
             );
             None
         }

--- a/src/init.rs
+++ b/src/init.rs
@@ -4,9 +4,7 @@ use std::path::Path;
 pub fn init(shell_name: &str) {
     log::debug!("Shell name: {}", shell_name);
 
-    let shell_basename = Path::new(shell_name)
-        .file_stem()
-        .and_then(OsStr::to_str);
+    let shell_basename = Path::new(shell_name).file_stem().and_then(OsStr::to_str);
 
     let setup_script = match shell_basename {
         Some("bash") => {
@@ -22,10 +20,11 @@ pub fn init(shell_name: &str) {
             Some(script)
         }
         None => {
-            println!("Invalid shell name provided: {}\\n\
-                    If this issue persists, please open an \
-                    issue in the starship repo: \\n\
-                    https://github.com/starship/starship/issues/new\\n\"",
+            println!(
+                "Invalid shell name provided: {}\\n\
+                 If this issue persists, please open an \
+                 issue in the starship repo: \\n\
+                 https://github.com/starship/starship/issues/new\\n\"",
                 shell_name
             );
             None


### PR DESCRIPTION
This adds support for qualified paths (e.g. using
`/usr/local/bin/zsh` instead of `zsh`) to init.rs.
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

`init` now converts the shell name into an OsStr, then to a Path, then gets the file stem, and unwraps back into a str. While this process can fail (yielding a None), it's highly unlikely to unless the user has messed with their shells or there's an issue in Starship--therefore, the failure message in this case simply asks the user to file a bug report.

I'm a little torn about the design, even though it's probably not terribly consequential either way (just me getting my newbie jitters out, I guess). The alternative would be to simply `unwrap()` the file stem and let it panic if it does--the conversion should almost never fail unless the user has done something bizarre to their shell or there's a bug in the Rust standard libraries.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #100 

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I've tested `starship init` on Linux and MacOS using names both with and without leading path components (as well as unsupported names), and everything seems to work as expected.

I can't actually get the `None` case to trigger, since I don't know how to cause a failure in `OsStr::to_str()`, but I've verified that evaluating the printed text in that case prints the intended message.

<!--- Include details of your testing environment, tests ran to see how -->
On MacOS and Linux, using bash/zsh/fish or their absolute paths:
```
"eval $(./starship init $0)"
```

To test for error cases:
```
"eval $(./starship init silly)"
```


<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
