### PR TITLE
feat: Add "exit_code" module

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -107,11 +107,11 @@ prompt_order = [
     "aws",
     "env_var",
     "cmd_duration",
-    "exit_code",
     "line_break",
     "jobs",
     "battery",
     "time",
+    "exit_code",
     "character",
 ]
 ```
@@ -418,21 +418,14 @@ default = "unknown shell"
 The `exit_code` module displays the exit status of the previous command.
 The module will be shown only if the exit status of the previous command is non-zero.
 
-::: tip
-
-This module is disabled by default.
-To enable it, set `disabled` to `false` in your configuration file.
-
-:::
-
 ### Options
 
 | Variable   | Default          | Description                                                                  |
 | ---------- | ---------------- | ---------------------------------------------------------------------------- |
-| `prefix`   | `"exited "`      | Prefix to display immediately before the exit code.                          |
-| `suffix`   | `""`             | Suffix to display immediately after the exit code.                           |
+| `prefix`   | `""`             | Prefix to display immediately before the exit code.                          |
+| `suffix`   | `" "`            | Suffix to display immediately after the exit code.                           |
 | `style`    | `"bold red"    ` | The style for the module.                                                    |
-| `disabled` | `true`           | Disables the `exit_code` module.                                             |
+| `disabled` | `false`          | Disables the `exit_code` module.                                             |
 
 ### Example
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -107,6 +107,7 @@ prompt_order = [
     "aws",
     "env_var",
     "cmd_duration",
+    "exit_code",
     "line_break",
     "jobs",
     "battery",
@@ -410,6 +411,37 @@ The module will be shown only if any of the following conditions are met:
 [env_var]
 variable = "SHELL"
 default = "unknown shell"
+```
+
+## Exit Code
+
+The `exit_code` module displays the exit status of the previous command.
+The module will be shown only if the exit status of the previous command is non-zero.
+
+::: tip
+
+This module is disabled by default.
+To enable it, set `disabled` to `false` in your configuration file.
+
+:::
+
+### Options
+
+| Variable   | Default          | Description                                                                  |
+| ---------- | ---------------- | ---------------------------------------------------------------------------- |
+| `prefix`   | `"exited "`      | Prefix to display immediately before the exit code.                          |
+| `suffix`   | `""`             | Suffix to display immediately after the exit code.                           |
+| `style`    | `"bold red"    ` | The style for the module.                                                    |
+| `disabled` | `true`           | Disables the `exit_code` module.                                             |
+
+### Example
+
+```toml
+# ~/.config/starship.toml
+
+[exit_code]
+disabled = false
+prefix = "❌ "
 ```
 
 ## Git Branch

--- a/src/configs/exit_code.rs
+++ b/src/configs/exit_code.rs
@@ -14,10 +14,10 @@ pub struct ExitCodeConfig<'a> {
 impl<'a> RootModuleConfig<'a> for ExitCodeConfig<'a> {
     fn new() -> Self {
         ExitCodeConfig {
-            prefix: "exited ",
-            suffix: "",
+            prefix: "",
+            suffix: " ",
             style: Color::Red.bold(),
-            disabled: true,
+            disabled: false,
         }
     }
 }

--- a/src/configs/exit_code.rs
+++ b/src/configs/exit_code.rs
@@ -1,0 +1,23 @@
+use crate::config::{ModuleConfig, RootModuleConfig};
+
+use ansi_term::{Color, Style};
+use starship_module_config_derive::ModuleConfig;
+
+#[derive(Clone, ModuleConfig)]
+pub struct ExitCodeConfig<'a> {
+    pub prefix: &'a str,
+    pub suffix: &'a str,
+    pub style: Style,
+    pub disabled: bool,
+}
+
+impl<'a> RootModuleConfig<'a> for ExitCodeConfig<'a> {
+    fn new() -> Self {
+        ExitCodeConfig {
+            prefix: "exited ",
+            suffix: "",
+            style: Color::Red.bold(),
+            disabled: true,
+        }
+    }
+}

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -6,6 +6,7 @@ pub mod conda;
 pub mod directory;
 pub mod dotnet;
 pub mod env_var;
+pub mod exit_code;
 pub mod git_branch;
 pub mod git_state;
 pub mod git_status;

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -41,6 +41,7 @@ impl<'a> RootModuleConfig<'a> for StarshipRootConfig<'a> {
                 "aws",
                 "env_var",
                 "cmd_duration",
+                "exit_code",
                 "line_break",
                 "jobs",
                 #[cfg(feature = "battery")]

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -41,12 +41,12 @@ impl<'a> RootModuleConfig<'a> for StarshipRootConfig<'a> {
                 "aws",
                 "env_var",
                 "cmd_duration",
-                "exit_code",
                 "line_break",
                 "jobs",
                 #[cfg(feature = "battery")]
                 "battery",
                 "time",
+                "exit_code",
                 "character",
             ],
             scan_timeout: 30,

--- a/src/module.rs
+++ b/src/module.rs
@@ -17,6 +17,7 @@ pub const ALL_MODULES: &[&str] = &[
     "directory",
     "dotnet",
     "env_var",
+    "exit_code",
     "git_branch",
     "git_state",
     "git_status",

--- a/src/modules/exit_code.rs
+++ b/src/modules/exit_code.rs
@@ -1,0 +1,29 @@
+use super::{Context, Module, SegmentConfig};
+
+use crate::config::RootModuleConfig;
+use crate::configs::exit_code::ExitCodeConfig;
+
+/// Outputs the exit status of the previous command if non-zero
+pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let mut module = context.new_module("exit_code");
+    let config: ExitCodeConfig = ExitCodeConfig::try_load(module.config);
+
+    if config.disabled {
+        return None;
+    };
+
+    let props = &context.properties;
+    let exit_code_default = std::string::String::from("0");
+    let exit_code = props.get("status_code").unwrap_or(&exit_code_default);
+
+    if exit_code == &exit_code_default {
+        return None;
+    }
+
+    module.get_prefix().set_value(config.prefix);
+    module.get_suffix().set_value(config.suffix);
+    module.set_style(config.style);
+    module.create_segment("exit_code", &SegmentConfig::new(&exit_code));
+
+    Some(module)
+}

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -6,6 +6,7 @@ mod conda;
 mod directory;
 mod dotnet;
 mod env_var;
+mod exit_code;
 mod git_branch;
 mod git_state;
 mod git_status;
@@ -46,6 +47,7 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
         "directory" => directory::module(context),
         "dotnet" => dotnet::module(context),
         "env_var" => env_var::module(context),
+        "exit_code" => exit_code::module(context),
         "git_branch" => git_branch::module(context),
         "git_state" => git_state::module(context),
         "git_status" => git_status::module(context),

--- a/tests/testsuite/exit_code.rs
+++ b/tests/testsuite/exit_code.rs
@@ -1,0 +1,121 @@
+use ansi_term::Color;
+use std::io;
+
+use crate::common::{self, TestCommand};
+
+#[test]
+fn success_status_disabled() -> io::Result<()> {
+    let expected = String::new();
+
+    // Status code 0, implicitly disabled
+    let output = common::render_module("exit_code")
+        .arg("--status=0")
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+    assert_eq!(expected, actual);
+
+    // No status code, implicitly disabled
+    let output = common::render_module("exit_code").output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+    assert_eq!(expected, actual);
+
+    // Status code 0, explicitly disabled
+    let output = common::render_module("exit_code")
+        .use_config(toml::toml! {
+            [exit_code]
+            disabled = true
+        })
+        .arg("--status=0")
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+    assert_eq!(expected, actual);
+
+    // No status code, explicitly disabled
+    let output = common::render_module("exit_code")
+        .use_config(toml::toml! {
+            [exit_code]
+            disabled = true
+        })
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+    assert_eq!(expected, actual);
+
+    Ok(())
+}
+
+#[test]
+fn success_status_enabled() -> io::Result<()> {
+    let expected = String::new();
+
+    // Status code 0
+    let output = common::render_module("exit_code")
+        .use_config(toml::toml! {
+            [exit_code]
+            disabled = false
+        })
+        .arg("--status=0")
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+    assert_eq!(expected, actual);
+
+    // No status code
+    let output = common::render_module("exit_code")
+        .use_config(toml::toml! {
+            [exit_code]
+            disabled = false
+        })
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+    assert_eq!(expected, actual);
+
+    Ok(())
+}
+
+#[test]
+fn failure_status_disabled() -> io::Result<()> {
+    let expected = String::new();
+    let exit_values = ["1", "54321", "-5000"];
+
+    for status in exit_values.iter() {
+        // Implicitly disabled
+        let arg = format!("--status={}", status);
+        let output = common::render_module("exit_code").arg(arg).output()?;
+        let actual = String::from_utf8(output.stdout).unwrap();
+        assert_eq!(expected, actual);
+
+        // Explicitly disabled
+        let arg = format!("--status={}", status);
+        let output = common::render_module("exit_code")
+            .use_config(toml::toml! {
+                [exit_code]
+                disabled = true
+            })
+            .arg(arg)
+            .output()?;
+        let actual = String::from_utf8(output.stdout).unwrap();
+        assert_eq!(expected, actual);
+    }
+
+    Ok(())
+}
+
+#[test]
+fn failure_status_enabled() -> io::Result<()> {
+    let exit_values = ["1", "54321", "-5000"];
+
+    for status in exit_values.iter() {
+        let expected = format!("exited {}", Color::Red.bold().paint(*status));
+        let arg = format!("--status={}", status);
+        let output = common::render_module("exit_code")
+            .use_config(toml::toml! {
+                [exit_code]
+                disabled = false
+            })
+            .arg(arg)
+            .output()?;
+        let actual = String::from_utf8(output.stdout).unwrap();
+        assert_eq!(expected, actual);
+    }
+
+    Ok(())
+}

--- a/tests/testsuite/exit_code.rs
+++ b/tests/testsuite/exit_code.rs
@@ -7,19 +7,7 @@ use crate::common::{self, TestCommand};
 fn success_status_disabled() -> io::Result<()> {
     let expected = String::new();
 
-    // Status code 0, implicitly disabled
-    let output = common::render_module("exit_code")
-        .arg("--status=0")
-        .output()?;
-    let actual = String::from_utf8(output.stdout).unwrap();
-    assert_eq!(expected, actual);
-
-    // No status code, implicitly disabled
-    let output = common::render_module("exit_code").output()?;
-    let actual = String::from_utf8(output.stdout).unwrap();
-    assert_eq!(expected, actual);
-
-    // Status code 0, explicitly disabled
+    // Status code 0
     let output = common::render_module("exit_code")
         .use_config(toml::toml! {
             [exit_code]
@@ -30,7 +18,7 @@ fn success_status_disabled() -> io::Result<()> {
     let actual = String::from_utf8(output.stdout).unwrap();
     assert_eq!(expected, actual);
 
-    // No status code, explicitly disabled
+    // No status code
     let output = common::render_module("exit_code")
         .use_config(toml::toml! {
             [exit_code]
@@ -47,7 +35,19 @@ fn success_status_disabled() -> io::Result<()> {
 fn success_status_enabled() -> io::Result<()> {
     let expected = String::new();
 
-    // Status code 0
+    // Status code 0, implicitly enabled
+    let output = common::render_module("exit_code")
+        .arg("--status=0")
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+    assert_eq!(expected, actual);
+
+    // No status code, implicitly enabled
+    let output = common::render_module("exit_code").output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+    assert_eq!(expected, actual);
+
+    // Status code 0, explicitly enabled
     let output = common::render_module("exit_code")
         .use_config(toml::toml! {
             [exit_code]
@@ -58,7 +58,7 @@ fn success_status_enabled() -> io::Result<()> {
     let actual = String::from_utf8(output.stdout).unwrap();
     assert_eq!(expected, actual);
 
-    // No status code
+    // No status code, explicitly enabled
     let output = common::render_module("exit_code")
         .use_config(toml::toml! {
             [exit_code]
@@ -77,13 +77,6 @@ fn failure_status_disabled() -> io::Result<()> {
     let exit_values = ["1", "54321", "-5000"];
 
     for status in exit_values.iter() {
-        // Implicitly disabled
-        let arg = format!("--status={}", status);
-        let output = common::render_module("exit_code").arg(arg).output()?;
-        let actual = String::from_utf8(output.stdout).unwrap();
-        assert_eq!(expected, actual);
-
-        // Explicitly disabled
         let arg = format!("--status={}", status);
         let output = common::render_module("exit_code")
             .use_config(toml::toml! {
@@ -104,7 +97,15 @@ fn failure_status_enabled() -> io::Result<()> {
     let exit_values = ["1", "54321", "-5000"];
 
     for status in exit_values.iter() {
-        let expected = format!("exited {}", Color::Red.bold().paint(*status));
+        let expected = format!("{} ", Color::Red.bold().paint(*status));
+
+        // Implicitly enabled
+        let arg = format!("--status={}", status);
+        let output = common::render_module("exit_code").arg(arg).output()?;
+        let actual = String::from_utf8(output.stdout).unwrap();
+        assert_eq!(expected, actual);
+
+        // Explicitly enabled
         let arg = format!("--status={}", status);
         let output = common::render_module("exit_code")
             .use_config(toml::toml! {

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -7,6 +7,7 @@ mod configuration;
 mod directory;
 mod dotnet;
 mod env_var;
+mod exit_code;
 mod git_branch;
 mod git_state;
 mod git_status;


### PR DESCRIPTION
Although the "character" module can give the user feedback on whether or not the last command failed, it does not display the exit code.

This new "exit_code" module allows the user to display the exit code as part of the prompt.

Currently, it is placed in the default configuration at the end of the first line. Since, if you stay in one directory and run several commands the previous modules will probably not change much, I believe it makes sense to put this at the end to avoid shifting the other modules too much. I, for one, prefer for as much of my prompt as possible to stay constant.

The current configuration is to display, by default, the exit code as `"exited <code>"` (e.g. `"exited 127"`).

Since this functionality is already mostly present in the "character" module, I assumed it would be disabled by default.

The current options for configuration are:
  - `prefix`
  - `suffix`
  - `style`
  - `disabled`

#### Description
I went through what I believe is the standard process for adding another module.

I created a `Config`, implemented the module in the `modules` directory, added tests, and added the module to the `config` documentation.

#### Motivation and Context
My previous, custom-made prompt displayed the exit code in red when the exit code was non-zero. I actually really like knowing the exact error code, not just knowing that the exit code failed. It's not extremely important since if you need it you can use `$?`, but I think it's nice.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
I wrote several test cases in the `tests/` directory and used it as my prompt for a while. I tested all of the configuration options on my machine (MacOS). I also ran the `acceptance_test` script and all tests (that I could see) passed.
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.

I didn't add any tests that depended on any machine-specific integration, but I didn't see a reason why I would need to.