### PR TITLE
feat: Add option to select virtualenv visibility

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -474,36 +474,36 @@ current directory.
 
 ### Options
 
-| Variable            | Default                    | Description                                                     |
-| ------------------- | -------------------------- | --------------------------------------------------------------- |
-| `conflicted`        | `"="`                      | This branch has merge conflicts.                                |
-| `conflicted_count`  | [link](#git-status-counts) | Show and style the number of conflicts.                         |
-| `ahead`             | `"⇡"`                      | This branch is ahead of the branch being tracked.               |
-| `behind`            | `"⇣"`                      | This branch is behind of the branch being tracked.              |
-| `diverged`          | `"⇕"`                      | This branch has diverged from the branch being tracked.         |
-| `untracked`         | `"?"`                      | There are untracked files in the working directory.             |
-| `untracked_count`   | [link](#git-status-counts) | Show and style the number of untracked files.                   |
-| `stashed`           | `"$"`                      | A stash exists for the local repository.                        |
-| `modified`          | `"!"`                      | There are file modifications in the working directory.          |
-| `modified_count`    | [link](#git-status-counts) | Show and style the number of modified files.                    |
-| `staged`            | `"+"`                      | A new file has been added to the staging area.                  |
-| `staged_count`      | [link](#git-status-counts) | Show and style the number of files staged files.                |
-| `renamed`           | `"»"`                      | A renamed file has been added to the staging area.              |
-| `renamed_count`     | [link](#git-status-counts) | Show and style the number of renamed files.                     |
-| `deleted`           | `"✘"`                      | A file's deletion has been added to the staging area.           |
-| `deleted_count`     | [link](#git-status-counts) | Show and style the number of deleted files.                     |
-| `show_sync_count`   | `false`                    | Show ahead/behind count of the branch being tracked.            |
-| `prefix`            | `[`                        | Prefix to display immediately before git status.                |
-| `suffix`            | `]`                        | Suffix to display immediately after git status.                 |
-| `style`             | `"bold red"`               | The style for the module.                                       |
-| `disabled`          | `false`                    | Disables the `git_status` module.                               |
+| Variable           | Default                    | Description                                             |
+| ------------------ | -------------------------- | ------------------------------------------------------- |
+| `conflicted`       | `"="`                      | This branch has merge conflicts.                        |
+| `conflicted_count` | [link](#git-status-counts) | Show and style the number of conflicts.                 |
+| `ahead`            | `"⇡"`                      | This branch is ahead of the branch being tracked.       |
+| `behind`           | `"⇣"`                      | This branch is behind of the branch being tracked.      |
+| `diverged`         | `"⇕"`                      | This branch has diverged from the branch being tracked. |
+| `untracked`        | `"?"`                      | There are untracked files in the working directory.     |
+| `untracked_count`  | [link](#git-status-counts) | Show and style the number of untracked files.           |
+| `stashed`          | `"$"`                      | A stash exists for the local repository.                |
+| `modified`         | `"!"`                      | There are file modifications in the working directory.  |
+| `modified_count`   | [link](#git-status-counts) | Show and style the number of modified files.            |
+| `staged`           | `"+"`                      | A new file has been added to the staging area.          |
+| `staged_count`     | [link](#git-status-counts) | Show and style the number of files staged files.        |
+| `renamed`          | `"»"`                      | A renamed file has been added to the staging area.      |
+| `renamed_count`    | [link](#git-status-counts) | Show and style the number of renamed files.             |
+| `deleted`          | `"✘"`                      | A file's deletion has been added to the staging area.   |
+| `deleted_count`    | [link](#git-status-counts) | Show and style the number of deleted files.             |
+| `show_sync_count`  | `false`                    | Show ahead/behind count of the branch being tracked.    |
+| `prefix`           | `[`                        | Prefix to display immediately before git status.        |
+| `suffix`           | `]`                        | Suffix to display immediately after git status.         |
+| `style`            | `"bold red"`               | The style for the module.                               |
+| `disabled`         | `false`                    | Disables the `git_status` module.                       |
 
 #### Git Status Counts
 
-| Variable    | Default | Description                                            |
-| ----------- | ------- | ------------------------------------------------------ |
-| `enabled`   | `false` | Show the number of files                               |
-| `style`     |         | Optionally style the count differently than the module |
+| Variable  | Default | Description                                            |
+| --------- | ------- | ------------------------------------------------------ |
+| `enabled` | `false` | Show the number of files                               |
+| `style`   |         | Optionally style the count differently than the module |
 
 
 ### Example
@@ -739,7 +739,7 @@ The module will be shown if any of the following conditions are met:
 
 | Variable   | Default        | Description                                            |
 | ---------- | -------------- | ------------------------------------------------------ |
-| `symbol`   | `"☕ "`        | The symbol used before displaying the version of Java. |
+| `symbol`   | `"☕ "`         | The symbol used before displaying the version of Java. |
 | `style`    | `"dimmed red"` | The style for the module.                              |
 | `disabled` | `false`        | Disables the `java` module.                            |
 
@@ -818,9 +818,7 @@ The `python` module shows the currently installed version of Python.
 If `pyenv_version_name` is set to `true`, it will display the pyenv version name.
 
 Otherwise, it will display the version number from `python --version`
-and show the current Python virtual environment if one is
-activated.
-
+and the current Python virtual environment, according to `show_venv`
 The module will be shown if any of the following conditions are met:
 
 - The current directory contains a `.python-version` file
@@ -832,13 +830,17 @@ The module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Variable             | Default         | Description                                                                 |
-| -------------------- | --------------- | --------------------------------------------------------------------------- |
-| `symbol`             | `"🐍 "`         | The symbol used before displaying the version of Python.                    |
-| `pyenv_version_name` | `false`         | Use pyenv to get Python version                                             |
-| `pyenv_prefix`       | `"pyenv "`      | Prefix before pyenv version display (default display is `pyenv MY_VERSION`) |
-| `style`              | `"bold yellow"` | The style for the module.                                                   |
-| `disabled`           | `false`         | Disables the `python` module.                                               |
+| Variable             | Default         | Description                                                                         |
+| -------------------- | --------------- | ----------------------------------------------------------------------------------- |
+| `symbol`             | `"🐍 "`         | The symbol used before displaying the version of Python.                            |
+| `pyenv_version_name` | `false`         | Use pyenv to get Python version                                                     |
+| `pyenv_prefix`       | `"pyenv "`      | Prefix before pyenv version display (default display is `pyenv MY_VERSION`)         |
+| `show_venv`          | `"not_in_nix"`  | One of `always`, `never`, or `not_in_nix`. Selects when to show the virtualenv name |
+| `style`              | `"bold yellow"` | The style for the module.                                                           |
+| `disabled`           | `false`         | Disables the `python` module.                                                       |
+
+When `show_venv` is set to `"not_in_nix"`, the virtualenv name will not be shown
+while in a nix shell, as these tend to be very long.
 
 ### Example
 

--- a/src/configs/python.rs
+++ b/src/configs/python.rs
@@ -3,12 +3,15 @@ use crate::config::{ModuleConfig, RootModuleConfig, SegmentConfig};
 use ansi_term::{Color, Style};
 use starship_module_config_derive::ModuleConfig;
 
+use toml::Value;
+
 #[derive(Clone, ModuleConfig)]
 pub struct PythonConfig<'a> {
     pub symbol: SegmentConfig<'a>,
     pub version: SegmentConfig<'a>,
     pub pyenv_prefix: SegmentConfig<'a>,
     pub pyenv_version_name: bool,
+    pub show_venv: ShowVenv,
     pub style: Style,
     pub disabled: bool,
 }
@@ -20,8 +23,27 @@ impl<'a> RootModuleConfig<'a> for PythonConfig<'a> {
             version: SegmentConfig::default(),
             pyenv_prefix: SegmentConfig::new("pyenv "),
             pyenv_version_name: false,
+            show_venv: ShowVenv::NotInNix,
             style: Color::Yellow.bold(),
             disabled: false,
+        }
+    }
+}
+
+#[derive(Clone, PartialEq)]
+pub enum ShowVenv {
+    Always,
+    Never,
+    NotInNix,
+}
+
+impl<'a> ModuleConfig<'a> for ShowVenv {
+    fn from_config(config: &Value) -> Option<Self> {
+        match config.as_str() {
+            Some("always") => Some(ShowVenv::Always),
+            Some("never") => Some(ShowVenv::Never),
+            Some("not_in_nix") => Some(ShowVenv::NotInNix),
+            _ => None,
         }
     }
 }

--- a/src/modules/python.rs
+++ b/src/modules/python.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use std::process::Command;
 
 use super::{Context, Module, RootModuleConfig, SegmentConfig};
-use crate::configs::python::PythonConfig;
+use crate::configs::python::{PythonConfig, ShowVenv};
 
 /// Creates a module with the current Python version
 ///
@@ -46,12 +46,16 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         let formatted_version = format_python_version(&python_version);
         module.create_segment("version", &SegmentConfig::new(&formatted_version));
 
-        if let Some(virtual_env) = get_python_virtual_env() {
-            module.create_segment(
-                "virtualenv",
-                &SegmentConfig::new(&format!(" ({})", virtual_env)),
-            );
-        };
+        if config.show_venv == ShowVenv::Always
+            || (config.show_venv == ShowVenv::NotInNix && env::var("IN_NIX_SHELL").is_err())
+        {
+            if let Some(virtual_env) = get_python_virtual_env() {
+                module.create_segment(
+                    "virtualenv",
+                    &SegmentConfig::new(&format!(" ({})", virtual_env)),
+                );
+            };
+        }
     };
 
     Some(module)


### PR DESCRIPTION
#### Description
This adds the config option `show_venv`, which can be one of `always`, `never`, or `not_in_nix`, and selects whether to show the virtualenv name in brackets after the Python version.
always and never are self-explanatory, but not_in_nix only shows it when `$IN_NIX_SHELL` is *not* set.

I have put the enum in the config file, as I believe is only relevant in the context of configuration.

(Sorry for the large markdown diff, that's Prettier doing its thing)

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #615 

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
