### PR TITLE
test: Ignore AWS tests that depend on the File System

### DIFF
--- a/tests/testsuite/aws.rs
+++ b/tests/testsuite/aws.rs
@@ -7,6 +7,7 @@ use tempfile;
 use crate::common::{self, TestCommand};
 
 #[test]
+#[ignore]
 fn no_region_set() -> io::Result<()> {
     let output = common::render_module("aws")
         .env("PATH", env!("PATH"))
@@ -235,6 +236,7 @@ fn region_set_with_display_profile() -> io::Result<()> {
 }
 
 #[test]
+#[ignore]
 fn region_not_set_with_display_region() -> io::Result<()> {
     let output = common::render_module("aws")
         .use_config(toml::toml! {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Update AWS module tests to ignore the two tests that can fail if the
`~/.aws/config` file exists.

Note this will fix the issue reported in #748 but long term we should
consider maybe mocking the `read_file` helper function in when running
tests in the future.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #748

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.