### PR TITLE
fix: Don't print the first module prefix after a line-break

### DIFF
--- a/src/module.rs
+++ b/src/module.rs
@@ -127,6 +127,11 @@ impl<'a> Module<'a> {
         }
     }
 
+    /// Get module's name
+    pub fn get_name(&self) -> &String {
+        &self._name
+    }
+
     /// Whether a module has non-empty segments
     pub fn is_empty(&self) -> bool {
         self.segments.iter().all(|segment| segment.is_empty())

--- a/src/print.rs
+++ b/src/print.rs
@@ -41,16 +41,20 @@ pub fn prompt(args: ArgMatches) {
         .flatten()
         .collect::<Vec<Module>>(); // Remove segments set to `None`
 
+    let mut print_without_prefix = true;
     let mut printable = modules.iter();
 
-    // Print the first module without its prefix
-    if let Some(first_module) = printable.next() {
-        let module_without_prefix = first_module.to_string_without_prefix();
-        write!(handle, "{}", module_without_prefix).unwrap()
-    }
+    for module in printable {
+        // Skip printing the prefix of a module after the line_break
+        if print_without_prefix {
+            let module_without_prefix = module.to_string_without_prefix();
+            write!(handle, "{}", module_without_prefix).unwrap()
+        } else {
+            write!(handle, "{}", module).unwrap();
+        }
 
-    // Print all remaining modules
-    printable.for_each(|module| write!(handle, "{}", module).unwrap());
+        print_without_prefix = module.get_name() == "line_break"
+    }
 }
 
 pub fn module(module_name: &str, args: ArgMatches) {


### PR DESCRIPTION
#### Description
Not show the prefix of the first module of the 2nd line.
I'd never used Rust before - not sure if there is any more elegant way to do this so feedback is welcome.

#### Motivation and Context
Closes #461

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

<img width="535" alt="Screen Shot 2019-10-02 at 7 57 59 PM" src="https://user-images.githubusercontent.com/616399/66096177-07599800-e54f-11e9-94a0-f77dbe49a555.png">

#### How Has This Been Tested?
I config'ed my prompt to have 2 lines and made sure the prefixes of the 1st modules not show up.

- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
