### PR TITLE
fix: Fix directory_in_root integration test on Windows

### DIFF
--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -8,7 +8,7 @@ use super::{Context, Module};
 ///
 /// Will perform path contraction and truncation.
 /// **Contraction**
-///     - Paths begining with the home directory will be contracted to `~`
+///     - Paths beginning with the home directory will be contracted to `~`
 ///     - Paths containing a git repo will contract to begin at the repo root
 ///
 /// **Truncation**

--- a/tests/testsuite/directory.rs
+++ b/tests/testsuite/directory.rs
@@ -66,11 +66,23 @@ fn root_directory() -> io::Result<()> {
 }
 
 #[test]
+#[cfg(not(target_os = "windows"))]
 fn directory_in_root() -> io::Result<()> {
     let output = common::render_module("dir").arg("--path=/usr").output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
     let expected = format!("in {} ", Color::Cyan.bold().paint("/usr"));
+    assert_eq!(expected, actual);
+    Ok(())
+}
+
+#[test]
+#[cfg(target_os = "windows")]
+fn directory_in_root() -> io::Result<()> {
+    let output = common::render_module("dir").arg("--path=C:\\").output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+
+    let expected = format!("in {} ", Color::Cyan.bold().paint("/c"));
     assert_eq!(expected, actual);
     Ok(())
 }


### PR DESCRIPTION
#### Description
This merge request resolves the failing directory_in_root integration test on Windows

#### Motivation and Context
The test was failing because `/usr` is an invalid path on Windows. 

I have changed the `directory_in_root` test to have both a Windows and Unix version by using the `#[cfg(target_os)]` attribute.

Closes #97

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### How Has This Been Tested?
`cargo test` on Windows
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
