### PR TITLE
feat: add Fedora installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,12 @@ The prompt shows information you need while you're working, while staying sleek 
    scoop install starship
    ```
 
+   ##### Fedora
+
+   ```sh
+   sudo dnf install starship
+   ```
+   
 1. Add the init script to your shell's config file:
 
    #### Bash


### PR DESCRIPTION
#### Description

`starship` packaged and available in official [Fedora repos](https://src.fedoraproject.org/rpms/rust-starship). Now in Rawhide, soon will be for F31.

#### Motivation and Context

Users can easiely discover and install app via their native package managers. This solves https://github.com/starship/starship/issues/545

#### Types of changes

- [x] New feature (non-breaking change which adds functionality)

#### Screenshots (if appropriate):

#### How Has This Been Tested?

- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**