### PR TITLE
fix(git_branch,git_status): implement fallback branch_name for bare git repos

### DIFF
--- a/src/modules/git_branch.rs
+++ b/src/modules/git_branch.rs
@@ -30,7 +30,10 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     };
 
     let repo = context.get_repo().ok()?;
-    let branch_name = repo.branch.as_ref()?;
+    // bare repos don't have a branch name, so `repo.branch.as_ref` would return None,
+    // but git treats "master" as the default branch name
+    let default_branch = String::from("master");
+    let branch_name = repo.branch.as_ref().unwrap_or(&default_branch);
     let truncated_graphemes = get_graphemes(&branch_name, len);
     // The truncation symbol should only be added if we truncated
     let truncated_and_symbol = if len < graphemes_len(&branch_name) {

--- a/src/modules/git_status.rs
+++ b/src/modules/git_status.rs
@@ -23,7 +23,10 @@ use std::collections::HashMap;
 ///   - `✘` — A file's deletion has been added to the staging area
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let repo = context.get_repo().ok()?;
-    let branch_name = repo.branch.as_ref()?;
+    // bare repos don't have a branch name, so `repo.branch.as_ref` would return None,
+    // but git treats "master" as the default branch name
+    let default_branch = String::from("master");
+    let branch_name = repo.branch.as_ref().unwrap_or(&default_branch);
     let repo_root = repo.root.as_ref()?;
     let mut repository = Repository::open(repo_root).ok()?;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
As described in the linked issue, the `git_branch` and `git_status` modules are not working on bare repos, because they don't have an explicit branch_name (according to libgit2 anyway). 

Since `git status` reports the branch name of empty repos as `master` I implemented that name as a fallback for those two modules.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #686

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
