### PR TITLE
feat: clap -> structopt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,6 +303,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-segmentation 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "humantime"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -505,11 +513,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -523,6 +549,14 @@ version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -743,7 +777,6 @@ version = "0.13.1"
 dependencies = [
  "ansi_term 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "battery 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "git2 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -752,6 +785,7 @@ dependencies = [
  "pretty_env_logger 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -762,6 +796,27 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "structopt"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "structopt-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro-error 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "syn"
 version = "0.15.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -769,6 +824,16 @@ dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -875,6 +940,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -882,6 +952,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "unicode-xid"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -994,6 +1069,7 @@ dependencies = [
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum getrandom 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "e65cce4e5084b14874c4e7097f38cab54f47ee554f9194673456ea379dcc4c55"
 "checksum git2 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "327d698f86a7ebdfeb86a4238ccdb004828939d3a3555b6ead679541d14e36c0"
+"checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114"
 "checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
@@ -1021,9 +1097,12 @@ dependencies = [
 "checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
 "checksum ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e3cbf9f658cdb5000fcf6f362b8ea2ba154b9f146a61c7a20d647034c6b6561b"
 "checksum pretty_env_logger 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "717ee476b1690853d222af4634056d830b5197ffd747726a9a1eee6da9f49074"
+"checksum proc-macro-error 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "de0d281dfa5bd274bc29812b094477649bae12ef57e93575b52c0e10d0b94c09"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
+"checksum proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4c5c2380ae88876faae57698be9e9775e3544decad214599c3a6266cca6ac802"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "faf4799c5d274f3868a4aae320a0a182cbd2baee377b378f080e16a23e9d80db"
+"checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 "checksum rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d47eab0e83d9693d40f825f86948aa16eff6750ead4bdffc4ab95b8b3a7f052c"
 "checksum rand_chacha 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e193067942ef6f485a349a113329140d0ab9e2168ce92274499bb0e9a4190d9d"
 "checksum rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
@@ -1052,7 +1131,10 @@ dependencies = [
 "checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
 "checksum spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+"checksum structopt 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "48399718b3ad695558b979b08a9056a5272ec573cd3070f5ca34165bd4a5bf35"
+"checksum structopt-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2558075232402034384db060831349fb2d1303479593177cc84c25febbebbc6d"
 "checksum syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)" = "a1393e4a97a19c01e900df2aec855a29f71cf02c402e2f443b8d2747c25c5dbe"
+"checksum syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "66850e97125af79138385e9b88339cbcd037e3f28ceab8c5ad98e64f0f1f80bf"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 "checksum termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4096add70612622289f2fdcdbd5086dc81c1e2675e6ae58d6c4f62a16c6d7f2f"
@@ -1065,8 +1147,10 @@ dependencies = [
 "checksum ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "141339a08b982d942be2ca06ff8b076563cbe223d1befd5450716790d44e2426"
+"checksum unicode-segmentation 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1967f4cdfc355b37fd76d2a954fb2ed3871034eb4f26d60537d88795cfc332a9"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
+"checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum uom 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)" = "347fe3ff20637a62ab9749a5c90d167302bcbdab77ec961dda7f62a5ca6d368a"
 "checksum url 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "77ddaf52e65c6b81c56b7e957c0b1970f7937f21c5c6774c4e56fcb4e20b48c6"
 "checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ maintenance = { status = "actively-developed" }
 default = ["battery"]
 
 [dependencies]
-clap = "2.33.0"
 ansi_term = "0.12.0"
 dirs = "2.0.2"
 git2 = "0.10.0"
@@ -39,6 +38,7 @@ log = "0.4.8"
 battery = { version = "0.7.4", optional = true }
 lazy_static = "1.4.0"
 path-slash = "0.1.1"
+structopt = "0.3.0"
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ mod config;
 pub mod context;
 pub mod module;
 pub mod modules;
+mod opt;
 pub mod print;
 pub mod segment;
 mod utils;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,136 +1,47 @@
-#[macro_use]
-extern crate clap;
-
 mod config;
 mod context;
 mod init;
 mod module;
 mod modules;
+mod opt;
 mod print;
 mod segment;
 mod utils;
 
+use opt::{Opt, SubCommand};
+use structopt::StructOpt;
+
 use crate::module::ALL_MODULES;
-use clap::{App, AppSettings, Arg, SubCommand};
 
 fn main() {
-    pretty_env_logger::init();
+    let opt = Opt::from_args();
 
-    let status_code_arg = Arg::with_name("status_code")
-        .short("s")
-        .long("status")
-        .value_name("STATUS_CODE")
-        .help("The status code of the previously run command")
-        .takes_value(true);
-
-    let path_arg = Arg::with_name("path")
-        .short("p")
-        .long("path")
-        .value_name("PATH")
-        .help("The path that the prompt should render for")
-        .takes_value(true);
-
-    let shell_arg = Arg::with_name("shell")
-        .value_name("SHELL")
-        .help(
-            "The name of the currently running shell\nCurrently supported options: bash, zsh, fish",
-        )
-        .required(true);
-
-    let cmd_duration_arg = Arg::with_name("cmd_duration")
-        .short("d")
-        .long("cmd-duration")
-        .value_name("CMD_DURATION")
-        .help("The execution duration of the last command, in seconds")
-        .takes_value(true);
-
-    let keymap_arg = Arg::with_name("keymap")
-        .short("k")
-        .long("keymap")
-        .value_name("KEYMAP")
-        // fish/zsh only
-        .help("The keymap of fish/zsh")
-        .takes_value(true);
-
-    let jobs_arg = Arg::with_name("jobs")
-        .short("j")
-        .long("jobs")
-        .value_name("JOBS")
-        .help("The number of currently running jobs")
-        .takes_value(true);
-
-    let init_scripts_arg = Arg::with_name("print_full_init")
-        .long("print-full-init")
-        .help("Print the main initialization script (as opposed to the init stub)");
-
-    let matches = App::new("starship")
-        .about("The cross-shell prompt for astronauts. ☄🌌️")
-        // pull the version number from Cargo.toml
-        .version(crate_version!())
-        // pull the authors from Cargo.toml
-        .author(crate_authors!())
-        .after_help("https://github.com/starship/starship")
-        .setting(AppSettings::SubcommandRequiredElseHelp)
-        .subcommand(
-            SubCommand::with_name("init")
-                .about("Prints the shell function used to execute starship")
-                .arg(&shell_arg)
-                .arg(&init_scripts_arg),
-        )
-        .subcommand(
-            SubCommand::with_name("prompt")
-                .about("Prints the full starship prompt")
-                .arg(&status_code_arg)
-                .arg(&path_arg)
-                .arg(&cmd_duration_arg)
-                .arg(&keymap_arg)
-                .arg(&jobs_arg),
-        )
-        .subcommand(
-            SubCommand::with_name("module")
-                .about("Prints a specific prompt module")
-                .arg(
-                    Arg::with_name("name")
-                        .help("The name of the module to be printed")
-                        .required(true)
-                        .required_unless("list"),
-                )
-                .arg(
-                    Arg::with_name("list")
-                        .short("l")
-                        .long("list")
-                        .help("List out all supported modules"),
-                )
-                .arg(&status_code_arg)
-                .arg(&path_arg)
-                .arg(&cmd_duration_arg)
-                .arg(&keymap_arg)
-                .arg(&jobs_arg),
-        )
-        .get_matches();
-
-    match matches.subcommand() {
-        ("init", Some(sub_m)) => {
-            let shell_name = sub_m.value_of("shell").expect("Shell name missing.");
-            if sub_m.is_present("print_full_init") {
-                init::init_main(shell_name).expect("can't init_main");
+    match &opt.sub_command {
+        SubCommand::Init {
+            print_full_init,
+            shell,
+        } => {
+            if *print_full_init {
+                init::init_main(shell).expect("can't init_main");
             } else {
-                init::init_stub(shell_name).expect("can't init_stub");
+                init::init_stub(shell).expect("can't init_stub");
             }
         }
-        ("prompt", Some(sub_m)) => print::prompt(sub_m.clone()),
-        ("module", Some(sub_m)) => {
-            if sub_m.is_present("list") {
+        SubCommand::Prompt { common_opts: _ } => print::prompt(opt.clone()),
+        SubCommand::Module {
+            common_opts: _,
+            list,
+            shell,
+        } => {
+            if *list {
                 println!("Supported modules list");
                 println!("----------------------");
                 for modules in ALL_MODULES {
                     println!("{}", modules);
                 }
             }
-            if let Some(module_name) = sub_m.value_of("name") {
-                print::module(module_name, sub_m.clone());
-            }
+            // TODO: maybe without clone
+            print::module(shell, opt.clone());
         }
-        _ => {}
-    }
+    };
 }

--- a/src/modules/cmd_duration.rs
+++ b/src/modules/cmd_duration.rs
@@ -1,3 +1,4 @@
+use crate::opt::SubCommand;
 use ansi_term::Color;
 
 use super::{Context, Module};
@@ -9,12 +10,18 @@ use super::{Context, Module};
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let mut module = context.new_module("cmd_duration")?;
 
-    let arguments = &context.arguments;
-    let elapsed = arguments
-        .value_of("cmd_duration")
-        .unwrap_or("invalid_time")
-        .parse::<u64>()
-        .ok()?;
+    let elapsed = match &context.arguments.sub_command {
+        SubCommand::Init {
+            print_full_init: _,
+            shell: _,
+        } => unreachable!(),
+        SubCommand::Prompt { common_opts } => common_opts.cmd_duration?,
+        SubCommand::Module {
+            common_opts,
+            list: _,
+            shell: _,
+        } => common_opts.cmd_duration?,
+    };
 
     let signed_config_min = module.config_value_i64("min_time").unwrap_or(2);
 

--- a/src/modules/jobs.rs
+++ b/src/modules/jobs.rs
@@ -1,3 +1,4 @@
+use crate::opt::SubCommand;
 use ansi_term::Color;
 
 use super::{Context, Module};
@@ -13,13 +14,19 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
     module.set_style(module_color);
 
-    let arguments = &context.arguments;
-    let num_of_jobs = arguments
-        .value_of("jobs")
-        .unwrap_or("0")
-        .trim()
-        .parse::<i64>()
-        .ok()?;
+    let num_of_jobs = match &context.arguments.sub_command {
+        SubCommand::Init {
+            print_full_init: _,
+            shell: _,
+        } => unreachable!(),
+        SubCommand::Prompt { common_opts } => common_opts.jobs,
+        SubCommand::Module {
+            common_opts,
+            list: _,
+            shell: _,
+        } => common_opts.jobs,
+    };
+
     if num_of_jobs == 0 {
         return None;
     }

--- a/src/opt.rs
+++ b/src/opt.rs
@@ -1,0 +1,76 @@
+use std::path::PathBuf;
+use structopt::StructOpt;
+
+#[derive(Clone, Debug, StructOpt)]
+pub struct CommonOpts {
+    /// The execution duration of the last command, in seconds
+    #[structopt(short = "d", long = "cmd-duration")]
+    pub cmd_duration: Option<u64>,
+
+    /// The number of currently running jobs
+    #[structopt(short = "j", long = "jobs", default_value = "0")]
+    pub jobs: i64,
+
+    /// The keymap of fish/zsh
+    #[structopt(short = "k", long = "keymap", default_value = "viins")]
+    pub keymap: String,
+
+    /// The path that the prompt should render for
+    #[structopt(short = "p", long = "path")]
+    pub path: Option<PathBuf>,
+
+    /// The status code of the previously run command
+    #[structopt(
+        name = "STATUS_CODE",
+        short = "s",
+        long = "status",
+        default_value = "0"
+    )]
+    pub status: String,
+}
+
+#[derive(Clone, Debug, StructOpt)]
+#[structopt(name = "git", about = "the stupid content tracker")]
+pub enum SubCommand {
+    /// Prints a specific prompt module
+    #[structopt(name = "module")]
+    Module {
+        /// List out all supported modules
+        #[structopt(short = "l", long = "list")]
+        list: bool,
+
+        #[structopt(flatten)]
+        common_opts: CommonOpts,
+
+        /// The name of the currently running shell
+        /// Currently supported options: bash, zsh, fish
+        #[structopt(name = "SHELL")]
+        shell: String,
+    },
+    /// Prints the shell function used to execute starship
+    #[structopt(name = "init")]
+    Init {
+        /// The name of the currently running shell
+        /// Currently supported options: bash, zsh, fish
+        #[structopt(name = "SHELL")]
+        shell: String,
+
+        /// Print the main initialization script (as opposed to the init stub)
+        #[structopt(long = "print-full-init")]
+        print_full_init: bool,
+    },
+    /// Prints the full starship prompt
+    #[structopt(name = "prompt")]
+    Prompt {
+        #[structopt(flatten)]
+        common_opts: CommonOpts,
+    },
+}
+
+/// The cross-shell prompt for astronauts. ☄🌌️
+#[derive(Clone, Debug, StructOpt)]
+#[structopt(author, after_help = "https://github.com/starship/starship")]
+pub struct Opt {
+    #[structopt(subcommand)]
+    pub sub_command: SubCommand,
+}

--- a/src/print.rs
+++ b/src/print.rs
@@ -1,4 +1,4 @@
-use clap::ArgMatches;
+use crate::opt::Opt;
 use rayon::prelude::*;
 use std::io::{self, Write};
 
@@ -31,7 +31,7 @@ const DEFAULT_PROMPT_ORDER: &[&str] = &[
     "character",
 ];
 
-pub fn prompt(args: ArgMatches) {
+pub fn prompt(args: Opt) {
     let context = Context::new(args);
     let config = &context.config;
 
@@ -95,7 +95,7 @@ pub fn prompt(args: ArgMatches) {
     printable.for_each(|module| write!(handle, "{}", module).unwrap());
 }
 
-pub fn module(module_name: &str, args: ArgMatches) {
+pub fn module(module_name: &str, args: Opt) {
     let context = Context::new(args);
 
     // If the module returns `None`, print an empty string


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
switch from clap to structopt (which uses clap).
[structopt 0.3 was just released](https://old.reddit.com/r/rust/comments/cxgw86/announcing_structopt_03/)

#### Motivation and Context
Structopt is pretty nice. It allows to specify a struct with all the command line options.
It also supports default values and parsing.

Using an enum for the subcommands is also nice to prevent bugs if we use a flag from another subcommand.

This is a simple PR just to see if you are interested. If this get merged maybe the next step could be to pass the subcommand's enum to the right functions instead of matching the enum everywhere like I did.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
