### PR TITLE
feat(python): Add scan_for_pyfiles option

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -881,9 +881,11 @@ The module will be shown if any of the following conditions are met:
 - The current directory contains a `.python-version` file
 - The current directory contains a `requirements.txt` file
 - The current directory contains a `pyproject.toml` file
-- The current directory contains a file with the `.py` extension
+- The current directory contains a file with the `.py` extension (and `scan_for_pyfiles` is true)
 - The current directory contains a `Pipfile` file
 - The current directory contains a `tox.ini` file
+- The current directory contains a `setup.py` file
+- The current directory contains a `__init__.py` file
 - A virtual environment is currently activated
 
 ### Options
@@ -893,6 +895,7 @@ The module will be shown if any of the following conditions are met:
 | `symbol`             | `"🐍 "`         | The symbol used before displaying the version of Python.                    |
 | `pyenv_version_name` | `false`         | Use pyenv to get Python version                                             |
 | `pyenv_prefix`       | `"pyenv "`      | Prefix before pyenv version display (default display is `pyenv MY_VERSION`) |
+| `scan_for_pyfiles`   | `true`          | If false, Python files in the current directory will not show this module.  |
 | `style`              | `"bold yellow"` | The style for the module.                                                   |
 | `disabled`           | `false`         | Disables the `python` module.                                               |
 

--- a/src/configs/python.rs
+++ b/src/configs/python.rs
@@ -9,6 +9,7 @@ pub struct PythonConfig<'a> {
     pub version: SegmentConfig<'a>,
     pub pyenv_prefix: SegmentConfig<'a>,
     pub pyenv_version_name: bool,
+    pub scan_for_pyfiles: bool,
     pub style: Style,
     pub disabled: bool,
 }
@@ -20,6 +21,7 @@ impl<'a> RootModuleConfig<'a> for PythonConfig<'a> {
             version: SegmentConfig::default(),
             pyenv_prefix: SegmentConfig::new("pyenv "),
             pyenv_version_name: false,
+            scan_for_pyfiles: true,
             style: Color::Yellow.bold(),
             disabled: false,
         }

--- a/tests/testsuite/python.rs
+++ b/tests/testsuite/python.rs
@@ -4,7 +4,7 @@ use std::io;
 use ansi_term::Color;
 use tempfile;
 
-use crate::common;
+use crate::common::{self, TestCommand};
 
 #[test]
 #[ignore]
@@ -93,6 +93,40 @@ fn folder_with_tox() -> io::Result<()> {
 
 #[test]
 #[ignore]
+fn folder_with_setup_py() -> io::Result<()> {
+    let dir = tempfile::tempdir()?;
+    File::create(dir.path().join("setup.py"))?.sync_all()?;
+
+    let output = common::render_module("python")
+        .arg("--path")
+        .arg(dir.path())
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+
+    let expected = format!("via {} ", Color::Yellow.bold().paint("🐍 v3.7.5"));
+    assert_eq!(expected, actual);
+    Ok(())
+}
+
+#[test]
+#[ignore]
+fn folder_with_init_py() -> io::Result<()> {
+    let dir = tempfile::tempdir()?;
+    File::create(dir.path().join("__init__.py"))?.sync_all()?;
+
+    let output = common::render_module("python")
+        .arg("--path")
+        .arg(dir.path())
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+
+    let expected = format!("via {} ", Color::Yellow.bold().paint("🐍 v3.7.5"));
+    assert_eq!(expected, actual);
+    Ok(())
+}
+
+#[test]
+#[ignore]
 fn folder_with_py_file() -> io::Result<()> {
     let dir = tempfile::tempdir()?;
     File::create(dir.path().join("main.py"))?.sync_all()?;
@@ -138,6 +172,47 @@ fn with_active_venv() -> io::Result<()> {
     let actual = String::from_utf8(output.stdout).unwrap();
 
     let expected = format!("via {} ", Color::Yellow.bold().paint("🐍 v3.7.5 (my_venv)"));
+    assert_eq!(expected, actual);
+    Ok(())
+}
+
+#[test]
+fn disabled_scan_for_pyfiles_and_folder_with_ignored_py_file() -> io::Result<()> {
+    let dir = tempfile::tempdir()?;
+    File::create(dir.path().join("foo.py"))?.sync_all()?;
+
+    let output = common::render_module("python")
+        .use_config(toml::toml! {
+            [python]
+            scan_for_pyfiles = false
+        })
+        .arg("--path")
+        .arg(dir.path())
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+
+    let expected = "";
+    assert_eq!(expected, actual);
+    Ok(())
+}
+
+#[test]
+#[ignore]
+fn disabled_scan_for_pyfiles_and_folder_with_setup_py() -> io::Result<()> {
+    let dir = tempfile::tempdir()?;
+    File::create(dir.path().join("setup.py"))?.sync_all()?;
+
+    let output = common::render_module("python")
+        .use_config(toml::toml! {
+            [python]
+            scan_for_pyfiles = false
+        })
+        .arg("--path")
+        .arg(dir.path())
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+
+    let expected = format!("via {} ", Color::Yellow.bold().paint("🐍 v3.7.5"));
     assert_eq!(expected, actual);
     Ok(())
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
Adds a new Python module option to disable detecting `*.py` files in the current directory.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I have a lot of directories with random python files in them, that I don't want/need the Python module cluttering up my prompt. For example my home directory has a `test.py` file, a project I'm working on has a `test-webserver.py` file, and so on.

I only want the Python module activating in my real Python projects. Generally these are covered by the virtualenv detection and existing hardcoded filename checks (`requirements.txt` etc), but I've added `setup.py` and `__init__.py` as additional hardcoded failsafes to support this use-case.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):
![Screen Shot 2019-12-06 at 12 37 56 pm](https://user-images.githubusercontent.com/379509/70288188-43e29200-1825-11ea-8e94-f450eae65bfa.png)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.

Lots of Python tests are disabled. It seems because the tests hardcode the expected version of Python which requires them to be run with Python 3.7.5. I've added what tests I can following the same convention.