### PR TITLE
fix: Add Crystal module to default prompt order (documentation was updated in f665df2)

### DIFF
--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -50,6 +50,7 @@ impl<'a> RootModuleConfig<'a> for StarshipRootConfig<'a> {
                 "memory_usage",
                 "aws",
                 "env_var",
+                "crystal",
                 "cmd_duration",
                 "custom",
                 "line_break",

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -103,6 +103,7 @@ pub fn description(module: &str) -> &'static str {
         }
         "cmd_duration" => "How long the last command took to execute",
         "conda" => "The current conda environment, if $CONDA_DEFAULT_ENV is set",
+        "crystal" => "The currently installed version of Crystal",
         "directory" => "The current working directory",
         "docker_context" => "The current docker context",
         "dotnet" => "The relevant version of the .NET Core SDK for the current directory",


### PR DESCRIPTION

#### Description
This commit adds crystal to prompt_order, in the same position as specified in the docs.
Additionally, a description was missing for crystal, so we add one.

#### Motivation and Context
The docs say that the crystal module is part of the default prompt_order.
However, this was not the case in the actual code. 

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly. (**docs were already in place since f665df2**)
- [ ] I have updated the tests accordingly. (**no tests for the default prompt_order**)
