### PR TITLE
fix: Treat empty $VISUAL as if it's not set

### DIFF
--- a/src/configure.rs
+++ b/src/configure.rs
@@ -14,9 +14,20 @@ pub fn edit_configuration() {
         .expect("failed to open file");
 }
 
-fn get_editor() -> String {
-    let editor = env::var("VISUAL").or_else(|_| env::var("EDITOR"));
-    editor.unwrap_or_else(|_| STD_EDITOR.to_string())
+fn get_editor() -> OsString {
+    get_editor_internal(env::var_os("VISUAL"), env::var_os("EDITOR"))
+}
+
+fn get_editor_internal(visual: Option<OsString>, editor: Option<OsString>) -> OsString {
+    let mut editor_name = visual.unwrap_or_else(|| "".into());
+    if !editor_name.is_empty() {
+        return editor_name;
+    }
+    editor_name = editor.unwrap_or_else(|| "".into());
+    if !editor_name.is_empty() {
+        return editor_name;
+    }
+    STD_EDITOR.into()
 }
 
 fn get_config_path() -> OsString {
@@ -25,4 +36,59 @@ fn get_config_path() -> OsString {
         .join(".config/starship.toml")
         .as_os_str()
         .to_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // This is every possible permutation, 3² = 9.
+
+    #[test]
+    fn visual_set_editor_set() {
+        let actual = get_editor_internal(Some("foo".into()), Some("bar".into()));
+        assert_eq!("foo", actual);
+    }
+    #[test]
+    fn visual_set_editor_empty() {
+        let actual = get_editor_internal(Some("foo".into()), None);
+        assert_eq!("foo", actual);
+    }
+    #[test]
+    fn visual_set_editor_not_set() {
+        let actual = get_editor_internal(Some("foo".into()), None);
+        assert_eq!("foo", actual);
+    }
+
+    #[test]
+    fn visual_empty_editor_set() {
+        let actual = get_editor_internal(Some("".into()), Some("bar".into()));
+        assert_eq!("bar", actual);
+    }
+    #[test]
+    fn visual_empty_editor_empty() {
+        let actual = get_editor_internal(Some("".into()), Some("".into()));
+        assert_eq!("vi", actual);
+    }
+    #[test]
+    fn visual_empty_editor_not_set() {
+        let actual = get_editor_internal(Some("".into()), None);
+        assert_eq!("vi", actual);
+    }
+
+    #[test]
+    fn visual_not_set_editor_set() {
+        let actual = get_editor_internal(None, Some("bar".into()));
+        assert_eq!("bar", actual);
+    }
+    #[test]
+    fn visual_not_set_editor_empty() {
+        let actual = get_editor_internal(None, Some("".into()));
+        assert_eq!("vi", actual);
+    }
+    #[test]
+    fn visual_not_set_editor_not_set() {
+        let actual = get_editor_internal(None, None);
+        assert_eq!("vi", actual);
+    }
 }


### PR DESCRIPTION
Also adds *extensive* tests

#### Description
In #756, I neglected that environment variables can be empty too (as opposed to not set at all), so this fixes that by checking if variables are empty before returning them

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #769 

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
