### PR TITLE
fix: correct some typos in docs and comments

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -268,7 +268,7 @@ more than the `threshold` config value, if it exists.
 
 | Variable    | Default | Description                      |
 | ----------- | ------- | -------------------------------- |
-| `threshold` | `1`     | Show number of jobs if execeded. |
+| `threshold` | `1`     | Show number of jobs if exceeded. |
 | `disabled`  | `false` | Disables the `jobs` module.      |
 
 ### Example

--- a/src/context.rs
+++ b/src/context.rs
@@ -37,7 +37,7 @@ impl<'a> Context<'a> {
     /// Identify the current working directory and create an instance of Context
     /// for it.
     pub fn new(arguments: ArgMatches) -> Context {
-        // Retreive the "path" flag. If unavailable, use the current directory instead.
+        // Retrieve the "path" flag. If unavailable, use the current directory instead.
         let path = arguments
             .value_of("path")
             .map(From::from)

--- a/src/modules/username.rs
+++ b/src/modules/username.rs
@@ -6,7 +6,7 @@ use super::{Context, Module};
 
 /// Creates a module with the current user's username
 ///
-/// Will display the usename if any of the following criteria are met:
+/// Will display the username if any of the following criteria are met:
 ///     - The current user isn't the same as the one that is logged in (`$LOGNAME` != `$USER`)
 ///     - The current user is root (UID = 0)
 ///     - The user is currently connected as an SSH session (`$SSH_CONNECTION`)


### PR DESCRIPTION
Just a few fixes to typos in the docs and comments.