### PR TITLE
revert: chore: Remove logic for the `disabled` option from modules

### DIFF
--- a/src/modules/memory_usage.rs
+++ b/src/modules/memory_usage.rs
@@ -12,6 +12,10 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
     let mut module = context.new_module("memory_usage");
 
+    if module.config_value_bool("disabled").unwrap_or(true) {
+        return None;
+    }
+
     let module_style = module
         .config_value_style("style")
         .unwrap_or_else(|| Color::White.bold().dimmed());

--- a/src/modules/time.rs
+++ b/src/modules/time.rs
@@ -7,6 +7,10 @@ use super::{Context, Module};
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let mut module = context.new_module("time");
 
+    if module.config_value_bool("disabled").unwrap_or(true) {
+        return None;
+    }
+
     let module_style = module
         .config_value_style("style")
         .unwrap_or_else(|| Color::Yellow.bold());

--- a/tests/testsuite/time.rs
+++ b/tests/testsuite/time.rs
@@ -11,8 +11,13 @@ should not display when disabled, should display *something* when enabled,
 and should have the correct prefixes and suffixes in a given config */
 
 #[test]
-fn config_default() -> io::Result<()> {
-    let output = common::render_module("time").output()?;
+fn config_enabled() -> io::Result<()> {
+    let output = common::render_module("time")
+        .use_config(toml::toml! {
+            [time]
+            disabled = false
+        })
+        .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
     // We can't test what it actually is...but we can assert it's not blank
@@ -21,10 +26,21 @@ fn config_default() -> io::Result<()> {
 }
 
 #[test]
+fn config_blank() -> io::Result<()> {
+    let output = common::render_module("time").output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+
+    let expected = "";
+    assert_eq!(expected, actual);
+    Ok(())
+}
+
+#[test]
 fn config_check_prefix_and_suffix() -> io::Result<()> {
     let output = common::render_module("time")
         .use_config(toml::toml! {
             [time]
+            disabled = false
             format = "[%T]"
         })
         .output()?;


### PR DESCRIPTION
Due to the removal of the `disabled` logic, modules that were previously hidden by default are now shown by default:

![image](https://user-images.githubusercontent.com/4658208/66253184-37977580-e79f-11e9-87ca-f4689c7e4e12.png)

I mistakenly skimmed this PR and thought that these modules were already refactored, leaving the `disabled` logic as unnecessary artifacts before the refactor.

We'll have to revisit this at a later point. 😅 