### PR TITLE
fix(java): Add detection for *.gradle files

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -774,8 +774,8 @@ pure_msg = "pure shell"
 The `java` module shows the currently installed version of Java.
 The module will be shown if any of the following conditions are met:
 
-- The current directory contains a `pom.xml`, `build.gradle`, `build.gradle.kts` or `build.sbt` file
-- The current directory contains a file with the `.java`, `.class` or `.jar` extension
+- The current directory contains a `pom.xml`, `build.gradle.kts` or `build.sbt` file
+- The current directory contains a file with the `.java`, `.class`, `.gradle` or `.jar` extension
 
 ### Options
 

--- a/src/modules/java.rs
+++ b/src/modules/java.rs
@@ -8,12 +8,12 @@ use crate::utils;
 /// Creates a module with the current Java version
 ///
 /// Will display the Java version if any of the following criteria are met:
-///     - Current directory contains a file with a `.java`, `.class` or `.jar` extension
-///     - Current directory contains a `pom.xml`, `build.gradle`, `build.gradle.kts` or `build.sbt` file
+///     - Current directory contains a file with a `.java`, `.class`, `.gradle` or `.jar` extension
+///     - Current directory contains a `pom.xml`, `build.gradle.kts` or `build.sbt` file
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let is_java_project = context
         .try_begin_scan()?
-        .set_files(&["pom.xml", "build.gradle", "build.gradle.kts", "build.sbt"])
+        .set_files(&["pom.xml", "build.gradle.kts", "build.sbt"])
         .set_extensions(&["java", "class", "jar", "gradle"])
         .is_match();
 

--- a/src/modules/java.rs
+++ b/src/modules/java.rs
@@ -14,7 +14,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let is_java_project = context
         .try_begin_scan()?
         .set_files(&["pom.xml", "build.gradle", "build.gradle.kts", "build.sbt"])
-        .set_extensions(&["java", "class", "jar"])
+        .set_extensions(&["java", "class", "jar", "gradle"])
         .is_match();
 
     if !is_java_project {


### PR DESCRIPTION
## Description

Currently the Java module detection looks for `build.gradle` specifically, but it's possible to rename `build.gradle` to `*.gradle`. This change adds Gradle files to the list of detected file extensions.

#### Motivation and Context

Closes #833.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.

No tests existed for this, so I wasn't sure whether I should add any. I can if you'd like. 😄 