### PR TITLE
fix: Correct broken zsh init in absence of precmd_functions

### DIFF
--- a/src/init.rs
+++ b/src/init.rs
@@ -152,6 +152,12 @@ starship_precmd() {
 starship_preexec(){
     STARSHIP_START_TIME="$(date +%s)"
 };
+if [[ -z "${precmd_functions+1}" ]]; then
+    precmd_functions=()
+fi;
+if [[ -z "${preexec_functions+1}" ]]; then
+    preexec_functions=()
+fi;
 if [[ ${precmd_functions[(ie)starship_precmd]} -gt ${#precmd_functions} ]]; then
     precmd_functions+=(starship_precmd);
 fi;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Hotfix: if the user does not already have a defined `precmd_functions` or `preexec_functions` array, the zsh init script will not register the starship functions.

This patch fixes that by pre-defining the arrays if they do not already exist.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
