### PR TITLE
refactor: Refactor config.rs to pure functional style

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -281,6 +281,13 @@ mod tests {
     }
 
     #[test]
+    fn table_get_config() {
+        let mut table = toml::value::Table::new();
+        table.insert(String::from("config"), Value::Boolean(true));
+        assert_eq!(table.get_config("config"), Some(&Value::Boolean(true)));
+    }
+
+    #[test]
     fn table_get_as_bool() {
         let mut table = toml::value::Table::new();
 
@@ -325,22 +332,24 @@ mod tests {
     }
 
     #[test]
-    fn table_get_styles_bold_italic_underline_green_silly_caps() {
+    fn table_get_styles_bold_italic_underline_green_dimmy_silly_caps() {
         let mut table = toml::value::Table::new();
 
         table.insert(
             String::from("mystyle"),
-            Value::String(String::from("bOlD ItAlIc uNdErLiNe GrEeN")),
+            Value::String(String::from("bOlD ItAlIc uNdErLiNe GrEeN dimmed")),
         );
         assert!(table.get_as_ansi_style("mystyle").unwrap().is_bold);
         assert!(table.get_as_ansi_style("mystyle").unwrap().is_italic);
         assert!(table.get_as_ansi_style("mystyle").unwrap().is_underline);
+        assert!(table.get_as_ansi_style("mystyle").unwrap().is_dimmed);
         assert_eq!(
             table.get_as_ansi_style("mystyle").unwrap(),
             ansi_term::Style::new()
                 .bold()
                 .italic()
                 .underline()
+                .dimmed()
                 .fg(Color::Green)
         );
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -276,11 +276,9 @@ mod tests {
     fn table_get_as_bool() {
         let mut table = toml::value::Table::new();
 
-        // Use with boolean value
         table.insert(String::from("boolean"), Value::Boolean(true));
         assert_eq!(table.get_as_bool("boolean"), Some(true));
 
-        // Use with string value
         table.insert(String::from("string"), Value::String(String::from("true")));
         assert_eq!(table.get_as_bool("string"), None);
     }
@@ -289,11 +287,9 @@ mod tests {
     fn table_get_as_str() {
         let mut table = toml::value::Table::new();
 
-        // Use with string value
         table.insert(String::from("string"), Value::String(String::from("hello")));
         assert_eq!(table.get_as_str("string"), Some("hello"));
 
-        // Use with boolean value
         table.insert(String::from("boolean"), Value::Boolean(true));
         assert_eq!(table.get_as_str("boolean"), None);
     }
@@ -302,20 +298,28 @@ mod tests {
     fn table_get_as_i64() {
         let mut table = toml::value::Table::new();
 
-        // Use with integer value
         table.insert(String::from("integer"), Value::Integer(82));
         assert_eq!(table.get_as_i64("integer"), Some(82));
 
-        // Use with string value
         table.insert(String::from("string"), Value::String(String::from("82")));
         assert_eq!(table.get_as_bool("string"), None);
     }
 
     #[test]
-    fn table_get_styles_simple() {
+    fn table_get_as_array() {
         let mut table = toml::value::Table::new();
 
-        // Test for a bold italic underline green module (with SiLlY cApS)
+        table.insert(String::from("array"), Value::Array(vec![Value::Integer(1), Value::Integer(2)]));
+        assert_eq!(table.get_as_array("array"), Some(&vec![Value::Integer(1), Value::Integer(2)]));
+
+        table.insert(String::from("string"), Value::String(String::from("82")));
+        assert_eq!(table.get_as_array("string"), None);
+    }
+
+    #[test]
+    fn table_get_styles_bold_italic_underline_green_silly_caps() {
+        let mut table = toml::value::Table::new();
+
         table.insert(
             String::from("mystyle"),
             Value::String(String::from("bOlD ItAlIc uNdErLiNe GrEeN")),
@@ -331,7 +335,11 @@ mod tests {
                 .underline()
                 .fg(Color::Green)
         );
+    }
 
+    #[test]
+    fn table_get_styles_plain_and_broken_styles() {
+        let mut table = toml::value::Table::new();
         // Test a "plain" style with no formatting
         table.insert(String::from("plainstyle"), Value::String(String::from("")));
         assert_eq!(
@@ -356,6 +364,16 @@ mod tests {
         );
         assert_eq!(
             table.get_as_ansi_style("nullified").unwrap(),
+            ansi_term::Style::new()
+        );
+
+        // Test a string that's nullified by `none` at the start
+        table.insert(
+            String::from("nullified-start"),
+            Value::String(String::from("none fg:red bg:green bold")),
+        );
+        assert_eq!(
+            table.get_as_ansi_style("nullified-start").unwrap(),
             ansi_term::Style::new()
         );
     }


### PR DESCRIPTION
Hi maintainers 👋 ! This a bit of a test balloon if you are open to refactorings that move the code base towards a more pure functional style, e.g. avoiding mutable variables or using values instead of return statements. I'm an FP Scala developer by day so please excuse any Rust newbie mistakes made.

#### Description
- Replaced for loop that iterates over mutable state with a fold expression
- Unified the logging for the different accessors. The code is now screaming for further refactoring (`get_module_config`, `get_as_bool`, `get_as_str`, `get_as_i64` and `get_as_array` are basically the same up to higher order functions but I didn't manage to get the life times right)
- Increased test coverage (especially a test case for `none` not at the end)
- Removed code comments that literally repeated the code in the next line (see e.g. https://blog.usejournal.com/stop-writing-code-comments-28fef5272752)
- Added `TODO` for the problematic line that swallows the `None` and produces `Some(Style::new())` (this also happened before but in a less obvious way)

#### Motivation and Context
It increases test coverage, makes reasoning about the error cases easier and should pave the path for better error handling in the config in the future.

#### Types of changes
Behaviour should be identical

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [X] I have tested using **MacOS**
- [X] I have tested using **Docker**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have updated the documentation accordingly. (nothing to update)
- [X] I have updated the tests accordingly.

#### PS
I tried out `tarpaulin` and got a pretty nice coverage xml out of it that I could upload to codecov https://codecov.io/gh/bijancn/starship/src/8ef4843c234c4c026f4ffb26091aa3f1444e686e/src/config.rs . Would be pretty cool to add it to the build but I guess a maintainer has to do it. I've run it locally with
```
docker run --security-opt seccomp=unconfined -v "${PWD}:/volume" xd009642/tarpaulin sh -c "cargo tarpaulin --out Xml "
bash <(curl -s https://codecov.io/bash) -t MY-TOKEN-HERE
```