### PR TITLE
build: Improve release binary optimization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,10 @@ yaml-rust = "0.4"
 [dev-dependencies]
 tempfile = "3.1.0"
 
+[profile.release]
+codegen-units = 1
+lto = true
+
 [[bin]]
 name = "starship"
 path = "src/main.rs"


### PR DESCRIPTION
#### Description
Currently, the release profile uses Cargo defaults. It *might* be useful to enable common optimizations - allowing LTO and improving optimization opportunities by restricting parallel code generation.

#### Motivation and Context
Numerous projects opt for these options to gain runtime speed and/or smaller binary size at the expense of release build compile times. Since this project aims to run blazing fast it seems like a good fit.

_Feel free to reject this PR if not suitable!_

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### How Has This Been Tested?
No reliable runtime benchmarking has been performed. Please, suggest a methodology if you have one.

Release binary sizes with and without the optimizations enabled (and the stripped versions):

`-rwxr-xr-x 1 foo foo 6619120 Oct 12 10:26 starship_v22`
`-rwxr-xr-x 1 foo foo 4773088 Oct 12 10:28 starship_v22_lto`
`-rwxr-xr-x 1 foo foo 3723104 Oct 12 10:26 starship_v22_stripped`
`-rwxr-xr-x 1 foo foo 3219312 Oct 12 10:29 starship_v22_lto_stripped`

- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
