### PR TITLE
feat: Add singularity module

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1091,6 +1091,33 @@ The module will be shown if any of the following conditions are met:
 symbol = "⚙️ "
 ```
 
+## Singularity
+
+The `singularity` module shows the current singularity image, if inside a container
+and `$SINGULARITY_NAME` is set.
+
+:::
+
+### Options
+
+| Variable   | Default              | Description                                      |
+| ---------- | -------------------- | ------------------------------------------------ |
+| `label`    | `""`                 | Prefix before the image name display.            |
+| `prefix`   | `"["`                | Prefix to display immediately before image name. |
+| `suffix`   | `"]"`                | Suffix to display immediately after image name.  |
+| `symbol`   | `""`                 | The symbol used before the image name.           |
+| `style`    | `"bold dimmed blue"` | The style for the module.                        |
+| `disabled` | `false`              | Disables the `singularity` module.               |
+
+### Example
+
+```toml
+# ~/.config/starship.toml
+
+[singularity]
+symbol = "📦 "
+```
+
 ## Terraform
 
 The `terraform` module shows the currently selected terraform workspace and version.

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -27,6 +27,7 @@ pub mod php;
 pub mod python;
 pub mod ruby;
 pub mod rust;
+pub mod singularity;
 mod starship_root;
 pub mod terraform;
 pub mod time;

--- a/src/configs/singularity.rs
+++ b/src/configs/singularity.rs
@@ -1,0 +1,27 @@
+use crate::config::{ModuleConfig, RootModuleConfig, SegmentConfig};
+
+use ansi_term::{Color, Style};
+use starship_module_config_derive::ModuleConfig;
+
+#[derive(Clone, ModuleConfig)]
+pub struct SingularityConfig<'a> {
+    pub symbol: SegmentConfig<'a>,
+    pub label: &'a str,
+    pub prefix: &'a str,
+    pub suffix: &'a str,
+    pub style: Style,
+    pub disabled: bool,
+}
+
+impl<'a> RootModuleConfig<'a> for SingularityConfig<'a> {
+    fn new() -> Self {
+        SingularityConfig {
+            symbol: SegmentConfig::default(),
+            label: "",
+            prefix: "[",
+            suffix: "]",
+            style: Color::Blue.bold().dimmed(),
+            disabled: false,
+        }
+    }
+}

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -19,6 +19,7 @@ impl<'a> RootModuleConfig<'a> for StarshipRootConfig<'a> {
             prompt_order: vec![
                 "username",
                 "hostname",
+                "singularity",
                 "kubernetes",
                 "directory",
                 "git_branch",

--- a/src/module.rs
+++ b/src/module.rs
@@ -42,6 +42,7 @@ pub const ALL_MODULES: &[&str] = &[
     "rust",
     "php",
     "terraform",
+    "singularity",
     "time",
     "username",
 ];

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -28,6 +28,7 @@ mod php;
 mod python;
 mod ruby;
 mod rust;
+mod singularity;
 mod terraform;
 mod time;
 mod username;
@@ -74,6 +75,7 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
         "python" => python::module(context),
         "ruby" => ruby::module(context),
         "rust" => rust::module(context),
+        "singularity" => singularity::module(context),
         "terraform" => terraform::module(context),
         "time" => time::module(context),
         "crystal" => crystal::module(context),

--- a/src/modules/singularity.rs
+++ b/src/modules/singularity.rs
@@ -1,0 +1,28 @@
+use std::env;
+
+use super::{Context, Module, SegmentConfig};
+
+use crate::config::RootModuleConfig;
+use crate::configs::singularity::SingularityConfig;
+
+/// Creates a module with the current Singularity image
+///
+/// Will display the Singularity image if `$SINGULARITY_NAME` is set.
+pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let singularity_env = env::var("SINGULARITY_NAME").unwrap_or_else(|_| "".into());
+    if singularity_env.trim().is_empty() {
+        return None;
+    }
+
+    let mut module = context.new_module("singularity");
+    let config = SingularityConfig::try_load(module.config);
+
+    module.get_prefix().set_value(config.label);
+    module.set_style(config.style);
+    module.create_segment("symbol", &config.symbol);
+
+    let env_var_stacked = format!("{}{}{}", config.prefix, singularity_env, config.suffix);
+    module.create_segment("singularity", &SegmentConfig::new(&env_var_stacked));
+
+    Some(module)
+}

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -18,6 +18,7 @@ mod line_break;
 mod modules;
 mod nix_shell;
 mod python;
+mod singularity;
 mod terraform;
 mod time;
 mod username;

--- a/tests/testsuite/singularity.rs
+++ b/tests/testsuite/singularity.rs
@@ -1,0 +1,18 @@
+use ansi_term::Color;
+use std::io;
+
+use crate::common;
+
+#[test]
+fn env_set() -> io::Result<()> {
+    let output = common::render_module("singularity")
+        .env_clear()
+        .env("SINGULARITY_NAME", "centos.img")
+        .output()?;
+
+    let expected = format!("{} ", Color::Blue.bold().dimmed().paint("[centos.img]"));
+    let actual = String::from_utf8(output.stdout).unwrap();
+
+    assert_eq!(expected, actual);
+    Ok(())
+}


### PR DESCRIPTION
(Reopened #602)

#### Description
Singularity is one of the tools to run containers. A popular use case is to run it as a development environment, especially for older platforms.

#### Motivation and Context
As one might use several different images it is useful to display the image we are currently in.

Currently the default display is after hostname wrapped in `[` and `]` as it is the shortest. I'm open to suggestions if another defaults are more reasonable.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
