### PR TITLE
fix: Don't include `.app` in terminal name

### DIFF
--- a/src/bug_report.rs
+++ b/src/bug_report.rs
@@ -149,9 +149,15 @@ struct TerminalInfo {
 }
 
 fn get_terminal_info() -> TerminalInfo {
-    let terminal = std::env::var("TERM_PROGRAM")
+    let terminal_str = std::env::var("TERM_PROGRAM")
         .or_else(|_| std::env::var("LC_TERMINAL"))
         .unwrap_or_else(|_| UNKNOWN_TERMINAL.to_string());
+
+    let terminal = terminal_str
+        .splitn(2, ".app")
+        .nth(0)
+        .unwrap_or_else(|| &terminal_str)
+        .to_string();
 
     let version = std::env::var("TERM_PROGRAM_VERSION")
         .or_else(|_| std::env::var("LC_TERMINAL_VERSION"))

--- a/src/bug_report.rs
+++ b/src/bug_report.rs
@@ -149,14 +149,10 @@ struct TerminalInfo {
 }
 
 fn get_terminal_info() -> TerminalInfo {
-    let terminal_str = std::env::var("TERM_PROGRAM")
+    let terminal = std::env::var("TERM_PROGRAM")
         .or_else(|_| std::env::var("LC_TERMINAL"))
-        .unwrap_or_else(|_| UNKNOWN_TERMINAL.to_string());
-
-    let terminal = terminal_str
-        .splitn(2, ".app")
-        .nth(0)
-        .unwrap_or_else(|| &terminal_str)
+        .unwrap_or_else(|_| UNKNOWN_TERMINAL.to_string())
+        .trim_end_matches(".app")
         .to_string();
 
     let version = std::env::var("TERM_PROGRAM_VERSION")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
I personally use iTerm as my terminal emulator. When running `echo $TERM_PROGRAM`, I receive `iTerm.app`. This output is used in the `bug-report` command. We would just ideally want `iTerm`. The code now concatenates the `.app` off of the output, if it exists.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
