### PR TITLE
refactor: improve as-a-library usage by removing ArgMatches dependencies

### DIFF
--- a/src/modules/character.rs
+++ b/src/modules/character.rs
@@ -22,17 +22,20 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let config: CharacterConfig = CharacterConfig::try_load(module.config);
     module.get_prefix().set_value("");
 
-    let arguments = &context.arguments;
-    let exit_success = arguments.value_of("status_code").unwrap_or("0") == "0";
+    let props = &context.properties;
+    let exit_code_default = std::string::String::from("0");
+    let exit_code = props.get("status_code").unwrap_or(&exit_code_default);
     let shell = std::env::var("STARSHIP_SHELL").unwrap_or_default();
-    let keymap = arguments.value_of("keymap").unwrap_or("viins");
+    let keymap_default = std::string::String::from("viins");
+    let keymap = props.get("keymap").unwrap_or(&keymap_default);
+    let exit_success = exit_code == "0";
 
     // Match shell "keymap" names to normalized vi modes
     // NOTE: in vi mode, fish reports normal mode as "default".
     // Unfortunately, this is also the name of the non-vi default mode.
     // We do some environment detection in src/init.rs to translate.
     // The result: in non-vi fish, keymap is always reported as "insert"
-    let mode = match (shell.as_str(), keymap) {
+    let mode = match (shell.as_str(), keymap.as_str()) {
         ("fish", "default") | ("zsh", "vicmd") => ShellEditMode::Normal,
         _ => ASSUMED_MODE,
     };

--- a/src/modules/cmd_duration.rs
+++ b/src/modules/cmd_duration.rs
@@ -9,10 +9,10 @@ use super::{Context, Module};
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let mut module = context.new_module("cmd_duration");
 
-    let arguments = &context.arguments;
-    let elapsed = arguments
-        .value_of("cmd_duration")
-        .unwrap_or("invalid_time")
+    let props = &context.properties;
+    let elapsed = props
+        .get("cmd_duration")
+        .unwrap_or(&"invalid_time".into())
         .parse::<u64>()
         .ok()?;
 

--- a/src/modules/jobs.rs
+++ b/src/modules/jobs.rs
@@ -10,10 +10,10 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
     module.set_style(config.style);
 
-    let arguments = &context.arguments;
-    let num_of_jobs = arguments
-        .value_of("jobs")
-        .unwrap_or("0")
+    let props = &context.properties;
+    let num_of_jobs = props
+        .get("jobs")
+        .unwrap_or(&"0".into())
         .trim()
         .parse::<i64>()
         .ok()?;


### PR DESCRIPTION
#### Description

This removes ArgMatches from the Context struct and replaces it with a simple HashMap.

#### Motivation and Context

This work is towards getting Starship in a better place for use as a library in other shells written in Rust so they don't need to use a command-line interface to invoke and configure things.

Contributes to #521

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Internal and API changes 


#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
