### PR TITLE
feat: add docker context module

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -387,12 +387,12 @@ The `docker_context` module shows the currently active
 
 ### Options
 
-| Variable                | Default       | Description                                                                  |
-| ----------------------- | ------------- | ---------------------------------------------------------------------------- |
-| `symbol`                | `"🐳 "`       | The symbol used before displaying the Docker context .                       |
-| `style`                 | `"bold blue"` | The style for the module.                                                    |
-| `only_with_compose_yml` | `false`       | Only show when there's a `docker-compose.yml` file in the current directory. |
-| `disabled`              | `true`        | Disables the `docker_context` module.                                        |
+| Variable          | Default       | Description                                                                  |
+| ----------------- | ------------- | ---------------------------------------------------------------------------- |
+| `symbol`          | `"🐳 "`       | The symbol used before displaying the Docker context .                       |
+| `style`           | `"bold blue"` | The style for the module.                                                    |
+| `only_with_files` | `false`       | Only show when there's a `docker-compose.yml` file in the current directory. |
+| `disabled`        | `true`        | Disables the `docker_context` module.                                        |
 
 ### Example
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -100,6 +100,7 @@ prompt_order = [
     "git_state",
     "git_status",
     "hg_branch",
+    "docker_context",
     "package",
     "dotnet",
     "elixir",
@@ -376,6 +377,29 @@ a single character. For `fish_style_pwd_dir_length = 2`, it would be `/bu/th/ci/
 
 [directory]
 truncation_length = 8
+```
+
+## Docker Context
+
+The `docker_context` module shows the currently active
+[Docker context](https://docs.docker.com/engine/context/working-with-contexts/) if it's not set to
+`default`.
+
+### Options
+
+| Variable   | Default       | Description                                            |
+| ---------- | ------------- | ------------------------------------------------------ |
+| `symbol`   | `"🐳 "`       | The symbol used before displaying the Docker context . |
+| `style`    | `"bold blue"` | The style for the module.                              |
+| `disabled` | `true`        | Disables the `docker_context` module.                  |
+
+### Example
+
+```toml
+# ~/.config/starship.toml
+
+[docker_context]
+symbol = "🐋 "
 ```
 
 ## Dotnet

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -387,11 +387,12 @@ The `docker_context` module shows the currently active
 
 ### Options
 
-| Variable   | Default       | Description                                            |
-| ---------- | ------------- | ------------------------------------------------------ |
-| `symbol`   | `"🐳 "`       | The symbol used before displaying the Docker context . |
-| `style`    | `"bold blue"` | The style for the module.                              |
-| `disabled` | `true`        | Disables the `docker_context` module.                  |
+| Variable                | Default       | Description                                                                  |
+| ----------------------- | ------------- | ---------------------------------------------------------------------------- |
+| `symbol`                | `"🐳 "`       | The symbol used before displaying the Docker context .                       |
+| `style`                 | `"bold blue"` | The style for the module.                                                    |
+| `only_with_compose_yml` | `false`       | Only show when there's a `docker-compose.yml` file in the current directory. |
+| `disabled`              | `true`        | Disables the `docker_context` module.                                        |
 
 ### Example
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -390,7 +390,7 @@ The `docker_context` module shows the currently active
 | Variable          | Default       | Description                                                                  |
 | ----------------- | ------------- | ---------------------------------------------------------------------------- |
 | `symbol`          | `"🐳 "`       | The symbol used before displaying the Docker context .                       |
-| `only_with_files` | `false`       | Only show when there's a `docker-compose.yml` file in the current directory. |
+| `only_with_files` | `false`       | Only show when there's a `docker-compose.yml` or `Dockerfile` in the current directory. |
 | `style`           | `"bold blue"` | The style for the module.                                                    |
 | `disabled`        | `true`        | Disables the `docker_context` module.                                        |
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -390,8 +390,8 @@ The `docker_context` module shows the currently active
 | Variable          | Default       | Description                                                                  |
 | ----------------- | ------------- | ---------------------------------------------------------------------------- |
 | `symbol`          | `"🐳 "`       | The symbol used before displaying the Docker context .                       |
-| `style`           | `"bold blue"` | The style for the module.                                                    |
 | `only_with_files` | `false`       | Only show when there's a `docker-compose.yml` file in the current directory. |
+| `style`           | `"bold blue"` | The style for the module.                                                    |
 | `disabled`        | `true`        | Disables the `docker_context` module.                                        |
 
 ### Example

--- a/src/configs/docker_context.rs
+++ b/src/configs/docker_context.rs
@@ -18,8 +18,8 @@ impl<'a> RootModuleConfig<'a> for DockerContextConfig<'a> {
             symbol: SegmentConfig::new("🐳 "),
             context: SegmentConfig::default(),
             style: Color::Blue.bold(),
-            only_with_files: false,
-            disabled: true,
+            only_with_files: true,
+            disabled: false,
         }
     }
 }

--- a/src/configs/docker_context.rs
+++ b/src/configs/docker_context.rs
@@ -8,7 +8,7 @@ pub struct DockerContextConfig<'a> {
     pub symbol: SegmentConfig<'a>,
     pub context: SegmentConfig<'a>,
     pub style: Style,
-    pub only_with_compose_yml: bool,
+    pub only_with_files: bool,
     pub disabled: bool,
 }
 
@@ -18,7 +18,7 @@ impl<'a> RootModuleConfig<'a> for DockerContextConfig<'a> {
             symbol: SegmentConfig::new("🐳 "),
             context: SegmentConfig::default(),
             style: Color::Blue.bold(),
-            only_with_compose_yml: false,
+            only_with_files: false,
             disabled: true,
         }
     }

--- a/src/configs/docker_context.rs
+++ b/src/configs/docker_context.rs
@@ -8,6 +8,7 @@ pub struct DockerContextConfig<'a> {
     pub symbol: SegmentConfig<'a>,
     pub context: SegmentConfig<'a>,
     pub style: Style,
+    pub only_with_compose_yml: bool,
     pub disabled: bool,
 }
 
@@ -17,6 +18,7 @@ impl<'a> RootModuleConfig<'a> for DockerContextConfig<'a> {
             symbol: SegmentConfig::new("🐳 "),
             context: SegmentConfig::default(),
             style: Color::Blue.bold(),
+            only_with_compose_yml: false,
             disabled: true,
         }
     }

--- a/src/configs/docker_context.rs
+++ b/src/configs/docker_context.rs
@@ -1,0 +1,23 @@
+use crate::config::{ModuleConfig, RootModuleConfig, SegmentConfig};
+
+use ansi_term::{Color, Style};
+use starship_module_config_derive::ModuleConfig;
+
+#[derive(Clone, ModuleConfig)]
+pub struct DockerContextConfig<'a> {
+    pub symbol: SegmentConfig<'a>,
+    pub context: SegmentConfig<'a>,
+    pub style: Style,
+    pub disabled: bool,
+}
+
+impl<'a> RootModuleConfig<'a> for DockerContextConfig<'a> {
+    fn new() -> Self {
+        DockerContextConfig {
+            symbol: SegmentConfig::new("🐳 "),
+            context: SegmentConfig::default(),
+            style: Color::Blue.bold(),
+            disabled: true,
+        }
+    }
+}

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -5,6 +5,7 @@ pub mod cmd_duration;
 pub mod conda;
 pub mod crystal;
 pub mod directory;
+pub mod docker_context;
 pub mod dotnet;
 pub mod elixir;
 pub mod elm;

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -27,6 +27,7 @@ impl<'a> RootModuleConfig<'a> for StarshipRootConfig<'a> {
                 "git_state",
                 "git_status",
                 "hg_branch",
+                "docker_context",
                 "package",
                 // ↓ Toolchain version modules ↓
                 // (Let's keep these sorted alphabetically)

--- a/src/module.rs
+++ b/src/module.rs
@@ -17,6 +17,7 @@ pub const ALL_MODULES: &[&str] = &[
     "cmd_duration",
     "conda",
     "directory",
+    "docker_context",
     "dotnet",
     "elixir",
     "elm",

--- a/src/modules/docker_context.rs
+++ b/src/modules/docker_context.rs
@@ -17,6 +17,15 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let mut module = context.new_module(DOCKER_CONFIG_FILE);
     let config: DockerContextConfig = DockerContextConfig::try_load(module.config);
 
+    if config.only_with_compose_yml
+        && !context
+            .try_begin_scan()?
+            .set_files(&["docker-compose.yml"])
+            .is_match()
+    {
+        return None;
+    }
+
     let config_path = home_dir()?.join(".docker/config.json");
     let json = utils::read_file(config_path).ok()?;
     let parsed_json = serde_json::from_str(&json).ok()?;

--- a/src/modules/docker_context.rs
+++ b/src/modules/docker_context.rs
@@ -1,0 +1,39 @@
+use dirs::home_dir;
+
+use super::{Context, Module, RootModuleConfig};
+
+use crate::configs::docker_context::DockerContextConfig;
+use crate::utils;
+
+const DOCKER_CONFIG_FILE: &str = ".docker/config.json";
+
+/// Creates a module with the currently active Docker context
+///
+/// Will display the Docker context if the following criteria are met:
+///     - There is a file named `$HOME/.docker/config.json`
+///     - The file is JSON and contains a field named `currentContext`
+///     - The value of `currentContext` is not `default`
+pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let mut module = context.new_module(DOCKER_CONFIG_FILE);
+    let config: DockerContextConfig = DockerContextConfig::try_load(module.config);
+
+    let config_path = home_dir()?.join(".docker/config.json");
+    let json = utils::read_file(config_path).ok()?;
+    let parsed_json = serde_json::from_str(&json).ok()?;
+
+    match parsed_json {
+        serde_json::Value::Object(root) => {
+            let current_context = root.get("currentContext")?;
+            match current_context {
+                serde_json::Value::String(ctx) => {
+                    module.set_style(config.style);
+                    module.create_segment("symbol", &config.symbol);
+                    module.create_segment("context", &config.context.with_value(&ctx));
+                    Some(module)
+                }
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}

--- a/src/modules/docker_context.rs
+++ b/src/modules/docker_context.rs
@@ -17,7 +17,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let mut module = context.new_module("docker_context");
     let config: DockerContextConfig = DockerContextConfig::try_load(module.config);
 
-    if config.only_with_compose_yml
+    if config.only_with_files
         && !context
             .try_begin_scan()?
             .set_files(&["docker-compose.yml"])

--- a/src/modules/docker_context.rs
+++ b/src/modules/docker_context.rs
@@ -14,7 +14,7 @@ const DOCKER_CONFIG_FILE: &str = ".docker/config.json";
 ///     - The file is JSON and contains a field named `currentContext`
 ///     - The value of `currentContext` is not `default`
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
-    let mut module = context.new_module(DOCKER_CONFIG_FILE);
+    let mut module = context.new_module("docker_context");
     let config: DockerContextConfig = DockerContextConfig::try_load(module.config);
 
     if config.only_with_compose_yml

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -5,6 +5,7 @@ mod cmd_duration;
 mod conda;
 mod crystal;
 mod directory;
+mod docker_context;
 mod dotnet;
 mod elixir;
 mod elm;
@@ -53,6 +54,7 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
         "cmd_duration" => cmd_duration::module(context),
         "conda" => conda::module(context),
         "directory" => directory::module(context),
+        "docker_context" => docker_context::module(context),
         "dotnet" => dotnet::module(context),
         "elixir" => elixir::module(context),
         "elm" => elm::module(context),
@@ -99,6 +101,7 @@ pub fn description(module: &str) -> &'static str {
         "cmd_duration" => "How long the last command took to execute",
         "conda" => "The current conda environment, if $CONDA_DEFAULT_ENV is set",
         "directory" => "The current working directory",
+        "docker_context" => "The current docker context",
         "dotnet" => "The relevant version of the .NET Core SDK for the current directory",
         "env_var" => "Displays the current value of a selected environment variable",
         "git_branch" => "The active branch of the repo in your current directory",


### PR DESCRIPTION
#### Description

Adds a simple module that checks for a Docker config file and if present, reads the `currentContext` value out and displays on the prompt with a whale.

#### Motivation and Context
Closes #995 

#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS** 
- [x] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
