### PR TITLE
fix: Wrap prefix and suffix in shell-specific escape codes

### DIFF
--- a/src/module.rs
+++ b/src/module.rs
@@ -121,20 +121,20 @@ impl<'a> Module<'a> {
     /// `ANSIStrings()` to optimize ANSI codes
     pub fn ansi_strings(&self) -> Vec<ANSIString> {
         let shell = std::env::var("STARSHIP_SHELL").unwrap_or_default();
-        let ansi_strings = self
+        let mut ansi_strings = self
             .segments
             .iter()
             .map(Segment::ansi_string)
             .collect::<Vec<ANSIString>>();
 
-        let mut ansi_strings = match shell.as_str() {
+        ansi_strings.insert(0, self.prefix.ansi_string());
+        ansi_strings.push(self.suffix.ansi_string());
+
+        ansi_strings = match shell.as_str() {
             "bash" => ansi_strings_modified(ansi_strings, shell),
             "zsh" => ansi_strings_modified(ansi_strings, shell),
             _ => ansi_strings,
         };
-
-        ansi_strings.insert(0, self.prefix.ansi_string());
-        ansi_strings.push(self.suffix.ansi_string());
 
         ansi_strings
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
Wrap the module prefix and suffix in shell-specific escape codes. These shell-specific codes help the terminal emulator calculate the size of the prompt.

#### Motivation and Context
Closes #290

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots
bash 3.2
![image](https://user-images.githubusercontent.com/938138/70596100-4d138c00-1ba2-11ea-8df8-7e78f1e3e844.png)

zsh 5.7
![image](https://user-images.githubusercontent.com/938138/70596125-58ff4e00-1ba2-11ea-8c8c-158bdb4f8ed6.png)

starship.toml:
```toml
add_newline = false

prompt_order = [
    "directory",
    "git_branch",
    "git_state",
    "git_status",
    "character"
]
```

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**


Tested on MacOs Catalina with iTerm2 and the built-in Terminal app. Tested on both bash and zsh. Tested rust, node, python and battery modules.

There aren't any unit tests in this area. As a rust newbie I was a little lost on how to approach. Tips welcome.


#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
