### PR TITLE
refactor(cmd_duration): Use format strings

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -358,7 +358,7 @@ running `eval $(starship init $0)`, and then proceed as normal.
 
 ### Options
 
-| Variable            | Default                       | Description                                                |
+| Option              | Default                       | Description                                                |
 | ------------------- | ----------------------------- | ---------------------------------------------------------- |
 | `min_time`          | `2_000`                       | Shortest duration to show time for (in milliseconds).      |
 | `show_milliseconds` | `false`                       | Show milliseconds in addition to seconds for the duration. |

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -358,13 +358,20 @@ running `eval $(starship init $0)`, and then proceed as normal.
 
 ### Options
 
-| Variable            | Default         | Description                                                |
-| ------------------- | --------------- | ---------------------------------------------------------- |
-| `min_time`          | `2_000`         | Shortest duration to show time for (in milliseconds).      |
-| `show_milliseconds` | `false`         | Show milliseconds in addition to seconds for the duration. |
-| `prefix`            | `took`          | Prefix to display immediately before the command duration. |
-| `style`             | `"bold yellow"` | The style for the module.                                  |
-| `disabled`          | `false`         | Disables the `cmd_duration` module.                        |
+| Variable            | Default                       | Description                                                |
+| ------------------- | ----------------------------- | ---------------------------------------------------------- |
+| `min_time`          | `2_000`                       | Shortest duration to show time for (in milliseconds).      |
+| `show_milliseconds` | `false`                       | Show milliseconds in addition to seconds for the duration. |
+| `format`            | `"took [$duration]($style) "` | The format for the module.                                 |
+| `style`             | `"bold yellow"`               | The style for the module.                                  |
+| `disabled`          | `false`                       | Disables the `cmd_duration` module.                        |
+
+### Variables
+
+| Variable | Example  | Description                             |
+| -------- | -------- | --------------------------------------- |
+| duration | `16m40s` | The time it took to execute the command |
+| style\*  |          | Mirrors the value of option `style`     |
 
 ### Example
 
@@ -373,7 +380,7 @@ running `eval $(starship init $0)`, and then proceed as normal.
 
 [cmd_duration]
 min_time = 500
-prefix = "underwent "
+format = "underwent [$duration](bold yellow)"
 ```
 
 ## Conda

--- a/src/configs/cmd_duration.rs
+++ b/src/configs/cmd_duration.rs
@@ -1,13 +1,12 @@
 use crate::config::{ModuleConfig, RootModuleConfig};
 
-use ansi_term::{Color, Style};
 use starship_module_config_derive::ModuleConfig;
 
 #[derive(Clone, ModuleConfig)]
 pub struct CmdDurationConfig<'a> {
     pub min_time: i64,
-    pub prefix: &'a str,
-    pub style: Style,
+    pub format: &'a str,
+    pub style: &'a str,
     pub show_milliseconds: bool,
     pub disabled: bool,
 }
@@ -16,9 +15,9 @@ impl<'a> RootModuleConfig<'a> for CmdDurationConfig<'a> {
     fn new() -> Self {
         CmdDurationConfig {
             min_time: 2_000,
-            prefix: "took ",
+            format: "took [$duration]($style) ",
             show_milliseconds: false,
-            style: Color::Yellow.bold(),
+            style: "yellow bold",
             disabled: false,
         }
     }

--- a/src/modules/cmd_duration.rs
+++ b/src/modules/cmd_duration.rs
@@ -1,7 +1,7 @@
-use super::{Context, Module, SegmentConfig};
+use super::{Context, Module, RootModuleConfig};
 
-use crate::config::RootModuleConfig;
 use crate::configs::cmd_duration::CmdDurationConfig;
+use crate::formatter::StringFormatter;
 
 /// Outputs the time it took the last command to execute
 ///
@@ -35,12 +35,29 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         _ => config.style,
     };
 
-    module.set_style(module_color);
-    module.create_segment(
-        "cmd_duration",
-        &SegmentConfig::new(&render_time(elapsed, config.show_milliseconds)),
-    );
-    module.get_prefix().set_value(config.prefix);
+    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
+        formatter
+            .map_style(|variable| match variable {
+                "style" => Some(Ok(module_color)),
+                _ => None,
+            })
+            .map(|variable| match variable {
+                "duration" => Some(Ok(render_time(elapsed, config.show_milliseconds))),
+                _ => None,
+            })
+            .parse(None)
+    });
+
+    module.set_segments(match parsed {
+        Ok(segments) => segments,
+        Err(error) => {
+            log::warn!("Error in module `cmd_duration`: \n{}", error);
+            return None;
+        }
+    });
+
+    module.get_prefix().set_value("");
+    module.get_suffix().set_value("");
 
     Some(module)
 }

--- a/src/modules/cmd_duration.rs
+++ b/src/modules/cmd_duration.rs
@@ -28,17 +28,14 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         return None;
     }
 
-    let config_min = config.min_time as u128;
-
-    let module_color = match elapsed {
-        time if time < config_min => return None,
-        _ => config.style,
-    };
+    if elapsed < config.min_time as u128 {
+        return None;
+    }
 
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter
             .map_style(|variable| match variable {
-                "style" => Some(Ok(module_color)),
+                "style" => Some(Ok(config.style)),
                 _ => None,
             })
             .map(|variable| match variable {

--- a/tests/testsuite/cmd_duration.rs
+++ b/tests/testsuite/cmd_duration.rs
@@ -64,7 +64,7 @@ fn config_1s_duration_prefix_underwent() -> io::Result<()> {
     let output = common::render_module("cmd_duration")
         .use_config(toml::toml! {
             [cmd_duration]
-            prefix = "underwent "
+            format = "underwent [$duration]($style) "
         })
         .arg("--cmd-duration=1000")
         .output()?;
@@ -80,7 +80,7 @@ fn config_5s_duration_prefix_underwent() -> io::Result<()> {
     let output = common::render_module("cmd_duration")
         .use_config(toml::toml! {
             [cmd_duration]
-            prefix = "underwent "
+            format = "underwent [$duration]($style) "
         })
         .arg("--cmd-duration=5000")
         .output()?;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR deprecates `symbol` and `style` keys in the `cmd_duration` module to replace it with the `format` key instead.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to issue #1057

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):
![Screenshot-09-31-32-14-05-20](https://user-images.githubusercontent.com/47182955/81905951-be2df400-95c5-11ea-865d-f31dea092715.png)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
