### PR TITLE
refactor: just match enum

### DIFF
--- a/src/init.rs
+++ b/src/init.rs
@@ -63,15 +63,13 @@ pub fn init_stub(shell_name: &str) -> io::Result<()> {
             );
             None
         }
-        _ => {
-            /* Calling unwrap() here is fine because the None case will have
-            already matched on the previous arm */
+        Some(shell_basename) => {
             println!(
                 "printf \"\\n{0} is not yet supported by starship.\\n\
                  For the time being, we support bash, zsh, and fish.\\n\
                  Please open an issue in the starship repo if you would like to \
                  see support for {0}:\\nhttps://github.com/starship/starship/issues/new\"\\n\\n",
-                shell_basename.unwrap()
+                shell_basename
             );
             None
         }


### PR DESCRIPTION
Remove forced unwrap since match is already exhausted

<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Replace `.unwrap()` with data extraction since match is already exhausted.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
