### PR TITLE
fix: Truncate long paths in conda environment names

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -299,7 +299,7 @@ This does not suppress conda's own prompt modifier, you may want to run `conda c
 
 | Variable            | Default        | Description                                                                                                                                                                                   |
 | ------------------- | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `truncation_length` | `1`            | The number of directories the environment path should be truncated to, if the environment was created via `conda create -p [path]`. `0` means no truncation. Also see the `directory` module. |
+| `truncation_length` | `1`            | The number of directories the environment path should be truncated to, if the environment was created via `conda create -p [path]`. `0` means no truncation. Also see the [`directory`](#directory) module. |
 | `symbol`            | `"C "`         | The symbol used before the environment name.                                                                                                                                                  |
 | `style`             | `"bold green"` | The style for the module.                                                                                                                                                                     |
 | `disabled`          | `false`        | Disables the `conda` module.                                                                                                                                                                  |

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -288,15 +288,17 @@ prefix = "underwent "
 ## Conda
 
 The `conda` module shows the current conda environment, if `$CONDA_DEFAULT_ENV` is set.
+
 Note: This does not suppress conda's own prompt modifier, you may want to run `conda config --set changeps1 False`
 
 ### Options
 
-| Variable   | Default        | Description                                  |
-| ---------- | -------------- | -------------------------------------------- |
-| `symbol`   | `"C "`         | The symbol used before the environment name. |
-| `style`    | `"bold green"` | The style for the module.                    |
-| `disabled` | `false`        | Disables the `conda` module.                 |
+| Variable            | Default        | Description                                                                                                                                                                                   |
+| ------------------- | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `truncation_length` | `1`            | The number of directories the environment path should be truncated to, if the environment was created via `conda create -p [path]`. `0` means no truncation. Also see the `directory` module. |
+| `symbol`            | `"C "`         | The symbol used before the environment name.                                                                                                                                                  |
+| `style`             | `"bold green"` | The style for the module.                                                                                                                                                                     |
+| `disabled`          | `false`        | Disables the `conda` module.                                                                                                                                                                  |
 
 ### Example
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -289,7 +289,11 @@ prefix = "underwent "
 
 The `conda` module shows the current conda environment, if `$CONDA_DEFAULT_ENV` is set.
 
-Note: This does not suppress conda's own prompt modifier, you may want to run `conda config --set changeps1 False`
+::: tip
+
+This does not suppress conda's own prompt modifier, you may want to run `conda config --set changeps1 False`.
+
+:::
 
 ### Options
 

--- a/src/configs/conda.rs
+++ b/src/configs/conda.rs
@@ -5,6 +5,7 @@ use starship_module_config_derive::ModuleConfig;
 
 #[derive(Clone, ModuleConfig)]
 pub struct CondaConfig<'a> {
+    pub truncation_length: usize,
     pub symbol: SegmentConfig<'a>,
     pub environment: SegmentConfig<'a>,
     pub style: Style,
@@ -14,6 +15,7 @@ pub struct CondaConfig<'a> {
 impl<'a> RootModuleConfig<'a> for CondaConfig<'a> {
     fn new() -> Self {
         CondaConfig {
+            truncation_length: 1,
             symbol: SegmentConfig {
                 value: "C ",
                 style: None,

--- a/src/modules/conda.rs
+++ b/src/modules/conda.rs
@@ -2,6 +2,7 @@ use std::env;
 
 use super::{Context, Module};
 
+use super::utils::directory::truncate;
 use crate::config::RootModuleConfig;
 use crate::configs::conda::CondaConfig;
 
@@ -17,6 +18,8 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
     let mut module = context.new_module("conda");
     let config = CondaConfig::try_load(module.config);
+
+    let conda_env = truncate(conda_env, config.truncation_length);
 
     module.set_style(config.style);
 

--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -4,6 +4,7 @@ use unicode_segmentation::UnicodeSegmentation;
 
 use super::{Context, Module};
 
+use super::utils::directory::truncate;
 use crate::config::{RootModuleConfig, SegmentConfig};
 use crate::configs::directory::DirectoryConfig;
 
@@ -135,30 +136,6 @@ fn replace_c_dir(path: String) -> String {
 #[cfg(not(target_os = "windows"))]
 const fn replace_c_dir(path: String) -> String {
     path
-}
-
-/// Truncate a path to only have a set number of path components
-///
-/// Will truncate a path to only show the last `length` components in a path.
-/// If a length of `0` is provided, the path will not be truncated.
-fn truncate(dir_string: String, length: usize) -> String {
-    if length == 0 {
-        return dir_string;
-    }
-
-    let mut components = dir_string.split('/').collect::<Vec<&str>>();
-
-    // If the first element is "" then there was a leading "/" and we should remove it so we can check the actual count of components
-    if components[0] == "" {
-        components.remove(0);
-    }
-
-    if components.len() <= length {
-        return dir_string;
-    }
-
-    let truncated_components = &components[components.len() - length..];
-    truncated_components.join("/")
 }
 
 /// Takes part before contracted path and replaces it with fish style path

--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -236,48 +236,6 @@ mod tests {
     }
 
     #[test]
-    fn truncate_smaller_path_than_provided_length() {
-        let path = "~/starship";
-        let output = truncate(path.to_string(), 3);
-        assert_eq!(output, "~/starship")
-    }
-
-    #[test]
-    fn truncate_same_path_as_provided_length() {
-        let path = "~/starship/engines";
-        let output = truncate(path.to_string(), 3);
-        assert_eq!(output, "~/starship/engines")
-    }
-
-    #[test]
-    fn truncate_slightly_larger_path_than_provided_length() {
-        let path = "~/starship/engines/booster";
-        let output = truncate(path.to_string(), 3);
-        assert_eq!(output, "starship/engines/booster")
-    }
-
-    #[test]
-    fn truncate_larger_path_than_provided_length() {
-        let path = "~/starship/engines/booster/rocket";
-        let output = truncate(path.to_string(), 3);
-        assert_eq!(output, "engines/booster/rocket")
-    }
-
-    #[test]
-    fn truncate_same_path_as_provided_length_from_root() {
-        let path = "/starship/engines/booster";
-        let output = truncate(path.to_string(), 3);
-        assert_eq!(output, "/starship/engines/booster");
-    }
-
-    #[test]
-    fn truncate_larger_path_than_provided_length_from_root() {
-        let path = "/starship/engines/booster/rocket";
-        let output = truncate(path.to_string(), 3);
-        assert_eq!(output, "engines/booster/rocket");
-    }
-
-    #[test]
     fn fish_style_with_user_home_contracted_path() {
         let path = "~/starship/engines/booster/rocket";
         let output = to_fish_style(1, path.to_string(), "engines/booster/rocket");

--- a/src/modules/utils/directory.rs
+++ b/src/modules/utils/directory.rs
@@ -1,0 +1,23 @@
+/// Truncate a path to only have a set number of path components
+///
+/// Will truncate a path to only show the last `length` components in a path.
+/// If a length of `0` is provided, the path will not be truncated.
+pub fn truncate(dir_string: String, length: usize) -> String {
+    if length == 0 {
+        return dir_string;
+    }
+
+    let mut components = dir_string.split('/').collect::<Vec<&str>>();
+
+    // If the first element is "" then there was a leading "/" and we should remove it so we can check the actual count of components
+    if components[0] == "" {
+        components.remove(0);
+    }
+
+    if components.len() <= length {
+        return dir_string;
+    }
+
+    let truncated_components = &components[components.len() - length..];
+    truncated_components.join("/")
+}

--- a/src/modules/utils/directory.rs
+++ b/src/modules/utils/directory.rs
@@ -21,3 +21,50 @@ pub fn truncate(dir_string: String, length: usize) -> String {
     let truncated_components = &components[components.len() - length..];
     truncated_components.join("/")
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncate_smaller_path_than_provided_length() {
+        let path = "~/starship";
+        let output = truncate(path.to_string(), 3);
+        assert_eq!(output, "~/starship")
+    }
+
+    #[test]
+    fn truncate_same_path_as_provided_length() {
+        let path = "~/starship/engines";
+        let output = truncate(path.to_string(), 3);
+        assert_eq!(output, "~/starship/engines")
+    }
+
+    #[test]
+    fn truncate_slightly_larger_path_than_provided_length() {
+        let path = "~/starship/engines/booster";
+        let output = truncate(path.to_string(), 3);
+        assert_eq!(output, "starship/engines/booster")
+    }
+
+    #[test]
+    fn truncate_larger_path_than_provided_length() {
+        let path = "~/starship/engines/booster/rocket";
+        let output = truncate(path.to_string(), 3);
+        assert_eq!(output, "engines/booster/rocket")
+    }
+
+    #[test]
+    fn truncate_same_path_as_provided_length_from_root() {
+        let path = "/starship/engines/booster";
+        let output = truncate(path.to_string(), 3);
+        assert_eq!(output, "/starship/engines/booster");
+    }
+
+    #[test]
+    fn truncate_larger_path_than_provided_length_from_root() {
+        let path = "/starship/engines/booster/rocket";
+        let output = truncate(path.to_string(), 3);
+        assert_eq!(output, "engines/booster/rocket");
+    }
+}

--- a/src/modules/utils/mod.rs
+++ b/src/modules/utils/mod.rs
@@ -1,1 +1,2 @@
+pub mod directory;
 pub mod java_version_parser;

--- a/tests/testsuite/conda.rs
+++ b/tests/testsuite/conda.rs
@@ -30,3 +30,14 @@ fn env_set() -> io::Result<()> {
     assert_eq!(expected, actual);
     Ok(())
 }
+
+#[test]
+fn truncate() -> io::Result<()> {
+    let output = common::render_module("conda").env_clear().env("CONDA_DEFAULT_ENV", "/some/really/long/and/really/annoying/path/that/shouldnt/be/displayed/fully/conda/my_env").output()?;
+
+    let expected = format!("via {} ", Color::Green.bold().paint("C my_env"));
+    let actual = String::from_utf8(output.stdout).unwrap();
+
+    assert_eq!(expected, actual);
+    Ok(())
+}


### PR DESCRIPTION
#### Description
Environment names created via `conda create -p [path]` tend to be too long for comfort, so this truncates them.
This uses the same function as the `directory` module, since I moved the function into `utils`.
#### Motivation and Context
Closes #675

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/20385973/70343790-722d9500-1858-11ea-8773-a52531afb893.png)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
