### PR TITLE
feat(package): configurable displaying package version for packages marked as private

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1074,11 +1074,12 @@ package, and shows its current version. The module currently supports `npm`, `ca
 
 ### Options
 
-| Variable   | Default      | Description                                                |
-| ---------- | ------------ | ---------------------------------------------------------- |
-| `symbol`   | `"📦 "`      | The symbol used before displaying the version the package. |
-| `style`    | `"bold red"` | The style for the module.                                  |
-| `disabled` | `false`      | Disables the `package` module.                             |
+| Variable          | Default      | Description                                                |
+| ----------------- | ------------ | ---------------------------------------------------------- |
+| `symbol`          | `"📦 "`      | The symbol used before displaying the version the package. |
+| `style`           | `"bold red"` | The style for the module.                                  |
+| `display_private` | `false`      | Enable displaying version for packages marked as private.  |
+| `disabled`        | `false`      | Disables the `package` module.                             |
 
 ### Example
 

--- a/src/configs/package.rs
+++ b/src/configs/package.rs
@@ -7,6 +7,7 @@ use starship_module_config_derive::ModuleConfig;
 pub struct PackageConfig<'a> {
     pub symbol: SegmentConfig<'a>,
     pub style: Style,
+    pub display_private: bool,
     pub disabled: bool,
 }
 
@@ -15,6 +16,7 @@ impl<'a> RootModuleConfig<'a> for PackageConfig<'a> {
         PackageConfig {
             symbol: SegmentConfig::new("📦 "),
             style: Color::Fixed(208).bold(),
+            display_private: false,
             disabled: false,
         }
     }

--- a/src/modules/crystal.rs
+++ b/src/modules/crystal.rs
@@ -55,7 +55,7 @@ mod tests {
     #[test]
     fn folder_without_crystal_files() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
-        let actual = render_module("crystal", dir.path());
+        let actual = render_module("crystal", dir.path(), None);
         let expected = None;
         assert_eq!(expected, actual);
 
@@ -67,7 +67,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("shard.yml"))?.sync_all()?;
 
-        let actual = render_module("crystal", dir.path());
+        let actual = render_module("crystal", dir.path(), None);
         let expected = Some(format!("via {} ", Color::Red.bold().paint("🔮 v0.32.1")));
         assert_eq!(expected, actual);
 
@@ -79,7 +79,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("main.cr"))?.sync_all()?;
 
-        let actual = render_module("crystal", dir.path());
+        let actual = render_module("crystal", dir.path(), None);
         let expected = Some(format!("via {} ", Color::Red.bold().paint("🔮 v0.32.1")));
         assert_eq!(expected, actual);
 

--- a/src/modules/elixir.rs
+++ b/src/modules/elixir.rs
@@ -83,7 +83,7 @@ Elixir 1.10 (compiled with Erlang/OTP 22)
         let dir = tempfile::tempdir()?;
 
         let expected = None;
-        let output = render_module("elixir", dir.path());
+        let output = render_module("elixir", dir.path(), None);
 
         assert_eq!(output, expected);
 
@@ -99,7 +99,7 @@ Elixir 1.10 (compiled with Erlang/OTP 22)
             "via {} ",
             Color::Purple.bold().paint("💧 1.10 (OTP 22)")
         ));
-        let output = render_module("elixir", dir.path());
+        let output = render_module("elixir", dir.path(), None);
 
         assert_eq!(output, expected);
 

--- a/src/modules/elm.rs
+++ b/src/modules/elm.rs
@@ -46,7 +46,7 @@ mod tests {
     #[test]
     fn folder_without_elm() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
-        let actual = render_module("elm", dir.path());
+        let actual = render_module("elm", dir.path(), None);
         let expected = None;
         assert_eq!(expected, actual);
         dir.close()
@@ -56,7 +56,7 @@ mod tests {
     fn folder_with_elm_json() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("elm.json"))?.sync_all()?;
-        let actual = render_module("elm", dir.path());
+        let actual = render_module("elm", dir.path(), None);
         let expected = Some(format!("via {} ", Color::Cyan.bold().paint("🌳 v0.19.1")));
         assert_eq!(expected, actual);
         dir.close()
@@ -66,7 +66,7 @@ mod tests {
     fn folder_with_elm_package_json() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("elm-package.json"))?.sync_all()?;
-        let actual = render_module("elm", dir.path());
+        let actual = render_module("elm", dir.path(), None);
         let expected = Some(format!("via {} ", Color::Cyan.bold().paint("🌳 v0.19.1")));
         assert_eq!(expected, actual);
         dir.close()
@@ -76,7 +76,7 @@ mod tests {
     fn folder_with_elm_version() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join(".elm-version"))?.sync_all()?;
-        let actual = render_module("elm", dir.path());
+        let actual = render_module("elm", dir.path(), None);
         let expected = Some(format!("via {} ", Color::Cyan.bold().paint("🌳 v0.19.1")));
         assert_eq!(expected, actual);
         dir.close()
@@ -87,7 +87,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         let elmstuff = dir.path().join("elm-stuff");
         fs::create_dir_all(&elmstuff)?;
-        let actual = render_module("elm", dir.path());
+        let actual = render_module("elm", dir.path(), None);
         let expected = Some(format!("via {} ", Color::Cyan.bold().paint("🌳 v0.19.1")));
         assert_eq!(expected, actual);
         dir.close()
@@ -97,7 +97,7 @@ mod tests {
     fn folder_with_elm_file() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("main.elm"))?.sync_all()?;
-        let actual = render_module("elm", dir.path());
+        let actual = render_module("elm", dir.path(), None);
         let expected = Some(format!("via {} ", Color::Cyan.bold().paint("🌳 v0.19.1")));
         assert_eq!(expected, actual);
         dir.close()

--- a/src/modules/erlang.rs
+++ b/src/modules/erlang.rs
@@ -57,7 +57,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
 
         let expected = None;
-        let output = render_module("erlang", dir.path());
+        let output = render_module("erlang", dir.path(), None);
 
         assert_eq!(output, expected);
 
@@ -70,7 +70,7 @@ mod tests {
         File::create(dir.path().join("rebar.config"))?.sync_all()?;
 
         let expected = Some(format!("via {} ", Color::Red.bold().paint("🖧 22.1.3")));
-        let output = render_module("erlang", dir.path());
+        let output = render_module("erlang", dir.path(), None);
 
         assert_eq!(output, expected);
 

--- a/src/modules/golang.rs
+++ b/src/modules/golang.rs
@@ -75,7 +75,7 @@ mod tests {
     fn folder_without_go_files() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
 
-        let actual = render_module("golang", dir.path());
+        let actual = render_module("golang", dir.path(), None);
 
         let expected = None;
         assert_eq!(expected, actual);
@@ -87,7 +87,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("main.go"))?.sync_all()?;
 
-        let actual = render_module("golang", dir.path());
+        let actual = render_module("golang", dir.path(), None);
 
         let expected = Some(format!("via {} ", Color::Cyan.bold().paint("🐹 v1.12.1")));
         assert_eq!(expected, actual);
@@ -99,7 +99,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("go.mod"))?.sync_all()?;
 
-        let actual = render_module("golang", dir.path());
+        let actual = render_module("golang", dir.path(), None);
 
         let expected = Some(format!("via {} ", Color::Cyan.bold().paint("🐹 v1.12.1")));
         assert_eq!(expected, actual);
@@ -111,7 +111,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("go.sum"))?.sync_all()?;
 
-        let actual = render_module("golang", dir.path());
+        let actual = render_module("golang", dir.path(), None);
 
         let expected = Some(format!("via {} ", Color::Cyan.bold().paint("🐹 v1.12.1")));
         assert_eq!(expected, actual);
@@ -124,7 +124,7 @@ mod tests {
         let godeps = dir.path().join("Godeps");
         fs::create_dir_all(&godeps)?;
 
-        let actual = render_module("golang", dir.path());
+        let actual = render_module("golang", dir.path(), None);
 
         let expected = Some(format!("via {} ", Color::Cyan.bold().paint("🐹 v1.12.1")));
         assert_eq!(expected, actual);
@@ -136,7 +136,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("glide.yaml"))?.sync_all()?;
 
-        let actual = render_module("golang", dir.path());
+        let actual = render_module("golang", dir.path(), None);
 
         let expected = Some(format!("via {} ", Color::Cyan.bold().paint("🐹 v1.12.1")));
         assert_eq!(expected, actual);
@@ -148,7 +148,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("Gopkg.yml"))?.sync_all()?;
 
-        let actual = render_module("golang", dir.path());
+        let actual = render_module("golang", dir.path(), None);
 
         let expected = Some(format!("via {} ", Color::Cyan.bold().paint("🐹 v1.12.1")));
         assert_eq!(expected, actual);
@@ -159,7 +159,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("Gopkg.lock"))?.sync_all()?;
 
-        let actual = render_module("golang", dir.path());
+        let actual = render_module("golang", dir.path(), None);
         let expected = Some(format!("via {} ", Color::Cyan.bold().paint("🐹 v1.12.1")));
         assert_eq!(expected, actual);
         dir.close()
@@ -169,7 +169,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join(".go-version"))?.sync_all()?;
 
-        let actual = render_module("golang", dir.path());
+        let actual = render_module("golang", dir.path(), None);
         let expected = Some(format!("via {} ", Color::Cyan.bold().paint("🐹 v1.12.1")));
         assert_eq!(expected, actual);
         dir.close()

--- a/src/modules/haskell.rs
+++ b/src/modules/haskell.rs
@@ -47,7 +47,7 @@ mod tests {
     #[test]
     fn folder_without_stack_yaml() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
-        let actual = render_module("haskell", dir.path());
+        let actual = render_module("haskell", dir.path(), None);
         let expected = None;
         assert_eq!(expected, actual);
         dir.close()
@@ -57,7 +57,7 @@ mod tests {
     fn folder_with_hpack_file() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("package.yaml"))?.sync_all()?;
-        let actual = render_module("haskell", dir.path());
+        let actual = render_module("haskell", dir.path(), None);
         let expected = Some(format!("via {} ", Color::Red.bold().paint("λ v8.6.5")));
         assert_eq!(expected, actual);
         dir.close()
@@ -66,7 +66,7 @@ mod tests {
     fn folder_with_cabal_file() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("test.cabal"))?.sync_all()?;
-        let actual = render_module("haskell", dir.path());
+        let actual = render_module("haskell", dir.path(), None);
         let expected = Some(format!("via {} ", Color::Red.bold().paint("λ v8.6.5")));
         assert_eq!(expected, actual);
         dir.close()
@@ -76,7 +76,7 @@ mod tests {
     fn folder_with_stack_yaml() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("stack.yaml"))?.sync_all()?;
-        let actual = render_module("haskell", dir.path());
+        let actual = render_module("haskell", dir.path(), None);
         let expected = Some(format!("via {} ", Color::Red.bold().paint("λ v8.6.5")));
         assert_eq!(expected, actual);
         dir.close()

--- a/src/modules/julia.rs
+++ b/src/modules/julia.rs
@@ -60,7 +60,7 @@ mod tests {
     fn folder_without_julia_file() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
 
-        let actual = render_module("julia", dir.path());
+        let actual = render_module("julia", dir.path(), None);
 
         let expected = None;
         assert_eq!(expected, actual);
@@ -72,7 +72,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("hello.jl"))?.sync_all()?;
 
-        let actual = render_module("julia", dir.path());
+        let actual = render_module("julia", dir.path(), None);
 
         let expected = Some(format!("via {} ", Color::Purple.bold().paint("ஃ v1.4.0")));
         assert_eq!(expected, actual);
@@ -84,7 +84,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("Project.toml"))?.sync_all()?;
 
-        let actual = render_module("julia", dir.path());
+        let actual = render_module("julia", dir.path(), None);
 
         let expected = Some(format!("via {} ", Color::Purple.bold().paint("ஃ v1.4.0")));
         assert_eq!(expected, actual);
@@ -96,7 +96,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("Manifest.toml"))?.sync_all()?;
 
-        let actual = render_module("julia", dir.path());
+        let actual = render_module("julia", dir.path(), None);
 
         let expected = Some(format!("via {} ", Color::Purple.bold().paint("ஃ v1.4.0")));
         assert_eq!(expected, actual);

--- a/src/modules/nodejs.rs
+++ b/src/modules/nodejs.rs
@@ -45,7 +45,7 @@ mod tests {
     #[test]
     fn folder_without_node_files() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
-        let actual = render_module("nodejs", dir.path());
+        let actual = render_module("nodejs", dir.path(), None);
         let expected = None;
         assert_eq!(expected, actual);
         dir.close()
@@ -56,7 +56,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("package.json"))?.sync_all()?;
 
-        let actual = render_module("nodejs", dir.path());
+        let actual = render_module("nodejs", dir.path(), None);
         let expected = Some(format!("via {} ", Color::Green.bold().paint("⬢ v12.0.0")));
         assert_eq!(expected, actual);
         dir.close()
@@ -67,7 +67,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join(".node-version"))?.sync_all()?;
 
-        let actual = render_module("nodejs", dir.path());
+        let actual = render_module("nodejs", dir.path(), None);
         let expected = Some(format!("via {} ", Color::Green.bold().paint("⬢ v12.0.0")));
         assert_eq!(expected, actual);
         dir.close()
@@ -78,7 +78,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("index.js"))?.sync_all()?;
 
-        let actual = render_module("nodejs", dir.path());
+        let actual = render_module("nodejs", dir.path(), None);
         let expected = Some(format!("via {} ", Color::Green.bold().paint("⬢ v12.0.0")));
         assert_eq!(expected, actual);
         dir.close()
@@ -90,7 +90,7 @@ mod tests {
         let node_modules = dir.path().join("node_modules");
         fs::create_dir_all(&node_modules)?;
 
-        let actual = render_module("nodejs", dir.path());
+        let actual = render_module("nodejs", dir.path(), None);
         let expected = Some(format!("via {} ", Color::Green.bold().paint("⬢ v12.0.0")));
         assert_eq!(expected, actual);
         dir.close()

--- a/src/modules/package.rs
+++ b/src/modules/package.rs
@@ -134,6 +134,12 @@ fn format_version(version: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::modules::utils::test::render_module;
+    use ansi_term::Color;
+    use std::fs::File;
+    use std::io;
+    use std::io::Write;
+    use tempfile::TempDir;
 
     #[test]
     fn test_format_version() {
@@ -151,152 +157,151 @@ mod tests {
     }
 
     #[test]
-    fn test_extract_cargo_version() {
-        let cargo_with_version = toml::toml! {
+    fn test_extract_cargo_version() -> io::Result<()> {
+        let config_name = "Cargo.toml";
+        let config_content = toml::toml! {
             [package]
             name = "starship"
             version = "0.1.0"
         }
         .to_string();
 
-        let expected_version = Some("v0.1.0".to_string());
-        assert_eq!(extract_cargo_version(&cargo_with_version), expected_version);
-
-        let cargo_without_version = toml::toml! {
-            [package]
-            name = "starship"
-        }
-        .to_string();
-
-        let expected_version = None;
-        assert_eq!(
-            extract_cargo_version(&cargo_without_version),
-            expected_version
-        );
+        let project_dir = create_project_dir()?;
+        fill_config(&project_dir, config_name, Some(&config_content))?;
+        expect_output(&project_dir, Some("v0.1.0"), None)?;
+        project_dir.close()
     }
 
     #[test]
-    fn test_extract_package_version() {
-        let package_with_version = json::json!({
-            "name": "spacefish",
+    fn test_extract_package_version() -> io::Result<()> {
+        let config_name = "package.json";
+        let config_content = json::json!({
+            "name": "starship",
             "version": "0.1.0"
         })
         .to_string();
 
-        let expected_version = Some("v0.1.0".to_string());
-        assert_eq!(
-            extract_package_version(&package_with_version, false),
-            expected_version
-        );
+        let project_dir = create_project_dir()?;
+        fill_config(&project_dir, config_name, Some(&config_content))?;
+        expect_output(&project_dir, Some("v0.1.0"), None)?;
+        project_dir.close()
     }
 
     #[test]
-    fn test_extract_package_version_without_version() {
-        let package_without_version = json::json!({
-            "name": "spacefish"
+    fn test_extract_package_version_without_version() -> io::Result<()> {
+        let config_name = "package.json";
+        let config_content = json::json!({
+            "name": "starship"
         })
         .to_string();
 
-        let expected_version = None;
-        assert_eq!(
-            extract_package_version(&package_without_version, false),
-            expected_version
-        );
+        let project_dir = create_project_dir()?;
+        fill_config(&project_dir, config_name, Some(&config_content))?;
+        expect_output(&project_dir, None, None)?;
+        project_dir.close()
     }
 
     #[test]
-    fn test_extract_package_version_with_null_version() {
-        let package_with_null_version = json::json!({
-            "name": "spacefish",
+    fn test_extract_package_version_with_null_version() -> io::Result<()> {
+        let config_name = "package.json";
+        let config_content = json::json!({
+            "name": "starship",
             "version": null
         })
         .to_string();
 
-        let expected_version = None;
-        assert_eq!(
-            extract_package_version(&package_with_null_version, false),
-            expected_version
-        );
+        let project_dir = create_project_dir()?;
+        fill_config(&project_dir, config_name, Some(&config_content))?;
+        expect_output(&project_dir, None, None)?;
+        project_dir.close()
     }
 
     #[test]
-    fn test_extract_package_version_with_null_string_version() {
-        let package_with_null_string_version = json::json!({
-            "name": "spacefish",
+    fn test_extract_package_version_with_null_string_version() -> io::Result<()> {
+        let config_name = "package.json";
+        let config_content = json::json!({
+            "name": "starship",
             "version": "null"
         })
         .to_string();
 
-        let expected_version = None;
-        assert_eq!(
-            extract_package_version(&package_with_null_string_version, false),
-            expected_version
-        );
+        let project_dir = create_project_dir()?;
+        fill_config(&project_dir, config_name, Some(&config_content))?;
+        expect_output(&project_dir, None, None)?;
+        project_dir.close()
     }
 
     #[test]
-    fn test_extract_private_package_version_with_default_config() {
-        let private_package = json::json!({
-            "name": "spacefish",
+    fn test_extract_private_package_version_with_default_config() -> io::Result<()> {
+        let config_name = "package.json";
+        let config_content = json::json!({
+            "name": "starship",
             "version": "0.1.0",
             "private": true
         })
         .to_string();
 
-        let expected_version = None;
-        assert_eq!(
-            extract_package_version(&private_package, false),
-            expected_version
-        );
+        let project_dir = create_project_dir()?;
+        fill_config(&project_dir, config_name, Some(&config_content))?;
+        expect_output(&project_dir, None, None)?;
+        project_dir.close()
     }
 
     #[test]
-    fn test_extract_private_package_version_with_display_private() {
-        let private_package = json::json!({
-            "name": "spacefish",
+    fn test_extract_private_package_version_with_display_private() -> io::Result<()> {
+        let config_name = "package.json";
+        let config_content = json::json!({
+            "name": "starship",
             "version": "0.1.0",
             "private": true
         })
         .to_string();
+        let starship_config = toml::toml! {
+            [package]
+            display_private = true
+        };
 
-        let expected_version = Some("v0.1.0".to_string());
-        assert_eq!(
-            extract_package_version(&private_package, true),
-            expected_version
-        );
+        let project_dir = create_project_dir()?;
+        fill_config(&project_dir, config_name, Some(&config_content))?;
+        expect_output(&project_dir, Some("v0.1.0"), Some(starship_config))?;
+        project_dir.close()
     }
 
     #[test]
-    fn test_extract_poetry_version() {
-        let poetry_with_version = toml::toml! {
+    fn test_extract_poetry_version() -> io::Result<()> {
+        let config_name = "pyproject.toml";
+        let config_content = toml::toml! {
             [tool.poetry]
             name = "starship"
             version = "0.1.0"
         }
         .to_string();
 
-        let expected_version = Some("v0.1.0".to_string());
-        assert_eq!(
-            extract_poetry_version(&poetry_with_version),
-            expected_version
-        );
+        let project_dir = create_project_dir()?;
+        fill_config(&project_dir, config_name, Some(&config_content))?;
+        expect_output(&project_dir, Some("v0.1.0"), None)?;
+        project_dir.close()
+    }
 
-        let poetry_without_version = toml::toml! {
+    #[test]
+    fn test_extract_poetry_version_without_version() -> io::Result<()> {
+        let config_name = "pyproject.toml";
+        let config_content = toml::toml! {
             [tool.poetry]
             name = "starship"
         }
         .to_string();
 
-        let expected_version = None;
-        assert_eq!(
-            extract_poetry_version(&poetry_without_version),
-            expected_version
-        );
+        let project_dir = create_project_dir()?;
+        fill_config(&project_dir, config_name, Some(&config_content))?;
+        expect_output(&project_dir, None, None)?;
+        project_dir.close()
     }
 
     #[test]
-    fn test_extract_gradle_version() {
-        let gradle_single_quotes = "plugins {
+    fn test_extract_gradle_version_single_quote() -> io::Result<()> {
+        let config_name = "build.gradle";
+        let config_content = "plugins {
     id 'java'
     id 'test.plugin' version '0.2.0'
 }
@@ -306,13 +311,16 @@ java {
     targetCompatibility = JavaVersion.VERSION_1_8
 }";
 
-        let expected_version = Some("v0.1.0".to_string());
-        assert_eq!(
-            extract_gradle_version(&gradle_single_quotes),
-            expected_version
-        );
+        let project_dir = create_project_dir()?;
+        fill_config(&project_dir, config_name, Some(&config_content))?;
+        expect_output(&project_dir, Some("v0.1.0"), None)?;
+        project_dir.close()
+    }
 
-        let gradle_double_quotes = "plugins {
+    #[test]
+    fn test_extract_gradle_version_double_quote() -> io::Result<()> {
+        let config_name = "build.gradle";
+        let config_content = "plugins {
     id 'java'
     id 'test.plugin' version '0.2.0'
 }
@@ -322,13 +330,16 @@ java {
     targetCompatibility = JavaVersion.VERSION_1_8
 }";
 
-        let expected_version = Some("v0.1.0".to_string());
-        assert_eq!(
-            extract_gradle_version(&gradle_double_quotes),
-            expected_version
-        );
+        let project_dir = create_project_dir()?;
+        fill_config(&project_dir, config_name, Some(&config_content))?;
+        expect_output(&project_dir, Some("v0.1.0"), None)?;
+        project_dir.close()
+    }
 
-        let gradle_release_candidate = "plugins {
+    #[test]
+    fn test_extract_gradle_version_rc_version() -> io::Result<()> {
+        let config_name = "build.gradle";
+        let config_content = "plugins {
     id 'java'
     id 'test.plugin' version '0.2.0'
 }
@@ -338,13 +349,16 @@ java {
     targetCompatibility = JavaVersion.VERSION_1_8
 }";
 
-        let expected_version = Some("v0.1.0-rc1".to_string());
-        assert_eq!(
-            extract_gradle_version(&gradle_release_candidate),
-            expected_version
-        );
+        let project_dir = create_project_dir()?;
+        fill_config(&project_dir, config_name, Some(&config_content))?;
+        expect_output(&project_dir, Some("v0.1.0-rc1"), None)?;
+        project_dir.close()
+    }
 
-        let gradle_without_version = "plugins {
+    #[test]
+    fn test_extract_gradle_version_without_version() -> io::Result<()> {
+        let config_name = "build.gradle";
+        let config_content = "plugins {
     id 'java'
     id 'test.plugin' version '0.2.0'
 }
@@ -353,16 +367,16 @@ java {
     targetCompatibility = JavaVersion.VERSION_1_8
 }";
 
-        let expected_version = None;
-        assert_eq!(
-            extract_gradle_version(&gradle_without_version),
-            expected_version
-        );
+        let project_dir = create_project_dir()?;
+        fill_config(&project_dir, config_name, Some(&config_content))?;
+        expect_output(&project_dir, None, None)?;
+        project_dir.close()
     }
 
     #[test]
-    fn test_extract_mix_version() {
-        let mix_complete = "defmodule MyApp.MixProject do
+    fn test_extract_mix_version() -> io::Result<()> {
+        let config_name = "mix.exs";
+        let config_content = "defmodule MyApp.MixProject do
   use Mix.Project
 
   def project do
@@ -386,91 +400,150 @@ java {
   end
 end";
 
-        let expected_version = Some("v1.2.3".to_string());
-        assert_eq!(extract_mix_version(&mix_complete), expected_version);
+        let project_dir = create_project_dir()?;
+        fill_config(&project_dir, config_name, Some(&config_content))?;
+        expect_output(&project_dir, Some("v1.2.3"), None)?;
+        project_dir.close()
+    }
 
-        let mix_partial_oneline = "  def project, do: [app: :my_app,version: \"3.2.1\"]";
+    #[test]
+    fn test_extract_mix_version_partial_online() -> io::Result<()> {
+        let config_name = "mix.exs";
+        let config_content = "  def project, do: [app: :my_app,version: \"3.2.1\"]";
 
-        let expected_version = Some("v3.2.1".to_string());
-        assert_eq!(extract_mix_version(&mix_partial_oneline), expected_version);
+        let project_dir = create_project_dir()?;
+        fill_config(&project_dir, config_name, Some(&config_content))?;
+        expect_output(&project_dir, Some("v3.2.1"), None)?;
+        project_dir.close()
+    }
 
-        let mix_partial_prerelease = "  def project do
+    #[test]
+    fn test_extract_mix_version_rc_version() -> io::Result<()> {
+        let config_name = "mix.exs";
+        let config_content = "  def project do
     [
       app: :my_app,
       version: \"1.0.0-alpha.3\"
     ]
   end";
 
-        let expected_version = Some("v1.0.0-alpha.3".to_string());
-        assert_eq!(
-            extract_mix_version(&mix_partial_prerelease),
-            expected_version
-        );
+        let project_dir = create_project_dir()?;
+        fill_config(&project_dir, config_name, Some(&config_content))?;
+        expect_output(&project_dir, Some("v1.0.0-alpha.3"), None)?;
+        project_dir.close()
+    }
 
-        let mix_partial_prerelease_and_build_info = "  def project do
+    #[test]
+    fn test_extract_mix_version_rc_with_build_version() -> io::Result<()> {
+        let config_name = "mix.exs";
+        let config_content = "  def project do
     [
       app: :my_app,
       version: \"0.9.9-dev+20130417140000.amd64\"
     ]
   end";
 
-        let expected_version = Some("v0.9.9-dev+20130417140000.amd64".to_string());
-        assert_eq!(
-            extract_mix_version(&mix_partial_prerelease_and_build_info),
-            expected_version
-        );
+        let project_dir = create_project_dir()?;
+        fill_config(&project_dir, config_name, Some(&config_content))?;
+        expect_output(&project_dir, Some("v0.9.9-dev+20130417140000.amd64"), None)?;
+        project_dir.close()
     }
 
     #[test]
-    fn test_extract_composer_version() {
-        let composer_with_version = json::json!({
-            "name": "spacefish",
+    fn test_extract_composer_version() -> io::Result<()> {
+        let config_name = "composer.json";
+        let config_content = json::json!({
+            "name": "starship",
             "version": "0.1.0"
         })
         .to_string();
 
-        let expected_version = Some("v0.1.0".to_string());
-        assert_eq!(
-            extract_composer_version(&composer_with_version),
-            expected_version
-        );
-
-        let composer_without_version = json::json!({
-            "name": "spacefish"
-        })
-        .to_string();
-
-        let expected_version = None;
-        assert_eq!(
-            extract_composer_version(&composer_without_version),
-            expected_version
-        );
+        let project_dir = create_project_dir()?;
+        fill_config(&project_dir, config_name, Some(&config_content))?;
+        expect_output(&project_dir, Some("v0.1.0"), None)?;
+        project_dir.close()
     }
 
     #[test]
-    fn test_extract_project_version() {
-        let project_with_version = toml::toml! {
+    fn test_extract_composer_version_without_version() -> io::Result<()> {
+        let config_name = "composer.json";
+        let config_content = json::json!({
+            "name": "starship"
+        })
+        .to_string();
+
+        let project_dir = create_project_dir()?;
+        fill_config(&project_dir, config_name, Some(&config_content))?;
+        expect_output(&project_dir, None, None)?;
+        project_dir.close()
+    }
+
+    #[test]
+    fn test_extract_project_version() -> io::Result<()> {
+        let config_name = "Project.toml";
+        let config_content = toml::toml! {
             name = "starship"
             version = "0.1.0"
         }
         .to_string();
 
-        let expected_version = Some("v0.1.0".to_string());
-        assert_eq!(
-            extract_project_version(&project_with_version),
-            expected_version
-        );
+        let project_dir = create_project_dir()?;
+        fill_config(&project_dir, config_name, Some(&config_content))?;
+        expect_output(&project_dir, Some("v0.1.0"), None)?;
+        project_dir.close()
+    }
 
-        let project_without_version = toml::toml! {
-            [package]
+    #[test]
+    fn test_extract_project_version_without_version() -> io::Result<()> {
+        let config_name = "Project.toml";
+        let config_content = toml::toml! {
             name = "starship"
         }
         .to_string();
 
-        let expected_version = None;
-        assert_eq!(
-            extract_project_version(&project_without_version),
-            expected_version
-        );
+        let project_dir = create_project_dir()?;
+        fill_config(&project_dir, config_name, Some(&config_content))?;
+        expect_output(&project_dir, None, None)?;
+        project_dir.close()
+    }
+
+    fn create_project_dir() -> io::Result<TempDir> {
+        Ok(tempfile::tempdir()?)
+    }
+
+    fn fill_config(
+        project_dir: &TempDir,
+        file_name: &str,
+        contents: Option<&str>,
+    ) -> io::Result<()> {
+        let mut file = File::create(project_dir.path().join(file_name))?;
+        file.write_all(contents.unwrap_or("").as_bytes())?;
+        file.sync_all()
+    }
+
+    fn expect_output(
+        project_dir: &TempDir,
+        contains: Option<&str>,
+        config: Option<toml::Value>,
+    ) -> io::Result<()> {
+        let starship_config = Some(config.unwrap_or(toml::toml! {
+            [package]
+            disabled = false
+        }));
+
+        let actual = render_module("package", project_dir.path(), starship_config);
+        let text = String::from(contains.unwrap_or(""));
+        let expected = Some(format!(
+            "is {} ",
+            Color::Fixed(208).bold().paint(format!("📦 {}", text))
+        ));
+
+        if contains.is_some() {
+            assert_eq!(actual, expected);
+        } else {
+            assert_eq!(actual, None);
+        }
+
+        Ok(())
     }
 }

--- a/src/modules/php.rs
+++ b/src/modules/php.rs
@@ -69,7 +69,7 @@ mod tests {
     fn folder_without_php_files() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
 
-        let actual = render_module("php", dir.path());
+        let actual = render_module("php", dir.path(), None);
 
         let expected = None;
         assert_eq!(expected, actual);
@@ -81,7 +81,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("composer.json"))?.sync_all()?;
 
-        let actual = render_module("php", dir.path());
+        let actual = render_module("php", dir.path(), None);
 
         let expected = Some(format!(
             "via {} ",
@@ -96,7 +96,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join(".php-version"))?.sync_all()?;
 
-        let actual = render_module("php", dir.path());
+        let actual = render_module("php", dir.path(), None);
 
         let expected = Some(format!(
             "via {} ",
@@ -111,7 +111,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("any.php"))?.sync_all()?;
 
-        let actual = render_module("php", dir.path());
+        let actual = render_module("php", dir.path(), None);
 
         let expected = Some(format!(
             "via {} ",

--- a/src/modules/ruby.rs
+++ b/src/modules/ruby.rs
@@ -61,7 +61,7 @@ mod tests {
     fn folder_without_ruby_files() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
 
-        let actual = render_module("ruby", dir.path());
+        let actual = render_module("ruby", dir.path(), None);
 
         let expected = None;
         assert_eq!(expected, actual);
@@ -73,7 +73,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("Gemfile"))?.sync_all()?;
 
-        let actual = render_module("ruby", dir.path());
+        let actual = render_module("ruby", dir.path(), None);
 
         let expected = Some(format!("via {} ", Color::Red.bold().paint("💎 v2.5.1")));
         assert_eq!(expected, actual);
@@ -85,7 +85,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join(".ruby-version"))?.sync_all()?;
 
-        let actual = render_module("ruby", dir.path());
+        let actual = render_module("ruby", dir.path(), None);
 
         let expected = Some(format!("via {} ", Color::Red.bold().paint("💎 v2.5.1")));
         assert_eq!(expected, actual);
@@ -97,7 +97,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("any.rb"))?.sync_all()?;
 
-        let actual = render_module("ruby", dir.path());
+        let actual = render_module("ruby", dir.path(), None);
 
         let expected = Some(format!("via {} ", Color::Red.bold().paint("💎 v2.5.1")));
         assert_eq!(expected, actual);

--- a/src/modules/utils/test.rs
+++ b/src/modules/utils/test.rs
@@ -3,9 +3,13 @@ use crate::context::{Context, Shell};
 use std::path::Path;
 
 /// Render a specific starship module by name
-pub fn render_module(module_name: &str, path: &Path) -> Option<String> {
+pub fn render_module(
+    module_name: &str,
+    path: &Path,
+    config: Option<toml::Value>,
+) -> Option<String> {
     let mut context = Context::new_with_dir(clap::ArgMatches::default(), path);
-    context.config = StarshipConfig { config: None };
+    context.config = StarshipConfig { config };
     context.shell = Shell::Unknown;
 
     crate::print::get_module(module_name, context)


### PR DESCRIPTION
#### Description
This PR adds config `display_private` in package scope.
If true, it will display version for `package.json` marked as private

#### Motivation and Context
In my job, we mark as private company packages that are not published to npm registry,
without this i can't see current package version

Closes #1053

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
