### PR TITLE
feat(format_string): Add helper to get environment variables

### DIFF
--- a/src/formatter/helper/env.rs
+++ b/src/formatter/helper/env.rs
@@ -1,0 +1,52 @@
+use std::env;
+
+/// Helper function that maps `env:ENV` to the corresponding environment variable `$ENV`
+pub fn env_helper(variable: &str) -> Option<String> {
+    if variable.starts_with("env:") {
+        let name: &str = &variable[4..];
+        get_env_value(name)
+    } else {
+        None
+    }
+}
+
+fn get_env_value(name: &str) -> Option<String> {
+    let os_value = env::var_os(name)?;
+    match os_value.into_string() {
+        Ok(value) => Some(value),
+        Err(_error) => {
+            log::error!(
+                "Environment variable `{}` is not a valid unicode string",
+                &name
+            );
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::formatter::string_formatter::StringFormatter;
+
+    // match_next(result: Iter<Segment>, value, style)
+    macro_rules! match_next {
+        ($iter:ident, $value:literal, $($style:tt)+) => {
+            let _next = $iter.next().unwrap();
+            assert_eq!(_next.value, $value);
+            assert_eq!(_next.style, $($style)+);
+        }
+    }
+
+    #[test]
+    fn test_format() {
+        env::set_var("_ENV_TEST", "SOME_VAR");
+
+        const FORMAT_STR: &str = "${env:_ENV_TEST}";
+
+        let formatter = StringFormatter::new(FORMAT_STR).unwrap().map(env_helper);
+        let result = formatter.parse(None);
+        let mut result_iter = result.iter();
+        match_next!(result_iter, "SOME_VAR", None);
+    }
+}

--- a/src/formatter/helper/mod.rs
+++ b/src/formatter/helper/mod.rs
@@ -1,0 +1,3 @@
+mod env;
+
+pub use env::env_helper;

--- a/src/formatter/mod.rs
+++ b/src/formatter/mod.rs
@@ -3,4 +3,4 @@ pub mod model;
 mod parser;
 pub mod string_formatter;
 
-pub use string_formatter::StringFormatter;
+pub use string_formatter::*;

--- a/src/formatter/mod.rs
+++ b/src/formatter/mod.rs
@@ -1,6 +1,6 @@
+pub mod helper;
 pub mod model;
 mod parser;
 pub mod string_formatter;
-pub mod helper;
 
 pub use string_formatter::StringFormatter;

--- a/src/formatter/mod.rs
+++ b/src/formatter/mod.rs
@@ -1,5 +1,6 @@
 pub mod model;
 mod parser;
 pub mod string_formatter;
+pub mod helper;
 
 pub use string_formatter::StringFormatter;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
This PR adds `formatter::helper::env_helper` that maps a variable `env:(.*)` to a environment variable `$\1`.

Usage:

```rust
let segments = StringFormatter::new(config.format)
    .map(env_helper)
    .map(|var| match var{
        "foo" => Some("bar"),
        _ => None,
    })
    .parse();
```

#### Motivation and Context

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
