### PR TITLE
fix(utils): Print log for exec_cmd failure

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -155,7 +155,10 @@ fn internal_exec_cmd(cmd: &str, args: &[&str]) -> Option<CommandOutput> {
                 stderr: stderr_string,
             })
         }
-        Err(_) => None,
+        Err(error) => {
+            log::error!("Executing command {:?} failed by: {:?}", cmd, error);
+            None
+        }
     }
 }
 


### PR DESCRIPTION
#### Description
This patch prints error log for `utils::exec_cmd` failure.

#### Motivation and Context
I was debugging #983 and just found the errors are silenced.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/7413880/76090986-00541b80-6000-11ea-976c-4d8fe9e940c2.png)

#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

I think this patch will work on most platforms; it's a small fix.

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
