### PR TITLE
fix: branch_name in fresh repo (unborn master)

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -3,7 +3,7 @@ use crate::module::Module;
 
 use crate::modules;
 use clap::ArgMatches;
-use git2::{Repository, RepositoryState};
+use git2::{ErrorCode::UnbornBranch, Repository, RepositoryState};
 use once_cell::sync::OnceCell;
 use std::collections::{HashMap, HashSet};
 use std::env;
@@ -312,7 +312,19 @@ impl<'a> ScanDir<'a> {
 }
 
 fn get_current_branch(repository: &Repository) -> Option<String> {
-    let head = repository.head().ok()?;
+    let head = match repository.head() {
+        Ok(reference) => reference,
+        Err(e) => {
+            return if e.code() == UnbornBranch {
+                // HEAD should only be an unborn branch if the repository is fresh,
+                // in that case assume "master"
+                Some(String::from("master"))
+            } else {
+                None
+            };
+        }
+    };
+
     let shorthand = head.shorthand();
 
     shorthand.map(std::string::ToString::to_string)

--- a/tests/testsuite/git_branch.rs
+++ b/tests/testsuite/git_branch.rs
@@ -83,6 +83,30 @@ fn test_japanese_truncation() -> io::Result<()> {
     test_truncate_length("がんばってね", 4, "がんばっ", "…")
 }
 
+#[test]
+fn test_works_with_unborn_master() -> io::Result<()> {
+    let repo_dir = tempfile::tempdir()?.into_path();
+
+    Command::new("git")
+        .args(&["init"])
+        .current_dir(&repo_dir)
+        .output()?;
+
+    let output = common::render_module("git_branch")
+        .arg("--path")
+        .arg(&repo_dir)
+        .output()
+        .unwrap();
+    let actual = String::from_utf8(output.stdout).unwrap();
+
+    let expected = format!(
+        "on {} ",
+        Color::Purple.bold().paint(format!("\u{e0a0} {}", "master")),
+    );
+    assert_eq!(expected, actual);
+    remove_dir_all(repo_dir)
+}
+
 fn test_truncate_length(
     branch_name: &str,
     truncate_length: i64,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Since #1035 didn't quite do what it was supposed to, I had another look and figured out the problem is actually that libgit2 doesn't return a `HEAD` if it's pointing to an unborn branch (like in the case of a freshly initialised repo). 

AFAIK (please correct me if I'm wrong) the only valid case where this error would occur is a fresh repo, so I think it's fine if the module assumes the branch name to be "master" in that case, since the git cli acts the same.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #686 

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
