### PR TITLE
feat: Implement a two-phase init which allows us to write normal init scripts

### DIFF
--- a/src/init.rs
+++ b/src/init.rs
@@ -112,10 +112,10 @@ const BASH_INIT: &str = r##"
 starship_preexec() {
     # Avoid restarting the timer for commands in the same pipeline
     if [ "$PREEXEC_READY" = "true" ]; then
-        PREEXEC_READY=false;
-        STARSHIP_START_TIME=$(date +%s);
+        PREEXEC_READY=false
+        STARSHIP_START_TIME=$(date +%s)
     fi
-};
+}
 # Will be run before the prompt is drawn
 starship_precmd() {
     # Save the status, because commands in this pipeline will change $?
@@ -123,7 +123,9 @@ starship_precmd() {
     export STARSHIP_SHELL="bash"
 
     # Run the bash precmd function, if relevant
-    "${starship_precmd_user_func-:}";
+    "${starship_precmd_user_func-:}"
+
+    # Prepare the timer data, if needed.
     if [[ $STARSHIP_START_TIME ]]; then
         STARSHIP_END_TIME=$(date +%s)
         STARSHIP_DURATION=$((STARSHIP_END_TIME - STARSHIP_START_TIME))
@@ -133,7 +135,7 @@ starship_precmd() {
         PS1="$(starship prompt --status=$STATUS --jobs="$(jobs -p | wc -l)")"
     fi
     PREEXEC_READY=true;  # Signal that we can safely restart the timer
-};
+}
 
 # If the user appears to be using https://github.com/rcaloras/bash-preexec,
 # then hook our functions into their framework.
@@ -151,14 +153,14 @@ else
     elif [[ "$dbg_trap" != "starship_preexec" && "$dbg_trap" != "starship_preexec_all" ]]; then
         function starship_preexec_all(){
             $dbg_trap; starship_preexec
-        };
+        }
         trap starship_preexec_all DEBUG
-    fi;
+    fi
 
     # Finally, prepare the precmd function and set up the start time.
     PROMPT_COMMAND=starship_precmd
     STARSHIP_START_TIME=$(date +%s)
-fi;
+fi
 "##;
 
 /* ZSH INIT SCRIPT
@@ -189,29 +191,31 @@ starship_precmd() {
     else
         PROMPT="$(starship prompt --status=$STATUS --jobs="$(jobs | wc -l)")"
     fi
-};
+}
 starship_preexec(){
     STARSHIP_START_TIME="$(date +%s)"
-};
-if [[ -z "${precmd_functions+1}" ]]; then
-    precmd_functions=()
-fi;
-if [[ -z "${preexec_functions+1}" ]]; then
-    preexec_functions=()
-fi;
+}
+
+# If precmd/preexec arrays are not already set, set them. If we don't do this,
+# the code to detect whether starship_precmd is already in precmd_functions will
+# fail because the array doesn't exist (and same for starship_preexec)
+[[ -z "${precmd_functions+1}" ]] && precmd_functions=()
+[[ -z "${preexec_functions+1}" ]] && preexec_functions=()
+
+# If starship precmd/preexec functions are already hooked, don't double-hook
 if [[ ${precmd_functions[(ie)starship_precmd]} -gt ${#precmd_functions} ]]; then
-    precmd_functions+=(starship_precmd);
-fi;
+    precmd_functions+=(starship_precmd)
+fi
 if [[ ${preexec_functions[(ie)starship_preexec]} -gt ${#preexec_functions} ]]; then
-    preexec_functions+=(starship_preexec);
-fi;
-STARSHIP_START_TIME="$(date +%s)";
+    preexec_functions+=(starship_preexec)
+fi
+STARSHIP_START_TIME="$(date +%s)"
 function zle-keymap-select
 {
-    PROMPT=$(starship prompt --keymap=$KEYMAP --jobs="$(jobs | wc -l)");
-    zle reset-prompt;
-};
-zle -N zle-keymap-select;
+    PROMPT=$(starship prompt --keymap=$KEYMAP --jobs="$(jobs | wc -l)")
+    zle reset-prompt
+}
+zle -N zle-keymap-select
 "##;
 
 const FISH_INIT: &str = r##"
@@ -219,7 +223,7 @@ function fish_prompt
     set -l exit_code $status
     # Account for changes in variable name between v2.7 and v3.0
     set -l CMD_DURATION "$CMD_DURATION$cmd_duration"
-    set -l starship_duration (math --scale=0 "$CMD_DURATION / 1000");
+    set -l starship_duration (math --scale=0 "$CMD_DURATION / 1000")
     starship prompt --status=$exit_code --cmd-duration=$starship_duration --jobs=(count (jobs -p))
 end
 "##;

--- a/src/init.rs
+++ b/src/init.rs
@@ -83,11 +83,11 @@ pub fn init_main(shell_name: &str) {
 /* GENERAL INIT SCRIPT NOTES
 
 Each init script will be passed as-is. Global notes for init scripts are in this
-comment, with additional per-script comments in the strings themselves.AsMut
+comment, with additional per-script comments in the strings themselves.
 
 JOBS: The argument to `--jobs` is quoted because MacOS's `wc` leaves whitespace
 in the output. We pass it to starship and do the whitespace removal in Rust,
-to avoid the cost of an additional shell fork every shell draw.AsMut
+to avoid the cost of an additional shell fork every shell draw.
 
 */
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,6 +58,11 @@ fn main() {
         .help("The number of currently running jobs")
         .takes_value(true);
 
+    let init_scripts_arg = Arg::with_name("print_full_init")
+        .short("i")
+        .long("print-full-init")
+        .help("The number of currently running jobs");
+
     let matches = App::new("starship")
         .about("The cross-shell prompt for astronauts. ☄🌌️")
         // pull the version number from Cargo.toml
@@ -69,7 +74,8 @@ fn main() {
         .subcommand(
             SubCommand::with_name("init")
                 .about("Prints the shell function used to execute starship")
-                .arg(&shell_arg),
+                .arg(&shell_arg)
+                .arg(&init_scripts_arg),
         )
         .subcommand(
             SubCommand::with_name("prompt")
@@ -99,7 +105,11 @@ fn main() {
     match matches.subcommand() {
         ("init", Some(sub_m)) => {
             let shell_name = sub_m.value_of("shell").expect("Shell name missing.");
-            init::init(shell_name)
+            if sub_m.is_present("print_full_init") {
+                init::init_main(shell_name);
+            } else {
+                init::init_stub(shell_name);
+            }
         }
         ("prompt", Some(sub_m)) => print::prompt(sub_m.clone()),
         ("module", Some(sub_m)) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,9 +59,8 @@ fn main() {
         .takes_value(true);
 
     let init_scripts_arg = Arg::with_name("print_full_init")
-        .short("i")
         .long("print-full-init")
-        .help("The number of currently running jobs");
+        .help("Print the main initialization script (as opposed to the init stub)");
 
     let matches = App::new("starship")
         .about("The cross-shell prompt for astronauts. ☄🌌️")


### PR DESCRIPTION
#### Description
<!--- Describe your changes in detail -->

Implement a two-phase init procedure in starship. The first phase causes the shell to source a subshell, while the second phase (in the subshell) prints the main init script.

This allows us to have nice init scripts with good styling, comments, and no pile of semicolons. Even better, it works as a drop-in replacement, so we don't need to update the docs.

#### Motivation and Context
One of the problems with using `eval` directly is that our scripts all end up on one line. This leads to several problems when it comes to script development:

 - You cannot comment the script, because `#` characters continue to the end of the line, which is the rest of the script when it's all on one line.
 - Debugging is a nightmare--all you know is that there's an error *somewhere* within the script
 - You're forced to place semicolons in places which are not intuitive, even for experienced script writers (you have to have semicolons after every conditional statement, but if you put it after a `then`, it breaks badly and I don't know why)

This can be solved by using subshells to capture output from `source`. However, this leads to an additional problem: if we change our command to `source <(starship init $0)`, the users will have to change their shell rcfiles, which is going to be a bit of a hassle.

Instead, this update allows us to get the benefits of sourcing configs without any of the downside. It does this with a two-phase algorithm (the code is demoed with zsh syntax, but the same idea holds for all shells):

**Main invocation**

The output of `starship init zsh` is `source <(starship init zsh --print-full-init)`. This causes zsh to run a subshell which runs `starship init zsh --print-full-init`, then feed that output to `source` as a file.

**Inner invocation**

The output of `starship init zsh --print-full-init` is the zsh init script (`ZSH_INIT` in the code), complete with whitespace and newlines.

Since this is passed as a file to `source`, whitespace is retained and we can do things like comments.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

Ideally, nothing should change. However, error reporting and recovery is a lot better.

In the following screenshot, I put the same malformed zsh statement into the init script. On the right is what the error looks like before this PR, on the left is after.

![image](https://user-images.githubusercontent.com/4605384/63206446-5adc5900-c069-11e9-88d5-de4b1403ce97.png)

Note that the left side (the "after" image) tells us the error is on line 20, which we can use to debug. Meanwhile, the right side (the "before") just tells us that something has gone wrong at one of the many conditional tokens in the init script.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

So one major, major caveat here: this is definitely pushing a little into dark shell sorcery, and I'm not 100% confident that this solution is portable across all versions of all shells. I already hit one weird edge case due to the fact that MacOS's version of `bash` is ancient, and there may be more in an older version of zsh, or maybe even in fish.

An alternative is to simply use `source <(starship init <shell>)`, which I am fairly confident will almost always work, but requires users to change their rcfiles. On one hand, we're pre-1.0, so a little breakage is to be expected, but on the other, I don't like springing surprises on people.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly. (not needed)
- [ ] I have updated the tests accordingly.
