### PR TITLE
fix: battery percentage character on Zsh. #226

### DIFF
--- a/src/init.rs
+++ b/src/init.rs
@@ -167,8 +167,8 @@ if [[ $preexec_functions ]]; then
     preexec_functions+=(starship_preexec)
     precmd_functions+=(starship_precmd)
 else
-# We want to avoid destroying an existing DEBUG hook. If we detect one, create 
-# a new function that runs both the existing function AND our function, then 
+# We want to avoid destroying an existing DEBUG hook. If we detect one, create
+# a new function that runs both the existing function AND our function, then
 # re-trap DEBUG to use this new function. This prevents a trap clobber.
     dbg_trap="$(trap -p DEBUG | cut -d' ' -f3 | tr -d \')"
     if [[ -z "$dbg_trap" ]]; then
@@ -255,4 +255,5 @@ function fish_prompt
     set -l starship_duration (math --scale=0 "$CMD_DURATION / 1000")
     ## STARSHIP ## prompt --status=$exit_code --cmd-duration=$starship_duration --jobs=(count (jobs -p))
 end
+export STARSHIP_SHELL="fish"
 "##;

--- a/src/modules/battery.rs
+++ b/src/modules/battery.rs
@@ -9,6 +9,12 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     const BATTERY_DISCHARGING: &str = "⇣";
     const BATTERY_THRESHOLD: f32 = 10.0;
 
+    let shell = std::env::var("STARSHIP_SHELL").unwrap_or_default();
+    let percentage_char = match shell.as_str() {
+        "zsh" => "%%",
+        _ => "%",
+    };
+
     let battery_status = get_battery_status()?;
     let BatteryStatus { state, percentage } = battery_status;
 
@@ -42,7 +48,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let mut percent_string = Vec::<String>::with_capacity(2);
     // Round the percentage to a whole number
     percent_string.push(percentage.round().to_string());
-    percent_string.push("%".to_string());
+    percent_string.push(percentage_char.to_string());
     module.new_segment("percentage", percent_string.join("").as_ref());
 
     Some(module)

--- a/src/modules/battery.rs
+++ b/src/modules/battery.rs
@@ -8,7 +8,8 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     const BATTERY_CHARGING: &str = "⇡";
     const BATTERY_DISCHARGING: &str = "⇣";
     const BATTERY_THRESHOLD: f32 = 10.0;
-
+// TODO: Update when v1.0 printing refactor is implemented to only
+// print escapes in a prompt context.
     let shell = std::env::var("STARSHIP_SHELL").unwrap_or_default();
     let percentage_char = match shell.as_str() {
         "zsh" => "%%",   // % is an escape in zsh, see PROMPT in `man zshmisc`

--- a/src/modules/battery.rs
+++ b/src/modules/battery.rs
@@ -8,11 +8,11 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     const BATTERY_CHARGING: &str = "⇡";
     const BATTERY_DISCHARGING: &str = "⇣";
     const BATTERY_THRESHOLD: f32 = 10.0;
-// TODO: Update when v1.0 printing refactor is implemented to only
-// print escapes in a prompt context.
+    // TODO: Update when v1.0 printing refactor is implemented to only
+    // print escapes in a prompt context.
     let shell = std::env::var("STARSHIP_SHELL").unwrap_or_default();
     let percentage_char = match shell.as_str() {
-        "zsh" => "%%",   // % is an escape in zsh, see PROMPT in `man zshmisc`
+        "zsh" => "%%", // % is an escape in zsh, see PROMPT in `man zshmisc`
         _ => "%",
     };
 

--- a/src/modules/battery.rs
+++ b/src/modules/battery.rs
@@ -11,7 +11,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
     let shell = std::env::var("STARSHIP_SHELL").unwrap_or_default();
     let percentage_char = match shell.as_str() {
-        "zsh" => "%%",
+        "zsh" => "%%",   // % is an escape in zsh, see PROMPT in `man zshmisc`
         _ => "%",
     };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
on Zsh, battery percentage character print `%{`.
this PR fix print `%{` -> `%`.

#### Description
on Zsh, `%` is prompt sequence prefix.
http://zsh.sourceforge.net/Doc/Release/Prompt-Expansion.html

i.e,
`%n` will print username,
`%%` will print `%`, etc.

this problem on only Zsh. Bash and Fish are print `%`.
So, switch percentage character by `STARSHIP_SHELL`.

<!--- Describe your changes in detail -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #226 

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):
those screenshots are change `BATTERY_THRESHOLD` to `100.0` for this.
on Bash:
![スクリーンショット 2019-08-25 14 54 21](https://user-images.githubusercontent.com/39114857/63646124-3f97da80-c748-11e9-8f72-2fd633e234af.png)

on Zsh:
![スクリーンショット 2019-08-25 14 44 26](https://user-images.githubusercontent.com/39114857/63646095-8933f580-c747-11e9-81a0-0f83437d2441.png)

on Fish:
![スクリーンショット 2019-08-25 14 44 30](https://user-images.githubusercontent.com/39114857/63646092-80432400-c747-11e9-8bb3-f1afef96c7aa.png)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
