### PR TITLE
ci: Switch to the msvc rust toolchain

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -177,7 +177,7 @@ jobs:
           - x86_64-unknown-linux-gnu
           - x86_64-unknown-linux-musl
           - x86_64-apple-darwin
-          - x86_64-pc-windows-gnu
+          - x86_64-pc-windows-msvc
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
@@ -188,9 +188,9 @@ jobs:
           - target: x86_64-apple-darwin
             os: macOS-latest
             name: starship-x86_64-apple-darwin.tar.gz
-          - target: x86_64-pc-windows-gnu
+          - target: x86_64-pc-windows-msvc
             os: windows-latest
-            name: starship-x86_64-pc-windows-gnu.zip
+            name: starship-x86_64-pc-windows-msvc.zip
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
Changes the github actions from the rust gnu toolchain to msvc

#### Description
The x86_64-pc-windows-gnu toolchain has a bug where one of the libs is out of date. Switching to the msvc toolchain allows for latest windows builds to compile.

#### Motivation and Context
Fix github actions and release builds
see: https://github.com/rust-lang/rust/issues/49078

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
