### PR TITLE
fix: Be more restrictive with bash init fallback

### DIFF
--- a/src/init.rs
+++ b/src/init.rs
@@ -32,12 +32,40 @@ pub fn init_stub(shell_name: &str) -> io::Result<()> {
 
     let setup_stub = match shell_basename {
         Some("bash") => {
-            /* This *should* look like the zsh function, but bash 3.2 (MacOS default shell)
-            does not support using source with process substitution, so we use this
-            workaround from https://stackoverflow.com/a/32596626 */
+            /*
+             * The standard bash bootstrap is:
+             *      `source <(starship init bash --print-full-init)`
+             *
+             * Unfortunately there is an issue with bash 3.2 (the MacOS
+             * default) which prevents this from working. It does not support
+             * `source` with process substitution.
+             *
+             * There are more details here: https://stackoverflow.com/a/32596626
+             *
+             * The workaround for MacOS is to use the `/dev/stdin` trick you
+             * see below. However, there are some systems with emulated POSIX
+             * environments which do not support `/dev/stdin`. For example,
+             * `Git Bash` within `Git for Windows and `Termux` on Android.
+             *
+             * Fortunately, these apps ship with recent-ish versions of bash.
+             * Git Bash is currently shipping bash 4.4 and Termux is shipping
+             * bash 5.0.
+             *
+             * Some testing has suggested that bash 4.0 is also incompatible
+             * with the standard bootstrap, whereas bash 4.1 appears to be
+             * consistently compatible.
+             *
+             * The upshot of all of this, is that we will use the standard
+             * bootstrap whenever the bash version is 4.1 or higher. Otherwise,
+             * we fall back to the `/dev/stdin` solution.
+             *
+             * More background can be found in these pull requests:
+             * https://github.com/starship/starship/pull/241
+             * https://github.com/starship/starship/pull/278
+             */
             let script = {
                 format!(
-                    r#"if [ "${{BASH_VERSINFO[0]}}" -gt 4 ]
+                    r#"if [ "${{BASH_VERSINFO[0]}}" -gt 4 ] || ([ "${{BASH_VERSINFO[0]}}" -eq 4 ] && [ "${{BASH_VERSINFO[1]}}" -ge 1 ])
 then
 source <("{}" init bash --print-full-init)
 else


### PR DESCRIPTION
Changes the bash init fallback to be `Major Version > 3` rather than `Major Version > 4`.

#### Description
The issue being worked around affects bash 3.2, so `Major Version > 3` is sufficient.
The fallback requires `/dev/stdin`, which may not exist on all systems - so it's preferable to use the normal bootstrap when possible.

This should fix starship for some Windows users who are using bash without full POSIX emulation.

For example: Git Bash, which is part of Git for Windows, does not recognise `/dev/stdin`, but does ship with bash 4.x.

#### Motivation and Context
Improve support for starship on Windows 😃 

Bash on Windows is a bit of a minefield, because there are various projects maintaining various POSIX emulation layers and various patch lists. This change will not fix starship for ALL bash users on windows, but it should fix it for a portion of them.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### How Has This Been Tested?
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

(I did specifically test this on bash 3.2 on MacOS).

#### Checklist:
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
