### PR TITLE
fix(bug-report): URLs too long

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ reqwest = { version = "0.9.24", default-features = false, features = ["rustls-tl
 unicode-width = "0.1.7"
 textwrap = "0.11.0"
 term_size = "0.3.1"
+clipboard = "0.5.0"
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,6 @@ reqwest = { version = "0.9.24", default-features = false, features = ["rustls-tl
 unicode-width = "0.1.7"
 textwrap = "0.11.0"
 term_size = "0.3.1"
-clipboard = "0.5.0"
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/src/bug_report.rs
+++ b/src/bug_report.rs
@@ -19,10 +19,9 @@ pub fn create() {
 
     let link = get_github_issue_link();
     let env_info = format_env_info(crate_version!(), environment);
-    let copy_success = clipboard::ClipboardProvider::new()
+    let copy_failed = clipboard::ClipboardProvider::new()
         .and_then(|mut ctx: clipboard::ClipboardContext| ctx.set_contents(env_info.to_string()))
-        .map(|_| true)
-        .unwrap_or(false);
+        .is_err();
 
     if open::that(&link).is_ok() {
         print!("Take a look at your browser. A GitHub issue has been created and your environment info has been copied to your clipboard.")
@@ -41,7 +40,7 @@ pub fn create() {
         );
     }
 
-    if !copy_success {
+    if copy_failed {
         println!(
             "\n\nYour clipboard was unavailable, so here's the summary of your environment:\n\n{}",
             env_info

--- a/src/bug_report.rs
+++ b/src/bug_report.rs
@@ -93,7 +93,8 @@ fn make_github_issue_link(starship_version: &str, environment: Environment) -> S
         .replace("%20", "+");
 
     format!(
-        "https://github.com/starship/starship/issues/new?body={}",
+        "https://github.com/starship/starship/issues/new?template={}&body={}",
+        urlencoding::encode("Bug_report.md"),
         body
     )
     .chars()

--- a/src/bug_report.rs
+++ b/src/bug_report.rs
@@ -62,8 +62,7 @@ struct Environment {
 }
 
 fn get_github_issue_link() -> String {
-    let body = urlencoding::encode(&format!(
-        "#### Current Behavior
+    let body = urlencoding::encode( "#### Current Behavior
 <!-- A clear and concise description of the behavior. -->
 
 #### Expected Behavior
@@ -77,8 +76,7 @@ fn get_github_issue_link() -> String {
 
 #### Environment
 <!-- Your environment information has been copied to the clipboard automatically. Paste it here. -->
-",
-    ))
+" )
         .replace("%20", "+");
 
     format!(

--- a/src/bug_report.rs
+++ b/src/bug_report.rs
@@ -207,7 +207,7 @@ mod tests {
     use std::env;
 
     #[test]
-    fn test_make_github_issue_link() {
+    fn test_format_env_info() {
         let starship_version = "0.1.2";
         let environment = Environment {
             os_type: os_info::Type::Linux,
@@ -224,15 +224,15 @@ mod tests {
             starship_config: "No Starship config".to_string(),
         };
 
-        let link = format_env_info(starship_version, environment);
+        let env_info = format_env_info(starship_version, environment);
 
-        assert!(link.contains(starship_version));
-        assert!(link.contains("Linux"));
-        assert!(link.contains("1.2.3"));
-        assert!(link.contains("test_shell"));
-        assert!(link.contains("2.3.4"));
-        assert!(link.contains("No%20config"));
-        assert!(link.contains("No%20Starship%20config"));
+        assert!(env_info.contains(starship_version));
+        assert!(env_info.contains("Linux"));
+        assert!(env_info.contains("1.2.3"));
+        assert!(env_info.contains("test_shell"));
+        assert!(env_info.contains("2.3.4"));
+        assert!(env_info.contains("No config"));
+        assert!(env_info.contains("No Starship config"));
     }
 
     #[test]

--- a/src/bug_report.rs
+++ b/src/bug_report.rs
@@ -178,8 +178,16 @@ fn get_config_path(shell: &str) -> Option<PathBuf> {
 }
 
 fn get_starship_config() -> String {
-    dirs::home_dir()
-        .and_then(|home_dir| fs::read_to_string(home_dir.join(".config/starship.toml")).ok())
+    std::env::var("STARSHIP_CONFIG")
+        .map(PathBuf::from)
+        .ok()
+        .or_else(|| {
+            dirs::home_dir().map(|mut home_dir| {
+                home_dir.push(".config/starship.toml");
+                home_dir
+            })
+        })
+        .and_then(|config_path| fs::read_to_string(config_path).ok())
         .unwrap_or_else(|| UNKNOWN_CONFIG.to_string())
 }
 

--- a/src/bug_report.rs
+++ b/src/bug_report.rs
@@ -189,7 +189,7 @@ mod tests {
     use std::env;
 
     #[test]
-    fn test_format_env_info() {
+    fn test_make_github_link() {
         let starship_version = "0.1.2";
         let environment = Environment {
             os_type: os_info::Type::Linux,
@@ -213,16 +213,8 @@ mod tests {
         assert!(link.contains("1.2.3"));
         assert!(link.contains("test_shell"));
         assert!(link.contains("2.3.4"));
-        assert!(link.contains("No%20config"));
-        assert!(link.contains("No%20Starship%20config"));
-
-        assert!(env_info.contains(starship_version));
-        assert!(env_info.contains("Linux"));
-        assert!(env_info.contains("1.2.3"));
-        assert!(env_info.contains("test_shell"));
-        assert!(env_info.contains("2.3.4"));
-        assert!(env_info.contains("No config"));
-        assert!(env_info.contains("No Starship config"));
+        assert!(link.contains("No+config"));
+        assert!(link.contains("No+Starship+config"));
     }
 
     #[test]

--- a/src/bug_report.rs
+++ b/src/bug_report.rs
@@ -41,7 +41,7 @@ pub fn create() {
         );
     }
 
-    if copy_success {
+    if !copy_success {
         println!(
             "\n\nYour clipboard was unavailable, so here's the summary of your environment:\n\n{}",
             env_info

--- a/src/bug_report.rs
+++ b/src/bug_report.rs
@@ -40,6 +40,7 @@ const UNKNOWN_SHELL: &str = "<unknown shell>";
 const UNKNOWN_TERMINAL: &str = "<unknown terminal>";
 const UNKNOWN_VERSION: &str = "<unknown version>";
 const UNKNOWN_CONFIG: &str = "<unknown config>";
+const GITHUB_CHAR_LIMIT: usize = 8100; // Magic number accepted by Github
 
 struct Environment {
     os_type: os_info::Type,
@@ -96,7 +97,7 @@ fn make_github_issue_link(starship_version: &str, environment: Environment) -> S
         body
     )
     .chars()
-    .take(8100) // Magic number accepted by Github
+    .take(GITHUB_CHAR_LIMIT)
     .collect()
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->
This fixes the issue reported in #749 

#### Description
<!--- Describe your changes in detail -->
By only using a simple template in the url and instead copy the environment info to the clipboard, I think we can land on a nice middle ground between not loosing to much of the convenience while still being able to handle large configs.

A quick search on the web tells me that most browsers are happy as long as URLs are not much longer than ~2000 character, which may present some problems in regards to larger configs. The URL linked in the issue is almost 10,000 characters long.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #749

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This works consistently when testing with HUGE configs (300,000+ characters).
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
