### PR TITLE
Added module support for z.lua.

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -95,6 +95,7 @@ prompt_order = [
     "hostname",
     "kubernetes",
     "directory",
+    "z.lua",
     "git_branch",
     "git_commit",
     "git_state",
@@ -1297,4 +1298,36 @@ The module will be shown if any of the following conditions are met:
 
 [username]
 disabled = true
+```
+
+## z.lua
+
+The `z.lua` module shows the Z rank of the current directory for
+determining its [frecency](https://en.wikipedia.org/wiki/Frecency).
+The module will be shown if any of the following conditions are met:
+
+- The current user has the `z.lua` command detected via environment variables such as `ZLUA_LUAEXE` and `ZLUA_SCRIPT`
+- The configuration explicitly targets the Lua and Z script location
+
+### Options
+
+| Variable                | Default         | Description                             |
+| ----------------------- | --------------- | --------------------------------------- |
+| `prefix`                | `"[z"`          | The prompt prefix for z.lua module.     |
+| `suffix`                | `"] "`          | The prompt suffix for z.lua module.     |
+| `symbol`                | `""`            | The prompt symbol for z.lua module.     |
+| `style`                 | `"bold cyan"`   | The style for the module.               |
+| `disabled`              | `false`         | Disables the `z.lua` module.            |
+| `lua_exe_location`      | `""`            | Configures the Lua executable location. |
+| `zlua_script_location`  | `""`            | Configures the z.lua script location.   |
+
+### Example
+
+```toml
+# ~/.config/starship.toml
+
+[zlua]
+disabled = false
+symbol = "🌊"
+prefix = "["
 ```

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -35,5 +35,6 @@ mod starship_root;
 pub mod terraform;
 pub mod time;
 pub mod username;
+pub mod zlua;
 
 pub use starship_root::*;

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -22,6 +22,7 @@ impl<'a> RootModuleConfig<'a> for StarshipRootConfig<'a> {
                 "singularity",
                 "kubernetes",
                 "directory",
+                "zlua",
                 "git_branch",
                 "git_commit",
                 "git_state",

--- a/src/configs/zlua.rs
+++ b/src/configs/zlua.rs
@@ -1,0 +1,29 @@
+use crate::config::{ModuleConfig, RootModuleConfig, SegmentConfig};
+
+use ansi_term::{Color, Style};
+use starship_module_config_derive::ModuleConfig;
+
+#[derive(Clone, ModuleConfig)]
+pub struct ZluaConfig<'a> {
+    pub prefix: &'a str,
+    pub suffix: &'a str,
+    pub symbol: SegmentConfig<'a>,
+    pub style: Style,
+    pub disabled: bool,
+    pub lua_exe_location: &'a str,
+    pub zlua_script_location: &'a str,
+}
+
+impl<'a> RootModuleConfig<'a> for ZluaConfig<'a> {
+    fn new() -> Self {
+        ZluaConfig {
+            prefix: "[z",
+            suffix: "] ",
+            symbol: SegmentConfig::new(""),
+            style: Color::Cyan.bold(),
+            disabled: false,
+            lua_exe_location: "",
+            zlua_script_location: "",
+        }
+    }
+}

--- a/src/module.rs
+++ b/src/module.rs
@@ -48,6 +48,7 @@ pub const ALL_MODULES: &[&str] = &[
     "singularity",
     "time",
     "username",
+    "zlua",
 ];
 
 /// A module is a collection of segments showing data for a single integration

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -36,6 +36,7 @@ mod terraform;
 mod time;
 mod username;
 mod utils;
+mod zlua;
 
 #[cfg(feature = "battery")]
 mod battery;
@@ -86,6 +87,7 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
         "time" => time::module(context),
         "crystal" => crystal::module(context),
         "username" => username::module(context),
+        "zlua" => zlua::module(context),
         _ => {
             eprintln!("Error: Unknown module {}. Use starship module --list to list out all supported modules.", module);
             None

--- a/src/modules/zlua.rs
+++ b/src/modules/zlua.rs
@@ -1,0 +1,248 @@
+use crate::configs::zlua::ZluaConfig;
+
+use super::{Context, Module, RootModuleConfig, SegmentConfig};
+
+use crate::utils;
+
+use std::fmt;
+use std::str::Lines;
+use std::str::SplitWhitespace;
+
+// Constants
+
+/// Stores the environment variable hosting the LUA executable.
+static ENV_VAR_LUA_EXE: &str = "ZLUA_LUAEXE";
+
+/// Stores the environment variable hosting the _z.lua_ script.
+static ENV_VAR_ZLUA_SCRIPT: &str = "ZLUA_SCRIPT";
+
+/// Creates a module with the z.lua weight of the current working directory.
+///
+/// Will display the weight if the z.lua script is loaded in the current
+/// shell.
+///
+/// Will activate on explicit configuration enabling and on presence of
+/// environment variables `ZLUA_LUAEXE` and `ZLUA_SCRIPT`.
+pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let mut module = context.new_module("zlua");
+    let config: ZluaConfig<'_> = ZluaConfig::try_load(module.config);
+
+    module.set_style(config.style);
+    module.get_prefix().set_value(config.prefix);
+    module.get_suffix().set_value(config.suffix);
+
+    let zlua_lines = get_zlua_line_entries(&config)?;
+    let cwd = context.current_dir.to_str()?;
+    let zentry = get_cwd_entry(&zlua_lines, cwd)?;
+
+    module.create_segment("zsymbol", &config.symbol);
+    module.create_segment("zweight", &SegmentConfig::new(zentry.weight));
+
+    Some(module)
+}
+
+/// Gets the z.lua entries as lines describing weights and folders.
+fn get_zlua_line_entries(config: &ZluaConfig<'_>) -> Option<String> {
+    let lua_exe = get_loc_lua_exe(config)?;
+    let zlua_script = get_loc_zlua_script(config)?;
+
+    let output = utils::exec_cmd(&lua_exe, &[&zlua_script, "-l"])?;
+    Some(format!("{}", output.stdout))
+}
+
+/// Gets the ZEntry for the current directory.
+///
+/// # Arguments
+///
+/// * `zlines` - The z.lua line entries as a string.
+/// * `cwd` - The current working directory.
+fn get_cwd_entry<'a>(zlines: &'a str, cwd: &str) -> Option<ZEntry<'a>> {
+    let mut lines: Lines = zlines.lines();
+    lines.find_map(|line| to_z_entry(line).filter(|entry| entry.folder == cwd))
+}
+
+fn get_env_variable(name: &str) -> Option<String> {
+    match std::env::var(name) {
+        Ok(value) => Some(value),
+        Err(_) => {
+            log::debug!("Could not get the value of the '{}' env variable.", name);
+            None
+        }
+    }
+}
+
+fn get_config_var(config_value: &str, env_var_name: &str) -> Option<String> {
+    let clean_value = config_value.trim();
+    if !clean_value.is_empty() {
+        log::debug!("Found z.lua configuration value '{}'.", clean_value);
+        Some(String::from(clean_value))
+    } else {
+        let env_var_value: Option<String> = get_env_variable(env_var_name);
+        let unwrapped_value: &str = env_var_value.as_deref().unwrap_or("Missing");
+        log::debug!(
+            "Try to use the z.lua environment value '{}'.",
+            unwrapped_value
+        );
+        env_var_value
+    }
+}
+
+fn get_loc_lua_exe(config: &ZluaConfig<'_>) -> Option<String> {
+    get_config_var(config.lua_exe_location, ENV_VAR_LUA_EXE)
+}
+
+fn get_loc_zlua_script(config: &ZluaConfig<'_>) -> Option<String> {
+    get_config_var(config.zlua_script_location, ENV_VAR_ZLUA_SCRIPT)
+}
+
+/// Transforms a string line from the z.lua output into a ZEntry struct.
+///
+/// # Arguments
+///
+/// * `zline` - The z.lua line output.
+fn to_z_entry(zline: &str) -> Option<ZEntry> {
+    let mut zentries: SplitWhitespace = zline.split_whitespace();
+    zentries
+        .next()
+        .and_then(|weight| zentries.next().map(|folder| (weight, folder)))
+        .map(|(weight, folder)| ZEntry {
+            weight: weight.trim(),
+            folder: folder.trim(),
+        })
+}
+
+#[derive(Debug)]
+struct ZEntry<'a> {
+    weight: &'a str,
+    folder: &'a str,
+}
+
+impl fmt::Display for ZEntry<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "weight: {}, folder: {}", self.weight, self.folder)
+    }
+}
+
+impl std::cmp::PartialEq for ZEntry<'_> {
+    fn eq(&self, other: &ZEntry) -> bool {
+        self.weight == other.weight && self.folder == other.folder
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_similar_z_entry() {
+        let line = "686        D:\\Projects\\starship";
+        assert_eq!(
+            to_z_entry(line),
+            Some(ZEntry {
+                weight: "686",
+                folder: "D:\\Projects\\starship"
+            })
+        );
+    }
+
+    #[test]
+    fn test_non_similar_z_entry() {
+        let line = "78         D:\\Projects\\guides";
+        assert_ne!(
+            to_z_entry(line),
+            Some(ZEntry {
+                weight: "",
+                folder: "D:\\Projects\\starship"
+            })
+        );
+    }
+
+    #[test]
+    fn test_z_entry_with_missing_weight() {
+        let line = "        D:\\Projects\\starship";
+        assert_eq!(to_z_entry(line), None);
+    }
+
+    #[test]
+    fn test_z_entry_with_missing_folder() {
+        let line = "78         ";
+        assert_eq!(to_z_entry(line), None);
+    }
+
+    #[test]
+    fn test_z_entry_equality() {
+        let entry1 = ZEntry {
+            folder: "D:\\Projects\\starship",
+            weight: "1",
+        };
+        let entry2 = ZEntry {
+            folder: "D:\\Projects\\starship",
+            weight: "1",
+        };
+
+        assert_eq!(entry1, entry2);
+    }
+
+    #[test]
+    fn test_z_entry_inequal_weight() {
+        let entry1 = ZEntry {
+            folder: "D:\\Projects\\starship",
+            weight: "1",
+        };
+        let entry2 = ZEntry {
+            folder: "D:\\Projects\\starship",
+            weight: "2",
+        };
+
+        assert_ne!(entry1, entry2);
+    }
+
+    #[test]
+    fn test_z_entry_inequal_folder() {
+        let entry1 = ZEntry {
+            folder: "D:\\Projects\\starship",
+            weight: "1",
+        };
+        let entry2 = ZEntry {
+            folder: "D:\\Projects\\starship\\docs",
+            weight: "1",
+        };
+
+        assert_ne!(entry1, entry2);
+    }
+
+    #[test]
+    fn test_present_cwd_entry() {
+        let ex_output = "21         D:\\Projects
+76         D:\\Projects\\starship\\docs
+78         D:\\Projects\\guides
+686        D:\\Projects\\starship";
+        let zentry: Option<ZEntry> = get_cwd_entry(ex_output, "D:\\Projects\\starship");
+
+        assert_eq!(
+            zentry,
+            Some(ZEntry {
+                weight: "686",
+                folder: "D:\\Projects\\starship"
+            })
+        );
+    }
+
+    #[test]
+    fn test_missing_cwd_entry() {
+        let ex_output = "21         D:\\Projects
+76         D:\\Projects\\starship\\docs
+78         D:\\Projects\\guides
+686        D:\\Projects\\starship";
+        let zentry: Option<ZEntry> = get_cwd_entry(ex_output, "D:\\Projects\\starship\\target");
+
+        assert_eq!(zentry, None);
+    }
+
+    #[test]
+    #[ignore]
+    fn test_exec_cmd() {
+        let result = get_zlua_line_entries(&ZluaConfig::new());
+        assert!(result.is_some(), "No result was returned!");
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -86,6 +86,15 @@ Elixir 1.10 (compiled with Erlang/OTP 22)",
             ),
             stderr: String::default(),
         }),
+        "z -l" => Some(CommandOutput {
+            stdout: String::from(
+                "21         /Projects
+76         /Projects/starship/docs
+78         /Projects/guides
+686        /Projects/starship",
+            ),
+            stderr: String::default(),
+        }),
         // If we don't have a mocked command fall back to executing the command
         _ => internal_exec_cmd(&cmd, &args),
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description

Added module support for [z.lua](https://github.com/skywind3000/z.lua). This also covers configuration, tests and mock command. The way the module is detected is either via:

1- The presence of the environment variables `ZLUA_LUAEXE` and `ZLUA_SCRIPT` which are usually configured by the *z.lua* installation script.
2- The explicit configuration of the Lua executable location and z.lua script location.

Number 2 is necessary for customization as the *z.lua* installation script might not render the variables in the environment scope but in some others unfortunately, such as  is the case for PowerShell where it resides in `$Script` scope rather than `$env`.

Regarding the icon for z.lua, it would have been nice to use the project's lightning emoji but I had a hard time to get some of these to correctly display on the prompt. I left it out to the user to customize this to his liking. 

#### Motivation and Context

The [z.lua](https://github.com/skywind3000/z.lua) project offers a way to quickly change directory based on keywords and frecency algorithms without having to type the full paths. It's a convenient alternative for the classic shell [z command](https://github.com/rupa/z). It supports various platforms (including Windows) and shells. It's generally more performant than its counterparts. 

This module display the rank of the current directory. It's useful to me so I can track which directories are better ranked and manually intervene on a folder that should not be. 

#### Warning

I'm a rookie when it comes to Rust. Feel free to direct me on better coding practices. 

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**
- [x] I have tested using **Windows Subsystem for Linux**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
