### PR TITLE
perf: Lazy load files from directory

### DIFF
--- a/src/module.rs
+++ b/src/module.rs
@@ -35,7 +35,7 @@ pub struct Module<'a> {
     config: Option<&'a toml::value::Table>,
 
     /// The module's name, to be used in configuration and logging.
-    name: String,
+    _name: String,
 
     /// The styling to be inherited by all segments contained within this module.
     style: Style,
@@ -55,7 +55,7 @@ impl<'a> Module<'a> {
     pub fn new(name: &str, config: Option<&'a toml::value::Table>) -> Module<'a> {
         Module {
             config,
-            name: name.to_string(),
+            _name: name.to_string(),
             style: Style::default(),
             prefix: Affix::default_prefix(name),
             segments: Vec::new(),
@@ -204,7 +204,7 @@ fn ansi_strings_modified(ansi_strings: Vec<ANSIString>, shell: String) -> Vec<AN
 /// Module affixes are to be used for the prefix or suffix of a module.
 pub struct Affix {
     /// The affix's name, to be used in configuration and logging.
-    name: String,
+    _name: String,
 
     /// The affix's style.
     style: Style,
@@ -216,7 +216,7 @@ pub struct Affix {
 impl Affix {
     pub fn default_prefix(name: &str) -> Self {
         Self {
-            name: format!("{}_prefix", name),
+            _name: format!("{}_prefix", name),
             style: Style::default(),
             value: "via ".to_string(),
         }
@@ -224,7 +224,7 @@ impl Affix {
 
     pub fn default_suffix(name: &str) -> Self {
         Self {
-            name: format!("{}_suffix", name),
+            _name: format!("{}_suffix", name),
             style: Style::default(),
             value: " ".to_string(),
         }

--- a/src/modules/golang.rs
+++ b/src/modules/golang.rs
@@ -15,11 +15,11 @@ use super::{Context, Module};
 ///     - Current directory contains a file with the `.go` extension
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let is_go_project = context
-        .new_scan_dir()
+        .try_begin_scan()?
         .set_files(&["go.mod", "go.sum", "glide.yaml", "Gopkg.yml", "Gopkg.lock"])
         .set_extensions(&["go"])
         .set_folders(&["Godeps"])
-        .scan();
+        .is_match();
 
     if !is_go_project {
         return None;

--- a/src/modules/nodejs.rs
+++ b/src/modules/nodejs.rs
@@ -11,11 +11,11 @@ use super::{Context, Module};
 ///     - Current directory contains a `node_modules` directory
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let is_js_project = context
-        .new_scan_dir()
+        .try_begin_scan()?
         .set_files(&["package.json"])
         .set_extensions(&["js"])
         .set_folders(&["node_modules"])
-        .scan();
+        .is_match();
 
     if !is_js_project {
         return None;

--- a/src/modules/python.rs
+++ b/src/modules/python.rs
@@ -16,7 +16,7 @@ use super::{Context, Module};
 ///     - Current directory contains a `Pipfile` file
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let is_py_project = context
-        .new_scan_dir()
+        .try_begin_scan()?
         .set_files(&[
             "requirements.txt",
             ".python-version",
@@ -24,7 +24,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             "Pipfile",
         ])
         .set_extensions(&["py"])
-        .scan();
+        .is_match();
 
     if !is_py_project {
         return None;

--- a/src/modules/ruby.rs
+++ b/src/modules/ruby.rs
@@ -10,10 +10,10 @@ use super::{Context, Module};
 ///     - Current directory contains a `Gemfile` file
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let is_rb_project = context
-        .new_scan_dir()
+        .try_begin_scan()?
         .set_files(&["Gemfile"])
         .set_extensions(&["rb"])
-        .scan();
+        .is_match();
 
     if !is_rb_project {
         return None;

--- a/src/modules/rust.rs
+++ b/src/modules/rust.rs
@@ -10,10 +10,10 @@ use super::{Context, Module};
 ///     - Current directory contains a `Cargo.toml` file
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let is_rs_project = context
-        .new_scan_dir()
+        .try_begin_scan()?
         .set_files(&["Cargo.toml"])
         .set_extensions(&["rs"])
-        .scan();
+        .is_match();
 
     if !is_rs_project {
         return None;

--- a/src/modules/time.rs
+++ b/src/modules/time.rs
@@ -41,8 +41,8 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
 /// Format a given time into the given string. This function should be referentially
 /// transparent, which makes it easy to test (unlike anything involving the actual time)
-fn format_time(time_format: &str, localtime: DateTime<Local>) -> String {
-    localtime.format(time_format).to_string()
+fn format_time(time_format: &str, local_time: DateTime<Local>) -> String {
+    local_time.format(time_format).to_string()
 }
 
 /* Because we cannot make acceptance tests for the time module, these unit

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -6,7 +6,7 @@ use std::fmt;
 /// (e.g. The version that software is running).
 pub struct Segment {
     /// The segment's name, to be used in configuration and logging.
-    name: String,
+    _name: String,
 
     /// The segment's style. If None, will inherit the style of the module containing it.
     style: Option<Style>,
@@ -19,7 +19,7 @@ impl Segment {
     /// Creates a new segment with default fields.
     pub fn new(name: &str) -> Self {
         Self {
-            name: name.to_string(),
+            _name: name.to_string(),
             style: None,
             value: "".to_string(),
         }

--- a/tests/testsuite/git_branch.rs
+++ b/tests/testsuite/git_branch.rs
@@ -1,5 +1,4 @@
 use ansi_term::Color;
-use git2::Repository;
 use std::io;
 use std::process::Command;
 

--- a/tests/testsuite/git_status.rs
+++ b/tests/testsuite/git_status.rs
@@ -1,5 +1,4 @@
 use ansi_term::Color;
-use git2::Repository;
 use std::fs::{self, File};
 use std::io;
 use std::process::Command;

--- a/tests/testsuite/time.rs
+++ b/tests/testsuite/time.rs
@@ -1,8 +1,4 @@
-use ansi_term::Color;
-use std::fs;
 use std::io;
-use std::path::Path;
-use tempfile::TempDir;
 
 use crate::common::{self, TestCommand};
 


### PR DESCRIPTION
Currently starship is guaranteed to enumerate all files in the current directory, and it will not start evaluating modules until this operation completes. This PR will change it so that the list is lazily loaded when it is first used, in a similar fashion to the git details in #306 

#### Description
Updates `Context` to use `OnceCell<Vec<PathBuf>>`.

One side effect is `new_scan_dir` is now fallible. I've change the name to `try_begin_scan` and `scan` to `is_match`.

#### Motivation and Context
Allows modules which do not use `ScanDir` to be evaluated sooner, reducing total latency.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### How Has This Been Tested?
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
