### PR TITLE
feat: Add configuration for add_newline

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -14,6 +14,9 @@ $ touch ~/.config/starship.toml
 All configuration for starship is done in this [TOML](https://github.com/toml-lang/toml) file:
 
 ```toml
+# Don't print a new line at the start of the prompt
+add_newline = false
+
 # Replace the "➜" symbol in the prompt with "❯"
 [character]      # The name of the module we are confguring is "character"
 symbol = "❯"     # The "symbol" segment is being set to "❯"
@@ -35,6 +38,24 @@ are segments within it. Every module also has a prefix and suffix that are the d
 ```
 [prefix]      [symbol]     [version]    [suffix]
  "via "         "⬢"        "v10.4.1"       ""
+```
+
+## Prompt
+
+This is the list of prompt-wide configuration options.
+
+### Options
+
+| Variable | Default | Description|
+| `add_newline` | `true` | Add a new line before the start of the prompt |
+
+### Example
+
+```toml
+# ~/.config/starship.toml
+
+# Disable the newline at the start of the prompt
+add_newline = false
 ```
 
 ## Battery

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,4 +1,4 @@
-use crate::config::{Config, TableExt};
+use crate::config::Config;
 use crate::module::Module;
 
 use clap::ArgMatches;
@@ -13,7 +13,7 @@ use std::path::PathBuf;
 /// of the prompt.
 pub struct Context<'a> {
     /// The deserialized configuration map from the user's `starship.toml` file.
-    pub config: Config,
+    pub config: toml::value::Table,
 
     /// The current working directory that starship is being called in.
     pub current_dir: PathBuf,
@@ -51,7 +51,7 @@ impl<'a> Context<'a> {
     where
         T: Into<PathBuf>,
     {
-        let config = Config::initialize();
+        let config = toml::value::Table::initialize();
 
         // TODO: Currently gets the physical directory. Get the logical directory.
         let current_dir = Context::expand_tilde(dir.into());

--- a/src/module.rs
+++ b/src/module.rs
@@ -1,4 +1,4 @@
-use crate::config::TableExt;
+use crate::config::Config;
 use crate::segment::Segment;
 use ansi_term::Style;
 use ansi_term::{ANSIString, ANSIStrings};

--- a/src/print.rs
+++ b/src/print.rs
@@ -5,6 +5,7 @@ use std::io::{self, Write};
 use crate::context::Context;
 use crate::module::Module;
 use crate::modules;
+use crate::config::Config;
 
 const PROMPT_ORDER: &[&str] = &[
     "battery",
@@ -23,12 +24,15 @@ const PROMPT_ORDER: &[&str] = &[
 
 pub fn prompt(args: ArgMatches) {
     let context = Context::new(args);
+    let config = &context.config;
 
     let stdout = io::stdout();
     let mut handle = stdout.lock();
 
     // Write a new line before the prompt
-    writeln!(handle).unwrap();
+    if config.get_as_bool("add_newline") != Some(false) {
+        writeln!(handle).unwrap();
+    }
 
     let modules = PROMPT_ORDER
         .par_iter()

--- a/src/print.rs
+++ b/src/print.rs
@@ -2,10 +2,10 @@ use clap::ArgMatches;
 use rayon::prelude::*;
 use std::io::{self, Write};
 
+use crate::config::Config;
 use crate::context::Context;
 use crate::module::Module;
 use crate::modules;
-use crate::config::Config;
 
 const PROMPT_ORDER: &[&str] = &[
     "battery",

--- a/tests/testsuite/common.rs
+++ b/tests/testsuite/common.rs
@@ -9,8 +9,8 @@ lazy_static! {
     static ref EMPTY_CONFIG: PathBuf = MANIFEST_DIR.join("empty_config.toml");
 }
 
-/// Run an instance of starship
-fn run_starship() -> process::Command {
+/// Render the full starship prompt
+pub fn render_prompt() -> process::Command {
     let mut command = process::Command::new("./target/debug/starship");
 
     command
@@ -22,6 +22,7 @@ fn run_starship() -> process::Command {
     command
 }
 
+/// Render a specific starship module by name
 pub fn render_module(module_name: &str) -> process::Command {
     let mut command = process::Command::new("./target/debug/starship");
 

--- a/tests/testsuite/configuration.rs
+++ b/tests/testsuite/configuration.rs
@@ -32,3 +32,24 @@ fn disabled_module() -> io::Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn add_newline_configuration() -> io::Result<()> {
+    // Start prompt with newline
+    let default_output = common::render_prompt().output()?;
+    let actual = String::from_utf8(default_output.stdout).unwrap();
+    let expected = actual.trim_start();
+    assert_ne!(actual, expected);
+
+    // Start prompt without newline
+    let output = common::render_prompt()
+        .use_config(toml::toml! {
+            add_newline = false
+        })
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+    let expected = actual.trim_start();
+    assert_eq!(expected, actual);
+
+    Ok(())
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
- Replace `TableExt` with a `Config` trait that extends `toml::value::Table`
- Add configuration for `add_newline`
	`add_newline` is a root-level configuration value. When set to `false`, the initial newline before the prompt is removed.

What are your thoughts on making `add_newline` a root-level config value?

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
