### PR TITLE
feat: add k8s granular config

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -772,7 +772,8 @@ threshold = 4
 
 Displays the current Kubernetes context name and, if set, the namespace from
 the kubeconfig file. The namespace needs to be set in the kubeconfig file, this
-can be done via `kubectl config set-context starship-cluster --namespace astronaut`. If the `$KUBECONFIG` env var is set the module will use that if
+can be done via `kubectl config set-context starship-cluster --namespace astronaut`. 
+If the `$KUBECONFIG` env var is set the module will use that if
 not it will use the `~/.kube/config`.
 
 ::: tip
@@ -784,11 +785,21 @@ To enable it, set `disabled` to `false` in your configuration file.
 
 ### Options
 
-| Variable   | Default       | Description                                         |
-| ---------- | ------------- | --------------------------------------------------- |
-| `symbol`   | `"☸ "`        | The symbol used before displaying the Cluster info. |
-| `style`    | `"bold blue"` | The style for the module.                           |
-| `disabled` | `true`        | Disables the `kubernetes` module                    |
+| Variable       | Default       | Description                                          |
+| -------------- | ------------- | ---------------------------------------------------- |
+| `symbol`       | `"☸ "`        | The symbol used before displaying the Cluster info.  |
+| `style`        | `"bold blue"` | The style for the module.                            |
+| `disabled`     | `true`        | Disables the `kubernetes` module.                    |
+| `environments` | `[]`          | Customized styles and symbols for specific contexts. |
+
+To customize the style of the module for specific environments, use the following configuration as
+part of the `environments` list:
+
+| Variable | Description                                                                                 |
+| -------- | ------------------------------------------------------------------------------------------- |
+| `name`   | **Required** If the value is part of the used context, this configuration will be used.     |
+| `style`  | The style for the module when using this context. If not set, will use module's style.      |
+| `symbol` | The symbol used before displaying the Cluster info. . If not set, will use module's symbol. |
 
 ### Example
 
@@ -799,6 +810,11 @@ To enable it, set `disabled` to `false` in your configuration file.
 symbol = "⛵ "
 style = "dimmed green"
 disabled = false
+environments = [
+    { name = "production", style = "bright-red", symbol = "☸☁ " },
+    { name = "staging", style = "yellow" },
+    { name = "develop", style = "green" },
+]
 ```
 
 ## Line Break

--- a/src/configs/kubernetes.rs
+++ b/src/configs/kubernetes.rs
@@ -2,6 +2,7 @@ use crate::config::{ModuleConfig, RootModuleConfig, SegmentConfig};
 
 use ansi_term::{Color, Style};
 use starship_module_config_derive::ModuleConfig;
+use toml::Value;
 
 #[derive(Clone, ModuleConfig)]
 pub struct KubernetesConfig<'a> {
@@ -10,6 +11,7 @@ pub struct KubernetesConfig<'a> {
     pub namespace: SegmentConfig<'a>,
     pub style: Style,
     pub disabled: bool,
+    pub environments: Vec<KubernetesEnvironmentConfig<'a>>,
 }
 
 impl<'a> RootModuleConfig<'a> for KubernetesConfig<'a> {
@@ -20,6 +22,27 @@ impl<'a> RootModuleConfig<'a> for KubernetesConfig<'a> {
             namespace: SegmentConfig::default(),
             style: Color::Cyan.bold(),
             disabled: true,
+            environments: Vec::new(),
         }
+    }
+}
+
+#[derive(Clone)]
+pub struct KubernetesEnvironmentConfig<'a> {
+    pub name: &'a str,
+    pub symbol: Option<SegmentConfig<'a>>,
+    pub style: Option<Style>,
+}
+
+impl<'a> ModuleConfig<'a> for KubernetesEnvironmentConfig<'a> {
+    fn from_config(config: &'a Value) -> Option<Self> {
+        let table = config.as_table()?;
+        Some(KubernetesEnvironmentConfig {
+            name: table.get("name").and_then(|v| <&str>::from_config(v))?,
+            symbol: table
+                .get("symbol")
+                .and_then(|v| SegmentConfig::from_config(v)),
+            style: table.get("style").and_then(|v| Style::from_config(v)),
+        })
     }
 }

--- a/tests/fixtures/kubeconfig.yaml
+++ b/tests/fixtures/kubeconfig.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+clusters: []
+contexts:
+  - context:
+      cluster: another_cluster
+      user: another_user
+      namespace: another_namespace
+    name: another_context
+  - context:
+      cluster: test_cluster
+      user: test_user
+      namespace: test_namespace
+    name: test_context
+current-context: test_context
+kind: Config
+preferences: {}
+users: []

--- a/tests/testsuite/common.rs
+++ b/tests/testsuite/common.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::{env, fs, io, process};
 
-static MANIFEST_DIR: Lazy<&'static Path> = Lazy::new(|| Path::new(env!("CARGO_MANIFEST_DIR")));
+pub static MANIFEST_DIR: Lazy<&'static Path> = Lazy::new(|| Path::new(env!("CARGO_MANIFEST_DIR")));
 static EMPTY_CONFIG: Lazy<PathBuf> = Lazy::new(|| MANIFEST_DIR.join("empty_config.toml"));
 
 #[cfg(windows)]

--- a/tests/testsuite/kubernetes.rs
+++ b/tests/testsuite/kubernetes.rs
@@ -1,0 +1,193 @@
+use std::io;
+use std::path::PathBuf;
+
+use once_cell::sync::Lazy;
+
+use crate::common::{self, TestCommand, MANIFEST_DIR};
+use ansi_term::{Color, Style};
+
+static KUBECTL_CONFIG: Lazy<PathBuf> =
+    Lazy::new(|| MANIFEST_DIR.join("tests/fixtures/kubeconfig.yaml"));
+
+#[test]
+fn config_disabled() -> io::Result<()> {
+    let output = common::render_module("kubernetes")
+        .env("KUBECONFIG", KUBECTL_CONFIG.as_os_str())
+        .use_config(toml::toml! {
+            [kubernetes]
+            disabled = true
+        })
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+    assert!(actual.is_empty());
+    Ok(())
+}
+
+#[test]
+fn config_enabled() -> io::Result<()> {
+    let output = common::render_module("kubernetes")
+        .env("KUBECONFIG", KUBECTL_CONFIG.as_os_str())
+        .use_config(toml::toml! {
+            [kubernetes]
+            disabled = false
+        })
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+    assert_eq!(expected_default(), actual);
+    Ok(())
+}
+
+#[test]
+fn custom_envs_empty() -> io::Result<()> {
+    let output = common::render_module("kubernetes")
+        .env("KUBECONFIG", KUBECTL_CONFIG.as_os_str())
+        .use_config(toml::toml! {
+            [kubernetes]
+            disabled = false
+            environments = []
+        })
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+    assert_eq!(expected_default(), actual);
+    Ok(())
+}
+
+#[test]
+fn custom_envs_empty_obj() -> io::Result<()> {
+    let output = common::render_module("kubernetes")
+        .env("KUBECONFIG", KUBECTL_CONFIG.as_os_str())
+        .use_config(toml::toml! {
+            [kubernetes]
+            disabled = false
+            environments = [{}]
+        })
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+    assert_eq!(expected_default(), actual);
+    Ok(())
+}
+
+#[test]
+fn custom_envs_invalid() -> io::Result<()> {
+    let output = common::render_module("kubernetes")
+        .env("KUBECONFIG", KUBECTL_CONFIG.as_os_str())
+        .use_config(toml::toml! {
+            [kubernetes]
+            disabled = false
+            environments = "foobar!"
+        })
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+    assert_eq!(expected_default(), actual);
+    Ok(())
+}
+
+#[test]
+fn custom_envs_no_name() -> io::Result<()> {
+    let output = common::render_module("kubernetes")
+        .env("KUBECONFIG", KUBECTL_CONFIG.as_os_str())
+        .use_config(toml::toml! {
+            [kubernetes]
+            disabled = false
+            environments = [
+                { style = "red", symbol = "[k8s] " }
+            ]
+        })
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+    assert_eq!(expected_default(), actual);
+    Ok(())
+}
+
+#[test]
+fn custom_envs_none_matched() -> io::Result<()> {
+    let output = common::render_module("kubernetes")
+        .env("KUBECONFIG", KUBECTL_CONFIG.as_os_str())
+        .use_config(toml::toml! {
+            [kubernetes]
+            disabled = false
+            environments = [
+                { name = "this-is-not-set", style = "red", symbol = "[k8s] " }
+            ]
+        })
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+    assert_eq!(expected_default(), actual);
+    Ok(())
+}
+
+#[test]
+fn custom_envs_all_values() -> io::Result<()> {
+    let output = common::render_module("kubernetes")
+        .env("KUBECONFIG", KUBECTL_CONFIG.as_os_str())
+        .use_config(toml::toml! {
+            [kubernetes]
+            disabled = false
+            environments = [
+                { name = "test", style = "red", symbol = "[k8s] " }
+            ]
+        })
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+    let expected = format!(
+        "on {} ",
+        Color::Red
+            .normal()
+            .paint("[k8s] test_context (test_namespace)")
+    );
+    assert_eq!(expected, actual);
+    Ok(())
+}
+
+#[test]
+fn custom_envs_no_symbol() -> io::Result<()> {
+    let output = common::render_module("kubernetes")
+        .env("KUBECONFIG", KUBECTL_CONFIG.as_os_str())
+        .use_config(toml::toml! {
+            [kubernetes]
+            disabled = false
+            environments = [
+                { name = "test", style = "red" }
+            ]
+        })
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+    let expected = format!(
+        "on {} ",
+        Color::Red.normal().paint("☸ test_context (test_namespace)")
+    );
+    assert_eq!(expected, actual);
+    Ok(())
+}
+
+#[test]
+fn custom_envs_no_style() -> io::Result<()> {
+    let output = common::render_module("kubernetes")
+        .env("KUBECONFIG", KUBECTL_CONFIG.as_os_str())
+        .use_config(toml::toml! {
+            [kubernetes]
+            disabled = false
+            environments = [
+                { name = "test", symbol = "[k8s] " }
+            ]
+        })
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+    let expected = format!(
+        "on {} ",
+        default_style().paint("[k8s] test_context (test_namespace)")
+    );
+    assert_eq!(expected, actual);
+    Ok(())
+}
+
+fn default_style() -> Style {
+    Color::Cyan.bold()
+}
+
+fn expected_default() -> String {
+    format!(
+        "on {} ",
+        default_style().paint("☸ test_context (test_namespace)")
+    )
+}

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -14,6 +14,7 @@ mod git_status;
 mod hg_branch;
 mod hostname;
 mod jobs;
+mod kubernetes;
 mod line_break;
 mod modules;
 mod nix_shell;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
This PR implements the suggestion from https://github.com/starship/starship/issues/570 to add an ability to customize the configuration of the `kubernetes` module style, based on the current context.

A new variable is added to the config section, called `environments`, which is a list of possible customizations. Each such customization is an object with a `name` variable, which includes a possible substring of an context name, and an optional `style` and `icon` that will override the global configuration, if the currently used context matched the `names` (substring match).

#### Motivation and Context
It is common to work with development, testing, staging and production environments when deploying to kubernetes clusters, especially with continuous deployment. However, it is too easy to be using a production context (for example, for inspecting logs) and forgetting to switch to the personal development context when deploying any changes. 

This change helps giving better visibility, by allowing to change the style of the kubernetes module in the prompt to draw attention, or changing the color to red (as an example) if using a context that should be used with care.

Closes #570 

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):
![Screen Shot 2019-10-28 at 11 36 26](https://user-images.githubusercontent.com/9551921/67667802-542a6600-f977-11e9-9603-c46f315e004e.png)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [X] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
