### PR TITLE
feat(env_var): trim_before_last

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -444,15 +444,16 @@ The module will be shown only if any of the following conditions are met:
 
 ### Options
 
-| Variable   | Default          | Description                                                                  |
-| ---------- | ---------------- | ---------------------------------------------------------------------------- |
-| `symbol`   |                  | The symbol used before displaying the variable value.                        |
-| `variable` |                  | The environment variable to be displayed.                                    |
-| `default`  |                  | The default value to be displayed when the selected variable is not defined. |
-| `prefix`   | `""`             | Prefix to display immediately before the variable value.                     |
-| `suffix`   | `""`             | Suffix to display immediately after the variable value.                      |
-| `style`    | `"dimmed black"` | The style for the module.                                                    |
-| `disabled` | `false`          | Disables the `env_var` module.                                               |
+| Variable           | Default          | Description                                                                                                                                     |
+| ------------------ | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `symbol`           |                  | The symbol used before displaying the variable value.                                                                                           |
+| `variable`         |                  | The environment variable to be displayed.                                                                                                       |
+| `default`          |                  | The default value to be displayed when the selected variable is not defined.                                                                    |
+| `prefix`           | `""`             | Prefix to display immediately before the variable value.                                                                                        |
+| `suffix`           | `""`             | Suffix to display immediately after the variable value.                                                                                         |
+| `trim_before_last` | `""`             | String that the variable value is cut off before, until the last match. `"/"` will start after the last slash. `""` will disable any truncation |
+| `style`            | `"dimmed black"` | The style for the module.                                                                                                                       |
+| `disabled`         | `false`          | Disables the `env_var` module.                                                                                                                  |
 
 ### Example
 
@@ -462,6 +463,7 @@ The module will be shown only if any of the following conditions are met:
 [env_var]
 variable = "SHELL"
 default = "unknown shell"
+trim_before_last = "/"
 ```
 
 ## Git Branch

--- a/src/configs/env_var.rs
+++ b/src/configs/env_var.rs
@@ -10,6 +10,7 @@ pub struct EnvVarConfig<'a> {
     pub default: Option<&'a str>,
     pub prefix: &'a str,
     pub suffix: &'a str,
+    pub trim_before_last: &'a str,
     pub style: Style,
     pub disabled: bool,
 }
@@ -22,6 +23,7 @@ impl<'a> RootModuleConfig<'a> for EnvVarConfig<'a> {
             default: None,
             prefix: "",
             suffix: "",
+            trim_before_last: "",
             style: Color::Black.bold().dimmed(),
             disabled: false,
         }

--- a/src/modules/env_var.rs
+++ b/src/modules/env_var.rs
@@ -17,6 +17,18 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
     let env_value = get_env_value(config.variable?, config.default)?;
 
+    //rustc doesn't let you do an "if" and an "if let" in the same if statement
+    // if this changes in the future this can become a lot cleaner
+    let env_value = if config.trim_before_last != "" {
+        if let Some(index) = env_value.rfind(config.trim_before_last) {
+            env_value.split_at(index + 1).1
+        } else {
+            env_value.as_ref()
+        }
+    } else {
+        env_value.as_ref()
+    };
+
     module.set_style(config.style);
     module.get_prefix().set_value("with ");
 

--- a/tests/testsuite/env_var.rs
+++ b/tests/testsuite/env_var.rs
@@ -135,6 +135,24 @@ fn suffix() -> io::Result<()> {
     Ok(())
 }
 
+#[test]
+fn trim_before_last() -> io::Result<()> {
+    let output = common::render_module("env_var")
+        .env_clear()
+        .use_config(toml::toml! {
+            [env_var]
+            variable = "TEST_VAR"
+            suffix = "_"
+            trim_before_last = "-"
+        })
+        .env("TEST_VAR", "long-variable-value-with-hyphens")
+        .output()?;
+    let expected = format!("with {} ", style().paint("hyphens_"));
+    let actual = String::from_utf8(output.stdout).unwrap();
+    assert_eq!(expected, actual);
+    Ok(())
+}
+
 fn style() -> Style {
     // default style
     Color::Black.bold().dimmed()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Adds a config item `trim_before_last` to `env_var`.

`trim_at` in `hostname` allows the hostname to be trimmed *after* the first occurrence of some string.

`trim_before_last` in `env_var` allows the variable value to be trimmed *before* the last occurrence of some string.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`env_var` with `SHELL` (no `trim_before_last`):
![image](https://user-images.githubusercontent.com/6677292/74006332-5b371c00-4949-11ea-94e3-96c23c94ebd2.png)


`env_var` with `SHELL` and `trim_before_last = "/"`:
![image](https://user-images.githubusercontent.com/6677292/74006397-91749b80-4949-11ea-9f48-79d1e655d45b.png)



#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
