### PR TITLE
fix: prompt now updates on bash and zsh

### DIFF
--- a/src/init.rs
+++ b/src/init.rs
@@ -7,12 +7,23 @@ pub fn init(shell_name: &str) {
     let shell_basename = Path::new(shell_name).file_stem().and_then(OsStr::to_str);
 
     let setup_script = match shell_basename {
+        // The contents of `PROMPT_COMMAND` are executed as a regular Bash command
+        // just before Bash displays a prompt.
         Some("bash") => {
-            let script = "PS1=\"$(starship prompt --status=$?)\"";
+            let script = "
+            PROMPT_COMMAND=starship_prompt
+            
+            starship_prompt() {
+                PS1=\"$(starship prompt --status=$?)\"
+            }";
             Some(script)
         }
+        // `precmd` executes a command before the zsh prompt is displayed.
         Some("zsh") => {
-            let script = "PROMPT=\"$(starship prompt --status=$?)\"";
+            let script = "
+            precmd() {
+                PROMPT=\"$(starship prompt --status=$?)\"
+            }";
             Some(script)
         }
         Some("fish") => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Making use of `PROMPT_COMMAND` in bash and `precmd` in zsh, the prompt is no longer being expanded and rendered when the variable is initially set.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #108 

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
