### PR TITLE
docs: Fix typo in directory module description

### DIFF
--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -8,7 +8,7 @@ use super::{Context, Module};
 ///
 /// Will perform path contraction and truncation.
 /// **Contraction**
-///     - Paths begining with the home directory will be contracted to `~`
+///     - Paths beginning with the home directory will be contracted to `~`
 ///     - Paths containing a git repo will contract to begin at the repo root
 ///
 /// **Truncation**


### PR DESCRIPTION
I noticed a small typo in the documentation of the directory module, so I figured I'd make a PR to fix it. Feel free to push a fix separately and close this if it's easier!