### PR TITLE
fix: Solve bash & zsh cursor location confusion issue

### DIFF
--- a/src/init.rs
+++ b/src/init.rs
@@ -96,10 +96,10 @@ starship_precmd() {
     if [[ $STARSHIP_START_TIME ]]; then
         STARSHIP_END_TIME=$(date +%s);
         STARSHIP_DURATION=$((STARSHIP_END_TIME - STARSHIP_START_TIME));
-        PS1="$(starship prompt --status=$STATUS --jobs="$(jobs -p | wc -l)" --cmd-duration=$STARSHIP_DURATION)";
+        PS1="$(STARSHIP_SHELL="bash" starship prompt --status=$STATUS --jobs="$(jobs -p | wc -l)" --cmd-duration=$STARSHIP_DURATION)";
         unset STARSHIP_START_TIME;
     else
-        PS1="$(starship prompt --status=$STATUS --jobs="$(jobs -p | wc -l)")";
+        PS1="$(STARSHIP_SHELL="bash" starship prompt --status=$STATUS --jobs="$(jobs -p | wc -l)")";
     fi;
     PREEXEC_READY=true;
 };
@@ -143,10 +143,10 @@ starship_precmd() {
     if [[ $STARSHIP_START_TIME ]]; then
         STARSHIP_END_TIME="$(date +%s)";
         STARSHIP_DURATION=$((STARSHIP_END_TIME - STARSHIP_START_TIME));
-        PROMPT="$(starship prompt --status=$STATUS --cmd-duration=$STARSHIP_DURATION --jobs="$(jobs | wc -l)")";
+        PROMPT="$(STARSHIP_SHELL="zsh" starship prompt --status=$STATUS --cmd-duration=$STARSHIP_DURATION --jobs="$(jobs | wc -l)")";
         unset STARSHIP_START_TIME;
     else
-        PROMPT="$(starship prompt --status=$STATUS --jobs="$(jobs | wc -l)")";
+        PROMPT="$(STARSHIP_SHELL="zsh" starship prompt --status=$STATUS --jobs="$(jobs | wc -l)")";
     fi
 };
 starship_preexec(){

--- a/src/init.rs
+++ b/src/init.rs
@@ -92,14 +92,15 @@ starship_preexec() {
 };
 starship_precmd() {
     STATUS=$?;
+    export STARSHIP_SHELL="bash";
     "${starship_precmd_user_func-:}";
     if [[ $STARSHIP_START_TIME ]]; then
         STARSHIP_END_TIME=$(date +%s);
         STARSHIP_DURATION=$((STARSHIP_END_TIME - STARSHIP_START_TIME));
-        PS1="$(STARSHIP_SHELL="bash" starship prompt --status=$STATUS --jobs="$(jobs -p | wc -l)" --cmd-duration=$STARSHIP_DURATION)";
+        PS1="$(starship prompt --status=$STATUS --jobs="$(jobs -p | wc -l)" --cmd-duration=$STARSHIP_DURATION)";
         unset STARSHIP_START_TIME;
     else
-        PS1="$(STARSHIP_SHELL="bash" starship prompt --status=$STATUS --jobs="$(jobs -p | wc -l)")";
+        PS1="$(starship prompt --status=$STATUS --jobs="$(jobs -p | wc -l)")";
     fi;
     PREEXEC_READY=true;
 };
@@ -140,13 +141,14 @@ fi;
 const ZSH_INIT: &str = r##"
 starship_precmd() {
     STATUS=$?;
+    export STARSHIP_SHELL="zsh";
     if [[ $STARSHIP_START_TIME ]]; then
         STARSHIP_END_TIME="$(date +%s)";
         STARSHIP_DURATION=$((STARSHIP_END_TIME - STARSHIP_START_TIME));
-        PROMPT="$(STARSHIP_SHELL="zsh" starship prompt --status=$STATUS --cmd-duration=$STARSHIP_DURATION --jobs="$(jobs | wc -l)")";
+        PROMPT="$(starship prompt --status=$STATUS --cmd-duration=$STARSHIP_DURATION --jobs="$(jobs | wc -l)")";
         unset STARSHIP_START_TIME;
     else
-        PROMPT="$(STARSHIP_SHELL="zsh" starship prompt --status=$STATUS --jobs="$(jobs | wc -l)")";
+        PROMPT="$(starship prompt --status=$STATUS --jobs="$(jobs | wc -l)")";
     fi
 };
 starship_preexec(){

--- a/src/module.rs
+++ b/src/module.rs
@@ -80,42 +80,17 @@ impl<'a> Module<'a> {
     /// `ANSIStrings()` to optimize ANSI codes
     pub fn ansi_strings(&self) -> Vec<ANSIString> {
         let shell = std::env::var("STARSHIP_SHELL").unwrap_or_default();
-        let mut ansi_strings = self
+        let ansi_strings = self
             .segments
             .iter()
             .map(Segment::ansi_string)
-            .map(|ansi| {
-                let mut replaced_initial = false;
-                let final_string: String = ansi
-                    .to_string()
-                    .chars()
-                    .map(|x| match x {
-                        '\u{1b}' => {
-                            replaced_initial = true;
-                            match shell.as_str() {
-                                "bash" => String::from("\u{5c}\u{5b}\u{1b}"), // => \[ESC
-                                "zsh" => String::from("\u{25}\u{7b}\u{1b}"),  // => %{ESC
-                                _ => x.to_string(),
-                            }
-                        }
-                        'm' => {
-                            if replaced_initial {
-                                replaced_initial = false;
-                                match shell.as_str() {
-                                    "bash" => String::from("m\u{5c}\u{5d}"), // => m\]
-                                    "zsh" => String::from("m\u{25}\u{7d}"),  // => m%}
-                                    _ => x.to_string(),
-                                }
-                            } else {
-                                x.to_string()
-                            }
-                        }
-                        _ => x.to_string(),
-                    })
-                    .collect();
-                ANSIString::from(final_string)
-            })
             .collect::<Vec<ANSIString>>();
+
+        let mut ansi_strings = match shell.as_str() {
+            "bash" => ansi_strings_modified(ansi_strings, shell),
+            "zsh" => ansi_strings_modified(ansi_strings, shell),
+            _ => ansi_strings,
+        };
 
         ansi_strings.insert(0, self.prefix.ansi_string());
         ansi_strings.push(self.suffix.ansi_string());
@@ -148,6 +123,43 @@ impl<'a> fmt::Display for Module<'a> {
         let ansi_strings = self.ansi_strings();
         write!(f, "{}", ANSIStrings(&ansi_strings))
     }
+}
+
+fn ansi_strings_modified(ansi_strings: Vec<ANSIString>, shell: String) -> Vec<ANSIString> {
+    ansi_strings
+        .iter()
+        .map(|ansi| {
+            let mut escaped = false;
+            let final_string: String = ansi
+                .to_string()
+                .chars()
+                .map(|x| match x {
+                    '\u{1b}' => {
+                        escaped = true;
+                        match shell.as_str() {
+                            "bash" => String::from("\u{5c}\u{5b}\u{1b}"), // => \[ESC
+                            "zsh" => String::from("\u{25}\u{7b}\u{1b}"),  // => %{ESC
+                            _ => x.to_string(),
+                        }
+                    }
+                    'm' => {
+                        if escaped {
+                            escaped = false;
+                            match shell.as_str() {
+                                "bash" => String::from("m\u{5c}\u{5d}"), // => m\]
+                                "zsh" => String::from("m\u{25}\u{7d}"),  // => m%}
+                                _ => x.to_string(),
+                            }
+                        } else {
+                            x.to_string()
+                        }
+                    }
+                    _ => x.to_string(),
+                })
+                .collect();
+            ANSIString::from(final_string)
+        })
+        .collect::<Vec<ANSIString>>()
 }
 
 /// Module affixes are to be used for the prefix or suffix of a module.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
This PR solves issue of cursor location confusion on bash and zsh as discussed over #110 . It solves this issue by modifying out ANSIString and wrap non-printing character escape for all of ansi-term additional parts.  

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #110 

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [X] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
