### PR TITLE
feat: Implement `starship configure` command

### DIFF
--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -7,7 +7,6 @@ pub struct StarshipRootConfig<'a> {
     pub add_newline: bool,
     pub prompt_order: Vec<&'a str>,
     pub scan_timeout: u64,
-    pub editor: &'a str,
 }
 
 impl<'a> RootModuleConfig<'a> for StarshipRootConfig<'a> {
@@ -54,7 +53,6 @@ impl<'a> RootModuleConfig<'a> for StarshipRootConfig<'a> {
                 "character",
             ],
             scan_timeout: 30,
-            editor: "",
         }
     }
 }

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -7,6 +7,7 @@ pub struct StarshipRootConfig<'a> {
     pub add_newline: bool,
     pub prompt_order: Vec<&'a str>,
     pub scan_timeout: u64,
+    pub editor: &'a str,
 }
 
 impl<'a> RootModuleConfig<'a> for StarshipRootConfig<'a> {
@@ -53,6 +54,7 @@ impl<'a> RootModuleConfig<'a> for StarshipRootConfig<'a> {
                 "character",
             ],
             scan_timeout: 30,
+            editor: "",
         }
     }
 }

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -1,15 +1,11 @@
-use crate::context::Context;
-use clap::ArgMatches;
-
 use std::env;
 use std::process::Command;
 
 const UNKNOWN_CONFIG: &str = "<unknown config>";
 const STD_EDITOR: &str = "vi";
 
-pub fn edit_configuration(args: ArgMatches) {
-    let context = Context::new(args);
-    let editor = get_editor(context);
+pub fn edit_configuration() {
+    let editor = get_editor();
     let config_path = get_config_path();
 
     Command::new(editor)
@@ -18,16 +14,10 @@ pub fn edit_configuration(args: ArgMatches) {
         .expect("failed to open file");
 }
 
-fn get_editor(context: Context) -> String {
-    let config = context.config.get_root_config();
-
-    if config.editor != "" {
-        config.editor.to_string()
-    } else {
-        match env::var("EDITOR") {
-            Ok(val) => val,
-            Err(_) => STD_EDITOR.to_string(),
-        }
+fn get_editor() -> String {
+    match env::var("EDITOR") {
+        Ok(val) => val,
+        Err(_) => STD_EDITOR.to_string(),
     }
 }
 

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -1,0 +1,21 @@
+use crate::context::Context;
+use clap::ArgMatches;
+
+use std::process::Command;
+
+pub fn edit_configuration(args: ArgMatches) {
+    let context = Context::new(args);
+    let editor = get_editor(context);
+
+    println!("using {} as editor", editor);
+
+    Command::new(editor)
+        .arg("~/.config/starship.toml")
+        .status()
+        .expect("failed to open file");
+}
+
+fn get_editor(context: Context) -> String {
+    let config = context.config.get_root_config();
+    String::from(config.editor)
+}

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -12,9 +12,6 @@ pub fn edit_configuration(args: ArgMatches) {
     let editor = get_editor(context);
     let config_path = get_config_path();
 
-    println!("using {} as editor", editor);
-    println!("path: {}", config_path);
-
     Command::new(editor)
         .arg(config_path)
         .status()

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -1,21 +1,52 @@
 use crate::context::Context;
 use clap::ArgMatches;
 
+use std::env;
 use std::process::Command;
+
+const UNKNOWN_CONFIG: &str = "<unknown config>";
+const STD_EDITOR: &str = "vi";
 
 pub fn edit_configuration(args: ArgMatches) {
     let context = Context::new(args);
     let editor = get_editor(context);
+    let config_path = get_config_path();
 
     println!("using {} as editor", editor);
+    println!("path: {}", config_path);
 
     Command::new(editor)
-        .arg("~/.config/starship.toml")
+        .arg(config_path)
         .status()
         .expect("failed to open file");
 }
 
 fn get_editor(context: Context) -> String {
     let config = context.config.get_root_config();
-    String::from(config.editor)
+    
+    let mut editor = match env::var("EDITOR") {
+        Ok(e) => e,
+        Err(_) => STD_EDITOR.to_string(),
+    };
+
+    if config.editor != "" {
+        editor = config.editor.to_string();
+    }
+    
+    editor
+}
+
+fn get_config_path() -> String {
+    let home_dir = dirs::home_dir();
+
+    if home_dir.is_none() {
+        return UNKNOWN_CONFIG.to_string();
+    }
+
+    let path = home_dir.unwrap().join(".config/starship.toml");
+
+    return match path.to_str() {
+        Some(p) => String::from(p),
+        None => UNKNOWN_CONFIG.to_string(),
+    }
 }

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -20,17 +20,15 @@ pub fn edit_configuration(args: ArgMatches) {
 
 fn get_editor(context: Context) -> String {
     let config = context.config.get_root_config();
-    
-    let mut editor = match env::var("EDITOR") {
-        Ok(e) => e,
-        Err(_) => STD_EDITOR.to_string(),
-    };
 
     if config.editor != "" {
-        editor = config.editor.to_string();
+        config.editor.to_string()
+    } else {
+        match env::var("EDITOR") {
+            Ok(val) => val,
+            Err(_) => STD_EDITOR.to_string(),
+        }
     }
-    
-    editor
 }
 
 fn get_config_path() -> String {
@@ -42,7 +40,7 @@ fn get_config_path() -> String {
 
     let path = home_dir.unwrap().join(".config/starship.toml");
 
-    return match path.to_str() {
+    match path.to_str() {
         Some(p) => String::from(p),
         None => UNKNOWN_CONFIG.to_string(),
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -139,7 +139,7 @@ fn main() {
                 print::module(module_name, sub_m.clone());
             }
         }
-        ("configure", Some(sub_m)) => configure::edit_configuration(sub_m.clone()),
+        ("configure", Some(_)) => configure::edit_configuration(),
         ("bug-report", Some(_)) => bug_report::create(),
         _ => {}
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ extern crate clap;
 
 mod bug_report;
 mod config;
+mod configure;
 mod configs;
 mod context;
 mod init;
@@ -110,6 +111,10 @@ fn main() {
                     .arg(&keymap_arg)
                     .arg(&jobs_arg),
             )
+            .subcommand(
+                SubCommand::with_name("configure")
+                    .about("Edit the starship configuration")   
+            )
             .subcommand(SubCommand::with_name("bug-report").about(
                 "Create a pre-populated GitHub issue with information about your configuration",
             ))
@@ -137,6 +142,7 @@ fn main() {
                 print::module(module_name, sub_m.clone());
             }
         }
+        ("configure", Some(sub_m)) => configure::edit_configuration(sub_m.clone()),
         ("bug-report", Some(_)) => bug_report::create(),
         _ => {}
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,8 +3,8 @@ extern crate clap;
 
 mod bug_report;
 mod config;
-mod configure;
 mod configs;
+mod configure;
 mod context;
 mod init;
 mod module;
@@ -111,10 +111,7 @@ fn main() {
                     .arg(&keymap_arg)
                     .arg(&jobs_arg),
             )
-            .subcommand(
-                SubCommand::with_name("configure")
-                    .about("Edit the starship configuration")   
-            )
+            .subcommand(SubCommand::with_name("configure").about("Edit the starship configuration"))
             .subcommand(SubCommand::with_name("bug-report").about(
                 "Create a pre-populated GitHub issue with information about your configuration",
             ))


### PR DESCRIPTION
#### Description
This is a implementation of the `starship configure` command that I proposed in https://github.com/starship/starship/issues/743. I don't even know if this enhancement is wanted or not, but if you want a preview, just checkout my branch and run `cargo run -- configure` or something.

#### Motivation and Context
Starship is highly configurable and customizing it is a very common thing, at least for me. It is a bit tedious to type `vi ~/.config/starship.toml` each time i want to configure Starship. This PR introduces the flexible and ergonomic `starship configure` command.

**Behavior:** `configure` opens the Starship configuration file in a desired editor. This may be a simple editor like nano or even an editor with a GUI. The command waits for the user to finish editing and then exists.

**Editor configuration and preferences:** Which editor is used depends on the user's configuration. The configured editor in the Starship root configuration has the highest priority:

```toml
add_newline = false
editor = "nano"
```

If the `editor` key does not exist, the `$EDITOR` environment variable will be checked. It has the second-highest priority and if it exists, the Starship configuration file will be opened using `$EDITOR`.

If this environment variable is not set, there's a default editor as fallback which can be found in `configure.rs` and is currently set to `vi`.

Tests and documentation will be updated accordingly in case you want to merge. Feel free to close this PR if you don't want to add the command and don't hesitate to propose any improvements!

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/36575275/71042924-66ca4b80-212d-11ea-95a1-92d2df152dde.png)

![image](https://user-images.githubusercontent.com/36575275/71042933-6df15980-212d-11ea-98f2-3b4fa42f5589.png)

#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
