### PR TITLE
refactor: Rewrite `time` module to use module config

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -867,13 +867,13 @@ To enable it, set `disabled` to `false` in your configuration file.
 
 | Variable   | Default       | Description                                                                                                         |
 | ---------- | ------------- | ------------------------------------------------------------------------------------------------------------------- |
-| `12hr`     | `false`       | Enables 12 hour formatting                                                                                          |
+| `use_12hr` | `false`       | Enables 12 hour formatting                                                                                          |
 | `format`   | see below     | The [chrono format string](https://docs.rs/chrono/0.4.7/chrono/format/strftime/index.html) used to format the time. |
 | `style`    | `bold yellow` | The style for the module time                                                                                       |
 | `disabled` | `true`        | Disables the `time` module.                                                                                         |
 
-If `12hr` is `true`, then `format` defaults to `"%r"`. Otherwise, it defaults to `"%T"`.
-Manually setting `format` will override the `12hr` setting.
+If `use_12hr` is `true`, then `format` defaults to `"%r"`. Otherwise, it defaults to `"%T"`.
+Manually setting `format` will override the `use_12hr` setting.
 
 ### Example
 

--- a/docs/de/config/README.md
+++ b/docs/de/config/README.md
@@ -812,12 +812,12 @@ This module is disabled by default. To enable it, set `disabled` to `false` in y
 
 | Variable   | Default       | Description                                                                                                         |
 | ---------- | ------------- | ------------------------------------------------------------------------------------------------------------------- |
-| `12hr`     | `false`       | Enables 12 hour formatting                                                                                          |
+| `use_12hr`     | `false`       | Enables 12 hour formatting                                                                                          |
 | `format`   | see below     | The [chrono format string](https://docs.rs/chrono/0.4.7/chrono/format/strftime/index.html) used to format the time. |
 | `style`    | `bold yellow` | The style for the module time                                                                                       |
 | `disabled` | `true`        | Disables the `time` module.                                                                                         |
 
-If `12hr` is `true`, then `format` defaults to `"%r"`. Otherwise, it defaults to `"%T"`. Manually setting `format` will override the `12hr` setting.
+If `use_12hr` is `true`, then `format` defaults to `"%r"`. Otherwise, it defaults to `"%T"`. Manually setting `format` will override the `use_12hr` setting.
 
 ### Example
 

--- a/docs/fr/config/README.md
+++ b/docs/fr/config/README.md
@@ -812,12 +812,12 @@ This module is disabled by default. To enable it, set `disabled` to `false` in y
 
 | Variable   | Default       | Description                                                                                                         |
 | ---------- | ------------- | ------------------------------------------------------------------------------------------------------------------- |
-| `12hr`     | `false`       | Enables 12 hour formatting                                                                                          |
+| `use_12hr`     | `false`       | Enables 12 hour formatting                                                                                          |
 | `format`   | see below     | The [chrono format string](https://docs.rs/chrono/0.4.7/chrono/format/strftime/index.html) used to format the time. |
 | `style`    | `bold yellow` | The style for the module time                                                                                       |
 | `disabled` | `true`        | Disables the `time` module.                                                                                         |
 
-If `12hr` is `true`, then `format` defaults to `"%r"`. Otherwise, it defaults to `"%T"`. Manually setting `format` will override the `12hr` setting.
+If `use_12hr` is `true`, then `format` defaults to `"%r"`. Otherwise, it defaults to `"%T"`. Manually setting `format` will override the `use_12hr` setting.
 
 ### Example
 

--- a/docs/ja/config/README.md
+++ b/docs/ja/config/README.md
@@ -813,12 +813,12 @@ This module is disabled by default. To enable it, set `disabled` to `false` in y
 
 | Variable   | Default       | Description                                                                                                         |
 | ---------- | ------------- | ------------------------------------------------------------------------------------------------------------------- |
-| `12hr`     | `false`       | Enables 12 hour formatting                                                                                          |
+| `use_12hr`     | `false`       | Enables 12 hour formatting                                                                                          |
 | `format`   | see below     | The [chrono format string](https://docs.rs/chrono/0.4.7/chrono/format/strftime/index.html) used to format the time. |
 | `style`    | `bold yellow` | The style for the module time                                                                                       |
 | `disabled` | `true`        | Disables the `time` module.                                                                                         |
 
-If `12hr` is `true`, then `format` defaults to `"%r"`. Otherwise, it defaults to `"%T"`. Manually setting `format` will override the `12hr` setting.
+If `use_12hr` is `true`, then `format` defaults to `"%r"`. Otherwise, it defaults to `"%T"`. Manually setting `format` will override the `use_12hr` setting.
 
 ### Example
 

--- a/docs/ru/config/README.md
+++ b/docs/ru/config/README.md
@@ -812,12 +812,12 @@ This module is disabled by default. To enable it, set `disabled` to `false` in y
 
 | Variable   | Default       | Description                                                                                                         |
 | ---------- | ------------- | ------------------------------------------------------------------------------------------------------------------- |
-| `12hr`     | `false`       | Enables 12 hour formatting                                                                                          |
+| `use_12hr`     | `false`       | Enables 12 hour formatting                                                                                          |
 | `format`   | see below     | The [chrono format string](https://docs.rs/chrono/0.4.7/chrono/format/strftime/index.html) used to format the time. |
 | `style`    | `bold yellow` | The style for the module time                                                                                       |
 | `disabled` | `true`        | Disables the `time` module.                                                                                         |
 
-If `12hr` is `true`, then `format` defaults to `"%r"`. Otherwise, it defaults to `"%T"`. Manually setting `format` will override the `12hr` setting.
+If `use_12hr` is `true`, then `format` defaults to `"%r"`. Otherwise, it defaults to `"%T"`. Manually setting `format` will override the `use_12hr` setting.
 
 ### Example
 

--- a/docs/zh/config/README.md
+++ b/docs/zh/config/README.md
@@ -812,12 +812,12 @@ This module is disabled by default. To enable it, set `disabled` to `false` in y
 
 | Variable   | Default       | Description                                                                                                         |
 | ---------- | ------------- | ------------------------------------------------------------------------------------------------------------------- |
-| `12hr`     | `false`       | Enables 12 hour formatting                                                                                          |
+| `use_12hr`     | `false`       | Enables 12 hour formatting                                                                                          |
 | `format`   | see below     | The [chrono format string](https://docs.rs/chrono/0.4.7/chrono/format/strftime/index.html) used to format the time. |
 | `style`    | `bold yellow` | The style for the module time                                                                                       |
 | `disabled` | `true`        | Disables the `time` module.                                                                                         |
 
-If `12hr` is `true`, then `format` defaults to `"%r"`. Otherwise, it defaults to `"%T"`. Manually setting `format` will override the `12hr` setting.
+If `use_12hr` is `true`, then `format` defaults to `"%r"`. Otherwise, it defaults to `"%T"`. Manually setting `format` will override the `use_12hr` setting.
 
 ### Example
 

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -3,6 +3,7 @@ pub mod battery;
 pub mod character;
 pub mod dotnet;
 pub mod rust;
+pub mod time;
 
 use crate::config::{ModuleConfig, RootModuleConfig};
 

--- a/src/configs/time.rs
+++ b/src/configs/time.rs
@@ -1,0 +1,28 @@
+use crate::config::{ModuleConfig, RootModuleConfig, SegmentConfig};
+
+use ansi_term::{Color, Style};
+use starship_module_config_derive::ModuleConfig;
+
+#[derive(Clone, ModuleConfig)]
+pub struct TimeConfig<'a> {
+    pub time: SegmentConfig<'a>,
+    pub use_12hr: bool,
+    pub format: Option<&'a str>,
+    pub style: Style,
+    pub disabled: bool,
+}
+
+impl<'a> RootModuleConfig<'a> for TimeConfig<'a> {
+    fn new() -> Self {
+        TimeConfig {
+            time: SegmentConfig {
+                value: "",
+                style: None,
+            },
+            use_12hr: false,
+            format: None,
+            style: Color::Yellow.bold(),
+            disabled: true,
+        }
+    }
+}

--- a/src/configs/time.rs
+++ b/src/configs/time.rs
@@ -1,11 +1,10 @@
-use crate::config::{ModuleConfig, RootModuleConfig, SegmentConfig};
+use crate::config::{ModuleConfig, RootModuleConfig};
 
 use ansi_term::{Color, Style};
 use starship_module_config_derive::ModuleConfig;
 
 #[derive(Clone, ModuleConfig)]
 pub struct TimeConfig<'a> {
-    pub time: SegmentConfig<'a>,
     pub use_12hr: bool,
     pub format: Option<&'a str>,
     pub style: Style,
@@ -15,10 +14,6 @@ pub struct TimeConfig<'a> {
 impl<'a> RootModuleConfig<'a> for TimeConfig<'a> {
     fn new() -> Self {
         TimeConfig {
-            time: SegmentConfig {
-                value: "",
-                style: None,
-            },
             use_12hr: false,
             format: None,
             style: Color::Yellow.bold(),

--- a/src/modules/time.rs
+++ b/src/modules/time.rs
@@ -11,6 +11,9 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
     let mut module = context.new_module("time");
     let config: TimeConfig = TimeConfig::try_load(module.config);
+    if config.disabled {
+        return None;
+    };
 
     let default_format = if config.use_12hr { "%r" } else { "%T" };
     let time_format = config.format.unwrap_or(default_format);

--- a/src/modules/time.rs
+++ b/src/modules/time.rs
@@ -2,7 +2,7 @@ use chrono::{DateTime, Local};
 
 use super::{Context, Module};
 
-use crate::config::RootModuleConfig;
+use crate::config::{RootModuleConfig, SegmentConfig};
 use crate::configs::time::TimeConfig;
 
 /// Outputs the current time
@@ -27,7 +27,13 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
     module.get_prefix().set_value(TIME_PREFIX);
 
-    module.create_segment("time", &config.time.with_value(&formatted_time_string));
+    module.create_segment(
+        "time",
+        &SegmentConfig {
+            value: &formatted_time_string,
+            style: None,
+        },
+    );
 
     Some(module)
 }

--- a/src/modules/time.rs
+++ b/src/modules/time.rs
@@ -1,29 +1,19 @@
-use ansi_term::Color;
 use chrono::{DateTime, Local};
 
 use super::{Context, Module};
 
+use crate::config::RootModuleConfig;
+use crate::configs::time::TimeConfig;
+
 /// Outputs the current time
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    const TIME_PREFIX: &str = "at ";
+
     let mut module = context.new_module("time");
+    let config: TimeConfig = TimeConfig::try_load(module.config);
 
-    if module.config_value_bool("disabled").unwrap_or(true) {
-        return None;
-    }
-
-    let module_style = module
-        .config_value_style("style")
-        .unwrap_or_else(|| Color::Yellow.bold());
-    module.set_style(module_style);
-
-    // Load module settings
-    let is_12hr = module.config_value_bool("12hr").unwrap_or(false);
-
-    let default_format = if is_12hr { "%r" } else { "%T" };
-    let time_format = module
-        .config_value_str("format")
-        .unwrap_or(default_format)
-        .to_owned();
+    let default_format = if config.use_12hr { "%r" } else { "%T" };
+    let time_format = config.format.unwrap_or(default_format);
 
     log::trace!(
         "Timer module is enabled with format string: {}",
@@ -31,9 +21,13 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     );
 
     let local: DateTime<Local> = Local::now();
-    let formatted_time_string = format_time(&time_format, local);
-    module.new_segment("time", &formatted_time_string);
-    module.get_prefix().set_value("at ");
+    let formatted_time_string = format_time(time_format, local);
+
+    module.set_style(config.style);
+
+    module.get_prefix().set_value(TIME_PREFIX);
+
+    module.create_segment("time", &config.time.with_value(&formatted_time_string));
 
     Some(module)
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Rewrite `time` module to use module config

Since the new module config uses struct fields, we cannot use `12hr` as a config key. So I updated `12hr` to `use_12hr`.

If `ModuleConfig` proc macro has `rename`-like attribute, we can keep backward compatibility.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related #383

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
