### PR TITLE
battery's (%) display "%{" -> "%"

### DIFF
--- a/src/modules/battery.rs
+++ b/src/modules/battery.rs
@@ -42,7 +42,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let mut percent_string = Vec::<String>::with_capacity(2);
     // Round the percentage to a whole number
     percent_string.push(percentage.round().to_string());
-    percent_string.push("%".to_string());
+    percent_string.push("%%".to_string());
     module.new_segment("percentage", percent_string.join("").as_ref());
 
     Some(module)


### PR DESCRIPTION
#### Description
when battery module enable, show battery status like this.(I'm changed show threshold for this)
```
⚡️68%{ 🦄 💬 ❯
```

looks like mixed `{` Unintentionally.

This PR is remove `{` like this.
```
⚡️68% 🦄 💬 ❯
```
#### Motivation and Context
closes #226

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
