### PR TITLE
Support vicmd_symbol in fish-shell

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -122,13 +122,13 @@ can do this in two ways: by changing color (red/green) or by changing its shape
 
 ### Options
 
-| Variable                | Default | Description                                                                       |
-| ----------------------- | ------- | --------------------------------------------------------------------------------- |
-| `symbol`                | `"❯"`   | The symbol used before the text input in the prompt.                              |
-| `error_symbol`          | `"✖"`   | The symbol used before text input if the previous command failed.                 |
-| `use_symbol_for_status` | `false` | Indicate error status by changing the symbol.                                     |
-| `vicmd_symbol`          | `"❮"`   | The symbol used before the text input in the prompt if zsh is in vim normal mode. |
-| `disabled`              | `false` | Disables the `character` module.                                                  |
+| Variable                | Default | Description                                                                         |
+| ----------------------- | ------- | ----------------------------------------------------------------------------------- |
+| `symbol`                | `"❯"`   | The symbol used before the text input in the prompt.                                |
+| `error_symbol`          | `"✖"`   | The symbol used before text input if the previous command failed.                   |
+| `use_symbol_for_status` | `false` | Indicate error status by changing the symbol.                                       |
+| `vicmd_symbol`          | `"❮"`   | The symbol used before the text input in the prompt if shell is in vim normal mode. |
+| `disabled`              | `false` | Disables the `character` module.                                                    |
 
 ### Example
 

--- a/src/init.rs
+++ b/src/init.rs
@@ -255,11 +255,18 @@ export STARSHIP_SHELL="zsh"
 
 const FISH_INIT: &str = r##"
 function fish_prompt
+    switch "$fish_key_bindings"
+        case fish_hybrid_key_bindings fish_vi_key_bindings
+            set keymap "$fish_bind_mode"
+        case '*'
+            set keymap insert
+    end
     set -l exit_code $status
     # Account for changes in variable name between v2.7 and v3.0
     set -l CMD_DURATION "$CMD_DURATION$cmd_duration"
     set -l starship_duration (math --scale=0 "$CMD_DURATION / 1000")
-    ## STARSHIP ## prompt --status=$exit_code --cmd-duration=$starship_duration --jobs=(count (jobs -p))
+    ## STARSHIP ## prompt --status=$exit_code --keymap=$keymap --cmd-duration=$starship_duration --jobs=(count (jobs -p))
 end
+function fish_mode_prompt; end
 export STARSHIP_SHELL="fish"
 "##;

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,8 +48,8 @@ fn main() {
         .short("k")
         .long("keymap")
         .value_name("KEYMAP")
-        // zsh only
-        .help("The keymap of zsh")
+        // fish/zsh only
+        .help("The keymap of fish/zsh")
         .takes_value(true);
 
     let jobs_arg = Arg::with_name("jobs")

--- a/tests/testsuite/character.rs
+++ b/tests/testsuite/character.rs
@@ -74,7 +74,7 @@ fn char_module_symbolyes_status() -> io::Result<()> {
 }
 
 #[test]
-fn char_module_vicmd_keymap() -> io::Result<()> {
+fn char_module_zsh_keymap() -> io::Result<()> {
     let expected_vicmd = "❮";
     // TODO make this less... well, stupid when ANSI escapes can be mocked out
     let expected_specified = "I HIGHLY DOUBT THIS WILL SHOW UP IN OTHER OUTPUT";
@@ -103,6 +103,44 @@ fn char_module_vicmd_keymap() -> io::Result<()> {
     // zle keymap is other
     let output = common::render_module("character")
         .env("STARSHIP_SHELL", "zsh")
+        .arg("--keymap=visual")
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+    assert!(actual.contains(&expected_other));
+
+    Ok(())
+}
+
+#[test]
+fn char_module_fish_keymap() -> io::Result<()> {
+    let expected_vicmd = "❮";
+    // TODO make this less... well, stupid when ANSI escapes can be mocked out
+    let expected_specified = "I HIGHLY DOUBT THIS WILL SHOW UP IN OTHER OUTPUT";
+    let expected_other = "❯";
+
+    // fish keymap is default
+    let output = common::render_module("character")
+        .env("STARSHIP_SHELL", "fish")
+        .arg("--keymap=default")
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+    assert!(actual.contains(&expected_vicmd));
+
+    // specified vicmd character
+    let output = common::render_module("character")
+        .use_config(toml::toml! {
+            [character]
+            vicmd_symbol = "I HIGHLY DOUBT THIS WILL SHOW UP IN OTHER OUTPUT"
+        })
+        .env("STARSHIP_SHELL", "fish")
+        .arg("--keymap=default")
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+    assert!(actual.contains(&expected_specified));
+
+    // fish keymap is other
+    let output = common::render_module("character")
+        .env("STARSHIP_SHELL", "fish")
         .arg("--keymap=visual")
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();

--- a/tests/testsuite/character.rs
+++ b/tests/testsuite/character.rs
@@ -75,34 +75,38 @@ fn char_module_symbolyes_status() -> io::Result<()> {
 
 #[test]
 fn char_module_vicmd_keymap() -> io::Result<()> {
-    let expected_vicmd = format!("{} ", Color::Green.bold().paint("❮"));
-    let expected_specified = format!("{} ", Color::Green.bold().paint("N"));
-    let expected_other = format!("{} ", Color::Green.bold().paint("❯"));
+    let expected_vicmd = "❮";
+    // TODO make this less... well, stupid when ANSI escapes can be mocked out
+    let expected_specified = "I HIGHLY DOUBT THIS WILL SHOW UP IN OTHER OUTPUT";
+    let expected_other = "❯";
 
     // zle keymap is vicmd
     let output = common::render_module("character")
+        .env("STARSHIP_SHELL", "zsh")
         .arg("--keymap=vicmd")
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
-    assert_eq!(expected_vicmd, actual);
+    assert!(actual.contains(&expected_vicmd));
 
     // specified vicmd character
     let output = common::render_module("character")
         .use_config(toml::toml! {
             [character]
-            vicmd_symbol = "N"
+            vicmd_symbol = "I HIGHLY DOUBT THIS WILL SHOW UP IN OTHER OUTPUT"
         })
+        .env("STARSHIP_SHELL", "zsh")
         .arg("--keymap=vicmd")
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
-    assert_eq!(expected_specified, actual);
+    assert!(actual.contains(&expected_specified));
 
     // zle keymap is other
     let output = common::render_module("character")
+        .env("STARSHIP_SHELL", "zsh")
         .arg("--keymap=visual")
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
-    assert_eq!(expected_other, actual);
+    assert!(actual.contains(&expected_other));
 
     Ok(())
 }


### PR DESCRIPTION
#### Description
Bear with me; this is my first foray into Rust. This changeset extends the existing `vicmd_symbol` logic to fish-shell; fish makes this quite simple, but abstracting the existing logic (especially the tests) to be shell-agnostic proved quite challenging. I hope I'm on the right track.

#### Motivation and Context
I use fish and it ships with this feature built-in. Most fish prompts support it. I like this prompt but it didn't have this feature, so I added it.

Closes #198 (I think)

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.

Tested locally on Arch Linux in `fish` and `zsh` for breakage; none found. Red colour still applied on nonzero exit codes in both shells. Symbol responds to keymap change in both shells.

```
fish, version 3.0.2
zsh 5.7.1 (x86_64-pc-linux-gnu)
Linux vergadain 5.2.9-arch1-1-ARCH #1 SMP PREEMPT Fri Aug 16 11:29:43 UTC 2019 x86_64 GNU/Linux
```

