### PR TITLE
fix: Fix issue with jobs and extra whitespace on MacOS with BSD utils

### DIFF
--- a/src/init.rs
+++ b/src/init.rs
@@ -54,11 +54,16 @@ pub fn init(shell_name: &str) {
 
 /* Bash does not currently support command durations (see issue #124) for details
 https://github.com/starship/starship/issues/124
+
+We need to quote the output of `$(jobs -p | wc -l)` since MacOS `wc` leaves
+giant spaces in front of the number (e.g. "    3"), which messes up the
+word-splitting. Instead, quote the whole thing, then let Rust do the whitespace
+trimming within the jobs module.
 */
 
 const BASH_INIT: &str = r##"
 starship_precmd() {
-        PS1="$(starship prompt --status=$? --jobs=$(jobs -p | wc -l))";
+        PS1="$(starship prompt --status=$? --jobs="$(jobs -p | wc -l)")";
 };
 PROMPT_COMMAND=starship_precmd;
 "##;
@@ -83,10 +88,10 @@ starship_precmd() {
     if [[ $STARSHIP_START_TIME ]]; then
         STARSHIP_END_TIME="$(date +%s)";
         STARSHIP_DURATION=$((STARSHIP_END_TIME - STARSHIP_START_TIME));
-        PROMPT="$(starship prompt --status=$STATUS --cmd-duration=$STARSHIP_DURATION --jobs=$(jobs | wc -l))";
+        PROMPT="$(starship prompt --status=$STATUS --cmd-duration=$STARSHIP_DURATION --jobs="$(jobs | wc -l)")";
         unset STARSHIP_START_TIME;
     else
-        PROMPT="$(starship prompt --status=$STATUS --jobs=$(jobs | wc -l))";
+        PROMPT="$(starship prompt --status=$STATUS --jobs="$(jobs | wc -l)")";
     fi
 };
 starship_preexec(){

--- a/src/modules/jobs.rs
+++ b/src/modules/jobs.rs
@@ -17,6 +17,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let num_of_jobs = arguments
         .value_of("jobs")
         .unwrap_or("0")
+        .trim()
         .parse::<i64>()
         .ok()?;
     if num_of_jobs == 0 {


### PR DESCRIPTION
MacOS wc has a habit of leaving nasty spaces in the output, which was
messing up our argparser.

To fix, quote the output from the jobs command, then have Rust trim out
whitespace in the jobs module before parsing.

<!--- Provide a general summary of your changes in the Title above -->

#### Description

Quote argument to jobs in prompt setup, then have jobs module trim out whitespace before parsing.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes an issue discovered on Discord.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/4605384/62912936-f8b8e680-bd3e-11e9-88d9-3b767b9af77d.png)


#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
