### PR TITLE
feat: Added ability for setting command duration prefix

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -257,11 +257,12 @@ running `eval $(starship init $0)`, and then proceed as normal.
 
 ### Options
 
-| Variable   | Default         | Description                         |
-| ---------- | --------------- | ----------------------------------- |
-| `min_time` | `2`             | Shortest duration to show time for. |
-| `style`    | `"bold yellow"` | The style for the module.           |
-| `disabled` | `false`         | Disables the `cmd_duration` module. |
+| Variable   | Default         | Description                                 |
+| ---------- | --------------- | ------------------------------------------- |
+| `min_time` | `2`             | Shortest duration to show time for.         |
+| `prefix`   | `took `         | Prefix to display immediately cmd_duration. |
+| `style`    | `"bold yellow"` | The style for the module.                   |
+| `disabled` | `false`         | Disables the `cmd_duration` module.         |
 
 ### Example
 
@@ -270,6 +271,7 @@ running `eval $(starship init $0)`, and then proceed as normal.
 
 [cmd_duration]
 min_time = 4
+prefix = "underwent "
 ```
 
 ## Directory

--- a/src/modules/cmd_duration.rs
+++ b/src/modules/cmd_duration.rs
@@ -16,6 +16,11 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         .parse::<u64>()
         .ok()?;
 
+    let prefix = module
+        .config_value_str("prefix")
+        .unwrap_or("took ")
+        .to_owned();
+
     let signed_config_min = module.config_value_i64("min_time").unwrap_or(2);
 
     /* TODO: Once error handling is implemented, warn the user if their config
@@ -38,7 +43,10 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     };
 
     module.set_style(module_color);
-    module.new_segment("cmd_duration", &format!("took {}", render_time(elapsed)));
+    module.new_segment(
+        "cmd_duration",
+        &format!("{}{}", prefix, render_time(elapsed)),
+    );
     module.get_prefix().set_value("");
 
     Some(module)

--- a/tests/testsuite/cmd_duration.rs
+++ b/tests/testsuite/cmd_duration.rs
@@ -90,3 +90,35 @@ fn config_5s_duration_prefix_underwent() -> io::Result<()> {
     assert_eq!(expected, actual);
     Ok(())
 }
+
+#[test]
+fn config_1s_duration_prefix_underwent() -> io::Result<()> {
+    let output = common::render_module("cmd_duration")
+        .use_config(toml::toml! {
+            [cmd_duration]
+            prefix = "underwent "
+        })
+        .arg("--cmd-duration=1")
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+
+    let expected = "";
+    assert_eq!(expected, actual);
+    Ok(())
+}
+
+#[test]
+fn config_5s_duration_prefix_underwent() -> io::Result<()> {
+    let output = common::render_module("cmd_duration")
+        .use_config(toml::toml! {
+            [cmd_duration]
+            prefix = "underwent "
+        })
+        .arg("--cmd-duration=5")
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+
+    let expected = format!("{} ", Color::Yellow.bold().paint("underwent 5s"));
+    assert_eq!(expected, actual);
+    Ok(())
+}

--- a/tests/testsuite/cmd_duration.rs
+++ b/tests/testsuite/cmd_duration.rs
@@ -66,11 +66,11 @@ fn config_1s_duration_prefix_underwent() -> io::Result<()> {
             [cmd_duration]
             prefix = "underwent "
         })
-        .arg("--cmd-duration=1000000000")
+        .arg("--cmd-duration=1")
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
-    let expected = format!("{} ", Color::RGB(80, 80, 80).bold().paint("underwent 1s"));
+    let expected = "";
     assert_eq!(expected, actual);
     Ok(())
 }
@@ -82,7 +82,7 @@ fn config_5s_duration_prefix_underwent() -> io::Result<()> {
             [cmd_duration]
             prefix = "underwent "
         })
-        .arg("--cmd-duration=5000000000")
+        .arg("--cmd-duration=5")
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 

--- a/tests/testsuite/cmd_duration.rs
+++ b/tests/testsuite/cmd_duration.rs
@@ -58,3 +58,35 @@ fn config_5s_duration_10s() -> io::Result<()> {
     assert_eq!(expected, actual);
     Ok(())
 }
+
+#[test]
+fn config_1s_duration_prefix_underwent() -> io::Result<()> {
+    let output = common::render_module("cmd_duration")
+        .use_config(toml::toml! {
+            [cmd_duration]
+            prefix = "underwent "
+        })
+        .arg("--cmd-duration=1")
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+
+    let expected = "";
+    assert_eq!(expected, actual);
+    Ok(())
+}
+
+#[test]
+fn config_5s_duration_prefix_underwent() -> io::Result<()> {
+    let output = common::render_module("cmd_duration")
+        .use_config(toml::toml! {
+            [cmd_duration]
+            prefix = "underwent "
+        })
+        .arg("--cmd-duration=5")
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+
+    let expected = format!("{} ", Color::Yellow.bold().paint("underwent 5s"));
+    assert_eq!(expected, actual);
+    Ok(())
+}

--- a/tests/testsuite/cmd_duration.rs
+++ b/tests/testsuite/cmd_duration.rs
@@ -66,11 +66,11 @@ fn config_1s_duration_prefix_underwent() -> io::Result<()> {
             [cmd_duration]
             prefix = "underwent "
         })
-        .arg("--cmd-duration=1")
+        .arg("--cmd-duration=1000000000")
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
-    let expected = "";
+    let expected = format!("{} ", Color::RGB(80, 80, 80).bold().paint("underwent 1s"));
     assert_eq!(expected, actual);
     Ok(())
 }
@@ -82,7 +82,7 @@ fn config_5s_duration_prefix_underwent() -> io::Result<()> {
             [cmd_duration]
             prefix = "underwent "
         })
-        .arg("--cmd-duration=5")
+        .arg("--cmd-duration=5000000000")
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 

--- a/tests/testsuite/cmd_duration.rs
+++ b/tests/testsuite/cmd_duration.rs
@@ -98,11 +98,11 @@ fn config_1s_duration_prefix_underwent() -> io::Result<()> {
             [cmd_duration]
             prefix = "underwent "
         })
-        .arg("--cmd-duration=1")
+        .arg("--cmd-duration=1000000000")
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
-    let expected = "";
+    let expected = format!("{} ", Color::RGB(80, 80, 80).bold().paint("underwent 1s"));
     assert_eq!(expected, actual);
     Ok(())
 }
@@ -114,7 +114,7 @@ fn config_5s_duration_prefix_underwent() -> io::Result<()> {
             [cmd_duration]
             prefix = "underwent "
         })
-        .arg("--cmd-duration=5")
+        .arg("--cmd-duration=5000000000")
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 

--- a/tests/testsuite/cmd_duration.rs
+++ b/tests/testsuite/cmd_duration.rs
@@ -90,35 +90,3 @@ fn config_5s_duration_prefix_underwent() -> io::Result<()> {
     assert_eq!(expected, actual);
     Ok(())
 }
-
-#[test]
-fn config_1s_duration_prefix_underwent() -> io::Result<()> {
-    let output = common::render_module("cmd_duration")
-        .use_config(toml::toml! {
-            [cmd_duration]
-            prefix = "underwent "
-        })
-        .arg("--cmd-duration=1000000000")
-        .output()?;
-    let actual = String::from_utf8(output.stdout).unwrap();
-
-    let expected = format!("{} ", Color::RGB(80, 80, 80).bold().paint("underwent 1s"));
-    assert_eq!(expected, actual);
-    Ok(())
-}
-
-#[test]
-fn config_5s_duration_prefix_underwent() -> io::Result<()> {
-    let output = common::render_module("cmd_duration")
-        .use_config(toml::toml! {
-            [cmd_duration]
-            prefix = "underwent "
-        })
-        .arg("--cmd-duration=5000000000")
-        .output()?;
-    let actual = String::from_utf8(output.stdout).unwrap();
-
-    let expected = format!("{} ", Color::Yellow.bold().paint("underwent 5s"));
-    assert_eq!(expected, actual);
-    Ok(())
-}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR aims to implement a configurable prefix for the command duration module

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #402 

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):
![screenshot-b51ec139](https://user-images.githubusercontent.com/22729355/65452216-b5bb5a00-de38-11e9-87d9-e957875dc861.png)
```toml
[cmd_duration]
prefix = "underwent "
```
#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
