### PR TITLE
fix: snap build failure

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -50,6 +50,9 @@ parts:
     plugin: rust
     source: https://github.com/starship/starship.git
     #source-tag: v$SNAPCRAFT_PROJECT_VERSION
+    build-packages:
+      - libssl-dev
+      - pkg-config
     override-build: |
       last_committed_tag="$(git describe --tags --abbrev=0)"
       last_committed_tag_ver="$(echo ${last_committed_tag} | sed 's/v//')"


### PR DESCRIPTION
## Description
Add required dependencies for successful build.

#### Motivation and Context
The snap has been failing to build. Apologies for not noticing.

Here's a snippet of a recent [build log](https://snapcraft.io/starship/builds/942067).

```
 Compiling starship_module_config_derive v0.1.1 (/build/starship/parts/starship/build/starship_module_config_derive)
   Compiling pretty_env_logger v0.4.0
error: failed to run custom build command for `openssl-sys v0.9.55`

Caused by:
  process didn't exit successfully: `/build/starship/parts/starship/build/target/release/build/openssl-sys-2d4e1b6abab932ae/build-script-main` (exit code: 101)
--- stdout
cargo:rustc-cfg=const_fn
cargo:rerun-if-env-changed=X86_64_UNKNOWN_LINUX_GNU_OPENSSL_LIB_DIR
X86_64_UNKNOWN_LINUX_GNU_OPENSSL_LIB_DIR unset
cargo:rerun-if-env-changed=OPENSSL_LIB_DIR
OPENSSL_LIB_DIR unset
cargo:rerun-if-env-changed=X86_64_UNKNOWN_LINUX_GNU_OPENSSL_INCLUDE_DIR
X86_64_UNKNOWN_LINUX_GNU_OPENSSL_INCLUDE_DIR unset
cargo:rerun-if-env-changed=OPENSSL_INCLUDE_DIR
OPENSSL_INCLUDE_DIR unset
cargo:rerun-if-env-changed=X86_64_UNKNOWN_LINUX_GNU_OPENSSL_DIR
X86_64_UNKNOWN_LINUX_GNU_OPENSSL_DIR unset
cargo:rerun-if-env-changed=OPENSSL_DIR
OPENSSL_DIR unset
run pkg_config fail: "Failed to run `\"pkg-config\" \"--libs\" \"--cflags\" \"openssl\"`: No such file or directory (os error 2)"

--- stderr
thread 'main' panicked at '

Could not find directory of OpenSSL installation, and this `-sys` crate cannot
proceed without this knowledge. If OpenSSL is installed and this crate had
trouble finding it,  you can set the `OPENSSL_DIR` environment variable for the
compilation process.

Make sure you also have the development packages of openssl installed.
For example, `libssl-dev` on Ubuntu or `openssl-devel` on Fedora.

If you're in a situation where you think the directory *should* be found
automatically, please open a bug at https://github.com/sfackler/rust-openssl
and include information about your system as well as this message.

$HOST = x86_64-unknown-linux-gnu
$TARGET = x86_64-unknown-linux-gnu
openssl-sys = 0.9.55


It looks like you're compiling on Linux and also targeting Linux. Currently this
requires the `pkg-config` utility to find OpenSSL but unfortunately `pkg-config`
could not be found. If you have OpenSSL installed you can likely fix this by
installing `pkg-config`.

', /root/.cargo/registry/src/github.com-1ecc6299db9ec823/openssl-sys-0.9.55/build/find_normal.rs:155:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

warning: build failed, waiting for other jobs to finish...
error: failed to compile `starship v0.41.0 (/build/starship/parts/starship/build)`, intermediate artifacts can be found at `/build/starship/parts/starship/build/target`
```


#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
I build the snap on my Ubuntu 20.04 system using an Ubuntu 18.04 container. The build with these changes succeeded, and once installed functioned as I expected.
- [ ] I have tested using **MacOS**
- [X] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
I don't believe these are necessary, but correct me if I'm wrong.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
