### PR TITLE
fix: Consider `$STARSHIP_CONFIG` in `configure`

### DIFF
--- a/src/configure.rs
+++ b/src/configure.rs
@@ -40,11 +40,16 @@ fn get_editor_internal(visual: Option<OsString>, editor: Option<OsString>) -> Os
 }
 
 fn get_config_path() -> OsString {
-    dirs::home_dir()
-        .expect("Couldn't find home directory")
-        .join(".config/starship.toml")
-        .as_os_str()
-        .to_owned()
+    let config_path = env::var_os("STARSHIP_CONFIG").unwrap_or_else(|| "".into());
+    if config_path.is_empty() {
+        dirs::home_dir()
+            .expect("couldn't find home directory")
+            .join(".config/starship.toml")
+            .as_os_str()
+            .to_owned()
+    } else {
+        config_path
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
Makes `starship configure` consider the `$STARSHIP_CONFIG` variable before falling back to the default of `~/.config/starship.toml`.
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It seems that @dominikbraun and I both forgot this environment variable.
#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.