### PR TITLE
feat: Add support for detecting Python from Pipenv files

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -421,6 +421,7 @@ The module will be shown if any of the following conditions are met:
 - The current directory contains a `requirements.txt` file
 - The current directory contains a `pyproject.toml` file
 - The current directory contains a file with the `.py` extension
+- The current directory contains a `Pipfile` file
 
 ### Options
 

--- a/src/modules/python.rs
+++ b/src/modules/python.rs
@@ -15,10 +15,16 @@ use super::{Context, Module};
 ///     - Current directory contains a `requirements.txt` file
 ///     - Current directory contains a `pyproject.toml` file
 ///     - Current directory contains a file with the `.py` extension
+///     - Current directory contains a `Pipfile` file
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let is_py_project = context
         .new_scan_dir()
-        .set_files(&["requirements.txt", ".python-version", "pyproject.toml"])
+        .set_files(&[
+            "requirements.txt",
+            ".python-version",
+            "pyproject.toml",
+            "Pipfile",
+        ])
         .set_extensions(&["py"])
         .scan();
 

--- a/tests/testsuite/python.rs
+++ b/tests/testsuite/python.rs
@@ -59,6 +59,23 @@ fn folder_with_pyproject_toml() -> io::Result<()> {
 
 #[test]
 #[ignore]
+fn folder_with_pipfile() -> io::Result<()> {
+    let dir = common::new_tempdir()?;
+    File::create(dir.path().join("Pipfile"))?;
+
+    let output = common::render_module("python")
+        .arg("--path")
+        .arg(dir.path())
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+
+    let expected = format!("via {} ", Color::Yellow.bold().paint("🐍 v3.6.9"));
+    assert_eq!(expected, actual);
+    Ok(())
+}
+
+#[test]
+#[ignore]
 fn folder_with_py_file() -> io::Result<()> {
     let dir = common::new_tempdir()?;
     File::create(dir.path().join("main.py"))?;


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Have added the ability to enable the Python module based on the
existence of the a `Pipfile`.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #218

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
