### PR TITLE
feat: Add global configuration paths

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -55,6 +55,22 @@ Most modules in starship allow you to configure their display styles. This is do
 
 Note that what styling looks like will be controlled by your terminal emulator. For example, some terminal emulators will brighten the colors instead of bolding text, and some color themes use the same values for the normal and bright colors. Also, to get italic text, your terminal must support italics.
 
+### Global Config
+
+Default, system-wide configs can be added with the following config paths (later paths overrite former ones):
+
+#### Unix-like
+
+1. `/etc/starship.toml`
+2. `/usr/local/etc/starship.toml`
+3. `$HOME/starship.toml`
+
+#### Windows
+
+1. `%ProgramData%\starship.toml`
+2. `%AppData%\starship.toml`
+3. `%HomeDrive%%HomePath%\.config\starship.toml`
+
 ## Prompt
 
 This is the list of prompt-wide configuration options.


### PR DESCRIPTION
#### Description
Added the ability to have global configuration settings per host.

#### Motivation and Context
Closes #565

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### How Has This Been Tested?
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
