### PR TITLE
chore: Move StarshipRootConfig to a separate file

### DIFF
--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -17,58 +17,8 @@ pub mod package;
 pub mod python;
 pub mod ruby;
 pub mod rust;
+mod starship_root;
 pub mod time;
 pub mod username;
 
-use crate::config::{ModuleConfig, RootModuleConfig};
-
-use starship_module_config_derive::ModuleConfig;
-
-#[derive(Clone, ModuleConfig)]
-pub struct StarshipRootConfig<'a> {
-    pub add_newline: bool,
-    pub prompt_order: Vec<&'a str>,
-}
-
-impl<'a> RootModuleConfig<'a> for StarshipRootConfig<'a> {
-    fn new() -> Self {
-        StarshipRootConfig {
-            add_newline: true,
-            // List of default prompt order
-            // NOTE: If this const value is changed then Default prompt order subheading inside
-            // prompt heading of config docs needs to be updated according to changes made here.
-            prompt_order: vec![
-                "username",
-                "hostname",
-                "kubernetes",
-                "directory",
-                "git_branch",
-                "git_state",
-                "git_status",
-                "package",
-                // ↓ Toolchain version modules ↓
-                // (Let's keep these sorted alphabetically)
-                "dotnet",
-                "golang",
-                "java",
-                "nodejs",
-                "python",
-                "ruby",
-                "rust",
-                // ↑ Toolchain version modules ↑
-                "nix_shell",
-                "conda",
-                "memory_usage",
-                "aws",
-                "env_var",
-                "cmd_duration",
-                "line_break",
-                "jobs",
-                #[cfg(feature = "battery")]
-                "battery",
-                "time",
-                "character",
-            ],
-        }
-    }
-}
+pub use starship_root::*;

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -1,0 +1,52 @@
+use crate::config::{ModuleConfig, RootModuleConfig};
+
+use starship_module_config_derive::ModuleConfig;
+
+#[derive(Clone, ModuleConfig)]
+pub struct StarshipRootConfig<'a> {
+    pub add_newline: bool,
+    pub prompt_order: Vec<&'a str>,
+}
+
+impl<'a> RootModuleConfig<'a> for StarshipRootConfig<'a> {
+    fn new() -> Self {
+        StarshipRootConfig {
+            add_newline: true,
+            // List of default prompt order
+            // NOTE: If this const value is changed then Default prompt order subheading inside
+            // prompt heading of config docs needs to be updated according to changes made here.
+            prompt_order: vec![
+                "username",
+                "hostname",
+                "kubernetes",
+                "directory",
+                "git_branch",
+                "git_state",
+                "git_status",
+                "package",
+                // ↓ Toolchain version modules ↓
+                // (Let's keep these sorted alphabetically)
+                "dotnet",
+                "golang",
+                "java",
+                "nodejs",
+                "python",
+                "ruby",
+                "rust",
+                // ↑ Toolchain version modules ↑
+                "nix_shell",
+                "conda",
+                "memory_usage",
+                "aws",
+                "env_var",
+                "cmd_duration",
+                "line_break",
+                "jobs",
+                #[cfg(feature = "battery")]
+                "battery",
+                "time",
+                "character",
+            ],
+        }
+    }
+}


### PR DESCRIPTION
### Description
This PR moves `StarshipConfig` and its implementation to `starship_root.rs`.

It makes `src/configs/mod.rs` cleaner, but may make it harder for developers to find the default prompt order..

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
