### PR TITLE
feat: Allow directory truncation length to be configured

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -116,9 +116,10 @@ git repo that you're currently in.
 
 ### Options
 
-| Variable   | Default | Description                      |
-| ---------- | ------- | -------------------------------- |
-| `disabled` | `false` | Disables the `directory` module. |
+| Variable            | Default | Description                            |
+| ------------------- | ------- | -------------------------------------- |
+| `disabled`          | `false` | Disables the `directory` module.       |
+| `truncation_length` | `3`     | Truncates to this many parent folders. |
 
 ## Git Branch
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -121,6 +121,15 @@ git repo that you're currently in.
 | `disabled`          | `false` | Disables the `directory` module.       |
 | `truncation_length` | `3`     | Truncates to this many parent folders. |
 
+### Example
+
+```toml
+# ~/.config/starship.toml
+
+[directory]
+truncation_length = 8
+```
+
 ## Git Branch
 
 The `git_branch` module shows the active branch of the repo in your current directory.

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -118,8 +118,8 @@ git repo that you're currently in.
 
 | Variable            | Default | Description                            |
 | ------------------- | ------- | -------------------------------------- |
-| `disabled`          | `false` | Disables the `directory` module.       |
 | `truncation_length` | `3`     | Truncates to this many parent folders. |
+| `disabled`          | `false` | Disables the `directory` module.       |
 
 ### Example
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,7 @@ pub trait Config {
     // Config accessor methods
     fn get_as_bool(&self, key: &str) -> Option<bool>;
     fn get_as_str(&self, key: &str) -> Option<&str>;
+    fn get_as_i64(&self, key: &str) -> Option<i64>;
 
     // Internal implementation for accessors
     fn get_config(&self, key: &str) -> Option<&toml::value::Value>;
@@ -129,6 +130,23 @@ impl Config for Table {
 
         str_value
     }
+
+    /// Get a key from a module's configuration as a string
+    fn get_as_i64(&self, key: &str) -> Option<i64> {
+        let value = self.get_config(key)?;
+        let i64_value = value.as_integer();
+
+        if i64_value.is_none() {
+            log::debug!(
+                "Expected \"{}\" to be an integer. Instead received {} of type {}.",
+                key,
+                value,
+                value.type_str()
+            );
+        }
+
+        i64_value
+    }
 }
 
 mod tests {
@@ -164,5 +182,21 @@ mod tests {
         // Use with boolean value
         table.insert(String::from("boolean"), toml::value::Value::Boolean(true));
         assert_eq!(table.get_as_str("boolean"), None);
+    }
+
+    #[test]
+    fn table_get_as_i64() {
+        let mut table = toml::value::Table::new();
+
+        // Use with integer value
+        table.insert(String::from("integer"), toml::value::Value::Integer(82));
+        assert_eq!(table.get_as_i64("integer"), Some(82));
+
+        // Use with string value
+        table.insert(
+            String::from("string"),
+            toml::value::Value::String(String::from("82")),
+        );
+        assert_eq!(table.get_as_bool("string"), None);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -131,7 +131,7 @@ impl Config for Table {
         str_value
     }
 
-    /// Get a key from a module's configuration as a string
+    /// Get a key from a module's configuration as an integer
     fn get_as_i64(&self, key: &str) -> Option<i64> {
         let value = self.get_config(key)?;
         let i64_value = value.as_integer();

--- a/src/module.rs
+++ b/src/module.rs
@@ -96,8 +96,18 @@ impl<'a> Module<'a> {
     }
 
     /// Get a module's config value as a string
-    fn config_value(&self, key: &str) -> Option<&str> {
+    pub fn config_value(&self, key: &str) -> Option<&str> {
         self.config.and_then(|config| config.get_as_str(key))
+    }
+
+    /// Get a module's config value as an int
+    pub fn config_value_i64(&self, key: &str) -> Option<i64> {
+        self.config.and_then(|config| config.get_as_i64(key))
+    }
+
+    /// Get a module's config value as a bool
+    pub fn config_value_bool(&self, key: &str) -> Option<bool> {
+        self.config.and_then(|config| config.get_as_bool(key))
     }
 }
 

--- a/src/module.rs
+++ b/src/module.rs
@@ -96,7 +96,7 @@ impl<'a> Module<'a> {
     }
 
     /// Get a module's config value as a string
-    pub fn config_value(&self, key: &str) -> Option<&str> {
+    fn config_value(&self, key: &str) -> Option<&str> {
         self.config.and_then(|config| config.get_as_str(key))
     }
 

--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -14,11 +14,15 @@ use super::{Context, Module};
 /// Paths will be limited in length to `3` path components by default.
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     const HOME_SYMBOL: &str = "~";
-    const DIR_TRUNCATION_LENGTH: usize = 3;
+    const DIR_TRUNCATION_LENGTH: i64 = 3;
     let module_color = Color::Cyan.bold();
 
     let mut module = context.new_module("directory")?;
     module.set_style(module_color);
+
+    let truncation_length = module
+        .config_value_i64("truncation_length")
+        .unwrap_or(DIR_TRUNCATION_LENGTH);
 
     let current_dir = &context.current_dir;
     log::debug!("Current directory: {:?}", current_dir);
@@ -37,7 +41,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     }
 
     // Truncate the dir string to the maximum number of path components
-    let truncated_dir_string = truncate(dir_string, DIR_TRUNCATION_LENGTH);
+    let truncated_dir_string = truncate(dir_string, truncation_length as usize);
     module.new_segment("path", &truncated_dir_string);
 
     module.get_prefix().set_value("in ");

--- a/tests/testsuite/directory.rs
+++ b/tests/testsuite/directory.rs
@@ -97,7 +97,7 @@ fn truncated_directory_in_root() -> io::Result<()> {
 
 #[test]
 #[ignore]
-fn truncated_directory_config() -> io::Result<()> {
+fn truncated_directory_config_large() -> io::Result<()> {
     let dir = Path::new("/tmp/starship/thrusters/rocket");
     fs::create_dir_all(&dir)?;
 
@@ -114,6 +114,30 @@ fn truncated_directory_config() -> io::Result<()> {
     let expected = format!(
         "in {} ",
         Color::Cyan.bold().paint("/tmp/starship/thrusters/rocket")
+    );
+    assert_eq!(expected, actual);
+    Ok(())
+}
+
+#[test]
+#[ignore]
+fn truncated_directory_config_small() -> io::Result<()> {
+    let dir = Path::new("/tmp/starship/thrusters/rocket");
+    fs::create_dir_all(&dir)?;
+
+    let output = common::render_module("dir")
+        .use_config(toml::toml! {
+            [directory]
+            truncation_length = 2
+        })
+        .arg("--path")
+        .arg(dir)
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+
+    let expected = format!(
+        "in {} ",
+        Color::Cyan.bold().paint("thrusters/rocket")
     );
     assert_eq!(expected, actual);
     Ok(())

--- a/tests/testsuite/directory.rs
+++ b/tests/testsuite/directory.rs
@@ -6,7 +6,7 @@ use std::io;
 use std::path::Path;
 use tempfile::TempDir;
 
-use crate::common;
+use crate::common::{self, TestCommand};
 
 #[test]
 fn home_directory() -> io::Result<()> {
@@ -90,6 +90,30 @@ fn truncated_directory_in_root() -> io::Result<()> {
     let expected = format!(
         "in {} ",
         Color::Cyan.bold().paint("starship/thrusters/rocket")
+    );
+    assert_eq!(expected, actual);
+    Ok(())
+}
+
+#[test]
+#[ignore]
+fn truncated_directory_config() -> io::Result<()> {
+    let dir = Path::new("/tmp/starship/thrusters/rocket");
+    fs::create_dir_all(&dir)?;
+
+    let output = common::render_module("dir")
+        .use_config(toml::toml! {
+            [directory]
+            truncation_length = 100
+        })
+        .arg("--path")
+        .arg(dir)
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+
+    let expected = format!(
+        "in {} ",
+        Color::Cyan.bold().paint("/tmp/starship/thrusters/rocket")
     );
     assert_eq!(expected, actual);
     Ok(())

--- a/tests/testsuite/directory.rs
+++ b/tests/testsuite/directory.rs
@@ -135,10 +135,7 @@ fn truncated_directory_config_small() -> io::Result<()> {
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
-    let expected = format!(
-        "in {} ",
-        Color::Cyan.bold().paint("thrusters/rocket")
-    );
+    let expected = format!("in {} ", Color::Cyan.bold().paint("thrusters/rocket"));
     assert_eq!(expected, actual);
     Ok(())
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
This allows the directory truncation length to be configured. Previously, it was hard-coded to truncate to `3` parent directories.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [x] I have tested using **Windows**

Tested locally on Windows and using Docker.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
