### PR TITLE
feat(package): Add project version for Elixir

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1028,7 +1028,7 @@ symbol = "🤖 "
 
 The `package` module is shown when the current directory is the repository for a
 package, and shows its current version. The module currently supports `npm`, `cargo`,
-`poetry`, `composer`, and `gradle` packages.
+`poetry`, `composer`, `gradle`, `julia` and `mix` packages.
 
 - **npm** – The `npm` package version is extracted from the `package.json` present
   in the current directory
@@ -1040,6 +1040,7 @@ package, and shows its current version. The module currently supports `npm`, `ca
   in the current directory
 - **gradle** – The `gradle` package version is extracted from the `build.gradle` present
 - **julia** - The package version is extracted from the `Project.toml` present
+- **mix** - The `mix` package version is extracted from the `mix.exs` present
 
 > ⚠️ The version being shown is that of the package whose source code is in your
 > current directory, not your package manager.

--- a/src/modules/package.rs
+++ b/src/modules/package.rs
@@ -94,6 +94,14 @@ fn extract_project_version(file_contents: &str) -> Option<String> {
     Some(formatted_version)
 }
 
+fn extract_mix_version(file_contents: &str) -> Option<String> {
+    let re = Regex::new(r#"(?m)version: "(?P<version>[^"]+)""#).unwrap();
+    let caps = re.captures(file_contents)?;
+
+    let formatted_version = format_version(&caps["version"]);
+    Some(formatted_version)
+}
+
 fn get_package_version(base_dir: &PathBuf) -> Option<String> {
     if let Ok(cargo_toml) = utils::read_file(base_dir.join("Cargo.toml")) {
         extract_cargo_version(&cargo_toml)
@@ -107,6 +115,8 @@ fn get_package_version(base_dir: &PathBuf) -> Option<String> {
         extract_gradle_version(&build_gradle)
     } else if let Ok(project_toml) = utils::read_file(base_dir.join("Project.toml")) {
         extract_project_version(&project_toml)
+    } else if let Ok(mix_file) = utils::read_file(base_dir.join("mix.exs")) {
+        extract_mix_version(&mix_file)
     } else {
         None
     }
@@ -327,6 +337,67 @@ java {
         let expected_version = None;
         assert_eq!(
             extract_gradle_version(&gradle_without_version),
+            expected_version
+        );
+    }
+
+    #[test]
+    fn test_extract_mix_version() {
+        let mix_complete = "defmodule MyApp.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :my_app,
+      version: \"1.2.3\",
+      elixir: \"~> 1.10\",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  # Run \"mix help compile.app\" to learn about applications.
+  def application do
+    [extra_applications: [:logger]]
+  end
+
+  # Run \"mix help deps\" to learn about dependencies.
+  defp deps do
+    []
+  end
+end";
+
+        let expected_version = Some("v1.2.3".to_string());
+        assert_eq!(extract_mix_version(&mix_complete), expected_version);
+
+        let mix_partial_oneline = "  def project, do: [app: :my_app,version: \"3.2.1\"]";
+
+        let expected_version = Some("v3.2.1".to_string());
+        assert_eq!(extract_mix_version(&mix_partial_oneline), expected_version);
+
+        let mix_partial_prerelease = "  def project do
+    [
+      app: :my_app,
+      version: \"1.0.0-alpha.3\"
+    ]
+  end";
+
+        let expected_version = Some("v1.0.0-alpha.3".to_string());
+        assert_eq!(
+            extract_mix_version(&mix_partial_prerelease),
+            expected_version
+        );
+
+        let mix_partial_prerelease_and_build_info = "  def project do
+    [
+      app: :my_app,
+      version: \"0.9.9-dev+20130417140000.amd64\"
+    ]
+  end";
+
+        let expected_version = Some("v0.9.9-dev+20130417140000.amd64".to_string());
+        assert_eq!(
+            extract_mix_version(&mix_partial_prerelease_and_build_info),
             expected_version
         );
     }


### PR DESCRIPTION
#### Description
Elixir projects have their version in `mix.exs` and follow:
`MAJOR.MINOR.PATCH-PRERELEASE+BUILDINFORMATION`

See [Elixir Docs](https://hexdocs.pm/elixir/1.10.2/Version.html#content) for details.

#### Motivation and Context
I want to see the version number info for Elixir projects.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
