### PR TITLE
fix(directory): avoid confusing modules with PowerShell paths

### DIFF
--- a/src/init/starship.ps1
+++ b/src/init/starship.ps1
@@ -7,12 +7,14 @@ function global:prompt {
     # @ makes sure the result is an array even if single or no values are returned
     $jobs = @(Get-Job | Where-Object { $_.State -eq 'Running' }).Count
 
+    $current_directory = (Convert-Path $PWD)
+
     if ($lastCmd = Get-History -Count 1) {
         $duration = [math]::Round(($lastCmd.EndExecutionTime - $lastCmd.StartExecutionTime).TotalMilliseconds)
         # & ensures the path is interpreted as something to execute
-        $out = @(&::STARSHIP:: prompt "--path=$PWD" --status=$lastexitcode --jobs=$jobs --cmd-duration=$duration)
+        $out = @(&::STARSHIP:: prompt "--path=$current_directory" --status=$lastexitcode --jobs=$jobs --cmd-duration=$duration)
     } else {
-        $out = @(&::STARSHIP:: prompt "--path=$PWD" --status=$lastexitcode --jobs=$jobs)
+        $out = @(&::STARSHIP:: prompt "--path=$current_directory" --status=$lastexitcode --jobs=$jobs)
     }
 
     # Convert stdout (array of lines) to expected return type string

--- a/src/init/starship.ps1
+++ b/src/init/starship.ps1
@@ -7,6 +7,7 @@ function global:prompt {
     # @ makes sure the result is an array even if single or no values are returned
     $jobs = @(Get-Job | Where-Object { $_.State -eq 'Running' }).Count
 
+    $env:PWD = $PWD
     $current_directory = (Convert-Path $PWD)
 
     if ($lastCmd = Get-History -Count 1) {

--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -1,5 +1,5 @@
 use path_slash::PathExt;
-use std::path::Path;
+use std::path::{Path,PathBuf};
 use unicode_segmentation::UnicodeSegmentation;
 
 use super::{Context, Module};
@@ -29,7 +29,15 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     // Using environment PWD is the standard approach for determining logical path
     // If this is None for any reason, we fall back to reading the os-provided path
     let physical_current_dir = if config.use_logical_path {
-        None
+        match std::env::var("PWD") {
+            Ok(x) => {
+                Some(PathBuf::from(x))
+            },
+            Err(e) => {
+                log::debug!("Error getting PWD environment variable: {}", e);
+                None
+            }
+        }
     } else {
         match std::env::current_dir() {
             Ok(x) => Some(x),

--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -101,41 +101,23 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 /// `top_level_replacement`.
 fn contract_path(full_path: &Path, top_level_path: &Path, top_level_replacement: &str) -> String {
     if !full_path.starts_with(top_level_path) {
-        return replace_c_dir(full_path.to_slash().unwrap());
+        return full_path.to_slash().unwrap();
     }
 
     if full_path == top_level_path {
-        return replace_c_dir(top_level_replacement.to_string());
+        return top_level_replacement.to_string();
     }
 
     format!(
         "{replacement}{separator}{path}",
         replacement = top_level_replacement,
         separator = "/",
-        path = replace_c_dir(
-            full_path
+        path = full_path
                 .strip_prefix(top_level_path)
                 .unwrap()
                 .to_slash()
                 .unwrap()
-        )
     )
-}
-
-/// Replaces "C://" with "/c/" within a Windows path
-///
-/// On non-Windows OS, does nothing
-#[cfg(target_os = "windows")]
-fn replace_c_dir(path: String) -> String {
-    path.replace("C:/", "/c")
-}
-
-/// Replaces "C://" with "/c/" within a Windows path
-///
-/// On non-Windows OS, does nothing
-#[cfg(not(target_os = "windows"))]
-const fn replace_c_dir(path: String) -> String {
-    path
 }
 
 /// Takes part before contracted path and replaces it with fish style path
@@ -222,7 +204,7 @@ mod tests {
         let top_level_path = Path::new("C:\\Users\\astronaut");
 
         let output = contract_path(full_path, top_level_path, "~");
-        assert_eq!(output, "/c/Some/Other/Path");
+        assert_eq!(output, "C://Some/Other/Path");
     }
 
     #[test]
@@ -232,7 +214,7 @@ mod tests {
         let top_level_path = Path::new("C:\\Users\\astronaut");
 
         let output = contract_path(full_path, top_level_path, "~");
-        assert_eq!(output, "/c");
+        assert_eq!(output, "C:/");
     }
 
     #[test]

--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -1,5 +1,5 @@
 use path_slash::PathExt;
-use std::path::{Path,PathBuf};
+use std::path::{Path, PathBuf};
 use unicode_segmentation::UnicodeSegmentation;
 
 use super::{Context, Module};
@@ -30,9 +30,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     // If this is None for any reason, we fall back to reading the os-provided path
     let physical_current_dir = if config.use_logical_path {
         match std::env::var("PWD") {
-            Ok(x) => {
-                Some(PathBuf::from(x))
-            },
+            Ok(x) => Some(PathBuf::from(x)),
             Err(e) => {
                 log::debug!("Error getting PWD environment variable: {}", e);
                 None
@@ -121,10 +119,10 @@ fn contract_path(full_path: &Path, top_level_path: &Path, top_level_replacement:
         replacement = top_level_replacement,
         separator = "/",
         path = full_path
-                .strip_prefix(top_level_path)
-                .unwrap()
-                .to_slash()
-                .unwrap()
+            .strip_prefix(top_level_path)
+            .unwrap()
+            .to_slash()
+            .unwrap()
     )
 }
 

--- a/tests/testsuite/directory.rs
+++ b/tests/testsuite/directory.rs
@@ -132,7 +132,7 @@ fn directory_in_root() -> io::Result<()> {
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
-    let expected = format!("in {} ", Color::Cyan.bold().paint("/c"));
+    let expected = format!("in {} ", Color::Cyan.bold().paint("C:/"));
     assert_eq!(expected, actual);
     Ok(())
 }


### PR DESCRIPTION
#### Description

Powershell supports PSDrives (https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.management/new-psdrive?view=powershell-7) that allows to create "logical" drives mapped to actual Windows drives.

#### Motivation and Context

When using PSDrives, you can use paths that are related to a logical drive.
For example, test: can be "mapped" to c:\test folder.
You can then use "cd test:" to change the current location.

Many other drives exist be default (env, function, variable etc...). 

These "Powershell" paths confuse starship modules that fail to return the correct result.

Changing the --path argument to a Windows path (instead of the Powershell one) fixes the issue.

In our example, with the fix, when "cd test:\" is used, starship is called with --path C:\test (instead of test:\).

Closes:

#### Types of changes
This change introduces a call to Convert-Path in startship.ps1 to convert the variable $PWD (a "PowerShell" path to a Windows path. This change avoids modules (like Rust, Git, ...) being confused by a PowerShell path.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):


#### How Has This Been Tested?

Created a PSDrive:
     New-PSDrive -Scope 1 -Name test -PSProvider FileSystem -root c:\test -Description "PSDrive test with starship"
     Checked basic modules (Rust&Git) are now working properly.

- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [X] I have tested using **Windows**
- [X] I have tested using **Windows Subsystem for Linux**

#### Checklist:
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
