### PR TITLE
feat: Add Elixir module.

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -102,6 +102,7 @@ prompt_order = [
     "hg_branch",
     "package",
     "dotnet",
+    "elixir",
     "elm",
     "golang",
     "haskell",
@@ -468,6 +469,29 @@ The module will be shown only if any of the following conditions are met:
 [env_var]
 variable = "SHELL"
 default = "unknown shell"
+```
+
+## Elixir
+
+The `elixir` module shows the currently installed version of Elixir and Erlang/OTP.
+The module will be shown if any of the following conditions are met:
+
+- The current directory contains a `mix.exs` file.
+
+### Options
+
+| Variable   | Default      | Description                                            |
+| ---------- | ------------ | ------------------------------------------------------ |
+| `symbol`   | `"💧 "`      | The symbol used before displaying the version of Rust. |
+| `disabled` | `false`      | Disables the `elixir` module.                          |
+
+### Example
+
+```toml
+# ~/.config/starship.toml
+
+[elixir]
+symbol = "🔮 "
 ```
 
 ## Git Branch

--- a/src/configs/elixir.rs
+++ b/src/configs/elixir.rs
@@ -1,0 +1,25 @@
+use crate::config::{ModuleConfig, RootModuleConfig, SegmentConfig};
+
+use ansi_term::{Color, Style};
+use starship_module_config_derive::ModuleConfig;
+
+#[derive(Clone, ModuleConfig)]
+pub struct ElixirConfig<'a> {
+    pub symbol: SegmentConfig<'a>,
+    pub version: SegmentConfig<'a>,
+    pub otp_version: SegmentConfig<'a>,
+    pub style: Style,
+    pub disabled: bool,
+}
+
+impl<'a> RootModuleConfig<'a> for ElixirConfig<'a> {
+    fn new() -> Self {
+        ElixirConfig {
+            symbol: SegmentConfig::new("💧 "),
+            version: SegmentConfig::default(),
+            otp_version: SegmentConfig::default(),
+            style: Color::Purple.bold(),
+            disabled: false,
+        }
+    }
+}

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -6,6 +6,7 @@ pub mod conda;
 pub mod crystal;
 pub mod directory;
 pub mod dotnet;
+pub mod elixir;
 pub mod elm;
 pub mod env_var;
 pub mod git_branch;

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -31,6 +31,7 @@ impl<'a> RootModuleConfig<'a> for StarshipRootConfig<'a> {
                 // ↓ Toolchain version modules ↓
                 // (Let's keep these sorted alphabetically)
                 "dotnet",
+                "elixir",
                 "elm",
                 "golang",
                 "haskell",

--- a/src/module.rs
+++ b/src/module.rs
@@ -18,6 +18,7 @@ pub const ALL_MODULES: &[&str] = &[
     "conda",
     "directory",
     "dotnet",
+    "elixir",
     "elm",
     "env_var",
     "git_branch",

--- a/src/modules/elixir.rs
+++ b/src/modules/elixir.rs
@@ -1,0 +1,77 @@
+use ansi_term::Color;
+use regex::Regex;
+use std::process::Command;
+
+use super::{Context, Module};
+
+const ELIXIR_VERSION_PATTERN: &str = "\
+Erlang/OTP (?P<otp>\\d+)[^\\n]+
+
+Elixir (?P<elixir>\\d[.\\d]+).*";
+
+/// Create a module with the current Elixir version
+///
+/// Will display the Rust version if any of the following criteria are met:
+///     - Current directory contains a `mix.exs` file
+pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let is_elixir_project = context.try_begin_scan()?.set_files(&["mix.exs"]).is_match();
+
+    if !is_elixir_project {
+        return None;
+    }
+
+    let (otp_version, elixir_version) = get_elixir_version()?;
+
+    let mut module = context.new_module("elixir");
+    let module_style = module
+        .config_value_style("style")
+        .unwrap_or_else(|| Color::Purple.bold());
+    module.set_style(module_style);
+
+    module.new_segment("symbol", "🔮 ");
+    module.new_segment(
+        "version",
+        &format!("{} (OTP {})", elixir_version, otp_version),
+    );
+
+    Some(module)
+}
+
+fn get_elixir_version() -> Option<(String, String)> {
+    let output = Command::new("elixir")
+        .arg("--version")
+        .output()
+        .ok()
+        .and_then(|output| String::from_utf8(output.stdout).ok())?;
+
+    parse_elixir_version(&output)
+}
+
+fn parse_elixir_version(version: &str) -> Option<(String, String)> {
+    let version_regex = Regex::new(ELIXIR_VERSION_PATTERN).ok()?;
+    let captures = version_regex.captures(version)?;
+
+    let otp_version = captures["otp"].to_owned();
+    let elixir_version = captures["elixir"].to_owned();
+
+    Some((otp_version, elixir_version))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_elixir_version() {
+        const OUTPUT: &str = "\
+Erlang/OTP 22 [erts-10.5] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1] [hipe]
+
+Elixir 1.9.0 (compiled with Erlang/OTP 22)
+";
+
+        assert_eq!(
+            parse_elixir_version(OUTPUT),
+            Some(("22".to_owned(), "1.9.0".to_owned()))
+        );
+    }
+}

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -6,6 +6,7 @@ mod conda;
 mod crystal;
 mod directory;
 mod dotnet;
+mod elixir;
 mod elm;
 mod env_var;
 mod git_branch;
@@ -53,6 +54,7 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
         "conda" => conda::module(context),
         "directory" => directory::module(context),
         "dotnet" => dotnet::module(context),
+        "elixir" => elixir::module(context),
         "elm" => elm::module(context),
         "env_var" => env_var::module(context),
         "git_branch" => git_branch::module(context),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -73,6 +73,15 @@ pub fn exec_cmd(cmd: &str, args: &[&str]) -> Option<CommandOutput> {
             stdout: String::from("8.6.5"),
             stderr: String::default(),
         }),
+        "elixir --version" => Some(CommandOutput {
+            stdout: String::from(
+                "\
+Erlang/OTP 22 [erts-10.6.4] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1] [hipe]
+
+Elixir 1.10 (compiled with Erlang/OTP 22)",
+            ),
+            stderr: String::default(),
+        }),
         // If we don't have a mocked command fall back to executing the command
         _ => internal_exec_cmd(&cmd, &args),
     }


### PR DESCRIPTION
#### Description
Add an Elixir module, detecting Elixir and OTP versions when it detects a `mix.exs` file.

#### Motivation and Context
I have some Elixir projects and it missed me to not see versions while many others languages have them displayed.

Closes #149

#### Types of changes
- [x] Add `elixir` module

#### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/183116/65785645-28884600-e155-11e9-9b0b-36eb6adbb93e.png)

#### How Has This Been Tested?
- [x] I added tests for parsing `elixir --version` output.
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
- [x] I have added acceptance tests.
- [ ] Maybe add some more detection code (like testing if there's `.ex` or `exs` files)
