### PR TITLE
docs: Fix `Memory Usage` option key

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -706,7 +706,7 @@ To enable it, set `disabled` to `false` in your configuration file.
 show_percentage = true
 show_swap = true
 threshold = -1
-icon = " "
+symbol = " "
 style = "bold dimmed green"
 ```
 

--- a/docs/de-DE/config/README.md
+++ b/docs/de-DE/config/README.md
@@ -663,7 +663,7 @@ Dieses Modul ist standardmäßig deaktiviert. Setze in deiner Konfiguration `dis
 show_percentage = true
 show_swap = true
 threshold = -1
-icon = " "
+symbol = " "
 style = "bold dimmed green"
 ```
 

--- a/docs/fr-FR/config/README.md
+++ b/docs/fr-FR/config/README.md
@@ -662,7 +662,7 @@ This module is disabled by default. To enable it, set `disabled` to `false` in y
 show_percentage = true
 show_swap = true
 threshold = -1
-icon = " "
+symbol = " "
 style = "bold dimmed green"
 ```
 

--- a/docs/ja-JP/config/README.md
+++ b/docs/ja-JP/config/README.md
@@ -664,7 +664,7 @@ pure_msg = "pure shell"
 show_percentage = true
 show_swap = true
 threshold = -1
-icon = " "
+symbol = " "
 style = "bold dimmed green"
 ```
 

--- a/docs/ru-RU/config/README.md
+++ b/docs/ru-RU/config/README.md
@@ -662,7 +662,7 @@ This module is disabled by default. To enable it, set `disabled` to `false` in y
 show_percentage = true
 show_swap = true
 threshold = -1
-icon = " "
+symbol = " "
 style = "bold dimmed green"
 ```
 

--- a/docs/zh-CN/config/README.md
+++ b/docs/zh-CN/config/README.md
@@ -662,7 +662,7 @@ This module is disabled by default. To enable it, set `disabled` to `false` in y
 show_percentage = true
 show_swap = true
 threshold = -1
-icon = " "
+symbol = " "
 style = "bold dimmed green"
 ```
 

--- a/docs/zh-TW/config/README.md
+++ b/docs/zh-TW/config/README.md
@@ -661,7 +661,7 @@ pure_msg = "pure shell"
 show_percentage = true
 show_swap = true
 threshold = -1
-icon = " "
+symbol = " "
 style = "bold dimmed green"
 ```
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
I changed `icon` into `symbol`

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`Memory Usage` option key `icon` in [Configuration](https://starship.rs/config/#memory-usage) doesn't work.
So I fixed the documentation in all languages.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
