### PR TITLE
fix: Stop adding duplicated v to package versions

### DIFF
--- a/src/modules/package.rs
+++ b/src/modules/package.rs
@@ -72,7 +72,12 @@ fn get_package_version() -> Option<String> {
 }
 
 fn format_version(version: &str) -> String {
-    format!("v{}", version.replace('"', "").trim())
+    let cleaned = version.replace('"', "").trim().to_string();
+    if cleaned.starts_with('v') {
+        cleaned
+    } else {
+        format!("v{}", cleaned)
+    }
 }
 
 #[cfg(test)]
@@ -82,6 +87,16 @@ mod tests {
     #[test]
     fn test_format_version() {
         assert_eq!(format_version("0.1.0"), "v0.1.0");
+        assert_eq!(format_version(" 0.1.0 "), "v0.1.0");
+        assert_eq!(format_version("0.1.0 "), "v0.1.0");
+        assert_eq!(format_version(" 0.1.0"), "v0.1.0");
+        assert_eq!(format_version("\"0.1.0\""), "v0.1.0");
+
+        assert_eq!(format_version("v0.1.0"), "v0.1.0");
+        assert_eq!(format_version(" v0.1.0 "), "v0.1.0");
+        assert_eq!(format_version(" v0.1.0"), "v0.1.0");
+        assert_eq!(format_version("v0.1.0 "), "v0.1.0");
+        assert_eq!(format_version("\"v0.1.0\""), "v0.1.0");
     }
 
     #[test]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Have updated the package module to not add a `v` if the version already
has a prefixed `v`.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #647

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.