### PR TITLE
perf: Optimize files, folder and extension lookups in Context

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -169,9 +169,8 @@ impl DirContents {
                     folders.insert(path);
                 } else {
                     if !path.to_string_lossy().starts_with('.') {
-                        path.extension().map(|ext| {
-                            extensions.insert(ext.to_string_lossy().to_string())
-                        });
+                        path.extension()
+                            .map(|ext| extensions.insert(ext.to_string_lossy().to_string()));
                     }
                     files.insert(path);
                 }
@@ -182,7 +181,11 @@ impl DirContents {
             SystemTime::now().duration_since(start).unwrap()
         );
 
-        Ok(DirContents { folders, files, extensions })
+        Ok(DirContents {
+            folders,
+            files,
+            extensions,
+        })
     }
 
     pub fn files(&self) -> impl Iterator<Item = &PathBuf> {
@@ -255,9 +258,9 @@ impl<'a> ScanDir<'a> {
     /// based on the current Pathbuf check to see
     /// if any of this criteria match or exist and returning a boolean
     pub fn is_match(&self) -> bool {
-        self.dir_contents.has_any_extension(self.extensions) ||
-        self.dir_contents.has_any_folder(self.folders) ||
-        self.dir_contents.has_any_file(self.files)
+        self.dir_contents.has_any_extension(self.extensions)
+            || self.dir_contents.has_any_folder(self.folders)
+            || self.dir_contents.has_any_file(self.files)
     }
 }
 
@@ -289,40 +292,57 @@ mod tests {
         let t = Duration::from_secs(999);
 
         let empty = testdir(&[]).unwrap();
-        let empty_dc = DirContents::from_path_with_timeout(&PathBuf::from(empty.path()), t).unwrap();
+        let empty_dc =
+            DirContents::from_path_with_timeout(&PathBuf::from(empty.path()), t).unwrap();
 
-        assert_eq!(ScanDir {
-            dir_contents: &empty_dc,
-            files: &["package.json"],
-            extensions: &["js"],
-            folders: &["node_modules"],
-        }.is_match(), false);
+        assert_eq!(
+            ScanDir {
+                dir_contents: &empty_dc,
+                files: &["package.json"],
+                extensions: &["js"],
+                folders: &["node_modules"],
+            }
+            .is_match(),
+            false
+        );
 
         let rust = testdir(&["README.md", "Cargo.toml", "src/main.rs"]).unwrap();
         let rust_dc = DirContents::from_path_with_timeout(&PathBuf::from(rust.path()), t).unwrap();
-        assert_eq!(ScanDir {
-            dir_contents: &rust_dc,
-            files: &["package.json"],
-            extensions: &["js"],
-            folders: &["node_modules"],
-        }.is_match(), false);
+        assert_eq!(
+            ScanDir {
+                dir_contents: &rust_dc,
+                files: &["package.json"],
+                extensions: &["js"],
+                folders: &["node_modules"],
+            }
+            .is_match(),
+            false
+        );
 
         let java = testdir(&["README.md", "src/com/test/Main.java", "pom.xml"]).unwrap();
         let java_dc = DirContents::from_path_with_timeout(&PathBuf::from(java.path()), t).unwrap();
-        assert_eq!(ScanDir {
-            dir_contents: &java_dc,
-            files: &["package.json"],
-            extensions: &["js"],
-            folders: &["node_modules"],
-        }.is_match(), false);
+        assert_eq!(
+            ScanDir {
+                dir_contents: &java_dc,
+                files: &["package.json"],
+                extensions: &["js"],
+                folders: &["node_modules"],
+            }
+            .is_match(),
+            false
+        );
 
         let node = testdir(&["README.md", "node_modules/lodash/main.js", "package.json"]).unwrap();
         let node_dc = DirContents::from_path_with_timeout(&PathBuf::from(node.path()), t).unwrap();
-        assert_eq!(ScanDir {
-            dir_contents: &node_dc,
-            files: &["package.json"],
-            extensions: &["js"],
-            folders: &["node_modules"],
-        }.is_match(), true);
+        assert_eq!(
+            ScanDir {
+                dir_contents: &node_dc,
+                files: &["package.json"],
+                extensions: &["js"],
+                folders: &["node_modules"],
+            }
+            .is_match(),
+            true
+        );
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -176,7 +176,7 @@ impl DirContents {
             .filter_map(Result::ok)
             .for_each(|entry| {
                 let path = PathBuf::from(entry.path().strip_prefix(base).unwrap());
-                if path.is_dir() {
+                if entry.path().is_dir() {
                     folders.insert(path);
                 } else {
                     if !path.to_string_lossy().starts_with('.') {

--- a/src/context.rs
+++ b/src/context.rs
@@ -148,12 +148,14 @@ impl<'a> Context<'a> {
         Ok(files.contains(Path::new(name)))
     }
 
-    pub fn get_folders_files_extensions(&self) -> Result<&(HashSet<PathBuf>, HashSet<PathBuf>, HashSet<String>), std::io::Error> {
+    pub fn get_folders_files_extensions(
+        &self,
+    ) -> Result<&(HashSet<PathBuf>, HashSet<PathBuf>, HashSet<String>), std::io::Error> {
         let start_time = SystemTime::now();
         let scan_timeout = Duration::from_millis(self.config.get_root_config().scan_timeout);
 
-        self.folders_files_extensions
-            .get_or_try_init(|| -> Result<(HashSet<PathBuf>, HashSet<PathBuf>, HashSet<String>), std::io::Error> {
+        self.folders_files_extensions.get_or_try_init(
+            || -> Result<(HashSet<PathBuf>, HashSet<PathBuf>, HashSet<String>), std::io::Error> {
                 let mut folders: HashSet<PathBuf> = HashSet::new();
                 let mut files: HashSet<PathBuf> = HashSet::new();
                 let mut extensions: HashSet<String> = HashSet::new();
@@ -170,7 +172,9 @@ impl<'a> Context<'a> {
                         } else {
                             files.insert(path.clone());
                             if !path.to_string_lossy().starts_with('.') {
-                                path.extension().map(|ext| extensions.insert(ext.to_string_lossy().to_string()));
+                                path.extension().map(|ext| {
+                                    extensions.insert(ext.to_string_lossy().to_string())
+                                });
                             }
                         }
                     });
@@ -181,7 +185,8 @@ impl<'a> Context<'a> {
                 );
 
                 Ok((folders, files, extensions))
-            })
+            },
+        )
     }
 }
 
@@ -228,15 +233,27 @@ impl<'a> ScanDir<'a> {
     pub fn is_match(&self) -> bool {
         let (folders, files, extensions) = self.folders_files_extensions;
 
-        if self.folders.iter().any(|folder| folders.contains(Path::new(folder))) {
+        if self
+            .folders
+            .iter()
+            .any(|folder| folders.contains(Path::new(folder)))
+        {
             return true;
         }
 
-        if self.files.iter().any(|file| files.contains(Path::new(file))) {
+        if self
+            .files
+            .iter()
+            .any(|file| files.contains(Path::new(file)))
+        {
             return true;
         }
 
-        if self.extensions.iter().any(|ext| extensions.contains(ext.to_owned())) {
+        if self
+            .extensions
+            .iter()
+            .any(|ext| extensions.contains(ext.to_owned()))
+        {
             return true;
         }
 
@@ -257,11 +274,15 @@ mod tests {
     use std::iter::FromIterator;
     use std::str::FromStr;
 
-    fn folders_files_extensions(folders: &[&str], files: &[&str], extensions: &[&str]) -> (HashSet<PathBuf>, HashSet<PathBuf>, HashSet<String>) {
+    fn folders_files_extensions(
+        folders: &[&str],
+        files: &[&str],
+        extensions: &[&str],
+    ) -> (HashSet<PathBuf>, HashSet<PathBuf>, HashSet<String>) {
         (
             HashSet::from_iter(folders.iter().map(|f| PathBuf::from_str(f).unwrap())),
             HashSet::from_iter(files.iter().map(|f| PathBuf::from_str(f).unwrap())),
-            HashSet::from_iter(extensions.iter().map(|s| s.to_string()))
+            HashSet::from_iter(extensions.iter().map(|s| s.to_string())),
         )
     }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -148,6 +148,7 @@ impl<'a> Context<'a> {
 
 pub struct DirContents {
     files: HashSet<PathBuf>,
+    file_names: HashSet<String>,
     folders: HashSet<PathBuf>,
     extensions: HashSet<String>,
 }
@@ -158,6 +159,7 @@ impl DirContents {
 
         let mut folders: HashSet<PathBuf> = HashSet::new();
         let mut files: HashSet<PathBuf> = HashSet::new();
+        let mut file_names: HashSet<String> = HashSet::new();
         let mut extensions: HashSet<String> = HashSet::new();
 
         fs::read_dir(p)?
@@ -172,6 +174,9 @@ impl DirContents {
                         path.extension()
                             .map(|ext| extensions.insert(ext.to_string_lossy().to_string()));
                     }
+                    if let Some(file_name) = path.file_name() {
+                        file_names.insert(file_name.to_string_lossy().to_string());
+                    }
                     files.insert(path);
                 }
             });
@@ -184,6 +189,7 @@ impl DirContents {
         Ok(DirContents {
             folders,
             files,
+            file_names,
             extensions,
         })
     }
@@ -196,8 +202,12 @@ impl DirContents {
         self.files.contains(Path::new(path))
     }
 
-    pub fn has_any_file(&self, paths: &[&str]) -> bool {
-        paths.iter().any(|path| self.has_file(path))
+    pub fn has_file_name(&self, name: &str) -> bool {
+        self.file_names.contains(name)
+    }
+
+    pub fn has_any_file_name(&self, names: &[&str]) -> bool {
+        names.iter().any(|name| self.has_file_name(name))
     }
 
     pub fn has_folder(&self, path: &str) -> bool {
@@ -260,7 +270,7 @@ impl<'a> ScanDir<'a> {
     pub fn is_match(&self) -> bool {
         self.dir_contents.has_any_extension(self.extensions)
             || self.dir_contents.has_any_folder(self.folders)
-            || self.dir_contents.has_any_file(self.files)
+            || self.dir_contents.has_any_file_name(self.files)
     }
 }
 

--- a/src/modules/dotnet.rs
+++ b/src/modules/dotnet.rs
@@ -165,7 +165,8 @@ fn get_pinned_sdk_version(json: &str) -> Option<Version> {
 
 fn get_local_dotnet_files<'a>(context: &'a Context) -> Result<Vec<DotNetFile<'a>>, std::io::Error> {
     Ok(context
-        .files()?
+        .dir_contents()?
+        .files()
         .filter_map(|p| {
             get_dotnet_file_type(p).map(|t| DotNetFile {
                 path: p.as_ref(),

--- a/src/modules/dotnet.rs
+++ b/src/modules/dotnet.rs
@@ -165,8 +165,7 @@ fn get_pinned_sdk_version(json: &str) -> Option<Version> {
 
 fn get_local_dotnet_files<'a>(context: &'a Context) -> Result<Vec<DotNetFile<'a>>, std::io::Error> {
     Ok(context
-        .get_dir_files()?
-        .iter()
+        .files()?
         .filter_map(|p| {
             get_dotnet_file_type(p).map(|t| DotNetFile {
                 path: p.as_ref(),

--- a/src/modules/rust.rs
+++ b/src/modules/rust.rs
@@ -106,7 +106,10 @@ fn find_rust_toolchain_file(context: &Context) -> Option<String> {
         Some(line.trim().to_owned())
     }
 
-    if let Ok(true) = context.dir_contents().map(|dir| dir.has_file("rust-toolchain")) {
+    if let Ok(true) = context
+        .dir_contents()
+        .map(|dir| dir.has_file("rust-toolchain"))
+    {
         if let Some(toolchain) = read_first_line(Path::new("rust-toolchain")) {
             return Some(toolchain);
         }

--- a/src/modules/rust.rs
+++ b/src/modules/rust.rs
@@ -1,4 +1,3 @@
-use std::ffi::OsStr;
 use std::path::Path;
 use std::process::{Command, Output};
 use std::{env, fs};
@@ -107,13 +106,8 @@ fn find_rust_toolchain_file(context: &Context) -> Option<String> {
         Some(line.trim().to_owned())
     }
 
-    if let Some(path) = context
-        .get_dir_files()
-        .ok()?
-        .iter()
-        .find(|p| p.file_name() == Some(OsStr::new("rust-toolchain")))
-    {
-        if let Some(toolchain) = read_first_line(path) {
+    if let Ok(true) = context.has_file("rust-toolchain") {
+        if let Some(toolchain) = read_first_line(Path::new("rust-toolchain")) {
             return Some(toolchain);
         }
     }

--- a/src/modules/rust.rs
+++ b/src/modules/rust.rs
@@ -106,7 +106,7 @@ fn find_rust_toolchain_file(context: &Context) -> Option<String> {
         Some(line.trim().to_owned())
     }
 
-    if let Ok(true) = context.has_file("rust-toolchain") {
+    if let Ok(true) = context.dir_contents().map(|dir| dir.has_file("rust-toolchain")) {
         if let Some(toolchain) = read_first_line(Path::new("rust-toolchain")) {
             return Some(toolchain);
         }


### PR DESCRIPTION
#### Description

Changes the `Vec<PathBuf>` containing all files and folders in context.rs to be a new struct called `DirContents` that optimises for lookup time on various relevant entities, e.g. files, folders and file names.

#### Motivation and Context

Closes #852.

#### Types of changes 
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 
#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
