### PR TITLE
refactor: Move `create_fixture_repo` into common in integration tests

### DIFF
--- a/tests/testsuite/common.rs
+++ b/tests/testsuite/common.rs
@@ -44,34 +44,18 @@ pub fn new_tempdir() -> io::Result<tempfile::TempDir> {
     tempfile::tempdir_in("/tmp")
 }
 
-/// Helper function to run a `git config` command
-fn run_git_config_command(args: Vec<&str>) -> io::Result<process::Output> {
-    Ok(Command::new("git")
-        .arg("config")
-        .args(args.as_slice())
-        .output()?)
-}
-
-/// Helper function to see if a `git config <value>` command is set
-fn git_config_exists(key: &str) -> io::Result<bool> {
-    let output = run_git_config_command(vec![key])?;
-    let result = String::from_utf8(output.stdout).unwrap();
-
-    Ok(!result.is_empty())
-}
-
 /// Create a repo from the fixture to be used in git module tests
 pub fn create_fixture_repo() -> io::Result<std::path::PathBuf> {
     let fixture_repo_dir = new_tempdir()?.path().join("fixture");
     let fixture = env::current_dir()?.join("tests/fixtures/rocket.bundle");
 
-    if !git_config_exists("user.email")? {
-        run_git_config_command(vec!["--global", "user.email", "starship@example.com"])?;
-    }
+    Command::new("git")
+        .args(&["config", "--global", "user.email", "starship@example.com"])
+        .output()?;
 
-    if !git_config_exists("user.name")? {
-        run_git_config_command(vec!["--global", "user.name", "starship"])?;
-    }
+    Command::new("git")
+        .args(&["config", "--global", "user.name", "starship"])
+        .output()?;
 
     Command::new("git")
         .args(&[

--- a/tests/testsuite/common.rs
+++ b/tests/testsuite/common.rs
@@ -44,9 +44,34 @@ pub fn new_tempdir() -> io::Result<tempfile::TempDir> {
     tempfile::tempdir_in("/tmp")
 }
 
+/// Helper function to run a `git config` command
+fn run_git_config_command(args: Vec<&str>) -> io::Result<process::Output> {
+    Ok(Command::new("git")
+        .arg("config")
+        .args(args.as_slice())
+        .output()?)
+}
+
+/// Helper function to see if a `git config <value>` command is set
+fn git_config_exists(key: &str) -> io::Result<bool> {
+    let output = run_git_config_command(vec![key])?;
+    let result = String::from_utf8(output.stdout).unwrap();
+
+    Ok(!result.is_empty())
+}
+
+/// Create a repo from the fixture to be used in git module tests
 pub fn create_fixture_repo() -> io::Result<std::path::PathBuf> {
     let fixture_repo_dir = new_tempdir()?.path().join("fixture");
     let fixture = env::current_dir()?.join("tests/fixtures/rocket.bundle");
+
+    if !git_config_exists("user.email")? {
+        run_git_config_command(vec!["--global", "user.email", "starship@example.com"])?;
+    }
+
+    if !git_config_exists("user.name")? {
+        run_git_config_command(vec!["--global", "user.name", "starship"])?;
+    }
 
     Command::new("git")
         .args(&[
@@ -56,16 +81,6 @@ pub fn create_fixture_repo() -> io::Result<std::path::PathBuf> {
             &fixture.to_str().unwrap(),
             fixture_repo_dir.to_str().unwrap(),
         ])
-        .output()?;
-
-    Command::new("git")
-        .args(&["config", "user.email", "starship@example.com"])
-        .current_dir(fixture_repo_dir.as_path())
-        .output()?;
-
-    Command::new("git")
-        .args(&["config", "user.name", "starship"])
-        .current_dir(fixture_repo_dir.as_path())
         .output()?;
 
     Ok(fixture_repo_dir)

--- a/tests/testsuite/git_branch.rs
+++ b/tests/testsuite/git_branch.rs
@@ -106,7 +106,7 @@ fn test_truncate_length_with_config(
     truncation_symbol: &str,
     config_options: &str,
 ) -> io::Result<()> {
-    let fixture_repo_dir = create_fixture_repo()?;
+    let fixture_repo_dir = common::create_fixture_repo()?;
     let repo_dir = common::new_tempdir()?.path().join("rocket");
 
     Repository::clone(fixture_repo_dir.to_str().unwrap(), &repo_dir.as_path()).unwrap();
@@ -140,29 +140,4 @@ fn test_truncate_length_with_config(
     );
     assert_eq!(expected, actual);
     Ok(())
-}
-
-fn create_fixture_repo() -> io::Result<std::path::PathBuf> {
-    let fixture_repo_dir = common::new_tempdir()?.path().join("fixture");
-    let fixture = env::current_dir()?.join("tests/fixtures/rocket.bundle");
-
-    Command::new("git")
-        .args(&["config", "--global", "user.email", "starship@example.com"])
-        .output()?;
-
-    Command::new("git")
-        .args(&["config", "--global", "user.name", "starship"])
-        .output()?;
-
-    Command::new("git")
-        .args(&[
-            "clone",
-            "-b",
-            "master",
-            &fixture.to_str().unwrap(),
-            fixture_repo_dir.to_str().unwrap(),
-        ])
-        .output()?;
-
-    Ok(fixture_repo_dir)
 }

--- a/tests/testsuite/git_status.rs
+++ b/tests/testsuite/git_status.rs
@@ -7,35 +7,10 @@ use std::process::Command;
 
 use crate::common;
 
-fn create_fixture_repo() -> io::Result<std::path::PathBuf> {
-    let fixture_repo_dir = common::new_tempdir()?.path().join("fixture");
-    let fixture = env::current_dir()?.join("tests/fixtures/rocket.bundle");
-
-    Command::new("git")
-        .args(&["config", "--global", "user.email", "starship@example.com"])
-        .output()?;
-
-    Command::new("git")
-        .args(&["config", "--global", "user.name", "starship"])
-        .output()?;
-
-    Command::new("git")
-        .args(&[
-            "clone",
-            "-b",
-            "master",
-            &fixture.to_str().unwrap(),
-            fixture_repo_dir.to_str().unwrap(),
-        ])
-        .output()?;
-
-    Ok(fixture_repo_dir)
-}
-
 #[test]
 #[ignore]
 fn shows_behind_count() -> io::Result<()> {
-    let fixture_repo_dir = create_fixture_repo()?;
+    let fixture_repo_dir = common::create_fixture_repo()?;
     let repo_dir = common::new_tempdir()?.path().join("rocket");
 
     Repository::clone(fixture_repo_dir.to_str().unwrap(), &repo_dir.as_path()).unwrap();
@@ -63,7 +38,7 @@ fn shows_behind_count() -> io::Result<()> {
 #[test]
 #[ignore]
 fn shows_ahead_count() -> io::Result<()> {
-    let fixture_repo_dir = create_fixture_repo()?;
+    let fixture_repo_dir = common::create_fixture_repo()?;
     let repo_dir = common::new_tempdir()?.path().join("rocket");
 
     Repository::clone(fixture_repo_dir.to_str().unwrap(), &repo_dir.as_path()).unwrap();
@@ -93,7 +68,7 @@ fn shows_ahead_count() -> io::Result<()> {
 #[test]
 #[ignore]
 fn shows_diverged() -> io::Result<()> {
-    let fixture_repo_dir = create_fixture_repo()?;
+    let fixture_repo_dir = common::create_fixture_repo()?;
     let repo_dir = common::new_tempdir()?.path().join("rocket");
 
     Repository::clone(fixture_repo_dir.to_str().unwrap(), &repo_dir.as_path()).unwrap();
@@ -128,7 +103,7 @@ fn shows_diverged() -> io::Result<()> {
 #[test]
 #[ignore]
 fn shows_conflicted() -> io::Result<()> {
-    let fixture_repo_dir = create_fixture_repo()?;
+    let fixture_repo_dir = common::create_fixture_repo()?;
     let repo_dir = common::new_tempdir()?.path().join("rocket");
 
     Repository::clone(fixture_repo_dir.to_str().unwrap(), &repo_dir.as_path()).unwrap();
@@ -170,7 +145,7 @@ fn shows_conflicted() -> io::Result<()> {
 #[test]
 #[ignore]
 fn shows_untracked_file() -> io::Result<()> {
-    let fixture_repo_dir = create_fixture_repo()?;
+    let fixture_repo_dir = common::create_fixture_repo()?;
     let repo_dir = common::new_tempdir()?.path().join("rocket");
 
     Repository::clone(fixture_repo_dir.to_str().unwrap(), &repo_dir.as_path()).unwrap();
@@ -192,7 +167,7 @@ fn shows_untracked_file() -> io::Result<()> {
 #[test]
 #[ignore]
 fn doesnt_show_untracked_file_if_disabled() -> io::Result<()> {
-    let fixture_repo_dir = create_fixture_repo()?;
+    let fixture_repo_dir = common::create_fixture_repo()?;
     let repo_dir = common::new_tempdir()?.path().join("rocket");
 
     Repository::clone(fixture_repo_dir.to_str().unwrap(), &repo_dir.as_path()).unwrap();
@@ -219,7 +194,7 @@ fn doesnt_show_untracked_file_if_disabled() -> io::Result<()> {
 #[test]
 #[ignore]
 fn shows_stashed() -> io::Result<()> {
-    let fixture_repo_dir = create_fixture_repo()?;
+    let fixture_repo_dir = common::create_fixture_repo()?;
     let repo_dir = common::new_tempdir()?.path().join("rocket");
 
     Repository::clone(fixture_repo_dir.to_str().unwrap(), &repo_dir.as_path()).unwrap();
@@ -246,7 +221,7 @@ fn shows_stashed() -> io::Result<()> {
 #[test]
 #[ignore]
 fn shows_modified() -> io::Result<()> {
-    let fixture_repo_dir = create_fixture_repo()?;
+    let fixture_repo_dir = common::create_fixture_repo()?;
     let repo_dir = common::new_tempdir()?.path().join("rocket");
 
     Repository::clone(fixture_repo_dir.to_str().unwrap(), &repo_dir.as_path()).unwrap();
@@ -268,7 +243,7 @@ fn shows_modified() -> io::Result<()> {
 #[test]
 #[ignore]
 fn shows_staged_file() -> io::Result<()> {
-    let fixture_repo_dir = create_fixture_repo()?;
+    let fixture_repo_dir = common::create_fixture_repo()?;
     let repo_dir = common::new_tempdir()?.path().join("rocket");
 
     Repository::clone(fixture_repo_dir.to_str().unwrap(), &repo_dir.as_path()).unwrap();
@@ -295,7 +270,7 @@ fn shows_staged_file() -> io::Result<()> {
 #[test]
 #[ignore]
 fn shows_renamed_file() -> io::Result<()> {
-    let fixture_repo_dir = create_fixture_repo()?;
+    let fixture_repo_dir = common::create_fixture_repo()?;
     let repo_dir = common::new_tempdir()?.path().join("rocket");
 
     Repository::clone(fixture_repo_dir.to_str().unwrap(), &repo_dir.as_path()).unwrap();
@@ -325,7 +300,7 @@ fn shows_renamed_file() -> io::Result<()> {
 #[test]
 #[ignore]
 fn shows_deleted_file() -> io::Result<()> {
-    let fixture_repo_dir = create_fixture_repo()?;
+    let fixture_repo_dir = common::create_fixture_repo()?;
     let repo_dir = common::new_tempdir()?.path().join("rocket");
 
     Repository::clone(fixture_repo_dir.to_str().unwrap(), &repo_dir.as_path()).unwrap();


### PR DESCRIPTION
#### Description
I moved the fixture repo creation to common since it is now used by more than one module.

#### Motivation and Context
Remove duplicated code.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### How Has This Been Tested?
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
