### PR TITLE
Feat Add Composer package version detection to Package module

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -860,6 +860,8 @@ and `poetry` packages.
   in the current directory
 - **poetry** – The `poetry` package version is extracted from the `pyproject.toml` present
   in the current directory
+- **composer** – The `composer` package version is extracted from the `composer.json` present
+  in the current directory
 
 > ⚠️ The version being shown is that of the package whose source code is in your
 > current directory, not your package manager.

--- a/src/modules/package.rs
+++ b/src/modules/package.rs
@@ -59,6 +59,17 @@ fn extract_poetry_version(file_contents: &str) -> Option<String> {
     Some(formatted_version)
 }
 
+fn extract_composer_version(file_contents: &str) -> Option<String> {
+    let composer_json: json::Value = json::from_str(file_contents).ok()?;
+    let raw_version = composer_json.get("version")?.as_str()?;
+    if raw_version == "null" {
+        return None;
+    };
+
+    let formatted_version = format_version(raw_version);
+    Some(formatted_version)
+}
+
 fn get_package_version() -> Option<String> {
     if let Ok(cargo_toml) = utils::read_file("Cargo.toml") {
         extract_cargo_version(&cargo_toml)
@@ -66,6 +77,8 @@ fn get_package_version() -> Option<String> {
         extract_package_version(&package_json)
     } else if let Ok(poetry_toml) = utils::read_file("pyproject.toml") {
         extract_poetry_version(&poetry_toml)
+    } else if let Ok(composer_json) = utils::read_file("composer.json") {
+        extract_composer_version(&composer_json)
     } else {
         None
     }
@@ -174,6 +187,32 @@ mod tests {
         let expected_version = None;
         assert_eq!(
             extract_poetry_version(&poetry_without_version),
+            expected_version
+        );
+    }
+
+    #[test]
+    fn test_extract_composer_version() {
+        let composer_with_version = json::json!({
+            "name": "spacefish",
+            "version": "0.1.0"
+        })
+        .to_string();
+
+        let expected_version = Some("v0.1.0".to_string());
+        assert_eq!(
+            extract_composer_version(&composer_with_version),
+            expected_version
+        );
+
+        let composer_without_version = json::json!({
+            "name": "spacefish"
+        })
+        .to_string();
+
+        let expected_version = None;
+        assert_eq!(
+            extract_composer_version(&composer_without_version),
             expected_version
         );
     }


### PR DESCRIPTION
#### Description
Added an extra function to the Package module, allowing it to display the version number found in `composer.json` in the current folder.

#### Motivation and Context
I've never written a single line of Rust before in my life, but I figured I'd see if I could add this tiny feature. It's basically just a modified version of the `package.json` detection.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I've added a unit test (modified version of of the `package.json` test), and all tests are passing.
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
