### PR TITLE
refactor(dotnet): Use `exec_cmd` util

### DIFF
--- a/src/modules/dotnet.rs
+++ b/src/modules/dotnet.rs
@@ -2,11 +2,11 @@ use std::ffi::OsStr;
 use std::iter::Iterator;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
 use std::str;
 
 use super::{Context, Module, RootModuleConfig};
 use crate::configs::dotnet::DotnetConfig;
+use crate::utils;
 
 type JValue = serde_json::Value;
 
@@ -201,70 +201,44 @@ fn map_str_to_lower(value: Option<&OsStr>) -> Option<String> {
 }
 
 fn get_version_from_cli() -> Option<Version> {
-    let version_output = match Command::new("dotnet").arg("--version").output() {
-        Ok(output) => output,
-        Err(e) => {
-            log::warn!("Failed to execute `dotnet --version`. {}", e);
-            return None;
-        }
-    };
-    let version = str::from_utf8(version_output.stdout.as_slice())
-        .ok()?
-        .trim();
-
-    let mut buffer = String::with_capacity(version.len() + 1);
-    buffer.push('v');
-    buffer.push_str(version);
-
-    Some(Version(buffer))
+    let version_output = utils::exec_cmd("dotnet", &["--version"])?;
+    Some(Version(format!("v{}", version_output.stdout.trim())))
 }
 
 fn get_latest_sdk_from_cli() -> Option<Version> {
-    let mut cmd = Command::new("dotnet");
-    cmd.arg("--list-sdks")
-        .stdout(Stdio::piped())
-        .stderr(Stdio::null())
-        .stdin(Stdio::null());
-
-    let exit_code = match cmd.status() {
-        Ok(status) => status,
-        Err(e) => {
-            log::warn!("Failed to execute `dotnet --list-sdks`. {}", e);
-            return None;
+    match utils::exec_cmd("dotnet", &["--list-sdks"]) {
+        Some(sdks_output) => {
+            fn parse_failed<T>() -> Option<T> {
+                log::warn!("Unable to parse the output from `dotnet --list-sdks`.");
+                None
+            };
+            let latest_sdk = sdks_output
+                .stdout
+                .lines()
+                .map(str::trim)
+                .filter(|l| !l.is_empty())
+                .last()
+                .or_else(parse_failed)?;
+            let take_until = latest_sdk.find('[').or_else(parse_failed)? - 1;
+            if take_until > 1 {
+                let version = &latest_sdk[..take_until];
+                let mut buffer = String::with_capacity(version.len() + 1);
+                buffer.push('v');
+                buffer.push_str(version);
+                Some(Version(buffer))
+            } else {
+                parse_failed()
+            }
         }
-    };
-
-    if exit_code.success() {
-        let sdks_output = cmd.output().ok()?;
-        fn parse_failed<T>() -> Option<T> {
-            log::warn!("Unable to parse the output from `dotnet --list-sdks`.");
-            None
-        };
-        let latest_sdk = str::from_utf8(sdks_output.stdout.as_slice())
-            .ok()?
-            .lines()
-            .map(str::trim)
-            .filter(|l| !l.is_empty())
-            .last()
-            .or_else(parse_failed)?;
-        let take_until = latest_sdk.find('[').or_else(parse_failed)? - 1;
-        if take_until > 1 {
-            let version = &latest_sdk[..take_until];
-            let mut buffer = String::with_capacity(version.len() + 1);
-            buffer.push('v');
-            buffer.push_str(version);
-            Some(Version(buffer))
-        } else {
-            parse_failed()
+        None => {
+            // Older versions of the dotnet cli do not support the --list-sdks command
+            // So, if the status code indicates failure, fall back to `dotnet --version`
+            log::warn!(
+                "Received a non-success exit code from `dotnet --list-sdks`. \
+                 Falling back to `dotnet --version`.",
+            );
+            get_version_from_cli()
         }
-    } else {
-        // Older versions of the dotnet cli do not support the --list-sdks command
-        // So, if the status code indicates failure, fall back to `dotnet --version`
-        log::warn!(
-            "Received a non-success exit code from `dotnet --list-sdks`. \
-             Falling back to `dotnet --version`.",
-        );
-        get_version_from_cli()
     }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Have refactored the dotnet module to use the util::exec_cmd rather than
the Command module directly.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to #676, #768 and #289

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
