### PR TITLE
fix: fish_pwd option handles repeated directories properly

### DIFF
--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -145,7 +145,7 @@ fn truncate(dir_string: String, length: usize) -> String {
 /// Contracted Path: `in_a/repo/but_nested`
 /// With Fish Style: `/s/P/n/in_a/repo/but_nested`
 fn to_fish_style(pwd_dir_length: usize, dir_string: String, truncated_dir_string: &str) -> String {
-    let replaced_dir_string = dir_string.replace(truncated_dir_string, "");
+    let replaced_dir_string = dir_string.trim_end_matches(truncated_dir_string).to_owned();
     let components = replaced_dir_string.split('/').collect::<Vec<&str>>();
 
     if components.is_empty() {
@@ -282,5 +282,12 @@ mod tests {
         let path = "/absolute/Path/not/in_a/repo/but_nested";
         let output = to_fish_style(2, path.to_string(), "repo/but_nested");
         assert_eq!(output, "/ab/Pa/no/in/");
+    }
+
+    #[test]
+    fn fish_style_with_duplicate_directories() {
+        let path = "~/starship/tmp/C++/C++/C++";
+        let output = to_fish_style(1, path.to_string(), "C++");
+        assert_eq!(output, "~/s/t/C/C/");
     }
 }


### PR DESCRIPTION
#### Description
This is likely a more common scenario when a user had `truncation_length = 1`. When the user was in a directory where the final directory name was repeated somewhere else in the `pwd` path.

#### Motivation and Context
Closes #394 

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### How Has This Been Tested?
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
