### PR TITLE
fix(username): username was broken on Windows, improved Linux implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,12 @@ term_size = "0.3.1"
 attohttpc = { version = "0.13.0", optional = true, default-features = false, features = ["tls", "form"] }
 native-tls = { version = "0.2", optional = true }
 
+[target.'cfg(windows)'.dependencies]
+winapi = "0.3.8"
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2.69"
+
 [dev-dependencies]
 tempfile = "3.1.0"
 # More realiable than std::fs version on Windows

--- a/src/modules/username.rs
+++ b/src/modules/username.rs
@@ -23,9 +23,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let config: UsernameConfig = UsernameConfig::try_load(module.config);
 
     let user = get_username();
-    if user.is_none() {
-        return None;
-    }
+    user.as_ref()?;
 
     let domain = get_userdomain();
 
@@ -39,9 +37,10 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     log::debug!("user is admin: {}", user_is_admin);
 
     if user != logname || ssh_connection.is_some() || user_is_admin || config.show_always {
-        let module_style = match user_is_admin {
-            true => config.style_root,
-            false => config.style_user,
+        let module_style = if user_is_admin {
+            config.style_root
+        } else {
+            config.style_user
         };
 
         module.set_style(module_style);

--- a/src/modules/username.rs
+++ b/src/modules/username.rs
@@ -1,13 +1,15 @@
 use std::env;
-use std::mem;
 
 use super::{Context, Module, RootModuleConfig, SegmentConfig};
 use crate::configs::username::UsernameConfig;
 
 #[cfg(target_os = "windows")]
 use std::ptr::null_mut;
+#[cfg(target_os = "windows")]
 use winapi::shared::minwindef::{BOOL, DWORD, FALSE, PBOOL, PDWORD, TRUE};
+#[cfg(target_os = "windows")]
 use winapi::um::errhandlingapi::GetLastError;
+#[cfg(target_os = "windows")]
 use winapi::um::winnt::PVOID;
 
 /// Creates a module with the current user's username
@@ -68,8 +70,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
 #[cfg(not(target_os = "windows"))]
 fn is_admin() -> bool {
-    use libc;
-
     const ROOT_UID: u32 = 0u32;
     unsafe {
         match libc::geteuid() {
@@ -89,7 +89,7 @@ fn is_admin() -> bool {
     unsafe {
         let mut admin_sid = vec![0u8; SECURITY_MAX_SID_SIZE];
         let admin_sid_ptr = admin_sid.as_mut_ptr() as PVOID;
-        let mut sid_size = (mem::size_of::<u8>() * SECURITY_MAX_SID_SIZE) as DWORD;
+        let mut sid_size = (std::mem::size_of::<u8>() * SECURITY_MAX_SID_SIZE) as DWORD;
 
         if CreateWellKnownSid(
             WinBuiltinAdministratorsSid,
@@ -188,7 +188,7 @@ fn get_username() -> Option<String> {
 /// Get the user name on non-Windows OS
 ///
 #[cfg(not(target_os = "windows"))]
-const fn get_username() -> Option<String> {
+fn get_username() -> Option<String> {
     match env::var("USER") {
         Ok(username) => Some(username),
         Err(ref e) => {

--- a/src/modules/username.rs
+++ b/src/modules/username.rs
@@ -1,9 +1,14 @@
 use std::env;
+use std::mem;
 
 use super::{Context, Module, RootModuleConfig, SegmentConfig};
-
 use crate::configs::username::UsernameConfig;
-use crate::utils;
+
+#[cfg(target_os = "windows")]
+use std::ptr::null_mut;
+use winapi::shared::minwindef::{BOOL, DWORD, FALSE, PBOOL, PDWORD, TRUE};
+use winapi::um::errhandlingapi::GetLastError;
+use winapi::um::winnt::PVOID;
 
 /// Creates a module with the current user's username
 ///
@@ -12,24 +17,48 @@ use crate::utils;
 ///     - The current user is root (UID = 0)
 ///     - The user is currently connected as an SSH session (`$SSH_CONNECTION`)
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
-    let user = env::var("USER").ok();
-    let logname = env::var("LOGNAME").ok();
-    let ssh_connection = env::var("SSH_CONNECTION").ok();
-
-    const ROOT_UID: Option<u32> = Some(0);
-    let user_uid = get_uid();
-
     let mut module = context.new_module("username");
     let config: UsernameConfig = UsernameConfig::try_load(module.config);
 
-    if user != logname || ssh_connection.is_some() || user_uid == ROOT_UID || config.show_always {
-        let module_style = match user_uid {
-            Some(0) => config.style_root,
-            _ => config.style_user,
+    let user = get_username();
+    if user.is_none() {
+        return None;
+    }
+
+    let domain = get_userdomain();
+
+    let logname = match env::var("LOGNAME") {
+        Ok(logname) => Some(logname),
+        Err(_e) => user.clone(),
+    };
+    let ssh_connection = env::var("SSH_CONNECTION").ok();
+
+    let user_is_admin = is_admin();
+    log::debug!("user is admin: {}", user_is_admin);
+
+    if user != logname || ssh_connection.is_some() || user_is_admin || config.show_always {
+        let module_style = match user_is_admin {
+            true => config.style_root,
+            false => config.style_user,
         };
 
         module.set_style(module_style);
-        module.create_segment("username", &SegmentConfig::new(&user?));
+
+        match domain {
+            Some(domain_name) => {
+                module.create_segment(
+                    "username",
+                    &SegmentConfig::new(&format!(
+                        "{domain}\\{user}",
+                        domain = domain_name,
+                        user = user?
+                    )),
+                );
+            }
+            None => {
+                module.create_segment("username", &SegmentConfig::new(&user?));
+            }
+        }
 
         Some(module)
     } else {
@@ -37,10 +66,134 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     }
 }
 
-fn get_uid() -> Option<u32> {
-    utils::exec_cmd("id", &["-u"])?
-        .stdout
-        .trim()
-        .parse::<u32>()
-        .ok()
+#[cfg(not(target_os = "windows"))]
+fn is_admin() -> bool {
+    use libc;
+
+    const ROOT_UID: u32 = 0u32;
+    unsafe {
+        match libc::geteuid() {
+            ROOT_UID => true,
+            _ => false,
+        }
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn is_admin() -> bool {
+    use winapi::um::securitybaseapi::{CheckTokenMembership, CreateWellKnownSid};
+    use winapi::um::winnt::{WinBuiltinAdministratorsSid, PSID, SECURITY_MAX_SID_SIZE};
+
+    let mut is_member: BOOL = FALSE;
+
+    unsafe {
+        let mut admin_sid = vec![0u8; SECURITY_MAX_SID_SIZE];
+        let admin_sid_ptr = admin_sid.as_mut_ptr() as PVOID;
+        let mut sid_size = (mem::size_of::<u8>() * SECURITY_MAX_SID_SIZE) as DWORD;
+
+        if CreateWellKnownSid(
+            WinBuiltinAdministratorsSid,
+            null_mut(),
+            admin_sid_ptr,
+            &mut sid_size,
+        ) == 0i32
+        {
+            log::debug!(
+                "Error getting wellknown administators sid, GetLastError() : {}",
+                GetLastError()
+            );
+            return false;
+        }
+
+        if CheckTokenMembership(
+            std::ptr::null_mut(),
+            admin_sid.as_mut_ptr() as PSID,
+            &mut is_member as PBOOL,
+        ) == 0i32
+        {
+            log::debug!(
+                "Error checking token's membership to admins group, GetLastError() : {}",
+                GetLastError()
+            );
+            return false;
+        }
+    }
+    is_member == TRUE
+}
+
+/// Get the user name on Windows systems
+///
+/// On non-Windows OS, does nothing
+#[cfg(target_os = "windows")]
+fn get_userdomain() -> Option<String> {
+    match std::env::var("USERDOMAIN") {
+        Ok(name) => {
+            match std::env::var("COMPUTERNAME") {
+                Ok(computer) => {
+                    match computer {
+                        _ if computer == name => None, // if computer name & domain name are identical, then the user is a local account
+                        _ => Some(name),
+                    }
+                }
+                Err(e) => {
+                    log::debug!("COMPUTERNAME is undefined: {}", e);
+                    None
+                }
+            }
+        }
+        Err(e) => {
+            log::debug!("USERDOMAIN is undefined: {}", e);
+            None
+        }
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+fn get_userdomain() -> Option<String> {
+    None
+}
+
+#[cfg(target_os = "windows")]
+fn get_username() -> Option<String> {
+    match std::env::var("USERNAME") {
+        Ok(name) => Some(name),
+        Err(e) => {
+            log::debug!("USERNAME is undefined: {}", e);
+            unsafe {
+                use winapi::um::winbase::GetUserNameW;
+
+                const BUFFER_SIZE: usize = 256 as usize;
+                let mut output_string = vec![0u16; BUFFER_SIZE + 1];
+                let mut length: DWORD = BUFFER_SIZE as u32;
+
+                match GetUserNameW(output_string.as_mut_ptr(), &mut length as PDWORD) {
+                    0i32 => {
+                        log::debug!("Error getting GetUserNameW");
+                        None
+                    }
+                    _ if length == 0 => {
+                        log::debug!("Invalid username size returned from GetUserNameW");
+                        None
+                    }
+                    _ => {
+                        output_string.truncate((length - 1) as usize);
+                        Some(String::from_utf16(&output_string).unwrap())
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Get the user name on non-Windows OS
+///
+#[cfg(not(target_os = "windows"))]
+const fn get_username() -> Option<String> {
+    match env::var("USER") {
+        Ok(username) => Some(username),
+        Err(ref e) => {
+            log::debug!("Error getting USER environment variable: {}", e);
+            None
+        }
+    }
 }

--- a/tests/testsuite/username.rs
+++ b/tests/testsuite/username.rs
@@ -72,6 +72,10 @@ fn ssh_connection() -> io::Result<()> {
     let output = common::render_module("username")
         .env("USERNAME", "astronaut")
         .env("SSH_CONNECTION", "192.168.223.17 36673 192.168.223.229 22")
+        .use_config(toml::toml! {
+        [username]
+        style_root	= "bold yellow"
+        style_user	= "bold yellow"})
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
@@ -104,7 +108,9 @@ fn show_always() -> io::Result<()> {
         .env("USERNAME", "astronaut")
         .use_config(toml::toml! {
         [username]
-        show_always = true})
+        show_always = true
+        style_root	= "bold yellow"
+        style_user	= "bold yellow"})
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
@@ -123,7 +129,9 @@ fn current_user_local_account() -> io::Result<()> {
         .env("COMPUTERNAME", "myhost")
         .use_config(toml::toml! {
         [username]
-        show_always = true})
+        show_always = true
+        style_root	= "bold yellow"
+        style_user	= "bold yellow"})
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
@@ -141,7 +149,9 @@ fn current_user_domain_account() -> io::Result<()> {
         .env("COMPUTERNAME", "myhost")
         .use_config(toml::toml! {
         [username]
-        show_always = true})
+        show_always = true
+        style_root	= "bold yellow"
+        style_user	= "bold yellow"})
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 

--- a/tests/testsuite/username.rs
+++ b/tests/testsuite/username.rs
@@ -74,9 +74,9 @@ fn ssh_connection() -> io::Result<()> {
         .env("USERNAME", "astronaut")
         .env("SSH_CONNECTION", "192.168.223.17 36673 192.168.223.229 22")
         .use_config(toml::toml! {
-            [username]
-            style_root	= "bold red"
-            style_user	= "bold red"})
+        [username]
+        style_root	= "bold red"
+        style_user	= "bold red"})
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 

--- a/tests/testsuite/username.rs
+++ b/tests/testsuite/username.rs
@@ -7,6 +7,7 @@ use crate::common::{self, TestCommand};
 // Requires mocking
 
 #[test]
+#[cfg(not(target_os = "windows"))]
 fn no_env_variables() -> io::Result<()> {
     let output = common::render_module("username").output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
@@ -73,13 +74,13 @@ fn ssh_connection() -> io::Result<()> {
         .env("USERNAME", "astronaut")
         .env("SSH_CONNECTION", "192.168.223.17 36673 192.168.223.229 22")
         .use_config(toml::toml! {
-        [username]
-        style_root	= "bold yellow"
-        style_user	= "bold yellow"})
+            [username]
+            style_root	= "bold red"
+            style_user	= "bold red"})
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
-    let expected = format!("via {} ", Color::Yellow.bold().paint("astronaut"));
+    let expected = format!("via {} ", Color::Red.bold().paint("astronaut"));
     assert_eq!(expected, actual);
     Ok(())
 }
@@ -109,12 +110,12 @@ fn show_always() -> io::Result<()> {
         .use_config(toml::toml! {
         [username]
         show_always = true
-        style_root	= "bold yellow"
-        style_user	= "bold yellow"})
+        style_root	= "bold red"
+        style_user	= "bold red"})
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
-    let expected = format!("via {} ", Color::Yellow.bold().paint("astronaut"));
+    let expected = format!("via {} ", Color::Red.bold().paint("astronaut"));
 
     assert_eq!(expected, actual);
     Ok(())
@@ -130,12 +131,12 @@ fn current_user_local_account() -> io::Result<()> {
         .use_config(toml::toml! {
         [username]
         show_always = true
-        style_root	= "bold yellow"
-        style_user	= "bold yellow"})
+        style_root	= "bold red"
+        style_user	= "bold red"})
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
-    let expected = format!("via {} ", Color::Yellow.bold().paint("astronaut"));
+    let expected = format!("via {} ", Color::Red.bold().paint("astronaut"));
     assert_eq!(expected, actual);
     Ok(())
 }
@@ -150,12 +151,12 @@ fn current_user_domain_account() -> io::Result<()> {
         .use_config(toml::toml! {
         [username]
         show_always = true
-        style_root	= "bold yellow"
-        style_user	= "bold yellow"})
+        style_root	= "bold red"
+        style_user	= "bold red"})
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
-    let expected = format!("via {} ", Color::Yellow.bold().paint("nasa\\astronaut"));
+    let expected = format!("via {} ", Color::Red.bold().paint("nasa\\astronaut"));
     assert_eq!(expected, actual);
     Ok(())
 }


### PR DESCRIPTION
#### Description

This PR fixes the username module on Windows.

#### Motivation and Context

The username module was broken on Windows (nothing ever displayed).

The Linux implementation spawned a process to get user id, there is a C api to get this information.
Upon review, it seemed the Linux implementation could be improved.

Fixes #1350
Fixes #1579 

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

After the fix, 
- elevated prompt on Windows (local account):
![image](https://user-images.githubusercontent.com/7120091/80704480-ebb67000-8ae4-11ea-97ff-3c564cf22620.png)

- elevated prompt on Windows (domain account):
![image](https://user-images.githubusercontent.com/7120091/80704587-24eee000-8ae5-11ea-8c2f-e9f06786a2c1.png)

- root prompt on WSL2 (unchanged):
![image](https://user-images.githubusercontent.com/7120091/80704772-7b5c1e80-8ae5-11ea-9cee-ab1fceaeff50.png)

#### How Has This Been Tested?

- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**
- [x] I have tested using **Windows SubSystem for Linux**

#### Checklist:
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
