### PR TITLE
feat(Azure): Azure module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,6 +303,14 @@ version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1011,6 +1019,7 @@ dependencies = [
  "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "encoding_rs 0.8.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "gethostname 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "git2 0.13.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1322,6 +1331,7 @@ dependencies = [
 "checksum doc-comment 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 "checksum dtoa 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "4358a9e11b9a09cf52383b451b49a169e8d797b68aa02301ff586d70d9661ea3"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
+"checksum encoding_rs 0.8.22 (registry+https://github.com/rust-lang/crates.io-index)" = "cd8d03faa7fe0c1431609dfad7bbe827af30f82e1e2ae6f7ee4fca6bd764bc28"
 "checksum env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ open = "1.4.0"
 unicode-width = "0.1.7"
 textwrap = "0.11.0"
 term_size = "0.3.1"
+encoding_rs = "0.8.22"
 
 # Optional/http:
 attohttpc = { version = "0.12.0", optional = true, default-features = false, features = ["tls", "form"] }

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -119,6 +119,7 @@ prompt_order = [
     "conda",
     "memory_usage",
     "aws",
+    "azure",
     "env_var",
     "crystal",
     "cmd_duration",
@@ -163,6 +164,28 @@ displayed_items = "region"
 ap-southeast-2 = "au"
 us-east-1 = "va"
 ```
+
+## AZURE
+
+The `azure` module shows the current Azure Subscription. This is based on 
+`~/.azure/clouds.config` and `~/.azure/azureProfile.json` files.
+
+### Options
+
+| Variable          | Default         | Description                                                                 |
+| ----------------- | --------------- | --------------------------------------------------------------------------- |
+| `format`          | `"on ☁️ [$subscription](blue bold) "`         | The format for the Azure module to render in                  |
+| `disabled`        | `false`         | Disables the `Azure` module.                                                  |
+
+### Example
+
+```toml
+# ~/.config/starship.toml
+
+[azure]
+format= "on 🅰️ [$subscription](blue bold) "
+```
+
 
 ## Battery
 

--- a/src/configs/azure.rs
+++ b/src/configs/azure.rs
@@ -1,0 +1,18 @@
+use crate::config::{ModuleConfig, RootModuleConfig};
+
+use starship_module_config_derive::ModuleConfig;
+
+#[derive(Clone, ModuleConfig)]
+pub struct AzureConfig<'a> {
+    pub format: &'a str,
+    pub disabled: bool,
+}
+
+impl<'a> RootModuleConfig<'a> for AzureConfig<'a> {
+    fn new() -> Self {
+        AzureConfig {
+            format: "on ☁️ [$subscription](blue bold) ",
+            disabled: false,
+        }
+    }
+}

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -1,4 +1,5 @@
 pub mod aws;
+pub mod azure;
 pub mod battery;
 pub mod character;
 pub mod cmd_duration;

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -49,6 +49,7 @@ impl<'a> RootModuleConfig<'a> for StarshipRootConfig<'a> {
                 "conda",
                 "memory_usage",
                 "aws",
+                "azure",
                 "env_var",
                 "cmd_duration",
                 "custom",

--- a/src/module.rs
+++ b/src/module.rs
@@ -11,6 +11,7 @@ use std::fmt;
 // Default ordering is handled in configs/mod.rs
 pub const ALL_MODULES: &[&str] = &[
     "aws",
+    "azure",
     #[cfg(feature = "battery")]
     "battery",
     "character",

--- a/src/modules/azure.rs
+++ b/src/modules/azure.rs
@@ -1,0 +1,89 @@
+use dirs::home_dir;
+use encoding_rs::*;
+use std::env;
+use std::fs::File;
+use std::io::{BufRead, BufReader, Read};
+use std::path::PathBuf;
+use std::str::FromStr;
+
+use super::{Context, Module, RootModuleConfig};
+
+type JValue = serde_json::Value;
+
+use crate::configs::azure::AzureConfig;
+use crate::formatter::StringFormatter;
+
+pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let mut module = context.new_module("azure");
+    let config = AzureConfig::try_load(module.config);
+
+    let subscription_name = get_azure_subscription_name()?;
+
+    let formatter = if let Ok(formatter) = StringFormatter::new(config.format) {
+        formatter.map(|variable| match variable {
+            "subscription" => Some(subscription_name.to_string()),
+            _ => None,
+        })
+    } else {
+        log::warn!("Error parsing format string in `azure.format`");
+        return None;
+    };
+
+    module.set_segments(formatter.parse(None));
+
+    module.get_prefix().set_value("");
+    module.get_suffix().set_value("");
+
+    Some(module)
+}
+
+fn get_azure_config_file_location() -> Option<PathBuf> {
+    env::var("AZURE_CONFIG_DIR")
+        .ok()
+        .and_then(|path| PathBuf::from_str(&path).ok())
+        .or_else(|| {
+            let mut home = home_dir()?;
+            home.push(".azure");
+            Some(home)
+        })
+}
+
+fn get_azure_subscription_name() -> Option<String> {
+    let mut azure_profile_json = get_azure_config_file_location()?;
+    azure_profile_json.push("azureProfile.json");
+
+    let mut cloud_config = get_azure_config_file_location()?;
+    cloud_config.push("clouds.config");
+
+    let file = File::open(&cloud_config).ok()?;
+    let reader = BufReader::new(file);
+    let lines = reader.lines().filter_map(Result::ok);
+
+    let region_line = lines
+        .skip_while(|line| line != "[AzureCloud]")
+        .find(|line| line.starts_with("subscription"))
+        .unwrap();
+
+    let region = region_line.split('=').nth(1)?;
+    let region = region.trim();
+
+    let file = File::open(&azure_profile_json).ok()?;
+    let mut buffer: Vec<u8> = Vec::new();
+    let mut reader = BufReader::new(file);
+    reader.read_to_end(&mut buffer).ok()?;
+    let bytes = buffer.as_mut_slice();
+    let decodedbuffer = UTF_8.decode_with_bom_removal(bytes).0;
+
+    let parsed_json: JValue = serde_json::from_str(&decodedbuffer).ok()?;
+
+    let subscriptions = parsed_json["subscriptions"].as_array()?;
+
+    for sub in subscriptions {
+        let subscription_id = sub["id"].as_str()?;
+        if subscription_id == region {
+            let subscription_name = sub["name"].as_str()?;
+            return Some(subscription_name.to_string());
+        }
+    }
+    None
+}

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -1,5 +1,6 @@
 // While adding out new module add out module to src/module.rs ALL_MODULES const array also.
 mod aws;
+mod azure;
 mod character;
 mod cmd_duration;
 mod conda;
@@ -50,6 +51,7 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
         // Keep these ordered alphabetically.
         // Default ordering is handled in configs/mod.rs
         "aws" => aws::module(context),
+        "azure" => azure::module(context),
         #[cfg(feature = "battery")]
         "battery" => battery::module(context),
         "character" => character::module(context),
@@ -97,6 +99,7 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
 pub fn description(module: &str) -> &'static str {
     match module {
         "aws" => "The current AWS region and profile",
+        "azure" => "The current Azure subscription",
         "battery" => "The current charge of the device's battery and its current charging status",
         "character" => {
             "A character (usually an arrow) beside where the text is entered in your terminal"

--- a/tests/testsuite/azure.rs
+++ b/tests/testsuite/azure.rs
@@ -1,0 +1,200 @@
+use ansi_term::Color;
+use std::fs::File;
+use std::io::{self, Write};
+
+use tempfile;
+
+use crate::common::{self};
+use tempfile::TempDir;
+
+fn generate_test_config(dir: &TempDir, cloud_config_contents: &str, azure_profile_contents: &str) {
+    let clouds_config_path = dir.path().join("clouds.config");
+    let mut clouds_config_file = File::create(&clouds_config_path).unwrap();
+
+    clouds_config_file
+        .write_all(cloud_config_contents.as_bytes())
+        .unwrap();
+
+    let azure_profile_path = dir.path().join("azureProfile.json");
+    let mut azure_profile_file = File::create(&azure_profile_path).unwrap();
+
+    azure_profile_file
+        .write_all(azure_profile_contents.as_bytes())
+        .unwrap()
+}
+
+#[test]
+fn subscription_set_correctly() -> io::Result<()> {
+    let dir = tempfile::tempdir()?;
+
+    let cloud_config_contents = r#"[AzureCloud]
+subscription = f3935dc9-92b5-9a93-da7b-42c325d86939
+"#;
+
+    let azure_profile_contents = r#"{
+    "installationId": "3deacd2a-b9db-77e1-aa42-23e2f8dfffc3",
+    "subscriptions": [
+      {
+        "id": "f3935dc9-92b5-9a93-da7b-42c325d86939",
+        "name": "Subscription 1",
+        "state": "Enabled",
+        "user": {
+          "name": "user@domain.com",
+          "type": "user"
+        },
+        "isDefault": false,
+        "tenantId": "f0273a19-7779-e40a-00a1-53b8331b3bb6",
+        "environmentName": "AzureCloud",
+        "homeTenantId": "f0273a19-7779-e40a-00a1-53b8331b3bb6",
+        "managedByTenants": []
+      },
+      {
+        "id": "f568c543-d12e-de0b-3d85-69843598b565",
+        "name": "Subscription 2",
+        "state": "Enabled",
+        "user": {
+          "name": "user@domain.com",
+          "type": "user"
+        },
+        "isDefault": true,
+        "tenantId": "0e8a15ec-b0f5-d355-7062-8ece54c59aee",
+        "environmentName": "AzureCloud",
+        "homeTenantId": "0e8a15ec-b0f5-d355-7062-8ece54c59aee",
+        "managedByTenants": []
+      },
+      {
+        "id": "d4442d26-ea6d-46c4-07cb-4f70b8ae5465",
+        "name": "Subscription 3",
+        "state": "Enabled",
+        "user": {
+          "name": "user@domain.com",
+          "type": "user"
+        },
+        "isDefault": false,
+        "tenantId": "a4e1bb4b-5330-2d50-339d-b9674d3a87bc",
+        "environmentName": "AzureCloud",
+        "homeTenantId": "a4e1bb4b-5330-2d50-339d-b9674d3a87bc",
+        "managedByTenants": []
+      }
+    ]
+  }
+"#;
+
+    generate_test_config(&dir, cloud_config_contents, azure_profile_contents);
+    let dir_path = &dir.path().to_string_lossy();
+    let output = common::render_module("azure")
+        .env("AZURE_CONFIG_DIR", dir_path.as_ref())
+        .output()?;
+    let expected = format!("on ☁️ {} ", Color::Blue.bold().paint("Subscription 1"));
+    let actual = String::from_utf8(output.stdout).unwrap();
+    assert_eq!(actual, expected);
+    dir.close()
+}
+
+#[test]
+fn subscription_missmatch_between_cloud_config_and_azure_profile() -> io::Result<()> {
+    let dir = tempfile::tempdir()?;
+
+    let cloud_config_contents = r#"[AzureCloud]
+subscription = f3935dc9-92b5-9a93-da7b-42c325d86940
+"#;
+
+    let azure_profile_contents = r#"{
+    "installationId": "3deacd2a-b9db-77e1-aa42-23e2f8dfffc3",
+    "subscriptions": [
+      {
+        "id": "f3935dc9-92b5-9a93-da7b-42c325d86939",
+        "name": "Subscription 1",
+        "state": "Enabled",
+        "user": {
+          "name": "user@domain.com",
+          "type": "user"
+        },
+        "isDefault": false,
+        "tenantId": "f0273a19-7779-e40a-00a1-53b8331b3bb6",
+        "environmentName": "AzureCloud",
+        "homeTenantId": "f0273a19-7779-e40a-00a1-53b8331b3bb6",
+        "managedByTenants": []
+      },
+      {
+        "id": "f568c543-d12e-de0b-3d85-69843598b565",
+        "name": "Subscription 2",
+        "state": "Enabled",
+        "user": {
+          "name": "user@domain.com",
+          "type": "user"
+        },
+        "isDefault": true,
+        "tenantId": "0e8a15ec-b0f5-d355-7062-8ece54c59aee",
+        "environmentName": "AzureCloud",
+        "homeTenantId": "0e8a15ec-b0f5-d355-7062-8ece54c59aee",
+        "managedByTenants": []
+      },
+      {
+        "id": "d4442d26-ea6d-46c4-07cb-4f70b8ae5465",
+        "name": "Subscription 3",
+        "state": "Enabled",
+        "user": {
+          "name": "user@domain.com",
+          "type": "user"
+        },
+        "isDefault": false,
+        "tenantId": "a4e1bb4b-5330-2d50-339d-b9674d3a87bc",
+        "environmentName": "AzureCloud",
+        "homeTenantId": "a4e1bb4b-5330-2d50-339d-b9674d3a87bc",
+        "managedByTenants": []
+      }
+    ]
+  }
+"#;
+
+    generate_test_config(&dir, cloud_config_contents, azure_profile_contents);
+    let dir_path = &dir.path().to_string_lossy();
+    let output = common::render_module("azure")
+        .env("AZURE_CONFIG_DIR", dir_path.as_ref())
+        .output()?;
+    let expected = "";
+    let actual = String::from_utf8(output.stdout).unwrap();
+    assert_eq!(actual, expected);
+    dir.close()
+}
+
+#[test]
+fn subscription_azure_profile_empty() -> io::Result<()> {
+    let dir = tempfile::tempdir()?;
+
+    let cloud_config_contents = r#"[AzureCloud]
+subscription = f3935dc9-92b5-9a93-da7b-42c325d86940
+"#;
+
+    let azure_profile_contents = r#"{
+    "installationId": "3deacd2a-b9db-77e1-aa42-23e2f8dfffc3",
+    "subscriptions": []
+  }
+"#;
+
+    generate_test_config(&dir, cloud_config_contents, azure_profile_contents);
+    let dir_path = &dir.path().to_string_lossy();
+    let output = common::render_module("azure")
+        .env("AZURE_CONFIG_DIR", dir_path.as_ref())
+        .output()?;
+    let expected = "";
+    let actual = String::from_utf8(output.stdout).unwrap();
+    assert_eq!(actual, expected);
+    dir.close()
+}
+
+#[test]
+fn files_missing() -> io::Result<()> {
+    let dir = tempfile::tempdir()?;
+
+    let dir_path = &dir.path().to_string_lossy();
+
+    let output = common::render_module("azure")
+        .env("AZURE_CONFIG_DIR", dir_path.as_ref())
+        .output()?;
+    let expected = "";
+    let actual = String::from_utf8(output.stdout).unwrap();
+    assert_eq!(actual, expected);
+    dir.close()
+}

--- a/tests/testsuite/azure.rs
+++ b/tests/testsuite/azure.rs
@@ -2,8 +2,6 @@ use ansi_term::Color;
 use std::fs::File;
 use std::io::{self, Write};
 
-use tempfile;
-
 use crate::common::{self};
 use tempfile::TempDir;
 

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -1,4 +1,5 @@
 mod aws;
+mod azure;
 mod character;
 mod cmd_duration;
 mod common;


### PR DESCRIPTION
#### Description
This adds support for showing the Azure subscription you are currently executing as for commands with the Azure CLI.

#### Motivation and Context
Myself and a few people I know are managing multiple Azure Subscriptions and need to ensure we are currently selected into the correct one.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
I have tested against the current version of the Azure CLI with and without the environment variable specifying where to find the configuration. I am not set up currently to test MacOS or Linux sorry.
- [x] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.

I am have updated the English documentation but I don't know other languages to do those.

I just noticed the big move to format strings. Is there an easy bit of doco on their format? I will move this module over to using that.