### PR TITLE
refactor: Move ANSI escaping into its own functions

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -270,7 +270,7 @@ fn get_current_branch(repository: &Repository) -> Option<String> {
     shorthand.map(std::string::ToString::to_string)
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Shell {
     Bash,
     Fish,

--- a/src/module.rs
+++ b/src/module.rs
@@ -1,6 +1,7 @@
 use crate::config::SegmentConfig;
 use crate::context::Shell;
 use crate::segment::Segment;
+use crate::utils::wrap_colorseq_for_shell;
 use ansi_term::Style;
 use ansi_term::{ANSIString, ANSIStrings};
 use std::fmt;
@@ -169,44 +170,12 @@ impl<'a> fmt::Display for Module<'a> {
     }
 }
 
-/// Many shells cannot deal with raw unprintable characters (like ANSI escape sequences) and
-/// miscompute the cursor position as a result, leading to strange visual bugs. Here, we wrap these
-/// characters in shell-specific escape codes to indicate to the shell that they are zero-length.
-fn ansi_strings_modified(ansi_strings: Vec<ANSIString>, shell: Shell) -> Vec<ANSIString> {
-    const ESCAPE_BEGIN: char = '\u{1b}';
-    const MAYBE_ESCAPE_END: char = 'm';
+fn ansi_strings_modified(ansi_strings: Vec<ANSIString>, shell: String) -> Vec<ANSIString> {
     ansi_strings
-        .iter()
+        .into_iter()
         .map(|ansi| {
-            let mut escaped = false;
-            let final_string: String = ansi
-                .to_string()
-                .chars()
-                .map(|x| match x {
-                    ESCAPE_BEGIN => {
-                        escaped = true;
-                        match shell {
-                            Shell::Bash => String::from("\u{5c}\u{5b}\u{1b}"), // => \[ESC
-                            Shell::Zsh => String::from("\u{25}\u{7b}\u{1b}"),  // => %{ESC
-                            _ => x.to_string(),
-                        }
-                    }
-                    MAYBE_ESCAPE_END => {
-                        if escaped {
-                            escaped = false;
-                            match shell {
-                                Shell::Bash => String::from("m\u{5c}\u{5d}"), // => m\]
-                                Shell::Zsh => String::from("m\u{25}\u{7d}"),  // => m%}
-                                _ => x.to_string(),
-                            }
-                        } else {
-                            x.to_string()
-                        }
-                    }
-                    _ => x.to_string(),
-                })
-                .collect();
-            ANSIString::from(final_string)
+            let wrapped = wrap_colorseq_for_shell(ansi.to_string(), &shell);
+            ANSIString::from(wrapped)
         })
         .collect::<Vec<ANSIString>>()
 }

--- a/src/module.rs
+++ b/src/module.rs
@@ -170,11 +170,11 @@ impl<'a> fmt::Display for Module<'a> {
     }
 }
 
-fn ansi_strings_modified(ansi_strings: Vec<ANSIString>, shell: String) -> Vec<ANSIString> {
+fn ansi_strings_modified(ansi_strings: Vec<ANSIString>, shell: Shell) -> Vec<ANSIString> {
     ansi_strings
         .into_iter()
         .map(|ansi| {
-            let wrapped = wrap_colorseq_for_shell(ansi.to_string(), &shell);
+            let wrapped = wrap_colorseq_for_shell(ansi.to_string(), shell);
             ANSIString::from(wrapped)
         })
         .collect::<Vec<ANSIString>>()

--- a/src/print.rs
+++ b/src/print.rs
@@ -29,7 +29,7 @@ pub fn get_prompt(context: Context) -> String {
 
     // Clear the screen from the cursor to the end of the line to avoid certain
     // shell bugs, while avoiding shell character-miscount bugs (see GH #739)
-    const CLEAR_TO_END: &'static str = "\x1b[J";
+    const CLEAR_TO_END: &str = "\x1b[J";
     let shell = std::env::var("STARSHIP_SHELL").unwrap_or_default();
     let escaped_clear_seq = wrap_seq_for_shell(CLEAR_TO_END.to_string(), &shell, '\x1b', 'J');
 

--- a/src/print.rs
+++ b/src/print.rs
@@ -29,11 +29,11 @@ pub fn get_prompt(context: Context) -> String {
 
     // Clear the screen from the cursor to the end of the line to avoid certain
     // shell bugs, while avoiding shell character-miscount bugs (see GH #739)
-    const CLEAR_TO_END: &str = "\x1b[J";
+    const CLEAR_TO_END: &str = "\x1b[J"; // An ASCII control code
     let shell = std::env::var("STARSHIP_SHELL").unwrap_or_default();
-    let escaped_clear_seq = wrap_seq_for_shell(CLEAR_TO_END.to_string(), &shell, '\x1b', 'J');
-
-    buf.push_str(&escaped_clear_seq);
+    if shell == "fish" {
+        buf.push_str(CLEAR_TO_END);
+    }
 
     let modules = compute_modules(&context);
 

--- a/src/print.rs
+++ b/src/print.rs
@@ -9,7 +9,6 @@ use crate::context::Context;
 use crate::module::Module;
 use crate::module::ALL_MODULES;
 use crate::modules;
-use crate::utils::wrap_seq_for_shell;
 
 pub fn prompt(args: ArgMatches) {
     let context = Context::new(args);
@@ -27,13 +26,7 @@ pub fn get_prompt(context: Context) -> String {
         writeln!(buf).unwrap();
     }
 
-    // Clear the screen from the cursor to the end of the line to avoid certain
-    // shell bugs, while avoiding shell character-miscount bugs (see GH #739)
-    const CLEAR_TO_END: &str = "\x1b[J"; // An ASCII control code
-    let shell = std::env::var("STARSHIP_SHELL").unwrap_or_default();
-    if shell == "fish" {
-        buf.push_str(CLEAR_TO_END);
-    }
+    buf.push_str("\x1b[J");
 
     let modules = compute_modules(&context);
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -50,7 +50,7 @@ pub fn exec_cmd(cmd: &str, args: &[&str]) -> Option<CommandOutput> {
     }
 }
 
-// Convenience function to wrap ANSI color sequences (ECMA-48 SGR in `man console_codes`)
+/// Wraps ANSI color escape sequences in the shell-appropriate wrappers.
 pub fn wrap_colorseq_for_shell(ansi: String, shell: &str) -> String {
     const ESCAPE_BEGIN: char = '\u{1b}';
     const ESCAPE_END: char = 'm';
@@ -58,8 +58,8 @@ pub fn wrap_colorseq_for_shell(ansi: String, shell: &str) -> String {
 }
 
 /// Many shells cannot deal with raw unprintable characters and miscompute the cursor position,
-/// leading to strange visual bugs like duplicated/missing chars. This wraps some escape seqs
-/// in shell-specific escapes to avoid this.
+/// leading to strange visual bugs like duplicated/missing chars. This function wraps a specified
+/// sequence in shell-specific escapes to avoid these problems.
 pub fn wrap_seq_for_shell(
     ansi: String,
     shell: &str,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -66,27 +66,30 @@ pub fn wrap_seq_for_shell(
     escape_begin: char,
     escape_end: char,
 ) -> String {
+    const BASH_BEG: &str = "\u{5c}\u{5b}"; // \[
+    const BASH_END: &str = "\u{5c}\u{5d}"; // \]
+    const ZSH_BEG: &str = "\u{25}\u{7b}"; // %{
+    const ZSH_END: &str = "\u{25}\u{7d}"; // %}
+
+    // ANSI escape codes cannot be nested, so we can keep track of whether we're
+    // in an escape or not with a single boolean variable
     let mut escaped = false;
     let final_string: String = ansi
         .chars()
         .map(|x| {
-            if x == escape_begin {
+            if x == escape_begin && !escaped {
                 escaped = true;
                 match shell {
-                    "bash" => String::from("\u{5c}\u{5b}\u{1b}"), // => \[ESC
-                    "zsh" => String::from("\u{25}\u{7b}\u{1b}"),  // => %{ESC
+                    "bash" => String::from(format!("{}{}", BASH_BEG, escape_begin)),
+                    "zsh" => String::from(format!("{}{}", ZSH_BEG, escape_begin)),
                     _ => x.to_string(),
                 }
-            } else if x == escape_end {
-                if escaped {
-                    escaped = false;
-                    match shell {
-                        "bash" => String::from("m\u{5c}\u{5d}"), // => m\]
-                        "zsh" => String::from("m\u{25}\u{7d}"),  // => m%}
-                        _ => x.to_string(),
-                    }
-                } else {
-                    x.to_string()
+            } else if x == escape_end && escaped {
+                escaped = false;
+                match shell {
+                    "bash" => String::from(format!("{}{}", escape_end, BASH_END)),
+                    "zsh" => String::from(format!("{}{}", escape_end, ZSH_END)),
+                    _ => x.to_string(),
                 }
             } else {
                 x.to_string()
@@ -185,5 +188,43 @@ mod tests {
         let expected = None;
 
         assert_eq!(result, expected)
+    }
+
+    #[test]
+    fn test_color_sequence_wrappers() {
+        let test0 = "\x1b2mhellomynamekeyes\x1b2m"; // BEGIN: \x1b     END: m
+        let test1 = "\x1b]330;mlol\x1b]0m"; // BEGIN: \x1b     END: m
+        let test2 = "\u{1b}J"; // BEGIN: \x1b     END: J
+        let test3 = "OH NO"; // BEGIN: O    END: O
+        let test4 = "herpaderp";
+        let test5 = "";
+
+        let zresult0 = wrap_seq_for_shell(test0.to_string(), "zsh", '\x1b', 'm');
+        let zresult1 = wrap_seq_for_shell(test1.to_string(), "zsh", '\x1b', 'm');
+        let zresult2 = wrap_seq_for_shell(test2.to_string(), "zsh", '\x1b', 'J');
+        let zresult3 = wrap_seq_for_shell(test3.to_string(), "zsh", 'O', 'O');
+        let zresult4 = wrap_seq_for_shell(test4.to_string(), "zsh", '\x1b', 'm');
+        let zresult5 = wrap_seq_for_shell(test5.to_string(), "zsh", '\x1b', 'm');
+
+        assert_eq!(&zresult0, "%{\x1b2m%}hellomynamekeyes%{\x1b2m%}");
+        assert_eq!(&zresult1, "%{\x1b]330;m%}lol%{\x1b]0m%}");
+        assert_eq!(&zresult2, "%{\x1bJ%}");
+        assert_eq!(&zresult3, "%{OH NO%}");
+        assert_eq!(&zresult4, "herpaderp");
+        assert_eq!(&zresult5, "");
+
+        let bresult0 = wrap_seq_for_shell(test0.to_string(), "bash", '\x1b', 'm');
+        let bresult1 = wrap_seq_for_shell(test1.to_string(), "bash", '\x1b', 'm');
+        let bresult2 = wrap_seq_for_shell(test2.to_string(), "bash", '\x1b', 'J');
+        let bresult3 = wrap_seq_for_shell(test3.to_string(), "bash", 'O', 'O');
+        let bresult4 = wrap_seq_for_shell(test4.to_string(), "bash", '\x1b', 'm');
+        let bresult5 = wrap_seq_for_shell(test5.to_string(), "bash", '\x1b', 'm');
+
+        assert_eq!(&bresult0, "\\[\x1b2m\\]hellomynamekeyes\\[\x1b2m\\]");
+        assert_eq!(&bresult1, "\\[\x1b]330;m\\]lol\\[\x1b]0m\\]");
+        assert_eq!(&bresult2, "\\[\x1bJ\\]");
+        assert_eq!(&bresult3, "\\[OH NO\\]");
+        assert_eq!(&bresult4, "herpaderp");
+        assert_eq!(&bresult5, "");
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -80,15 +80,15 @@ pub fn wrap_seq_for_shell(
             if x == escape_begin && !escaped {
                 escaped = true;
                 match shell {
-                    "bash" => String::from(format!("{}{}", BASH_BEG, escape_begin)),
-                    "zsh" => String::from(format!("{}{}", ZSH_BEG, escape_begin)),
+                    "bash" => format!("{}{}", BASH_BEG, escape_begin),
+                    "zsh" => format!("{}{}", ZSH_BEG, escape_begin),
                     _ => x.to_string(),
                 }
             } else if x == escape_end && escaped {
                 escaped = false;
                 match shell {
-                    "bash" => String::from(format!("{}{}", escape_end, BASH_END)),
-                    "zsh" => String::from(format!("{}{}", escape_end, ZSH_END)),
+                    "bash" => format!("{}{}", escape_end, BASH_END),
+                    "zsh" => format!("{}{}", escape_end, ZSH_END),
                     _ => x.to_string(),
                 }
             } else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

Moves ANSI colorseq escape functionality into its own functions and adds tests.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

One of the proposed changes in #865 involved escaping an ANSI code from within `print.rs`. Currently, escaping these sequences is done inside of a closure inside `module`, which prevents it from being used elsewhere.

This change allows us to escape unprintable characters from anywhere inside starship, as well as allowing a greater variety of escape sequences and tests specific to the escape parser (as opposed to just the module string generator).

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
Refactoring

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
