### PR TITLE
feat: Show Java icon and info when build.sbt detected

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -712,7 +712,7 @@ style = "bold dimmed green"
 The `java` module shows the currently installed version of Java.
 The module will be shown if any of the following conditions are met:
 
-- The current directory contains a `pom.xml` or `build.gradle` file
+- The current directory contains a `pom.xml`, `build.gradle` or `build.sbt` file
 - The current directory contains a file with the `.java`, `.class` or `.jar` extension
 
 ### Options

--- a/src/modules/java.rs
+++ b/src/modules/java.rs
@@ -8,11 +8,11 @@ use super::{Context, Module};
 ///
 /// Will display the Java version if any of the following criteria are met:
 ///     - Current directory contains a file with a `.java`, `.class` or `.jar` extension
-///     - Current directory contains a `pom.xml` or `build.gradle` file
+///     - Current directory contains a `pom.xml`, `build.gradle` or `build.sbt` file
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let is_java_project = context
         .try_begin_scan()?
-        .set_files(&["pom.xml", "build.gradle"])
+        .set_files(&["pom.xml", "build.gradle", "build.sbt"])
         .set_extensions(&["java", "class", "jar"])
         .is_match();
 


### PR DESCRIPTION
#### Description
Java information is also displayed when a build.sbt file is present.

#### Motivation and Context
Closes #467 

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [X] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
