### PR TITLE
fix: Remove trailing semicolon from `$PROMPT_COMMAND`

### DIFF
--- a/src/init/starship.bash
+++ b/src/init/starship.bash
@@ -70,7 +70,8 @@ else
     if [[ -z "$PROMPT_COMMAND" ]]; then
         PROMPT_COMMAND="starship_precmd"
     elif [[ "$PROMPT_COMMAND" != *"starship_precmd" ]]; then
-        PROMPT_COMMAND="$PROMPT_COMMAND;starship_precmd"
+        # Remove any trailing semicolon before appending (PR #784)
+        PROMPT_COMMAND="${PROMPT_COMMAND%;};starship_precmd"
     fi
 fi
 


### PR DESCRIPTION
Remove any trailing semicolon in $PROMPT_COMMAND before appending starship_precmd, to prevent syntax error.

<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Remove trailing semicolon if exist in PROMPT_COMMAND before appending starship_precmd
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #771 
Latest starship release breaks on my system with direnv and pyenv hooks enabled at login. Here is the error message
```shell
-bash: PROMPT_COMMAND: line 5: syntax error near unexpected token `;;'
-bash: PROMPT_COMMAND: line 5: `_direnv_hook;_pyenv_virtualenv_hook;;starship_precmd'
```
Semicolon is duplicated on the line and make the command become syntactically wrong. The fix is to remove any trailing semicolon from previous `$PROMPT_COMMAND` before appending `;starship_precmd`
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

Just tested the variable assigning, not yet build starship
#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.

Don't know much, I'm just started using starship recently and haven't read the doc (lol)