### PR TITLE
docs: Added dark theme to documentation

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -41,6 +41,7 @@ module.exports = {
     ["meta", { name: "twitter:image", content: "https://starship.rs/icon.png"}],
     ["meta", { name: "twitter:alt", content: "Starship: Cross-Shell Prompt"}],
   ],
+  theme: "default-prefers-color-scheme",
   themeConfig: {
     logo: "/icon.png",
     // the GitHub repo path

--- a/docs/.vuepress/styles/palette.styl
+++ b/docs/.vuepress/styles/palette.styl
@@ -1,4 +1,5 @@
 $accentColor = #DD0B78
+$accentDarkColor = #f757aa
 $textColor = #2c3e50
 $borderColor = #eaecef
 $codeBgColor = #282c34

--- a/docs/.vuepress/styles/palette.styl
+++ b/docs/.vuepress/styles/palette.styl
@@ -1,5 +1,5 @@
 $accentColor = #DD0B78
-$accentDarkColor = #f757aa
+$accentDarkColor = ##e50a6c
 $textColor = #2c3e50
 $borderColor = #eaecef
 $codeBgColor = #282c34

--- a/docs/.vuepress/styles/palette.styl
+++ b/docs/.vuepress/styles/palette.styl
@@ -1,5 +1,5 @@
 $accentColor = #DD0B78
-$accentDarkColor = ##e50a6c
+$accentDarkColor = #e50a6c
 $textColor = #2c3e50
 $borderColor = #eaecef
 $codeBgColor = #282c34

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1521,7 +1521,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -2254,7 +2253,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -2433,7 +2431,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -2441,8 +2438,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "color-string": {
       "version": "1.5.3",
@@ -2861,6 +2857,14 @@
       "dev": true,
       "requires": {
         "css": "^2.0.0"
+      }
+    },
+    "css-prefers-color-scheme": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/css-prefers-color-scheme/-/css-prefers-color-scheme-3.1.1.tgz",
+      "integrity": "sha512-MTu6+tMs9S3EUqzmqLXEcgNRbNkkD/TGFvowpeoWJn5Vfq7FMgsmRQs9X5NXAURiOBmOxm/lLjsDNXDE6k9bhg==",
+      "requires": {
+        "postcss": "^7.0.5"
       }
     },
     "css-select": {
@@ -3533,8 +3537,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "eslint-scope": {
       "version": "4.0.3",
@@ -4851,8 +4854,7 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-symbols": {
       "version": "1.0.1",
@@ -6934,7 +6936,6 @@
       "version": "7.0.25",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.25.tgz",
       "integrity": "sha512-NXXVvWq9icrm/TgQC0O6YVFi4StfJz46M1iNd/h6B26Nvh/HKI+q4YZtFN/EjcInZliEscO/WL10BXnc1E5nwg==",
-      "dev": true,
       "requires": {
         "chalk": "^2.4.2",
         "source-map": "^0.6.1",
@@ -6944,14 +6945,12 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "supports-color": {
           "version": "6.1.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
           "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -8993,7 +8992,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }
@@ -9780,6 +9778,14 @@
       "dev": true,
       "requires": {
         "smoothscroll-polyfill": "^0.4.3"
+      }
+    },
+    "vuepress-theme-default-prefers-color-scheme": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/vuepress-theme-default-prefers-color-scheme/-/vuepress-theme-default-prefers-color-scheme-1.0.3.tgz",
+      "integrity": "sha512-CNu+opm+yvdObtzhxa2Mm4d3Ho9aM3NM17RKFpJ77soXeNX7muox+npKTSZiZwY685CFgFAJpSTm01/2f3aPCA==",
+      "requires": {
+        "css-prefers-color-scheme": "^3.1.1"
       }
     },
     "watchpack": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -8,5 +8,5 @@
     "vuepress": "^1.2.0",
     "vuepress-theme-default-prefers-color-scheme": "^1.0.3",
     "vuepress-plugin-sitemap": "^2.3.1"
-  },
+  }
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -7,5 +7,8 @@
     "@vuepress/plugin-google-analytics": "^1.2.0",
     "vuepress": "^1.2.0",
     "vuepress-plugin-sitemap": "^2.3.1"
+  },
+  "dependencies": {
+    "vuepress-theme-default-prefers-color-scheme": "^1.0.3"
   }
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -6,9 +6,7 @@
   "devDependencies": {
     "@vuepress/plugin-google-analytics": "^1.2.0",
     "vuepress": "^1.2.0",
+    "vuepress-theme-default-prefers-color-scheme": "^1.0.3",
     "vuepress-plugin-sitemap": "^2.3.1"
   },
-  "dependencies": {
-    "vuepress-theme-default-prefers-color-scheme": "^1.0.3"
-  }
 }


### PR DESCRIPTION
I added a dark theme to the starship documentation. Currently it only supports the `prefers-colorscheme` media query with no manual toggle