### PR TITLE
feat(aws): Use AWS_VAULT as the profile if set

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -134,6 +134,9 @@ The `aws` module shows the current AWS region and profile. This is based on
 `AWS_REGION`, `AWS_DEFAULT_REGION`, and `AWS_PROFILE` env var with
 `~/.aws/config` file.
 
+When using [aws-vault](https://github.com/99designs/aws-vault) the profile
+is read from the `AWS_VAULT` env var.
+
 ### Options
 
 | Variable          | Default         | Description                                                                 |

--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -50,7 +50,9 @@ fn get_aws_region_from_config(aws_profile: Option<&str>) -> Option<Region> {
 
 fn get_aws_profile_and_region() -> (Option<Profile>, Option<Region>) {
     match (
-        env::var("AWS_PROFILE").ok(),
+        env::var("AWS_VAULT")
+            .or_else(|_| env::var("AWS_PROFILE"))
+            .ok(),
         env::var("AWS_REGION").ok(),
         env::var("AWS_DEFAULT_REGION").ok(),
     ) {

--- a/tests/testsuite/aws.rs
+++ b/tests/testsuite/aws.rs
@@ -68,6 +68,18 @@ fn profile_set() -> io::Result<()> {
 }
 
 #[test]
+fn profile_set_from_aws_vault() -> io::Result<()> {
+    let output = common::render_module("aws")
+        .env("AWS_VAULT", "astronauts-vault")
+        .env("AWS_PROFILE", "astronauts-profile")
+        .output()?;
+    let expected = format!("on {} ", Color::Yellow.bold().paint("☁️  astronauts-vault"));
+    let actual = String::from_utf8(output.stdout).unwrap();
+    assert_eq!(expected, actual);
+    Ok(())
+}
+
+#[test]
 fn profile_and_region_set() -> io::Result<()> {
     let output = common::render_module("aws")
         .env("AWS_PROFILE", "astronauts")


### PR DESCRIPTION
#### Description
[aws-vault](https://github.com/99designs/aws-vault) sets the `AWS_VAULT` env var instead of `AWS_PROFILE` when an aws-vault session is active.

This PR adds support for reading the AWS profile value from the `AWS_VAULT` env var, giving priority to `AWS_VAULT` if both it and `AWS_PROFILE` are set.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### How Has This Been Tested?
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

Tested locally on MacOS:

```
# "login" using `aws-vault`
❯ aws-vault exec dev --
Welcome to fish, the friendly interactive shell
☸ kube-dev in ~/s/starship on  aws-vault-profile is 📦 v0.37.0 via 🦀 v1.41.0 on ☁️  us-west-2

# Show that the AWS_VAULT env var is set
❯ env|grep AWS_PROFILE
❯ env|grep AWS_VAULT
AWS_VAULT=dev

# show the prompt with AWS_VAULT code update and see that the `dev` profile is picked up and added to the prompt
❯ ./target/debug/starship prompt
☸ kube-dev in ~/s/starship on  aws-vault-profile is 📦 v0.37.0 via 🦀 v1.41.0 on ☁️  dev(us-west-2)
```

I've also added a test to the `aws` testsuite.

#### Checklist:
- [?] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.

I'm happy to update the docs if deemed warranted.