### PR TITLE
feat: Use Unix-style slash on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,6 +472,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "path-slash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "percent-encoding"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -719,6 +724,7 @@ dependencies = [
  "git2 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "path-slash 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_env_logger 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -986,6 +992,7 @@ dependencies = [
 "checksum numtoa 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
 "checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 "checksum openssl-sys 0.9.46 (registry+https://github.com/rust-lang/crates.io-index)" = "05636e06b4f8762d4b81d24a351f3966f38bd25ccbcfd235606c91fdb82cc60f"
+"checksum path-slash 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a0858af4d9136275541f4eac7be1af70add84cf356d901799b065ac1b8ff6e2f"
 "checksum percent-encoding 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba4f28a6faf4ffea762ba8f4baef48c61a6db348647c73095034041fc79dd954"
 "checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
 "checksum ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e3cbf9f658cdb5000fcf6f362b8ea2ba154b9f146a61c7a20d647034c6b6561b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ pretty_env_logger = "0.3.0"
 log = "0.4.7"
 battery = "0.7.4"
 lazy_static = "1.3.0"
+path-slash = "0.1.1"
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -52,23 +52,41 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 /// `top_level_replacement`.
 fn contract_path(full_path: &Path, top_level_path: &Path, top_level_replacement: &str) -> String {
     if !full_path.starts_with(top_level_path) {
-        return full_path.to_str().unwrap().to_string();
+        return replace_c_dir(full_path.to_slash().unwrap());
     }
 
     if full_path == top_level_path {
-        return top_level_replacement.to_string();
+        return replace_c_dir(top_level_replacement.to_string());
     }
 
     format!(
         "{replacement}{separator}{path}",
         replacement = top_level_replacement,
         separator = "/",
-        path = full_path
-            .strip_prefix(top_level_path)
-            .unwrap()
-            .to_slash()
-            .unwrap()
+        path = replace_c_dir(
+            full_path
+                .strip_prefix(top_level_path)
+                .unwrap()
+                .to_slash()
+                .unwrap()
+        )
     )
+}
+
+/// Replaces "C://" with "/c/" within a Windows path
+///
+/// On non-Windows OS, does nothing
+#[cfg(target_os = "windows")]
+fn replace_c_dir(path: String) -> String {
+    return path.replace("C://", "/c/");
+}
+
+/// Replaces "C://" with "/c/" within a Windows path
+///
+/// On non-Windows OS, does nothing
+#[cfg(not(target_os = "windows"))]
+fn replace_c_dir(path: String) -> String {
+    return path;
 }
 
 /// Truncate a path to only have a set number of path components
@@ -109,6 +127,36 @@ mod tests {
 
         let output = contract_path(full_path, repo_root, "rocket-controls");
         assert_eq!(output, "rocket-controls/src");
+    }
+
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn contract_windows_style_home_directory() {
+        let full_path = Path::new("C:\\Users\\astronaut\\schematics\\rocket");
+        let home = Path::new("C:\\Users\\astronaut");
+
+        let output = contract_path(full_path, home, "~");
+        assert_eq!(output, "~/schematics/rocket");
+    }
+
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn contract_windows_style_repo_directory() {
+        let full_path = Path::new("C:\\Users\\astronaut\\dev\\rocket-controls\\src");
+        let repo_root = Path::new("C:\\Users\\astronaut\\dev\\rocket-controls");
+
+        let output = contract_path(full_path, repo_root, "rocket-controls");
+        assert_eq!(output, "rocket-controls/src");
+    }
+
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn contract_windows_style_no_top_level_directory() {
+        let full_path = Path::new("C:\\Some\\Other\\Path");
+        let top_level_path = Path::new("C:\\Users\\astronaut");
+
+        let output = contract_path(full_path, top_level_path, "~");
+        assert_eq!(output, "/c/Some/Other/Path");
     }
 
     #[test]

--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -78,7 +78,7 @@ fn contract_path(full_path: &Path, top_level_path: &Path, top_level_replacement:
 /// On non-Windows OS, does nothing
 #[cfg(target_os = "windows")]
 fn replace_c_dir(path: String) -> String {
-    return path.replace("C://", "/c/");
+    return path.replace("C:/", "/c");
 }
 
 /// Replaces "C://" with "/c/" within a Windows path
@@ -157,6 +157,16 @@ mod tests {
 
         let output = contract_path(full_path, top_level_path, "~");
         assert_eq!(output, "/c/Some/Other/Path");
+    }
+
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn contract_windows_style_root_directory() {
+        let full_path = Path::new("C:\\");
+        let top_level_path = Path::new("C:\\Users\\astronaut");
+
+        let output = contract_path(full_path, top_level_path, "~");
+        assert_eq!(output, "/c");
     }
 
     #[test]

--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -1,4 +1,5 @@
 use ansi_term::Color;
+use path_slash::PathExt;
 use std::path::Path;
 
 use super::{Context, Module};
@@ -65,7 +66,7 @@ fn contract_path(full_path: &Path, top_level_path: &Path, top_level_replacement:
         path = full_path
             .strip_prefix(top_level_path)
             .unwrap()
-            .to_str()
+            .to_slash()
             .unwrap()
     )
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
Prior to this change, starship would use inconsistent slashes when displaying the working directory:

```
~/Desktop\Programming
➜
```

With this change, starship uses Unix-style slashes on all platforms. This is consistent with the Git Bash and Cygwin prompts on Windows.

```
~/Desktop/Programming
➜
```

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [x] I have tested using **Windows**

Added several unit tests and tried out the changes locally. 

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
