### PR TITLE
refactor(env_var): Added formatter support for the env_var module

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -635,11 +635,11 @@ The module will be shown only if any of the following conditions are met:
 
 ### Variables
 
-| Variable  | Example             | Description                             |
-| --------- | ------------------- | --------------------------------------- |
-| env_value | `Windows NT`        | The environment value of $OS on Windows |
-| symbol    |                     | Mirrors the value of option `symbol`    |
-| style     | `black bold dimmed` | Mirrors the value of option `style`     |
+| Variable  | Example                                     | Description                                |
+| --------- | ------------------------------------------- | ------------------------------------------ |
+| env_value | `Windows NT` (if *variable* would be `$OS`) | The environment value of option `variable` |
+| symbol    |                                             | Mirrors the value of option `symbol`       |
+| style     | `black bold dimmed`                         | Mirrors the value of option `style`        |
 
 ### Example
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -560,8 +560,16 @@ The module will be shown only if any of the following conditions are met:
 | `symbol`   |                                        | The symbol used before displaying the variable value.                        |
 | `variable` |                                        | The environment variable to be displayed.                                    |
 | `default`  |                                        | The default value to be displayed when the selected variable is not defined. |
-| `format`   | `"with [$env_value](black bold dimmed) "` | The format for the module.                                                   |
+| `format`   | `"with [${env_value}]($style) "` | The format for the module.                                                   |
 | `disabled` | `false`                                | Disables the `env_var` module.                                               |
+
+### Variables
+
+| Variable  | Example             | Description                             |
+| --------- | ------------------- | --------------------------------------- |
+| env_value | `Windows NT`        | The environment value of $OS on Windows |
+| symbol    |                     | Mirrors the value of option `symbol`    |
+| style     | `black bold dimmed` | Mirrors the value of option `style`     |
 
 ### Example
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -555,15 +555,13 @@ The module will be shown only if any of the following conditions are met:
 
 ### Options
 
-| Variable   | Default          | Description                                                                  |
-| ---------- | ---------------- | ---------------------------------------------------------------------------- |
-| `symbol`   |                  | The symbol used before displaying the variable value.                        |
-| `variable` |                  | The environment variable to be displayed.                                    |
-| `default`  |                  | The default value to be displayed when the selected variable is not defined. |
-| `prefix`   | `""`             | Prefix to display immediately before the variable value.                     |
-| `suffix`   | `""`             | Suffix to display immediately after the variable value.                      |
-| `style`    | `"dimmed black"` | The style for the module.                                                    |
-| `disabled` | `false`          | Disables the `env_var` module.                                               |
+| Variable   | Default                                | Description                                                                  |
+| ---------- | -------------------------------------- | ---------------------------------------------------------------------------- |
+| `symbol`   |                                        | The symbol used before displaying the variable value.                        |
+| `variable` |                                        | The environment variable to be displayed.                                    |
+| `default`  |                                        | The default value to be displayed when the selected variable is not defined. |
+| `format`   | `"with [$env_value](black bold dimmed) "` | The format for the module.                                                   |
+| `disabled` | `false`                                | Disables the `env_var` module.                                               |
 
 ### Example
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -614,6 +614,7 @@ The module will be shown if any of the following conditions are met:
 [erlang]
 symbol = "e "
 ```
+
 ## Environment Variable
 
 The `env_var` module displays the current value of a selected environment variable.
@@ -624,7 +625,7 @@ The module will be shown only if any of the following conditions are met:
 
 ### Options
 
-| Variable   | Default                                | Description                                                                  |
+| Option     | Default                                | Description                                                                  |
 | ---------- | -------------------------------------- | ---------------------------------------------------------------------------- |
 | `symbol`   |                                        | The symbol used before displaying the variable value.                        |
 | `variable` |                                        | The environment variable to be displayed.                                    |

--- a/src/configs/env_var.rs
+++ b/src/configs/env_var.rs
@@ -4,6 +4,8 @@ use starship_module_config_derive::ModuleConfig;
 
 #[derive(Clone, ModuleConfig)]
 pub struct EnvVarConfig<'a> {
+    pub symbol: &'a str,
+    pub style: &'a str,
     pub variable: Option<&'a str>,
     pub default: Option<&'a str>,
     pub format: &'a str,
@@ -13,9 +15,11 @@ pub struct EnvVarConfig<'a> {
 impl<'a> RootModuleConfig<'a> for EnvVarConfig<'a> {
     fn new() -> Self {
         EnvVarConfig {
+            symbol: "",
+            style: "black bold dimmed",
             variable: None,
             default: None,
-            format: "with [$env_value](black bold dimmed) ",
+            format: "with [${env_value}]($style) ",
             disabled: false,
         }
     }

--- a/src/configs/env_var.rs
+++ b/src/configs/env_var.rs
@@ -1,28 +1,21 @@
-use crate::config::{ModuleConfig, RootModuleConfig, SegmentConfig};
+use crate::config::{ModuleConfig, RootModuleConfig};
 
-use ansi_term::{Color, Style};
 use starship_module_config_derive::ModuleConfig;
 
 #[derive(Clone, ModuleConfig)]
 pub struct EnvVarConfig<'a> {
-    pub symbol: Option<SegmentConfig<'a>>,
     pub variable: Option<&'a str>,
     pub default: Option<&'a str>,
-    pub prefix: &'a str,
-    pub suffix: &'a str,
-    pub style: Style,
+    pub format: &'a str,
     pub disabled: bool,
 }
 
 impl<'a> RootModuleConfig<'a> for EnvVarConfig<'a> {
     fn new() -> Self {
         EnvVarConfig {
-            symbol: None,
             variable: None,
             default: None,
-            prefix: "",
-            suffix: "",
-            style: Color::Black.bold().dimmed(),
+            format: "with [$env_value](black bold dimmed) ",
             disabled: false,
         }
     }

--- a/src/modules/env_var.rs
+++ b/src/modules/env_var.rs
@@ -17,18 +17,32 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let config: EnvVarConfig = EnvVarConfig::try_load(module.config);
 
     let env_value = get_env_value(config.variable?, config.default)?;
+    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
+        formatter
+            .map_meta(|var, _| match var {
+                "symbol" => Some(config.symbol),
+                _ => None,
+            })
+            .map_style(|variable| match variable {
+                "style" => Some(Ok(config.style)),
+                _ => None,
+            })
+            .map(|variable| match variable {
+                // This may result in multiple calls to `get_module_version` when a user have
+                // multiple `$version` variables defined in `format`.
+                "env_value" => Some(Ok(env_value.clone())),
+                _ => None,
+            })
+            .parse(None)
+    });
 
-    let formatter = if let Ok(formatter) = StringFormatter::new(config.format) {
-        formatter.map(|variable| match variable {
-            "env_value" => Some(env_value.clone()),
-            _ => None,
-        })
-    } else {
-        log::warn!("Error parsing format string in `env_var.format`");
-        return None;
-    };
-
-    module.set_segments(formatter.parse(None));
+    module.set_segments(match parsed {
+        Ok(segments) => segments,
+        Err(error) => {
+            log::warn!("Error in module `env_var`:\n{}", error);
+            return None;
+        }
+    });
     module.get_prefix().set_value("");
     module.get_suffix().set_value("");
 

--- a/src/modules/env_var.rs
+++ b/src/modules/env_var.rs
@@ -28,7 +28,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 _ => None,
             })
             .map(|variable| match variable {
-                "env_value" => Some(Ok(env_value.clone())),
+                "env_value" => Some(Ok(&env_value)),
                 _ => None,
             })
             .parse(None)

--- a/src/modules/env_var.rs
+++ b/src/modules/env_var.rs
@@ -28,8 +28,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 _ => None,
             })
             .map(|variable| match variable {
-                // This may result in multiple calls to `get_module_version` when a user have
-                // multiple `$version` variables defined in `format`.
                 "env_value" => Some(Ok(env_value.clone())),
                 _ => None,
             })

--- a/tests/testsuite/env_var.rs
+++ b/tests/testsuite/env_var.rs
@@ -90,8 +90,8 @@ fn symbol() -> io::Result<()> {
         .env_clear()
         .use_config(toml::toml! {
             [env_var]
-            symbol = "■ "
             variable = "TEST_VAR"
+            format = "with [■ $env_value](black bold dimmed) "
         })
         .env("TEST_VAR", TEST_VAR_VALUE)
         .output()?;
@@ -108,7 +108,7 @@ fn prefix() -> io::Result<()> {
         .use_config(toml::toml! {
             [env_var]
             variable = "TEST_VAR"
-            prefix = "_"
+            format = "with [_$env_value](black bold dimmed) "
         })
         .env("TEST_VAR", TEST_VAR_VALUE)
         .output()?;
@@ -125,11 +125,11 @@ fn suffix() -> io::Result<()> {
         .use_config(toml::toml! {
             [env_var]
             variable = "TEST_VAR"
-            suffix = "_"
+            format = "with [$env_value _](black bold dimmed) "
         })
         .env("TEST_VAR", TEST_VAR_VALUE)
         .output()?;
-    let expected = format!("with {} ", style().paint(format!("{}_", TEST_VAR_VALUE)));
+    let expected = format!("with {} ", style().paint(format!("{} _", TEST_VAR_VALUE)));
     let actual = String::from_utf8(output.stdout).unwrap();
     assert_eq!(expected, actual);
     Ok(())

--- a/tests/testsuite/env_var.rs
+++ b/tests/testsuite/env_var.rs
@@ -125,11 +125,11 @@ fn suffix() -> io::Result<()> {
         .use_config(toml::toml! {
             [env_var]
             variable = "TEST_VAR"
-            format = "with [$env_value _](black bold dimmed) "
+            format = "with [${env_value}_](black bold dimmed) "
         })
         .env("TEST_VAR", TEST_VAR_VALUE)
         .output()?;
-    let expected = format!("with {} ", style().paint(format!("{} _", TEST_VAR_VALUE)));
+    let expected = format!("with {} ", style().paint(format!("{}_", TEST_VAR_VALUE)));
     let actual = String::from_utf8(output.stdout).unwrap();
     assert_eq!(expected, actual);
     Ok(())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

This PR deprecates `symbol` and `style` keys in the `env_var` module to replace it with the `format` key instead.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Related to issue #1057

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/805567/81348411-001dde00-908c-11ea-97df-a728bba058f8.png)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
