### PR TITLE
feat: Add nodejs_npm and nodejs_yarn modules

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -95,6 +95,8 @@ prompt_order = [
     "golang",
     "java",
     "nodejs",
+    "nodejs_npm",
+    "nodejs_yarn",
     "python",
     "ruby",
     "rust",
@@ -758,6 +760,58 @@ The module will be shown if any of the following conditions are met:
 # ~/.config/starship.toml
 
 [nodejs]
+symbol = "🤖 "
+```
+
+## NodeJS NPM
+
+The `nodejs_npm` module shows the currently installed version of npm.
+The module will be shown if any of the following conditions are met:
+
+- The current directory contains a `package.json` file
+- The current directory contains a `node_modules` directory
+- The current directory contains a file with the `.js` extension
+
+### Options
+
+| Variable   | Default      | Description                                           |
+| ---------- | ------------ | ----------------------------------------------------- |
+| `symbol`   | `"npm "`     | The symbol used before displaying the version of npm. |
+| `style`    | `"bold red"` | The style for the module.                             |
+| `disabled` | `true`       | Disables the `nodejs_npm` module.                     |
+
+### Example
+
+```toml
+# ~/.config/starship.toml
+
+[nodejs_npm]
+symbol = "🤖 "
+```
+
+## NodeJS Yarn
+
+The `nodejs_yarn` module shows the currently installed version of Yarn.
+The module will be shown if any of the following conditions are met:
+
+- The current directory contains a `package.json` file
+- The current directory contains a `node_modules` directory
+- The current directory contains a file with the `.js` extension
+
+### Options
+
+| Variable   | Default       | Description                                            |
+| ---------- | ------------- | ------------------------------------------------------ |
+| `symbol`   | `"🐈 "`       | The symbol used before displaying the version of yarn. |
+| `style`    | `"bold blue"` | The style for the module.                              |
+| `disabled` | `true`        | Disables the `nodejs_yarn` module.                     |
+
+### Example
+
+```toml
+# ~/.config/starship.toml
+
+[nodejs_yarn]
 symbol = "🤖 "
 ```
 

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -13,6 +13,7 @@ pub mod jobs;
 pub mod kubernetes;
 pub mod nodejs;
 pub mod nodejs_npm;
+pub mod nodejs_yarn;
 pub mod package;
 pub mod python;
 pub mod ruby;
@@ -53,6 +54,7 @@ impl<'a> RootModuleConfig<'a> for StarshipRootConfig<'a> {
                 "java",
                 "nodejs",
                 "nodejs_npm",
+                "nodejs_yarn",
                 "python",
                 "ruby",
                 "rust",

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -12,6 +12,7 @@ pub mod hostname;
 pub mod jobs;
 pub mod kubernetes;
 pub mod nodejs;
+pub mod nodejs_npm;
 pub mod package;
 pub mod python;
 pub mod ruby;
@@ -51,6 +52,7 @@ impl<'a> RootModuleConfig<'a> for StarshipRootConfig<'a> {
                 "golang",
                 "java",
                 "nodejs",
+                "nodejs_npm",
                 "python",
                 "ruby",
                 "rust",

--- a/src/configs/nodejs_npm.rs
+++ b/src/configs/nodejs_npm.rs
@@ -1,0 +1,21 @@
+use crate::config::{ModuleConfig, RootModuleConfig, SegmentConfig};
+
+use ansi_term::{Color, Style};
+use starship_module_config_derive::ModuleConfig;
+
+#[derive(Clone, ModuleConfig)]
+pub struct NodejsNpmConfig<'a> {
+    pub symbol: SegmentConfig<'a>,
+    pub style: Style,
+    pub disabled: bool,
+}
+
+impl<'a> RootModuleConfig<'a> for NodejsNpmConfig<'a> {
+    fn new() -> Self {
+        NodejsNpmConfig {
+            symbol: SegmentConfig::new("npm "),
+            style: Color::Red.bold(),
+            disabled: true,
+        }
+    }
+}

--- a/src/configs/nodejs_yarn.rs
+++ b/src/configs/nodejs_yarn.rs
@@ -1,0 +1,21 @@
+use crate::config::{ModuleConfig, RootModuleConfig, SegmentConfig};
+
+use ansi_term::{Color, Style};
+use starship_module_config_derive::ModuleConfig;
+
+#[derive(Clone, ModuleConfig)]
+pub struct NodejsYarnConfig<'a> {
+    pub symbol: SegmentConfig<'a>,
+    pub style: Style,
+    pub disabled: bool,
+}
+
+impl<'a> RootModuleConfig<'a> for NodejsYarnConfig<'a> {
+    fn new() -> Self {
+        NodejsYarnConfig {
+            symbol: SegmentConfig::new("🐈 "),
+            style: Color::Blue.bold(),
+            disabled: true,
+        }
+    }
+}

--- a/src/module.rs
+++ b/src/module.rs
@@ -30,6 +30,7 @@ pub const ALL_MODULES: &[&str] = &[
     "nix_shell",
     "nodejs",
     "nodejs_npm",
+    "nodejs_yarn",
     "package",
     "python",
     "ruby",

--- a/src/module.rs
+++ b/src/module.rs
@@ -29,6 +29,7 @@ pub const ALL_MODULES: &[&str] = &[
     "memory_usage",
     "nix_shell",
     "nodejs",
+    "nodejs_npm",
     "package",
     "python",
     "ruby",

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -19,6 +19,7 @@ mod memory_usage;
 mod nix_shell;
 mod nodejs;
 mod nodejs_npm;
+mod nodejs_yarn;
 mod package;
 mod python;
 mod ruby;
@@ -59,6 +60,7 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
         "nix_shell" => nix_shell::module(context),
         "nodejs" => nodejs::module(context),
         "nodejs_npm" => nodejs_npm::module(context),
+        "nodejs_yarn" => nodejs_yarn::module(context),
         "package" => package::module(context),
         "python" => python::module(context),
         "ruby" => ruby::module(context),

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -18,6 +18,7 @@ mod line_break;
 mod memory_usage;
 mod nix_shell;
 mod nodejs;
+mod nodejs_npm;
 mod package;
 mod python;
 mod ruby;
@@ -57,6 +58,7 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
         "memory_usage" => memory_usage::module(context),
         "nix_shell" => nix_shell::module(context),
         "nodejs" => nodejs::module(context),
+        "nodejs_npm" => nodejs_npm::module(context),
         "package" => package::module(context),
         "python" => python::module(context),
         "ruby" => ruby::module(context),

--- a/src/modules/nodejs_npm.rs
+++ b/src/modules/nodejs_npm.rs
@@ -1,0 +1,53 @@
+use std::process::Command;
+
+use super::{Context, Module, RootModuleConfig, SegmentConfig};
+
+use crate::configs::nodejs_npm::NodejsNpmConfig;
+
+/// Creates a module with the current npm version
+///
+/// Will display the npm version if any of the following criteria are met:
+///     - Current directory contains a `.js` file
+///     - Current directory contains a `package.json` file
+///     - Current directory contains a `node_modules` directory
+pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let is_js_project = context
+        .try_begin_scan()?
+        .set_files(&["package.json"])
+        .set_extensions(&["js"])
+        .set_folders(&["node_modules"])
+        .is_match();
+
+    if !is_js_project {
+        return None;
+    }
+
+    let mut module = context.new_module("nodejs_npm");
+    let config = NodejsNpmConfig::try_load(module.config);
+
+    // This is currently needed for modules that are disabled by default.
+    if config.disabled {
+        return None;
+    }
+
+    match get_npm_version() {
+        Some(npm_version) => {
+            module.get_prefix().set_value("with ");
+            module.set_style(config.style);
+
+            let formatted_version = format!("v{}", npm_version.trim());
+            module.create_segment("symbol", &config.symbol);
+            module.create_segment("version", &SegmentConfig::new(&formatted_version));
+
+            Some(module)
+        }
+        None => None,
+    }
+}
+
+fn get_npm_version() -> Option<String> {
+    match Command::new("npm").arg("--version").output() {
+        Ok(output) => Some(String::from_utf8(output.stdout).unwrap()),
+        Err(_) => None,
+    }
+}

--- a/src/modules/nodejs_yarn.rs
+++ b/src/modules/nodejs_yarn.rs
@@ -1,0 +1,53 @@
+use std::process::Command;
+
+use super::{Context, Module, RootModuleConfig, SegmentConfig};
+
+use crate::configs::nodejs_yarn::NodejsYarnConfig;
+
+/// Creates a module with the current yarn version
+///
+/// Will display the yarn version if any of the following criteria are met:
+///     - Current directory contains a `.js` file
+///     - Current directory contains a `package.json` file
+///     - Current directory contains a `node_modules` directory
+pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let is_js_project = context
+        .try_begin_scan()?
+        .set_files(&["package.json"])
+        .set_extensions(&["js"])
+        .set_folders(&["node_modules"])
+        .is_match();
+
+    if !is_js_project {
+        return None;
+    }
+
+    let mut module = context.new_module("nodejs_yarn");
+    let config = NodejsYarnConfig::try_load(module.config);
+
+    // This is currently needed for modules that are disabled by default.
+    if config.disabled {
+        return None;
+    }
+
+    match get_yarn_version() {
+        Some(yarn_version) => {
+            module.get_prefix().set_value("with ");
+            module.set_style(config.style);
+
+            let formatted_version = format!("v{}", yarn_version.trim());
+            module.create_segment("symbol", &config.symbol);
+            module.create_segment("version", &SegmentConfig::new(&formatted_version));
+
+            Some(module)
+        }
+        None => None,
+    }
+}
+
+fn get_yarn_version() -> Option<String> {
+    match Command::new("yarn").arg("--version").output() {
+        Ok(output) => Some(String::from_utf8(output.stdout).unwrap()),
+        Err(_) => None,
+    }
+}

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -7,13 +7,14 @@ RUN mkdir /src && chmod -R a+w /src
 RUN useradd -ms /bin/bash nonroot
 USER nonroot
 
-# Install Node.js
+# Install Node.js and npm
 ENV NODE_VERSION 12.0.0
 ENV NVM_DIR /home/nonroot/.nvm
 ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 RUN curl https://raw.githubusercontent.com/creationix/nvm/master/install.sh | bash
 # Check that Node.js was correctly installed
 RUN node --version
+RUN npm --version
 
 # Install Go
 ENV GO_VERSION 1.12.1

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -17,7 +17,8 @@ RUN node --version
 RUN npm --version
 
 # Install yarn
-ENV YARN_VERSION 1.19.1
+# Yarn version needs to match the version avilable in actions/setup-node.
+ENV YARN_VERSION 1.19.0
 ENV YARN_DIR /home/nonroot/.yarn
 ENV PATH $YARN_DIR/bin:$PATH
 RUN curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version $YARN_VERSION

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -16,6 +16,14 @@ RUN curl https://raw.githubusercontent.com/creationix/nvm/master/install.sh | ba
 RUN node --version
 RUN npm --version
 
+# Install yarn
+ENV YARN_VERSION 1.19.1
+ENV YARN_DIR /home/nonroot/.yarn
+ENV PATH $YARN_DIR/bin:$PATH
+RUN curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version $YARN_VERSION
+# Check that yarn was correctly installed
+RUN yarn --version
+
 # Install Go
 ENV GO_VERSION 1.12.1
 ENV GOENV_ROOT /home/nonroot/.goenv

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -17,6 +17,7 @@ mod line_break;
 mod modules;
 mod nix_shell;
 mod nodejs;
+mod nodejs_npm;
 mod python;
 mod ruby;
 mod time;

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -18,6 +18,7 @@ mod modules;
 mod nix_shell;
 mod nodejs;
 mod nodejs_npm;
+mod nodejs_yarn;
 mod python;
 mod ruby;
 mod time;

--- a/tests/testsuite/nodejs_npm.rs
+++ b/tests/testsuite/nodejs_npm.rs
@@ -6,11 +6,31 @@ use tempfile;
 use crate::common;
 use crate::common::TestCommand;
 
+/// Wrapper around common::render_module("nodejs_npm") to work around platform quirks
+fn render_npm_module() -> std::process::Command {
+    let mut command = common::render_module("nodejs_npm");
+
+    // Appears to be the same issue as in the `nodejs` module.
+    if cfg!(windows) {
+        let system_root = std::env::var("SYSTEMROOT")
+            .map(|i| {
+                if i.trim().is_empty() {
+                    "C:\\WINDOWS".into()
+                } else {
+                    i
+                }
+            })
+            .unwrap_or_else(|_| "C:\\WINDOWS".into());
+        command.env("SYSTEMROOT", system_root);
+    }
+    command
+}
+
 #[test]
 fn folder_without_node_files() -> io::Result<()> {
     let dir = tempfile::tempdir()?;
 
-    let output = common::render_module("nodejs_npm")
+    let output = render_npm_module()
         .use_config(toml::toml! {
             [nodejs_npm]
             disabled = false
@@ -31,7 +51,7 @@ fn folder_with_package_json() -> io::Result<()> {
     let dir = tempfile::tempdir()?;
     File::create(dir.path().join("package.json"))?.sync_all()?;
 
-    let output = common::render_module("nodejs_npm")
+    let output = render_npm_module()
         .use_config(toml::toml! {
             [nodejs_npm]
             disabled = false
@@ -52,7 +72,7 @@ fn folder_with_js_file() -> io::Result<()> {
     let dir = tempfile::tempdir()?;
     File::create(dir.path().join("index.js"))?.sync_all()?;
 
-    let output = common::render_module("nodejs_npm")
+    let output = render_npm_module()
         .use_config(toml::toml! {
             [nodejs_npm]
             disabled = false
@@ -74,7 +94,7 @@ fn folder_with_node_modules() -> io::Result<()> {
     let node_modules = dir.path().join("node_modules");
     fs::create_dir_all(&node_modules)?;
 
-    let output = common::render_module("nodejs_npm")
+    let output = render_npm_module()
         .use_config(toml::toml! {
             [nodejs_npm]
             disabled = false

--- a/tests/testsuite/nodejs_npm.rs
+++ b/tests/testsuite/nodejs_npm.rs
@@ -1,0 +1,90 @@
+use ansi_term::Color;
+use std::fs::{self, File};
+use std::io;
+use tempfile;
+
+use crate::common;
+use crate::common::TestCommand;
+
+#[test]
+fn folder_without_node_files() -> io::Result<()> {
+    let dir = tempfile::tempdir()?;
+
+    let output = common::render_module("nodejs_npm")
+        .use_config(toml::toml! {
+            [nodejs_npm]
+            disabled = false
+        })
+        .arg("--path")
+        .arg(dir.path())
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+
+    let expected = "";
+    assert_eq!(expected, actual);
+    Ok(())
+}
+
+#[test]
+#[ignore]
+fn folder_with_package_json() -> io::Result<()> {
+    let dir = tempfile::tempdir()?;
+    File::create(dir.path().join("package.json"))?.sync_all()?;
+
+    let output = common::render_module("nodejs_npm")
+        .use_config(toml::toml! {
+            [nodejs_npm]
+            disabled = false
+        })
+        .arg("--path")
+        .arg(dir.path())
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+
+    let expected = format!("with {} ", Color::Red.bold().paint("npm v6.9.0"));
+    assert_eq!(expected, actual);
+    Ok(())
+}
+
+#[test]
+#[ignore]
+fn folder_with_js_file() -> io::Result<()> {
+    let dir = tempfile::tempdir()?;
+    File::create(dir.path().join("index.js"))?.sync_all()?;
+
+    let output = common::render_module("nodejs_npm")
+        .use_config(toml::toml! {
+            [nodejs_npm]
+            disabled = false
+        })
+        .arg("--path")
+        .arg(dir.path())
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+
+    let expected = format!("with {} ", Color::Red.bold().paint("npm v6.9.0"));
+    assert_eq!(expected, actual);
+    Ok(())
+}
+
+#[test]
+#[ignore]
+fn folder_with_node_modules() -> io::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let node_modules = dir.path().join("node_modules");
+    fs::create_dir_all(&node_modules)?;
+
+    let output = common::render_module("nodejs_npm")
+        .use_config(toml::toml! {
+            [nodejs_npm]
+            disabled = false
+        })
+        .arg("--path")
+        .arg(dir.path())
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+
+    let expected = format!("with {} ", Color::Red.bold().paint("npm v6.9.0"));
+    assert_eq!(expected, actual);
+    Ok(())
+}

--- a/tests/testsuite/nodejs_yarn.rs
+++ b/tests/testsuite/nodejs_yarn.rs
@@ -6,11 +6,31 @@ use tempfile;
 use crate::common;
 use crate::common::TestCommand;
 
+/// Wrapper around common::render_module("nodejs_yarn") to work around platform quirks
+fn render_yarn_module() -> std::process::Command {
+    let mut command = common::render_module("nodejs_yarn");
+
+    // Appears to be the same issue as in the `nodejs` module.
+    if cfg!(windows) {
+        let system_root = std::env::var("SYSTEMROOT")
+            .map(|i| {
+                if i.trim().is_empty() {
+                    "C:\\WINDOWS".into()
+                } else {
+                    i
+                }
+            })
+            .unwrap_or_else(|_| "C:\\WINDOWS".into());
+        command.env("SYSTEMROOT", system_root);
+    }
+    command
+}
+
 #[test]
 fn folder_without_node_files() -> io::Result<()> {
     let dir = tempfile::tempdir()?;
 
-    let output = common::render_module("nodejs_yarn")
+    let output = render_yarn_module()
         .use_config(toml::toml! {
             [nodejs_yarn]
             disabled = false
@@ -31,7 +51,7 @@ fn folder_with_package_json() -> io::Result<()> {
     let dir = tempfile::tempdir()?;
     File::create(dir.path().join("package.json"))?.sync_all()?;
 
-    let output = common::render_module("nodejs_yarn")
+    let output = render_yarn_module()
         .use_config(toml::toml! {
             [nodejs_yarn]
             disabled = false
@@ -52,7 +72,7 @@ fn folder_with_js_file() -> io::Result<()> {
     let dir = tempfile::tempdir()?;
     File::create(dir.path().join("index.js"))?.sync_all()?;
 
-    let output = common::render_module("nodejs_yarn")
+    let output = render_yarn_module()
         .use_config(toml::toml! {
             [nodejs_yarn]
             disabled = false
@@ -74,7 +94,7 @@ fn folder_with_node_modules() -> io::Result<()> {
     let node_modules = dir.path().join("node_modules");
     fs::create_dir_all(&node_modules)?;
 
-    let output = common::render_module("nodejs_yarn")
+    let output = render_yarn_module()
         .use_config(toml::toml! {
             [nodejs_yarn]
             disabled = false

--- a/tests/testsuite/nodejs_yarn.rs
+++ b/tests/testsuite/nodejs_yarn.rs
@@ -1,0 +1,90 @@
+use ansi_term::Color;
+use std::fs::{self, File};
+use std::io;
+use tempfile;
+
+use crate::common;
+use crate::common::TestCommand;
+
+#[test]
+fn folder_without_node_files() -> io::Result<()> {
+    let dir = tempfile::tempdir()?;
+
+    let output = common::render_module("nodejs_yarn")
+        .use_config(toml::toml! {
+            [nodejs_yarn]
+            disabled = false
+        })
+        .arg("--path")
+        .arg(dir.path())
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+
+    let expected = "";
+    assert_eq!(expected, actual);
+    Ok(())
+}
+
+#[test]
+#[ignore]
+fn folder_with_package_json() -> io::Result<()> {
+    let dir = tempfile::tempdir()?;
+    File::create(dir.path().join("package.json"))?.sync_all()?;
+
+    let output = common::render_module("nodejs_yarn")
+        .use_config(toml::toml! {
+            [nodejs_yarn]
+            disabled = false
+        })
+        .arg("--path")
+        .arg(dir.path())
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+
+    let expected = format!("with {} ", Color::Blue.bold().paint("🐈 v1.19.1"));
+    assert_eq!(expected, actual);
+    Ok(())
+}
+
+#[test]
+#[ignore]
+fn folder_with_js_file() -> io::Result<()> {
+    let dir = tempfile::tempdir()?;
+    File::create(dir.path().join("index.js"))?.sync_all()?;
+
+    let output = common::render_module("nodejs_yarn")
+        .use_config(toml::toml! {
+            [nodejs_yarn]
+            disabled = false
+        })
+        .arg("--path")
+        .arg(dir.path())
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+
+    let expected = format!("with {} ", Color::Blue.bold().paint("🐈 v1.19.1"));
+    assert_eq!(expected, actual);
+    Ok(())
+}
+
+#[test]
+#[ignore]
+fn folder_with_node_modules() -> io::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let node_modules = dir.path().join("node_modules");
+    fs::create_dir_all(&node_modules)?;
+
+    let output = common::render_module("nodejs_yarn")
+        .use_config(toml::toml! {
+            [nodejs_yarn]
+            disabled = false
+        })
+        .arg("--path")
+        .arg(dir.path())
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+
+    let expected = format!("with {} ", Color::Blue.bold().paint("🐈 v1.19.1"));
+    assert_eq!(expected, actual);
+    Ok(())
+}

--- a/tests/testsuite/nodejs_yarn.rs
+++ b/tests/testsuite/nodejs_yarn.rs
@@ -41,7 +41,7 @@ fn folder_with_package_json() -> io::Result<()> {
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
-    let expected = format!("with {} ", Color::Blue.bold().paint("🐈 v1.19.1"));
+    let expected = format!("with {} ", Color::Blue.bold().paint("🐈 v1.19.0"));
     assert_eq!(expected, actual);
     Ok(())
 }
@@ -62,7 +62,7 @@ fn folder_with_js_file() -> io::Result<()> {
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
-    let expected = format!("with {} ", Color::Blue.bold().paint("🐈 v1.19.1"));
+    let expected = format!("with {} ", Color::Blue.bold().paint("🐈 v1.19.0"));
     assert_eq!(expected, actual);
     Ok(())
 }
@@ -84,7 +84,7 @@ fn folder_with_node_modules() -> io::Result<()> {
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
-    let expected = format!("with {} ", Color::Blue.bold().paint("🐈 v1.19.1"));
+    let expected = format!("with {} ", Color::Blue.bold().paint("🐈 v1.19.0"));
     assert_eq!(expected, actual);
     Ok(())
 }


### PR DESCRIPTION
#### Description
Adds modules for the two most used Node/JS package managers, [`npm`](https://www.npmjs.com/get-npm) and [`yarn`](https://yarnpkg.com).

Both of these modules are disabled by default.

#### Motivation and Context
From #557:
> As a JavaScript developer I am never aware of a time when I would be using Node and not also using NPM. In addition, the version of NPM being used can have an impact on the way packages are resolved, lockfiles written, etc. It is also useful to know the NPM version when comparing my work environment to that of my coworkers/collaborators.

Closes #557 

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):
![Screenshot from 2019-10-18 22-51-29](https://user-images.githubusercontent.com/7308850/67137385-e1442100-f1f9-11e9-9b12-aec29e9be4b1.png)

#### How Has This Been Tested?
I've added acceptance tests to make sure both modules work as expected.

- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
