### PR TITLE
fix: make echo test use /bin/sh

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -102,7 +102,7 @@ mod tests {
 
     #[test]
     fn exec_with_output_stdout() {
-        let result = internal_exec_cmd("/bin/echo", &["-n", "hello"]);
+        let result = internal_exec_cmd("/bin/sh", &["-c", "echo -n hello"]);
         let expected = Some(CommandOutput {
             stdout: String::from("hello"),
             stderr: String::from(""),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -102,9 +102,9 @@ mod tests {
 
     #[test]
     fn exec_with_output_stdout() {
-        let result = internal_exec_cmd("/bin/sh", &["-c", "echo -n hello"]);
+        let result = internal_exec_cmd("/bin/sh", &["-c", "echo hello"]);
         let expected = Some(CommandOutput {
-            stdout: String::from("hello"),
+            stdout: String::from("hello\n"),
             stderr: String::from(""),
         });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Changed a test that failed on my machine (NixOS - `echo` is not in `/bin`):
https://github.com/starship/starship/blob/2968aac3ca173954cfc9eaef22c062a6ec0946cc/src/utils.rs#L105
 to use `/bin/sh` like the tests that follow it:
https://github.com/starship/starship/blob/2968aac3ca173954cfc9eaef22c062a6ec0946cc/src/utils.rs#L116
https://github.com/starship/starship/blob/2968aac3ca173954cfc9eaef22c062a6ec0946cc/src/utils.rs#L127


#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Test no longer fails when `echo` is not in `/bin`.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.

#### Other
I have been using starship for a few months now and am loving it. Looking to start contributing back, and just found this issue when running the tests for the first time.