### PR TITLE
fix: Update Module::is_empty to check value of segments

### DIFF
--- a/src/module.rs
+++ b/src/module.rs
@@ -271,7 +271,7 @@ mod tests {
         let name = "unit_test";
         let module = Module {
             config: None,
-            name: name.to_string(),
+            _name: name.to_string(),
             style: Style::default(),
             prefix: Affix::default_prefix(name),
             segments: Vec::new(),
@@ -286,7 +286,7 @@ mod tests {
         let name = "unit_test";
         let module = Module {
             config: None,
-            name: name.to_string(),
+            _name: name.to_string(),
             style: Style::default(),
             prefix: Affix::default_prefix(name),
             segments: vec![Segment::new("test_segment")],

--- a/src/module.rs
+++ b/src/module.rs
@@ -74,9 +74,9 @@ impl<'a> Module<'a> {
         self.segments.last_mut().unwrap()
     }
 
-    /// Whether a module has any segments
+    /// Whether a module has non-empty segments
     pub fn is_empty(&self) -> bool {
-        self.segments.is_empty()
+        self.segments.iter().all(|segment| segment.is_empty())
     }
 
     /// Get the module's prefix
@@ -259,5 +259,40 @@ impl Affix {
 impl fmt::Display for Affix {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.ansi_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_module_is_empty_with_no_segments() {
+        let name = "unit_test";
+        let module = Module {
+            config: None,
+            name: name.to_string(),
+            style: Style::default(),
+            prefix: Affix::default_prefix(name),
+            segments: Vec::new(),
+            suffix: Affix::default_suffix(name),
+        };
+
+        assert!(module.is_empty());
+    }
+
+    #[test]
+    fn test_module_is_empty_with_all_empty_segments() {
+        let name = "unit_test";
+        let module = Module {
+            config: None,
+            name: name.to_string(),
+            style: Style::default(),
+            prefix: Affix::default_prefix(name),
+            segments: vec![Segment::new("test_segment")],
+            suffix: Affix::default_suffix(name),
+        };
+
+        assert!(module.is_empty());
     }
 }

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -52,6 +52,11 @@ impl Segment {
             None => ANSIString::from(&self.value),
         }
     }
+
+    /// Determines if the segment contains a value.
+    pub fn is_empty(&self) -> bool {
+        self.value.trim().is_empty()
+    }
 }
 
 impl fmt::Display for Segment {


### PR DESCRIPTION
#### Description
Change the logic of `Module::is_empty` to use newly created `Segment::is_empty` to determine if the module is empty and should print.

#### Motivation and Context
Closes #325

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### How Has This Been Tested?
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
