### PR TITLE
fix: Show leading slash when truncating from root

### DIFF
--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -142,7 +142,13 @@ fn truncate(dir_string: String, length: usize) -> String {
         return dir_string;
     }
 
-    let components = dir_string.split('/').collect::<Vec<&str>>();
+    let mut components = dir_string.split('/').collect::<Vec<&str>>();
+
+    // If the first element is "" then there was a leading "/" and we should remove it so we can check the actual count of components
+    if (components[0] == "") {
+        components.remove(0);
+    }
+
     if components.len() <= length {
         return dir_string;
     }

--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -280,6 +280,20 @@ mod tests {
     }
 
     #[test]
+    fn truncate_same_path_as_provided_length_from_root() {
+        let path = "/starship/engines/booster";
+        let output = truncate(path.to_string(), 3);
+        assert_eq!(output, "/starship/engines/booster");
+    }
+
+    #[test]
+    fn truncate_larger_path_than_provided_length_from_root() {
+        let path = "/starship/engines/booster/rocket";
+        let output = truncate(path.to_string(), 3);
+        assert_eq!(output, "engines/booster/rocket");
+    }
+
+    #[test]
     fn fish_style_with_user_home_contracted_path() {
         let path = "~/starship/engines/booster/rocket";
         let output = to_fish_style(1, path.to_string(), "engines/booster/rocket");


### PR DESCRIPTION
#### Description
Fixed a bug on unix systems where the leading `/` of the path was being removed when exactly `truncation_length` directories deep into a path.

The issue was that the method used to find the depth leveraged a `<string>.split('/')` which resulted in a vector of `["", "foo", "bar", "baz"]` instead of `["foo", "bar", "baz"]`. This resulted in the leading `/` being removed because the logic considered the user to be 4 directories deep when they were actually only 3 directories deep.

#### Motivation and Context
Closes #458 

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots:
It works!
![Screenshot from 2019-10-11 21-12-58](https://user-images.githubusercontent.com/7308850/66693370-db849380-ec6d-11e9-949c-39fab54bc0fa.png)

#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [N/A] I have updated the documentation accordingly.
- [N/A] I have updated the tests accordingly.
