### PR TITLE
feat: Add stash count to git_status module

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -533,6 +533,7 @@ current directory.
 | `untracked`        | `"?"`                      | There are untracked files in the working directory.     |
 | `untracked_count`  | [link](#git-status-counts) | Show and style the number of untracked files.           |
 | `stashed`          | `"$"`                      | A stash exists for the local repository.                |
+| `stashed_count`    | [link](#git-status-counts) | Show and style the number of stashes.                           |
 | `modified`         | `"!"`                      | There are file modifications in the working directory.  |
 | `modified_count`   | [link](#git-status-counts) | Show and style the number of modified files.            |
 | `staged`           | `"+"`                      | A new file has been added to the staging area.          |

--- a/src/configs/git_status.rs
+++ b/src/configs/git_status.rs
@@ -6,6 +6,7 @@ use starship_module_config_derive::ModuleConfig;
 #[derive(Clone, ModuleConfig)]
 pub struct GitStatusConfig<'a> {
     pub stashed: SegmentConfig<'a>,
+    pub stashed_count: CountConfig,
     pub ahead: SegmentConfig<'a>,
     pub behind: SegmentConfig<'a>,
     pub diverged: SegmentConfig<'a>,
@@ -32,6 +33,7 @@ impl<'a> RootModuleConfig<'a> for GitStatusConfig<'a> {
     fn new() -> Self {
         GitStatusConfig {
             stashed: SegmentConfig::new("$"),
+            stashed_count: CountConfig::default(),
             ahead: SegmentConfig::new("⇡"),
             behind: SegmentConfig::new("⇣"),
             diverged: SegmentConfig::new("⇕"),


### PR DESCRIPTION
Added stash count to the git status module.

#### Description
The git_module has been updated to add the number of stashes for the current repo after the stash symbol ("$"). Documentation has been updated accordingly.

#### Motivation and Context
Closes #595

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/6401427/67644144-b4c09100-f8ec-11e9-870b-0d0cd40888e5.png)


#### How Has This Been Tested?
Tested on mac by running new unit tests and running the docker test. Also built a release build and manually tested that.
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.

---

I'm new to rust so please correct me if I made any obvious mistakes! I'll update the PR as soon as I can.