### PR TITLE
fix(conda): Do not depend on user's config in conda tests

### DIFF
--- a/tests/testsuite/conda.rs
+++ b/tests/testsuite/conda.rs
@@ -2,12 +2,14 @@ use ansi_term::Color;
 use std::io;
 
 use crate::common;
+use crate::common::TestCommand;
 
 #[test]
 fn not_in_env() -> io::Result<()> {
     let output = common::render_module("conda")
         .env_clear()
         .env("PATH", env!("PATH"))
+        .use_config("".parse().unwrap())
         .output()?;
 
     let expected = "";
@@ -22,6 +24,7 @@ fn env_set() -> io::Result<()> {
     let output = common::render_module("conda")
         .env_clear()
         .env("CONDA_DEFAULT_ENV", "astronauts")
+        .use_config("".parse().unwrap())
         .output()?;
 
     let expected = format!("via {} ", Color::Green.bold().paint("C astronauts"));
@@ -33,7 +36,11 @@ fn env_set() -> io::Result<()> {
 
 #[test]
 fn truncate() -> io::Result<()> {
-    let output = common::render_module("conda").env_clear().env("CONDA_DEFAULT_ENV", "/some/really/long/and/really/annoying/path/that/shouldnt/be/displayed/fully/conda/my_env").output()?;
+    let output = common::render_module("conda")
+        .env_clear()
+        .use_config("".parse().unwrap())
+        .env("CONDA_DEFAULT_ENV", "/some/really/long/and/really/annoying/path/that/shouldnt/be/displayed/fully/conda/my_env")
+        .output()?;
 
     let expected = format!("via {} ", Color::Green.bold().paint("C my_env"));
     let actual = String::from_utf8(output.stdout).unwrap();


### PR DESCRIPTION



<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
The user's config is automatically loaded in context.new_module. This change explicitly sets the empty config to avoid depending on the environment.

#### Motivation and Context
Without this fix, the tests do not pass for users who have a custom symbol defined for conda. This prevents installing/upgrading from Arch Linux AUR.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tests (`cargo test`) no longer fail on my machine.
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
