### PR TITLE
fix(haskell): avoid creating .lock files or downloading GHC

### DIFF
--- a/src/modules/haskell.rs
+++ b/src/modules/haskell.rs
@@ -22,7 +22,8 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
     let haskell_version = utils::exec_cmd(
         "stack",
-        &["ghc", "--", "--numeric-version", "--no-install-ghc"],
+        &["--no-install-ghc", "--lock-file", "read-only", "ghc", "--", "--numeric-version"],
+
     )?
     .stdout;
     let formatted_version = Some(format!("v{}", haskell_version.trim()))?;

--- a/src/modules/haskell.rs
+++ b/src/modules/haskell.rs
@@ -22,8 +22,14 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
     let haskell_version = utils::exec_cmd(
         "stack",
-        &["--no-install-ghc", "--lock-file", "read-only", "ghc", "--", "--numeric-version"],
-
+        &[
+            "--no-install-ghc",
+            "--lock-file",
+            "read-only",
+            "ghc",
+            "--",
+            "--numeric-version",
+        ],
     )?
     .stdout;
     let formatted_version = Some(format!("v{}", haskell_version.trim()))?;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -73,10 +73,12 @@ pub fn exec_cmd(cmd: &str, args: &[&str]) -> Option<CommandOutput> {
             stdout: String::from("ruby 2.5.1p57 (2018-03-29 revision 63029) [x86_64-linux-gnu]"),
             stderr: String::default(),
         }),
-        "stack ghc -- --numeric-version --no-install-ghc" => Some(CommandOutput {
-            stdout: String::from("8.6.5"),
-            stderr: String::default(),
-        }),
+        "stack --no-install-ghc --lock-file read-only ghc -- --numeric-version" => {
+            Some(CommandOutput {
+                stdout: String::from("8.6.5"),
+                stderr: String::default(),
+            })
+        }
         "elixir --version" => Some(CommandOutput {
             stdout: String::from(
                 "\


### PR DESCRIPTION
#### Description
This PR changes the arguments to `stack` in the Haskell module to avoid creating a `stack.yaml.lock` file which interferes with Git. It also reorders the arguments to avoid downloading GHC if the required version isn't already installed.

#### Motivation and Context
Starship was creating `stack.yaml.lock` files, even right after deleting them. This made it awkward for me to pull new changes to a Git repo containing a `stack.yaml` -- in fact I had to open a bash shell without Starship.
After I had updated the repo, Starship hung for quite a while before I killed it. I'm not 100% sure, but suspect that it was downloading and building a new version of GHC.

In terms of both the `stack.yaml.lock` and downloading GHC behaviour, I think Starship should generally be side-effect free.

Closes #1146.

#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [?] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### How Has This Been Tested?
1. Executed `stack` manually and messed with the command line args until it had the desired behaviour
1. Updated the Haskell module to use the same args.
1. Built with `cargo build`, then tested in a new shell by pasting the results of `./target/debug/starship prompt` and checking that lock files are not created.

- [ ] I have tested using **MacOS**
- [X] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [ ] I have updated the documentation accordingly.
- [X] I have updated the tests accordingly.

#### Problems

~~`cargo test modules::haskell::tests` passes all 4 relevant tests, but `cargo test` fails for those exact same tests. I have absolutely no clue as to why this would be the case, and spent some time debugging to see if `cargo test modules::haskell::tests` was somehow skipping the actual assertions (by making it so they must fail), but it's definitely running the tests in both cases.~~

~Any insight here would be appreciated!~

Ok, figured it out and the test suite passes normally now!