### PR TITLE
fix: Turn off label confinement for docker run.

### DIFF
--- a/integration_test
+++ b/integration_test
@@ -13,4 +13,4 @@ docker build -f tests/Dockerfile \
   .
 
 printf 'Running test suite:\n'
-docker run --rm -v $(pwd):/src/starship starshipcommand/starship-test
+docker run --rm -v $(pwd):/src/starship --security-opt="label=disable" starshipcommand/starship-test


### PR DESCRIPTION
#### Description
Allows usage of the integration_test script on OS using SELinux.
No influence on other OS is expected.
The configuration is described [here](https://docs.docker.com/engine/reference/run/) 

#### Motivation and Context
As discussed in https://github.com/starship/starship/issues/302, mounting of `$(pwd)` into the Docker container fails if an OS with SELinux is used. One option is to use :z or :Z, as discussed [here](https://docs.docker.com/storage/bind-mounts/#configure-the-selinux-label). However, this might be dangerous of misused.
But it should be rather unproblematic to disable the label confinement for the container all together.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**