### PR TITLE
fix: Disable memory_usage by default

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -578,6 +578,13 @@ The `memory_usage` module shows current system memory and swap usage.
 
 By default the swap usage is displayed if the total system swap is non-zero.
 
+::: tip
+
+This module is disabled by default.
+To enable it, set `disabled` to `false` in your configuration file.
+
+:::
+
 ### Options
 
 | Variable          | Default                  | Description                                                   |
@@ -587,7 +594,7 @@ By default the swap usage is displayed if the total system swap is non-zero.
 | `threshold`       | `75`                     | Hide the memory usage unless it exceeds this percentage.      |
 | `symbol`          | `"🐏 "`                  | The symbol used before displaying the memory usage.           |
 | `style`           | `"bold dimmed white"`    | The style for the module.                                     |
-| `disabled`        | `false`                  | Disables the `memory_usage` module.                           |
+| `disabled`        | `true`                   | Disables the `memory_usage` module.                           |
 
 ### Example
 

--- a/src/modules/memory_usage.rs
+++ b/src/modules/memory_usage.rs
@@ -12,6 +12,10 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
     let mut module = context.new_module("memory_usage");
 
+    if module.config_value_bool("disabled").unwrap_or(true) {
+        return None;
+    }
+
     let module_style = module
         .config_value_style("style")
         .unwrap_or_else(|| Color::White.bold().dimmed());

--- a/src/modules/time.rs
+++ b/src/modules/time.rs
@@ -7,7 +7,6 @@ use super::{Context, Module};
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let mut module = context.new_module("time");
 
-    // Remove when logic for disabled by default exists
     if module.config_value_bool("disabled").unwrap_or(true) {
         return None;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR disables the `memory_usage` module by default.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The `memory_usage` module is very long  (many characters in length) by default, and can be active in any directory based on current memory usage. For many, this may be considered a little too noisy and unactionable.

The modules we usually have enabled by default should be affected by your working directory, keeping modules that aren't smaller or optional.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
