### PR TITLE
fix: Modified Install Script to work in WSL

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -241,7 +241,7 @@ confirm "Install Starship ${GREEN}latest${NO_COLOR} to ${BOLD}${GREEN}${BIN_DIR}
 info "Installing Starship, please wait…"
 
 fetch "${URL}" \
-  | tar xzf${VERBOSE} - \
+  | sudo tar xzf${VERBOSE} - \
     -C "${BIN_DIR}"
 
 complete "Starship installed"


### PR DESCRIPTION
Added sudo for the tar command to be able to extract the archive with in WSL propperly

If you want to install starship.rs within the WSL the install.sh script fails because of the missing permissions.
![image](https://user-images.githubusercontent.com/1046539/74021728-610a1d00-499c-11ea-8591-720f20eb9161.png)

#### Description
added sudo prior to the extract command so WSL is able to extract the archive

#### Types of changes
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ x ] I have tested using **MacOS**
- [ x ] I have tested using **Linux**
- [ ] I have tested using **Windows**
