### PR TITLE
feat(format_string): Allow positional segments

### DIFF
--- a/src/formatter/model.rs
+++ b/src/formatter/model.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 use std::collections::BTreeSet;
 
+/// Type that holds a number of variables of type `T`
 pub trait VariableHolder<T> {
     fn get_variables(&self) -> BTreeSet<T>;
 }

--- a/src/formatter/model.rs
+++ b/src/formatter/model.rs
@@ -1,4 +1,9 @@
 use std::borrow::Cow;
+use std::collections::BTreeSet;
+
+pub trait VariableHolder<T> {
+    fn get_variables(&self) -> BTreeSet<T>;
+}
 
 pub struct TextGroup<'a> {
     pub format: Vec<FormatElement<'a>>,
@@ -9,9 +14,34 @@ pub enum FormatElement<'a> {
     Text(Cow<'a, str>),
     Variable(Cow<'a, str>),
     TextGroup(TextGroup<'a>),
+    Positional(Vec<FormatElement<'a>>),
 }
 
 pub enum StyleElement<'a> {
     Text(Cow<'a, str>),
     Variable(Cow<'a, str>),
+}
+
+impl<'a> VariableHolder<Cow<'a, str>> for FormatElement<'a> {
+    fn get_variables(&self) -> BTreeSet<Cow<'a, str>> {
+        match self {
+            FormatElement::Variable(var) => {
+                let mut variables = BTreeSet::new();
+                variables.insert(var.clone());
+                variables
+            }
+            FormatElement::TextGroup(textgroup) => textgroup.format.get_variables(),
+            FormatElement::Positional(format) => format.get_variables(),
+            _ => Default::default(),
+        }
+    }
+}
+
+impl<'a> VariableHolder<Cow<'a, str>> for Vec<FormatElement<'a>> {
+    fn get_variables(&self) -> BTreeSet<Cow<'a, str>> {
+        self.iter().fold(BTreeSet::new(), |mut acc, el| {
+            acc.extend(el.get_variables());
+            acc
+        })
+    }
 }

--- a/src/formatter/parser.rs
+++ b/src/formatter/parser.rs
@@ -6,6 +6,18 @@ use super::model::*;
 #[grammar = "formatter/spec.pest"]
 struct IdentParser;
 
+fn _parse_value(value: Pair<Rule>) -> FormatElement {
+    match value.as_rule() {
+        Rule::text => FormatElement::Text(_parse_text(value).into()),
+        Rule::variable => FormatElement::Variable(_parse_variable(value).into()),
+        Rule::textgroup => FormatElement::TextGroup(_parse_textgroup(value)),
+        Rule::positional => {
+            FormatElement::Positional(_parse_format(value.into_inner().next().unwrap()))
+        }
+        _ => unreachable!(),
+    }
+}
+
 fn _parse_textgroup(textgroup: Pair<Rule>) -> TextGroup {
     let mut inner_rules = textgroup.into_inner();
     let format = inner_rules.next().unwrap();
@@ -29,15 +41,7 @@ fn _parse_text(text: Pair<Rule>) -> String {
 }
 
 fn _parse_format(format: Pair<Rule>) -> Vec<FormatElement> {
-    format
-        .into_inner()
-        .map(|pair| match pair.as_rule() {
-            Rule::text => FormatElement::Text(_parse_text(pair).into()),
-            Rule::variable => FormatElement::Variable(_parse_variable(pair).into()),
-            Rule::textgroup => FormatElement::TextGroup(_parse_textgroup(pair)),
-            _ => unreachable!(),
-        })
-        .collect()
+    format.into_inner().map(_parse_value).collect()
 }
 
 fn _parse_style(style: Pair<Rule>) -> Vec<StyleElement> {
@@ -55,12 +59,7 @@ pub fn parse(format: &str) -> Result<Vec<FormatElement>, Error<Rule>> {
     IdentParser::parse(Rule::expression, format).map(|pairs| {
         pairs
             .take_while(|pair| pair.as_rule() != Rule::EOI)
-            .map(|pair| match pair.as_rule() {
-                Rule::text => FormatElement::Text(_parse_text(pair).into()),
-                Rule::variable => FormatElement::Variable(_parse_variable(pair).into()),
-                Rule::textgroup => FormatElement::TextGroup(_parse_textgroup(pair)),
-                _ => unreachable!(),
-            })
+            .map(_parse_value)
             .collect()
     })
 }

--- a/src/formatter/spec.pest
+++ b/src/formatter/spec.pest
@@ -4,7 +4,7 @@
 //
 // Should be started with SOI and ended with EOI, with a format string in it.
 expression = _{ SOI ~ value* ~ EOI }
-value = _{ text | variable | textgroup }
+value = _{ text | variable | textgroup | positional }
 
 // Variable
 //
@@ -44,3 +44,8 @@ escaped_char = { "[" | "]" | "(" | ")" | "\\" | "$" }
 textgroup = { "[" ~ format ~ "]" ~ "(" ~ style ~ ")" }
 format = { value* }
 style = { (variable | string)* }
+
+// Positional
+//
+// A positional format string that won't render if all the containing variables are empty.
+positional = { "(" ~ format ~ ")" }

--- a/src/formatter/spec.pest
+++ b/src/formatter/spec.pest
@@ -36,7 +36,7 @@ escape = _{ "\\" ~ escaped_char }
 escaped_char = { "[" | "]" | "(" | ")" | "\\" | "$" }
 
 // TextGroup
-// 
+//
 // A textgroup is a pair of `format` and `style` (`[format](style)`)
 //
 // - `format`: A format string, can contain any number of variables, texts or textgroups.

--- a/src/formatter/string_formatter.rs
+++ b/src/formatter/string_formatter.rs
@@ -177,7 +177,7 @@ mod tests {
     use super::*;
     use ansi_term::Color;
 
-    // match_next(result: Iter<Segment>, value, style)
+    // match_next(result: IterMut<Segment>, value, style)
     macro_rules! match_next {
         ($iter:ident, $value:literal, $($style:tt)+) => {
             let _next = $iter.next().unwrap();
@@ -340,6 +340,17 @@ mod tests {
         match_next!(result_iter, " and ", None);
         match_next!(result_iter, " ", None);
         match_next!(result_iter, "$some", None);
+    }
+
+    #[test]
+    fn test_variable_holder() {
+        const FORMAT_STR: &str = "($a [($b) $c](none $s)) $d [t]($t)";
+        let expected_variables =
+            BTreeSet::from_iter(vec!["a", "b", "c", "d"].into_iter().map(String::from));
+
+        let formatter = StringFormatter::new(FORMAT_STR).unwrap().map(empty_mapper);
+        let variables = formatter.get_variables();
+        assert_eq!(variables, expected_variables);
     }
 
     #[test]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
This PR adds a `()` wrapper that hides the format string inside when all variables in that format string are empty (or `None`).

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See https://github.com/starship/starship/discussions/1116#discussioncomment-5414 Option 4

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
