### PR TITLE
refactor(git_commit): Use format strings

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -675,14 +675,22 @@ The `git_commit` module shows the current commit hash of the repo in your curren
 
 ### Options
 
-| Variable             | Default        | Description                                           |
-| -------------------- | -------------- | ----------------------------------------------------- |
-| `commit_hash_length` | `7`            | The length of the displayed git commit hash.          |
-| `prefix`             | `"("`          | Prefix to display immediately before git commit.      |
-| `suffix`             | `")"`          | Suffix to display immediately after git commit.       |
-| `style`              | `"bold green"` | The style for the module.                             |
-| `only_detached`      | `true`         | Only show git commit hash when in detached HEAD state |
-| `disabled`           | `false`        | Disables the `git_commit` module.                     |
+| Option               | Default                    | Description                                           |
+| -------------------- | -------------------------- | ----------------------------------------------------- |
+| `commit_hash_length` | `7`                        | The length of the displayed git commit hash.          |
+| `format`             | `"[\\($hash\\)]($style) "` | The format for the module.                            |
+| `style`              | `"bold green"`             | The style for the module.                             |
+| `only_detached`      | `true`                     | Only show git commit hash when in detached HEAD state |
+| `disabled`           | `false`                    | Disables the `git_commit` module.                     |
+
+### Variables
+
+| Variable | Example   | Description                          |
+| -------- | --------- | ------------------------------------ |
+| hash     | `b703eb3` | The current git commit hash          |
+| style\*  |           | Mirrors the value of option `style`  |
+
+\*: This variable can only be used as a part of a style string
 
 ### Example
 

--- a/src/configs/git_commit.rs
+++ b/src/configs/git_commit.rs
@@ -1,15 +1,12 @@
-use crate::config::{ModuleConfig, RootModuleConfig, SegmentConfig};
+use crate::config::{ModuleConfig, RootModuleConfig};
 
-use ansi_term::{Color, Style};
 use starship_module_config_derive::ModuleConfig;
 
 #[derive(Clone, ModuleConfig)]
 pub struct GitCommitConfig<'a> {
     pub commit_hash_length: usize,
-    pub hash: SegmentConfig<'a>,
-    pub prefix: &'a str,
-    pub suffix: &'a str,
-    pub style: Style,
+    pub format: &'a str,
+    pub style: &'a str,
     pub only_detached: bool,
     pub disabled: bool,
 }
@@ -19,10 +16,8 @@ impl<'a> RootModuleConfig<'a> for GitCommitConfig<'a> {
         GitCommitConfig {
             // be consistent with git by default, which has DEFAULT_ABBREV set to 7
             commit_hash_length: 7,
-            hash: SegmentConfig::default(),
-            prefix: "(",
-            suffix: ") ",
-            style: Color::Green.bold(),
+            format: "[\\($hash\\)]($style) ",
+            style: "green bold",
             only_detached: true,
             disabled: false,
         }

--- a/src/modules/git_commit.rs
+++ b/src/modules/git_commit.rs
@@ -2,23 +2,14 @@ use super::{Context, Module, RootModuleConfig};
 use git2::Repository;
 
 use crate::configs::git_commit::GitCommitConfig;
+use crate::formatter::StringFormatter;
 
 /// Creates a module with the Git commit in the current directory
 ///
 /// Will display the commit hash if the current directory is a git repo
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let mut module = context.new_module("git_commit");
-    let config = GitCommitConfig::try_load(module.config);
-
-    module
-        .get_prefix()
-        .set_value(config.prefix)
-        .set_style(config.style);
-    module
-        .get_suffix()
-        .set_value(config.suffix)
-        .set_style(config.style);
-    module.set_style(config.style);
+    let config: GitCommitConfig = GitCommitConfig::try_load(module.config);
 
     let repo = context.get_repo().ok()?;
     let repo_root = repo.root.as_ref()?;
@@ -32,13 +23,33 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let git_head = git_repo.head().ok()?;
     let head_commit = git_head.peel_to_commit().ok()?;
     let commit_oid = head_commit.id();
-    module.create_segment(
-        "hash",
-        &config.hash.with_value(&id_to_hex_abbrev(
-            commit_oid.as_bytes(),
-            config.commit_hash_length,
-        )),
-    );
+
+    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
+        formatter
+            .map_style(|variable| match variable {
+                "style" => Some(Ok(config.style)),
+                _ => None,
+            })
+            .map(|variable| match variable {
+                "hash" => Some(Ok(id_to_hex_abbrev(
+                    commit_oid.as_bytes(),
+                    config.commit_hash_length,
+                ))),
+                _ => None,
+            })
+            .parse(None)
+    });
+
+    module.set_segments(match parsed {
+        Ok(segments) => segments,
+        Err(error) => {
+            log::warn!("Error in module `git_commit`:\n{}", error);
+            return None;
+        }
+    });
+
+    module.get_prefix().set_value("");
+    module.get_suffix().set_value("");
 
     Some(module)
 }

--- a/tests/testsuite/git_commit.rs
+++ b/tests/testsuite/git_commit.rs
@@ -42,10 +42,11 @@ fn test_render_commit_hash() -> io::Result<()> {
         .output()?;
 
     let actual = String::from_utf8(output.stdout).unwrap();
-    let expected = Color::Green
+    let mut expected = Color::Green
         .bold()
-        .paint(format!("({}) ", expected_hash))
+        .paint(format!("({})", expected_hash))
         .to_string();
+    expected.push(' ');
 
     assert_eq!(expected, actual);
     remove_dir_all(repo_dir)
@@ -74,10 +75,11 @@ fn test_render_commit_hash_len_override() -> io::Result<()> {
         .output()?;
 
     let actual = String::from_utf8(output.stdout).unwrap();
-    let expected = Color::Green
+    let mut expected = Color::Green
         .bold()
-        .paint(format!("({}) ", expected_hash))
+        .paint(format!("({})", expected_hash))
         .to_string();
+    expected.push(' ');
 
     assert_eq!(expected, actual);
     remove_dir_all(repo_dir)
@@ -122,10 +124,11 @@ fn test_render_commit_hash_only_detached_on_detached() -> io::Result<()> {
 
     let actual = String::from_utf8(output.stdout).unwrap();
 
-    let expected = Color::Green
+    let mut expected = Color::Green
         .bold()
-        .paint(format!("({}) ", expected_hash))
+        .paint(format!("({})", expected_hash))
         .to_string();
+    expected.push(' ');
 
     assert_eq!(expected, actual);
     remove_dir_all(repo_dir)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR deprecates `prefix`, `suffix` and `style` keys in the `git_commit` module to replace it with the `format` key instead.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to issue #1057

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/47182955/82069907-48647e00-96d4-11ea-823c-108686091c89.png)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
