### PR TITLE
fix: Escape data that bash can execute

### DIFF
--- a/src/init/starship.bash
+++ b/src/init/starship.bash
@@ -33,10 +33,10 @@ starship_precmd() {
     if [[ $STARSHIP_START_TIME ]]; then
         STARSHIP_END_TIME=$(date +%s)
         STARSHIP_DURATION=$((STARSHIP_END_TIME - STARSHIP_START_TIME))
-        PS1="$(::STARSHIP:: prompt --status=$STATUS --jobs="$(jobs -p | wc -l)" --cmd-duration=$STARSHIP_DURATION)"
+        PS1="\$(export STARSHIP_SHELL=""; ::STARSHIP:: prompt --status=$STATUS --jobs=\"$(jobs -p | wc -l)\" --cmd-duration=$STARSHIP_DURATION)"
         unset STARSHIP_START_TIME
     else
-        PS1="$(::STARSHIP:: prompt --status=$STATUS --jobs="$(jobs -p | wc -l)")"
+        PS1="\$(export STARSHIP_SHELL=""; ::STARSHIP:: prompt --status=$STATUS --jobs=\"$(jobs -p | wc -l)\")"
     fi
     PREEXEC_READY=true;  # Signal that we can safely restart the timer
 }


### PR DESCRIPTION
#### Description
This change sets the PS1 variable to call starship itself, so the
'$(foo)' construct returned by starship will not be evaluated by bash.

#### Motivation and Context
When PS1 includes something like '$(foo)' it will be evaluated. This
means that if the value of `starship prompt` includes such a construct,
that will be evaluated. It is possible for malicious parties to use this
behavior to execute code. See https://github.com/njhartwell/pw3nage for
a proof of concept.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

bash 5.0.11: Issue present, this fixes it
zsh 5.7.1: Issue not present
fish: Untested

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
