### PR TITLE
Enable to display language version when `.<lang>-version` exists.

### DIFF
--- a/src/modules/elm.rs
+++ b/src/modules/elm.rs
@@ -8,12 +8,13 @@ use crate::utils;
 /// Will display the Elm version if any of the following criteria are met:
 ///     - The current directory contains a `elm.json` file
 ///     - The current directory contains a `elm-package.json` file
+///     - The current directory contains a `.elm-version` file
 ///     - The current directory contains a `elm-stuff` folder
 ///     - The current directory contains a `*.elm` files
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let is_elm_project = context
         .try_begin_scan()?
-        .set_files(&["elm.json", "elm-package.json"])
+        .set_files(&["elm.json", "elm-package.json", ".elm-version"])
         .set_extensions(&["elm"])
         .set_folders(&["elm-stuff"])
         .is_match();

--- a/src/modules/golang.rs
+++ b/src/modules/golang.rs
@@ -11,12 +11,20 @@ use crate::utils;
 ///     - Current directory contains a `glide.yaml` file
 ///     - Current directory contains a `Gopkg.yml` file
 ///     - Current directory contains a `Gopkg.lock` file
+///     - Current directory contains a `.go-version` file
 ///     - Current directory contains a `Godeps` directory
 ///     - Current directory contains a file with the `.go` extension
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let is_go_project = context
         .try_begin_scan()?
-        .set_files(&["go.mod", "go.sum", "glide.yaml", "Gopkg.yml", "Gopkg.lock"])
+        .set_files(&[
+                   "go.mod",
+                   "go.sum",
+                   "glide.yaml",
+                   "Gopkg.yml",
+                   "Gopkg.lock",
+                   ".go-version",
+        ])
         .set_extensions(&["go"])
         .set_folders(&["Godeps"])
         .is_match();

--- a/src/modules/java.rs
+++ b/src/modules/java.rs
@@ -9,11 +9,11 @@ use crate::utils;
 ///
 /// Will display the Java version if any of the following criteria are met:
 ///     - Current directory contains a file with a `.java`, `.class`, `.gradle` or `.jar` extension
-///     - Current directory contains a `pom.xml`, `build.gradle.kts` or `build.sbt` file
+///     - Current directory contains a `pom.xml`, `build.gradle.kts`, `build.sbt` or `.java-version` file
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let is_java_project = context
         .try_begin_scan()?
-        .set_files(&["pom.xml", "build.gradle.kts", "build.sbt"])
+        .set_files(&["pom.xml", "build.gradle.kts", "build.sbt", ".java-version"])
         .set_extensions(&["java", "class", "jar", "gradle"])
         .is_match();
 

--- a/src/modules/nodejs.rs
+++ b/src/modules/nodejs.rs
@@ -7,12 +7,12 @@ use crate::utils;
 ///
 /// Will display the Node.js version if any of the following criteria are met:
 ///     - Current directory contains a `.js` file
-///     - Current directory contains a `package.json` file
+///     - Current directory contains a `package.json` or `.node-version` file
 ///     - Current directory contains a `node_modules` directory
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let is_js_project = context
         .try_begin_scan()?
-        .set_files(&["package.json"])
+        .set_files(&["package.json", ".node-version"])
         .set_extensions(&["js"])
         .set_folders(&["node_modules"])
         .is_match();

--- a/src/modules/php.rs
+++ b/src/modules/php.rs
@@ -7,11 +7,11 @@ use crate::utils;
 ///
 /// Will display the PHP version if any of the following criteria are met:
 ///     - Current directory contains a `.php` file
-///     - Current directory contains a `composer.json` file
+///     - Current directory contains a `composer.json` or `.php-version` file
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let is_php_project = context
         .try_begin_scan()?
-        .set_files(&["composer.json"])
+        .set_files(&["composer.json", ".php-version"])
         .set_extensions(&["php"])
         .is_match();
 

--- a/src/modules/ruby.rs
+++ b/src/modules/ruby.rs
@@ -7,11 +7,11 @@ use crate::utils;
 ///
 /// Will display the Ruby version if any of the following criteria are met:
 ///     - Current directory contains a `.rb` file
-///     - Current directory contains a `Gemfile` file
+///     - Current directory contains a `Gemfile` or `.ruby-version` file
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let is_rb_project = context
         .try_begin_scan()?
-        .set_files(&["Gemfile"])
+        .set_files(&["Gemfile", ".ruby-version"])
         .set_extensions(&["rb"])
         .is_match();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
* `python` module displays language version when `.python-version` file exists.
  * [starship/python\.rs at master · starship/starship](https://github.com/starship/starship/blob/ecc01af23e2df6bf4411aa8487cf10d5d3e6f77f/src/modules/python.rs#L11)
* I found this useful, so I added it to other languages
  * go
  * elm
  * ruby
  * java
  * node
  * php
* The corresponding `<lang>env` was written in the commit message!

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
