### PR TITLE
fix(format_string): Allow multiple variable mappers

### DIFF
--- a/src/formatter/string_formatter.rs
+++ b/src/formatter/string_formatter.rs
@@ -322,6 +322,29 @@ mod tests {
     }
 
     #[test]
+    fn test_multiple_mapper() {
+        const FORMAT_STR: &str = "$a$b$c";
+
+        let formatter = StringFormatter::new(FORMAT_STR)
+            .unwrap()
+            .map(|var| match var {
+                "a" => Some("$a".to_owned()),
+                "b" => Some("$b".to_owned()),
+                _ => None,
+            })
+            .map(|var| match var {
+                "b" => Some("$B".to_owned()),
+                "c" => Some("$c".to_owned()),
+                _ => None,
+            });
+        let result = formatter.parse(None);
+        let mut result_iter = result.iter();
+        match_next!(result_iter, "$a", None);
+        match_next!(result_iter, "$B", None);
+        match_next!(result_iter, "$c", None);
+    }
+
+    #[test]
     fn test_parse_error() {
         // brackets without escape
         {

--- a/src/formatter/string_formatter.rs
+++ b/src/formatter/string_formatter.rs
@@ -374,13 +374,13 @@ mod tests {
         let formatter = StringFormatter::new(FORMAT_STR)
             .unwrap()
             .map(|var| match var {
-                "a" => Some("$a".to_owned()),
-                "b" => Some("$b".to_owned()),
+                "a" => Some("$a"),
+                "b" => Some("$b"),
                 _ => None,
             })
             .map(|var| match var {
-                "b" => Some("$B".to_owned()),
-                "c" => Some("$c".to_owned()),
+                "b" => Some("$B"),
+                "c" => Some("$c"),
                 _ => None,
             });
         let result = formatter.parse(None);

--- a/src/formatter/string_formatter.rs
+++ b/src/formatter/string_formatter.rs
@@ -64,7 +64,7 @@ impl<'a> StringFormatter<'a> {
     pub fn map<T: Into<String>>(mut self, mapper: impl Fn(&str) -> Option<T> + Sync) -> Self {
         self.variables.par_iter_mut().for_each(|(key, value)| {
             if let Some(v) = mapper(key) {
-                *value = Some(VariableValue::Plain(v));
+                *value = Some(VariableValue::Plain(v.into()));
             };
         });
         self
@@ -84,11 +84,13 @@ impl<'a> StringFormatter<'a> {
     }
 
     /// Maps variable name in a style string to its value
-    pub fn map_style(mut self, mapper: impl Fn(&str) -> Option<String> + Sync) -> Self {
+    pub fn map_style<T: Into<String>>(mut self, mapper: impl Fn(&str) -> Option<T> + Sync) -> Self {
         self.style_variables
             .par_iter_mut()
             .for_each(|(key, value)| {
-                *value = mapper(key);
+                if let Some(v) = mapper(key) {
+                    *value = Some(v.into());
+                }
             });
         self
     }

--- a/src/formatter/string_formatter.rs
+++ b/src/formatter/string_formatter.rs
@@ -42,7 +42,9 @@ impl<'a> StringFormatter<'a> {
     /// Maps variable name to its value
     pub fn map(mut self, mapper: impl Fn(&str) -> Option<String> + Sync) -> Self {
         self.variables.par_iter_mut().for_each(|(key, value)| {
-            *value = mapper(key).map(VariableValue::Plain);
+            mapper(key).map(|v| {
+                *value = Some(VariableValue::Plain(v));
+            });
         });
         self
     }
@@ -53,7 +55,9 @@ impl<'a> StringFormatter<'a> {
         mapper: impl Fn(&str) -> Option<Vec<Segment>> + Sync,
     ) -> Self {
         self.variables.par_iter_mut().for_each(|(key, value)| {
-            *value = mapper(key).map(VariableValue::Styled);
+            mapper(key).map(|v| {
+                *value = Some(VariableValue::Styled(v));
+            });
         });
         self
     }

--- a/src/formatter/string_formatter.rs
+++ b/src/formatter/string_formatter.rs
@@ -42,9 +42,9 @@ impl<'a> StringFormatter<'a> {
     /// Maps variable name to its value
     pub fn map(mut self, mapper: impl Fn(&str) -> Option<String> + Sync) -> Self {
         self.variables.par_iter_mut().for_each(|(key, value)| {
-            mapper(key).map(|v| {
+            if let Some(v) = mapper(key) {
                 *value = Some(VariableValue::Plain(v));
-            });
+            };
         });
         self
     }
@@ -55,9 +55,9 @@ impl<'a> StringFormatter<'a> {
         mapper: impl Fn(&str) -> Option<Vec<Segment>> + Sync,
     ) -> Self {
         self.variables.par_iter_mut().for_each(|(key, value)| {
-            mapper(key).map(|v| {
+            if let Some(v) = mapper(key) {
                 *value = Some(VariableValue::Styled(v));
-            });
+            };
         });
         self
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
This PR will make multiple mappers working in `StringFormatter`.

e.g. In the following string formatter

```rust
let formatter = StringFormatter::new(FORMAT_STR)
    .unwrap()
    .map(|var| match var {
        "a" => Some("$a"),
        "b" => Some("$b"),
        _ => None,
    })
    .map(|var| match var {
        "b" => Some("$B"),
        "c" => Some("$c"),
        _ => None,
    });
```

Variables before:

```json
{
  "b": "B",
  "c": "c"
}
```

Variables in this PR:

```json
{
  "a": "a",
  "b": "b",
  "c": "c"
}
```


A drawback is that, it becomes impossible to update an existing variable when the variable is already filled.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)


#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
