### PR TITLE
feat: Terminate $PROMPT_COMMAND properly

### DIFF
--- a/src/init/starship.bash
+++ b/src/init/starship.bash
@@ -71,7 +71,7 @@ else
         PROMPT_COMMAND="starship_precmd"
     elif [[ "$PROMPT_COMMAND" != *"starship_precmd" ]]; then
         # Remove any trailing semicolon before appending (PR #784)
-        PROMPT_COMMAND="${PROMPT_COMMAND%;};starship_precmd"
+        PROMPT_COMMAND="${PROMPT_COMMAND%;};starship_precmd;"
     fi
 fi
 


### PR DESCRIPTION
feat: Add trailing semicolon to end $PROMPT_COMMAND properly.
This will prevent starship_precmd to accidentally mess with other hooks invoked after it.

<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Just add trailing semicolon to end the command properly
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Just to make starship play nice with any hooks invoked after it.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
