### PR TITLE
fix: Don't trigger an extension match on hidden files

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -177,20 +177,20 @@ pub fn path_has_name<'a>(dir_entry: &PathBuf, names: &'a [&'a str]) -> bool {
     }
 }
 
-/// checks if pathbuf matches the extension provided
+/// checks if pathbuf doesn't start with a dot and matches any provided extension
 pub fn has_extension<'a>(dir_entry: &PathBuf, extensions: &'a [&'a str]) -> bool {
-    let found_ext = extensions.iter().find(|ext| {
-        dir_entry
-            .extension()
-            .and_then(OsStr::to_str)
-            .unwrap_or_default()
-            == **ext
-    });
-
-    match found_ext {
-        Some(extension) => !extension.is_empty(),
-        None => false,
+    if let Some(file_name) = dir_entry.file_name() {
+        if file_name.to_string_lossy().starts_with('.') {
+            return false;
+        }
+        return extensions.iter().any(|ext| {
+            dir_entry
+                .extension()
+                .and_then(OsStr::to_str)
+                .map_or(false, |e| e == *ext)
+        });
     }
+    false
 }
 
 fn get_current_branch(repository: &Repository) -> Option<String> {
@@ -226,6 +226,9 @@ mod tests {
         assert_eq!(has_extension(&buf, &extensions), false);
 
         buf.set_file_name("some-file.rs");
+        assert_eq!(has_extension(&buf, &extensions), false);
+
+        buf.set_file_name(".some-file.js");
         assert_eq!(has_extension(&buf, &extensions), false);
 
         buf.set_file_name("some-file.js");


### PR DESCRIPTION
Addresses #52, closes #280.

This ignores filenames starting with a dot and streamlines the matching logic. 

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
Added a test and ran `cargo test`
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
