### PR TITLE
Respect status.showUntrackedFiles

### DIFF
--- a/src/modules/git_status.rs
+++ b/src/modules/git_status.rs
@@ -119,7 +119,10 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 fn get_repo_status(repository: &Repository) -> Result<Status, git2::Error> {
     let mut status_options = git2::StatusOptions::new();
 
-    status_options.include_untracked(true);
+    match repository.config()?.get_entry("status.showUntrackedFiles") {
+        Ok(entry) => status_options.include_untracked(entry.value() != Some("no")),
+        _ => status_options.include_untracked(true),
+    };
     status_options.renames_from_rewrites(true);
     status_options.renames_head_to_index(true);
     status_options.renames_index_to_workdir(true);

--- a/tests/testsuite/git_status.rs
+++ b/tests/testsuite/git_status.rs
@@ -191,6 +191,33 @@ fn shows_untracked_file() -> io::Result<()> {
 
 #[test]
 #[ignore]
+fn doesnt_show_untracked_file_if_disabled() -> io::Result<()> {
+    let fixture_repo_dir = create_fixture_repo()?;
+    let repo_dir = common::new_tempdir()?.path().join("rocket");
+
+    Repository::clone(fixture_repo_dir.to_str().unwrap(), &repo_dir.as_path()).unwrap();
+
+    File::create(repo_dir.join("license"))?;
+
+    Command::new("git")
+        .args(&["config", "status.showUntrackedFiles", "no"])
+        .current_dir(repo_dir.as_path())
+        .output()?;
+
+    let output = common::render_module("git_status")
+        .arg("--path")
+        .arg(repo_dir)
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+    let expected = "";
+
+    assert_eq!(expected, actual);
+
+    Ok(())
+}
+
+#[test]
+#[ignore]
 fn shows_stashed() -> io::Result<()> {
     let fixture_repo_dir = create_fixture_repo()?;
     let repo_dir = common::new_tempdir()?.path().join("rocket");
@@ -240,7 +267,7 @@ fn shows_modified() -> io::Result<()> {
 
 #[test]
 #[ignore]
-fn shows_added_file() -> io::Result<()> {
+fn shows_staged_file() -> io::Result<()> {
     let fixture_repo_dir = create_fixture_repo()?;
     let repo_dir = common::new_tempdir()?.path().join("rocket");
 


### PR DESCRIPTION
## Feature Request

#### Is your feature request related to a problem? Please describe.
<!-- A clear and concise description of what the problem is. Ex. I have an issue when [...] -->

On some repository I have `git config status.showUntrackedFiles no` but when there are untracked files in this repository I still get a permanent `[?]` in the prompt.

#### Describe the solution you'd like
<!-- A clear and concise description of what you want to happen. Add any considered drawbacks. -->

I think `showUntrackedFiles` should be respected, and when it's set to `no`, then the prompt should follow it.

#### Describe alternatives you've considered
<!-- A clear and concise description of any alternative solutions or features you've considered. -->

None.
