### PR TITLE
refactor: Add error handling to variables

### DIFF
--- a/src/formatter/model.rs
+++ b/src/formatter/model.rs
@@ -11,11 +11,13 @@ pub trait StyleVariableHolder<T> {
     fn get_style_variables(&self) -> BTreeSet<T>;
 }
 
+#[derive(Clone)]
 pub struct TextGroup<'a> {
     pub format: Vec<FormatElement<'a>>,
     pub style: Vec<StyleElement<'a>>,
 }
 
+#[derive(Clone)]
 pub enum FormatElement<'a> {
     Text(Cow<'a, str>),
     Variable(Cow<'a, str>),
@@ -23,6 +25,7 @@ pub enum FormatElement<'a> {
     Positional(Vec<FormatElement<'a>>),
 }
 
+#[derive(Clone)]
 pub enum StyleElement<'a> {
     Text(Cow<'a, str>),
     Variable(Cow<'a, str>),

--- a/src/formatter/string_formatter.rs
+++ b/src/formatter/string_formatter.rs
@@ -601,4 +601,21 @@ mod tests {
             assert!(StringFormatter::new(FORMAT_STR).is_err());
         }
     }
+
+    #[test]
+    fn test_variable_error() {
+        const FORMAT_STR: &str = "$never$some";
+        let never_error = StringFormatterError::Custom("NEVER".to_owned());
+
+        let segments = StringFormatter::new(FORMAT_STR).and_then(|formatter| {
+            formatter
+                .map(|var| match var {
+                    "some" => Some(Ok("some")),
+                    "never" => Some(Err(never_error.clone())),
+                    _ => None,
+                })
+                .parse(None)
+        });
+        assert!(segments.is_err());
+    }
 }

--- a/src/formatter/string_formatter.rs
+++ b/src/formatter/string_formatter.rs
@@ -122,20 +122,19 @@ impl<'a> StringFormatter<'a> {
                 (VariableMapType::new(), StyleVariableMapType::new()),
                 |(mut v, mut sv), (key, value)| {
                     *value = mapper(key, &variables).map(|format| {
-                        StringFormatter::new(format)
-                            .map(|formatter| {
-                                let StringFormatter {
-                                    format,
-                                    mut variables,
-                                    mut style_variables,
-                                } = formatter;
+                        StringFormatter::new(format).map(|formatter| {
+                            let StringFormatter {
+                                format,
+                                mut variables,
+                                mut style_variables,
+                            } = formatter;
 
-                                // Add variables in meta variables to self
-                                v.append(&mut variables);
-                                sv.append(&mut style_variables);
+                            // Add variables in meta variables to self
+                            v.append(&mut variables);
+                            sv.append(&mut style_variables);
 
-                                VariableValue::Meta(format)
-                            })
+                            VariableValue::Meta(format)
+                        })
                     });
 
                     (v, sv)

--- a/src/formatter/string_formatter.rs
+++ b/src/formatter/string_formatter.rs
@@ -62,7 +62,7 @@ pub struct StringFormatter<'a> {
 
 impl<'a> StringFormatter<'a> {
     /// Creates an instance of StringFormatter from a format string
-    pub fn new(format: &'a str) -> Result<Self, PestError<Rule>> {
+    pub fn new(format: &'a str) -> Result<Self, StringFormatterError> {
         parse(format)
             .map(|format| {
                 // Cache all variables
@@ -87,6 +87,7 @@ impl<'a> StringFormatter<'a> {
                 variables,
                 style_variables,
             })
+            .map_err(StringFormatterError::Parse)
     }
 
     /// Maps variable name to its value
@@ -135,7 +136,6 @@ impl<'a> StringFormatter<'a> {
 
                                 VariableValue::Meta(format)
                             })
-                            .map_err(StringFormatterError::Parse)
                     });
 
                     (v, sv)

--- a/src/formatter/string_formatter.rs
+++ b/src/formatter/string_formatter.rs
@@ -1,7 +1,10 @@
 use ansi_term::Style;
-use pest::error::Error;
+use pest::error::Error as PestError;
 use rayon::prelude::*;
+use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet};
+use std::error::Error;
+use std::fmt;
 use std::iter::FromIterator;
 
 use crate::config::parse_style_string;
@@ -11,29 +14,55 @@ use super::model::*;
 use super::parser::{parse, Rule};
 
 #[derive(Clone)]
-enum VariableValue {
-    Plain(String),
+enum VariableValue<'a> {
+    Plain(Cow<'a, str>),
     Styled(Vec<Segment>),
+    Meta(Vec<FormatElement<'a>>),
 }
 
-impl Default for VariableValue {
+impl<'a> Default for VariableValue<'a> {
     fn default() -> Self {
-        VariableValue::Plain(String::new())
+        VariableValue::Plain(Cow::Borrowed(""))
     }
 }
 
-type VariableMapType = BTreeMap<String, Option<VariableValue>>;
-type StyleVariableMapType = BTreeMap<String, Option<String>>;
+type VariableMapType<'a> =
+    BTreeMap<String, Option<Result<VariableValue<'a>, StringFormatterError>>>;
+type StyleVariableMapType<'a> =
+    BTreeMap<String, Option<Result<Cow<'a, str>, StringFormatterError>>>;
+
+#[derive(Debug, Clone)]
+pub enum StringFormatterError {
+    Custom(String),
+    Parse(PestError<Rule>),
+}
+
+impl fmt::Display for StringFormatterError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Custom(error) => write!(f, "{}", error),
+            Self::Parse(error) => write!(f, "{}", error),
+        }
+    }
+}
+
+impl Error for StringFormatterError {}
+
+impl From<String> for StringFormatterError {
+    fn from(error: String) -> Self {
+        StringFormatterError::Custom(error)
+    }
+}
 
 pub struct StringFormatter<'a> {
     format: Vec<FormatElement<'a>>,
-    variables: VariableMapType,
-    style_variables: StyleVariableMapType,
+    variables: VariableMapType<'a>,
+    style_variables: StyleVariableMapType<'a>,
 }
 
 impl<'a> StringFormatter<'a> {
     /// Creates an instance of StringFormatter from a format string
-    pub fn new(format: &'a str) -> Result<Self, Error<Rule>> {
+    pub fn new(format: &'a str) -> Result<Self, PestError<Rule>> {
         parse(format)
             .map(|format| {
                 // Cache all variables
@@ -61,96 +90,159 @@ impl<'a> StringFormatter<'a> {
     }
 
     /// Maps variable name to its value
-    pub fn map<T: Into<String>>(mut self, mapper: impl Fn(&str) -> Option<T> + Sync) -> Self {
+    pub fn map<T, M>(mut self, mapper: M) -> Self
+    where
+        T: Into<Cow<'a, str>>,
+        M: Fn(&str) -> Option<Result<T, StringFormatterError>> + Sync,
+    {
         self.variables
             .par_iter_mut()
             .filter(|(_, value)| value.is_none())
             .for_each(|(key, value)| {
-                *value = mapper(key).map(|var| var.into()).map(VariableValue::Plain);
+                *value = mapper(key).map(|var| var.map(|var| VariableValue::Plain(var.into())));
             });
         self
     }
 
+    /// Maps a meta-variable to a format string containing other variables.
+    ///
+    /// This function should be called **before** other map methods so that variables can be cached
+    /// properly.
+    pub fn map_meta<M>(mut self, mapper: M) -> Self
+    where
+        M: Fn(&str, &BTreeSet<String>) -> Option<&'a str> + Sync,
+    {
+        let variables = self.get_variables();
+        let (variables, style_variables) = self
+            .variables
+            .iter_mut()
+            .filter(|(_, value)| value.is_none())
+            .fold(
+                (VariableMapType::new(), StyleVariableMapType::new()),
+                |(mut v, mut sv), (key, value)| {
+                    *value = mapper(key, &variables).map(|format| {
+                        StringFormatter::new(format)
+                            .map(|formatter| {
+                                let StringFormatter {
+                                    format,
+                                    mut variables,
+                                    mut style_variables,
+                                } = formatter;
+
+                                // Add variables in meta variables to self
+                                v.append(&mut variables);
+                                sv.append(&mut style_variables);
+
+                                VariableValue::Meta(format)
+                            })
+                            .map_err(StringFormatterError::Parse)
+                    });
+
+                    (v, sv)
+                },
+            );
+
+        self.variables.extend(variables);
+        self.style_variables.extend(style_variables);
+
+        self
+    }
+
     /// Maps variable name to an array of segments
-    pub fn map_variables_to_segments(
-        mut self,
-        mapper: impl Fn(&str) -> Option<Vec<Segment>> + Sync,
-    ) -> Self {
+    pub fn map_variables_to_segments<M>(mut self, mapper: M) -> Self
+    where
+        M: Fn(&str) -> Option<Result<Vec<Segment>, StringFormatterError>> + Sync,
+    {
         self.variables
             .par_iter_mut()
             .filter(|(_, value)| value.is_none())
             .for_each(|(key, value)| {
-                *value = mapper(key).map(VariableValue::Styled);
+                *value = mapper(key).map(|var| var.map(VariableValue::Styled));
             });
         self
     }
 
     /// Maps variable name in a style string to its value
-    pub fn map_style<T: Into<String>>(mut self, mapper: impl Fn(&str) -> Option<T> + Sync) -> Self {
+    pub fn map_style<T, M>(mut self, mapper: M) -> Self
+    where
+        T: Into<Cow<'a, str>>,
+        M: Fn(&str) -> Option<Result<T, StringFormatterError>> + Sync,
+    {
         self.style_variables
             .par_iter_mut()
             .filter(|(_, value)| value.is_none())
             .for_each(|(key, value)| {
-                *value = mapper(key).map(|var| var.into());
+                *value = mapper(key).map(|var| var.map(|var| var.into()));
             });
         self
     }
 
     /// Parse the format string and consume self.
-    pub fn parse(self, default_style: Option<Style>) -> Vec<Segment> {
+    pub fn parse(self, default_style: Option<Style>) -> Result<Vec<Segment>, StringFormatterError> {
         fn _parse_textgroup<'a>(
             textgroup: TextGroup<'a>,
-            variables: &'a VariableMapType,
-            style_variables: &'a StyleVariableMapType,
-        ) -> Vec<Segment> {
+            variables: &'a VariableMapType<'a>,
+            style_variables: &'a StyleVariableMapType<'a>,
+        ) -> Result<Vec<Segment>, StringFormatterError> {
             let style = _parse_style(textgroup.style, style_variables);
-            _parse_format(textgroup.format, style, &variables, &style_variables)
+            _parse_format(
+                textgroup.format,
+                style.transpose()?,
+                &variables,
+                &style_variables,
+            )
         }
 
         fn _parse_style<'a>(
             style: Vec<StyleElement>,
-            variables: &'a StyleVariableMapType,
-        ) -> Option<Style> {
-            let style_string = style
-                .iter()
-                .flat_map(|style| match style {
-                    StyleElement::Text(text) => text.as_ref().chars(),
+            variables: &'a StyleVariableMapType<'a>,
+        ) -> Option<Result<Style, StringFormatterError>> {
+            let style_strings = style
+                .into_iter()
+                .map(|style| match style {
+                    StyleElement::Text(text) => Ok(text),
                     StyleElement::Variable(name) => {
                         let variable = variables.get(name.as_ref()).unwrap_or(&None);
                         match variable {
-                            Some(style_string) => style_string.chars(),
-                            None => "".chars(),
+                            Some(style_string) => style_string.clone().map(|string| string),
+                            None => Ok("".into()),
                         }
                     }
                 })
-                .collect::<String>();
-            parse_style_string(&style_string)
+                .collect::<Result<Vec<Cow<str>>, StringFormatterError>>();
+            style_strings
+                .map(|style_strings| {
+                    let style_string: String =
+                        style_strings.iter().flat_map(|s| s.chars()).collect();
+                    parse_style_string(&style_string)
+                })
+                .transpose()
         }
 
         fn _parse_format<'a>(
             format: Vec<FormatElement<'a>>,
             style: Option<Style>,
-            variables: &'a VariableMapType,
-            style_variables: &'a StyleVariableMapType,
-        ) -> Vec<Segment> {
-            format
+            variables: &'a VariableMapType<'a>,
+            style_variables: &'a StyleVariableMapType<'a>,
+        ) -> Result<Vec<Segment>, StringFormatterError> {
+            let results: Result<Vec<Vec<Segment>>, StringFormatterError> = format
                 .into_iter()
-                .flat_map(|el| match el {
-                    FormatElement::Text(text) => {
-                        vec![_new_segment("_text".into(), text.into_owned(), style)]
-                    }
-                    FormatElement::TextGroup(textgroup) => {
-                        let textgroup = TextGroup {
-                            format: textgroup.format,
-                            style: textgroup.style,
-                        };
-                        _parse_textgroup(textgroup, &variables, &style_variables)
-                    }
-                    FormatElement::Variable(name) => variables
-                        .get(name.as_ref())
-                        .and_then(|segments| {
-                            Some(match segments.clone()? {
-                                VariableValue::Styled(segments) => segments
+                .map(|el| {
+                    match el {
+                        FormatElement::Text(text) => Ok(vec![_new_segment("_text", text, style)]),
+                        FormatElement::TextGroup(textgroup) => {
+                            let textgroup = TextGroup {
+                                format: textgroup.format,
+                                style: textgroup.style,
+                            };
+                            _parse_textgroup(textgroup, &variables, &style_variables)
+                        }
+                        FormatElement::Variable(name) => variables
+                            .get(name.as_ref())
+                            .expect("Uncached variable found")
+                            .as_ref()
+                            .map(|segments| match segments.clone()? {
+                                VariableValue::Styled(segments) => Ok(segments
                                     .into_iter()
                                     .map(|mut segment| {
                                         // Derive upper style if the style of segments are none.
@@ -161,31 +253,40 @@ impl<'a> StringFormatter<'a> {
                                         }
                                         segment
                                     })
-                                    .collect(),
+                                    .collect()),
                                 VariableValue::Plain(text) => {
-                                    vec![_new_segment(name.to_string(), text, style)]
+                                    Ok(vec![_new_segment(name, text, style)])
+                                }
+                                VariableValue::Meta(format) => {
+                                    let formatter = StringFormatter {
+                                        format,
+                                        variables: _clone_without_meta(variables),
+                                        style_variables: style_variables.clone(),
+                                    };
+                                    formatter.parse(style)
                                 }
                             })
-                        })
-                        .unwrap_or_default(),
-                    FormatElement::Positional(format) => {
-                        // Show the positional format string if all the variables inside are not
-                        // none.
-                        let should_show: bool = format.get_variables().iter().any(|var| {
-                            variables
-                                .get(var.as_ref())
-                                .map(|segments| segments.is_some())
-                                .unwrap_or(false)
-                        });
+                            .unwrap_or_else(|| Ok(Vec::new())),
+                        FormatElement::Positional(format) => {
+                            // Show the positional format string if all the variables inside are not
+                            // none.
+                            let should_show: bool = format.get_variables().iter().any(|var| {
+                                variables
+                                    .get(var.as_ref())
+                                    .map(|segments| segments.is_some())
+                                    .unwrap_or(false)
+                            });
 
-                        if should_show {
-                            _parse_format(format, style, variables, style_variables)
-                        } else {
-                            Vec::new()
+                            if should_show {
+                                _parse_format(format, style, variables, style_variables)
+                            } else {
+                                Ok(Vec::new())
+                            }
                         }
                     }
                 })
-                .collect()
+                .collect();
+            Ok(results?.into_iter().flatten().collect())
         }
 
         _parse_format(
@@ -210,12 +311,30 @@ impl<'a> StyleVariableHolder<String> for StringFormatter<'a> {
 }
 
 /// Helper function to create a new segment
-fn _new_segment(name: String, value: String, style: Option<Style>) -> Segment {
+fn _new_segment(
+    name: impl Into<String>,
+    value: impl Into<String>,
+    style: Option<Style>,
+) -> Segment {
     Segment {
-        _name: name,
-        value,
+        _name: name.into(),
+        value: value.into(),
         style,
     }
+}
+
+fn _clone_without_meta<'a>(variables: &VariableMapType<'a>) -> VariableMapType<'a> {
+    VariableMapType::from_iter(variables.iter().map(|(key, value)| {
+        let value = match value {
+            Some(Ok(value)) => match value {
+                VariableValue::Meta(_) => None,
+                other => Some(Ok(other.clone())),
+            },
+            Some(Err(e)) => Some(Err(e.clone())),
+            None => None,
+        };
+        (key.clone(), value)
+    }))
 }
 
 #[cfg(test)]
@@ -232,7 +351,7 @@ mod tests {
         }
     }
 
-    fn empty_mapper(_: &str) -> Option<String> {
+    fn empty_mapper(_: &str) -> Option<Result<String, StringFormatterError>> {
         None
     }
 
@@ -242,7 +361,7 @@ mod tests {
         let style = Some(Color::Red.bold());
 
         let formatter = StringFormatter::new(FORMAT_STR).unwrap().map(empty_mapper);
-        let result = formatter.parse(style);
+        let result = formatter.parse(style).unwrap();
         let mut result_iter = result.iter();
         match_next!(result_iter, "text", style);
     }
@@ -251,7 +370,7 @@ mod tests {
     fn test_textgroup_text_only() {
         const FORMAT_STR: &str = "[text](red bold)";
         let formatter = StringFormatter::new(FORMAT_STR).unwrap().map(empty_mapper);
-        let result = formatter.parse(None);
+        let result = formatter.parse(None).unwrap();
         let mut result_iter = result.iter();
         match_next!(result_iter, "text", Some(Color::Red.bold()));
     }
@@ -263,10 +382,10 @@ mod tests {
         let formatter = StringFormatter::new(FORMAT_STR)
             .unwrap()
             .map(|variable| match variable {
-                "var1" => Some("text1".to_owned()),
+                "var1" => Some(Ok("text1".to_owned())),
                 _ => None,
             });
-        let result = formatter.parse(None);
+        let result = formatter.parse(None).unwrap();
         let mut result_iter = result.iter();
         match_next!(result_iter, "text1", None);
     }
@@ -279,10 +398,10 @@ mod tests {
         let formatter = StringFormatter::new(FORMAT_STR)
             .unwrap()
             .map_style(|variable| match variable {
-                "style" => Some("red bold".to_owned()),
+                "style" => Some(Ok("red bold".to_owned())),
                 _ => None,
             });
-        let result = formatter.parse(None);
+        let result = formatter.parse(None).unwrap();
         let mut result_iter = result.iter();
         match_next!(result_iter, "root", root_style);
     }
@@ -293,8 +412,8 @@ mod tests {
 
         let formatter = StringFormatter::new(FORMAT_STR)
             .unwrap()
-            .map(|variable| Some(format!("${{{}}}", variable)));
-        let result = formatter.parse(None);
+            .map(|variable| Some(Ok(format!("${{{}}}", variable))));
+        let result = formatter.parse(None).unwrap();
         let mut result_iter = result.iter();
         match_next!(result_iter, "${env:PWD}", None);
     }
@@ -304,7 +423,7 @@ mod tests {
         const FORMAT_STR: &str = r#"\\\[\$text\]\(red bold\)"#;
 
         let formatter = StringFormatter::new(FORMAT_STR).unwrap().map(empty_mapper);
-        let result = formatter.parse(None);
+        let result = formatter.parse(None).unwrap();
         let mut result_iter = result.iter();
         match_next!(result_iter, r#"\[$text](red bold)"#, None);
     }
@@ -317,7 +436,7 @@ mod tests {
         let inner_style = Some(Color::Blue.normal());
 
         let formatter = StringFormatter::new(FORMAT_STR).unwrap().map(empty_mapper);
-        let result = formatter.parse(outer_style);
+        let result = formatter.parse(outer_style).unwrap();
         let mut result_iter = result.iter();
         match_next!(result_iter, "outer ", outer_style);
         match_next!(result_iter, "middle ", middle_style);
@@ -332,10 +451,10 @@ mod tests {
         let formatter = StringFormatter::new(FORMAT_STR)
             .unwrap()
             .map(|variable| match variable {
-                "var" => Some("text".to_owned()),
+                "var" => Some(Ok("text".to_owned())),
                 _ => None,
             });
-        let result = formatter.parse(None);
+        let result = formatter.parse(None).unwrap();
         let mut result_iter = result.iter();
         match_next!(result_iter, "text", var_style);
     }
@@ -350,7 +469,7 @@ mod tests {
         let formatter = StringFormatter::new(FORMAT_STR)
             .unwrap()
             .map_variables_to_segments(|variable| match variable {
-                "var" => Some(vec![
+                "var" => Some(Ok(vec![
                     _new_segment("_1".to_owned(), "styless".to_owned(), None),
                     _new_segment("_2".to_owned(), "styled".to_owned(), styled_style),
                     _new_segment(
@@ -358,14 +477,36 @@ mod tests {
                         "styled_no_modifier".to_owned(),
                         styled_no_modifier_style,
                     ),
-                ]),
+                ])),
                 _ => None,
             });
-        let result = formatter.parse(None);
+        let result = formatter.parse(None).unwrap();
         let mut result_iter = result.iter();
         match_next!(result_iter, "styless", var_style);
         match_next!(result_iter, "styled", styled_style);
         match_next!(result_iter, "styled_no_modifier", styled_no_modifier_style);
+    }
+
+    #[test]
+    fn test_meta_variable() {
+        const FORMAT_STR: &str = "$all";
+        const FORMAT_STR__ALL: &str = "$a$b";
+
+        let formatter = StringFormatter::new(FORMAT_STR)
+            .unwrap()
+            .map_meta(|var, _| match var {
+                "all" => Some(FORMAT_STR__ALL),
+                _ => None,
+            })
+            .map(|var| match var {
+                "a" => Some(Ok("$a")),
+                "b" => Some(Ok("$b")),
+                _ => None,
+            });
+        let result = formatter.parse(None).unwrap();
+        let mut result_iter = result.iter();
+        match_next!(result_iter, "$a", None);
+        match_next!(result_iter, "$b", None);
     }
 
     #[test]
@@ -375,16 +516,16 @@ mod tests {
         let formatter = StringFormatter::new(FORMAT_STR)
             .unwrap()
             .map(|var| match var {
-                "a" => Some("$a"),
-                "b" => Some("$b"),
+                "a" => Some(Ok("$a")),
+                "b" => Some(Ok("$b")),
                 _ => None,
             })
             .map(|var| match var {
-                "b" => Some("$B"),
-                "c" => Some("$c"),
+                "b" => Some(Ok("$B")),
+                "c" => Some(Ok("$c")),
                 _ => None,
             });
-        let result = formatter.parse(None);
+        let result = formatter.parse(None).unwrap();
         let mut result_iter = result.iter();
         match_next!(result_iter, "$a", None);
         match_next!(result_iter, "$b", None);
@@ -398,10 +539,10 @@ mod tests {
         let formatter = StringFormatter::new(FORMAT_STR)
             .unwrap()
             .map(|var| match var {
-                "some" => Some("$some"),
+                "some" => Some(Ok("$some")),
                 _ => None,
             });
-        let result = formatter.parse(None);
+        let result = formatter.parse(None).unwrap();
         let mut result_iter = result.iter();
         match_next!(result_iter, "$some", None);
         match_next!(result_iter, " should render but ", None);
@@ -415,10 +556,10 @@ mod tests {
         let formatter = StringFormatter::new(FORMAT_STR)
             .unwrap()
             .map(|var| match var {
-                "some" => Some("$some"),
+                "some" => Some(Ok("$some")),
                 _ => None,
             });
-        let result = formatter.parse(None);
+        let result = formatter.parse(None).unwrap();
         let mut result_iter = result.iter();
         match_next!(result_iter, "$some", None);
         match_next!(result_iter, " ", None);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
This PR adds error handling to the API of `StringFormatter`.


```rust
impl StringFormatter {
    // Before
    pub fn map<T, M>(mut self, mapper: M) -> Self
    where
        T: Into<Cow<'a, str>>
        M: Fn(&str) -> Option<T> + Sync
    {}

    // After
    // similar changes are done to `self.map_*()`
    pub fn map<T, M>(mut self, mapper: M) -> Self
    where
        T: Into<Cow<'a, str>>
        M: Fn(&str) -> Option<Result<T, StringFormatterError>> + Sync
    {}

    // Before
    pub fn parse(self, default_style: Option<Style>) -> Vec<Segment> {}

    // After
    pub fn parse(self, default_style: Option<Style>) -> Result<Vec<Segment>, StringFormatterError> {}
}
```

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related https://github.com/starship/starship/discussions/1116#discussioncomment-6878

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
