### PR TITLE
docs: Add x86-64 linux binary installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ The prompt shows information you need while you're working, while staying sleek 
    Download a prebuilt binary and place in /usr/local/bin/
 
    ```sh
-   $ curl -s https://api.github.com/repos/starship/starship/releases/latest   | grep browser_download_url   | grep x86_64-unknown-linux-gnu   | cut -d '"' -f 4   | wget -qi -
+   $ wget -q --show-progress https://github.com/starship/starship/releases/latest/download/starship-x86_64-unknown-linux-gnu.tar.gz
    $ tar xvf starship-*.tar.gz
    $ sudo mv starship /usr/local/bin/
    ```

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ The prompt shows information you need while you're working, while staying sleek 
 
    ```sh
    $ wget -q --show-progress https://github.com/starship/starship/releases/latest/download/starship-x86_64-unknown-linux-gnu.tar.gz
-   $ tar xvf starship-*.tar.gz
+   $ tar xvf starship-x86_64-unknown-linux-gnu.tar.gz
    $ sudo mv starship /usr/local/bin/
    ```
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,16 @@ The prompt shows information you need while you're working, while staying sleek 
    ```sh
    $ pkg install starship
    ```
+   
+   #### Other x86-64 Linux Platforms
+   
+   Download a prebuilt binary and place in /usr/local/bin/
+
+   ```sh
+   $ curl -s https://api.github.com/repos/starship/starship/releases/latest   | grep browser_download_url   | grep x86_64-unknown-linux-gnu   | cut -d '"' -f 4   | wget -qi -
+   $ tar xvf starship-*.tar.gz
+   $ sudo mv starship /usr/local/bin/
+   ```
 
 1. Add the init script to your shell's config file:
 


### PR DESCRIPTION
Added installation method for generic x64 Linux to README.md (tested method on Ubuntu 16.04 / bash)