### PR TITLE
refactor(memory_usage): Added formatter support for memory_usage module

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1013,15 +1013,27 @@ To enable it, set `disabled` to `false` in your configuration file.
 
 ### Options
 
-| Variable          | Default               | Description                                                   |
-| ----------------- | --------------------- | ------------------------------------------------------------- |
-| `show_percentage` | `false`               | Display memory usage as a percentage of the available memory. |
-| `show_swap`       | `true`                | Display swap usage if total swap is non-zero.                 |
-| `threshold`       | `75`                  | Hide the memory usage unless it exceeds this percentage.      |
-| `symbol`          | `"🐏 "`               | The symbol used before displaying the memory usage.           |
-| `separator`       | `" | "`               | The symbol or text that will seperate the ram and swap usage. |
-| `style`           | `"bold dimmed white"` | The style for the module.                                     |
-| `disabled`        | `true`                | Disables the `memory_usage` module.                           |
+| Variable    | Default                                       | Description                                              |
+| ----------- | --------------------------------------------- | -------------------------------------------------------- |
+| `threshold` | `75`                                          | Hide the memory usage unless it exceeds this percentage. |
+| `format`    | `"via $symbol [${ram}( | ${swap})]($style) "` | The format for the module.                               |
+| `symbol`    | `"🐏"`                                         | The symbol used before displaying the memory usage.      |
+| `style`     | `"bold dimmed white"`                         | The style for the module.                                |
+| `disabled`  | `true`                                        | Disables the `memory_usage` module.                      |
+
+### Variables
+
+| Variable    | Example       | Description                                                        |
+| ----------- | ------------- | ------------------------------------------------------------------ |
+| ram         | `31GiB/65GiB` | The usage/total RAM of the current system memory.                  |
+| ram_pct     | `48%`         | The percentage of the current system memory.                       |
+| swap\**     | `1GiB/4GiB`   | The swap memory size of the current system swap memory file.       |
+| swap_pct\** | `77%`         | The swap memory percentage of the current system swap memory file. |
+| symbol      | `🐏`           | Mirrors the value of option `symbol`                               |
+| style\*     |               | Mirrors the value of option `style`                                |
+
+\*: This variable can only be used as a part of a style string
+\**: The SWAP file information is only displayed if detected on the current system
 
 ### Example
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1026,7 +1026,7 @@ To enable it, set `disabled` to `false` in your configuration file.
 
 ### Options
 
-| Variable    | Default                                       | Description                                              |
+| Option      | Default                                       | Description                                              |
 | ----------- | --------------------------------------------- | -------------------------------------------------------- |
 | `threshold` | `75`                                          | Hide the memory usage unless it exceeds this percentage. |
 | `format`    | `"via $symbol [${ram}( | ${swap})]($style) "` | The format for the module.                               |

--- a/src/configs/memory_usage.rs
+++ b/src/configs/memory_usage.rs
@@ -1,32 +1,23 @@
-use crate::config::{ModuleConfig, RootModuleConfig, SegmentConfig};
+use crate::config::{ModuleConfig, RootModuleConfig};
 
-use ansi_term::{Color, Style};
 use starship_module_config_derive::ModuleConfig;
 
 #[derive(Clone, ModuleConfig)]
 pub struct MemoryConfig<'a> {
-    pub show_percentage: bool,
-    pub show_swap: bool,
     pub threshold: i64,
-    pub symbol: SegmentConfig<'a>,
-    pub separator: SegmentConfig<'a>,
-    pub ram: SegmentConfig<'a>,
-    pub swap: SegmentConfig<'a>,
-    pub style: Style,
+    pub format: &'a str,
+    pub style: &'a str,
+    pub symbol: &'a str,
     pub disabled: bool,
 }
 
 impl<'a> RootModuleConfig<'a> for MemoryConfig<'a> {
     fn new() -> Self {
         MemoryConfig {
-            show_percentage: false,
-            show_swap: true,
             threshold: 75,
-            symbol: SegmentConfig::new("🐏 "),
-            separator: SegmentConfig::new(" | "),
-            ram: SegmentConfig::default(),
-            swap: SegmentConfig::default(),
-            style: Color::White.bold().dimmed(),
+            format: "via $symbol [${ram}( | ${swap})]($style) ",
+            style: "white bold dimmed",
+            symbol: "🐏",
             disabled: true,
         }
     }

--- a/src/configs/memory_usage.rs
+++ b/src/configs/memory_usage.rs
@@ -15,9 +15,9 @@ impl<'a> RootModuleConfig<'a> for MemoryConfig<'a> {
     fn new() -> Self {
         MemoryConfig {
             threshold: 75,
-            format: "via $symbol [${ram}( | ${swap})]($style) ",
+            format: "via ${symbol}[${ram}( | ${swap})]($style) ",
             style: "white bold dimmed",
-            symbol: "🐏",
+            symbol: "🐏 ",
             disabled: true,
         }
     }

--- a/src/modules/memory_usage.rs
+++ b/src/modules/memory_usage.rs
@@ -66,11 +66,11 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 _ => None,
             })
             .map(|variable| match variable {
-                "ram" => Some(Ok(ram.clone())),
-                "ram_pct" => Some(Ok(ram_pct.clone())),
+                "ram" => Some(Ok(&ram)),
+                "ram_pct" => Some(Ok(&ram_pct)),
                 // swap only shown if there is swap on the system
-                "swap" if total_swap_kib > 0 => Some(Ok(swap.clone())),
-                "swap_pct" if total_swap_kib > 0 => Some(Ok(swap_pct.clone())),
+                "swap" if total_swap_kib > 0 => Some(Ok(&swap)),
+                "swap_pct" if total_swap_kib > 0 => Some(Ok(&swap_pct)),
                 _ => None,
             })
             .parse(None)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

This PR adds support for string formatter to the memory_usage module. 

Because the format string allows for more customization, more variables are exposed to the user so that he can control how he exactly wants to display the memory usage string. Hence instead of using boolean configuration options to either display percentage or usage/total values, the user can display one or the other via the format string, or both if he desires so. Also the swap is not hidden via a boolean flag anymore: the user simply has to specify it via the string format. I kept the restriction to only display the SWAP usage though if it is present on the system. The default format string contains an optional SWAP variable so it should not prevent the memory to be displayed if the former is missing. 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

Related to issue #1057

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/805567/81453325-4724d580-9157-11ea-8087-efa5596e1e4a.png)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
