### PR TITLE
feat: Implement Python virtual environment display

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -327,6 +327,8 @@ symbol = "🎁 "
 ## Python
 
 The `python` module shows the currently installed version of Python.
+It will also show the current Python virtual environment if one is
+activated.
 The module will be shown if any of the following conditions are met:
 
 - The current directory contains a `.python-version` file

--- a/src/modules/cmd_duration.rs
+++ b/src/modules/cmd_duration.rs
@@ -88,5 +88,4 @@ mod tests {
     fn test_1d() {
         assert_eq!(render_time(86400 as u64), "1d")
     }
-
 }

--- a/src/modules/python.rs
+++ b/src/modules/python.rs
@@ -70,7 +70,7 @@ fn get_python_virtual_env() -> Option<String> {
     env::var("VIRTUAL_ENV").ok().and_then(|venv| {
         Path::new(&venv)
             .file_name()
-            .map(|filaname| String::from(filaname.to_str().unwrap_or("")))
+            .map(|filename| String::from(filename.to_str().unwrap_or("")))
     })
 }
 

--- a/tests/testsuite/python.rs
+++ b/tests/testsuite/python.rs
@@ -1,6 +1,8 @@
-use ansi_term::Color;
+use std::env;
 use std::fs::File;
 use std::io;
+
+use ansi_term::Color;
 
 use crate::common;
 
@@ -68,6 +70,23 @@ fn folder_with_py_file() -> io::Result<()> {
     let actual = String::from_utf8(output.stdout).unwrap();
 
     let expected = format!("via {} ", Color::Yellow.bold().paint("🐍 v3.6.9"));
+    assert_eq!(expected, actual);
+    Ok(())
+}
+
+#[test]
+#[ignore]
+fn with_virtual_env() -> io::Result<()> {
+    let dir = common::new_tempdir()?;
+    File::create(dir.path().join("main.py"))?;
+    let output = common::render_module("python")
+        .env("VIRTUAL_ENV", "/foo/bar/my_venv")
+        .arg("--path")
+        .arg(dir.path())
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+
+    let expected = format!("via {} ", Color::Yellow.bold().paint("🐍 v3.6.9(my_venv)"));
     assert_eq!(expected, actual);
     Ok(())
 }

--- a/tests/testsuite/python.rs
+++ b/tests/testsuite/python.rs
@@ -86,7 +86,10 @@ fn with_virtual_env() -> io::Result<()> {
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
-    let expected = format!("via {} ", Color::Yellow.bold().paint("🐍 v3.6.9(my_venv)"));
+    let expected = format!(
+        "via {} ",
+        Color::Yellow.bold().paint("🐍 v3.6.9(my_venv)")
+    );
     assert_eq!(expected, actual);
     Ok(())
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

The prompt will now display the current Python virtual environment like this:
`foo on  master via 🐍 v3.7.4(bar)`

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It is handy to show the active Python virtual environment in the prompt

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
