### PR TITLE
fix: Wrap clear screen character in unprintable escapes

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -92,6 +92,23 @@ jobs:
       # Checkout the branch being tested
       - uses: actions/checkout@v2
 
+      # Cache files between builds
+      - name: Cache cargo registry
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo index
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+      - name: Cache cargo build
+        uses: actions/cache@v1
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+
       # Install all the required dependencies for testing
       - uses: actions-rs/toolchain@v1
         with:
@@ -110,14 +127,14 @@ jobs:
           go-version: "1.12.1"
 
       # Install Ruby at a fixed version
-      - uses: actions/setup-ruby@v1
+      - uses: eregon/use-ruby-action@v1
         with:
           ruby-version: "2.6.3"
 
       # Install Python at a fixed version
       - uses: actions/setup-python@v1
         with:
-          python-version: "3.7.5"
+          python-version: "3.7.6"
 
       # Install dotnet at a fixed version
       - uses: actions/setup-dotnet@v1
@@ -129,16 +146,12 @@ jobs:
         with:
           php-version: "7.3"
 
-      # Install Mercurial (pre-installed on linux, installed from pip on macos
-      # and from choco on windows),
+      # Install Mercurial (pre-installed on Linux and windows)
       - name: Install Mercurial (macos)
         if: matrix.os == 'macOS-latest'
         env:
           HGPYTHON3: 1
         run: pip install mercurial
-      - name: Install Mercurial (windows)
-        if: matrix.os == 'windows-latest'
-        run: choco install hg
 
       # Install Terraform at a fixed version
       - uses: volcano-coffee-company/setup-terraform@v1

--- a/src/modules/cmd_duration.rs
+++ b/src/modules/cmd_duration.rs
@@ -36,13 +36,11 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     };
 
     module.set_style(module_color);
-    let cmd_duration_stacked = &format!(
-        "{}{}",
-        config.prefix,
-        render_time(elapsed, config.show_milliseconds)
+    module.create_segment(
+        "cmd_duration",
+        &SegmentConfig::new(&render_time(elapsed, config.show_milliseconds)),
     );
-    module.create_segment("cmd_duration", &SegmentConfig::new(&cmd_duration_stacked));
-    module.get_prefix().set_value("");
+    module.get_prefix().set_value(config.prefix);
 
     Some(module)
 }

--- a/src/print.rs
+++ b/src/print.rs
@@ -28,7 +28,7 @@ pub fn get_prompt(context: Context) -> String {
 
     // Clear the screen from the cursor to the end of the line to avoid certain
     // shell bugs, while avoiding shell character-miscount bugs (see GH #739)
-    const CLEAR_TO_END: &'static str = "\x1b[J";
+    const CLEAR_TO_END: &str = "\x1b[J";
     let shell = std::env::var("STARSHIP_SHELL").unwrap_or_default();
     let escaped_clear_seq = wrap_seq_for_shell(CLEAR_TO_END.to_string(), &shell, '\x1b', 'J');
 

--- a/src/print.rs
+++ b/src/print.rs
@@ -8,6 +8,7 @@ use crate::context::Context;
 use crate::module::Module;
 use crate::module::ALL_MODULES;
 use crate::modules;
+use crate::utils::wrap_seq_for_shell;
 
 pub fn prompt(args: ArgMatches) {
     let context = Context::new(args);
@@ -25,7 +26,13 @@ pub fn get_prompt(context: Context) -> String {
         writeln!(buf).unwrap();
     }
 
-    buf.push_str("\x1b[J");
+    // Clear the screen from the cursor to the end of the line to avoid certain
+    // shell bugs, while avoiding shell character-miscount bugs (see GH #739)
+    const CLEAR_TO_END: &'static str = "\x1b[J";
+    let shell = std::env::var("STARSHIP_SHELL").unwrap_or_default();
+    let escaped_clear_seq = wrap_seq_for_shell(CLEAR_TO_END.to_string(), &shell, '\x1b', 'J');
+
+    buf.push_str(&escaped_clear_seq);
 
     let modules = compute_modules(&context);
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -63,27 +63,30 @@ pub fn wrap_seq_for_shell(
     escape_begin: char,
     escape_end: char,
 ) -> String {
+    const BASH_BEG: &str = "\u{5c}\u{5b}"; // \[
+    const BASH_END: &str = "\u{5c}\u{5d}"; // \]
+    const ZSH_BEG: &str = "\u{25}\u{7b}"; // %{
+    const ZSH_END: &str = "\u{25}\u{7d}"; // %}
+
+    // ANSI escape codes cannot be nested, so we can keep track of whether we're
+    // in an escape or not with a single boolean variable
     let mut escaped = false;
     let final_string: String = ansi
         .chars()
         .map(|x| {
-            if x == escape_begin {
+            if x == escape_begin && !escaped {
                 escaped = true;
                 match shell {
-                    "bash" => String::from("\u{5c}\u{5b}\u{1b}"), // => \[ESC
-                    "zsh" => String::from("\u{25}\u{7b}\u{1b}"),  // => %{ESC
+                    "bash" => String::from(format!("{}{}", BASH_BEG, escape_begin)),
+                    "zsh" => String::from(format!("{}{}", ZSH_BEG, escape_begin)),
                     _ => x.to_string(),
                 }
-            } else if x == escape_end {
-                if escaped {
-                    escaped = false;
-                    match shell {
-                        "bash" => String::from("m\u{5c}\u{5d}"), // => m\]
-                        "zsh" => String::from("m\u{25}\u{7d}"),  // => m%}
-                        _ => x.to_string(),
-                    }
-                } else {
-                    x.to_string()
+            } else if x == escape_end && escaped {
+                escaped = false;
+                match shell {
+                    "bash" => String::from(format!("{}{}", escape_end, BASH_END)),
+                    "zsh" => String::from(format!("{}{}", escape_end, ZSH_END)),
+                    _ => x.to_string(),
                 }
             } else {
                 x.to_string()
@@ -182,5 +185,43 @@ mod tests {
         let expected = None;
 
         assert_eq!(result, expected)
+    }
+
+    #[test]
+    fn test_color_sequence_wrappers() {
+        let test0 = "\x1b2mhellomynamekeyes\x1b2m"; // BEGIN: \x1b     END: m
+        let test1 = "\x1b]330;mlol\x1b]0m"; // BEGIN: \x1b     END: m
+        let test2 = "\u{1b}J"; // BEGIN: \x1b     END: J
+        let test3 = "OH NO"; // BEGIN: O    END: O
+        let test4 = "herpaderp";
+        let test5 = "";
+
+        let zresult0 = wrap_seq_for_shell(test0.to_string(), "zsh", '\x1b', 'm');
+        let zresult1 = wrap_seq_for_shell(test1.to_string(), "zsh", '\x1b', 'm');
+        let zresult2 = wrap_seq_for_shell(test2.to_string(), "zsh", '\x1b', 'J');
+        let zresult3 = wrap_seq_for_shell(test3.to_string(), "zsh", 'O', 'O');
+        let zresult4 = wrap_seq_for_shell(test4.to_string(), "zsh", '\x1b', 'm');
+        let zresult5 = wrap_seq_for_shell(test5.to_string(), "zsh", '\x1b', 'm');
+
+        assert_eq!(&zresult0, "%{\x1b2m%}hellomynamekeyes%{\x1b2m%}");
+        assert_eq!(&zresult1, "%{\x1b]330;m%}lol%{\x1b]0m%}");
+        assert_eq!(&zresult2, "%{\x1bJ%}");
+        assert_eq!(&zresult3, "%{OH NO%}");
+        assert_eq!(&zresult4, "herpaderp");
+        assert_eq!(&zresult5, "");
+
+        let bresult0 = wrap_seq_for_shell(test0.to_string(), "bash", '\x1b', 'm');
+        let bresult1 = wrap_seq_for_shell(test1.to_string(), "bash", '\x1b', 'm');
+        let bresult2 = wrap_seq_for_shell(test2.to_string(), "bash", '\x1b', 'J');
+        let bresult3 = wrap_seq_for_shell(test3.to_string(), "bash", 'O', 'O');
+        let bresult4 = wrap_seq_for_shell(test4.to_string(), "bash", '\x1b', 'm');
+        let bresult5 = wrap_seq_for_shell(test5.to_string(), "bash", '\x1b', 'm');
+
+        assert_eq!(&bresult0, "\\[\x1b2m\\]hellomynamekeyes\\[\x1b2m\\]");
+        assert_eq!(&bresult1, "\\[\x1b]330;m\\]lol\\[\x1b]0m\\]");
+        assert_eq!(&bresult2, "\\[\x1bJ\\]");
+        assert_eq!(&bresult3, "\\[OH NO\\]");
+        assert_eq!(&bresult4, "herpaderp");
+        assert_eq!(&bresult5, "");
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -77,15 +77,15 @@ pub fn wrap_seq_for_shell(
             if x == escape_begin && !escaped {
                 escaped = true;
                 match shell {
-                    "bash" => String::from(format!("{}{}", BASH_BEG, escape_begin)),
-                    "zsh" => String::from(format!("{}{}", ZSH_BEG, escape_begin)),
+                    "bash" => format!("{}{}", BASH_BEG, escape_begin),
+                    "zsh" => format!("{}{}", ZSH_BEG, escape_begin),
                     _ => x.to_string(),
                 }
             } else if x == escape_end && escaped {
                 escaped = false;
                 match shell {
-                    "bash" => String::from(format!("{}{}", escape_end, BASH_END)),
-                    "zsh" => String::from(format!("{}{}", escape_end, ZSH_END)),
+                    "bash" => format!("{}{}", escape_end, BASH_END),
+                    "zsh" => format!("{}{}", escape_end, ZSH_END),
                     _ => x.to_string(),
                 }
             } else {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -47,6 +47,52 @@ pub fn exec_cmd(cmd: &str, args: &[&str]) -> Option<CommandOutput> {
     }
 }
 
+// Convenience function to wrap ANSI color sequences (ECMA-48 SGR in `man console_codes`)
+pub fn wrap_colorseq_for_shell(ansi: String, shell: &str) -> String {
+    const ESCAPE_BEGIN: char = '\u{1b}';
+    const ESCAPE_END: char = 'm';
+    wrap_seq_for_shell(ansi, shell, ESCAPE_BEGIN, ESCAPE_END)
+}
+
+/// Many shells cannot deal with raw unprintable characters and miscompute the cursor position,
+/// leading to strange visual bugs like duplicated/missing chars. This wraps some escape seqs
+/// in shell-specific escapes to avoid this.
+pub fn wrap_seq_for_shell(
+    ansi: String,
+    shell: &str,
+    escape_begin: char,
+    escape_end: char,
+) -> String {
+    let mut escaped = false;
+    let final_string: String = ansi
+        .chars()
+        .map(|x| {
+            if x == escape_begin {
+                escaped = true;
+                match shell {
+                    "bash" => String::from("\u{5c}\u{5b}\u{1b}"), // => \[ESC
+                    "zsh" => String::from("\u{25}\u{7b}\u{1b}"),  // => %{ESC
+                    _ => x.to_string(),
+                }
+            } else if x == escape_end {
+                if escaped {
+                    escaped = false;
+                    match shell {
+                        "bash" => String::from("m\u{5c}\u{5d}"), // => m\]
+                        "zsh" => String::from("m\u{25}\u{7d}"),  // => m%}
+                        _ => x.to_string(),
+                    }
+                } else {
+                    x.to_string()
+                }
+            } else {
+                x.to_string()
+            }
+        })
+        .collect();
+    final_string
+}
+
 fn internal_exec_cmd(cmd: &str, args: &[&str]) -> Option<CommandOutput> {
     log::trace!("Executing command '{:?}' with args '{:?}'", cmd, args);
     match Command::new(cmd).args(args).output() {

--- a/tests/testsuite/cmd_duration.rs
+++ b/tests/testsuite/cmd_duration.rs
@@ -22,7 +22,7 @@ fn config_blank_duration_5s() -> io::Result<()> {
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
-    let expected = format!("{} ", Color::Yellow.bold().paint("took 5s"));
+    let expected = format!("took {} ", Color::Yellow.bold().paint("5s"));
     assert_eq!(expected, actual);
     Ok(())
 }
@@ -54,7 +54,7 @@ fn config_5s_duration_10s() -> io::Result<()> {
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
-    let expected = format!("{} ", Color::Yellow.bold().paint("took 10s"));
+    let expected = format!("took {} ", Color::Yellow.bold().paint("10s"));
     assert_eq!(expected, actual);
     Ok(())
 }
@@ -86,7 +86,7 @@ fn config_5s_duration_prefix_underwent() -> io::Result<()> {
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
-    let expected = format!("{} ", Color::Yellow.bold().paint("underwent 5s"));
+    let expected = format!("underwent {} ", Color::Yellow.bold().paint("5s"));
     assert_eq!(expected, actual);
     Ok(())
 }

--- a/tests/testsuite/python.rs
+++ b/tests/testsuite/python.rs
@@ -18,7 +18,7 @@ fn folder_with_python_version() -> io::Result<()> {
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
-    let expected = format!("via {} ", Color::Yellow.bold().paint("🐍 v3.7.5"));
+    let expected = format!("via {} ", Color::Yellow.bold().paint("🐍 v3.7.6"));
     assert_eq!(expected, actual);
     Ok(())
 }
@@ -35,7 +35,7 @@ fn folder_with_requirements_txt() -> io::Result<()> {
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
-    let expected = format!("via {} ", Color::Yellow.bold().paint("🐍 v3.7.5"));
+    let expected = format!("via {} ", Color::Yellow.bold().paint("🐍 v3.7.6"));
     assert_eq!(expected, actual);
     Ok(())
 }
@@ -52,7 +52,7 @@ fn folder_with_pyproject_toml() -> io::Result<()> {
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
-    let expected = format!("via {} ", Color::Yellow.bold().paint("🐍 v3.7.5"));
+    let expected = format!("via {} ", Color::Yellow.bold().paint("🐍 v3.7.6"));
     assert_eq!(expected, actual);
     Ok(())
 }
@@ -69,7 +69,7 @@ fn folder_with_pipfile() -> io::Result<()> {
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
-    let expected = format!("via {} ", Color::Yellow.bold().paint("🐍 v3.7.5"));
+    let expected = format!("via {} ", Color::Yellow.bold().paint("🐍 v3.7.6"));
     assert_eq!(expected, actual);
     Ok(())
 }
@@ -86,7 +86,7 @@ fn folder_with_tox() -> io::Result<()> {
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
-    let expected = format!("via {} ", Color::Yellow.bold().paint("🐍 v3.7.5"));
+    let expected = format!("via {} ", Color::Yellow.bold().paint("🐍 v3.7.6"));
     assert_eq!(expected, actual);
     Ok(())
 }
@@ -103,7 +103,7 @@ fn folder_with_py_file() -> io::Result<()> {
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
-    let expected = format!("via {} ", Color::Yellow.bold().paint("🐍 v3.7.5"));
+    let expected = format!("via {} ", Color::Yellow.bold().paint("🐍 v3.7.6"));
     assert_eq!(expected, actual);
     Ok(())
 }
@@ -120,7 +120,7 @@ fn with_virtual_env() -> io::Result<()> {
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
-    let expected = format!("via {} ", Color::Yellow.bold().paint("🐍 v3.7.5 (my_venv)"));
+    let expected = format!("via {} ", Color::Yellow.bold().paint("🐍 v3.7.6 (my_venv)"));
     assert_eq!(expected, actual);
     Ok(())
 }
@@ -137,7 +137,7 @@ fn with_active_venv() -> io::Result<()> {
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
-    let expected = format!("via {} ", Color::Yellow.bold().paint("🐍 v3.7.5 (my_venv)"));
+    let expected = format!("via {} ", Color::Yellow.bold().paint("🐍 v3.7.6 (my_venv)"));
     assert_eq!(expected, actual);
     Ok(())
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

Minor refactor + bugfix.

One solution to the bugs linked below is to have the clear screen control code wrapped in shell-specific sequences that indicate a zero-length string. Unfortunately, our current escape wrapping code is hardcoded within `module.rs` and cannot be reused.

This PR does two things:
- Moves the wrapping code to its own function and allows it to wrap any specified pair of delimiters (as opposed to being hardcoded to wrap color escape codes previously)
- Uses this new function to escape the clear screen character introduced in #739 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #824 
Closes #834

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Tested before + after on Linux, using Konsole, Alacritty, and xterm, in bash, fish, and zsh.

Point of concern: there is still a remnant of this issue present in VSCode terminal when the autocomplete menu pops up in ZSH. I'm not clear whether that's an xterm.js issue or whether this is another bug, but this patch fixes the issue in all the standard terminal emulators I've tried.

EDIT: This bug persists even when rolling back to starship v0.30.0 (before #739 was merged) so I'm inclined to believe it's an xterm.js bug.

- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
