### PR TITLE
fix: Fixture repo will now clone and set git config locally

### DIFF
--- a/tests/testsuite/common.rs
+++ b/tests/testsuite/common.rs
@@ -48,15 +48,8 @@ pub fn new_tempdir() -> io::Result<tempfile::TempDir> {
 /// Create a repo from the fixture to be used in git module tests
 pub fn create_fixture_repo() -> io::Result<std::path::PathBuf> {
     let fixture_repo_dir = new_tempdir()?.path().join("fixture");
+    let repo_dir = new_tempdir()?.path().join("rocket");
     let fixture = env::current_dir()?.join("tests/fixtures/rocket.bundle");
-
-    Command::new("git")
-        .args(&["config", "--global", "user.email", "starship@example.com"])
-        .output()?;
-
-    Command::new("git")
-        .args(&["config", "--global", "user.name", "starship"])
-        .output()?;
 
     Command::new("git")
         .args(&[
@@ -68,7 +61,19 @@ pub fn create_fixture_repo() -> io::Result<std::path::PathBuf> {
         ])
         .output()?;
 
-    Ok(fixture_repo_dir)
+    git2::Repository::clone(fixture_repo_dir.to_str().unwrap(), &repo_dir.as_path()).unwrap();
+
+    Command::new("git")
+        .args(&["config", "--local", "user.email", "starship@example.com"])
+        .current_dir(repo_dir.as_path())
+        .output()?;
+
+    Command::new("git")
+        .args(&["config", "--local", "user.name", "starship"])
+        .current_dir(repo_dir.as_path())
+        .output()?;
+
+    Ok(repo_dir)
 }
 
 /// Extends `std::process::Command` with methods for testing

--- a/tests/testsuite/git_branch.rs
+++ b/tests/testsuite/git_branch.rs
@@ -106,10 +106,8 @@ fn test_truncate_length_with_config(
     truncation_symbol: &str,
     config_options: &str,
 ) -> io::Result<()> {
-    let fixture_repo_dir = common::create_fixture_repo()?;
-    let repo_dir = common::new_tempdir()?.path().join("rocket");
+    let repo_dir = common::create_fixture_repo()?;
 
-    Repository::clone(fixture_repo_dir.to_str().unwrap(), &repo_dir.as_path()).unwrap();
     Command::new("git")
         .args(&["checkout", "-b", branch_name])
         .current_dir(repo_dir.as_path())

--- a/tests/testsuite/git_status.rs
+++ b/tests/testsuite/git_status.rs
@@ -10,10 +10,7 @@ use crate::common::{self, TestCommand};
 #[test]
 #[ignore]
 fn shows_behind() -> io::Result<()> {
-    let fixture_repo_dir = common::create_fixture_repo()?;
-    let repo_dir = common::new_tempdir()?.path().join("rocket");
-
-    Repository::clone(fixture_repo_dir.to_str().unwrap(), &repo_dir.as_path()).unwrap();
+    let repo_dir = common::create_fixture_repo()?;
 
     Command::new("git")
         .args(&["reset", "--hard", "HEAD^"])
@@ -35,10 +32,7 @@ fn shows_behind() -> io::Result<()> {
 #[test]
 #[ignore]
 fn shows_behind_with_count() -> io::Result<()> {
-    let fixture_repo_dir = common::create_fixture_repo()?;
-    let repo_dir = common::new_tempdir()?.path().join("rocket");
-
-    Repository::clone(fixture_repo_dir.to_str().unwrap(), &repo_dir.as_path()).unwrap();
+    let repo_dir = common::create_fixture_repo()?;
 
     Command::new("git")
         .args(&["reset", "--hard", "HEAD^"])
@@ -67,10 +61,7 @@ fn shows_behind_with_count() -> io::Result<()> {
 #[test]
 #[ignore]
 fn shows_ahead() -> io::Result<()> {
-    let fixture_repo_dir = common::create_fixture_repo()?;
-    let repo_dir = common::new_tempdir()?.path().join("rocket");
-
-    Repository::clone(fixture_repo_dir.to_str().unwrap(), &repo_dir.as_path()).unwrap();
+    let repo_dir = common::create_fixture_repo()?;
 
     File::create(repo_dir.join("readme.md"))?;
 
@@ -94,10 +85,7 @@ fn shows_ahead() -> io::Result<()> {
 #[test]
 #[ignore]
 fn shows_ahead_with_count() -> io::Result<()> {
-    let fixture_repo_dir = common::create_fixture_repo()?;
-    let repo_dir = common::new_tempdir()?.path().join("rocket");
-
-    Repository::clone(fixture_repo_dir.to_str().unwrap(), &repo_dir.as_path()).unwrap();
+    let repo_dir = common::create_fixture_repo()?;
 
     File::create(repo_dir.join("readme.md"))?;
 
@@ -128,10 +116,7 @@ fn shows_ahead_with_count() -> io::Result<()> {
 #[test]
 #[ignore]
 fn shows_diverged() -> io::Result<()> {
-    let fixture_repo_dir = common::create_fixture_repo()?;
-    let repo_dir = common::new_tempdir()?.path().join("rocket");
-
-    Repository::clone(fixture_repo_dir.to_str().unwrap(), &repo_dir.as_path()).unwrap();
+    let repo_dir = common::create_fixture_repo()?;
 
     Command::new("git")
         .args(&["reset", "--hard", "HEAD^"])
@@ -160,10 +145,7 @@ fn shows_diverged() -> io::Result<()> {
 #[test]
 #[ignore]
 fn shows_diverged_with_count() -> io::Result<()> {
-    let fixture_repo_dir = common::create_fixture_repo()?;
-    let repo_dir = common::new_tempdir()?.path().join("rocket");
-
-    Repository::clone(fixture_repo_dir.to_str().unwrap(), &repo_dir.as_path()).unwrap();
+    let repo_dir = common::create_fixture_repo()?;
 
     Command::new("git")
         .args(&["reset", "--hard", "HEAD^"])
@@ -199,10 +181,7 @@ fn shows_diverged_with_count() -> io::Result<()> {
 #[test]
 #[ignore]
 fn shows_conflicted() -> io::Result<()> {
-    let fixture_repo_dir = common::create_fixture_repo()?;
-    let repo_dir = common::new_tempdir()?.path().join("rocket");
-
-    Repository::clone(fixture_repo_dir.to_str().unwrap(), &repo_dir.as_path()).unwrap();
+    let repo_dir = common::create_fixture_repo()?;
 
     Command::new("git")
         .args(&["reset", "--hard", "HEAD^"])
@@ -241,10 +220,7 @@ fn shows_conflicted() -> io::Result<()> {
 #[test]
 #[ignore]
 fn shows_untracked_file() -> io::Result<()> {
-    let fixture_repo_dir = common::create_fixture_repo()?;
-    let repo_dir = common::new_tempdir()?.path().join("rocket");
-
-    Repository::clone(fixture_repo_dir.to_str().unwrap(), &repo_dir.as_path()).unwrap();
+    let repo_dir = common::create_fixture_repo()?;
 
     File::create(repo_dir.join("license"))?;
 
@@ -263,10 +239,7 @@ fn shows_untracked_file() -> io::Result<()> {
 #[test]
 #[ignore]
 fn doesnt_show_untracked_file_if_disabled() -> io::Result<()> {
-    let fixture_repo_dir = common::create_fixture_repo()?;
-    let repo_dir = common::new_tempdir()?.path().join("rocket");
-
-    Repository::clone(fixture_repo_dir.to_str().unwrap(), &repo_dir.as_path()).unwrap();
+    let repo_dir = common::create_fixture_repo()?;
 
     File::create(repo_dir.join("license"))?;
 
@@ -290,10 +263,7 @@ fn doesnt_show_untracked_file_if_disabled() -> io::Result<()> {
 #[test]
 #[ignore]
 fn shows_stashed() -> io::Result<()> {
-    let fixture_repo_dir = common::create_fixture_repo()?;
-    let repo_dir = common::new_tempdir()?.path().join("rocket");
-
-    Repository::clone(fixture_repo_dir.to_str().unwrap(), &repo_dir.as_path()).unwrap();
+    let repo_dir = common::create_fixture_repo()?;
 
     File::create(repo_dir.join("readme.md"))?;
 
@@ -317,10 +287,7 @@ fn shows_stashed() -> io::Result<()> {
 #[test]
 #[ignore]
 fn shows_modified() -> io::Result<()> {
-    let fixture_repo_dir = common::create_fixture_repo()?;
-    let repo_dir = common::new_tempdir()?.path().join("rocket");
-
-    Repository::clone(fixture_repo_dir.to_str().unwrap(), &repo_dir.as_path()).unwrap();
+    let repo_dir = common::create_fixture_repo()?;
 
     File::create(repo_dir.join("readme.md"))?;
 
@@ -339,10 +306,7 @@ fn shows_modified() -> io::Result<()> {
 #[test]
 #[ignore]
 fn shows_staged_file() -> io::Result<()> {
-    let fixture_repo_dir = common::create_fixture_repo()?;
-    let repo_dir = common::new_tempdir()?.path().join("rocket");
-
-    Repository::clone(fixture_repo_dir.to_str().unwrap(), &repo_dir.as_path()).unwrap();
+    let repo_dir = common::create_fixture_repo()?;
 
     File::create(repo_dir.join("license"))?;
 
@@ -366,10 +330,7 @@ fn shows_staged_file() -> io::Result<()> {
 #[test]
 #[ignore]
 fn shows_renamed_file() -> io::Result<()> {
-    let fixture_repo_dir = common::create_fixture_repo()?;
-    let repo_dir = common::new_tempdir()?.path().join("rocket");
-
-    Repository::clone(fixture_repo_dir.to_str().unwrap(), &repo_dir.as_path()).unwrap();
+    let repo_dir = common::create_fixture_repo()?;
 
     Command::new("git")
         .args(&["mv", "readme.md", "readme.md.bak"])
@@ -396,10 +357,7 @@ fn shows_renamed_file() -> io::Result<()> {
 #[test]
 #[ignore]
 fn shows_deleted_file() -> io::Result<()> {
-    let fixture_repo_dir = common::create_fixture_repo()?;
-    let repo_dir = common::new_tempdir()?.path().join("rocket");
-
-    Repository::clone(fixture_repo_dir.to_str().unwrap(), &repo_dir.as_path()).unwrap();
+    let repo_dir = common::create_fixture_repo()?;
 
     fs::remove_file(repo_dir.join("readme.md"))?;
 


### PR DESCRIPTION
#### Description
The common function in the test suite will now clone the repo into the fixture directory, and then set the git config locally to that repo.

#### Motivation and Context
Closes #300

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### How Has This Been Tested?
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
