### PR TITLE
feat(directory): Add directory substitutions

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -398,8 +398,18 @@ it would have been `nixpkgs/pkgs`.
 
 | Variable                    | Default | Description                                                                              |
 | --------------------------- | ------- | ---------------------------------------------------------------------------------------- |
+| `substitutions`             |         | A table of substitutions to be made to the path.                                         |
 | `fish_style_pwd_dir_length` | `0`     | The number of characters to use when applying fish shell pwd path logic.                 |
 | `use_logical_path`          | `true`  | Displays the logical path provided by the shell (`PWD`) instead of the path from the OS. |
+
+`substitutions` allows you to define arbitrary replacements for literal strings that occur in the path, for example long network
+prefixes or development directories (i.e. Java). Note that this will disable the fish style PWD.
+
+```toml
+[directory.substitutions]
+"/Volumes/network/path" = "/net"
+"src/com/long/java/path" = "mypath"
+```
 
 `fish_style_pwd_dir_length` interacts with the standard truncation options in a way that can be surprising at first: if it's non-zero,
 the components of the path that would normally be truncated are instead displayed with that many characters. For example, the path

--- a/src/configs/directory.rs
+++ b/src/configs/directory.rs
@@ -1,4 +1,5 @@
 use crate::config::{ModuleConfig, RootModuleConfig};
+use std::collections::HashMap;
 
 use ansi_term::{Color, Style};
 use starship_module_config_derive::ModuleConfig;
@@ -7,6 +8,7 @@ use starship_module_config_derive::ModuleConfig;
 pub struct DirectoryConfig<'a> {
     pub truncation_length: i64,
     pub truncate_to_repo: bool,
+    pub substitutions: HashMap<String, &'a str>,
     pub fish_style_pwd_dir_length: i64,
     pub use_logical_path: bool,
     pub prefix: &'a str,
@@ -20,6 +22,7 @@ impl<'a> RootModuleConfig<'a> for DirectoryConfig<'a> {
             truncation_length: 3,
             truncate_to_repo: true,
             fish_style_pwd_dir_length: 0,
+            substitutions: HashMap::new(),
             use_logical_path: true,
             prefix: "in ",
             style: Color::Cyan.bold(),


### PR DESCRIPTION
Hello, this is my first real piece of rust code, so any tips are greatly appreciated! I left some review comments myself.

#### Description
This adds an option to provide a list of pairs of strings to substitute in the directory string. If this option is used, fish-style PWD is disabled.

The reason for fish-style PWD being disabled is an implementation detail -- I perform the `replace` on the `dir_string`, since it is a string type rather than a path type. To make this work with fish-style PWD would need more code, and IMO I don't see the need to use both features at once. Would definitely appreciate more input here.

#### Motivation and Context
I'm currently using this at work to shorten paths that have a long common prefix, interesting middle, and some long development directories. It's a more tailored way of shortening paths while retaining more information than, say the fish-style.
Closes #1065.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### How Has This Been Tested?
Added a unit test and two "testsuite" tests. They test the interaction with `truncation_length` and (non-)interaction with `fish_style_pwd_dir_length`.

- [x] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
