### PR TITLE
docs: reorder misplaced Ruby option example

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -427,15 +427,6 @@ disabled = true
 ```
 
 
-### Example
-
-```toml
-# ~/.config/starship.toml
-
-[ruby]
-symbol = "🔺 "
-```
-
 ## Nix-shell
 
 The `nix_shell` module shows the nix-shell environment.
@@ -577,6 +568,15 @@ The module will be shown if any of the following conditions are met:
 | `symbol`   | `"💎 "`      | The symbol used before displaying the version of Ruby. |
 | `style`    | `"bold red"` | The style for the module.                              |
 | `disabled` | `false`      | Disables the `ruby` module.                            |
+
+### Example
+
+```toml
+# ~/.config/starship.toml
+
+[ruby]
+symbol = "🔺 "
+```
 
 ## Rust
 


### PR DESCRIPTION
Reorder misplaced Ruby option example

#### Description

Ruby example is misplaced at Linebreak section.

#### Types of changes

Docs updated

#### Screenshots (if appropriate):

Ruby example shouldn't show at linebreak section.

<img width="500" alt="image" src="https://user-images.githubusercontent.com/14314532/64488399-1adc5080-d27a-11e9-8b74-8adcf13a2241.png">

#### How Has This Been Tested?

Need not.

#### Checklist:

- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
