### PR TITLE
feat: Add option python module to disable virtualenv name display.

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -835,13 +835,15 @@ The module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Variable             | Default         | Description                                                                 |
-| -------------------- | --------------- | --------------------------------------------------------------------------- |
-| `symbol`             | `"🐍 "`         | The symbol used before displaying the version of Python.                    |
-| `pyenv_version_name` | `false`         | Use pyenv to get Python version                                             |
-| `pyenv_prefix`       | `"pyenv "`      | Prefix before pyenv version display (default display is `pyenv MY_VERSION`) |
-| `style`              | `"bold yellow"` | The style for the module.                                                   |
-| `disabled`           | `false`         | Disables the `python` module.                                               |
+| Variable                     | Default         | Description                                                                 |
+| ---------------------------- | --------------- | --------------------------------------------------------------------------- |
+| `symbol`                     | `"🐍 "`         | The symbol used before displaying the version of Python.                    |
+| `pyenv_version_name`         | `false`         | Use pyenv to get Python version                                             |
+| `pyenv_prefix`               | `"pyenv "`      | Prefix before pyenv version display (default display is `pyenv MY_VERSION`) |
+| `display_virtualenv`         | `true`          | Configures whether to show the virtual environment's name.                  |
+| `only_display_in_virtualenv` | `false`         | Disables showing python information until the virtual environment is active.|
+| `style`                      | `"bold yellow"` | The style for the module.                                                   |
+| `disabled`                   | `false`         | Disables the `python` module.                                               |
 
 ### Example
 

--- a/src/configs/python.rs
+++ b/src/configs/python.rs
@@ -9,6 +9,8 @@ pub struct PythonConfig<'a> {
     pub version: SegmentConfig<'a>,
     pub pyenv_prefix: SegmentConfig<'a>,
     pub pyenv_version_name: bool,
+    pub display_virtualenv: bool,
+    pub only_display_in_virtualenv: bool,
     pub style: Style,
     pub disabled: bool,
 }
@@ -20,6 +22,8 @@ impl<'a> RootModuleConfig<'a> for PythonConfig<'a> {
             version: SegmentConfig::default(),
             pyenv_prefix: SegmentConfig::new("pyenv "),
             pyenv_version_name: false,
+            display_virtualenv: true,
+            only_display_in_virtualenv: false,
             style: Color::Yellow.bold(),
             disabled: false,
         }

--- a/src/modules/python.rs
+++ b/src/modules/python.rs
@@ -36,6 +36,10 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let mut module = context.new_module("python");
     let config: PythonConfig = PythonConfig::try_load(module.config);
 
+    if config.only_display_in_virtualenv && !is_venv {
+        return None;
+    }
+
     module.set_style(config.style);
     module.create_segment("symbol", &config.symbol);
 
@@ -48,12 +52,14 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         let formatted_version = format_python_version(&python_version);
         module.create_segment("version", &SegmentConfig::new(&formatted_version));
 
-        if let Some(virtual_env) = get_python_virtual_env() {
-            module.create_segment(
-                "virtualenv",
-                &SegmentConfig::new(&format!(" ({})", virtual_env)),
-            );
-        };
+        if config.display_virtualenv {
+            if let Some(virtual_env) = get_python_virtual_env() {
+                module.create_segment(
+                    "virtualenv",
+                    &SegmentConfig::new(&format!(" ({})", virtual_env)),
+                );
+            };
+        }
     };
 
     Some(module)


### PR DESCRIPTION
#### Motivation and Context
As someone who uses local .venv folders, all my virtualenv names end up being .venv, and the name is irrelevant. However seeing the version is nice!

To that end, I added 2 options:
* one to optionally only show anything if the virtualenvironment is active (because *really* i can't do anything with python until I'm in that virtualenv)
* one to disable the inclusion of the virtualenvironment name.

A couple of notes:
* I'm not at all married to the option names, feel free to suggest new ones if the changes are otherwise agreeable. 
* I wasn't sure what to do about pyenv. I dont use pyenv, and i wasn't sure what would be appropriate in that context.
* It wasn't obvious to me if/how i could add tests for the behavior, looking at the existing tests for python.
* It seems like, rather than adding a bunch of flag options, it'd be better to support a sort of interpolationy thing like:
```toml
[python]
pyenv = true/false
prompt = "🐍 ${version} ${virtualenv}"
```
because it'd replace: symbol, pyenv_prefix, display_virtualenv, and maybe pyenv_version_name. But I wasn't prepared to go down that road, myself.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
