### PR TITLE
fix: Disable venv custom prompt when starship is in use

### DIFF
--- a/src/init/starship.fish
+++ b/src/init/starship.fish
@@ -11,5 +11,9 @@ function fish_prompt
     set -l starship_duration (math --scale=0 "$CMD_DURATION / 1000")
     ::STARSHIP:: prompt --status=$exit_code --keymap=$keymap --cmd-duration=$starship_duration --jobs=(count (jobs -p))
 end
+
+# disable virtualenv prompt, it breaks starship
+set VIRTUAL_ENV_DISABLE_PROMPT 1
+
 function fish_mode_prompt; end
 export STARSHIP_SHELL="fish"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
Set the `VIRTUAL_ENV_DISABLE_PROMPT` variable in `starship.fish`, venv status is already shown in the prompt via the python module.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #549 

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):
![DeepinScreenshot_select-area_20191016173222](https://user-images.githubusercontent.com/20362627/66964048-0b9bb000-f03b-11e9-95e5-60832216a7b4.png)


#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
