### PR TITLE
feat: Add option to control git directory truncation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ Cargo.lock
 
 # Intellij IDE configuration
 .idea/
+/*.iml
 
 # Compiled files for documentation
 docs/node_modules

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -148,7 +148,8 @@ min_time = 4
 ## Directory
 
 The `directory` module shows the path to your current directory, truncated to
-three parent folders.
+three parent folders. Your directory will also be truncated to the root of the
+git repo that you're currently in.
 
 ### Options
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -148,15 +148,15 @@ min_time = 4
 ## Directory
 
 The `directory` module shows the path to your current directory, truncated to
-three parent folders. Your directory will also be truncated to the root of the
-git repo that you're currently in.
+three parent folders.
 
 ### Options
 
-| Variable            | Default | Description                                                                     |
-| ------------------- | ------- | ------------------------------------------------------------------------------- |
-| `truncation_length` | `3`     | The number of parent folders that the current directory should be truncated to. |
-| `disabled`          | `false` | Disables the `directory` module.                                                |
+| Variable            | Default | Description                                                                      |
+| ------------------- | ------- | -------------------------------------------------------------------------------- |
+| `truncation_length` | `3`     | The number of parent folders that the current directory should be truncated to.  |
+| `truncate_to_repo`  | `true`  | Whether or not to truncate to the root of the git repo that you're currently in. |
+| `disabled`          | `false` | Disables the `directory` module.                                                 |
 
 ### Example
 

--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -24,22 +24,26 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let truncation_length = module
         .config_value_i64("truncation_length")
         .unwrap_or(DIR_TRUNCATION_LENGTH);
+    let truncate_to_repo = module.config_value_bool("truncate_to_repo").unwrap_or(true);
 
     let current_dir = &context.current_dir;
     log::debug!("Current directory: {:?}", current_dir);
 
     let dir_string;
-    if let Some(repo_root) = &context.repo_root {
-        // Contract the path to the git repo root
-        let repo_folder_name = repo_root.file_name().unwrap().to_str().unwrap();
+    match &context.repo_root {
+        Some(repo_root) if truncate_to_repo => {
+            // Contract the path to the git repo root
+            let repo_folder_name = repo_root.file_name().unwrap().to_str().unwrap();
 
-        dir_string = contract_path(current_dir, repo_root, repo_folder_name);
-    } else {
-        // Contract the path to the home directory
-        let home_dir = dirs::home_dir().unwrap();
+            dir_string = contract_path(current_dir, repo_root, repo_folder_name);
+        }
+        _ => {
+            // Contract the path to the home directory
+            let home_dir = dirs::home_dir().unwrap();
 
-        dir_string = contract_path(current_dir, &home_dir, HOME_SYMBOL);
-    }
+            dir_string = contract_path(current_dir, &home_dir, HOME_SYMBOL);
+        }
+    };
 
     // Truncate the dir string to the maximum number of path components
     let truncated_dir_string = truncate(dir_string, truncation_length as usize);

--- a/tests/testsuite/directory.rs
+++ b/tests/testsuite/directory.rs
@@ -251,7 +251,7 @@ fn directory_in_git_repo_truncate_to_repo_true() -> io::Result<()> {
     let output = common::render_module("directory")
         .use_config(toml::toml! {
             [directory]
-            // `truncate_tro_repo` should ensure that the longer path should not be displayed.
+            // `truncate_to_repo = true` should display the truncated path
             truncation_length = 5
             truncate_to_repo = true
         })

--- a/tests/testsuite/directory.rs
+++ b/tests/testsuite/directory.rs
@@ -207,3 +207,65 @@ fn truncated_directory_in_git_repo() -> io::Result<()> {
     assert_eq!(expected, actual);
     Ok(())
 }
+
+#[test]
+#[ignore]
+fn directory_in_git_repo_truncate_to_repo_false() -> io::Result<()> {
+    let tmp_dir = TempDir::new_in(dirs::home_dir().unwrap())?;
+    let repo_dir = tmp_dir.path().join("above-repo").join("rocket-controls");
+    let dir = repo_dir.join("src/meters/fuel-gauge");
+    fs::create_dir_all(&dir)?;
+    Repository::init(&repo_dir).unwrap();
+
+    let output = common::render_module("directory")
+        .use_config(toml::toml! {
+            [directory]
+            // Don't truncate the path at all.
+            truncation_length = 5
+            truncate_to_repo = false
+        })
+        .arg("--path")
+        .arg(dir)
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+
+    let expected = format!(
+        "in {} ",
+        Color::Cyan
+            .bold()
+            .paint("above-repo/rocket-controls/src/meters/fuel-gauge")
+    );
+    assert_eq!(expected, actual);
+    Ok(())
+}
+
+#[test]
+#[ignore]
+fn directory_in_git_repo_truncate_to_repo_true() -> io::Result<()> {
+    let tmp_dir = TempDir::new_in(dirs::home_dir().unwrap())?;
+    let repo_dir = tmp_dir.path().join("above-repo").join("rocket-controls");
+    let dir = repo_dir.join("src/meters/fuel-gauge");
+    fs::create_dir_all(&dir)?;
+    Repository::init(&repo_dir).unwrap();
+
+    let output = common::render_module("directory")
+        .use_config(toml::toml! {
+            [directory]
+            // `truncate_tro_repo` should ensure that the longer path should not be displayed.
+            truncation_length = 5
+            truncate_to_repo = true
+        })
+        .arg("--path")
+        .arg(dir)
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+
+    let expected = format!(
+        "in {} ",
+        Color::Cyan
+            .bold()
+            .paint("rocket-controls/src/meters/fuel-gauge")
+    );
+    assert_eq!(expected, actual);
+    Ok(())
+}


### PR DESCRIPTION
As mentioned in #162, I'd like to be able to to disable truncation of the directory to the git repository root. I'm not sure about proper conventions of naming new config options or how to describe them in the docs, so I'm happy to make any changes to improve the language that I used!

Unrelatedly, I updated the .gitignore to ignore Inteliilj .iml module files in the root of the repository in a separate commit, as importing this project into Intellij created that file for me. If it's preferred not to add this to the config, I'd be happy to rebase to remove that commit.

#### Description
I modified the `module` function in `src/modules/directory.rs` to read a boolean option called "truncate_to_repo" from the directory module in the TOML config file, which defaults to "true" in order to preserve backwards compatibility. I subsequently changed the behavior of the truncation to fall back to the same behavior as outside of a git repository (namely, truncating to "truncation_length") if this option is explicitly set to false.

I also updated the directory module documentation in `docs/config/README.md` to list this new option; as part of that change, I removed the sentence from the top-level documentation on the directory module that described the old behavior of always truncating to the root of a git repo.

#### Motivation and Context
I generally prefer not to have my directory truncated in my prompt at all. I can achieve this fairly easily outside of git repos by specifying an arbitrarily large number for the "truncation_length" variable in the directory module, but currently I don't believe it's possible to achieve this inside of a git directory.

Closes #162

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
I'm not quite sure what the best method to write a test for this functionality is, so I'd definitely appreciate some advice on that! I've manually tested this on my machine (which runs Linux) with the `truncate_to_repo` unset, set to `true`, and set to `false` to ensure that the behavior worked as expected. Unfortunately, I don't own a MacOS or Windows machine, so I haven't been able to test on either of those platforms.

I'm also not quite sure how to render the documentation to test that the changes I made don't break anything or look bad; I can see that there's a `package.json` and `package-lock.json` in the `docs` directory, so I assume I have to do something with Node to run it, but unfortunately I have next to no experience in that ecosystem, so I'm not sure exactly what command(s) to run. 

- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:

As mentioned above, I think there are additional steps needed to test this, so I'm leaving that box unmarked.

- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
