### PR TITLE
feat: Add ability to always show username module

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -731,6 +731,7 @@ The module will be shown if any of the following conditions are met:
 - The current user is root
 - The current user isn't the same as the one that is logged in
 - The user is currently connected as an SSH session
+- The variable `show_always` is set to true
 
 ### Options
 
@@ -738,6 +739,7 @@ The module will be shown if any of the following conditions are met:
 | ------------ | --------------- | ------------------------------------- |
 | `style_root` | `"bold red"`    | The style used when the user is root. |
 | `style_user` | `"bold yellow"` | The style used for non-root users.    |
+| `show_always`| `false`         | Always shows the `username` module.   |
 | `disabled`   | `false`         | Disables the `username` module.       |
 
 ### Example

--- a/src/modules/username.rs
+++ b/src/modules/username.rs
@@ -17,8 +17,11 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
     const ROOT_UID: Option<u32> = Some(0);
     let user_uid = get_uid();
-    if user != logname || ssh_connection.is_some() || user_uid == ROOT_UID {
-        let mut module = context.new_module("username");
+
+    let mut module = context.new_module("username");
+    let show_always = module.config_value_bool("show_always").unwrap_or(false);
+
+    if user != logname || ssh_connection.is_some() || user_uid == ROOT_UID || show_always {
         let module_style = get_mod_style(user_uid, &module);
         module.set_style(module_style);
         module.new_segment("username", &user?);

--- a/tests/testsuite/username.rs
+++ b/tests/testsuite/username.rs
@@ -1,7 +1,7 @@
 use ansi_term::Color;
 use std::io;
 
-use crate::common;
+use crate::common::{self, TestCommand};
 
 // TODO: Add tests for if root user (UID == 0)
 // Requires mocking
@@ -58,6 +58,22 @@ fn ssh_connection() -> io::Result<()> {
     let actual = String::from_utf8(output.stdout).unwrap();
 
     let expected = format!("via {} ", Color::Yellow.bold().paint("astronaut"));
+    assert_eq!(expected, actual);
+    Ok(())
+}
+
+#[test]
+fn show_always() -> io::Result<()> {
+    let output = common::render_module("username")
+        .env("USER", "astronaut")
+        .use_config(toml::toml! {
+        [username]
+        show_always = true})
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+
+    let expected = format!("via {} ", Color::Yellow.bold().paint("astronaut"));
+
     assert_eq!(expected, actual);
     Ok(())
 }


### PR DESCRIPTION
#### Description
I added the option to always show the username.
It is possible to activate this by adding "show always = true" to the "username" section.
The default behavior has not changed.

#### Motivation and Context

Closes #401

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### How Has This Been Tested?
I built a  local version of the starship crate and tried the following scenarios:
Preconditions: user is not root, user is not in a ssh session, current user is the same as the logged in user
1. config without "show_always" entry -> no username visible
2. config with entry "show_always = false" -> no username visible 
3. config with entry "show_always = true" -> username is always visible 

Additionally I added a new test to ensure the user is rendered when this option is set.
I don't think it necessary to write an additional test to cover the default case. This should be covered by the already excisting tests.

- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
