### PR TITLE
feat: Enable the python module for tox files

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -568,6 +568,7 @@ The module will be shown if any of the following conditions are met:
 - The current directory contains a `pyproject.toml` file
 - The current directory contains a file with the `.py` extension
 - The current directory contains a `Pipfile` file
+- The current directory contains a `tox.ini` file
 
 ### Options
 

--- a/src/modules/python.rs
+++ b/src/modules/python.rs
@@ -14,6 +14,7 @@ use super::{Context, Module};
 ///     - Current directory contains a `pyproject.toml` file
 ///     - Current directory contains a file with the `.py` extension
 ///     - Current directory contains a `Pipfile` file
+///     - Current directory contains a `tox.ini` file
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let is_py_project = context
         .try_begin_scan()?
@@ -22,6 +23,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             ".python-version",
             "pyproject.toml",
             "Pipfile",
+            "tox.ini",
         ])
         .set_extensions(&["py"])
         .is_match();

--- a/tests/testsuite/python.rs
+++ b/tests/testsuite/python.rs
@@ -75,6 +75,23 @@ fn folder_with_pipfile() -> io::Result<()> {
 
 #[test]
 #[ignore]
+fn folder_with_tox() -> io::Result<()> {
+    let dir = common::new_tempdir()?;
+    File::create(dir.path().join("tox.ini"))?;
+
+    let output = common::render_module("python")
+        .arg("--path")
+        .arg(dir.path())
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+
+    let expected = format!("via {} ", Color::Yellow.bold().paint("🐍 v3.6.9"));
+    assert_eq!(expected, actual);
+    Ok(())
+}
+
+#[test]
+#[ignore]
 fn folder_with_py_file() -> io::Result<()> {
     let dir = common::new_tempdir()?;
     File::create(dir.path().join("main.py"))?;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Enable the python module if the current directory contains a `tox.ini`
file.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #365

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.