### PR TITLE
chore: Remove logic for the `disabled` option from modules

### DIFF
--- a/src/modules/memory_usage.rs
+++ b/src/modules/memory_usage.rs
@@ -12,10 +12,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
     let mut module = context.new_module("memory_usage");
 
-    if module.config_value_bool("disabled").unwrap_or(true) {
-        return None;
-    }
-
     let module_style = module
         .config_value_style("style")
         .unwrap_or_else(|| Color::White.bold().dimmed());

--- a/src/modules/time.rs
+++ b/src/modules/time.rs
@@ -7,10 +7,6 @@ use super::{Context, Module};
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let mut module = context.new_module("time");
 
-    if module.config_value_bool("disabled").unwrap_or(true) {
-        return None;
-    }
-
     let module_style = module
         .config_value_style("style")
         .unwrap_or_else(|| Color::Yellow.bold());

--- a/tests/testsuite/time.rs
+++ b/tests/testsuite/time.rs
@@ -11,13 +11,8 @@ should not display when disabled, should display *something* when enabled,
 and should have the correct prefixes and suffixes in a given config */
 
 #[test]
-fn config_enabled() -> io::Result<()> {
-    let output = common::render_module("time")
-        .use_config(toml::toml! {
-            [time]
-            disabled = false
-        })
-        .output()?;
+fn config_default() -> io::Result<()> {
+    let output = common::render_module("time").output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
     // We can't test what it actually is...but we can assert it's not blank
@@ -30,7 +25,6 @@ fn config_check_prefix_and_suffix() -> io::Result<()> {
     let output = common::render_module("time")
         .use_config(toml::toml! {
             [time]
-            disabled = false
             format = "[%T]"
         })
         .output()?;

--- a/tests/testsuite/time.rs
+++ b/tests/testsuite/time.rs
@@ -26,16 +26,6 @@ fn config_enabled() -> io::Result<()> {
 }
 
 #[test]
-fn config_blank() -> io::Result<()> {
-    let output = common::render_module("time").output()?;
-    let actual = String::from_utf8(output.stdout).unwrap();
-
-    let expected = "";
-    assert_eq!(expected, actual);
-    Ok(())
-}
-
-#[test]
 fn config_check_prefix_and_suffix() -> io::Result<()> {
     let output = common::render_module("time")
         .use_config(toml::toml! {


### PR DESCRIPTION
#### Description
This PR will remove code judging the `disable` option from `src/modules`, as long as related tests.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
