### PR TITLE
fix(bash): save and restore "$_"

### DIFF
--- a/src/init/starship.bash
+++ b/src/init/starship.bash
@@ -14,11 +14,16 @@
 
 # Will be run before *every* command (even ones in pipes!)
 starship_preexec() {
+    # Save previous command's last argument, otherwise it will be set to "starship_preexec"
+    local PREV_LAST_ARG=$1
+
     # Avoid restarting the timer for commands in the same pipeline
     if [ "$PREEXEC_READY" = "true" ]; then
         PREEXEC_READY=false
         STARSHIP_START_TIME=$(date +%s)
     fi
+    
+    : "$PREV_LAST_ARG"
 }
 
 # Will be run before the prompt is drawn
@@ -44,7 +49,7 @@ starship_precmd() {
 # If the user appears to be using https://github.com/rcaloras/bash-preexec,
 # then hook our functions into their framework.
 if [[ $preexec_functions ]]; then
-    preexec_functions+=(starship_preexec)
+    preexec_functions+=('starship_preexec "$_"')
     precmd_functions+=(starship_precmd)
 else
 # We want to avoid destroying an existing DEBUG hook. If we detect one, create
@@ -52,12 +57,12 @@ else
 # re-trap DEBUG to use this new function. This prevents a trap clobber.
     dbg_trap="$(trap -p DEBUG | cut -d' ' -f3 | tr -d \')"
     if [[ -z "$dbg_trap" ]]; then
-        trap starship_preexec DEBUG
-    elif [[ "$dbg_trap" != "starship_preexec" && "$dbg_trap" != "starship_preexec_all" ]]; then
+        trap 'starship_preexec "$_"' DEBUG
+    elif [[ "$dbg_trap" != 'starship_preexec "$_"' && "$dbg_trap" != 'starship_preexec_all "$_"' ]]; then
         function starship_preexec_all(){
-            $dbg_trap; starship_preexec
+            local PREV_LAST_ARG=$1 ; $dbg_trap; starship_preexec; : "$PREV_LAST_ARG";
         }
-        trap starship_preexec_all DEBUG
+        trap 'starship_preexec_all "$_"' DEBUG
     fi
 
     # Finally, prepare the precmd function and set up the start time.


### PR DESCRIPTION
This fixes the issue reported in #629 

#### Description
I just modified the `starship.bash` script template, to save the original `$_` special parameter when DEBUG is trapped and restore it at the end of the starship_preexec[_all] function.

#### Motivation and Context
Closes #629
When we get our prompt, last executed command is `starship_preexec`. This overwrites the original $_ special parameter.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):
##### Before fix:
```bash
~ 
❯ echo foo
foo
~ 
❯ echo $_
starship_preexec
~ 
❯ 
```



#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**
##### After fix :
```bash
~ 
❯ echo foo
foo
~ 
❯ echo $_
foo
~ 
❯ 
```

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
