### PR TITLE
refactor(nodejs): Add more matches for files

### DIFF
--- a/src/modules/nodejs.rs
+++ b/src/modules/nodejs.rs
@@ -17,7 +17,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             "package-lock.json",
             "yarn.lock",
             "pnpm-workspace.yaml",
-            "pnpm-lock.yaml"
+            "pnpm-lock.yaml",
         ])
         .set_extensions(&["js"])
         .set_folders(&["node_modules"])

--- a/src/modules/nodejs.rs
+++ b/src/modules/nodejs.rs
@@ -12,7 +12,13 @@ use crate::utils;
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let is_js_project = context
         .try_begin_scan()?
-        .set_files(&["package.json"])
+        .set_files(&[
+            "package.json",
+            "package-lock.json",
+            "yarn.lock",
+            "pnpm-workspace.yaml",
+            "pnpm-lock.yaml"
+        ])
         .set_extensions(&["js"])
         .set_folders(&["node_modules"])
         .is_match();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
This adds several other filenames to the matcher for the Node.js module, Like the npm, Yarn, and pnpm package manager lockfiles.

#### Motivation and Context

This will make the matcher for Node.js slightly more effective since it is checking for other Node.js project files that may be present.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?

- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**
- [x] I am committing this straight from the GitHub web editor

#### Checklist:
- [ ] I have updated the documentation accordingly ([relevant section](https://starship.rs/config/#nodejs)).
- [ ] I have updated the tests accordingly ([related tests](https://github.com/starship/starship/blob/master/tests/testsuite/nodejs.rs#L45)).
