### PR TITLE
docs: Remove unused closing tag

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1191,8 +1191,6 @@ symbol = "⚙️ "
 The `singularity` module shows the current singularity image, if inside a container
 and `$SINGULARITY_NAME` is set.
 
-:::
-
 ### Options
 
 | Variable   | Default              | Description                                      |


### PR DESCRIPTION
Minor fix in configuration README, it showed an unused `:::` tag, this PR removes it.