### PR TITLE
feat(nix_shell): add symbol to nix-shell module

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -977,13 +977,14 @@ The module will be shown when inside a nix-shell environment.
 
 ### Options
 
-| Variable     | Default      | Description                        |
-| ------------ | ------------ | ---------------------------------- |
-| `use_name`   | `false`      | Display the name of the nix-shell. |
-| `impure_msg` | `"impure"`   | Customize the "impure" msg.        |
-| `pure_msg`   | `"pure"`     | Customize the "pure" msg.          |
-| `style`      | `"bold red"` | The style for the module.          |
-| `disabled`   | `false`      | Disables the `nix_shell` module.   |
+| Variable     | Default      | Description                                       |
+| ------------ | ------------ | ------------------------------------------------- |
+| `use_name`   | `false`      | Display the name of the nix-shell.                |
+| `impure_msg` | `"impure"`   | Customize the "impure" msg.                       |
+| `pure_msg`   | `"pure"`     | Customize the "pure" msg.                         |
+| `symbol`     | `"❄️  "`      | The symbol used before displaying the shell name. |
+| `style`      | `"bold red"` | The style for the module.                         |
+| `disabled`   | `false`      | Disables the `nix_shell` module.                  |
 
 ### Example
 
@@ -995,6 +996,7 @@ disabled = true
 use_name = true
 impure_msg = "impure shell"
 pure_msg = "pure shell"
+symbol = "☃️  "
 ```
 
 ## NodeJS

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -977,14 +977,14 @@ The module will be shown when inside a nix-shell environment.
 
 ### Options
 
-| Variable     | Default      | Description                                       |
-| ------------ | ------------ | ------------------------------------------------- |
-| `use_name`   | `false`      | Display the name of the nix-shell.                |
-| `impure_msg` | `"impure"`   | Customize the "impure" msg.                       |
-| `pure_msg`   | `"pure"`     | Customize the "pure" msg.                         |
-| `symbol`     | `"❄️  "`      | The symbol used before displaying the shell name. |
-| `style`      | `"bold red"` | The style for the module.                         |
-| `disabled`   | `false`      | Disables the `nix_shell` module.                  |
+| Variable     | Default       | Description                                       |
+| ------------ | ------------- | ------------------------------------------------- |
+| `use_name`   | `false`       | Display the name of the nix-shell.                |
+| `impure_msg` | `"impure"`    | Customize the "impure" msg.                       |
+| `pure_msg`   | `"pure"`      | Customize the "pure" msg.                         |
+| `symbol`     | `"❄️  "`       | The symbol used before displaying the shell name. |
+| `style`      | `"bold blue"` | The style for the module.                         |
+| `disabled`   | `false`       | Disables the `nix_shell` module.                  |
 
 ### Example
 

--- a/src/configs/nix_shell.rs
+++ b/src/configs/nix_shell.rs
@@ -9,6 +9,7 @@ pub struct NixShellConfig<'a> {
     pub impure_msg: SegmentConfig<'a>,
     pub pure_msg: SegmentConfig<'a>,
     pub style: Style,
+    pub symbol: SegmentConfig<'a>,
     pub disabled: bool,
 }
 
@@ -19,6 +20,7 @@ impl<'a> RootModuleConfig<'a> for NixShellConfig<'a> {
             impure_msg: SegmentConfig::new("impure"),
             pure_msg: SegmentConfig::new("pure"),
             style: Color::Red.bold(),
+            symbol: SegmentConfig::new("❄️  "),
             disabled: false,
         }
     }

--- a/src/configs/nix_shell.rs
+++ b/src/configs/nix_shell.rs
@@ -19,7 +19,7 @@ impl<'a> RootModuleConfig<'a> for NixShellConfig<'a> {
             use_name: false,
             impure_msg: SegmentConfig::new("impure"),
             pure_msg: SegmentConfig::new("pure"),
-            style: Color::Red.bold(),
+            style: Color::Blue.bold(),
             symbol: SegmentConfig::new("❄️  "),
             disabled: false,
         }

--- a/src/modules/nix_shell.rs
+++ b/src/modules/nix_shell.rs
@@ -27,6 +27,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let config: NixShellConfig = NixShellConfig::try_load(module.config);
 
     module.set_style(config.style);
+    module.create_segment("symbol", &config.symbol);
 
     let shell_type = env::var("IN_NIX_SHELL").ok()?;
     let shell_type_segment: SegmentConfig = match shell_type.as_ref() {

--- a/tests/testsuite/nix_shell.rs
+++ b/tests/testsuite/nix_shell.rs
@@ -28,7 +28,7 @@ fn pure_shell() -> io::Result<()> {
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
-    let expected = format!("via {} ", Color::Red.bold().paint("❄️  pure"));
+    let expected = format!("via {} ", Color::Blue.bold().paint("❄️  pure"));
     assert_eq!(expected, actual);
     Ok(())
 }
@@ -40,7 +40,7 @@ fn impure_shell() -> io::Result<()> {
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
-    let expected = format!("via {} ", Color::Red.bold().paint("❄️  impure"));
+    let expected = format!("via {} ", Color::Blue.bold().paint("❄️  impure"));
     assert_eq!(expected, actual);
     Ok(())
 }
@@ -52,7 +52,7 @@ fn lorri_shell() -> io::Result<()> {
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
-    let expected = format!("via {} ", Color::Red.bold().paint("❄️  impure"));
+    let expected = format!("via {} ", Color::Blue.bold().paint("❄️  impure"));
     assert_eq!(expected, actual);
     Ok(())
 }

--- a/tests/testsuite/nix_shell.rs
+++ b/tests/testsuite/nix_shell.rs
@@ -28,7 +28,7 @@ fn pure_shell() -> io::Result<()> {
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
-    let expected = format!("via {} ", Color::Red.bold().paint("pure"));
+    let expected = format!("via {} ", Color::Red.bold().paint("❄️  pure"));
     assert_eq!(expected, actual);
     Ok(())
 }
@@ -40,7 +40,7 @@ fn impure_shell() -> io::Result<()> {
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
-    let expected = format!("via {} ", Color::Red.bold().paint("impure"));
+    let expected = format!("via {} ", Color::Red.bold().paint("❄️  impure"));
     assert_eq!(expected, actual);
     Ok(())
 }
@@ -52,7 +52,7 @@ fn lorri_shell() -> io::Result<()> {
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
-    let expected = format!("via {} ", Color::Red.bold().paint("impure"));
+    let expected = format!("via {} ", Color::Red.bold().paint("❄️  impure"));
     assert_eq!(expected, actual);
     Ok(())
 }


### PR DESCRIPTION
#### Description
<!--- Describe your changes in detail -->
Add's a ❄️ icon to the nix-shell module. While at it, changed the default color to blue to be consistent with the nix colorscheme.
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1048

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):
Before:
![image](https://user-images.githubusercontent.com/7243783/78632626-0ce1c300-788f-11ea-8c10-4803130e0af4.png)

After:
![image](https://user-images.githubusercontent.com/7243783/78632647-1834ee80-788f-11ea-9322-5171d469bac0.png)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
