### PR TITLE
fix: Fix compilation on NixOS with sandboxing by changing '/usr' to '/etc' in test

### DIFF
--- a/tests/testsuite/directory.rs
+++ b/tests/testsuite/directory.rs
@@ -72,11 +72,11 @@ fn root_directory() -> io::Result<()> {
 #[test]
 fn directory_in_root() -> io::Result<()> {
     let output = common::render_module("directory")
-        .arg("--path=/usr")
+        .arg("--path=/etc")
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
-    let expected = format!("in {} ", Color::Cyan.bold().paint("/usr"));
+    let expected = format!("in {} ", Color::Cyan.bold().paint("/etc"));
     assert_eq!(expected, actual);
     Ok(())
 }


### PR DESCRIPTION
#### Description

With sandboxing NixOS only has those directories in / :
- /dev
- /etc
- /nix
- /build
- /tmp
- /bin
- /proc

As the `directory_in_root()` test was using `/usr`, it failed.

`/usr` was replaced to `/etc`

#### Motivation and Context
Fix compilation on NixOS with sandboxing (which is enabled by default)

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
