### PR TITLE
fix: Long directory names trigger truncation in Fish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1424,6 +1424,7 @@ dependencies = [
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "urlencoding 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "yaml-rust 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ os_info = "1.2.0"
 urlencoding = "1.0.0"
 open = "1.3.2"
 reqwest = "0.9.24"
+unicode-width = "0.1.7"
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/src/init/starship.fish
+++ b/src/init/starship.fish
@@ -9,7 +9,7 @@ function fish_prompt
     # Account for changes in variable name between v2.7 and v3.0
     set -l CMD_DURATION "$CMD_DURATION$cmd_duration"
     set -l starship_duration (math --scale=0 "$CMD_DURATION / 1000")
-    ::STARSHIP:: prompt --status=$exit_code --keymap=$keymap --cmd-duration=$starship_duration --jobs=(count (jobs -p))
+    ::STARSHIP:: prompt --status=$exit_code --keymap=$keymap --cmd-duration=$starship_duration --jobs=(count (jobs -p)) --max-length=$COLUMNS
 end
 
 # disable virtualenv prompt, it breaks starship

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,7 +95,8 @@ fn main() {
                     .arg(&path_arg)
                     .arg(&cmd_duration_arg)
                     .arg(&keymap_arg)
-                    .arg(&jobs_arg),
+                    .arg(&jobs_arg)
+                    .arg(&max_length_arg),
             )
             .subcommand(
                 SubCommand::with_name("module")

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,6 +62,13 @@ fn main() {
         .help("The number of currently running jobs")
         .takes_value(true);
 
+    let max_length_arg = Arg::with_name("max_length")
+        .short("m")
+        .long("max-length")
+        .value_name("MAX_LENGTH")
+        .help("The maximum length of first prompt line")
+        .takes_value(true);
+
     let init_scripts_arg = Arg::with_name("print_full_init")
         .long("print-full-init")
         .help("Print the main initialization script (as opposed to the init stub)");

--- a/src/module.rs
+++ b/src/module.rs
@@ -96,6 +96,21 @@ impl<'a> Module<'a> {
         self.segments.iter().all(|segment| segment.is_empty())
     }
 
+    /// Total number of character in the module
+    pub fn segments_len(&self) -> usize {
+        self.segments.iter()
+            .fold(0, |acc, curr| acc + curr.value().chars().count())
+        + self.prefix.value.chars().count()
+        + self.suffix.value.chars().count()
+    }
+
+    /// Total number of character in the module, excluding the prefix
+    pub fn segments_len_without_prefix(&self) -> usize {
+        self.segments.iter()
+            .fold(0, |acc, curr| acc + curr.value().chars().count())
+            + self.suffix.value.chars().count()
+    }
+
     /// Get the module's prefix
     pub fn get_prefix(&mut self) -> &mut Affix {
         &mut self.prefix

--- a/src/module.rs
+++ b/src/module.rs
@@ -98,15 +98,17 @@ impl<'a> Module<'a> {
 
     /// Total number of character in the module
     pub fn segments_len(&self) -> usize {
-        self.segments.iter()
+        self.segments
+            .iter()
             .fold(0, |acc, curr| acc + curr.value().chars().count())
-        + self.prefix.value.chars().count()
-        + self.suffix.value.chars().count()
+            + self.prefix.value.chars().count()
+            + self.suffix.value.chars().count()
     }
 
     /// Total number of character in the module, excluding the prefix
     pub fn segments_len_without_prefix(&self) -> usize {
-        self.segments.iter()
+        self.segments
+            .iter()
             .fold(0, |acc, curr| acc + curr.value().chars().count())
             + self.suffix.value.chars().count()
     }

--- a/src/module.rs
+++ b/src/module.rs
@@ -99,19 +99,35 @@ impl<'a> Module<'a> {
 
     /// Total number of character in the module
     pub fn segments_len(&self) -> usize {
-        self.segments
-            .iter()
-            .fold(0, |acc, curr| acc + curr.value().chars().fold(0, |acc, curr| acc + curr.width().unwrap_or(0)))
-            + self.prefix.value.chars().fold(0, |acc, curr| acc + curr.width().unwrap_or(0))
-            + self.suffix.value.chars().fold(0, |acc, curr| acc + curr.width().unwrap_or(0))
+        self.segments.iter().fold(0, |acc, curr| {
+            acc + curr
+                .value()
+                .chars()
+                .fold(0, |acc, curr| acc + curr.width().unwrap_or(0))
+        }) + self
+            .prefix
+            .value
+            .chars()
+            .fold(0, |acc, curr| acc + curr.width().unwrap_or(0))
+            + self
+                .suffix
+                .value
+                .chars()
+                .fold(0, |acc, curr| acc + curr.width().unwrap_or(0))
     }
 
     /// Total number of character in the module, excluding the prefix
     pub fn segments_len_without_prefix(&self) -> usize {
-        self.segments
-            .iter()
-            .fold(0, |acc, curr| acc + curr.value().chars().fold(0, |acc, curr| acc + curr.width().unwrap_or(0)))
-            + self.suffix.value.chars().fold(0, |acc, curr| acc + curr.width().unwrap_or(0))
+        self.segments.iter().fold(0, |acc, curr| {
+            acc + curr
+                .value()
+                .chars()
+                .fold(0, |acc, curr| acc + curr.width().unwrap_or(0))
+        }) + self
+            .suffix
+            .value
+            .chars()
+            .fold(0, |acc, curr| acc + curr.width().unwrap_or(0))
     }
 
     /// Get the module's prefix

--- a/src/module.rs
+++ b/src/module.rs
@@ -3,6 +3,7 @@ use crate::segment::Segment;
 use ansi_term::Style;
 use ansi_term::{ANSIString, ANSIStrings};
 use std::fmt;
+use unicode_width::UnicodeWidthChar;
 
 // List of all modules
 // Keep these ordered alphabetically.
@@ -100,17 +101,17 @@ impl<'a> Module<'a> {
     pub fn segments_len(&self) -> usize {
         self.segments
             .iter()
-            .fold(0, |acc, curr| acc + curr.value().chars().count())
-            + self.prefix.value.chars().count()
-            + self.suffix.value.chars().count()
+            .fold(0, |acc, curr| acc + curr.value().chars().fold(0, |acc, curr| acc + curr.width().unwrap_or(0)))
+            + self.prefix.value.chars().fold(0, |acc, curr| acc + curr.width().unwrap_or(0))
+            + self.suffix.value.chars().fold(0, |acc, curr| acc + curr.width().unwrap_or(0))
     }
 
     /// Total number of character in the module, excluding the prefix
     pub fn segments_len_without_prefix(&self) -> usize {
         self.segments
             .iter()
-            .fold(0, |acc, curr| acc + curr.value().chars().count())
-            + self.suffix.value.chars().count()
+            .fold(0, |acc, curr| acc + curr.value().chars().fold(0, |acc, curr| acc + curr.width().unwrap_or(0)))
+            + self.suffix.value.chars().fold(0, |acc, curr| acc + curr.width().unwrap_or(0))
     }
 
     /// Get the module's prefix

--- a/src/print.rs
+++ b/src/print.rs
@@ -59,21 +59,23 @@ pub fn get_prompt(context: Context) -> String {
 
     for module in printable {
         // Skip printing the prefix of a module after the line_break
-        let len = if print_without_prefix {
+        segments_len += if print_without_prefix {
             segments_len = 0;
             module.segments_len_without_prefix()
         } else {
             module.segments_len()
         };
 
-        if max_len == 0 || module.get_name() == "line_break" || segments_len + len < max_len - 1 {
-            if print_without_prefix {
-                write!(buf, "{}", module.to_string_without_prefix()).unwrap();
-            } else {
-                write!(buf, "{}", module).unwrap();
-            }
+        if max_len > 0 && segments_len > max_len - 1 {
+            write!(buf, "{}", modules::handle("line_break", &context).unwrap()).unwrap();
+            segments_len = module.segments_len_without_prefix();
+            print_without_prefix = true;
+        }
 
-            segments_len += len;
+        if print_without_prefix {
+            write!(buf, "{}", module.to_string_without_prefix()).unwrap();
+        } else {
+            write!(buf, "{}", module).unwrap();
         }
 
         print_without_prefix = module.get_name() == "line_break"

--- a/src/print.rs
+++ b/src/print.rs
@@ -59,12 +59,13 @@ pub fn get_prompt(context: Context) -> String {
 
     for module in printable {
         // Skip printing the prefix of a module after the line_break
-        segments_len += if print_without_prefix {
+        let len = if print_without_prefix {
             segments_len = 0;
             module.segments_len_without_prefix()
         } else {
             module.segments_len()
         };
+        segments_len += len;
 
         if max_len > 0 && segments_len > max_len - 1 {
             write!(buf, "{}", modules::handle("line_break", &context).unwrap()).unwrap();

--- a/src/print.rs
+++ b/src/print.rs
@@ -39,9 +39,10 @@ pub fn get_prompt(context: Context) -> String {
         }
     }
 
-    let max_len = context.properties
+    let max_len = context
+        .properties
         .get("max_length")
-        .and_then(|value| { value.trim().parse::<usize>().ok() })
+        .and_then(|value| value.trim().parse::<usize>().ok())
         .unwrap_or(0);
 
     let modules = &prompt_order
@@ -65,10 +66,7 @@ pub fn get_prompt(context: Context) -> String {
             module.segments_len()
         };
 
-        if max_len == 0 ||
-            module.get_name() == "line_break" ||
-            segments_len + len < max_len - 1 {
-
+        if max_len == 0 || module.get_name() == "line_break" || segments_len + len < max_len - 1 {
             if print_without_prefix {
                 write!(buf, "{}", module.to_string_without_prefix()).unwrap();
             } else {

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -45,6 +45,11 @@ impl Segment {
         self
     }
 
+    /// Returns the raw value of the segment
+    pub fn value(&self) -> &String {
+        &self.value
+    }
+
     // Returns the ANSIString of the segment value, not including its prefix and suffix
     pub fn ansi_string(&self) -> ANSIString {
         match self.style {


### PR DESCRIPTION
After counting the module's number of characters, decide whether to print the module or skip it.

#### Description
This introduces a new CLI option, `--max-length` which can be used to specify the maximum length the prompt. If specified it's used to decide whether to print a module. When iterating through the modules their length is determined by way of the new `segments_len` function. If the length exceeds the remaining space the module is not printed.

This is mostly intended as a proof of concept and to see whether it's deemed a proper solution. I've not written any tests, only "anecdotally" tested it in my environment.

#### Motivation and Context
In Fish (shell), if the shell determines the length of the prompt exceeds the number of columns, it will use a default truncated prompt instead. This is to prevent undesired behavior when navigating the cursor in the shell. See the issue below for link to related issue in Fish repo.
Closes #585

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
I've tested this "anecdotally" to see that the proof of concept works.
OS: macOS Catalina (10.15.1 (19B88))
Terminal: Alacritty / Tmux
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
