### PR TITLE
feat(kubernetes): Configure module output

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -692,10 +692,17 @@ threshold = 4
 
 ## Kubernetes
 
-Displays the current Kubernetes context name and, if set, the namespace from
-the kubeconfig file. The namespace needs to be set in the kubeconfig file, this
-can be done via `kubectl config set-context starship-cluster --namespace astronaut`. If the `$KUBECONFIG` env var is set the module will use that if
-not it will use the `~/.kube/config`.
+Displays the current Kubernetes context name and/or the namespace -
+from the kubeconfig file (file pointed by `$KUBECONFIG` env var, or
+`~/.kube/config` by default).
+
+Module output depends whether Kubernetes namespace is configured
+for current context (this can be done via `kubectl config set-context starship-cluster
+--namespace astronaut`):
+
+- when namespace isn't configured, module simply shows the context name
+- when namespace is configured, module by default shows `context (namespace)`,
+  but this can be configured by `show_…` settings.
 
 ::: tip
 
@@ -706,11 +713,13 @@ To enable it, set `disabled` to `false` in your configuration file.
 
 ### Options
 
-| Variable   | Default       | Description                                         |
-| ---------- | ------------- | --------------------------------------------------- |
-| `symbol`   | `"☸ "`        | The symbol used before displaying the Cluster info. |
-| `style`    | `"bold blue"` | The style for the module.                           |
-| `disabled` | `true`        | Disables the `kubernetes` module                    |
+| Variable         | Default       | Description                                         |
+| ---------------- | ------------- | --------------------------------------------------- |
+| `symbol`         | `"☸ "`        | The symbol used before displaying the Cluster info. |
+| `style`          | `"bold blue"` | The style for the module.                           |
+| `disabled`       | `true`        | Disables the `kubernetes` module                    |
+| `show_context`   | `true`        | Should context name be shown?                       |
+| `show_namespace` | `true`        | Should namespace name be shown?                     |
 
 ### Example
 
@@ -721,6 +730,8 @@ To enable it, set `disabled` to `false` in your configuration file.
 symbol = "⛵ "
 style = "dim green"
 disabled = false
+show_context = false
+show_namespace = true
 ```
 
 ## Line Break

--- a/src/configs/kubernetes.rs
+++ b/src/configs/kubernetes.rs
@@ -10,6 +10,8 @@ pub struct KubernetesConfig<'a> {
     pub namespace: SegmentConfig<'a>,
     pub style: Style,
     pub disabled: bool,
+    pub show_context: bool,
+    pub show_namespace: bool,
 }
 
 impl<'a> RootModuleConfig<'a> for KubernetesConfig<'a> {
@@ -20,6 +22,8 @@ impl<'a> RootModuleConfig<'a> for KubernetesConfig<'a> {
             namespace: SegmentConfig::default(),
             style: Color::Cyan.bold(),
             disabled: true,
+            show_context: true,
+            show_namespace: true,
         }
     }
 }

--- a/src/modules/kubernetes.rs
+++ b/src/modules/kubernetes.rs
@@ -80,7 +80,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 } else {
                     module.create_segment(
                         "namespace",
-                        &config.namespace.with_value(kube_ns.to_string()),
+                        &config.namespace.with_value(&kube_ns),
                     );
                 }
             }

--- a/src/modules/kubernetes.rs
+++ b/src/modules/kubernetes.rs
@@ -68,12 +68,21 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             module.get_prefix().set_value(KUBERNETES_PREFIX);
 
             module.create_segment("symbol", &config.symbol);
-            module.create_segment("context", &config.context.with_value(&kube_ctx));
-            if kube_ns != "" {
-                module.create_segment(
-                    "namespace",
-                    &config.namespace.with_value(&format!(" ({})", kube_ns)),
-                );
+            if config.show_context || kube_ns == "" {
+                module.create_segment("context", &config.context.with_value(&kube_ctx));
+            }
+            if config.show_namespace && kube_ns != "" {
+                if config.show_context {
+                    module.create_segment(
+                        "namespace",
+                        &config.namespace.with_value(&format!(" ({})", kube_ns)),
+                    );
+                } else {
+                    module.create_segment(
+                        "namespace",
+                        &config.namespace.with_value(&format!("{}", kube_ns)),
+                    );
+                }
             }
             Some(module)
         }

--- a/src/modules/kubernetes.rs
+++ b/src/modules/kubernetes.rs
@@ -80,7 +80,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 } else {
                     module.create_segment(
                         "namespace",
-                        &config.namespace.with_value(&format!("{}", kube_ns)),
+                        &config.namespace.with_value(kube_ns.to_string()),
                     );
                 }
             }

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -100,7 +100,7 @@ pub fn description(module: &str) -> &'static str {
         "hostname" => "The system hostname",
         "java" => "The currently installed version of Java",
         "jobs" => "The current number of jobs running",
-        "kubernetes" => "The current Kubernetes context name and, if set, the namespace",
+        "kubernetes" => "The current Kubernetes context name and/or namespace",
         "line_break" => "Separates the prompt into two lines",
         "memory_usage" => "Current system memory and swap usage",
         "nix_shell" => "The nix-shell environment",


### PR DESCRIPTION
Adding two new configuration settings: `show_namespace` and `show_context` which let user manage Kubernetes module display. 

Both settings matter only if namespace is known (if not, we show context name and that's it) and simply enable/disable appropriate segments. So by default (with both set to true) we get `context (namespace)` but we setting one of those to false we can get `context` or `namespace`.

This in particular resolves https://github.com/starship/starship/issues/839 

Warning: this is my first contact with Rust, after briefing some book yesterday.