### PR TITLE
fix: nicer error message when current directory is gone

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -43,7 +43,7 @@ impl<'a> Context<'a> {
             .unwrap_or_else(|| {
                 env::var("PWD").map(PathBuf::from).unwrap_or_else(|err| {
                     log::debug!("Unable to get path from $PWD: {}", err);
-                    env::current_dir().expect("Unable to identify current directory.")
+                    env::current_dir().expect("Unable to identify current directory. Error")
                 })
             });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
Changes the error message that is presented when the current directory can't be read for some reason, so as not to have a ".: <error message>".

#### Motivation and Context
This is a pretty common condition - for example, when you create a new directory in a git repo and then `git reset --hard`, or `git checkout`, or whatever - so the error message is important.

The message goes from 

```
thread 'main' panicked at 'Unable to identify current directory.: Os { code: 2, kind: NotFound, message: "No such file or directory" }', src/libcore/result.rs:1084:5
```

to

```
thread 'main' panicked at 'Unable to identify current directory. Error: Os { code: 2, kind: NotFound, message: "No such file or directory" }', src/libcore/result.rs:1084:5
```
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

I don't think it needs a lot of testing, it's just a change to a constant string.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.

I really don't think either of these are necessary.