### PR TITLE
Suggest to use force flag with cargo install to allow installing updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ The prompt shows information you need while you're working, while staying sleek 
    #### Rust (v1.38 or higher)
 
    ```sh
-   $ cargo install starship
+   $ cargo install starship -f
    ```
 
    #### Arch Linux (AUR)

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,7 +43,7 @@ footer: ISC Licensed | Copyright © 2019-present Starship Contributors
    #### Rust (v1.38 or higher)
 
    ```sh
-   $ cargo install starship
+   $ cargo install starship -f
    ```
 
    #### Arch Linux (AUR)

--- a/docs/de-DE/README.md
+++ b/docs/de-DE/README.md
@@ -45,7 +45,7 @@ footer: ICS lizenziert | Copyright © 2019-heute Starship-Mitwirkende
    #### Rust (v1.38 oder neuer)
 
    ```sh
-   $ cargo install starship
+   $ cargo install starship -f
    ```
 
 

--- a/docs/de-DE/guide/README.md
+++ b/docs/de-DE/guide/README.md
@@ -126,7 +126,7 @@
    #### Rust (v1.38 oder neuer)
 
    ```sh
-   $ cargo install starship
+   $ cargo install starship -f
    ```
 
 

--- a/docs/fr-FR/README.md
+++ b/docs/fr-FR/README.md
@@ -45,7 +45,7 @@ footer: ISC licencié | Copyright © 2019-present Starship Contributors
    #### Rust (v1.38 ou plus)
 
    ```sh
-   $ cargo install starship
+   $ cargo install starship -f
    ```
 
 

--- a/docs/fr-FR/guide/README.md
+++ b/docs/fr-FR/guide/README.md
@@ -126,7 +126,7 @@
    #### Rust (v1.38 or higher)
 
    ```sh
-   $ cargo install starship
+   $ cargo install starship -f
    ```
 
 

--- a/docs/ja-JP/README.md
+++ b/docs/ja-JP/README.md
@@ -45,7 +45,7 @@ footer: ISC Licensed | Copyright © 2019-present Starship Contributors
    #### Rust (v1.38 もしくはそれ以上)
 
    ```sh
-   $ cargo install starship
+   $ cargo install starship -f
    ```
 
 

--- a/docs/ja-JP/guide/README.md
+++ b/docs/ja-JP/guide/README.md
@@ -126,7 +126,7 @@
    #### Rust (v1.38 もしくはそれ以上)
 
    ```sh
-   $ cargo install starship
+   $ cargo install starship -f
    ```
 
 

--- a/docs/ru-RU/README.md
+++ b/docs/ru-RU/README.md
@@ -45,7 +45,7 @@ footer: ISC Licensed | Copyright © 2019-present Starship Contributors
    #### Rust (v1.38 or higher)
 
    ```sh
-   $ cargo install starship
+   $ cargo install starship -f
    ```
 
 

--- a/docs/ru-RU/guide/README.md
+++ b/docs/ru-RU/guide/README.md
@@ -126,7 +126,7 @@
    #### Rust (v1.38 or higher)
 
    ```sh
-   $ cargo install starship
+   $ cargo install starship -f
    ```
 
 

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -45,7 +45,7 @@ footer: ISC Licensed | Copyright © 2019-present Starship Contributors
    #### Rust (v1.38 or higher)
 
    ```sh
-   $ cargo install starship
+   $ cargo install starship -f
    ```
 
 

--- a/docs/zh-CN/guide/README.md
+++ b/docs/zh-CN/guide/README.md
@@ -126,7 +126,7 @@
    #### Rust (v1.38 or higher)
 
    ```sh
-   $ cargo install starship
+   $ cargo install starship -f
    ```
 
 

--- a/docs/zh-TW/README.md
+++ b/docs/zh-TW/README.md
@@ -45,7 +45,7 @@ footer: ISC Licensed | Copyright © 2019-present Starship Contributors
    #### Rust (v1.38 或更高版本)
 
    ```sh
-   $ cargo install starship
+   $ cargo install starship -f
    ```
 
 

--- a/docs/zh-TW/guide/README.md
+++ b/docs/zh-TW/guide/README.md
@@ -126,7 +126,7 @@
    #### Rust (v1.38 或更高版本)
 
    ```sh
-   $ cargo install starship
+   $ cargo install starship -f
    ```
 
 


### PR DESCRIPTION
#### Description
The `cargo install` command requires use of the `-f` flag when recompiling/reinstalling the crate to update.

This PR adds this flag as default in the installation instructions.

---

#### Checklist:
- [x] I have updated the documentation accordingly.
