### PR TITLE
fix: check if editor is not found for `configure`

### DIFF
--- a/src/configure.rs
+++ b/src/configure.rs
@@ -1,6 +1,6 @@
 use std::env;
-use std::io::ErrorKind;
 use std::ffi::OsString;
+use std::io::ErrorKind;
 use std::process::Command;
 
 const STD_EDITOR: &str = "vi";
@@ -17,17 +17,16 @@ pub fn edit_configuration() {
     let editor = cmd_iter.next().unwrap_or(STD_EDITOR);
     let args: Vec<_> = cmd_iter.collect();
 
-    let command = Command::new(editor)
-        .args(args)
-        .arg(config_path)
-        .status();
+    let command = Command::new(editor).args(args).arg(config_path).status();
 
     match command {
         Ok(_) => (),
         Err(error) => match error.kind() {
-            ErrorKind::NotFound => panic!("editor {:?} was not found. Did you set your $EDITOR \
-                                           or $VISUAL environment variables correctly? {:?}",
-                                          editor, error),
+            ErrorKind::NotFound => panic!(
+                "editor {:?} was not found. Did you set your $EDITOR or $VISUAL environment \
+                 variables correctly? {:?}",
+                editor, error
+            ),
             other_error => panic!("failed to open file: {:?}", other_error),
         },
     };

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -22,11 +22,15 @@ pub fn edit_configuration() {
     match command {
         Ok(_) => (),
         Err(error) => match error.kind() {
-            ErrorKind::NotFound => panic!(
-                "editor {:?} was not found. Did you set your $EDITOR or $VISUAL environment \
-                 variables correctly? {:?}",
-                editor, error
-            ),
+            ErrorKind::NotFound => {
+                eprintln!(
+                    "Error: editor {:?} was not found. Did you set your $EDITOR or $VISUAL \
+                    environment variables correctly?",
+                    editor
+                );
+                eprintln!("Full error: {:?}", error);
+                std::process::exit(1)
+            }
             other_error => panic!("failed to open file: {:?}", other_error),
         },
     };


### PR DESCRIPTION
#### Description
STD_EDITOR falls back on `vi` if `$EDITOR` and `$VISUAL` is not set.
However, some machines might not have `vi` symlinked or installed and a bad error message is displayed.
![image](https://user-images.githubusercontent.com/4933577/75393280-b2b52000-5928-11ea-86a7-e333561646ad.png)
This commit adds a better error message.
![image](https://user-images.githubusercontent.com/4933577/75393348-d4160c00-5928-11ea-9c17-1f0a63ca26de.png)

#### Motivation and Context
Was trying to configure starship on a fresh Arch Linux install where I:
- have yet to properly set `$EDITOR` and `$VISUAL`
- have `vim` installed but not `vi`
- have yet to symlink `vi` to `vim`

I was pretty confused about the first error message and had to do some digging to resolve the issue, so I decided to improve the error message.

#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):
See above

#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [X] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.

Not really sure how to write tests for this specific scenario.

Also, these are literally the first few lines of rust I have ever written, so do let me know if I'm doing anything incorrectly or if anything can be improved. Thanks!