### PR TITLE
wip: Add ability to have ScanDir ignore files/folders

### DIFF
--- a/src/modules/nodejs.rs
+++ b/src/modules/nodejs.rs
@@ -15,6 +15,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         .set_files(&["package.json"])
         .set_extensions(&["js"])
         .set_folders(&["node_modules"])
+        .set_ignores(&["~/.mongorc.js", "~/.hyper.js"])
         .scan();
 
     if !is_js_project {


### PR DESCRIPTION
#### Description
Add ability for `ScanDir` to ignore files or folders. 

#### Motivation and Context
Closes #280

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### How Has This Been Tested?
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
