### PR TITLE
feat: Add Nim module

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -643,6 +643,29 @@ The `line_break` module separates the prompt into two lines.
 disabled = true
 ```
 
+## Nim
+
+The `nim` module shows the Nim compiler version.
+The module will be shown when inside a directory with a `*.nimble` file.
+
+### Options
+
+| Variable   | Default         | Description                                             |
+| ---------- | --------------- | ------------------------------------------------------- |
+| `symbol`   | `"👑 "`         | The symbol used before displaying the compiler version. |
+| `style`    | `"bold yellow"` | The style for the module.                               |
+| `disabled` | `false`         | Disables the `nim` module.                              |
+
+### Example
+
+```toml
+# ~/.config/starship.toml
+
+[nim]
+symbol = "💛 "
+style = "dim yellow"
+```
+
 ## Nix-shell
 
 The `nix_shell` module shows the nix-shell environment.

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -6,6 +6,7 @@ pub mod dotnet;
 pub mod hostname;
 pub mod jobs;
 pub mod kubernetes;
+pub mod nim;
 pub mod rust;
 pub mod time;
 
@@ -40,6 +41,7 @@ impl<'a> RootModuleConfig<'a> for StarshipRootConfig<'a> {
                 "dotnet",
                 "golang",
                 "java",
+                "nim",
                 "nodejs",
                 "python",
                 "ruby",

--- a/src/configs/nim.rs
+++ b/src/configs/nim.rs
@@ -1,0 +1,29 @@
+use crate::config::{ModuleConfig, RootModuleConfig, SegmentConfig};
+
+use ansi_term::{Color, Style};
+use starship_module_config_derive::ModuleConfig;
+
+#[derive(Clone, ModuleConfig)]
+pub struct NimConfig<'a> {
+    pub symbol: SegmentConfig<'a>,
+    pub environment: SegmentConfig<'a>,
+    pub style: Style,
+    pub disabled: bool,
+}
+
+impl<'a> RootModuleConfig<'a> for NimConfig<'a> {
+    fn new() -> Self {
+        NimConfig {
+            symbol: SegmentConfig {
+                value: "👑 ",
+                style: None,
+            },
+            environment: SegmentConfig {
+                value: "",
+                style: None,
+            },
+            style: Color::Yellow.bold(),
+            disabled: false,
+        }
+    }
+}

--- a/src/module.rs
+++ b/src/module.rs
@@ -27,6 +27,7 @@ pub const ALL_MODULES: &[&str] = &[
     "kubernetes",
     "line_break",
     "memory_usage",
+    "nim",
     "nix_shell",
     "nodejs",
     "package",

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -16,6 +16,7 @@ mod jobs;
 mod kubernetes;
 mod line_break;
 mod memory_usage;
+mod nim;
 mod nix_shell;
 mod nodejs;
 mod package;
@@ -55,6 +56,7 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
         "kubernetes" => kubernetes::module(context),
         "line_break" => line_break::module(context),
         "memory_usage" => memory_usage::module(context),
+        "nim" => nim::module(context),
         "nix_shell" => nix_shell::module(context),
         "nodejs" => nodejs::module(context),
         "package" => package::module(context),

--- a/src/modules/nim.rs
+++ b/src/modules/nim.rs
@@ -1,0 +1,98 @@
+use std::process::Command;
+
+use super::{Context, Module};
+
+use crate::config::RootModuleConfig;
+use crate::configs::nim::NimConfig;
+
+/// Creates a module with the current Nim environment
+///
+/// Will display the Nim environment if `*.nimble` is found in the directory.
+pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let is_nim_project = context
+        .try_begin_scan()?
+        .set_extensions(&["nimble"])
+        .is_match();
+
+    if !is_nim_project {
+        return None;
+    }
+
+    match get_nim_version() {
+        Some(raw_nim_version) => {
+            let nim_version = format_nim_version(&raw_nim_version)?;
+
+            let mut module = context.new_module("nim");
+            let config = NimConfig::try_load(module.config);
+
+            module.set_style(config.style);
+
+            module.create_segment("symbol", &config.symbol);
+            module.create_segment("environment", &config.environment.with_value(&nim_version));
+
+            Some(module)
+        }
+        None => None,
+    }
+}
+
+fn get_nim_version() -> Option<String> {
+    match Command::new("nim").arg("--version").output() {
+        Ok(output) => Some(String::from_utf8(output.stdout).unwrap()),
+        Err(_) => None,
+    }
+}
+
+fn format_nim_version(nim_version: &str) -> Option<String> {
+    let version = nim_version
+        // split into ["Nim", "Compiler", "Version", "0.19.4", "[Linux:", "amd64]", ...]
+        .split_whitespace()
+        // return "0.19.4"
+        .nth(3)?;
+
+    let mut formatted_version = String::with_capacity(version.len() + 1);
+    formatted_version.push('v');
+    formatted_version.push_str(version);
+    Some(formatted_version)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_nim_version() {
+        let nim_output = "Nim Compiler Version 0.19.4 [Linux: amd64]
+Compiled at 2019-03-05
+Copyright (c) 2006-2018 by Andreas Rumpf
+
+active boot switches: -d:release";
+
+        let actual = format_nim_version(nim_output).unwrap();
+        assert_eq!(actual, "v0.19.4");
+    }
+
+    #[test]
+    fn test_format_nim_version_with_short_version() {
+        let nim_output = "Nim Compiler Version 1.2.3 [Linux: amd64]
+Compiled at 2019-03-05
+Copyright (c) 2006-2018 by Andreas Rumpf
+
+active boot switches: -d:release";
+
+        let actual = format_nim_version(nim_output).unwrap();
+        assert_eq!(actual, "v1.2.3");
+    }
+
+    #[test]
+    fn test_format_nim_version_with_long_version() {
+        let nim_output = "Nim Compiler Version 999.888.777 [Linux: amd64]
+Compiled at 2019-03-05
+Copyright (c) 2006-2018 by Andreas Rumpf
+
+active boot switches: -d:release";
+
+        let actual = format_nim_version(nim_output).unwrap();
+        assert_eq!(actual, "v999.888.777");
+    }
+}

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -15,6 +15,7 @@ mod hostname;
 mod jobs;
 mod line_break;
 mod modules;
+mod nim;
 mod nix_shell;
 mod nodejs;
 mod python;

--- a/tests/testsuite/nim.rs
+++ b/tests/testsuite/nim.rs
@@ -1,0 +1,22 @@
+use std::fs::File;
+use std::io;
+
+use ansi_term::Color;
+
+use crate::common;
+
+#[test]
+fn folder_with_nim_version() -> io::Result<()> {
+    let dir = common::new_tempdir()?;
+    File::create(dir.path().join("nim_test.nimble"))?;
+
+    let output = common::render_module("nim")
+        .arg("--path")
+        .arg(dir.path())
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+
+    let expected = format!("via {} ", Color::Yellow.bold().paint("👑 v0.19.4"));
+    assert_eq!(expected, actual);
+    Ok(())
+}


### PR DESCRIPTION
#### Description
I've added a module that displays the Nim compiler version when in the presence of `*.nimble` files.

#### Motivation and Context
Closes #159 

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots:
![Screenshot from 2019-10-11 07-31-38](https://user-images.githubusercontent.com/7308850/66651660-362fd800-ebf9-11e9-92d0-3def8e177542.png)

#### How Has This Been Tested?
I've added unit tests of the version string formatter I added to pull the version number out of the data provided by `nim --version`.

I've also added a test to the test suite to verify the right data is displayed when in a folder with a `*.nimble` file.

- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
