### PR TITLE
fix: Add support for multiple Kubeconfig files

### DIFF
--- a/src/modules/kubernetes.rs
+++ b/src/modules/kubernetes.rs
@@ -38,15 +38,23 @@ fn get_kube_context(contents: &str) -> Option<(String, String)> {
     Some((current_ctx.to_string(), ns.to_string()))
 }
 
+fn parse_kubectl_file(filename: &path::PathBuf) -> Option<(String, String)> {
+    let contents = utils::read_file(filename).ok()?;
+    get_kube_context(&contents)
+}
+
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
-    let filename = match env::var("KUBECONFIG") {
-        Ok(path) => path::PathBuf::from(path),
-        Err(_) => dirs::home_dir()?.join(".kube").join("config"),
+    let kube_cfg = match env::var("KUBECONFIG") {
+        Ok(paths) => env::split_paths(&paths)
+            .filter_map(|filename| parse_kubectl_file(&filename))
+            .nth(0),
+        Err(_) => {
+            let filename = dirs::home_dir()?.join(".kube").join("config");
+            parse_kubectl_file(&filename)
+        }
     };
 
-    let contents = utils::read_file(filename).ok()?;
-
-    match get_kube_context(&contents) {
+    match kube_cfg {
         Some(kube_cfg) => {
             let (kube_ctx, kube_ns) = kube_cfg;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

This adds support for having multiple Kubeconfig file set as part of the
`KUBECONFIG` env var.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #464

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.