### PR TITLE
docs: Correct a copy/paste error in the docs

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -509,7 +509,7 @@ The module will be shown when inside a nix-shell environment.
 
 | Variable     | Default  | Description                        |
 | ------------ | -------- | ---------------------------------- |
-| `disabled`   | `false`  | Disables the `username` module.    |
+| `disabled`   | `false`  | Disables the `nix_shell` module.    |
 | `use_name`   | `false`  | Display the name of the nix-shell. |
 | `impure_msg` | `impure` | Customize the "impure" msg.        |
 | `pure_msg`   | `pure`   | Customize the "pure" msg.          |


### PR DESCRIPTION
#### Description
When the docs were copy pasted for the nix_shell module from the username module the module name wasn't updated.

#### Motivation and Context
It makes the docs correct.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
Not tested as no code is changed.
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
