### PR TITLE
refactor: Rewrite is_module_enabled

### DIFF
--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -59,3 +59,18 @@ impl<'a> RootModuleConfig<'a> for StarshipRootConfig<'a> {
         }
     }
 }
+
+/// Get the default disabled option in a module by name
+pub fn is_module_disabled_by_default(name: &str) -> bool {
+    match name {
+        "aws" => aws::AwsConfig::new().disabled,
+        "battery" => battery::BatteryConfig::new().disabled,
+        "character" => character::CharacterConfig::new().disabled,
+        "conda" => conda::CondaConfig::new().disabled,
+        "dotnet" => dotnet::DotnetConfig::new().disabled,
+        "kubernetes" => kubernetes::KubernetesConfig::new().disabled,
+        "rust" => rust::RustConfig::new().disabled,
+        "time" => time::TimeConfig::new().disabled,
+        _ => true,
+    }
+}

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,4 +1,5 @@
 use crate::config::StarshipConfig;
+use crate::configs::is_module_disabled_by_default;
 use crate::module::Module;
 
 use clap::ArgMatches;
@@ -77,14 +78,18 @@ impl<'a> Context<'a> {
         Module::new(name, config)
     }
 
-    /// Check if `disabled` option of the module is true in configuration file.
-    pub fn is_module_disabled_in_config(&self, name: &str) -> bool {
+    /// Check the `disabled` configuration of the module
+    pub fn is_module_enabled(&self, name: &str) -> bool {
         let config = self.config.get_module_config(name);
 
-        // If the segment has "disabled" set to "true", don't show it
-        let disabled = config.and_then(|table| table.as_table()?.get("disabled")?.as_bool());
+        // Check the disabled option in the config
+        let config_disabled = config.and_then(|table| table.as_table()?.get("disabled")?.as_bool());
 
-        disabled == Some(true)
+        if let Some(disabled) = config_disabled {
+            disabled
+        } else {
+            is_module_disabled_by_default(name)
+        }
     }
 
     // returns a new ScanDir struct with reference to current dir_files of context

--- a/src/print.rs
+++ b/src/print.rs
@@ -36,7 +36,7 @@ pub fn prompt(args: ArgMatches) {
 
     let modules = &prompt_order
         .par_iter()
-        .filter(|module| !context.is_module_disabled_in_config(module))
+        .filter(|module| context.is_module_enabled(module))
         .map(|module| modules::handle(module, &context)) // Compute modules
         .flatten()
         .collect::<Vec<Module>>(); // Remove segments set to `None`


### PR DESCRIPTION
#### Description
This PR disables modules in `print.rs`.

It seems that we cannot multiple types with shared trait as return type. (#491)

Also, #486 can be safely merged after this PR got merged.

#### Motivation and Context
Related #486 #491

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
