### PR TITLE
feat: Trim "Anaconda, Inc." from Python version

### DIFF
--- a/src/modules/python.rs
+++ b/src/modules/python.rs
@@ -73,7 +73,13 @@ fn get_python_version() -> Option<String> {
 }
 
 fn format_python_version(python_stdout: &str) -> String {
-    format!("v{}", python_stdout.trim_start_matches("Python ").trim())
+    format!(
+        "v{}",
+        python_stdout
+            .trim_start_matches("Python ")
+            .trim_end_matches(":: Anaconda, Inc.")
+            .trim()
+    )
 }
 
 fn get_python_virtual_env() -> Option<String> {
@@ -92,5 +98,11 @@ mod tests {
     fn test_format_python_version() {
         let input = "Python 3.7.2";
         assert_eq!(format_python_version(input), "v3.7.2");
+    }
+
+    #[test]
+    fn test_format_python_version_anaconda() {
+        let input = "Python 3.6.10 :: Anaconda, Inc.";
+        assert_eq!(format_python_version(input), "v3.6.10");
     }
 }


### PR DESCRIPTION
#### Description
The `python --version` command will return "Python 3.6.10 :: Anaconda, Inc." if it is an Anaconda build of Python. This makes the prompt very long. This PR trims that extra text so that the version segment is just the version.

#### Motivation and Context
Having the version of python include this text makes it very long.

#### Types of changes
- [x] New feature (non-breaking change which adds functionality)

#### Screenshots (if appropriate):

Here's an example of what I see before this fix:
![image](https://user-images.githubusercontent.com/1799186/72760681-74407e80-3b8e-11ea-8db9-f2d3edfefac8.png)

#### How Has This Been Tested?

Added a test case with the version string that appears for Anaconda versions of python.

- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly. 
Docs say "The `python` module shows the currently installed version of Python." which is still accurate.

- [x] I have updated the tests accordingly.
Added test including the Anaconda text in the version string
