### PR TITLE
fix: Change command duration variable to CMD_DURATION

### DIFF
--- a/src/init/starship.ion
+++ b/src/init/starship.ion
@@ -4,6 +4,7 @@ fn PROMPT
     let STARSHIP_ION_STATUS = $?
     # Save the ION_CMD_DURATION before running any other commands, but after the status since the
     # duration is not updated during variable assignment
+    # Account for variable name change sometime during December 2019 - January 2020
     let STARSHIP_ION_CMD_DURATION = $or($CMD_DURATION $ION_CMD_DURATION)
     let STARSHIP_ION_CMD_DURATION = $((STARSHIP_ION_CMD_DURATION * 1000))
 

--- a/src/init/starship.ion
+++ b/src/init/starship.ion
@@ -4,7 +4,7 @@ fn PROMPT
     let STARSHIP_ION_STATUS = $?
     # Save the ION_CMD_DURATION before running any other commands, but after the status since the
     # duration is not updated during variable assignment
-    let STARSHIP_ION_CMD_DURATION = $CMD_DURATION
+    let STARSHIP_ION_CMD_DURATION = $or($CMD_DURATION $ION_CMD_DURATION)
 
     # The STARSHIP between the colons will be replaced with the actual path to the starship executable.
     # The jobs command outputs to stderr, therefore we need to pipe stderr to `wc -l`.

--- a/src/init/starship.ion
+++ b/src/init/starship.ion
@@ -4,7 +4,7 @@ fn PROMPT
     let STARSHIP_ION_STATUS = $?
     # Save the ION_CMD_DURATION before running any other commands, but after the status since the
     # duration is not updated during variable assignment
-    let STARSHIP_ION_CMD_DURATION = $ION_CMD_DURATION
+    let STARSHIP_ION_CMD_DURATION = $CMD_DURATION
 
     # The STARSHIP between the colons will be replaced with the actual path to the starship executable.
     # The jobs command outputs to stderr, therefore we need to pipe stderr to `wc -l`.

--- a/src/init/starship.ion
+++ b/src/init/starship.ion
@@ -5,6 +5,7 @@ fn PROMPT
     # Save the ION_CMD_DURATION before running any other commands, but after the status since the
     # duration is not updated during variable assignment
     let STARSHIP_ION_CMD_DURATION = $or($CMD_DURATION $ION_CMD_DURATION)
+    let STARSHIP_ION_CMD_DURATION = $((STARSHIP_ION_CMD_DURATION * 1000))
 
     # The STARSHIP between the colons will be replaced with the actual path to the starship executable.
     # The jobs command outputs to stderr, therefore we need to pipe stderr to `wc -l`.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->
ion shell has apparently changed the name of the command duration variable at some point from `ION_CMD_DURATION` to `CMD_DURATION`. This breaks the prompt script and presents the following message instead of the prompt:

```
ion: prompt expansion failed: expansion error: Variable does not exist
>>> 
```

#### Description
<!--- Describe your changes in detail -->
This changes the variable in the prompt script from `ION_CMD_DURATION` to `CMD_DURATION`.

This could introduce a potential issue where starship would break in older versions of ion. As ion so far has to be compiled from source to use it on MacOS and most LInux distros, there is no _current_ version, so ion users will have starship break whenever they re-compile.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This makes starship work on version of ion compiled the last month (and a half?) or so.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
