### PR TITLE
feat: Implement threshold based styling for battery module

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -108,13 +108,13 @@ The module is only visible when the device's battery is below 10%.
 
 ### Options
 
-| Variable             | Default      | Description                                       |
-| -------------------- | ------------ | ------------------------------------------------- |
-| `full_symbol`        | `"•"`        | The symbol shown when the battery is full.        |
-| `charging_symbol`    | `"⇡"`        | The symbol shown when the battery is charging.    |
-| `discharging_symbol` | `"⇣"`        | The symbol shown when the battery is discharging. |
-| `style`              | `"bold red"` | The style for the module.                         |
-| `disabled`           | `false`      | Disables the `battery` module.                    |
+| Variable             | Default                                  | Description                                       |
+| -------------------- | ---------------------------------------- | ------------------------------------------------- |
+| `full_symbol`        | `"•"`                                    | The symbol shown when the battery is full.        |
+| `charging_symbol`    | `"⇡"`                                    | The symbol shown when the battery is charging.    |
+| `discharging_symbol` | `"⇣"`                                    | The symbol shown when the battery is discharging. |
+| `display`            | `{"threshold": 10, "style": "bold red"}` | Display threshold and style for the module.       |
+| `disabled`           | `false`                                  | Disables the `battery` module.                    |
 
 ### Example
 
@@ -125,6 +125,14 @@ The module is only visible when the device's battery is below 10%.
 full_symbol = "🔋"
 charging_symbol = "⚡️"
 discharging_symbol = "💀"
+
+  [[battery.display]]
+  threshold = 10
+  style = "bold red"
+
+  [[battery.display]]
+  threshold = 30
+  style = "bold yellow"
 ```
 
 ## Character

--- a/src/module.rs
+++ b/src/module.rs
@@ -144,6 +144,11 @@ impl<'a> Module<'a> {
     pub fn config_value_style(&self, key: &str) -> Option<Style> {
         self.config.and_then(|config| config.get_as_ansi_style(key))
     }
+
+    /// Get a module's config value as an array
+    pub fn config_value_array(&self, key: &str) -> Option<&Vec<toml::Value>> {
+        self.config.and_then(|config| config.get_as_array(key))
+    }
 }
 
 impl<'a> fmt::Display for Module<'a> {

--- a/src/modules/battery.rs
+++ b/src/modules/battery.rs
@@ -1,13 +1,13 @@
-use ansi_term::Color;
+use ansi_term::{Color, Style};
 
 use super::{Context, Module};
+use crate::config::Config;
 
 /// Creates a module for the battery percentage and charging state
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     const BATTERY_FULL: &str = "•";
     const BATTERY_CHARGING: &str = "⇡";
     const BATTERY_DISCHARGING: &str = "⇣";
-    const BATTERY_THRESHOLD: i64 = 10;
     // TODO: Update when v1.0 printing refactor is implemented to only
     // print escapes in a prompt context.
     let shell = std::env::var("STARSHIP_SHELL").unwrap_or_default();
@@ -20,57 +20,87 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let BatteryStatus { state, percentage } = battery_status;
 
     let mut module = context.new_module("battery")?;
-    let battery_threshold = match module.config_value_i64("display_threshold") {
-        Some(threshold) => {
-            if 0 <= threshold && threshold < 100 {
-                threshold
-            } else {
-                log::debug!(
-                    "Expect battery.battery_threshold in [0, 100), found `{}`",
-                    threshold
-                );
-                BATTERY_THRESHOLD
+
+    // Parse config under `display`
+    let display_styles = get_display_styles(&module);
+    let display_style = display_styles.iter().find(|display_style| {
+        let BatteryDisplayStyle {
+            threshold,
+            style: _,
+        } = display_style;
+        percentage <= *threshold as f32
+    });
+
+    if let Some(display_style) = display_style {
+        let BatteryDisplayStyle {
+            threshold: _,
+            style,
+        } = display_style;
+
+        // Set style based on percentage
+        module.set_style(*style);
+        module.get_prefix().set_value("");
+
+        match state {
+            battery::State::Full => {
+                module.new_segment("full_symbol", BATTERY_FULL);
+            }
+            battery::State::Charging => {
+                module.new_segment("charging_symbol", BATTERY_CHARGING);
+            }
+            battery::State::Discharging => {
+                module.new_segment("discharging_symbol", BATTERY_DISCHARGING);
+            }
+            _ => return None,
+        }
+
+        let mut percent_string = Vec::<String>::with_capacity(2);
+        // Round the percentage to a whole number
+        percent_string.push(percentage.round().to_string());
+        percent_string.push(percentage_char.to_string());
+        module.new_segment("percentage", percent_string.join("").as_ref());
+
+        Some(module)
+    } else {
+        None
+    }
+}
+
+fn get_display_styles(module: &Module) -> Vec<BatteryDisplayStyle> {
+    const DISPLAY_STYLES: &[BatteryDisplayStyle] = &[BatteryDisplayStyle {
+        threshold: 10,
+        style: Style {
+            background: None,
+            foreground: Some(Color::Red),
+            is_bold: true,
+            is_dimmed: false,
+            is_italic: false,
+            is_underline: false,
+            is_blink: false,
+            is_reverse: false,
+            is_hidden: false,
+            is_strikethrough: false,
+        },
+    }];
+
+    if let Some(display_configs) = module.config_value_array("display") {
+        let mut display_styles: Vec<BatteryDisplayStyle> = vec![];
+        for display_config in display_configs.iter() {
+            match display_config {
+                toml::Value::Table(config) => {
+                    if let Some(display_style) = BatteryDisplayStyle::from_config(config) {
+                        display_styles.push(display_style);
+                    }
+                }
+                _ => {}
             }
         }
-        None => BATTERY_THRESHOLD,
-    };
 
-    if percentage > battery_threshold as f32 {
-        log::debug!(
-            "Battery percentage is higher than threshold ({} > {})",
-            percentage,
-            battery_threshold
-        );
-        return None;
+        // Return display styles as long as display array exists, even if it is empty.
+        display_styles
+    } else {
+        Vec::from(DISPLAY_STYLES)
     }
-
-    // TODO: Set style based on percentage when threshold is modifiable
-    let module_style = module
-        .config_value_style("style")
-        .unwrap_or_else(|| Color::Red.bold());
-    module.set_style(module_style);
-    module.get_prefix().set_value("");
-
-    match state {
-        battery::State::Full => {
-            module.new_segment("full_symbol", BATTERY_FULL);
-        }
-        battery::State::Charging => {
-            module.new_segment("charging_symbol", BATTERY_CHARGING);
-        }
-        battery::State::Discharging => {
-            module.new_segment("discharging_symbol", BATTERY_DISCHARGING);
-        }
-        _ => return None,
-    }
-
-    let mut percent_string = Vec::<String>::with_capacity(2);
-    // Round the percentage to a whole number
-    percent_string.push(percentage.round().to_string());
-    percent_string.push(percentage_char.to_string());
-    module.new_segment("percentage", percent_string.join("").as_ref());
-
-    Some(module)
 }
 
 fn get_battery_status() -> Option<BatteryStatus> {
@@ -99,4 +129,29 @@ fn get_battery_status() -> Option<BatteryStatus> {
 struct BatteryStatus {
     percentage: f32,
     state: battery::State,
+}
+
+#[derive(Clone, Debug)]
+struct BatteryDisplayStyle {
+    threshold: i64,
+    style: Style,
+}
+
+impl BatteryDisplayStyle {
+    /// construct battery display style from toml table
+    pub fn from_config(config: &toml::value::Table) -> Option<BatteryDisplayStyle> {
+        let threshold = if let Some(threshold) = config.get_as_i64("threshold") {
+            threshold
+        } else {
+            return None;
+        };
+
+        let style = if let Some(style) = config.get_as_ansi_style("style") {
+            style
+        } else {
+            return None;
+        };
+
+        Some(BatteryDisplayStyle { threshold, style })
+    }
 }


### PR DESCRIPTION
#### Description
Add threshold based styling for battery.

Require changes to `starship.toml`:

- Remove key `style`
- Add key `display` which is an array of tables of
  ```
  threshold: i64 // required
  style: i64 // required
  ```

#### Motivation and Context
Fixes TODO described [here](https://github.com/starship/starship/blob/29eedeb698bb268bfc1659b5e3f0fe2ccef001a8/src/modules/battery.rs#L31)

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Example
A config of
```toml
[battery]
  [[battery.display]]
  threshold = 10
  style = "bold red"

  [[battery.display]]
  threshold = 30
  style = "bold yellow"

  [[battery.display]]  # This is ignored
  threshold = 15
  style = "bold orange"
```
makes the style `bold red` if capacity is below 10, and `bold yellow` if capacity is below 30.
The first table matching `capacity <= threshold` is applied so the third table is ignored.
When capacity is over 30, the battery info will not be displayed.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.

Since I don't know how to write multiple lines in the table, the doc is written in JSON format and should better be fixed.
The doc is not well described though.