### PR TITLE
docs: Update README to create ~/.config

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -10,7 +10,7 @@ Many new configuration options will be available in coming releases.
 To get started configuring starship, create the following file: `~/.config/starship.toml`.
 
 ```shell
-$ touch ~/.config/starship.toml
+$ mkdir -p ~/.config && touch ~/.config/starship.toml
 ```
 
 All configuration for starship is done in this [TOML](https://github.com/toml-lang/toml) file:


### PR DESCRIPTION
Our current instructions for setup include the following line:

"To get started configuring starship, create the following file: `~/.config/starship.toml`."

We then instruct the user to run the following command:

`touch ~/.config/starship.toml`

Although most users will have a `~/.config` directory and others will know to create one, there are new users who may not have a ~/.config` directory and may not know that they need to create one. One such user created issue #593.

We could prevent new users from having a similar reaction by adding a `mkdir -p` command to the instructions.

Although most users don't need it, it won't hurt anything and doesn't make the instructions significantly longer or more confusing.

#### Description
Add `mkdir -p ~/.config` to configuration setup instructions.

#### Motivation and Context
Addresses #593.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### ~Screenshots (if appropriate):~

#### ~How Has This Been Tested?~

#### Checklist:
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
