### PR TITLE
fix: Add disable option to kubernetes module

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -77,14 +77,14 @@ impl<'a> Context<'a> {
         Module::new(name, config)
     }
 
-    /// Check the `disabled` configuration of the module
-    pub fn is_module_enabled(&self, name: &str) -> bool {
+    /// Check if `disabled` option of the module is true in configuration file.
+    pub fn is_module_disabled_in_config(&self, name: &str) -> bool {
         let config = self.config.get_module_config(name);
 
         // If the segment has "disabled" set to "true", don't show it
         let disabled = config.and_then(|table| table.as_table()?.get("disabled")?.as_bool());
 
-        disabled != Some(true)
+        disabled == Some(true)
     }
 
     // returns a new ScanDir struct with reference to current dir_files of context

--- a/src/modules/kubernetes.rs
+++ b/src/modules/kubernetes.rs
@@ -53,6 +53,9 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
             let mut module = context.new_module("kubernetes");
             let config: KubernetesConfig = KubernetesConfig::try_load(module.config);
+            if config.disabled {
+                return None;
+            };
 
             module.set_style(config.style);
             module.get_prefix().set_value(KUBERNETES_PREFIX);

--- a/src/print.rs
+++ b/src/print.rs
@@ -36,7 +36,7 @@ pub fn prompt(args: ArgMatches) {
 
     let modules = &prompt_order
         .par_iter()
-        .filter(|module| context.is_module_enabled(module))
+        .filter(|module| !context.is_module_disabled_in_config(module))
         .map(|module| modules::handle(module, &context)) // Compute modules
         .flatten()
         .collect::<Vec<Module>>(); // Remove segments set to `None`


### PR DESCRIPTION
#### Description
This PR adds one line to skip the module if it is not enabled in the config.
It also renames `fn is_module_enabled` to better reflex its functionality.

#### Motivation and Context
I used to think `is_module_enabled` has a higher order functionality to judge if the module is disabled, but it turns out it only reads the user's config and ignores the default one. (Thanks to @andytom to point it out!)
Related #484 #486 #489

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
