### PR TITLE
refactor(kubernetes): Use format strings

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -956,12 +956,13 @@ The module will be shown if any of the following conditions are met:
 [julia]
 symbol = "∴ "
 ```
+
 ## Kubernetes
 
-Displays the current Kubernetes context name and, if set, the namespace from
-the kubeconfig file. The namespace needs to be set in the kubeconfig file, this
-can be done via `kubectl config set-context starship-cluster --namespace astronaut`. If the `$KUBECONFIG` env var is set the module will use that if
-not it will use the `~/.kube/config`.
+Displays the current Kubernetes context name and, if set, the namespace from the kubeconfig file
+otherwise it displays the `namespace_spaceholder` variable. The namespace needs to be set in the
+kubeconfig file, this can be done via `kubectl config set-context starship-cluster --namespace astronaut`.
+If the `$KUBECONFIG` env var is set the module will use that if not it will use the `~/.kube/config`.
 
 ::: tip
 
@@ -972,12 +973,25 @@ To enable it, set `disabled` to `false` in your configuration file.
 
 ### Options
 
-| Variable         | Default       | Description                                         |
-| ---------------- | ------------- | --------------------------------------------------- |
-| `symbol`         | `"☸ "`        | The symbol used before displaying the Cluster info. |
-| `context_aliases` |               | Table of context aliases to display                 |
-| `style`          | `"bold blue"` | The style for the module.                           |
-| `disabled`       | `true`        | Disables the `kubernetes` module                    |
+| Option                  | Default                                            | Description                                      |
+| ----------------------- | -------------------------------------------------- | ------------------------------------------------ |
+| `symbol`                | `"☸ "`                                             | A format string representing the symbol of Rust. |
+| `format`                | `"on [$symbol$context \\($namespace\\)]($style) "` | The format for the module.                       |
+| `style`                 | `"bold blue"`                                      | The style for the module.                        |
+| `namespace_spaceholder` | `none`                                             | The value to display if no namespace was found.  |
+| `context_aliases`       |                                                    | Table of context aliases to display.             |
+| `disabled`              | `true`                                             | Disables the `kubernetes` module.                |
+
+### Variables
+
+| Variable  | Example              | Description                                                                              |
+| --------- | -------------------- | ---------------------------------------------------------------------------------------- |
+| context   | `starship-cluster`   | The current kubernetes context                                                           |
+| namespace | `starship-namespace` | If set, the current kubernetes namespace, otherwise the `namespace_spaceholder` variable |
+| symbol    |                      | Mirrors the value of option `symbol`                                                     |
+| style\*   |                      | Mirrors the value of option `style`                                                      |
+
+\*: This variable can only be used as a part of a style string
 
 ### Example
 
@@ -985,8 +999,7 @@ To enable it, set `disabled` to `false` in your configuration file.
 # ~/.config/starship.toml
 
 [kubernetes]
-symbol = "⛵ "
-style = "dimmed green"
+format = "on [⛵ $context \\($namespace\\)](dimmed green) "
 disabled = false
 [kubernetes.context_aliases]
 "dev.local.cluster.k8s" = "dev"

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -973,14 +973,14 @@ To enable it, set `disabled` to `false` in your configuration file.
 
 ### Options
 
-| Option                  | Default                                            | Description                                      |
-| ----------------------- | -------------------------------------------------- | ------------------------------------------------ |
-| `symbol`                | `"☸ "`                                             | A format string representing the symbol of Rust. |
-| `format`                | `"on [$symbol$context \\($namespace\\)]($style) "` | The format for the module.                       |
-| `style`                 | `"bold blue"`                                      | The style for the module.                        |
-| `namespace_spaceholder` | `none`                                             | The value to display if no namespace was found.  |
-| `context_aliases`       |                                                    | Table of context aliases to display.             |
-| `disabled`              | `true`                                             | Disables the `kubernetes` module.                |
+| Option                  | Default                                            | Description                                                           |
+| ----------------------- | -------------------------------------------------- | --------------------------------------------------------------------- |
+| `symbol`                | `"☸ "`                                             | A format string representing the symbol displayed before the Cluster. |
+| `format`                | `"on [$symbol$context \\($namespace\\)]($style) "` | The format for the module.                                            |
+| `style`                 | `"bold blue"`                                      | The style for the module.                                             |
+| `namespace_spaceholder` | `none`                                             | The value to display if no namespace was found.                       |
+| `context_aliases`       |                                                    | Table of context aliases to display.                                  |
+| `disabled`              | `true`                                             | Disables the `kubernetes` module.                                     |
 
 ### Variables
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -977,7 +977,7 @@ To enable it, set `disabled` to `false` in your configuration file.
 | ----------------------- | --------------------------------------------------- | --------------------------------------------------------------------- |
 | `symbol`                | `"☸ "`                                              | A format string representing the symbol displayed before the Cluster. |
 | `format`                | `"on [$symbol$context( \\($namespace\\))]($style) "` | The format for the module.                                            |
-| `style`                 | `"bold blue"`                                       | The style for the module.                                             |
+| `style`                 | `"cyan bold"`                                       | The style for the module.                                             |
 | `namespace_spaceholder` | `none`                                              | The value to display if no namespace was found.                       |
 | `context_aliases`       |                                                     | Table of context aliases to display.                                  |
 | `disabled`              | `true`                                              | Disables the `kubernetes` module.                                     |

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -959,9 +959,9 @@ symbol = "∴ "
 
 ## Kubernetes
 
-Displays the current Kubernetes context name and, if set, the namespace from the kubeconfig file
-otherwise it displays the `namespace_spaceholder` variable. The namespace needs to be set in the
-kubeconfig file, this can be done via `kubectl config set-context starship-cluster --namespace astronaut`.
+Displays the current Kubernetes context name and, if set, the namespace from the kubeconfig file.
+The namespace needs to be set in the kubeconfig file, this can be done via
+`kubectl config set-context starship-cluster --namespace astronaut`.
 If the `$KUBECONFIG` env var is set the module will use that if not it will use the `~/.kube/config`.
 
 ::: tip
@@ -973,23 +973,23 @@ To enable it, set `disabled` to `false` in your configuration file.
 
 ### Options
 
-| Option                  | Default                                            | Description                                                           |
-| ----------------------- | -------------------------------------------------- | --------------------------------------------------------------------- |
-| `symbol`                | `"☸ "`                                             | A format string representing the symbol displayed before the Cluster. |
-| `format`                | `"on [$symbol$context \\($namespace\\)]($style) "` | The format for the module.                                            |
-| `style`                 | `"bold blue"`                                      | The style for the module.                                             |
-| `namespace_spaceholder` | `none`                                             | The value to display if no namespace was found.                       |
-| `context_aliases`       |                                                    | Table of context aliases to display.                                  |
-| `disabled`              | `true`                                             | Disables the `kubernetes` module.                                     |
+| Option                  | Default                                             | Description                                                           |
+| ----------------------- | --------------------------------------------------- | --------------------------------------------------------------------- |
+| `symbol`                | `"☸ "`                                              | A format string representing the symbol displayed before the Cluster. |
+| `format`                | `"on [$symbol$context( \\($namespace\\))]($style) "` | The format for the module.                                            |
+| `style`                 | `"bold blue"`                                       | The style for the module.                                             |
+| `namespace_spaceholder` | `none`                                              | The value to display if no namespace was found.                       |
+| `context_aliases`       |                                                     | Table of context aliases to display.                                  |
+| `disabled`              | `true`                                              | Disables the `kubernetes` module.                                     |
 
 ### Variables
 
-| Variable  | Example              | Description                                                                              |
-| --------- | -------------------- | ---------------------------------------------------------------------------------------- |
-| context   | `starship-cluster`   | The current kubernetes context                                                           |
-| namespace | `starship-namespace` | If set, the current kubernetes namespace, otherwise the `namespace_spaceholder` variable |
-| symbol    |                      | Mirrors the value of option `symbol`                                                     |
-| style\*   |                      | Mirrors the value of option `style`                                                      |
+| Variable  | Example              | Description                              |
+| --------- | -------------------- | ---------------------------------------- |
+| context   | `starship-cluster`   | The current kubernetes context           |
+| namespace | `starship-namespace` | If set, the current kubernetes namespace |
+| symbol    |                      | Mirrors the value of option `symbol`     |
+| style\*   |                      | Mirrors the value of option `style`      |
 
 \*: This variable can only be used as a part of a style string
 

--- a/src/configs/kubernetes.rs
+++ b/src/configs/kubernetes.rs
@@ -1,27 +1,26 @@
-use crate::config::{ModuleConfig, RootModuleConfig, SegmentConfig};
+use crate::config::{ModuleConfig, RootModuleConfig};
 
-use ansi_term::{Color, Style};
 use starship_module_config_derive::ModuleConfig;
 use std::collections::HashMap;
 
 #[derive(Clone, ModuleConfig)]
 pub struct KubernetesConfig<'a> {
-    pub symbol: SegmentConfig<'a>,
-    pub context: SegmentConfig<'a>,
-    pub namespace: SegmentConfig<'a>,
-    pub style: Style,
+    pub symbol: &'a str,
+    pub format: &'a str,
+    pub style: &'a str,
     pub disabled: bool,
+    pub namespace_spaceholder: &'a str,
     pub context_aliases: HashMap<String, &'a str>,
 }
 
 impl<'a> RootModuleConfig<'a> for KubernetesConfig<'a> {
     fn new() -> Self {
         KubernetesConfig {
-            symbol: SegmentConfig::new("☸ "),
-            context: SegmentConfig::default(),
-            namespace: SegmentConfig::default(),
-            style: Color::Cyan.bold(),
+            symbol: "☸ ",
+            format: "on [$symbol$context \\($namespace\\)]($style) ",
+            style: "cyan bold",
             disabled: true,
+            namespace_spaceholder: "none",
             context_aliases: HashMap::new(),
         }
     }

--- a/src/configs/kubernetes.rs
+++ b/src/configs/kubernetes.rs
@@ -9,7 +9,6 @@ pub struct KubernetesConfig<'a> {
     pub format: &'a str,
     pub style: &'a str,
     pub disabled: bool,
-    pub namespace_spaceholder: &'a str,
     pub context_aliases: HashMap<String, &'a str>,
 }
 
@@ -17,10 +16,9 @@ impl<'a> RootModuleConfig<'a> for KubernetesConfig<'a> {
     fn new() -> Self {
         KubernetesConfig {
             symbol: "☸ ",
-            format: "on [$symbol$context \\($namespace\\)]($style) ",
+            format: "on [$symbol$context( \\($namespace\\))]($style) ",
             style: "cyan bold",
             disabled: true,
-            namespace_spaceholder: "none",
             context_aliases: HashMap::new(),
         }
     }

--- a/src/modules/kubernetes.rs
+++ b/src/modules/kubernetes.rs
@@ -6,9 +6,8 @@ use std::path;
 use super::{Context, Module, RootModuleConfig};
 
 use crate::configs::kubernetes::KubernetesConfig;
+use crate::formatter::StringFormatter;
 use crate::utils;
-
-const KUBERNETES_PREFIX: &str = "on ";
 
 fn get_kube_context(contents: &str) -> Option<(String, String)> {
     let yaml_docs = YamlLoader::load_from_str(&contents).ok()?;
@@ -63,23 +62,44 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 return None;
             };
 
-            module.set_style(config.style);
-            module.get_prefix().set_value(KUBERNETES_PREFIX);
+            let parsed = StringFormatter::new(config.format).and_then(|formatter| {
+                formatter
+                    .map_meta(|variable, _| match variable {
+                        "symbol" => Some(config.symbol),
+                        _ => None,
+                    })
+                    .map_style(|variable| match variable {
+                        "style" => Some(Ok(config.style)),
+                        _ => None,
+                    })
+                    .map(|variable| match variable {
+                        "context" => match config.context_aliases.get(&kube_ctx) {
+                            None => Some(Ok(kube_ctx.as_str())),
+                            Some(&alias) => Some(Ok(alias)),
+                        },
+                        _ => None,
+                    })
+                    .map(|variable| match variable {
+                        "namespace" => match kube_ns.as_str() {
+                            "" => Some(Ok(config.namespace_spaceholder)),
+                            _ => Some(Ok(kube_ns.as_str())),
+                        },
+                        _ => None,
+                    })
+                    .parse(None)
+            });
 
-            module.create_segment("symbol", &config.symbol);
+            module.set_segments(match parsed {
+                Ok(segments) => segments,
+                Err(error) => {
+                    log::warn!("Error in module `kubernetes`: \n{}", error);
+                    return None;
+                }
+            });
 
-            let displayed_context = match config.context_aliases.get(&kube_ctx) {
-                None => &kube_ctx,
-                Some(&alias) => alias,
-            };
+            module.get_prefix().set_value("");
+            module.get_suffix().set_value("");
 
-            module.create_segment("context", &config.context.with_value(&displayed_context));
-            if kube_ns != "" {
-                module.create_segment(
-                    "namespace",
-                    &config.namespace.with_value(&format!(" ({})", kube_ns)),
-                );
-            }
             Some(module)
         }
         None => None,

--- a/src/modules/kubernetes.rs
+++ b/src/modules/kubernetes.rs
@@ -80,10 +80,13 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                         _ => None,
                     })
                     .map(|variable| match variable {
-                        "namespace" => match kube_ns.as_str() {
-                            "" => Some(Ok(config.namespace_spaceholder)),
-                            _ => Some(Ok(kube_ns.as_str())),
-                        },
+                        "namespace" => {
+                            if kube_ns != "" {
+                                Some(Ok(kube_ns.as_str()))
+                            } else {
+                                None
+                            }
+                        }
                         _ => None,
                     })
                     .parse(None)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR deprecates `symbol` and `style` keys in the `kubernetes` module to replace it with the `format` key instead.

~~It also adds a new key named `namespace_spaceholder` which is displayed if no namespace was found.
This is required as with the new format strings it would generate this, if no namespace was found:~~
```
on ☸ test_context ()
```
~~This is a limitation with the new format strings API.
If somebody has a better idea how to handle this, let me know!~~
Just found #1138. It should now only render the namespace if it is set.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to issue #1057

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/47182955/81946511-ba1ec800-95ff-11ea-9d53-43abf94ea031.png)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
