### PR TITLE
fix: Fixes the `nix_shell` module, allowing it to be used with `starship prompt`

### DIFF
--- a/src/module.rs
+++ b/src/module.rs
@@ -17,6 +17,7 @@ pub const ALL_MODULES: &[&str] = &[
     "jobs",
     "line_break",
     "nodejs",
+    "nix_shell",
     "package",
     "python",
     "ruby",


### PR DESCRIPTION
#### Description
Adds `nix_shell` to `module::ALL_MODULES`, so that it is not skipped when generating the user's prompt.

#### Motivation and Context
Currently including `nix_shell` in your `prompt_order` has no effect.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

Not yet. I'm having some build issues with `git2`...

#### Checklist:
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
