### PR TITLE
feat: Display Vi mode as PROMPT

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -100,7 +100,7 @@ can do this in two ways: by changing color (red/green) or by changing its shape
 | `symbol`                | `"➜"`   | The symbol used before the text input in the prompt. |
 | `error_symbol`          | `"✖"`   | The symbol used before text input if the previous command failed. |
 | `use_symbol_for_status` | `false` | Indicate error status by changing the symbol.         |
-| `vicmd_symbol`          | `"❮"`   | The symbol used before the text input in the prompt if Zsh Line Editor keymap is `vicmd`. |
+| `vicmd_symbol`          | `"❮"`   | The symbol used before the text input in the prompt if zsh is in vim normal mode. |
 | `disabled`              | `false` | Disables the `character` module.                      |
 
 ### Example

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -100,6 +100,7 @@ can do this in two ways: by changing color (red/green) or by changing its shape
 | `symbol`                | `"➜"`   | The symbol used before the text input in the prompt. |
 | `error_symbol`          | `"✖"`   | The symbol used before text input if the previous command failed. |
 | `use_symbol_for_status` | `false` | Indicate error status by changing the symbol.         |
+| `vicmd_symbol`          | `"❮"`   | The symbol used before the text input in the prompt if Zsh Line Editor keymap is `vicmd`. |
 | `disabled`              | `false` | Disables the `character` module.                      |
 
 ### Example

--- a/src/init.rs
+++ b/src/init.rs
@@ -158,6 +158,12 @@ if [[ ${preexec_functions[(ie)starship_preexec]} -gt ${#preexec_functions} ]]; t
     preexec_functions+=(starship_preexec);
 fi;
 STARSHIP_START_TIME="$(date +%s)";
+function zle-keymap-select
+{
+    PROMPT=$(starship prompt --keymap=$KEYMAP)
+    zle reset-prompt
+}
+zle -N zle-keymap-select
 "##;
 
 /* Fish setup is simple because they give us CMD_DURATION. Just account for name

--- a/src/init.rs
+++ b/src/init.rs
@@ -160,10 +160,10 @@ fi;
 STARSHIP_START_TIME="$(date +%s)";
 function zle-keymap-select
 {
-    PROMPT=$(starship prompt --keymap=$KEYMAP)
-    zle reset-prompt
-}
-zle -N zle-keymap-select
+    PROMPT=$(starship prompt --keymap=$KEYMAP --jobs="$(jobs | wc -l)");
+    zle reset-prompt;
+};
+zle -N zle-keymap-select;
 "##;
 
 /* Fish setup is simple because they give us CMD_DURATION. Just account for name

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,14 @@ fn main() {
         .help("The execution duration of the last command, in seconds")
         .takes_value(true);
 
+    let keymap_arg = Arg::with_name("keymap")
+        .short("k")
+        .long("keymap")
+        .value_name("KEYMAP")
+        // zsh only
+        .help("The keymap of zsh")
+        .takes_value(true);
+
     let jobs_arg = Arg::with_name("jobs")
         .short("j")
         .long("jobs")
@@ -69,6 +77,7 @@ fn main() {
                 .arg(&status_code_arg)
                 .arg(&path_arg)
                 .arg(&cmd_duration_arg)
+                .arg(&keymap_arg)
                 .arg(&jobs_arg),
         )
         .subcommand(

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,6 +91,7 @@ fn main() {
                 .arg(&status_code_arg)
                 .arg(&path_arg)
                 .arg(&cmd_duration_arg)
+                .arg(&keymap_arg)
                 .arg(&jobs_arg),
         )
         .get_matches();

--- a/src/modules/character.rs
+++ b/src/modules/character.rs
@@ -12,6 +12,8 @@ use ansi_term::Color;
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     const SUCCESS_CHAR: &str = "➜";
     const FAILURE_CHAR: &str = "✖";
+    const VICMD_CHAR: &str = "❮";
+
     let color_success = Color::Green.bold();
     let color_failure = Color::Red.bold();
 
@@ -23,11 +25,14 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         .config_value_bool("use_symbol_for_status")
         .unwrap_or(false);
     let exit_success = arguments.value_of("status_code").unwrap_or("0") == "0";
+    let keymap = arguments.value_of("keymap").unwrap_or("viins");
 
     /* If an error symbol is set in the config, use symbols to indicate
     success/failure, in addition to color */
     let symbol = if use_symbol && !exit_success {
         module.new_segment("error_symbol", FAILURE_CHAR)
+    } else if keymap == "vicmd" {
+        module.new_segment("vicmd_symbol", VICMD_CHAR)
     } else {
         module.new_segment("symbol", SUCCESS_CHAR)
     };

--- a/src/modules/python.rs
+++ b/src/modules/python.rs
@@ -111,17 +111,4 @@ mod tests {
         let input = "Python 3.7.2";
         assert_eq!(format_python_version(input), "v3.7.2");
     }
-
-    #[test]
-    fn test_no_virtual_env() {
-        env::set_var("VIRTUAL_ENV", "");
-        assert_eq!(get_python_virtual_env(), None)
-    }
-
-    #[test]
-    fn test_virtual_env() {
-        env::set_var("VIRTUAL_ENV", "/foo/bar/my_venv");
-        assert_eq!(get_python_virtual_env().unwrap(), "my_venv")
-    }
-
 }

--- a/tests/testsuite/character.rs
+++ b/tests/testsuite/character.rs
@@ -72,3 +72,37 @@ fn char_module_symbolyes_status() -> io::Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn char_module_vicmd_keymap() -> io::Result<()> {
+    let expected_vicmd = format!("{} ", Color::Green.bold().paint("❮"));
+    let expected_specified = format!("{} ", Color::Green.bold().paint("N"));
+    let expected_other = format!("{} ", Color::Green.bold().paint("➜"));
+
+    // zle keymap is vicmd
+    let output = common::render_module("character")
+        .arg("--keymap=vicmd")
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+    assert_eq!(expected_vicmd, actual);
+
+    // specified vicmd character
+    let output = common::render_module("character")
+        .use_config(toml::toml! {
+            [character]
+            vicmd_symbol = "N"
+        })
+        .arg("--keymap=vicmd")
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+    assert_eq!(expected_specified, actual);
+
+    // zle keymap is other
+    let output = common::render_module("character")
+        .arg("--keymap=visual")
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+    assert_eq!(expected_other, actual);
+
+    Ok(())
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
I enable to change prompt if [zsh: 18 Zsh Line Editor](http://zsh.sourceforge.net/Doc/Release/Zsh-Line-Editor.html#Keymaps) is `vicmd`.

KEYMAP is `vicmd`.
<img width="425" alt="Screen Shot 2019-08-17 at 20 27 15" src="https://user-images.githubusercontent.com/12455284/63211088-84f74f00-c12d-11e9-86b3-a225816d073f.png">

KEYMAP is other.
<img width="481" alt="Screen Shot 2019-08-17 at 20 27 03" src="https://user-images.githubusercontent.com/12455284/63211104-c425a000-c12d-11e9-9b53-1e6f8a352004.png">

`vicmd_symbol` is configurable.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #129 

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
