### PR TITLE
feat: add more configurable prefixes

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -583,6 +583,7 @@ The `git_branch` module shows the active branch of the repo in your current dire
 
 | Variable            | Default         | Description                                                                           |
 | ------------------- | --------------- | ------------------------------------------------------------------------------------- |
+| `prefix`            | `"on "`         | Prefix to display immediately before the Git branch.                                  |
 | `symbol`            | `" "`          | The symbol used before the branch name of the repo in your current directory.         |
 | `truncation_length` | `2^63 - 1`      | Truncates a git branch to X graphemes                                                 |
 | `truncation_symbol` | `"…"`           | The symbol used to indicate a branch name was truncated. You can use "" for no symbol |
@@ -780,7 +781,7 @@ The `hostname` module shows the system hostname.
 | Variable   | Default               | Description                                                                                                                          |
 | ---------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
 | `ssh_only` | `true`                | Only show hostname when connected to an SSH session.                                                                                 |
-| `prefix`   | `""`                  | Prefix to display immediately before the hostname.                                                                                   |
+| `prefix`   | `"on "`               | Prefix to display immediately before the hostname.                                                                                   |
 | `suffix`   | `""`                  | Suffix to display immediately after the hostname.                                                                                    |
 | `trim_at`  | `"."`                 | String that the hostname is cut off at, after the first match. `"."` will stop after the first dot. `""` will disable any truncation |
 | `style`    | `"bold dimmed green"` | The style for the module.                                                                                                            |
@@ -1142,6 +1143,7 @@ The module will be shown if any of the following conditions are met:
 
 | Variable             | Default         | Description                                                                 |
 | -------------------- | --------------- | --------------------------------------------------------------------------- |
+| `prefix`             | `"via "`        | Prefix to display before the Python version.                                |
 | `symbol`             | `"🐍 "`         | The symbol used before displaying the version of Python.                    |
 | `pyenv_version_name` | `false`         | Use pyenv to get Python version                                             |
 | `pyenv_prefix`       | `"pyenv "`      | Prefix before pyenv version display (default display is `pyenv MY_VERSION`) |
@@ -1313,6 +1315,7 @@ The module will be shown if any of the following conditions are met:
 
 | Variable      | Default         | Description                           |
 | ------------- | --------------- | ------------------------------------- |
+| `prefix`      | `"via "`        | Prefix to display before the username.|
 | `style_root`  | `"bold red"`    | The style used when the user is root. |
 | `style_user`  | `"bold yellow"` | The style used for non-root users.    |
 | `show_always` | `false`         | Always shows the `username` module.   |

--- a/src/configs/git_branch.rs
+++ b/src/configs/git_branch.rs
@@ -11,6 +11,7 @@ pub struct GitBranchConfig<'a> {
     pub branch_name: SegmentConfig<'a>,
     pub style: Style,
     pub disabled: bool,
+    pub prefix: &'a str,
 }
 
 impl<'a> RootModuleConfig<'a> for GitBranchConfig<'a> {
@@ -22,6 +23,7 @@ impl<'a> RootModuleConfig<'a> for GitBranchConfig<'a> {
             branch_name: SegmentConfig::default(),
             style: Color::Purple.bold(),
             disabled: false,
+            prefix: "on "
         }
     }
 }

--- a/src/configs/git_branch.rs
+++ b/src/configs/git_branch.rs
@@ -23,7 +23,7 @@ impl<'a> RootModuleConfig<'a> for GitBranchConfig<'a> {
             branch_name: SegmentConfig::default(),
             style: Color::Purple.bold(),
             disabled: false,
-            prefix: "on "
+            prefix: "on ",
         }
     }
 }

--- a/src/configs/hostname.rs
+++ b/src/configs/hostname.rs
@@ -17,7 +17,7 @@ impl<'a> RootModuleConfig<'a> for HostnameConfig<'a> {
     fn new() -> Self {
         HostnameConfig {
             ssh_only: true,
-            prefix: "",
+            prefix: "on ",
             suffix: "",
             trim_at: ".",
             style: Color::Green.bold().dimmed(),

--- a/src/configs/python.rs
+++ b/src/configs/python.rs
@@ -25,7 +25,7 @@ impl<'a> RootModuleConfig<'a> for PythonConfig<'a> {
             scan_for_pyfiles: true,
             style: Color::Yellow.bold(),
             disabled: false,
-            prefix: "with ",
+            prefix: "via ",
         }
     }
 }

--- a/src/configs/python.rs
+++ b/src/configs/python.rs
@@ -12,6 +12,7 @@ pub struct PythonConfig<'a> {
     pub scan_for_pyfiles: bool,
     pub style: Style,
     pub disabled: bool,
+    pub prefix: &'a str,
 }
 
 impl<'a> RootModuleConfig<'a> for PythonConfig<'a> {
@@ -24,6 +25,7 @@ impl<'a> RootModuleConfig<'a> for PythonConfig<'a> {
             scan_for_pyfiles: true,
             style: Color::Yellow.bold(),
             disabled: false,
+            prefix: "with ",
         }
     }
 }

--- a/src/configs/username.rs
+++ b/src/configs/username.rs
@@ -4,20 +4,22 @@ use ansi_term::{Color, Style};
 use starship_module_config_derive::ModuleConfig;
 
 #[derive(Clone, ModuleConfig)]
-pub struct UsernameConfig {
+pub struct UsernameConfig<'a> {
     pub style_root: Style,
     pub style_user: Style,
     pub show_always: bool,
     pub disabled: bool,
+    pub prefix: &'a str,
 }
 
-impl<'a> RootModuleConfig<'a> for UsernameConfig {
+impl<'a> RootModuleConfig<'a> for UsernameConfig<'a> {
     fn new() -> Self {
         UsernameConfig {
             style_root: Color::Red.bold(),
             style_user: Color::Yellow.bold(),
             show_always: false,
             disabled: false,
+            prefix: "as ",
         }
     }
 }

--- a/src/configs/username.rs
+++ b/src/configs/username.rs
@@ -19,7 +19,7 @@ impl<'a> RootModuleConfig<'a> for UsernameConfig<'a> {
             style_user: Color::Yellow.bold(),
             show_always: false,
             disabled: false,
-            prefix: "as ",
+            prefix: "via ",
         }
     }
 }

--- a/src/modules/git_branch.rs
+++ b/src/modules/git_branch.rs
@@ -12,7 +12,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let config = GitBranchConfig::try_load(module.config);
     module.set_style(config.style);
 
-    module.get_prefix().set_value("on ");
+    module.get_prefix().set_value(config.prefix);
 
     let truncation_symbol = get_graphemes(config.truncation_symbol, 1);
     module.create_segment("symbol", &config.symbol);

--- a/src/modules/hostname.rs
+++ b/src/modules/hostname.rs
@@ -45,7 +45,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_style(config.style);
     let hostname_stacked = format!("{}{}{}", config.prefix, host, config.suffix);
     module.create_segment("hostname", &SegmentConfig::new(&hostname_stacked));
-    module.get_prefix().set_value("on ");
+    module.get_prefix().set_value(config.prefix);
 
     Some(module)
 }

--- a/src/modules/hostname.rs
+++ b/src/modules/hostname.rs
@@ -43,7 +43,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     };
 
     module.set_style(config.style);
-    let hostname_stacked = format!("{}{}{}", config.prefix, host, config.suffix);
+    let hostname_stacked = format!("{}{}", host, config.suffix);
     module.create_segment("hostname", &SegmentConfig::new(&hostname_stacked));
     module.get_prefix().set_value(config.prefix);
 

--- a/src/modules/python.rs
+++ b/src/modules/python.rs
@@ -61,6 +61,8 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         );
     };
 
+    module.get_prefix().set_value(config.prefix);
+
     Some(module)
 }
 

--- a/src/modules/username.rs
+++ b/src/modules/username.rs
@@ -29,6 +29,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         };
 
         module.set_style(module_style);
+        module.get_prefix().set_value(config.prefix);
         module.create_segment("username", &SegmentConfig::new(&user?));
 
         Some(module)

--- a/tests/testsuite/hostname.rs
+++ b/tests/testsuite/hostname.rs
@@ -75,7 +75,7 @@ fn prefix() -> io::Result<()> {
         })
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
-    let expected = format!("on {} ", style().paint(format!("<{}", hostname)));
+    let expected = format!("<{} ", style().paint(hostname));
     assert_eq!(actual, expected);
     Ok(())
 }


### PR DESCRIPTION
#### Description

Add configurable prefixes for username, hostname, git_branch and
python modules.

#### Motivation and Context

Unlike with other modules, it's not possible to customise prefixes in the username, hostname, git_branch and python modules.

Closes #418 
Closes #1102 

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?

- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:

- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
