### PR TITLE
feat: Prefix & Suffix support for hostname & username

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -755,8 +755,8 @@ The `hostname` module shows the system hostname.
 | Variable   | Default               | Description                                                                                                                          |
 | ---------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
 | `ssh_only` | `true`                | Only show hostname when connected to an SSH session.                                                                                 |
-| `prefix`   | `""`                  | Prefix to display immediately before the hostname.                                                                                   |
-| `suffix`   | `""`                  | Suffix to display immediately after the hostname.                                                                                    |
+| `prefix`   | `"on "`               | Prefix to display immediately before the hostname.                                                                                   |
+| `suffix`   | `" "`                 | Suffix to display immediately after the hostname.                                                                                    |
 | `trim_at`  | `"."`                 | String that the hostname is cut off at, after the first match. `"."` will stop after the first dot. `""` will disable any truncation |
 | `style`    | `"bold dimmed green"` | The style for the module.                                                                                                            |
 | `disabled` | `false`               | Disables the `hostname` module.                                                                                                      |
@@ -1289,6 +1289,8 @@ The module will be shown if any of the following conditions are met:
 | `style_user`  | `"bold yellow"` | The style used for non-root users.    |
 | `show_always` | `false`         | Always shows the `username` module.   |
 | `disabled`    | `false`         | Disables the `username` module.       |
+| `prefix`   | `"via "`               | Prefix to display immediately before the username.                                                                                   |
+| `suffix`   | `" "`                 | Suffix to display immediately after the username.                                                                                    |
 
 ### Example
 

--- a/src/configs/hostname.rs
+++ b/src/configs/hostname.rs
@@ -17,8 +17,8 @@ impl<'a> RootModuleConfig<'a> for HostnameConfig<'a> {
     fn new() -> Self {
         HostnameConfig {
             ssh_only: true,
-            prefix: "",
-            suffix: "",
+            prefix: "on ",
+            suffix: " ",
             trim_at: ".",
             style: Color::Green.bold().dimmed(),
             disabled: false,

--- a/src/configs/username.rs
+++ b/src/configs/username.rs
@@ -4,20 +4,24 @@ use ansi_term::{Color, Style};
 use starship_module_config_derive::ModuleConfig;
 
 #[derive(Clone, ModuleConfig)]
-pub struct UsernameConfig {
+pub struct UsernameConfig<'a> {
     pub style_root: Style,
     pub style_user: Style,
     pub show_always: bool,
     pub disabled: bool,
+    pub prefix: &'a str,
+    pub suffix: &'a str,
 }
 
-impl<'a> RootModuleConfig<'a> for UsernameConfig {
+impl<'a> RootModuleConfig<'a> for UsernameConfig<'a> {
     fn new() -> Self {
         UsernameConfig {
             style_root: Color::Red.bold(),
             style_user: Color::Yellow.bold(),
             show_always: false,
             disabled: false,
+            prefix: "via ",
+            suffix: " ",
         }
     }
 }

--- a/src/modules/hostname.rs
+++ b/src/modules/hostname.rs
@@ -43,9 +43,11 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     };
 
     module.set_style(config.style);
-    let hostname_stacked = format!("{}{}{}", config.prefix, host, config.suffix);
-    module.create_segment("hostname", &SegmentConfig::new(&hostname_stacked));
-    module.get_prefix().set_value("on ");
+
+    module.get_prefix().set_value(config.prefix);
+    module.get_suffix().set_value(config.suffix);
+
+    module.create_segment("hostname", &SegmentConfig::new(&host));
 
     Some(module)
 }

--- a/src/modules/username.rs
+++ b/src/modules/username.rs
@@ -29,6 +29,8 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         };
 
         module.set_style(module_style);
+        module.get_prefix().set_value(config.prefix);
+        module.get_suffix().set_value(config.suffix);
         module.create_segment("username", &SegmentConfig::new(&user?));
 
         Some(module)

--- a/tests/testsuite/hostname.rs
+++ b/tests/testsuite/hostname.rs
@@ -75,7 +75,7 @@ fn prefix() -> io::Result<()> {
         })
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
-    let expected = format!("on {} ", style().paint(format!("<{}", hostname)));
+    let expected = format!("<{} ", style().paint(format!("{}", hostname)));
     assert_eq!(actual, expected);
     Ok(())
 }
@@ -96,7 +96,7 @@ fn suffix() -> io::Result<()> {
         })
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
-    let expected = format!("on {} ", style().paint(format!("{}>", hostname)));
+    let expected = format!("on {}>", style().paint(format!("{}", hostname)));
     assert_eq!(actual, expected);
     Ok(())
 }


### PR DESCRIPTION
#### Description
Instead of having `via` and `on` hardcoded, use the prefix & suffix values similar to other modules. 

#### Motivation and Context
I'd like to be able to format my prompt as `username@hostname:path`. Since `on` and `via` were hard-coded in the source, I couldn't configure them without a fork. 

Fixes #705 

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

This is technically a breaking change because if someone had configured the hostname prefix, they will no longer also get `on`. 



#### How Has This Been Tested?
`cargo test`
- [ ] I have tested using **MacOS**
- [X] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [X] I have updated the documentation accordingly.
- [X] I have updated the tests accordingly.
