### PR TITLE
fix(cmd_duration): Correct prefix usage

### DIFF
--- a/src/modules/cmd_duration.rs
+++ b/src/modules/cmd_duration.rs
@@ -36,13 +36,11 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     };
 
     module.set_style(module_color);
-    let cmd_duration_stacked = &format!(
-        "{}{}",
-        config.prefix,
-        render_time(elapsed, config.show_milliseconds)
+    module.create_segment(
+        "cmd_duration",
+        &SegmentConfig::new(&render_time(elapsed, config.show_milliseconds)),
     );
-    module.create_segment("cmd_duration", &SegmentConfig::new(&cmd_duration_stacked));
-    module.get_prefix().set_value("");
+    module.get_prefix().set_value(config.prefix);
 
     Some(module)
 }

--- a/tests/testsuite/cmd_duration.rs
+++ b/tests/testsuite/cmd_duration.rs
@@ -22,7 +22,7 @@ fn config_blank_duration_5s() -> io::Result<()> {
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
-    let expected = format!("{} ", Color::Yellow.bold().paint("took 5s"));
+    let expected = format!("took {} ", Color::Yellow.bold().paint("5s"));
     assert_eq!(expected, actual);
     Ok(())
 }
@@ -54,7 +54,7 @@ fn config_5s_duration_10s() -> io::Result<()> {
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
-    let expected = format!("{} ", Color::Yellow.bold().paint("took 10s"));
+    let expected = format!("took {} ", Color::Yellow.bold().paint("10s"));
     assert_eq!(expected, actual);
     Ok(())
 }
@@ -86,7 +86,7 @@ fn config_5s_duration_prefix_underwent() -> io::Result<()> {
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
-    let expected = format!("{} ", Color::Yellow.bold().paint("underwent 5s"));
+    let expected = format!("underwent {} ", Color::Yellow.bold().paint("5s"));
     assert_eq!(expected, actual);
     Ok(())
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Fixed the way the cmd_duration module is setting it's prefix to be the
same as the other modules.


#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #829

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.