### PR TITLE
feat: Add nix-shell support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ The prompt shows information you need while you're working, while staying sleek 
 - Current Ruby version (`💎`)
 - Current Python version (`🐍`)
 - Current Go version (`🐹`)
+- Nix-shell environment detection
 - Current version of package in current directory (`📦`)
   - npm (Node.js)
   - cargo (Rust)

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -490,3 +490,29 @@ The module will be shown if any of the following conditions are met:
 [username]
 disabled = true
 ```
+
+## Nix-shell
+
+The `nix_shell` module shows the nix-shell environment.
+The module will be shown when inside a nix-shell environment.
+
+### Options
+
+| Variable     | Default  | Description                        |
+| ------------ | -------- | ---------------------------------- |
+| `disabled`   | `false`  | Disables the `username` module.    |
+| `use_name`   | `false`  | Display the name of the nix-shell. |
+| `impure_msg` | `impure` | Customize the "impure" msg.        |
+| `pure_msg`   | `pure`   | Customize the "pure" msg.          |
+
+### Example
+
+```toml
+# ~/.config/starship.toml
+
+[nix_shell]
+disabled = true
+use_name = true
+impure_msg = "impure shell"
+pure_msg = "pure shell"
+```

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -8,6 +8,7 @@ mod git_status;
 mod golang;
 mod jobs;
 mod line_break;
+mod nix_shell;
 mod nodejs;
 mod package;
 mod python;
@@ -35,6 +36,7 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
         "battery" => battery::module(context),
         "cmd_duration" => cmd_duration::module(context),
         "jobs" => jobs::module(context),
+        "nix_shell" => nix_shell::module(context),
 
         _ => {
             eprintln!("Error: Unknown module {}. Use starship module --list to list out all supported modules.", module);

--- a/src/modules/nix_shell.rs
+++ b/src/modules/nix_shell.rs
@@ -1,0 +1,54 @@
+use ansi_term::Color;
+use std::env;
+
+use super::{Context, Module};
+
+// IN_NIX_SHELL should be "pure" or "impure" but lorri uses "1" for "impure"
+// https://github.com/target/lorri/issues/140
+
+/// Creates a module showing if inside a nix-shell
+///
+/// The module will use the `$IN_NIX_SHELL` and `$name` environment variable to
+/// determine if it's inside a nix-shell and the name of it.
+///
+/// The following options are availables:
+///     - use_name   (bool)   // print the name of the nix-shell
+///     - impure_msg (string) // change the impure msg
+///     - pure_msg (string)   // change the pure msg
+///
+/// Will display the following:
+///     - name (pure)    // use_name == true in a pure nix-shell
+///     - name (impure)  // use_name == true in an impure nix-shell
+///     - pure           // use_name == false in a pure nix-shell
+///     - impure         // use_name == false in an impure nix-shell
+pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let mut module = context.new_module("nix_shell")?;
+
+    env::var("IN_NIX_SHELL")
+        .ok()
+        .and_then(|shell_type| {
+            if shell_type == "1" || shell_type == "impure" {
+                Some(module.config_value_str("impure_msg").unwrap_or("impure"))
+            } else if shell_type == "pure" {
+                Some(module.config_value_str("pure_msg").unwrap_or("pure"))
+            } else {
+                None
+            }
+        })
+        .map(|shell_type| {
+            if module.config_value_bool("use_name").unwrap_or(false) {
+                match env::var("name").ok() {
+                    Some(name) => format!("{} ({})", name, shell_type),
+                    None => shell_type.to_string(),
+                }
+            } else {
+                shell_type.to_string()
+            }
+        })
+        .map(|segment| {
+            let module_color = Color::Red.bold();
+            module.set_style(module_color);
+            module.new_segment("nix_shell", &segment);
+            module
+        })
+}

--- a/src/print.rs
+++ b/src/print.rs
@@ -22,6 +22,7 @@ const DEFAULT_PROMPT_ORDER: &[&str] = &[
     "rust",
     "python",
     "golang",
+    "nix_shell",
     "cmd_duration",
     "line_break",
     "jobs",

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -7,6 +7,7 @@ mod golang;
 mod jobs;
 mod line_break;
 mod modules;
+mod nix_shell;
 mod nodejs;
 mod python;
 mod ruby;

--- a/tests/testsuite/nix_shell.rs
+++ b/tests/testsuite/nix_shell.rs
@@ -1,0 +1,58 @@
+use ansi_term::Color;
+use std::io;
+
+use crate::common;
+
+#[test]
+fn no_env_variables() -> io::Result<()> {
+    let output = common::render_module("nix_shell").output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+    assert_eq!("", actual);
+    Ok(())
+}
+
+#[test]
+fn invalid_env_variables() -> io::Result<()> {
+    let output = common::render_module("nix_shell")
+        .env("IN_NIX_SHELL", "something_wrong")
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+    assert_eq!("", actual);
+    Ok(())
+}
+
+#[test]
+fn pure_shell() -> io::Result<()> {
+    let output = common::render_module("nix_shell")
+        .env("IN_NIX_SHELL", "pure")
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+
+    let expected = format!("via {} ", Color::Red.bold().paint("pure"));
+    assert_eq!(expected, actual);
+    Ok(())
+}
+
+#[test]
+fn impure_shell() -> io::Result<()> {
+    let output = common::render_module("nix_shell")
+        .env("IN_NIX_SHELL", "impure")
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+
+    let expected = format!("via {} ", Color::Red.bold().paint("impure"));
+    assert_eq!(expected, actual);
+    Ok(())
+}
+
+#[test]
+fn lorri_shell() -> io::Result<()> {
+    let output = common::render_module("nix_shell")
+        .env("IN_NIX_SHELL", "1")
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+
+    let expected = format!("via {} ", Color::Red.bold().paint("impure"));
+    assert_eq!(expected, actual);
+    Ok(())
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
The module determine if inside a nix-shell env using `$IN_NIX_SHELL`.

#### Motivation and Context
It's useful to know when you're inside a nix-shell environment (like a python virtualenv).
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #172

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/24027/63214445-3a9eaf80-c0e6-11e9-8e1b-e034382dee00.png)


#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.

I didn't do the doc yet.

Is it a bad idea to show the content of `$IN_NIX_SHELL` in the prompt (for security maybe)? Maybe it could be safer if I validate that it's either "1", "pure" or "impure".

Also for some reason, [lorri](https://github.com/target/lorri) (a nix-shell tool) sets `IN_NIX_SHELL` to "1" instead of "pure" or "impure". Is it ok to show "nix-shell" instead of "1"? I can check with the devs if their env is considered "pure" or "impure". Or maybe they could add their own env var.