### PR TITLE
refactor(docker_context): Use format strings

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -488,12 +488,23 @@ The `docker_context` module shows the currently active
 
 ### Options
 
-| Variable          | Default       | Description                                                                  |
-| ----------------- | ------------- | ---------------------------------------------------------------------------- |
-| `symbol`          | `"🐳 "`       | The symbol used before displaying the Docker context .                       |
-| `only_with_files` | `false`       | Only show when there's a `docker-compose.yml` or `Dockerfile` in the current directory. |
-| `style`           | `"bold blue"` | The style for the module.                                                    |
-| `disabled`        | `true`        | Disables the `docker_context` module.                                        |
+| Option            | Default                            | Description                                                                             |
+| ----------------- | ---------------------------------- | --------------------------------------------------------------------------------------- |
+| `format`          | `"via [$symbol$context]($style) "` | The format for the module.                                                              |
+| `symbol`          | `"🐳 "`                            | The symbol used before displaying the Docker context.                                   |
+| `style`           | `"blue bold"`                      | The style for the module.                                                               |
+| `only_with_files` | `false`                            | Only show when there's a `docker-compose.yml` or `Dockerfile` in the current directory. |
+| `disabled`        | `true`                             | Disables the `docker_context` module.                                                   |
+
+### Variables
+
+| Variable | Example        | Description                          |
+| -------- | -------------- | ------------------------------------ |
+| context  | `test_context` | The current docker context           |
+| symbol   |                | Mirrors the value of option `symbol` |
+| style\*  |                | Mirrors the value of option `style`  |
+
+\*: This variable can only be used as a part of a style string
 
 ### Example
 
@@ -501,7 +512,7 @@ The `docker_context` module shows the currently active
 # ~/.config/starship.toml
 
 [docker_context]
-symbol = "🐋 "
+format = "via [🐋 $context](blue bold)"
 ```
 
 ## Dotnet

--- a/src/configs/docker_context.rs
+++ b/src/configs/docker_context.rs
@@ -1,13 +1,12 @@
-use crate::config::{ModuleConfig, RootModuleConfig, SegmentConfig};
+use crate::config::{ModuleConfig, RootModuleConfig};
 
-use ansi_term::{Color, Style};
 use starship_module_config_derive::ModuleConfig;
 
 #[derive(Clone, ModuleConfig)]
 pub struct DockerContextConfig<'a> {
-    pub symbol: SegmentConfig<'a>,
-    pub context: SegmentConfig<'a>,
-    pub style: Style,
+    pub symbol: &'a str,
+    pub style: &'a str,
+    pub format: &'a str,
     pub only_with_files: bool,
     pub disabled: bool,
 }
@@ -15,9 +14,9 @@ pub struct DockerContextConfig<'a> {
 impl<'a> RootModuleConfig<'a> for DockerContextConfig<'a> {
     fn new() -> Self {
         DockerContextConfig {
-            symbol: SegmentConfig::new("🐳 "),
-            context: SegmentConfig::default(),
-            style: Color::Blue.bold(),
+            symbol: "🐳 ",
+            style: "blue bold",
+            format: "via [$symbol$context]($style) ",
             only_with_files: true,
             disabled: false,
         }

--- a/src/modules/docker_context.rs
+++ b/src/modules/docker_context.rs
@@ -1,16 +1,18 @@
 use dirs::home_dir;
+use std::env;
+use std::path::PathBuf;
 
 use super::{Context, Module, RootModuleConfig};
 
 use crate::configs::docker_context::DockerContextConfig;
+use crate::formatter::StringFormatter;
 use crate::utils;
-
-const DOCKER_CONFIG_FILE: &str = ".docker/config.json";
 
 /// Creates a module with the currently active Docker context
 ///
 /// Will display the Docker context if the following criteria are met:
 ///     - There is a file named `$HOME/.docker/config.json`
+///     - Or a file named `$DOCKER_CONFIG/config.json`
 ///     - The file is JSON and contains a field named `currentContext`
 ///     - The value of `currentContext` is not `default`
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
@@ -25,9 +27,16 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     {
         return None;
     }
+    let docker_config = PathBuf::from(
+        &env::var_os("DOCKER_CONFIG").unwrap_or(home_dir()?.join(".docker").into_os_string()),
+    )
+    .join("config.json");
 
-    let config_path = home_dir()?.join(DOCKER_CONFIG_FILE);
-    let json = utils::read_file(config_path).ok()?;
+    if !docker_config.exists() {
+        return None;
+    }
+
+    let json = utils::read_file(docker_config).ok()?;
     let parsed_json = serde_json::from_str(&json).ok()?;
 
     match parsed_json {
@@ -35,9 +44,34 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             let current_context = root.get("currentContext")?;
             match current_context {
                 serde_json::Value::String(ctx) => {
-                    module.set_style(config.style);
-                    module.create_segment("symbol", &config.symbol);
-                    module.create_segment("context", &config.context.with_value(&ctx));
+                    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
+                        formatter
+                            .map_meta(|variable, _| match variable {
+                                "symbol" => Some(config.symbol),
+                                _ => None,
+                            })
+                            .map_style(|variable| match variable {
+                                "style" => Some(Ok(config.style)),
+                                _ => None,
+                            })
+                            .map(|variable| match variable {
+                                "context" => Some(Ok(ctx)),
+                                _ => None,
+                            })
+                            .parse(None)
+                    });
+
+                    module.set_segments(match parsed {
+                        Ok(segments) => segments,
+                        Err(error) => {
+                            log::warn!("Error in module `docker_context`:\n{}", error);
+                            return None;
+                        }
+                    });
+
+                    module.get_prefix().set_value("");
+                    module.get_suffix().set_value("");
+
                     Some(module)
                 }
                 _ => None,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR deprecates `symbol` and `style` keys in the `docker_context` module to replace it with the `format` key instead.
It also now searches for the docker config file in two different location:
1. `$DOCKER_CONFIG/config.json`
2. `$HOME/.docker/config.json`

If `DOCKER_CONFIG` is not set it falls back to Option 2.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to issue #1057

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/47182955/82028356-cf463600-9695-11ea-9cb0-fc715f86fe30.png)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
