### PR TITLE
fix: Give all modules a single name

### DIFF
--- a/src/modules/golang.rs
+++ b/src/modules/golang.rs
@@ -30,7 +30,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             const GO_CHAR: &str = "🐹 ";
             let module_color = Color::Cyan.bold();
 
-            let mut module = context.new_module("go")?;
+            let mut module = context.new_module("golang")?;
             module.set_style(module_color);
 
             let formatted_version = format_go_version(&go_version)?;

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -18,12 +18,12 @@ use crate::module::Module;
 
 pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
     match module {
-        "dir" | "directory" => directory::module(context),
-        "char" | "character" => character::module(context),
-        "node" | "nodejs" => nodejs::module(context),
-        "rust" | "rustlang" => rust::module(context),
+        "directory" => directory::module(context),
+        "character" => character::module(context),
+        "nodejs" => nodejs::module(context),
+        "rust" => rust::module(context),
         "python" => python::module(context),
-        "go" | "golang" => golang::module(context),
+        "golang" => golang::module(context),
         "line_break" => line_break::module(context),
         "package" => package::module(context),
         "git_branch" => git_branch::module(context),

--- a/src/modules/nodejs.rs
+++ b/src/modules/nodejs.rs
@@ -26,7 +26,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             const NODE_CHAR: &str = "⬢ ";
             let module_color = Color::Green.bold();
 
-            let mut module = context.new_module("node")?;
+            let mut module = context.new_module("nodejs")?;
             module.set_style(module_color);
 
             let formatted_version = node_version.trim();

--- a/tests/testsuite/cmd_duration.rs
+++ b/tests/testsuite/cmd_duration.rs
@@ -1,8 +1,5 @@
 use ansi_term::Color;
-use std::fs;
 use std::io;
-use std::path::Path;
-use tempfile::TempDir;
 
 use crate::common::{self, TestCommand};
 

--- a/tests/testsuite/directory.rs
+++ b/tests/testsuite/directory.rs
@@ -10,7 +10,9 @@ use crate::common::{self, TestCommand};
 
 #[test]
 fn home_directory() -> io::Result<()> {
-    let output = common::render_module("dir").arg("--path=~").output()?;
+    let output = common::render_module("directory")
+        .arg("--path=~")
+        .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
     let expected = format!("in {} ", Color::Cyan.bold().paint("~"));
@@ -24,7 +26,7 @@ fn directory_in_home() -> io::Result<()> {
     let dir = home_dir().unwrap().join("starship/engine");
     fs::create_dir_all(&dir)?;
 
-    let output = common::render_module("dir")
+    let output = common::render_module("directory")
         .arg("--path")
         .arg(dir)
         .output()?;
@@ -41,7 +43,7 @@ fn truncated_directory_in_home() -> io::Result<()> {
     let dir = home_dir().unwrap().join("starship/engine/schematics");
     fs::create_dir_all(&dir)?;
 
-    let output = common::render_module("dir")
+    let output = common::render_module("directory")
         .arg("--path")
         .arg(dir)
         .output()?;
@@ -57,7 +59,9 @@ fn truncated_directory_in_home() -> io::Result<()> {
 
 #[test]
 fn root_directory() -> io::Result<()> {
-    let output = common::render_module("dir").arg("--path=/").output()?;
+    let output = common::render_module("directory")
+        .arg("--path=/")
+        .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
     let expected = format!("in {} ", Color::Cyan.bold().paint("/"));
@@ -67,7 +71,9 @@ fn root_directory() -> io::Result<()> {
 
 #[test]
 fn directory_in_root() -> io::Result<()> {
-    let output = common::render_module("dir").arg("--path=/usr").output()?;
+    let output = common::render_module("directory")
+        .arg("--path=/usr")
+        .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
     let expected = format!("in {} ", Color::Cyan.bold().paint("/usr"));
@@ -81,7 +87,7 @@ fn truncated_directory_in_root() -> io::Result<()> {
     let dir = Path::new("/tmp/starship/thrusters/rocket");
     fs::create_dir_all(&dir)?;
 
-    let output = common::render_module("dir")
+    let output = common::render_module("directory")
         .arg("--path")
         .arg(dir)
         .output()?;
@@ -101,7 +107,7 @@ fn truncated_directory_config_large() -> io::Result<()> {
     let dir = Path::new("/tmp/starship/thrusters/rocket");
     fs::create_dir_all(&dir)?;
 
-    let output = common::render_module("dir")
+    let output = common::render_module("directory")
         .use_config(toml::toml! {
             [directory]
             truncation_length = 100
@@ -125,7 +131,7 @@ fn truncated_directory_config_small() -> io::Result<()> {
     let dir = Path::new("/tmp/starship/thrusters/rocket");
     fs::create_dir_all(&dir)?;
 
-    let output = common::render_module("dir")
+    let output = common::render_module("directory")
         .use_config(toml::toml! {
             [directory]
             truncation_length = 2
@@ -151,7 +157,7 @@ fn git_repo_root() -> io::Result<()> {
     fs::create_dir(&repo_dir)?;
     Repository::init(&repo_dir).unwrap();
 
-    let output = common::render_module("dir")
+    let output = common::render_module("directory")
         .arg("--path")
         .arg(repo_dir)
         .output()?;
@@ -171,7 +177,7 @@ fn directory_in_git_repo() -> io::Result<()> {
     fs::create_dir_all(&dir)?;
     Repository::init(&repo_dir).unwrap();
 
-    let output = common::render_module("dir")
+    let output = common::render_module("directory")
         .arg("--path")
         .arg(dir)
         .output()?;
@@ -191,7 +197,7 @@ fn truncated_directory_in_git_repo() -> io::Result<()> {
     fs::create_dir_all(&dir)?;
     Repository::init(&repo_dir).unwrap();
 
-    let output = common::render_module("dir")
+    let output = common::render_module("directory")
         .arg("--path")
         .arg(dir)
         .output()?;

--- a/tests/testsuite/golang.rs
+++ b/tests/testsuite/golang.rs
@@ -2,7 +2,7 @@ use ansi_term::Color;
 use std::fs::{self, File};
 use std::io;
 
-use crate::common;
+use crate::common::{self, TestCommand};
 
 #[test]
 fn folder_without_go_files() -> io::Result<()> {
@@ -135,6 +135,27 @@ fn folder_with_gopkg_lock() -> io::Result<()> {
     let actual = String::from_utf8(output.stdout).unwrap();
 
     let expected = format!("via {} ", Color::Cyan.bold().paint("🐹 v1.10"));
+    assert_eq!(expected, actual);
+    Ok(())
+}
+
+#[test]
+#[ignore]
+fn config_disabled() -> io::Result<()> {
+    let dir = common::new_tempdir()?;
+    File::create(dir.path().join("main.go"))?;
+
+    let output = common::render_module("golang")
+        .use_config(toml::toml! {
+            [golang]
+            disabled = true
+        })
+        .arg("--path")
+        .arg(dir.path())
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+
+    let expected = "";
     assert_eq!(expected, actual);
     Ok(())
 }

--- a/tests/testsuite/nodejs.rs
+++ b/tests/testsuite/nodejs.rs
@@ -2,7 +2,7 @@ use ansi_term::Color;
 use std::fs::{self, File};
 use std::io;
 
-use crate::common;
+use crate::common::{self, TestCommand};
 
 #[test]
 fn folder_without_node_files() -> io::Result<()> {
@@ -67,6 +67,27 @@ fn folder_with_node_modules() -> io::Result<()> {
     let actual = String::from_utf8(output.stdout).unwrap();
 
     let expected = format!("via {} ", Color::Green.bold().paint("⬢ v12.0.0"));
+    assert_eq!(expected, actual);
+    Ok(())
+}
+
+#[test]
+#[ignore]
+fn config_disabled() -> io::Result<()> {
+    let dir = common::new_tempdir()?;
+    File::create(dir.path().join("package.json"))?;
+
+    let output = common::render_module("nodejs")
+        .use_config(toml::toml! {
+            [nodejs]
+            disabled = true
+        })
+        .arg("--path")
+        .arg(dir.path())
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+
+    let expected = "";
     assert_eq!(expected, actual);
     Ok(())
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Until this point, modules could've had multiple names. This has caused some confusion when naming configuration values for modules. This PR makes all table names in the config file consistent with the one name for each module.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Bug reported on Discord.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
