### PR TITLE
fix: Restore python tests deleted in d90c43b

### DIFF
--- a/src/modules/python.rs
+++ b/src/modules/python.rs
@@ -111,4 +111,13 @@ mod tests {
         let input = "Python 3.7.2";
         assert_eq!(format_python_version(input), "v3.7.2");
     }
+
+    #[test]
+    #[ignore]
+    fn testvirtual_env() {
+        env::set_var("VIRTUAL_ENV", "/foo/bar/my_venv");
+        assert_eq!(get_python_virtual_env().unwrap(), "my_venv");
+        env::set_var("VIRTUAL_ENV", "");
+        assert_eq!(get_python_virtual_env(), None);
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

We deleted some python tests in d90c43b due to race condition. This PR restores them.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
