### PR TITLE
perf: hg_branch, fix: show active branch not previous branch

### DIFF
--- a/src/modules/hg_branch.rs
+++ b/src/modules/hg_branch.rs
@@ -60,7 +60,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 fn get_hg_branch_name(ctx: &Context) -> String {
     std::fs::read_to_string(ctx.current_dir.join(".hg").join("branch"))
         .map(|s| s.trim().into())
-        .unwrap_or_else(|_| "(no branch)".to_string())
+        .unwrap_or_else(|_| "default".to_string())
 }
 
 fn get_hg_current_bookmark(ctx: &Context) -> Option<String> {

--- a/src/modules/hg_branch.rs
+++ b/src/modules/hg_branch.rs
@@ -11,7 +11,6 @@ use crate::configs::hg_branch::HgBranchConfig;
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let is_hg_repo = context
         .try_begin_scan()?
-        .set_files(&[".hgignore"])
         .set_folders(&[".hg"])
         .is_match();
 

--- a/src/modules/hg_branch.rs
+++ b/src/modules/hg_branch.rs
@@ -8,10 +8,7 @@ use crate::configs::hg_branch::HgBranchConfig;
 ///
 /// Will display the bookmark or branch name if the current directory is an hg repo
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
-    let is_hg_repo = context
-        .try_begin_scan()?
-        .set_folders(&[".hg"])
-        .is_match();
+    let is_hg_repo = context.try_begin_scan()?.set_folders(&[".hg"]).is_match();
 
     if !is_hg_repo {
         return None;
@@ -37,8 +34,8 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         config.truncation_length as usize
     };
 
-    let branch_name = get_hg_current_bookmark(context)
-        .unwrap_or_else(|| get_hg_branch_name(context));
+    let branch_name =
+        get_hg_current_bookmark(context).unwrap_or_else(|| get_hg_branch_name(context));
 
     let truncated_graphemes = get_graphemes(&branch_name, len);
     // The truncation symbol should only be added if we truncated

--- a/tests/testsuite/hg_branch.rs
+++ b/tests/testsuite/hg_branch.rs
@@ -29,7 +29,7 @@ fn test_hg_get_branch_fails() -> io::Result<()> {
     expect_hg_branch_with_config(
         tempdir.path(),
         "",
-        &[Expect::BranchName(&"(no branch)"), Expect::NoTruncation],
+        &[Expect::BranchName(&"default"), Expect::NoTruncation],
     )
 }
 
@@ -156,7 +156,7 @@ fn expect_hg_branch_with_config(
 
     let actual = String::from_utf8(output.stdout).unwrap();
 
-    let mut expect_branch_name = "(no branch)";
+    let mut expect_branch_name = "default";
     let mut expect_style = Color::Purple.bold();
     let mut expect_symbol = "\u{e0a0}";
     let mut expect_truncation_symbol = "…";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

perf: don't use `hg` process to get branch / bookmark information, each call was taking 250ms and it was making on average 2 calls.
the branch and bookmark information is available in files in the root of the repo, use that instead.
now takes 300 micro seconds

fix: do not use `.hgignore` to decide if it is an hg repo. was providing false positives. #721 

fix: after changing branch the new branch was not show (the old branch was shown), the new branch is now correctly shown. #722 

fix?: if no branch override was set it would say `(no branch)` however if you commited in that state you would commit to the branch `default` so say that instead

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #721 and #722 
Perf: 402ms -> 373.4µs (1000x faster)

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
