### PR TITLE
feat: Add migration script for format strings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,3 +78,7 @@ lto = true
 [[bin]]
 name = "starship"
 path = "src/main.rs"
+
+[[bin]]
+name = "starship_migrate_0_40"
+path = "scripts/starship_migrate_0_40.rs"

--- a/scripts/starship_migrate_0_40.rs
+++ b/scripts/starship_migrate_0_40.rs
@@ -1,0 +1,224 @@
+/*
+ * starship_migrate_0_40
+ *
+ * A script for migrating starship configuration file from before v0.40 to v0.40.
+ *
+ */
+use dirs::home_dir;
+use std::env;
+use std::fs::{copy, File};
+use std::io::Write;
+use std::path::PathBuf;
+use toml::Value;
+
+use starship::config::{ModuleConfig, StarshipConfig};
+
+fn main() {
+    let file_path = get_file_path().expect("Fail to determine the path of the config file.");
+
+    // Backup the original config
+    let file_name = file_path
+        .file_name()
+        .expect("The config file does not have a file name");
+    let mut backup_file_path = file_path.clone();
+    backup_file_path.set_file_name(format!(
+        "{}.bkup",
+        file_name.to_str().expect("Invalid starship config path")
+    ));
+    copy(&file_path, &backup_file_path).expect("Failed to backup original config file");
+
+    // Load starship config
+    let mut starship_config = StarshipConfig::initialize();
+
+    if let Some(mut config) = starship_config.config.as_mut() {
+        update_starship_config(&mut config);
+    }
+
+    // Write to the config file
+    let config = starship_config
+        .config
+        .expect("Failed to load starship config");
+    let config_str =
+        toml::to_string_pretty(&config).expect("Failed to serialize the config to string");
+    File::create(&file_path)
+        .and_then(|mut file| file.write_all(config_str.as_ref()))
+        .expect("Error writing starship config");
+
+    eprintln!(
+        "Updated starship config written to `{}`.\nYou can find your original config file in `{}`.",
+        &file_path.to_str().unwrap(),
+        &backup_file_path.to_str().unwrap(),
+    );
+}
+
+fn get_file_path() -> Option<PathBuf> {
+    if let Ok(path) = env::var("STARSHIP_CONFIG") {
+        // Use $STARSHIP_CONFIG as the config path if available
+        Some(PathBuf::from(path))
+    } else {
+        // Default to using ~/.config/starship.toml
+        home_dir().map(|path| path.join(".config/starship.toml"))
+    }
+}
+
+fn update_starship_config(config: &mut Value) {
+    migrate_starship_root_config(config);
+}
+
+fn migrate_starship_root_config(root_config: &mut Value) {
+    let default_prompt_order = vec![
+        "username",
+        "hostname",
+        "singularity",
+        "kubernetes",
+        "directory",
+        "git_branch",
+        "git_commit",
+        "git_state",
+        "git_status",
+        "hg_branch",
+        "docker_context",
+        "package",
+        // ↓ Toolchain version modules ↓
+        // (Let's keep these sorted alphabetically)
+        "dotnet",
+        "elixir",
+        "elm",
+        "golang",
+        "haskell",
+        "java",
+        "julia",
+        "nodejs",
+        "php",
+        "python",
+        "ruby",
+        "rust",
+        "terraform",
+        // ↑ Toolchain version modules ↑
+        "nix_shell",
+        "conda",
+        "memory_usage",
+        "aws",
+        "env_var",
+        "cmd_duration",
+        "line_break",
+        "jobs",
+        "battery",
+        "time",
+        "character",
+    ];
+
+    if let Some(table) = root_config.as_table_mut() {
+        // Don't do anything in case there is a `format` key
+        if table.contains_key("format") {
+            return;
+        }
+
+        // Always add format to root even if there is no `add_newline` and `prompt_order`.
+        let add_newline = table
+            .get("add_newline")
+            .and_then(bool::from_config)
+            .unwrap_or(true);
+        let prompt_order: Vec<&str> = table
+            .get("prompt_order")
+            .and_then(Vec::from_config)
+            .unwrap_or(default_prompt_order);
+
+        let newline_format = if add_newline { "\n" } else { "" };
+        let prompt_format_list: Vec<String> = prompt_order
+            .into_iter()
+            .map(|module| format!("${}", module))
+            .collect();
+        let prompt_format = prompt_format_list.join("");
+        let format = format!("{}{}", &newline_format, &prompt_format);
+
+        table.remove("add_newline");
+        table.remove("prompt_order");
+        table.insert("format".to_owned(), Value::String(format));
+    }
+}
+
+#[allow(dead_code)]
+struct SegmentConfigValue {
+    value: Option<String>,
+    style: Option<String>,
+}
+
+impl From<&Value> for SegmentConfigValue {
+    fn from(value: &Value) -> Self {
+        let (value, style) = match value {
+            Value::String(config_str) => (Some(config_str.clone()), None),
+            Value::Table(ref config_table) => (
+                config_table
+                    .get("value")
+                    .and_then(|value| value.as_str())
+                    .map(|value| value.to_owned()),
+                config_table
+                    .get("style")
+                    .and_then(|style| style.as_str())
+                    .map(|value| value.to_owned()),
+            ),
+            _ => (None, None),
+        };
+        Self { value, style }
+    }
+}
+
+impl SegmentConfigValue {
+    /// Convert value of `SegmentConfig` to format string.
+    #[allow(dead_code)]
+    fn to_format(self, name: &str) -> String {
+        let Self { value, style } = self;
+        match style {
+            Some(style) => match value {
+                Some(value) => format!("[{}]({})", value, style),
+                None => format!("[${}]({})", name, style),
+            },
+            None => value.unwrap_or(String::new()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_segment_config_map() {
+        let config = toml::toml! {
+            symbol = { value = "R ", style = "red bold" }
+        };
+        let symbol = config.get("symbol").unwrap();
+        assert_eq!(
+            SegmentConfigValue::from(symbol).to_format("symbol"),
+            "[R ](red bold)"
+        );
+    }
+
+    #[test]
+    fn test_parse_segment_config_style_only() {
+        let config = toml::toml! {
+            version.style = "red bold"
+        };
+        let version = config.get("version").unwrap();
+        assert_eq!(
+            SegmentConfigValue::from(version).to_format("version"),
+            "[$version](red bold)"
+        );
+    }
+
+    #[test]
+    fn test_parse_segment_config_value_only() {
+        let config = toml::toml! {
+            symbol = "R "
+        };
+        let symbol = config.get("symbol").unwrap();
+        assert_eq!(SegmentConfigValue::from(symbol).to_format("symbol"), "R ");
+
+        let config = toml::toml! {
+            symbol.value = "R "
+        };
+        let symbol = config.get("symbol").unwrap();
+        assert_eq!(SegmentConfigValue::from(symbol).to_format("symbol"), "R ");
+    }
+}

--- a/scripts/starship_migrate_0_40.rs
+++ b/scripts/starship_migrate_0_40.rs
@@ -80,7 +80,7 @@ fn migrate_starship_root_config(root_config: &mut Value) {
         let prompt_order: Vec<&str> = table
             .get("prompt_order")
             .and_then(Vec::from_config)
-            .unwrap_or(vec!["all"]);
+            .unwrap_or_else(|| vec!["all"]);
 
         let newline_format = if add_newline { "\n" } else { "" };
         let prompt_format_list: Vec<String> = prompt_order

--- a/scripts/starship_migrate_0_40.rs
+++ b/scripts/starship_migrate_0_40.rs
@@ -167,14 +167,14 @@ impl From<&Value> for SegmentConfigValue {
 impl SegmentConfigValue {
     /// Convert value of `SegmentConfig` to format string.
     #[allow(dead_code)]
-    fn to_format(self, name: &str) -> String {
+    fn to_format(&self, name: &str) -> String {
         let Self { value, style } = self;
         match style {
             Some(style) => match value {
                 Some(value) => format!("[{}]({})", value, style),
                 None => format!("[${}]({})", name, style),
             },
-            None => value.unwrap_or(String::new()),
+            None => value.clone().unwrap_or_default(),
         }
     }
 }

--- a/scripts/starship_migrate_0_40.rs
+++ b/scripts/starship_migrate_0_40.rs
@@ -66,48 +66,6 @@ fn update_starship_config(config: &mut Value) {
 }
 
 fn migrate_starship_root_config(root_config: &mut Value) {
-    let default_prompt_order = vec![
-        "username",
-        "hostname",
-        "singularity",
-        "kubernetes",
-        "directory",
-        "git_branch",
-        "git_commit",
-        "git_state",
-        "git_status",
-        "hg_branch",
-        "docker_context",
-        "package",
-        // ↓ Toolchain version modules ↓
-        // (Let's keep these sorted alphabetically)
-        "dotnet",
-        "elixir",
-        "elm",
-        "golang",
-        "haskell",
-        "java",
-        "julia",
-        "nodejs",
-        "php",
-        "python",
-        "ruby",
-        "rust",
-        "terraform",
-        // ↑ Toolchain version modules ↑
-        "nix_shell",
-        "conda",
-        "memory_usage",
-        "aws",
-        "env_var",
-        "cmd_duration",
-        "line_break",
-        "jobs",
-        "battery",
-        "time",
-        "character",
-    ];
-
     if let Some(table) = root_config.as_table_mut() {
         // Don't do anything in case there is a `format` key
         if table.contains_key("format") {
@@ -122,7 +80,7 @@ fn migrate_starship_root_config(root_config: &mut Value) {
         let prompt_order: Vec<&str> = table
             .get("prompt_order")
             .and_then(Vec::from_config)
-            .unwrap_or(default_prompt_order);
+            .unwrap_or(vec!["all"]);
 
         let newline_format = if add_newline { "\n" } else { "" };
         let prompt_format_list: Vec<String> = prompt_order


### PR DESCRIPTION
#### Description
This adds a binary `starship_migrate_0_40` that updates the config file.

Changes proposed in #1056 are applied.



#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See https://github.com/starship/starship/issues/1057#issuecomment-611582686

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
