### PR TITLE
fix: Change panicking on unknown module to error print and support module listing flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod print;
 mod segment;
 mod utils;
 
+use crate::module::ALL_MODULES;
 use clap::{App, AppSettings, Arg, SubCommand};
 
 fn main() {
@@ -86,7 +87,14 @@ fn main() {
                 .arg(
                     Arg::with_name("name")
                         .help("The name of the module to be printed")
-                        .required(true),
+                        .required(true)
+                        .required_unless("list"),
+                )
+                .arg(
+                    Arg::with_name("list")
+                        .short("l")
+                        .long("list")
+                        .help("List out all supported modules"),
                 )
                 .arg(&status_code_arg)
                 .arg(&path_arg)
@@ -103,8 +111,16 @@ fn main() {
         }
         ("prompt", Some(sub_m)) => print::prompt(sub_m.clone()),
         ("module", Some(sub_m)) => {
-            let module_name = sub_m.value_of("name").expect("Module name missing.");
-            print::module(module_name, sub_m.clone());
+            if sub_m.is_present("list") {
+                println!("Supported modules list");
+                println!("----------------------");
+                for modules in ALL_MODULES {
+                    println!("{}", modules);
+                }
+            }
+            if let Some(module_name) = sub_m.value_of("name") {
+                print::module(module_name, sub_m.clone());
+            }
         }
         _ => {}
     }

--- a/src/module.rs
+++ b/src/module.rs
@@ -4,6 +4,25 @@ use ansi_term::Style;
 use ansi_term::{ANSIString, ANSIStrings};
 use std::fmt;
 
+// List of all modules
+pub const ALL_MODULES: &[&str] = &[
+    "battery",
+    "character",
+    "cmd_duration",
+    "directory",
+    "git_branch",
+    "git_status",
+    "golang",
+    "jobs",
+    "line_break",
+    "nodejs",
+    "package",
+    "python",
+    "ruby",
+    "rust",
+    "username",
+];
+
 /// A module is a collection of segments showing data for a single integration
 /// (e.g. The git module shows the current git branch and status)
 pub struct Module<'a> {

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -1,3 +1,4 @@
+// While adding out new module add out module to src/module.rs ALL_MODULES const array also.
 mod battery;
 mod character;
 mod cmd_duration;
@@ -35,6 +36,9 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
         "cmd_duration" => cmd_duration::module(context),
         "jobs" => jobs::module(context),
 
-        _ => panic!("Unknown module: {}", module),
+        _ => {
+            eprintln!("Error: Unknown module {}. Use starship module --list to list out all supported modules.", module);
+            None
+        }
     }
 }

--- a/src/print.rs
+++ b/src/print.rs
@@ -5,26 +5,8 @@ use std::io::{self, Write};
 use crate::config::Config;
 use crate::context::Context;
 use crate::module::Module;
+use crate::module::ALL_MODULES;
 use crate::modules;
-
-// List of all modules
-const ALL_MODULES: &[&str] = &[
-    "battery",
-    "character",
-    "cmd_duration",
-    "directory",
-    "git_branch",
-    "git_status",
-    "golang",
-    "jobs",
-    "line_break",
-    "nodejs",
-    "package",
-    "python",
-    "ruby",
-    "rust",
-    "username",
-];
 
 // List of default prompt order
 // NOTE: If this const value is changed then Default prompt order subheading inside

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -6,6 +6,7 @@ mod directory;
 mod golang;
 mod jobs;
 mod line_break;
+mod modules;
 mod nodejs;
 mod python;
 mod ruby;

--- a/tests/testsuite/modules.rs
+++ b/tests/testsuite/modules.rs
@@ -1,0 +1,31 @@
+use std::io;
+
+use crate::common;
+
+#[test]
+fn unknown_module_name() -> io::Result<()> {
+    let unknown_module_name = "some_random_name";
+    let output = common::render_module(unknown_module_name).output()?;
+    let actual_stdout = String::from_utf8(output.stdout).unwrap();
+    let actual_stderr = String::from_utf8(output.stderr).unwrap();
+    let expected_stdout = "";
+    let expected_stderr = format!(
+        "Error: Unknown module {}. Use starship module --list to list out all supported modules.\n",
+        unknown_module_name
+    );
+    assert_eq!(expected_stdout, actual_stdout);
+    assert_eq!(expected_stderr, actual_stderr);
+    Ok(())
+}
+
+#[test]
+fn known_module_name() -> io::Result<()> {
+    let output = common::render_module("line_break").output()?;
+    let actual_stdout = String::from_utf8(output.stdout).unwrap();
+    let actual_stderr = String::from_utf8(output.stderr).unwrap();
+    let expected_stdout = "\n";
+    let expected_stderr = "";
+    assert_eq!(expected_stdout, actual_stdout);
+    assert_eq!(expected_stderr, actual_stderr);
+    Ok(())
+}


### PR DESCRIPTION
#### Description
Instead of panicking out over unknown module supplied to `starship module` subcommand this PR print outs standard error over terminal. This PR also adds out new flag for module subcommand --list i.e `starship module --list` which list out all of supported modules.

#### Motivation and Context
Closes #190 

#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [X] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
