### PR TITLE
docs: Fix broken installation link anchor on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 <p align="center">
   <a href="https://starship.rs">Website</a>
   ·
-  <a href="#-installation">Installation</a>
+  <a href="#🚀-installation">Installation</a>
   ·
   <a href="https://starship.rs/config/">Configuration</a>
 </p>

--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@
 </p>
 
 
+<a name="🚀-installation"></a>
+
 ## 🚀 Installation
 
 ### Prerequisites


### PR DESCRIPTION
README does not include the "🚀" anchor for the installation sub-section.
This adds it.