### PR TITLE
fix: Parse arguments of $VISUAL and $EDITOR

### DIFF
--- a/src/configure.rs
+++ b/src/configure.rs
@@ -6,7 +6,6 @@ const STD_EDITOR: &str = "vi";
 
 pub fn edit_configuration() {
     let config_path = get_config_path();
-
     let editor_cmd = get_editor();
 
     let mut cmd_iter = editor_cmd

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -5,10 +5,20 @@ use std::process::Command;
 const STD_EDITOR: &str = "vi";
 
 pub fn edit_configuration() {
-    let editor = get_editor();
     let config_path = get_config_path();
 
+    let editor_cmd = get_editor();
+
+    let mut cmd_iter = editor_cmd
+        .to_str()
+        .expect("environment variable contains invalid unicode")
+        .split_whitespace();
+
+    let editor = cmd_iter.next().unwrap_or(STD_EDITOR);
+    let args: Vec<_> = cmd_iter.collect();
+
     Command::new(editor)
+        .args(args)
         .arg(config_path)
         .status()
         .expect("failed to open file");

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -14,9 +14,20 @@ pub fn edit_configuration() {
         .expect("failed to open file");
 }
 
-fn get_editor() -> String {
-    let editor = env::var("VISUAL").or_else(|_| env::var("EDITOR"));
-    editor.unwrap_or_else(|_| STD_EDITOR.to_string())
+fn get_editor() -> OsString {
+    get_editor_internal(env::var_os("VISUAL"), env::var_os("EDITOR"))
+}
+
+fn get_editor_internal(visual: Option<OsString>, editor: Option<OsString>) -> OsString {
+    let mut editor_name = visual.unwrap_or_else(|| "".into());
+    if !editor_name.is_empty() {
+        return editor_name;
+    }
+    editor_name = editor.unwrap_or_else(|| "".into());
+    if !editor_name.is_empty() {
+        return editor_name;
+    }
+    STD_EDITOR.into()
 }
 
 fn get_config_path() -> OsString {
@@ -25,4 +36,59 @@ fn get_config_path() -> OsString {
         .join(".config/starship.toml")
         .as_os_str()
         .to_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // This is every possible permutation, 3² = 9.
+
+    #[test]
+    fn visual_set_editor_set() {
+        let actual = get_editor_internal(Some("foo".into()), Some("bar".into()));
+        assert_eq!("foo", actual);
+    }
+    #[test]
+    fn visual_set_editor_empty() {
+        let actual = get_editor_internal(Some("foo".into()), None);
+        assert_eq!("foo", actual);
+    }
+    #[test]
+    fn visual_set_editor_not_set() {
+        let actual = get_editor_internal(Some("foo".into()), None);
+        assert_eq!("foo", actual);
+    }
+
+    #[test]
+    fn visual_empty_editor_set() {
+        let actual = get_editor_internal(Some("".into()), Some("bar".into()));
+        assert_eq!("bar", actual);
+    }
+    #[test]
+    fn visual_empty_editor_empty() {
+        let actual = get_editor_internal(Some("".into()), Some("".into()));
+        assert_eq!("vi", actual);
+    }
+    #[test]
+    fn visual_empty_editor_not_set() {
+        let actual = get_editor_internal(Some("".into()), None);
+        assert_eq!("vi", actual);
+    }
+
+    #[test]
+    fn visual_not_set_editor_set() {
+        let actual = get_editor_internal(None, Some("bar".into()));
+        assert_eq!("bar", actual);
+    }
+    #[test]
+    fn visual_not_set_editor_empty() {
+        let actual = get_editor_internal(None, Some("".into()));
+        assert_eq!("vi", actual);
+    }
+    #[test]
+    fn visual_not_set_editor_not_set() {
+        let actual = get_editor_internal(None, None);
+        assert_eq!("vi", actual);
+    }
 }


### PR DESCRIPTION
#### Description
We thought that Issue https://github.com/starship/starship/issues/769 was a result of empty `$VISUAL` and/or `$EDITOR` variables, which were indeed a problem. However, the same error occurs when an environment variable contains arguments or options. This will cause `starship configure` to panic:

```shell script
export VISUAL="vi -m"
```

While https://github.com/starship/starship/pull/770 fixes the bug for empty environment variables, this PR takes all options like `-m` into account when executing the editor.

#### Motivation and Context
Closes https://github.com/starship/starship/issues/769

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
