### PR TITLE
ci: Use fixed version of setup-php in test workflow

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -127,7 +127,7 @@ jobs:
       # Install PHP at a fixed version
       - uses: shivammathur/setup-php@v1
         with:
-          php-version: "7.3.8"
+          php-version: "7.3"
 
       # Install Mercurial (pre-installed on linux, installed from pip on macos
       # and from choco on windows),

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -125,9 +125,9 @@ jobs:
           dotnet-version: "2.2.402"
 
       # Install PHP at a fixed version
-      - uses: shivammathur/setup-php@master
+      - uses: shivammathur/setup-php@v1
         with:
-          php-version: "7.3.8"
+          php-version: "7.3"
 
       # Install Mercurial (pre-installed on linux, installed from pip on macos
       # and from choco on windows),

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -127,7 +127,7 @@ jobs:
       # Install PHP at a fixed version
       - uses: shivammathur/setup-php@v1
         with:
-          php-version: "7.3"
+          php-version: "7.3.8"
 
       # Install Mercurial (pre-installed on linux, installed from pip on macos
       # and from choco on windows),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
- Use `v1` tag instead of `master`
- Do not specify patch in `php-version` as the latest one is installed

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The action now advocates using `v1` tag.
Versions with patch are not supported, specifying just major and minor like `php-version 7.3` setups the latest patch of PHP for `7.3`

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [X] I have tested using **MacOS**
- [X] I have tested using **Linux**
- [X] I have tested using **Windows**