### PR TITLE
fix: Set default prompt character to ❯

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -89,8 +89,8 @@ discharging_symbol = "💀"
 The `character` module shows a character (usually an arrow) beside where the text
 is entered in your terminal.
 
-The character will tell you whether the last command was successful or not. It
-can do this in two ways: by changing color (red/green) or by changing its shape
+The character will tell you whether the last command was successful or not. It 
+can do this in two ways: by changing color (red/green) or by changing its shape 
 (❯/✖). The latter will only be done if `use_symbol_for_status` is set to `true`.
 
 ### Options
@@ -404,10 +404,6 @@ The module will be shown if any of the following conditions are met:
 | `disabled`           | `false`    | Disables the `python` module.                                               |
 | `pyenv_version_name` | `false`    | Use pyenv to get Python version                                             |
 | `pyenv_prefix`       | `"pyenv "` | Prefix before pyenv version display (default display is `pyenv MY_VERSION`) |
-<<<<<<< HEAD
-=======
-
->>>>>>> Set default prompt character to ❯
 
 ### Example
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -17,9 +17,9 @@ All configuration for starship is done in this [TOML](https://github.com/toml-la
 # Don't print a new line at the start of the prompt
 add_newline = false
 
-# Replace the "➜" symbol in the prompt with "❯"
+# Replace the "❯" symbol in the prompt with "➜"
 [character]      # The name of the module we are confguring is "character"
-symbol = "❯"     # The "symbol" segment is being set to "❯"
+symbol = "➜"     # The "symbol" segment is being set to "➜"
 
 # Disable the package module, hiding it from the prompt completely
 [package]
@@ -91,13 +91,13 @@ is entered in your terminal.
 
 The character will tell you whether the last command was successful or not. It
 can do this in two ways: by changing color (red/green) or by changing its shape
-(➜/✖). The latter will only be done if `use_symbol_for_status` is set to `true`.
+(❯/✖). The latter will only be done if `use_symbol_for_status` is set to `true`.
 
 ### Options
 
 | Variable                | Default | Description                                                                       |
 | ----------------------- | ------- | --------------------------------------------------------------------------------- |
-| `symbol`                | `"➜"`   | The symbol used before the text input in the prompt.                              |
+| `symbol`                | `"❯"`   | The symbol used before the text input in the prompt.                              |
 | `error_symbol`          | `"✖"`   | The symbol used before text input if the previous command failed.                 |
 | `use_symbol_for_status` | `false` | Indicate error status by changing the symbol.                                     |
 | `vicmd_symbol`          | `"❮"`   | The symbol used before the text input in the prompt if zsh is in vim normal mode. |
@@ -109,7 +109,7 @@ can do this in two ways: by changing color (red/green) or by changing its shape
 # ~/.config/starship.toml
 
 [character]
-symbol = "❯"
+symbol = "➜"
 error_symbol = "✗"
 use_symbol_for_status = true
 ```
@@ -404,6 +404,10 @@ The module will be shown if any of the following conditions are met:
 | `disabled`           | `false`    | Disables the `python` module.                                               |
 | `pyenv_version_name` | `false`    | Use pyenv to get Python version                                             |
 | `pyenv_prefix`       | `"pyenv "` | Prefix before pyenv version display (default display is `pyenv MY_VERSION`) |
+<<<<<<< HEAD
+=======
+
+>>>>>>> Set default prompt character to ❯
 
 ### Example
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -89,8 +89,8 @@ discharging_symbol = "💀"
 The `character` module shows a character (usually an arrow) beside where the text
 is entered in your terminal.
 
-The character will tell you whether the last command was successful or not. It 
-can do this in two ways: by changing color (red/green) or by changing its shape 
+The character will tell you whether the last command was successful or not. It
+can do this in two ways: by changing color (red/green) or by changing its shape
 (❯/✖). The latter will only be done if `use_symbol_for_status` is set to `true`.
 
 ### Options

--- a/src/modules/character.rs
+++ b/src/modules/character.rs
@@ -10,7 +10,7 @@ use ansi_term::Color;
 /// - If the exit-code was anything else, the arrow will be formatted with
 /// `COLOR_FAILURE` (red by default)
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
-    const SUCCESS_CHAR: &str = "➜";
+    const SUCCESS_CHAR: &str = "❯";
     const FAILURE_CHAR: &str = "✖";
     const VICMD_CHAR: &str = "❮";
 

--- a/tests/testsuite/character.rs
+++ b/tests/testsuite/character.rs
@@ -5,7 +5,7 @@ use crate::common::{self, TestCommand};
 
 #[test]
 fn char_module_success_status() -> io::Result<()> {
-    let expected = format!("{} ", Color::Green.bold().paint("➜"));
+    let expected = format!("{} ", Color::Green.bold().paint("❯"));
 
     // Status code 0
     let output = common::render_module("character")
@@ -24,7 +24,7 @@ fn char_module_success_status() -> io::Result<()> {
 
 #[test]
 fn char_module_failure_status() -> io::Result<()> {
-    let expected = format!("{} ", Color::Red.bold().paint("➜"));
+    let expected = format!("{} ", Color::Red.bold().paint("❯"));
 
     let exit_values = ["1", "54321", "-5000"];
 
@@ -41,7 +41,7 @@ fn char_module_failure_status() -> io::Result<()> {
 #[test]
 fn char_module_symbolyes_status() -> io::Result<()> {
     let expected_fail = format!("{} ", Color::Red.bold().paint("✖"));
-    let expected_success = format!("{} ", Color::Green.bold().paint("➜"));
+    let expected_success = format!("{} ", Color::Green.bold().paint("❯"));
 
     let exit_values = ["1", "54321", "-5000"];
 
@@ -77,7 +77,7 @@ fn char_module_symbolyes_status() -> io::Result<()> {
 fn char_module_vicmd_keymap() -> io::Result<()> {
     let expected_vicmd = format!("{} ", Color::Green.bold().paint("❮"));
     let expected_specified = format!("{} ", Color::Green.bold().paint("N"));
-    let expected_other = format!("{} ", Color::Green.bold().paint("➜"));
+    let expected_other = format!("{} ", Color::Green.bold().paint("❯"));
 
     // zle keymap is vicmd
     let output = common::render_module("character")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

As discussed on Discord, change the default prompt symbol to "❯" to make it more consistent with vi-mode after merging #169 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Not really any of these?

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
