### PR TITLE
fix: Don't run tests for ruby outside of the integration tests

### DIFF
--- a/tests/testsuite/ruby.rs
+++ b/tests/testsuite/ruby.rs
@@ -5,6 +5,7 @@ use std::io;
 use crate::common;
 
 #[test]
+#[ignore]
 fn folder_without_ruby_files() -> io::Result<()> {
     let dir = common::new_tempdir()?;
 
@@ -20,6 +21,7 @@ fn folder_without_ruby_files() -> io::Result<()> {
 }
 
 #[test]
+#[ignore]
 fn folder_with_gemfile() -> io::Result<()> {
     let dir = common::new_tempdir()?;
     File::create(dir.path().join("Gemfile"))?;

--- a/tests/testsuite/ruby.rs
+++ b/tests/testsuite/ruby.rs
@@ -38,6 +38,7 @@ fn folder_with_gemfile() -> io::Result<()> {
 }
 
 #[test]
+#[ignore]
 fn folder_with_rb_file() -> io::Result<()> {
     let dir = common::new_tempdir()?;
     File::create(dir.path().join("any.rb"))?;

--- a/tests/testsuite/ruby.rs
+++ b/tests/testsuite/ruby.rs
@@ -5,7 +5,6 @@ use std::io;
 use crate::common;
 
 #[test]
-#[ignore]
 fn folder_without_ruby_files() -> io::Result<()> {
     let dir = common::new_tempdir()?;
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

#### Description

Ruby tests are environment dependent and should not be run in the default test suite. Add `#[ignore]` to the Ruby integration tests to fix this.  


#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This issue is breaking deploy on the AUR package, as the installation involves running `cargo test --release` to ensure a basic level of function

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
