### PR TITLE
docs: Update README.md crate.io link and section numbering

### DIFF
--- a/docs/de-DE/guide/README.md
+++ b/docs/de-DE/guide/README.md
@@ -134,7 +134,7 @@
    ```
 
 
-   ##### Von Quellcode auf [crates.io](https://crates.io/):
+   ##### Von Quellcode auf [crates.io](https://crates.io/crates/starship):
 
    ```sh
    cargo install starship
@@ -157,7 +157,7 @@
    scoop install starship
    ```
 
-1. Füge das init-Skript zur Konfigurationsdatei deiner Shell hinzu:
+2. Füge das init-Skript zur Konfigurationsdatei deiner Shell hinzu:
 
 
    #### Bash


### PR DESCRIPTION
#### Description
updated the crate.io link to the actual starship crate
set the number for the init script section to "2."

#### Motivation and Context
this jost got my attention by re reading the german version of the website
Closes #

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
