### PR TITLE
refactor: ModuleConfig: Simplify generated `from_config()` implementations

### DIFF
--- a/starship_module_config_derive/src/lib.rs
+++ b/starship_module_config_derive/src/lib.rs
@@ -33,7 +33,7 @@ fn impl_module_config(dinput: DeriveInput) -> proc_macro::TokenStream {
                     }
                 };
                 let new_from_tokens = quote! {
-                    #ident: <#ty>::from_config(config.get(stringify!(#ident))?)?,
+                    #ident: config.get(stringify!(#ident)).and_then(<#ty>::from_config)?,
                 };
 
                 load_tokens = quote! {


### PR DESCRIPTION
#### Description

This PR slightly changes the `ModuleConfig` derive code to use the `Option::and_then()` method. `and_then()` is useful to string multiple `Option` values together so that we only need a single `?` assertion at the end. It also often makes the code simpler to read because the execution order matches the reading order.

#### Motivation and Context

> Why is this change required? What problem does it solve?

It is not required but I noticed it during some other development and thought it would be useful to improve this.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
