### PR TITLE
refactor: Allow starship to be better used programmatically

### DIFF
--- a/src/print.rs
+++ b/src/print.rs
@@ -1,5 +1,6 @@
 use clap::ArgMatches;
 use rayon::prelude::*;
+use std::fmt::Write as FmtWrite;
 use std::io::{self, Write};
 
 use crate::context::Context;
@@ -9,14 +10,18 @@ use crate::modules;
 
 pub fn prompt(args: ArgMatches) {
     let context = Context::new(args);
-    let config = context.config.get_root_config();
-
     let stdout = io::stdout();
     let mut handle = stdout.lock();
+    write!(handle, "{}", get_prompt(context)).unwrap();
+}
+
+pub fn get_prompt(context: Context) -> String {
+    let config = context.config.get_root_config();
+    let mut buf = String::new();
 
     // Write a new line before the prompt
     if config.add_newline {
-        writeln!(handle).unwrap();
+        writeln!(buf).unwrap();
     }
 
     let mut prompt_order: Vec<&str> = Vec::new();
@@ -48,13 +53,15 @@ pub fn prompt(args: ArgMatches) {
         // Skip printing the prefix of a module after the line_break
         if print_without_prefix {
             let module_without_prefix = module.to_string_without_prefix();
-            write!(handle, "{}", module_without_prefix).unwrap()
+            write!(buf, "{}", module_without_prefix).unwrap()
         } else {
-            write!(handle, "{}", module).unwrap();
+            write!(buf, "{}", module).unwrap();
         }
 
         print_without_prefix = module.get_name() == "line_break"
     }
+
+    buf
 }
 
 pub fn module(module_name: &str, args: ArgMatches) {


### PR DESCRIPTION
#### Description

This makes it easier to embed Starship into other Rust programs such as shells written in Rust. It also decouples the arguments from the context for more programmatic initialisation of the context.

#### Motivation and Context

Partially this issue: https://github.com/nushell/nushell/issues/356 and also just making it easier to use Starship as a Rust library for those building shells in Rust.

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


#### How Has This Been Tested?

Kind of N/A I suppose since the change is internal and tiny.

- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
