### PR TITLE
feat: Allow disabling git_status for large/slow repos

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -583,6 +583,7 @@ current directory.
 | `suffix`           | `]`                        | Suffix to display immediately after git status.         |
 | `style`            | `"bold red"`               | The style for the module.                               |
 | `disabled`         | `false`                    | Disables the `git_status` module.                       |
+| `disabled_for`     | `[]`                       | Disables the `git_status` module for the listed directories     |
 
 #### Git Status Counts
 
@@ -610,6 +611,7 @@ staged_count.enabled = true
 staged_count.style = "green"
 renamed = "👅"
 deleted = "🗑"
+disabled_for = ["my/big/slow/repo"]
 ```
 
 ## Golang

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,6 +10,8 @@ use dirs::home_dir;
 use std::env;
 use toml::Value;
 
+use std::path::PathBuf;
+
 /// Root config of a module.
 pub trait RootModuleConfig<'a>
 where
@@ -55,6 +57,12 @@ where
 impl<'a> ModuleConfig<'a> for &'a str {
     fn from_config(config: &'a Value) -> Option<Self> {
         config.as_str()
+    }
+}
+
+impl<'a> ModuleConfig<'a> for PathBuf {
+    fn from_config(config: &Value) -> Option<Self> {
+        config.as_str().map(|path| PathBuf::from(path))
     }
 }
 

--- a/src/configs/git_status.rs
+++ b/src/configs/git_status.rs
@@ -2,6 +2,7 @@ use crate::config::{ModuleConfig, RootModuleConfig, SegmentConfig};
 
 use ansi_term::{Color, Style};
 use starship_module_config_derive::ModuleConfig;
+use std::path::PathBuf;
 
 #[derive(Clone, ModuleConfig)]
 pub struct GitStatusConfig<'a> {
@@ -27,6 +28,7 @@ pub struct GitStatusConfig<'a> {
     pub suffix: &'a str,
     pub style: Style,
     pub disabled: bool,
+    pub disabled_for: Vec<PathBuf>
 }
 
 impl<'a> RootModuleConfig<'a> for GitStatusConfig<'a> {
@@ -54,6 +56,7 @@ impl<'a> RootModuleConfig<'a> for GitStatusConfig<'a> {
             suffix: "] ",
             style: Color::Red.bold(),
             disabled: false,
+            disabled_for: Vec::new()
         }
     }
 }

--- a/src/modules/git_status.rs
+++ b/src/modules/git_status.rs
@@ -4,7 +4,7 @@ use super::{Context, Module, RootModuleConfig};
 
 use crate::config::SegmentConfig;
 use crate::configs::git_status::{CountConfig, GitStatusConfig};
-use std::borrow::BorrowMut;
+use std::borrow::BorrowMut; 
 
 /// Creates a module with the Git branch in the current directory
 ///
@@ -21,13 +21,19 @@ use std::borrow::BorrowMut;
 ///   - `»` — A renamed file has been added to the staging area
 ///   - `✘` — A file's deletion has been added to the staging area
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let mut module = context.new_module("git_status");
+    let config: GitStatusConfig = GitStatusConfig::try_load(module.config);
+    
+    if config.disabled_for.iter().find(|x| context.current_dir.starts_with(x)).is_some() {
+        return None;
+    }
+    
     let repo = context.get_repo().ok()?;
     let branch_name = repo.branch.as_ref()?;
     let repo_root = repo.root.as_ref()?;
     let mut repository = Repository::open(repo_root).ok()?;
 
-    let mut module = context.new_module("git_status");
-    let config: GitStatusConfig = GitStatusConfig::try_load(module.config);
+   
 
     module
         .get_prefix()

--- a/tests/testsuite/git_status.rs
+++ b/tests/testsuite/git_status.rs
@@ -259,6 +259,60 @@ fn doesnt_show_untracked_file_if_disabled() -> io::Result<()> {
 }
 
 #[test]
+fn doesnt_show_untracked_file_if_disabled_for_path() -> io::Result<()> {
+    let repo_dir = common::create_fixture_repo()?;
+    let repo_path = repo_dir.as_path();
+
+    create_untracked(&repo_dir)?;
+
+    let output = common::render_module("git_status")
+        .use_config(toml::from_str(&format!(
+            "
+                [git_status]
+                disabled_for = [\"{}\"]
+            ",
+            repo_path.to_str().unwrap(),
+        )).unwrap()
+        )
+        .arg("--path")
+        .arg(repo_dir)
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+    let expected = "";
+
+    assert_eq!(expected, actual);
+
+    Ok(())
+}
+
+#[test]
+fn doesnt_show_untracked_file_if_disabled_for_many_path() -> io::Result<()> {
+    let repo_dir = common::create_fixture_repo()?;
+    let repo_path = repo_dir.as_path();
+
+    create_untracked(&repo_dir)?;
+
+    let output = common::render_module("git_status")
+        .use_config(toml::from_str(&format!(
+            "
+                [git_status]
+                disabled_for = [\"also/a/path\",\"{}\"]
+            ",
+            repo_path.to_str().unwrap(),
+        )).unwrap()
+        )
+        .arg("--path")
+        .arg(repo_dir)
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+    let expected = "";
+
+    assert_eq!(expected, actual);
+
+    Ok(())
+}
+
+#[test]
 #[ignore]
 fn shows_stashed() -> io::Result<()> {
     let repo_dir = common::create_fixture_repo()?;


### PR DESCRIPTION
#### Description
Some repos are very large. This can take a while to run git status on them.

I am creating this as a draft repo as I had some questions and some remaining work but wanted to get some early feedback.

1. What is the best way to fail reading the config file. E.g. If a path isn't absolute, we should skip it. Do we fail loading or do we warn and ignore.

2. I added tests and they run but they seem to be ignored. Is there a reason for that?  Should I also add mine to be ignored?

3. I need to test this on windows. 



#### Motivation and Context
As above, the repo I work with at work is rather large and using git status is prohibitively slow. I don't want to not have status on repos where it is still usable. This gives me the ability to turn it off just for the slow repos.



#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
