### PR TITLE
docs: Correct missed named git config in docs

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -241,7 +241,7 @@ current directory.
 | `untracked`  | `"?"`   | There are untracked files in the working directory.     |
 | `stashed`    | `"$"`   | A stash exists for the local repository.                |
 | `modified`   | `"!"`   | There are file modifications in the working directory.  |
-| `added`      | `"+"`   | A new file has been added to the staging area.          |
+| `staged`     | `"+"`   | A new file has been added to the staging area.          |
 | `renamed`    | `"»"`   | A renamed file has been added to the staging area.      |
 | `deleted`    | `"✘"`   | A file's deletion has been added to the staging area.   |
 | `disabled`   | `false` | Disables the `git_status` module.                       |
@@ -259,7 +259,7 @@ diverged = "😵"
 untracked = "🤷‍"
 stashed = "📦"
 modified = "📝"
-added = "➕"
+staged = "➕"
 renamed = "👅"
 deleted = "🗑"
 ```


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->
Have corrected the documentation for the git module. The docs now use
the correct option `staged` rather than `added`.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #261 

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
