### PR TITLE
docs: Move styles to index

### DIFF
--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -1,0 +1,17 @@
+.home .hero img
+  max-width: 500px !important
+  min-width: 300px
+  width: 100%
+
+.center
+  margin 0 auto;
+  width: 80%
+  .demo-video
+    width: 100%
+    margin: 50px 0
+
+#main-title
+  display: none
+
+.hero
+  margin: 150px 25px 70px

--- a/docs/.vuepress/styles/palette.styl
+++ b/docs/.vuepress/styles/palette.styl
@@ -2,21 +2,3 @@ $accentColor = #DD0B78
 $textColor = #2c3e50
 $borderColor = #eaecef
 $codeBgColor = #282c34
-
-.home .hero img
-  max-width: 500px
-  min-width: 300px
-  width: 100%
-
-.center
-  margin 0 auto;
-  width: 80%
-  .demo-video
-    width: 100%
-    margin: 50px 0
-
-#main-title
-  display: none
-
-.hero
-  margin: 150px 25px 70px


### PR DESCRIPTION
Hey boo @matchai 👋 

#### Description

While working with Vuepress for somethin' else, something pretty neeto if I do say so myself, I copied the structure of this repo's docs. However, I came across these FAQ items:

* https://vuepress.vuejs.org/config/#palette-styl
* https://vuepress.vuejs.org/faq/#why-can-t-palette-styl-and-index-styl-merge-into-one-api

TLDR (about `palette.styl`):

> You should ONLY write color variables in this file. Since palette.styl will be imported at the end of the root Stylus config file, as a config, several files will use it, so once you wrote styles here, your style would be duplicated by multiple times.

Aside from moving these styles to `index.styl`, the only additional change was slapping on an `!important` to the hero image's `max-width`. #css.

#### Motivation and Context

Speed, correctness, the desire for @matchai to notice me.

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

Nothing changed 😎 

#### How Has This Been Tested?

Note that this is solely a docs change.

- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
