### PR TITLE
refactor(php): Use format strings

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1182,11 +1182,22 @@ The module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Variable   | Default      | Description                                           |
-| ---------- | ------------ | ----------------------------------------------------- |
-| `symbol`   | `"🐘 "`      | The symbol used before displaying the version of PHP. |
-| `style`    | `"bold red"` | The style for the module.                             |
-| `disabled` | `false`      | Disables the `php` module.                            |
+| Option     | Default                            | Description                                           |
+| ---------- | ---------------------------------- | ----------------------------------------------------- |
+| `format`   | `"via [$symbol$version]($style) "` | The format for the module.                            |
+| `symbol`   | `"🐘 "`                            | The symbol used before displaying the version of PHP. |
+| `style`    | `"147 bold"`                       | The style for the module.                             |
+| `disabled` | `false`                            | Disables the `php` module.                            |
+
+### Variables
+
+| Variable | Example  | Description                          |
+| -------- | -------- | ------------------------------------ |
+| version  | `v7.3.8` | The version of `php`                 |
+| symbol   |          | Mirrors the value of option `symbol` |
+| style\*  |          | Mirrors the value of option `style`  |
+
+\*: This variable can only be used as a part of a style string
 
 ### Example
 
@@ -1194,7 +1205,7 @@ The module will be shown if any of the following conditions are met:
 # ~/.config/starship.toml
 
 [php]
-symbol = "🔹 "
+format = "via [🔹 $version](147 bold) "
 ```
 
 ## Python

--- a/src/configs/php.rs
+++ b/src/configs/php.rs
@@ -1,20 +1,21 @@
-use crate::config::{ModuleConfig, RootModuleConfig, SegmentConfig};
+use crate::config::{ModuleConfig, RootModuleConfig};
 
-use ansi_term::{Color, Style};
 use starship_module_config_derive::ModuleConfig;
 
 #[derive(Clone, ModuleConfig)]
 pub struct PhpConfig<'a> {
-    pub symbol: SegmentConfig<'a>,
-    pub style: Style,
+    pub symbol: &'a str,
+    pub style: &'a str,
+    pub format: &'a str,
     pub disabled: bool,
 }
 
 impl<'a> RootModuleConfig<'a> for PhpConfig<'a> {
     fn new() -> Self {
         PhpConfig {
-            symbol: SegmentConfig::new("🐘 "),
-            style: Color::Fixed(147).bold(),
+            symbol: "🐘 ",
+            style: "147 bold",
+            format: "via [$symbol$version]($style) ",
             disabled: false,
         }
     }

--- a/src/modules/php.rs
+++ b/src/modules/php.rs
@@ -1,6 +1,7 @@
-use super::{Context, Module, RootModuleConfig, SegmentConfig};
+use super::{Context, Module, RootModuleConfig};
 
 use crate::configs::php::PhpConfig;
+use crate::formatter::StringFormatter;
 use crate::utils;
 
 /// Creates a module with the current PHP version
@@ -27,16 +28,35 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         ],
     ) {
         Some(php_cmd_output) => {
-            let php_version = php_cmd_output.stdout;
-
             let mut module = context.new_module("php");
             let config: PhpConfig = PhpConfig::try_load(module.config);
 
-            module.set_style(config.style);
+            let parsed = StringFormatter::new(config.format).and_then(|formatter| {
+                formatter
+                    .map_meta(|variable, _| match variable {
+                        "symbol" => Some(config.symbol),
+                        _ => None,
+                    })
+                    .map_style(|variable| match variable {
+                        "style" => Some(Ok(config.style)),
+                        _ => None,
+                    })
+                    .map(|variable| match variable {
+                        "version" => format_php_version(&php_cmd_output.stdout).map(Ok),
+                        _ => None,
+                    })
+                    .parse(None)
+            });
 
-            let formatted_version = format_php_version(&php_version)?;
-            module.create_segment("symbol", &config.symbol);
-            module.create_segment("version", &SegmentConfig::new(&formatted_version));
+            module.set_segments(match parsed {
+                Ok(segments) => segments,
+                Err(error) => {
+                    log::warn!("Error in module `php`:\n{}", error);
+                    return None;
+                }
+            });
+            module.get_prefix().set_value("");
+            module.get_suffix().set_value("");
 
             Some(module)
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR deprecates `symbol` and `style` keys in the `php` module to replace it with the `format` key instead.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to issue #1057

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/47182955/82033178-a7a69c00-969c-11ea-8dda-2abf770b9135.png)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
