### PR TITLE
feat: Add an option to limit the duration of starship directory scanning

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -65,7 +65,7 @@ This is the list of prompt-wide configuration options.
 | -------------- | ----------------------------- | ------------------------------------------------------ |
 | `add_newline`  | `true`                        | Add a new line before the start of the prompt.         |
 | `prompt_order` | [link](#default-prompt-order) | Configure the order in which the prompt module occurs. |
-| `scan_timeout` | `50`                          | Timeout for starship to scan files (in milliseconds).  |
+| `scan_timeout` | `30`                          | Timeout for starship to scan files (in milliseconds).  |
 
 ### Example
 
@@ -76,8 +76,8 @@ This is the list of prompt-wide configuration options.
 add_newline = false
 # Overwrite a default_prompt_order and  use custom prompt_order
 prompt_order=["rust","line_break","package","line_break","character"]
-# Wait 100 milliseconds for starship to check files under the current directory.
-scan_timeout = 100
+# Wait 10 milliseconds for starship to check files under the current directory.
+scan_timeout = 10
 ```
 
 ### Default Prompt Order

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -65,6 +65,7 @@ This is the list of prompt-wide configuration options.
 | -------------- | ----------------------------- | ------------------------------------------------------ |
 | `add_newline`  | `true`                        | Add a new line before the start of the prompt.         |
 | `prompt_order` | [link](#default-prompt-order) | Configure the order in which the prompt module occurs. |
+| `scan_timeout` | `50`                          | Timeout for starship to scan files (in milliseconds).  |
 
 ### Example
 
@@ -75,6 +76,8 @@ This is the list of prompt-wide configuration options.
 add_newline = false
 # Overwrite a default_prompt_order and  use custom prompt_order
 prompt_order=["rust","line_break","package","line_break","character"]
+# Wait 100 milliseconds for starship to check files under the current directory.
+scan_timeout = 100
 ```
 
 ### Default Prompt Order

--- a/src/config.rs
+++ b/src/config.rs
@@ -75,16 +75,20 @@ impl<'a> ModuleConfig<'a> for i64 {
     }
 }
 
-impl<'a> ModuleConfig<'a> for usize {
+impl<'a> ModuleConfig<'a> for u64 {
     fn from_config(config: &Value) -> Option<Self> {
-        config.as_integer().and_then(|value: i64| {
-            // Downcasting i64 to usize
-            if value > 0 {
-                Some(value as usize)
-            } else {
-                None
+        match config {
+            Value::Integer(value) => {
+                // Converting i64 to u64
+                if *value > 0 {
+                    Some(*value as u64)
+                } else {
+                    None
+                }
             }
-        })
+            Value::String(value) => value.parse::<u64>().ok(),
+            _ => None,
+        }
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -75,6 +75,19 @@ impl<'a> ModuleConfig<'a> for i64 {
     }
 }
 
+impl<'a> ModuleConfig<'a> for usize {
+    fn from_config(config: &Value) -> Option<Self> {
+        config.as_integer().and_then(|value: i64| {
+            // Downcasting i64 to usize
+            if value > 0 {
+                Some(value as usize)
+            } else {
+                None
+            }
+        })
+    }
+}
+
 impl<'a> ModuleConfig<'a> for f64 {
     fn from_config(config: &Value) -> Option<Self> {
         config.as_float()

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -6,7 +6,6 @@ use starship_module_config_derive::ModuleConfig;
 pub struct StarshipRootConfig<'a> {
     pub add_newline: bool,
     pub prompt_order: Vec<&'a str>,
-    /// Milliseconds to wait before starship scans all files
     pub scan_timeout: u64,
 }
 

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -6,7 +6,8 @@ use starship_module_config_derive::ModuleConfig;
 pub struct StarshipRootConfig<'a> {
     pub add_newline: bool,
     pub prompt_order: Vec<&'a str>,
-    pub limit_files: usize,
+    /// Milliseconds to wait before starship scans all files
+    pub scan_timeout: u64,
 }
 
 impl<'a> RootModuleConfig<'a> for StarshipRootConfig<'a> {
@@ -48,7 +49,7 @@ impl<'a> RootModuleConfig<'a> for StarshipRootConfig<'a> {
                 "time",
                 "character",
             ],
-            limit_files: 3000,
+            scan_timeout: 50,
         }
     }
 }

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -48,7 +48,7 @@ impl<'a> RootModuleConfig<'a> for StarshipRootConfig<'a> {
                 "time",
                 "character",
             ],
-            scan_timeout: 50,
+            scan_timeout: 30,
         }
     }
 }

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -6,6 +6,7 @@ use starship_module_config_derive::ModuleConfig;
 pub struct StarshipRootConfig<'a> {
     pub add_newline: bool,
     pub prompt_order: Vec<&'a str>,
+    pub limit_files: usize,
 }
 
 impl<'a> RootModuleConfig<'a> for StarshipRootConfig<'a> {
@@ -47,6 +48,7 @@ impl<'a> RootModuleConfig<'a> for StarshipRootConfig<'a> {
                 "time",
                 "character",
             ],
+            limit_files: 3000,
         }
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -151,6 +151,10 @@ impl<'a> Context<'a> {
                     .map(|entry| entry.path())
                     .collect::<Vec<PathBuf>>();
 
+                log::trace!(
+                    "Building a vector of directory files took {:?}",
+                    SystemTime::now().duration_since(start_time).unwrap()
+                );
                 Ok(dir_files)
             })
     }

--- a/src/context.rs
+++ b/src/context.rs
@@ -10,6 +10,7 @@ use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::string::String;
+use std::time::{Duration, SystemTime};
 
 /// Context contains data or common methods that may be used by multiple modules.
 /// The data contained within Context will be relevant to this particular rendering
@@ -137,10 +138,15 @@ impl<'a> Context<'a> {
     }
 
     pub fn get_dir_files(&self) -> Result<&Vec<PathBuf>, std::io::Error> {
+        let start_time = SystemTime::now();
+        let scan_timeout = Duration::from_millis(self.config.get_root_config().scan_timeout);
+
         self.dir_files
             .get_or_try_init(|| -> Result<Vec<PathBuf>, std::io::Error> {
                 let dir_files = fs::read_dir(&self.current_dir)?
-                    .take(self.config.get_root_config().limit_files)
+                    .take_while(|_item| {
+                        SystemTime::now().duration_since(start_time).unwrap() < scan_timeout
+                    })
                     .filter_map(Result::ok)
                     .map(|entry| entry.path())
                     .collect::<Vec<PathBuf>>();

--- a/src/context.rs
+++ b/src/context.rs
@@ -140,6 +140,7 @@ impl<'a> Context<'a> {
         self.dir_files
             .get_or_try_init(|| -> Result<Vec<PathBuf>, std::io::Error> {
                 let dir_files = fs::read_dir(&self.current_dir)?
+                    .take(self.config.get_root_config().limit_files)
                     .filter_map(Result::ok)
                     .map(|entry| entry.path())
                     .collect::<Vec<PathBuf>>();


### PR DESCRIPTION
#### Description
Starship will now only scan a subset of the current directory to avoid slow down in a folder with a large amount of files. Currently the default limit is 3000.

(The limit is set so that it will cost less than 50ms to render the prompt. 264755 / 2.715 * 0.05 \sim 4876)

#### Motivation and Context
Fixes #588

#### Screenshots

![Screenshot from 2019-10-27 09-28-46](https://user-images.githubusercontent.com/25698503/67628220-b7939580-f89c-11e9-91f8-a7c1d29b8a16.png)

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
