### PR TITLE
revert: Revert the command duration in ms feature (#380)

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -212,7 +212,7 @@ use_symbol_for_status = true
 ## Command Duration
 
 The `cmd_duration` module shows how long the last command took to execute.
-The module will be shown only if the command took longer than 2000 milliseconds (2 seconds), or
+The module will be shown only if the command took longer than two seconds, or
 the `min_time` config value, if it exists.
 
 ::: warning Do not hook the DEBUG trap in Bash
@@ -227,11 +227,11 @@ running `eval $(starship init $0)`, and then proceed as normal.
 
 ### Options
 
-| Variable   | Default         | Description                                           |
-| ---------- | --------------- | ----------------------------------------------------- |
-| `min_time` | `2000`          | Shortest duration to show time for (in milliseconds). |
-| `style`    | `"bold yellow"` | The style for the module.                             |
-| `disabled` | `false`         | Disables the `cmd_duration` module.                   |
+| Variable   | Default         | Description                         |
+| ---------- | --------------- | ----------------------------------- |
+| `min_time` | `2`             | Shortest duration to show time for. |
+| `style`    | `"bold yellow"` | The style for the module.           |
+| `disabled` | `false`         | Disables the `cmd_duration` module. |
 
 ### Example
 
@@ -239,7 +239,7 @@ running `eval $(starship init $0)`, and then proceed as normal.
 # ~/.config/starship.toml
 
 [cmd_duration]
-min_time = 4000
+min_time = 4
 ```
 
 ## Directory

--- a/src/init/starship.bash
+++ b/src/init/starship.bash
@@ -17,7 +17,7 @@ starship_preexec() {
     # Avoid restarting the timer for commands in the same pipeline
     if [ "$PREEXEC_READY" = "true" ]; then
         PREEXEC_READY=false
-        STARSHIP_START_TIME=$(date +%s%0N)
+        STARSHIP_START_TIME=$(date +%s)
     fi
 }
 
@@ -31,7 +31,7 @@ starship_precmd() {
 
     # Prepare the timer data, if needed.
     if [[ $STARSHIP_START_TIME ]]; then
-        STARSHIP_END_TIME=$(date +%s%0N)
+        STARSHIP_END_TIME=$(date +%s)
         STARSHIP_DURATION=$((STARSHIP_END_TIME - STARSHIP_START_TIME))
         PS1="$(::STARSHIP:: prompt --status=$STATUS --jobs="$(jobs -p | wc -l)" --cmd-duration=$STARSHIP_DURATION)"
         unset STARSHIP_START_TIME
@@ -65,5 +65,5 @@ else
 fi
 
 # Set up the start time and STARSHIP_SHELL, which controls shell-specific sequences
-STARSHIP_START_TIME=$(date +%s%0N)
+STARSHIP_START_TIME=$(date +%s)
 export STARSHIP_SHELL="bash"

--- a/src/init/starship.fish
+++ b/src/init/starship.fish
@@ -8,8 +8,8 @@ function fish_prompt
     set -l exit_code $status
     # Account for changes in variable name between v2.7 and v3.0
     set -l CMD_DURATION "$CMD_DURATION$cmd_duration"
-    set -l starship_duration_ns {$CMD_DURATION}000000
-    ::STARSHIP:: prompt --status=$exit_code --keymap=$keymap --cmd-duration=$starship_duration_ns --jobs=(count (jobs -p))
+    set -l starship_duration (math --scale=0 "$CMD_DURATION / 1000")
+    ::STARSHIP:: prompt --status=$exit_code --keymap=$keymap --cmd-duration=$starship_duration --jobs=(count (jobs -p))
 end
 function fish_mode_prompt; end
 export STARSHIP_SHELL="fish"

--- a/src/init/starship.zsh
+++ b/src/init/starship.zsh
@@ -19,7 +19,7 @@ starship_precmd() {
     NUM_JOBS=$#jobstates  
     # Compute cmd_duration, if we have a time to consume
     if [[ ! -z "${STARSHIP_START_TIME+1}" ]]; then
-        STARSHIP_END_TIME="$(date +%s%0N)"
+        STARSHIP_END_TIME="$(date +%s)"
         STARSHIP_DURATION=$((STARSHIP_END_TIME - STARSHIP_START_TIME))
         PROMPT="$(::STARSHIP:: prompt --status=$STATUS --cmd-duration=$STARSHIP_DURATION --jobs="$NUM_JOBS")"
         unset STARSHIP_START_TIME
@@ -28,7 +28,7 @@ starship_precmd() {
     fi
 }
 starship_preexec(){
-    STARSHIP_START_TIME="$(date +%s%0N)"
+    STARSHIP_START_TIME="$(date +%s)"
 }
 
 # If precmd/preexec arrays are not already set, set them. If we don't do this,
@@ -53,6 +53,6 @@ function zle-keymap-select
     zle reset-prompt
 }
 
-STARSHIP_START_TIME="$(date +%s%0N)"
+STARSHIP_START_TIME="$(date +%s)"
 zle -N zle-keymap-select
 export STARSHIP_SHELL="zsh"

--- a/src/modules/cmd_duration.rs
+++ b/src/modules/cmd_duration.rs
@@ -14,10 +14,9 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         .value_of("cmd_duration")
         .unwrap_or("invalid_time")
         .parse::<u64>()
-        .ok()?
-        / 1_000_000;
+        .ok()?;
 
-    let signed_config_min = module.config_value_i64("min_time").unwrap_or(2000);
+    let signed_config_min = module.config_value_i64("min_time").unwrap_or(2);
 
     /* TODO: Once error handling is implemented, warn the user if their config
     min time is nonsensical */
@@ -32,39 +31,28 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let config_min = signed_config_min as u64;
 
     let module_color = match elapsed {
-        time if time < config_min => module
-            .config_value_style("style")
-            .unwrap_or_else(|| Color::RGB(80, 80, 80).bold()),
+        time if time < config_min => return None,
         _ => module
             .config_value_style("style")
             .unwrap_or_else(|| Color::Yellow.bold()),
     };
 
     module.set_style(module_color);
-    module.new_segment(
-        "cmd_duration",
-        &format!("took {}", render_time(elapsed, config_min)),
-    );
+    module.new_segment("cmd_duration", &format!("took {}", render_time(elapsed)));
     module.get_prefix().set_value("");
 
     Some(module)
 }
 
 // Render the time into a nice human-readable string
-fn render_time(raw_milliseconds: u64, config_min: u64) -> String {
+fn render_time(raw_seconds: u64) -> String {
     // Calculate a simple breakdown into days/hours/minutes/seconds
-    let (mut milliseconds, raw_seconds) = (raw_milliseconds % 1000, raw_milliseconds / 1000);
     let (seconds, raw_minutes) = (raw_seconds % 60, raw_seconds / 60);
     let (minutes, raw_hours) = (raw_minutes % 60, raw_minutes / 60);
     let (hours, days) = (raw_hours % 24, raw_hours / 24);
 
-    // Do not display milliseconds if command duration is less than config_min
-    if raw_milliseconds > config_min {
-        milliseconds = 0;
-    }
-
-    let components = [days, hours, minutes, seconds, milliseconds];
-    let suffixes = ["d", "h", "m", "s", "ms"];
+    let components = [days, hours, minutes, seconds];
+    let suffixes = ["d", "h", "m", "s"];
 
     let rendered_components: Vec<String> = components
         .iter()
@@ -87,23 +75,19 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_100ms() {
-        assert_eq!(render_time(100 as u64, 2000), "100ms")
-    }
-    #[test]
     fn test_10s() {
-        assert_eq!(render_time(10 * 1000 as u64, 2000), "10s")
+        assert_eq!(render_time(10 as u64), "10s")
     }
     #[test]
     fn test_90s() {
-        assert_eq!(render_time(90 * 1_000 as u64, 2000), "1m30s")
+        assert_eq!(render_time(90 as u64), "1m30s")
     }
     #[test]
     fn test_10110s() {
-        assert_eq!(render_time(10110 * 1_000 as u64, 2000), "2h48m30s")
+        assert_eq!(render_time(10110 as u64), "2h48m30s")
     }
     #[test]
     fn test_1d() {
-        assert_eq!(render_time(86400 * 1_000 as u64, 2000), "1d")
+        assert_eq!(render_time(86400 as u64), "1d")
     }
 }

--- a/tests/testsuite/cmd_duration.rs
+++ b/tests/testsuite/cmd_duration.rs
@@ -6,11 +6,11 @@ use crate::common::{self, TestCommand};
 #[test]
 fn config_blank_duration_1s() -> io::Result<()> {
     let output = common::render_module("cmd_duration")
-        .arg("--cmd-duration=1000000000")
+        .arg("--cmd-duration=1")
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
-    let expected = format!("{} ", Color::RGB(80, 80, 80).bold().paint("took 1s"));
+    let expected = "";
     assert_eq!(expected, actual);
     Ok(())
 }
@@ -18,7 +18,7 @@ fn config_blank_duration_1s() -> io::Result<()> {
 #[test]
 fn config_blank_duration_5s() -> io::Result<()> {
     let output = common::render_module("cmd_duration")
-        .arg("--cmd-duration=5000000000")
+        .arg("--cmd-duration=5")
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
@@ -32,13 +32,13 @@ fn config_5s_duration_3s() -> io::Result<()> {
     let output = common::render_module("cmd_duration")
         .use_config(toml::toml! {
             [cmd_duration]
-            min_time = 5000
+            min_time = 5
         })
-        .arg("--cmd-duration=3000000000")
+        .arg("--cmd-duration=3")
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
-    let expected = format!("{} ", Color::RGB(80, 80, 80).bold().paint("took 3s"));
+    let expected = "";
     assert_eq!(expected, actual);
     Ok(())
 }
@@ -48,9 +48,9 @@ fn config_5s_duration_10s() -> io::Result<()> {
     let output = common::render_module("cmd_duration")
         .use_config(toml::toml! {
             [cmd_duration]
-            min_time = 5000
+            min_time = 5
         })
-        .arg("--cmd-duration=10000000000")
+        .arg("--cmd-duration=10")
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

As a temporary measure, this PR reverts the command duration change from seconds to milliseconds due to incompatibilities with the macOS date utility.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
