### PR TITLE
fix: escape "$" character to avoid bash interpreting

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -270,7 +270,7 @@ fn get_current_branch(repository: &Repository) -> Option<String> {
     shorthand.map(std::string::ToString::to_string)
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Shell {
     Bash,
     Fish,

--- a/src/module.rs
+++ b/src/module.rs
@@ -191,18 +191,17 @@ fn ansi_strings_modified(ansi_strings: Vec<ANSIString>, shell: Shell) -> Vec<ANS
                             _ => x.to_string(),
                         }
                     }
-                    MAYBE_ESCAPE_END => {
-                        if escaped {
-                            escaped = false;
-                            match shell {
-                                Shell::Bash => String::from("m\u{5c}\u{5d}"), // => m\]
-                                Shell::Zsh => String::from("m\u{25}\u{7d}"),  // => m%}
-                                _ => x.to_string(),
-                            }
-                        } else {
-                            x.to_string()
+                    MAYBE_ESCAPE_END if escaped => {
+                        escaped = false;
+                        match shell {
+                            Shell::Bash => String::from("m\u{5c}\u{5d}"), // => m\]
+                            Shell::Zsh => String::from("m\u{25}\u{7d}"),  // => m%}
+                            _ => x.to_string(),
                         }
                     }
+                    // escape the $ character to avoid $() code injection on bash shell,
+                    // see #658 for more
+                    '$' if Shell::Bash == shell => String::from("\\$"),
                     _ => x.to_string(),
                 })
                 .collect();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
An alternative approach to fix the issue of PR #658.
I modify the method `ansi_strings_modified` in the `module` in order to replace the character `$` with `\$`. This avoid the possibility to inject code with the git branch name or other sources.

#### Motivation and Context
Alternative solution for PR #658

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
I used the repo [pw3nage](https://github.com/njhartwell/pw3nage) to test the solution.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
