### PR TITLE
style: Fix rustfmt formatting warnings in CI

### DIFF
--- a/tests/testsuite/git_status.rs
+++ b/tests/testsuite/git_status.rs
@@ -46,10 +46,7 @@ fn shows_behind_with_count() -> io::Result<()> {
         .arg(repo_dir)
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
-    let expected = Color::Red
-        .bold()
-        .paint(format!("[{}] ", "⇣1"))
-        .to_string();
+    let expected = Color::Red.bold().paint(format!("[{}] ", "⇣1")).to_string();
 
     assert_eq!(expected, actual);
 
@@ -101,10 +98,7 @@ fn shows_ahead_with_count() -> io::Result<()> {
         .arg(repo_dir)
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
-    let expected = Color::Red
-        .bold()
-        .paint(format!("[{}] ", "⇡1"))
-        .to_string();
+    let expected = Color::Red.bold().paint(format!("[{}] ", "⇡1")).to_string();
 
     assert_eq!(expected, actual);
 

--- a/tests/testsuite/python.rs
+++ b/tests/testsuite/python.rs
@@ -119,10 +119,7 @@ fn with_virtual_env() -> io::Result<()> {
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
-    let expected = format!(
-        "via {} ",
-        Color::Yellow.bold().paint("🐍 v3.6.9(my_venv)")
-    );
+    let expected = format!("via {} ", Color::Yellow.bold().paint("🐍 v3.6.9(my_venv)"));
     assert_eq!(expected, actual);
     Ok(())
 }


### PR DESCRIPTION
#### Description
I don't know which PR caused this but currently rustfmt will fail due to unformatted code in `tests/testsuite/`.
This will fix the rustfmt CI.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
