### PR TITLE
refactor(rust): Use format strings

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1171,12 +1171,12 @@ The module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Option     | Default                            | Description                                            |
-| ---------- | ---------------------------------- | ------------------------------------------------------ |
-| `format`   | `"via [$symbol$version]($style) "` | The format for the module.                             |
-| `symbol`   | `"🦀 "`                            | A format string representing the symbol of Rust        |
-| `style`    | `"bold red"`                       | The style for the module.                              |
-| `disabled` | `false`                            | Disables the `rust` module.                            |
+| Option     | Default                            | Description                                     |
+| ---------- | ---------------------------------- | ----------------------------------------------- |
+| `format`   | `"via [$symbol$version]($style) "` | The format for the module.                      |
+| `symbol`   | `"🦀 "`                            | A format string representing the symbol of Rust |
+| `style`    | `"bold red"`                       | The style for the module.                       |
+| `disabled` | `false`                            | Disables the `rust` module.                     |
 
 ### Variables
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1171,11 +1171,22 @@ The module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Variable   | Default      | Description                                            |
-| ---------- | ------------ | ------------------------------------------------------ |
-| `symbol`   | `"🦀 "`      | The symbol used before displaying the version of Rust. |
-| `style`    | `"bold red"` | The style for the module.                              |
-| `disabled` | `false`      | Disables the `rust` module.                            |
+| Option     | Default                            | Description                                            |
+| ---------- | ---------------------------------- | ------------------------------------------------------ |
+| `format`   | `"via [$symbol$version]($style) "` | The format for the module.                             |
+| `symbol`   | `"🦀 "`                            | A format string representing the symbol of Rust        |
+| `style`    | `"bold red"`                       | The style for the module.                              |
+| `disabled` | `false`                            | Disables the `rust` module.                            |
+
+### Variables
+
+| Variable | Example           | Description                          |
+| -------- | ----------------- | ------------------------------------ |
+| version  | `v1.43.0-nightly` | The version of `rustc`               |
+| symbol   |                   | Mirrors the value of option `symbol` |
+| style\*  |                   | Mirrors the value of option `style`  |
+
+\*: This variable can only be used as a part of a style string
 
 ### Example
 
@@ -1183,7 +1194,7 @@ The module will be shown if any of the following conditions are met:
 # ~/.config/starship.toml
 
 [rust]
-symbol = "⚙️ "
+format = "via [⚙️ $version](red bold)"
 ```
 
 ## Singularity

--- a/src/configs/rust.rs
+++ b/src/configs/rust.rs
@@ -1,22 +1,21 @@
-use crate::config::{ModuleConfig, RootModuleConfig, SegmentConfig};
+use crate::config::{ModuleConfig, RootModuleConfig};
 
-use ansi_term::{Color, Style};
 use starship_module_config_derive::ModuleConfig;
 
 #[derive(Clone, ModuleConfig)]
 pub struct RustConfig<'a> {
-    pub symbol: SegmentConfig<'a>,
-    pub version: SegmentConfig<'a>,
-    pub style: Style,
+    pub format: &'a str,
+    pub symbol: &'a str,
+    pub style: &'a str,
     pub disabled: bool,
 }
 
 impl<'a> RootModuleConfig<'a> for RustConfig<'a> {
     fn new() -> Self {
         RustConfig {
-            symbol: SegmentConfig::new("🦀 "),
-            version: SegmentConfig::default(),
-            style: Color::Red.bold(),
+            format: "via [$symbol$version]($style) ",
+            symbol: "🦀 ",
+            style: "bold red",
             disabled: false,
         }
     }

--- a/src/modules/rust.rs
+++ b/src/modules/rust.rs
@@ -5,6 +5,7 @@ use std::{env, fs};
 use super::{Context, Module, RootModuleConfig};
 
 use crate::configs::rust::RustConfig;
+use crate::formatter::StringFormatter;
 
 /// Creates a module with the current Rust version
 ///
@@ -22,6 +23,47 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         return None;
     }
 
+    let mut module = context.new_module("rust");
+    let config = RustConfig::try_load(module.config);
+    let formatter = match StringFormatter::new(config.format) {
+        Ok(formatter) => formatter
+            .map_style(|variable| match variable {
+                "style" => Some(config.style),
+                _ => None,
+            })
+            .map(|variable| match variable {
+                // This may result in multiple calls to `get_module_version` when a user have
+                // multiple `$version` variables defined in `format`.
+                "version" => get_module_version(context),
+                _ => None,
+            })
+            .map_variables_to_segments(|variable| match variable {
+                "symbol" => match StringFormatter::new(config.symbol) {
+                    Ok(formatter) => Some(formatter.parse(None)),
+                    Err(error) => {
+                        log::warn!("Error parsing format string in `rust.symbol`:\n{}", error);
+                        None
+                    }
+                },
+                _ => None,
+            }),
+        Err(error) => {
+            log::warn!("Error parsing format string in `rust.format`:\n{}", error);
+            return None;
+        }
+    };
+
+    // TODO Returns `None` if formatter has a version variable and its value is `None`
+
+    module.set_segments(formatter.parse(None));
+
+    module.get_prefix().set_value("");
+    module.get_suffix().set_value("");
+
+    Some(module)
+}
+
+fn get_module_version(context: &Context) -> Option<String> {
     // `$CARGO_HOME/bin/rustc(.exe) --version` may attempt installing a rustup toolchain.
     // https://github.com/starship/starship/issues/417
     //
@@ -56,14 +98,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         format_rustc_version(execute_rustc_version()?)
     };
 
-    let mut module = context.new_module("rust");
-    let config = RustConfig::try_load(module.config);
-    module.set_style(config.style);
-
-    module.create_segment("symbol", &config.symbol);
-    module.create_segment("version", &config.version.with_value(&module_version));
-
-    Some(module)
+    Some(module_version)
 }
 
 fn env_rustup_toolchain() -> Option<String> {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
This PR deprecates `symbol` `version` `style` keys in `RustConfig`, and adds `format` key instead.

Also can be used as an example of refactoring existing modules.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related #1057

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
