### PR TITLE
refactor: Refactor modules to use the exec_cmd util

### DIFF
--- a/src/modules/golang.rs
+++ b/src/modules/golang.rs
@@ -1,8 +1,7 @@
-use std::process::Command;
-
 use super::{Context, Module, RootModuleConfig};
 
 use crate::configs::go::GoConfig;
+use crate::utils;
 
 /// Creates a module with the current Go version
 ///
@@ -32,18 +31,11 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_style(config.style);
     module.create_segment("symbol", &config.symbol);
 
-    let formatted_version = format_go_version(&get_go_version()?)?;
+    let formatted_version =
+        format_go_version(&utils::exec_cmd("go", &["version"])?.stdout.as_str())?;
     module.create_segment("version", &config.version.with_value(&formatted_version));
 
     Some(module)
-}
-
-fn get_go_version() -> Option<String> {
-    Command::new("go")
-        .arg("version")
-        .output()
-        .ok()
-        .and_then(|output| String::from_utf8(output.stdout).ok())
 }
 
 fn format_go_version(go_stdout: &str) -> Option<String> {

--- a/src/modules/java.rs
+++ b/src/modules/java.rs
@@ -1,10 +1,9 @@
 use crate::configs::java::JavaConfig;
-use std::process::Command;
-use std::process::Output;
 
 use super::{Context, Module, RootModuleConfig, SegmentConfig};
 
 use crate::modules::utils::java_version_parser;
+use crate::utils;
 
 /// Creates a module with the current Java version
 ///
@@ -44,20 +43,8 @@ fn get_java_version() -> Option<String> {
         Err(_) => String::from("java"),
     };
 
-    match Command::new(java_command).arg("-Xinternalversion").output() {
-        Ok(output) => Some(combine_outputs(output)),
-        Err(_) => None,
-    }
-}
-
-/// Combines the standard and error outputs.
-///
-/// This is due some Java vendors using `STDERR` as the output.
-fn combine_outputs(output: Output) -> String {
-    let std_out = String::from_utf8(output.stdout).unwrap();
-    let std_err = String::from_utf8(output.stderr).unwrap();
-
-    format!("{}{}", std_out, std_err)
+    let output = utils::exec_cmd(&java_command.as_str(), &["-Xinternalversion"])?;
+    Some(format!("{}{}", output.stdout, output.stderr))
 }
 
 /// Extract the java version from `java_out`.

--- a/src/modules/python.rs
+++ b/src/modules/python.rs
@@ -1,9 +1,9 @@
 use std::env;
 use std::path::Path;
-use std::process::Command;
 
 use super::{Context, Module, RootModuleConfig, SegmentConfig};
 use crate::configs::python::PythonConfig;
+use crate::utils;
 
 /// Creates a module with the current Python version
 ///
@@ -40,7 +40,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.create_segment("symbol", &config.symbol);
 
     if config.pyenv_version_name {
-        let python_version = get_pyenv_version()?;
+        let python_version = utils::exec_cmd("pyenv", &["version-name"])?.stdout;
         module.create_segment("pyenv_prefix", &config.pyenv_prefix);
         module.create_segment("version", &SegmentConfig::new(&python_version.trim()));
     } else {
@@ -59,36 +59,16 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     Some(module)
 }
 
-fn get_pyenv_version() -> Option<String> {
-    Command::new("pyenv")
-        .arg("version-name")
-        .output()
-        .ok()
-        .and_then(|output| String::from_utf8(output.stdout).ok())
-}
-
 fn get_python_version() -> Option<String> {
-    match Command::new("python").arg("--version").output() {
-        Ok(output) => {
-            if !output.status.success() {
-                log::warn!(
-                    "Non-Zero exit code '{}' when executing `python --version`",
-                    output.status
-                );
-                return None;
-            }
-            // We have to check both stdout and stderr since for Python versions
-            // < 3.4, Python reports to stderr and for Python version >= 3.5,
-            // Python reports to stdout
+    match utils::exec_cmd("python", &["--version"]) {
+        Some(output) => {
             if output.stdout.is_empty() {
-                let stderr_string = String::from_utf8(output.stderr).unwrap();
-                Some(stderr_string)
+                Some(output.stderr)
             } else {
-                let stdout_string = String::from_utf8(output.stdout).unwrap();
-                Some(stdout_string)
+                Some(output.stdout)
             }
         }
-        Err(_) => None,
+        None => None,
     }
 }
 

--- a/src/modules/ruby.rs
+++ b/src/modules/ruby.rs
@@ -1,8 +1,7 @@
-use std::process::Command;
-
 use super::{Context, Module, RootModuleConfig, SegmentConfig};
 
 use crate::configs::ruby::RubyConfig;
+use crate::utils;
 
 /// Creates a module with the current Ruby version
 ///
@@ -20,7 +19,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         return None;
     }
 
-    let ruby_version = get_ruby_version()?;
+    let ruby_version = utils::exec_cmd("ruby", &["-v"])?.stdout;
     let formatted_version = format_ruby_version(&ruby_version)?;
 
     let mut module = context.new_module("ruby");
@@ -31,13 +30,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.create_segment("version", &SegmentConfig::new(&formatted_version));
 
     Some(module)
-}
-
-fn get_ruby_version() -> Option<String> {
-    match Command::new("ruby").arg("-v").output() {
-        Ok(output) => Some(String::from_utf8(output.stdout).unwrap()),
-        Err(_) => None,
-    }
 }
 
 fn format_ruby_version(ruby_version: &str) -> Option<String> {

--- a/src/modules/username.rs
+++ b/src/modules/username.rs
@@ -1,9 +1,9 @@
 use std::env;
-use std::process::Command;
 
 use super::{Context, Module, RootModuleConfig, SegmentConfig};
 
 use crate::configs::username::UsernameConfig;
+use crate::utils;
 
 /// Creates a module with the current user's username
 ///
@@ -38,10 +38,9 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 }
 
 fn get_uid() -> Option<u32> {
-    match Command::new("id").arg("-u").output() {
-        Ok(output) => String::from_utf8(output.stdout)
-            .map(|uid| uid.trim().parse::<u32>().ok())
-            .ok()?,
-        Err(_) => None,
-    }
+    utils::exec_cmd("id", &["-u"])?
+        .stdout
+        .trim()
+        .parse::<u32>()
+        .ok()
 }


### PR DESCRIPTION
#### Description
<!--- Describe your changes in detail -->
Have refactored the golang, java, nodejs, python, ruby and
username modules to use the new `exec_cmd` util.

I am not very familiar with how the command function is being using
in the `rust` and `dotnet` modules so leaving them for a later, or
someone else if they are more familiar than me. 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is just a refactor to reduce some common code.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.