### PR TITLE
fix: Improvements to `starship configure`

### DIFF
--- a/src/configure.rs
+++ b/src/configure.rs
@@ -15,13 +15,8 @@ pub fn edit_configuration() {
 }
 
 fn get_editor() -> String {
-    match env::var("VISUAL") {
-        Ok(val) => val,
-        Err(_) => match env::var("EDITOR") {
-            Ok(val) => val,
-            Err(_) => STD_EDITOR.to_string(),
-        },
-    }
+    let editor = env::var("VISUAL").or_else(|_| env::var("EDITOR"));
+    editor.unwrap_or_else(|_| STD_EDITOR.to_string())
 }
 
 fn get_config_path() -> OsString {

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -1,7 +1,7 @@
 use std::env;
+use std::ffi::OsString;
 use std::process::Command;
 
-const UNKNOWN_CONFIG: &str = "<unknown config>";
 const STD_EDITOR: &str = "vi";
 
 pub fn edit_configuration() {
@@ -15,23 +15,19 @@ pub fn edit_configuration() {
 }
 
 fn get_editor() -> String {
-    match env::var("EDITOR") {
+    match env::var("VISUAL") {
         Ok(val) => val,
-        Err(_) => STD_EDITOR.to_string(),
+        Err(_) => match env::var("EDITOR") {
+            Ok(val) => val,
+            Err(_) => STD_EDITOR.to_string(),
+        },
     }
 }
 
-fn get_config_path() -> String {
-    let home_dir = dirs::home_dir();
-
-    if home_dir.is_none() {
-        return UNKNOWN_CONFIG.to_string();
-    }
-
-    let path = home_dir.unwrap().join(".config/starship.toml");
-
-    match path.to_str() {
-        Some(p) => String::from(p),
-        None => UNKNOWN_CONFIG.to_string(),
-    }
+fn get_config_path() -> OsString {
+    dirs::home_dir()
+        .expect("Couldn't find home directory")
+        .join(".config/starship.toml")
+        .as_os_str()
+        .to_owned()
 }


### PR DESCRIPTION
#### Description
- look for $VISUAL first, then $EDITOR, then the default
- panic if we can't find the home dir

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [This seems to be the standard](https://unix.stackexchange.com/questions/4859/visual-vs-editor-what-s-the-difference/)
- If we can't find the home dir, there's not much reason to continue
  (originally, this would open a file called `<unknown config>`

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.