### PR TITLE
fix: Restore Ruby module

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -46,9 +46,9 @@ This is the list of prompt-wide configuration options.
 
 ### Options
 
-| Variable       | Default | Description                                                        |
-| -------------- | ------- | ------------------------------------------------------------------ |
-| `add_newline`  | `true`  | Add a new line before the start of the prompt.                     |
+| Variable       | Default                       | Description                                            |
+| -------------- | ----------------------------- | ------------------------------------------------------ |
+| `add_newline`  | `true`                        | Add a new line before the start of the prompt.         |
 | `prompt_order` | [link](#default-prompt-order) | Configure the order in which the prompt module occurs. |
 
 ### Example
@@ -72,6 +72,7 @@ default_prompt_order = [
     "git_status",
     "package",
     "nodejs",
+    "ruby",
     "rust",
     "python",
     "golang",

--- a/src/print.rs
+++ b/src/print.rs
@@ -18,6 +18,7 @@ const DEFAULT_PROMPT_ORDER: &[&str] = &[
     "git_status",
     "package",
     "nodejs",
+    "ruby",
     "rust",
     "python",
     "golang",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Adds ruby module to `DEFAULT_PROMPT_ORDER`

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #202 

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
