### PR TITLE
feat: Implement Python version from pyenv

### DIFF
--- a/ci/setup-test-env.yml
+++ b/ci/setup-test-env.yml
@@ -10,27 +10,16 @@ steps:
       versionSpec: "1.10"
     displayName: "Install a fixed version of Go"
 
-  # Because the Pipelines agent updates are out of sync, we can't install 3.6.9
-  # with PythonTool on macOS
-
+  # We are using pyenv to install Python for integration tests
   # Install Python
-  - task: UsePythonVersion@0
-    inputs:
-      versionSpec: "3.6.9"
-    displayName: "Install a fixed version of Python"
-    condition: not(eq(variables['Agent.OS'], 'Darwin'))
-  # Install Python (macOS)
   - script: |
       echo "##vso[task.setvariable variable=PYTHON_VERSION;]3.6.9"
       echo "##vso[task.setvariable variable=PYENV_ROOT;]$HOME/.pyenv"
-    condition: eq(variables['Agent.OS'], 'Darwin')
   - script: |
       curl https://pyenv.run | bash
       echo "##vso[task.setvariable variable=PATH;]$PYENV_ROOT/bin:$PYENV_ROOT/shims:$PATH"
-    condition: eq(variables['Agent.OS'], 'Darwin')
   - script: |
       eval "$(pyenv init -)"
       pyenv install $PYTHON_VERSION
       pyenv global $PYTHON_VERSION
-    condition: eq(variables['Agent.OS'], 'Darwin')
     displayName: "Install a fixed version of Python"

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -328,7 +328,7 @@ symbol = "🎁 "
 
 The `python` module shows the currently installed version of Python.
 
-If `use_pyenv` is set to `true`, it will display the pyenv version name.
+If `pyenv_version_name` is set to `true`, it will display the pyenv version name.
 
 Otherwise, it will display the version number from `python --version`
 and show the current Python virtual environment if one is
@@ -347,7 +347,7 @@ The module will be shown if any of the following conditions are met:
 | ---------- | ------- | -------------------------------------------------------- |
 | `symbol`   | `"🐍 "` | The symbol used before displaying the version of Python. |
 | `disabled` | `false` | Disables the `python` module.                            |
-| `use_pyenv` | `false` | Use pyenv to get Python version                            |
+| `pyenv_version_name` | `false` | Use pyenv to get Python version                            |
 | `pyenv_prefix` | `"pyenv "` | Prefix before pyenv version display (default display is `pyenv MY_VERSION`) |
 
 
@@ -358,7 +358,7 @@ The module will be shown if any of the following conditions are met:
 
 [python]
 symbol = "👾 "
-use_pyenv = true
+pyenv_version_name = true
 pyenv_prefix = "foo "
 ```
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -327,8 +327,13 @@ symbol = "🎁 "
 ## Python
 
 The `python` module shows the currently installed version of Python.
-It will also show the current Python virtual environment if one is
+
+If `use_pyenv` is set to `true`, it will display the pyenv version name.
+
+Otherwise, it will display the version number from `python --version`
+and show the current Python virtual environment if one is
 activated.
+
 The module will be shown if any of the following conditions are met:
 
 - The current directory contains a `.python-version` file
@@ -342,6 +347,9 @@ The module will be shown if any of the following conditions are met:
 | ---------- | ------- | -------------------------------------------------------- |
 | `symbol`   | `"🐍 "` | The symbol used before displaying the version of Python. |
 | `disabled` | `false` | Disables the `python` module.                            |
+| `use_pyenv` | `false` | Use pyenv to get Python version                            |
+| `pyenv_prefix` | `"pyenv "` | Prefix before pyenv version display (default display is `pyenv MY_VERSION`) |
+
 
 ### Example
 
@@ -350,6 +358,8 @@ The module will be shown if any of the following conditions are met:
 
 [python]
 symbol = "👾 "
+use_pyenv = true
+pyenv_prefix = "foo "
 ```
 
 ## Rust

--- a/src/modules/python.rs
+++ b/src/modules/python.rs
@@ -26,19 +26,19 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         return None;
     }
 
-    let use_pyenv = context
+    let pyenv_version_name = context
         .config
         .get_module_config("python")
-        .and_then(|table| table.get_as_bool("use_pyenv"))
+        .and_then(|table| table.get_as_bool("pyenv_version_name"))
         .unwrap_or(false);
 
-    select_python_version(use_pyenv)
-        .and_then(|python_version| python_module(context, use_pyenv, python_version))
+    select_python_version(pyenv_version_name)
+        .and_then(|python_version| python_module(context, pyenv_version_name, python_version))
 }
 
 fn python_module<'a>(
     context: &'a Context,
-    use_pyenv: bool,
+    pyenv_version_name: bool,
     python_version: String,
 ) -> Option<Module<'a>> {
     const PYTHON_CHAR: &str = "🐍 ";
@@ -49,7 +49,7 @@ fn python_module<'a>(
     module.set_style(module_color);
     module.new_segment("symbol", PYTHON_CHAR);
 
-    if use_pyenv {
+    if pyenv_version_name {
         module.new_segment("pyenv_prefix", PYENV_PREFIX);
         module.new_segment("version", &python_version.trim());
     } else {
@@ -62,8 +62,8 @@ fn python_module<'a>(
     Some(module)
 }
 
-fn select_python_version(use_pyenv: bool) -> Option<String> {
-    if use_pyenv {
+fn select_python_version(pyenv_version_name: bool) -> Option<String> {
+    if pyenv_version_name {
         get_pyenv_version()
     } else {
         get_python_version()

--- a/tests/testsuite/python.rs
+++ b/tests/testsuite/python.rs
@@ -1,10 +1,10 @@
-use std::env;
 use std::fs::File;
 use std::io;
 
 use ansi_term::Color;
 
 use crate::common;
+use crate::common::TestCommand;
 
 #[test]
 #[ignore]
@@ -91,5 +91,44 @@ fn with_virtual_env() -> io::Result<()> {
         Color::Yellow.bold().paint("🐍 v3.6.9(my_venv)")
     );
     assert_eq!(expected, actual);
+    Ok(())
+}
+
+#[test]
+#[ignore]
+fn with_pyenv() -> io::Result<()> {
+    let dir = common::new_tempdir()?;
+    File::create(dir.path().join("main.py"))?;
+    let output = common::render_module("python")
+        .use_config(toml::toml! {
+            [python]
+            use_pyenv = true
+        })
+        .env("VIRTUAL_ENV", "/foo/bar/my_venv")
+        .arg("--path")
+        .arg(dir.path())
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+    let expected = format!("via {} ", Color::Yellow.bold().paint("🐍 pyenv system"));
+    assert_eq!(expected, actual);
+    Ok(())
+}
+
+#[test]
+#[ignore]
+fn with_pyenv_no_output() -> io::Result<()> {
+    let dir = common::new_tempdir()?;
+    File::create(dir.path().join("main.py"))?;
+    let output = common::render_module("python")
+        .use_config(toml::toml! {
+            [python]
+            use_pyenv = true
+        })
+        .env("PATH", "")
+        .arg("--path")
+        .arg(dir.path())
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+    assert_eq!("", actual);
     Ok(())
 }

--- a/tests/testsuite/python.rs
+++ b/tests/testsuite/python.rs
@@ -102,7 +102,7 @@ fn with_pyenv() -> io::Result<()> {
     let output = common::render_module("python")
         .use_config(toml::toml! {
             [python]
-            use_pyenv = true
+            pyenv_version_name = true
         })
         .env("VIRTUAL_ENV", "/foo/bar/my_venv")
         .arg("--path")
@@ -122,7 +122,7 @@ fn with_pyenv_no_output() -> io::Result<()> {
     let output = common::render_module("python")
         .use_config(toml::toml! {
             [python]
-            use_pyenv = true
+            pyenv_version_name = true
         })
         .env("PATH", "")
         .arg("--path")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Implement pyenv version for the Python module, it looks like this:
`foo on  master via 🐍 pyenv system`

This behavior can be enabled via setting `use_pyenv` to true.
The "pyenv" prefix before the version name can be configured using `pyenv_prefix`

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

pyenv provides named Python versions, users might want to display that instead of `python --version`

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
