### PR TITLE
fix: Only print shell escapes when in a prompt context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -739,7 +739,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "starship"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "ansi_term 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "battery 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/module.rs
+++ b/src/module.rs
@@ -105,9 +105,15 @@ impl<'a> Module<'a> {
             .map(Segment::ansi_string)
             .collect::<Vec<ANSIString>>();
 
+        /* Only print escaped sequences if we are printing in a prompt (or
+        somewhere the user wants the shell-specific escapes), but not if e.g.
+        someone has called `starship prompt` from the command line */
+        let use_shell_escapes =
+            std::env::var("STARSHIP_PRINT_SHELL_ESCAPES").unwrap_or("false".to_string());
+        let use_shell_escapes = use_shell_escapes == "true" || use_shell_escapes == "yes";
         let mut ansi_strings = match shell.as_str() {
-            "bash" => ansi_strings_modified(ansi_strings, shell),
-            "zsh" => ansi_strings_modified(ansi_strings, shell),
+            "bash" if use_shell_escapes => ansi_strings_modified(ansi_strings, shell),
+            "zsh" if use_shell_escapes => ansi_strings_modified(ansi_strings, shell),
             _ => ansi_strings,
         };
 

--- a/src/module.rs
+++ b/src/module.rs
@@ -109,7 +109,7 @@ impl<'a> Module<'a> {
         somewhere the user wants the shell-specific escapes), but not if e.g.
         someone has called `starship prompt` from the command line */
         let use_shell_escapes =
-            std::env::var("STARSHIP_PRINT_SHELL_ESCAPES").unwrap_or("false".to_string());
+            std::env::var("STARSHIP_PRINT_SHELL_ESCAPES").unwrap_or_else(|_| "false".to_string());
         let use_shell_escapes = use_shell_escapes == "true" || use_shell_escapes == "yes";
         let mut ansi_strings = match shell.as_str() {
             "bash" if use_shell_escapes => ansi_strings_modified(ansi_strings, shell),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Add an additional variable to starship shell to let it know when it's printing in a shell prompt context. Zero-length wrappers are only printed when in a shell prompt context.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #211 

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
