### PR TITLE
feat: Add configuration for reordering the prompt module and disabling default order

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -49,7 +49,7 @@ This is the list of prompt-wide configuration options.
 | Variable       | Default | Description                                                        |
 | -------------- | ------- | ------------------------------------------------------------------ |
 | `add_newline`  | `true`  | Add a new line before the start of the prompt.                     |
-| `prompt_order` | `[]`    | Configure out custom prompt order overriding default prompt order. |
+| `prompt_order` | `[]`    | Configure out custom prompt order overriding [default prompt order](#default-prompt-order). |
 
 ### Example
 
@@ -58,8 +58,31 @@ This is the list of prompt-wide configuration options.
 
 # Disable the newline at the start of the prompt
 add_newline = false
+# Overwrite a default_prompt_order and  use custom prompt_order
 prompt_order=["rust","line_break","package","line_break","character"]
 ```
+
+### Default prompt order
+```default_prompt_order``` is used as ```prompt_order``` when config have no options named as ```prompt_order``` or when you have set ```prompt_order = []```
+```toml
+default_prompt_order = [
+    "username",
+    "directory",
+    "git_branch",
+    "git_status",
+    "package",
+    "nodejs",
+    "rust",
+    "python",
+    "golang",
+    "cmd_duration",
+    "line_break",
+    "jobs",
+    "battery",
+    "character",
+]
+```
+
 
 ## Battery
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -46,11 +46,10 @@ This is the list of prompt-wide configuration options.
 
 ### Options
 
-| Variable                | Default | Description                                                          |
-| ----------------------- | ------- | -------------------------------------------------------------------- |
-| `add_newline`           | `true`  | Add a new line before the start of the prompt.                       |
-| `prompt_order`          | `[]`    | Configure out custom prompt order modifying default order            |
-| `disable_default_order` | `false` | Disable default config order and only enable out custom prompt order |
+| Variable       | Default | Description                                                        |
+| -------------- | ------- | ------------------------------------------------------------------ |
+| `add_newline`  | `true`  | Add a new line before the start of the prompt.                     |
+| `prompt_order` | `[]`    | Configure out custom prompt order overriding default prompt order. |
 
 ### Example
 
@@ -59,8 +58,7 @@ This is the list of prompt-wide configuration options.
 
 # Disable the newline at the start of the prompt
 add_newline = false
-prompt_order=["rust","line_break","package","line_break","character"] 
-disable_default_order=true
+prompt_order=["rust","line_break","package","line_break","character"]
 ```
 
 ## Battery

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -46,9 +46,11 @@ This is the list of prompt-wide configuration options.
 
 ### Options
 
-| Variable      | Default | Description                                    |
-| ------------- | ------- | ---------------------------------------------- |
-| `add_newline` | `true`  | Add a new line before the start of the prompt. |
+| Variable                | Default | Description                                                          |
+| ----------------------- | ------- | -------------------------------------------------------------------- |
+| `add_newline`           | `true`  | Add a new line before the start of the prompt.                       |
+| `prompt_order`          | `[]`    | Configure out custom prompt order modifying default order            |
+| `disable_default_order` | `false` | Disable default config order and only enable out custom prompt order |
 
 ### Example
 
@@ -57,6 +59,8 @@ This is the list of prompt-wide configuration options.
 
 # Disable the newline at the start of the prompt
 add_newline = false
+prompt_order=["rust","line_break","package","line_break","character"] 
+disable_default_order=true
 ```
 
 ## Battery

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -49,7 +49,7 @@ This is the list of prompt-wide configuration options.
 | Variable       | Default | Description                                                        |
 | -------------- | ------- | ------------------------------------------------------------------ |
 | `add_newline`  | `true`  | Add a new line before the start of the prompt.                     |
-| `prompt_order` | `[]`    | Configure out custom prompt order overriding [default prompt order](#default-prompt-order). |
+| `prompt_order` | [link](#default-prompt-order) | Configure the order in which the prompt module occurs. |
 
 ### Example
 
@@ -63,8 +63,8 @@ prompt_order=["rust","line_break","package","line_break","character"]
 ```
 
 ### Default prompt order
-```default_prompt_order``` is used as ```prompt_order``` when config have no options named as ```prompt_order``` or when you have set ```prompt_order = []```
-```toml
+The ```default_prompt_order``` configuration option is used to define the order in which modules are shown in the prompt, if empty or no ```prompt_order``` is provided. The default is as shown:
+```
 default_prompt_order = [
     "username",
     "directory",

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,6 +13,7 @@ pub trait Config {
     fn get_as_bool(&self, key: &str) -> Option<bool>;
     fn get_as_str(&self, key: &str) -> Option<&str>;
     fn get_as_i64(&self, key: &str) -> Option<i64>;
+    fn get_as_array(&self, key: &str) -> Option<&Vec<toml::value::Value>>;
 
     // Internal implementation for accessors
     fn get_config(&self, key: &str) -> Option<&toml::value::Value>;
@@ -140,6 +141,21 @@ impl Config for Table {
         }
 
         i64_value
+    }
+
+    /// Get a key from a module's configuration as a vector
+    fn get_as_array(&self, key: &str) -> Option<&Vec<toml::value::Value>> {
+        let value = self.get_config(key)?;
+        let array_value = value.as_array();
+        if array_value.is_none() {
+            log::debug!(
+                "Expected \"{}\" to be a array. Instead received {} of type {}.",
+                key,
+                value,
+                value.type_str()
+            );
+        }
+        array_value
     }
 }
 

--- a/src/print.rs
+++ b/src/print.rs
@@ -27,6 +27,8 @@ const ALL_MODULES: &[&str] = &[
 ];
 
 // List of default prompt order
+// NOTE: If this const value is changed then Default prompt order subheading inside
+// prompt heading of config docs needs to be updated according to changes made here.
 const DEFAULT_PROMPT_ORDER: &[&str] = &[
     "username",
     "directory",

--- a/src/print.rs
+++ b/src/print.rs
@@ -7,8 +7,27 @@ use crate::context::Context;
 use crate::module::Module;
 use crate::modules;
 
-//List of all prompt order
-const ALL_PROMPT_LIST: &[&str] = &[
+//List of all modules
+const ALL_MODULES: &[&str] = &[
+    "battery",
+    "character",
+    "cmd_duration",
+    "directory",
+    "git_branch",
+    "git_status",
+    "golang",
+    "jobs",
+    "line_break",
+    "nodejs",
+    "package",
+    "python",
+    "ruby",
+    "rust",
+    "username",
+];
+
+//List of default prompt order
+const DEFAULT_PROMPT_ORDER: &[&str] = &[
     "username",
     "directory",
     "git_branch",
@@ -38,55 +57,37 @@ pub fn prompt(args: ArgMatches) {
     }
 
     let mut prompt_order: Vec<&str> = Vec::new();
-    //List of default prompt order
-    let default_prompt_order: &[&str] = &[
-        "username",
-        "directory",
-        "git_branch",
-        "git_status",
-        "package",
-        "nodejs",
-        "rust",
-        "python",
-        "golang",
-        "cmd_duration",
-        "line_break",
-        "jobs",
-        "battery",
-        "character",
-    ];
 
     // Write out a custom prompt order
-    if let Some(values) = config.get_as_array("prompt_order") {
-        for value in values {
-            let str_value = value.as_str();
+    if let Some(modules) = config.get_as_array("prompt_order") {
+        // if prompt_order = [] use default_prompt_order
+        if !modules.is_empty() {
+            for module in modules {
+                let str_value = module.as_str();
 
-            if let Some(value) = str_value {
-                if ALL_PROMPT_LIST.contains(&value) {
-                    prompt_order.push(value);
+                if let Some(value) = str_value {
+                    if ALL_MODULES.contains(&value) {
+                        prompt_order.push(value);
+                    } else {
+                        log::debug!(
+                            "Expected prompt_order to contain value from {:?}. Instead received {}",
+                            ALL_MODULES,
+                            value,
+                        );
+                    }
                 } else {
                     log::debug!(
-                        "Expected prompt_order to contain value from {:?}. Instead received {}",
-                        ALL_PROMPT_LIST,
-                        value,
-                    );
-                }
-            } else {
-                log::debug!(
-                    "Expected prompt_order to be a array of string. Instead received {} of type {}",
-                    value,
-                    value.type_str()
+                    "Expected prompt_order to be an array of strings. Instead received {} of type {}",
+                    module,
+                    module.type_str()
                 );
+                }
             }
+        } else {
+            prompt_order = DEFAULT_PROMPT_ORDER.to_vec();
         }
-    }
-
-    if config.get_as_bool("disable_default_order") != Some(true) {
-        for prompts in default_prompt_order {
-            if !prompt_order.contains(prompts) {
-                prompt_order.push(prompts);
-            }
-        }
+    } else {
+        prompt_order = DEFAULT_PROMPT_ORDER.to_vec();
     }
 
     let modules = &prompt_order

--- a/src/print.rs
+++ b/src/print.rs
@@ -7,7 +7,7 @@ use crate::context::Context;
 use crate::module::Module;
 use crate::modules;
 
-//List of all modules
+// List of all modules
 const ALL_MODULES: &[&str] = &[
     "battery",
     "character",
@@ -26,7 +26,7 @@ const ALL_MODULES: &[&str] = &[
     "username",
 ];
 
-//List of default prompt order
+// List of default prompt order
 const DEFAULT_PROMPT_ORDER: &[&str] = &[
     "username",
     "directory",
@@ -77,10 +77,10 @@ pub fn prompt(args: ArgMatches) {
                     }
                 } else {
                     log::debug!(
-                    "Expected prompt_order to be an array of strings. Instead received {} of type {}",
-                    module,
-                    module.type_str()
-                );
+                        "Expected prompt_order to be an array of strings. Instead received {} of type {}",
+                        module,
+                        module.type_str()
+                    );
                 }
             }
         } else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
This PR adds functionality for reordering the prompt module it provide out ~~two~~ one configuration setting i.e ```prompt_order``` which can be set as array of string ~~and ```disable_default_order``` as Boolean~~.

#### Example
1. configuration
```
prompt_order=["rust","git_status","package","character]
```  
![Screenshot_20190817_233555](https://user-images.githubusercontent.com/38726015/63215574-4458ff00-c148-11e9-830d-dc39041a7cab.png)

2. configuration
```
prompt_order=["rust","git_status","package","line_break","character"] 
```  
![Screenshot_20190817_233641](https://user-images.githubusercontent.com/38726015/63215578-520e8480-c148-11e9-82f8-8e856bd3468b.png)

3. configuration
```
prompt_order=["rust","line_break","package","line_break","character"]
```
![Screenshot_20190817_233718](https://user-images.githubusercontent.com/38726015/63215582-5f2b7380-c148-11e9-9781-55ec4b0e43ff.png)

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #158

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [X] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
