### PR TITLE
feat: Add `emberjs` module

### DIFF
--- a/src/configs/emberjs.rs
+++ b/src/configs/emberjs.rs
@@ -1,0 +1,21 @@
+use crate::config::{ModuleConfig, RootModuleConfig, SegmentConfig};
+
+use ansi_term::{Color, Style};
+use starship_module_config_derive::ModuleConfig;
+
+#[derive(Clone, ModuleConfig)]
+pub struct EmberjsConfig<'a> {
+    pub symbol: SegmentConfig<'a>,
+    pub style: Style,
+    pub disabled: bool,
+}
+
+impl<'a> RootModuleConfig<'a> for EmberjsConfig<'a> {
+    fn new() -> Self {
+        EmberjsConfig {
+            symbol: SegmentConfig::new("🐹 "),
+            style: Color::Red.bold(),
+            disabled: false,
+        }
+    }
+}

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -5,6 +5,7 @@ pub mod cmd_duration;
 pub mod conda;
 pub mod directory;
 pub mod dotnet;
+pub mod emberjs;
 pub mod env_var;
 pub mod git_branch;
 pub mod git_commit;

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -43,6 +43,7 @@ impl<'a> RootModuleConfig<'a> for StarshipRootConfig<'a> {
                 "conda",
                 "memory_usage",
                 "aws",
+                "emberjs",
                 "env_var",
                 "cmd_duration",
                 "line_break",

--- a/src/module.rs
+++ b/src/module.rs
@@ -16,6 +16,7 @@ pub const ALL_MODULES: &[&str] = &[
     "conda",
     "directory",
     "dotnet",
+    "emberjs",
     "env_var",
     "git_branch",
     "git_commit",

--- a/src/modules/emberjs.rs
+++ b/src/modules/emberjs.rs
@@ -1,0 +1,39 @@
+use super::{Context, Module, RootModuleConfig, SegmentConfig};
+
+use crate::configs::emberjs::EmberjsConfig;
+use crate::modules::package::extract_package_version;
+use crate::utils;
+
+/// Creates a module with the current Ember.js version
+pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let is_js_project = context
+        .try_begin_scan()?
+        .set_files(&["package.json"])
+        .set_folders(&["node_modules"])
+        .is_match();
+
+    if !is_js_project {
+        return None;
+    }
+
+    let pkg_path = context
+        .current_dir
+        .join("node_modules")
+        .join("ember-source")
+        .join("package.json");
+    let content = utils::read_file(pkg_path).ok()?;
+
+    extract_package_version(&content).map(|version| {
+        let mut module = context.new_module("emberjs");
+        let config = EmberjsConfig::try_load(module.config);
+
+        module.set_style(config.style);
+        module.get_prefix().set_value("with ");
+
+        let formatted_version = version.trim();
+        module.create_segment("symbol", &config.symbol);
+        module.create_segment("version", &SegmentConfig::new(formatted_version));
+
+        module
+    })
+}

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -5,6 +5,7 @@ mod cmd_duration;
 mod conda;
 mod directory;
 mod dotnet;
+mod emberjs;
 mod env_var;
 mod git_branch;
 mod git_commit;
@@ -49,6 +50,7 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
         "conda" => conda::module(context),
         "directory" => directory::module(context),
         "dotnet" => dotnet::module(context),
+        "emberjs" => emberjs::module(context),
         "env_var" => env_var::module(context),
         "git_branch" => git_branch::module(context),
         "git_commit" => git_commit::module(context),

--- a/src/modules/package.rs
+++ b/src/modules/package.rs
@@ -36,7 +36,7 @@ fn extract_cargo_version(file_contents: &str) -> Option<String> {
     Some(formatted_version)
 }
 
-fn extract_package_version(file_contents: &str) -> Option<String> {
+pub fn extract_package_version(file_contents: &str) -> Option<String> {
     let package_json: json::Value = json::from_str(file_contents).ok()?;
     let raw_version = package_json.get("version")?.as_str()?;
     if raw_version == "null" {

--- a/tests/testsuite/emberjs.rs
+++ b/tests/testsuite/emberjs.rs
@@ -1,0 +1,72 @@
+use ansi_term::Color;
+use std::fs;
+use std::io;
+use tempfile;
+
+use crate::common;
+
+#[test]
+fn without_node_modules() -> io::Result<()> {
+    let dir = tempfile::tempdir()?;
+
+    let output = common::render_module("emberjs")
+        .arg("--path")
+        .arg(dir.path())
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+
+    let expected = "";
+    assert_eq!(expected, actual);
+    Ok(())
+}
+
+#[test]
+fn without_ember_source_package() -> io::Result<()> {
+    let dir = tempfile::tempdir()?;
+    fs::create_dir(dir.path().join("node_modules"))?;
+
+    let output = common::render_module("emberjs")
+        .arg("--path")
+        .arg(dir.path())
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+
+    let expected = "";
+    assert_eq!(expected, actual);
+    Ok(())
+}
+
+#[test]
+fn without_ember_source_package_json() -> io::Result<()> {
+    let dir = tempfile::tempdir()?;
+    fs::create_dir_all(dir.path().join("node_modules").join("ember-source"))?;
+
+    let output = common::render_module("emberjs")
+        .arg("--path")
+        .arg(dir.path())
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+
+    let expected = "";
+    assert_eq!(expected, actual);
+    Ok(())
+}
+
+#[test]
+fn with_ember_source_package() -> io::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let pkg_path = dir.path().join("node_modules").join("ember-source");
+    fs::create_dir_all(&pkg_path)?;
+    let pkg_json_path = pkg_path.join("package.json");
+    fs::write(&pkg_json_path, "{\n  \"version\": \"3.14.0\"\n}")?;
+
+    let output = common::render_module("emberjs")
+        .arg("--path")
+        .arg(dir.path())
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+
+    let expected = format!("with {} ", Color::Red.bold().paint("🐹 v3.14.0"));
+    assert_eq!(expected, actual);
+    Ok(())
+}

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -6,6 +6,7 @@ mod conda;
 mod configuration;
 mod directory;
 mod dotnet;
+mod emberjs;
 mod env_var;
 mod git_branch;
 mod git_commit;


### PR DESCRIPTION
#### Description

This PR introduces a new `emberjs` module that shows the https://emberjs.com/ version as e.g. `with 🐹 v3.14.0`

The implementation relies on the existance of the `ember-source` package in the `node_modules` folder, which should exist for all conventional Ember.js projects.

#### Motivation and Context
> Why is this change required? What problem does it solve?

When working on multiple Ember.js projects it is very useful to see at a glance what Ember.js version is used by the project to figure out what features are available

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

<img width="729" alt="Bildschirmfoto 2019-12-13 um 09 30 24" src="https://user-images.githubusercontent.com/141300/70785632-35e3c280-1d8b-11ea-838d-914a71a094bf.png">


#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

I ran this locally via `target/debug/starship prompt` in several projects and I've included a few unit tests that should test the basic functionality.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.

I will update the documentation accordingly once the implementation is approved 🙏 