### PR TITLE
 fix: Move the battery to the newline before character

### DIFF
--- a/src/print.rs
+++ b/src/print.rs
@@ -8,7 +8,6 @@ use crate::module::Module;
 use crate::modules;
 
 const PROMPT_ORDER: &[&str] = &[
-    "battery",
     "username",
     "directory",
     "git_branch",
@@ -20,6 +19,7 @@ const PROMPT_ORDER: &[&str] = &[
     "go",
     "cmd_duration",
     "line_break",
+    "battery",
     "character",
 ];
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Show the battery module before the character module with the default prompt order.

![image](https://user-images.githubusercontent.com/4658208/62840097-2a5c7f80-bc63-11e9-952e-d4bf70340871.png)


#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This better aligns with the implementation in spaceship and spacefish.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
