### PR TITLE
fix: Disable Kubernetes module by default

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -574,13 +574,20 @@ can be done via `kubectl config set-context starship-cluster --namespace
 astronaut`. If the `$KUBECONFIG` env var is set the module will use that if
 not it will use the `~/.kube/config`.
 
+::: tip
+
+This module is disabled by default.
+To enable it, set `disabled` to `false` in your configuration file.
+
+:::
+
 ### Options
 
 | Variable   | Default       | Description                                         |
 | ---------- | ------------- | --------------------------------------------------- |
 | `symbol`   | `"☸ "`       | The symbol used before displaying the Cluster info. |
 | `style`    | `"bold blue"` | The style for the module.                           |
-| `disabled` | `false`       | Disables the `kubernetes` module                    |
+| `disabled` | `true`        | Disables the `kubernetes` module                    |
 
 ### Example
 
@@ -590,7 +597,7 @@ not it will use the `~/.kube/config`.
 [kubernetes]
 symbol = "⛵ "
 style = "dim green"
-disabled = true
+disabled = false
 ```
 
 

--- a/src/configs/kubernetes.rs
+++ b/src/configs/kubernetes.rs
@@ -28,7 +28,7 @@ impl<'a> RootModuleConfig<'a> for KubernetesConfig<'a> {
                 style: None,
             },
             style: Color::Cyan.bold(),
-            disabled: false,
+            disabled: true,
         }
     }
 }

--- a/src/configs/kubernetes.rs
+++ b/src/configs/kubernetes.rs
@@ -1,0 +1,34 @@
+use crate::config::{ModuleConfig, RootModuleConfig, SegmentConfig};
+
+use ansi_term::{Color, Style};
+use starship_module_config_derive::ModuleConfig;
+
+#[derive(Clone, ModuleConfig)]
+pub struct KubernetesConfig<'a> {
+    pub symbol: SegmentConfig<'a>,
+    pub context: SegmentConfig<'a>,
+    pub namespace: SegmentConfig<'a>,
+    pub style: Style,
+    pub disabled: bool,
+}
+
+impl<'a> RootModuleConfig<'a> for KubernetesConfig<'a> {
+    fn new() -> Self {
+        KubernetesConfig {
+            symbol: SegmentConfig {
+                value: "☸ ",
+                style: None,
+            },
+            context: SegmentConfig {
+                value: "",
+                style: None,
+            },
+            namespace: SegmentConfig {
+                value: "",
+                style: None,
+            },
+            style: Color::Cyan.bold(),
+            disabled: false,
+        }
+    }
+}

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -2,6 +2,7 @@ pub mod aws;
 pub mod battery;
 pub mod character;
 pub mod dotnet;
+pub mod kubernetes;
 pub mod rust;
 
 use crate::config::{ModuleConfig, RootModuleConfig};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Given the global nature of the Kubernetes module have disabled the
module by default. Have also taken this opertunity to refactor the
Kubernetes module to use the new config module.


#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #484

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.