### PR TITLE
refactor: Replace tempdir test utility with tempfile::tempdir

### DIFF
--- a/tests/testsuite/aws.rs
+++ b/tests/testsuite/aws.rs
@@ -2,6 +2,7 @@ use std::fs::File;
 use std::io::{self, Write};
 
 use ansi_term::Color;
+use tempfile;
 
 use crate::common;
 
@@ -53,7 +54,7 @@ fn profile_set() -> io::Result<()> {
 
 #[test]
 fn default_profile_set() -> io::Result<()> {
-    let dir = common::new_tempdir()?;
+    let dir = tempfile::tempdir()?;
     let config_path = dir.path().join("config");
     let mut file = File::create(&config_path)?;
 
@@ -79,7 +80,7 @@ region = us-east-2
 
 #[test]
 fn profile_and_config_set() -> io::Result<()> {
-    let dir = common::new_tempdir()?;
+    let dir = tempfile::tempdir()?;
     let config_path = dir.path().join("config");
     let mut file = File::create(&config_path)?;
 

--- a/tests/testsuite/common.rs
+++ b/tests/testsuite/common.rs
@@ -36,17 +36,10 @@ pub fn render_module(module_name: &str) -> process::Command {
     command
 }
 
-/// Create a temporary directory with full access permissions (rwxrwxrwt).
-pub fn new_tempdir() -> io::Result<tempfile::TempDir> {
-    //  Using `tempfile::TempDir` directly creates files on macOS within
-    // "/var/folders", which provides us with restricted permissions (rwxr-xr-x)
-    tempfile::tempdir_in("/tmp")
-}
-
 /// Create a repo from the fixture to be used in git module tests
 pub fn create_fixture_repo() -> io::Result<PathBuf> {
-    let fixture_repo_path = new_tempdir()?.path().join("fixture");
-    let repo_path = new_tempdir()?.path().join("rocket");
+    let fixture_repo_path = tempfile::tempdir()?.path().join("fixture");
+    let repo_path = tempfile::tempdir()?.path().join("rocket");
     let fixture_path = env::current_dir()?.join("tests/fixtures/rocket.bundle");
 
     let fixture_repo_dir = path_str(&fixture_repo_path)?;

--- a/tests/testsuite/dotnet.rs
+++ b/tests/testsuite/dotnet.rs
@@ -2,7 +2,7 @@ use super::common;
 use std::fs::{DirBuilder, OpenOptions};
 use std::io::{self, Error, ErrorKind, Write};
 use std::process::{Command, Stdio};
-use tempfile::TempDir;
+use tempfile::{self, TempDir};
 
 #[test]
 #[ignore]
@@ -81,7 +81,7 @@ fn shows_pinned_in_deeply_nested_project_within_repository() -> io::Result<()> {
 }
 
 fn create_workspace(is_repo: bool) -> io::Result<TempDir> {
-    let repo_dir = common::new_tempdir()?;
+    let repo_dir = tempfile::tempdir()?;
 
     if is_repo {
         let mut command = Command::new("git");

--- a/tests/testsuite/git_state.rs
+++ b/tests/testsuite/git_state.rs
@@ -3,6 +3,7 @@ use std::ffi::OsStr;
 use std::fs::OpenOptions;
 use std::io::{self, Error, ErrorKind, Write};
 use std::process::{Command, Stdio};
+use tempfile;
 
 #[test]
 #[ignore]
@@ -115,7 +116,7 @@ where
 }
 
 fn create_repo_with_conflict() -> io::Result<tempfile::TempDir> {
-    let repo_dir = common::new_tempdir()?;
+    let repo_dir = tempfile::tempdir()?;
     let path = path_str(&repo_dir)?;
     let conflicted_file = repo_dir.path().join("the_file");
 

--- a/tests/testsuite/golang.rs
+++ b/tests/testsuite/golang.rs
@@ -1,12 +1,13 @@
 use ansi_term::Color;
 use std::fs::{self, File};
 use std::io;
+use tempfile;
 
 use crate::common;
 
 #[test]
 fn folder_without_go_files() -> io::Result<()> {
-    let dir = common::new_tempdir()?;
+    let dir = tempfile::tempdir()?;
 
     let output = common::render_module("golang")
         .arg("--path")
@@ -22,7 +23,7 @@ fn folder_without_go_files() -> io::Result<()> {
 #[test]
 #[ignore]
 fn folder_with_go_file() -> io::Result<()> {
-    let dir = common::new_tempdir()?;
+    let dir = tempfile::tempdir()?;
     File::create(dir.path().join("main.go"))?;
 
     let output = common::render_module("golang")
@@ -39,7 +40,7 @@ fn folder_with_go_file() -> io::Result<()> {
 #[test]
 #[ignore]
 fn folder_with_go_mod() -> io::Result<()> {
-    let dir = common::new_tempdir()?;
+    let dir = tempfile::tempdir()?;
     File::create(dir.path().join("go.mod"))?;
 
     let output = common::render_module("golang")
@@ -56,7 +57,7 @@ fn folder_with_go_mod() -> io::Result<()> {
 #[test]
 #[ignore]
 fn folder_with_go_sum() -> io::Result<()> {
-    let dir = common::new_tempdir()?;
+    let dir = tempfile::tempdir()?;
     File::create(dir.path().join("go.sum"))?;
 
     let output = common::render_module("golang")
@@ -73,7 +74,7 @@ fn folder_with_go_sum() -> io::Result<()> {
 #[test]
 #[ignore]
 fn folder_with_godeps() -> io::Result<()> {
-    let dir = common::new_tempdir()?;
+    let dir = tempfile::tempdir()?;
     let godeps = dir.path().join("Godeps");
     fs::create_dir_all(&godeps)?;
 
@@ -91,7 +92,7 @@ fn folder_with_godeps() -> io::Result<()> {
 #[test]
 #[ignore]
 fn folder_with_glide_yaml() -> io::Result<()> {
-    let dir = common::new_tempdir()?;
+    let dir = tempfile::tempdir()?;
     File::create(dir.path().join("glide.yaml"))?;
 
     let output = common::render_module("golang")
@@ -108,7 +109,7 @@ fn folder_with_glide_yaml() -> io::Result<()> {
 #[test]
 #[ignore]
 fn folder_with_gopkg_yml() -> io::Result<()> {
-    let dir = common::new_tempdir()?;
+    let dir = tempfile::tempdir()?;
     File::create(dir.path().join("Gopkg.yml"))?;
 
     let output = common::render_module("golang")
@@ -125,7 +126,7 @@ fn folder_with_gopkg_yml() -> io::Result<()> {
 #[test]
 #[ignore]
 fn folder_with_gopkg_lock() -> io::Result<()> {
-    let dir = common::new_tempdir()?;
+    let dir = tempfile::tempdir()?;
     File::create(dir.path().join("Gopkg.lock"))?;
 
     let output = common::render_module("golang")

--- a/tests/testsuite/nodejs.rs
+++ b/tests/testsuite/nodejs.rs
@@ -1,12 +1,13 @@
 use ansi_term::Color;
 use std::fs::{self, File};
 use std::io;
+use tempfile;
 
 use crate::common;
 
 #[test]
 fn folder_without_node_files() -> io::Result<()> {
-    let dir = common::new_tempdir()?;
+    let dir = tempfile::tempdir()?;
 
     let output = common::render_module("nodejs")
         .arg("--path")
@@ -22,7 +23,7 @@ fn folder_without_node_files() -> io::Result<()> {
 #[test]
 #[ignore]
 fn folder_with_package_json() -> io::Result<()> {
-    let dir = common::new_tempdir()?;
+    let dir = tempfile::tempdir()?;
     File::create(dir.path().join("package.json"))?;
 
     let output = common::render_module("nodejs")
@@ -39,7 +40,7 @@ fn folder_with_package_json() -> io::Result<()> {
 #[test]
 #[ignore]
 fn folder_with_js_file() -> io::Result<()> {
-    let dir = common::new_tempdir()?;
+    let dir = tempfile::tempdir()?;
     File::create(dir.path().join("index.js"))?;
 
     let output = common::render_module("nodejs")
@@ -56,7 +57,7 @@ fn folder_with_js_file() -> io::Result<()> {
 #[test]
 #[ignore]
 fn folder_with_node_modules() -> io::Result<()> {
-    let dir = common::new_tempdir()?;
+    let dir = tempfile::tempdir()?;
     let node_modules = dir.path().join("node_modules");
     fs::create_dir_all(&node_modules)?;
 

--- a/tests/testsuite/python.rs
+++ b/tests/testsuite/python.rs
@@ -2,13 +2,14 @@ use std::fs::File;
 use std::io;
 
 use ansi_term::Color;
+use tempfile;
 
 use crate::common;
 
 #[test]
 #[ignore]
 fn folder_with_python_version() -> io::Result<()> {
-    let dir = common::new_tempdir()?;
+    let dir = tempfile::tempdir()?;
     File::create(dir.path().join(".python-version"))?;
 
     let output = common::render_module("python")
@@ -25,7 +26,7 @@ fn folder_with_python_version() -> io::Result<()> {
 #[test]
 #[ignore]
 fn folder_with_requirements_txt() -> io::Result<()> {
-    let dir = common::new_tempdir()?;
+    let dir = tempfile::tempdir()?;
     File::create(dir.path().join("requirements.txt"))?;
 
     let output = common::render_module("python")
@@ -42,7 +43,7 @@ fn folder_with_requirements_txt() -> io::Result<()> {
 #[test]
 #[ignore]
 fn folder_with_pyproject_toml() -> io::Result<()> {
-    let dir = common::new_tempdir()?;
+    let dir = tempfile::tempdir()?;
     File::create(dir.path().join("pyproject.toml"))?;
 
     let output = common::render_module("python")
@@ -59,7 +60,7 @@ fn folder_with_pyproject_toml() -> io::Result<()> {
 #[test]
 #[ignore]
 fn folder_with_pipfile() -> io::Result<()> {
-    let dir = common::new_tempdir()?;
+    let dir = tempfile::tempdir()?;
     File::create(dir.path().join("Pipfile"))?;
 
     let output = common::render_module("python")
@@ -76,7 +77,7 @@ fn folder_with_pipfile() -> io::Result<()> {
 #[test]
 #[ignore]
 fn folder_with_tox() -> io::Result<()> {
-    let dir = common::new_tempdir()?;
+    let dir = tempfile::tempdir()?;
     File::create(dir.path().join("tox.ini"))?;
 
     let output = common::render_module("python")
@@ -93,7 +94,7 @@ fn folder_with_tox() -> io::Result<()> {
 #[test]
 #[ignore]
 fn folder_with_py_file() -> io::Result<()> {
-    let dir = common::new_tempdir()?;
+    let dir = tempfile::tempdir()?;
     File::create(dir.path().join("main.py"))?;
 
     let output = common::render_module("python")
@@ -110,7 +111,7 @@ fn folder_with_py_file() -> io::Result<()> {
 #[test]
 #[ignore]
 fn with_virtual_env() -> io::Result<()> {
-    let dir = common::new_tempdir()?;
+    let dir = tempfile::tempdir()?;
     File::create(dir.path().join("main.py"))?;
     let output = common::render_module("python")
         .env("VIRTUAL_ENV", "/foo/bar/my_venv")

--- a/tests/testsuite/ruby.rs
+++ b/tests/testsuite/ruby.rs
@@ -1,12 +1,13 @@
 use ansi_term::Color;
 use std::fs::File;
 use std::io;
+use tempfile;
 
 use crate::common;
 
 #[test]
 fn folder_without_ruby_files() -> io::Result<()> {
-    let dir = common::new_tempdir()?;
+    let dir = tempfile::tempdir()?;
 
     let output = common::render_module("ruby")
         .arg("--path")
@@ -22,7 +23,7 @@ fn folder_without_ruby_files() -> io::Result<()> {
 #[test]
 #[ignore]
 fn folder_with_gemfile() -> io::Result<()> {
-    let dir = common::new_tempdir()?;
+    let dir = tempfile::tempdir()?;
     File::create(dir.path().join("Gemfile"))?;
 
     let output = common::render_module("ruby")
@@ -39,7 +40,7 @@ fn folder_with_gemfile() -> io::Result<()> {
 #[test]
 #[ignore]
 fn folder_with_rb_file() -> io::Result<()> {
-    let dir = common::new_tempdir()?;
+    let dir = tempfile::tempdir()?;
     File::create(dir.path().join("any.rb"))?;
 
     let output = common::render_module("ruby")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

We used to run into problems when running tests with tempdirs in Docker, but it looks like the problem has solved itself (perhaps in an update for tempfile or Docker).

This PR removes the test utility used for creating tempdirs and instead uses `tempfile::tempdir` directly. 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
