### PR TITLE
refactor(git_state): Use format strings

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -702,18 +702,29 @@ that information will be shown too.
 
 ### Options
 
-| Variable           | Default            | Description                                                                                                      |
-| ------------------ | ------------------ | ---------------------------------------------------------------------------------------------------------------- |
-| `rebase`           | `"REBASING"`       | The text displayed when a `rebase` is in progress.                                                               |
-| `merge`            | `"MERGING"`        | The text displayed when a `merge` is in progress.                                                                |
-| `revert`           | `"REVERTING"`      | The text displayed when a `revert` is in progress.                                                               |
-| `cherry_pick`      | `"CHERRY-PICKING"` | The text displayed when a `cherry-pick` is in progress.                                                          |
-| `bisect`           | `"BISECTING"`      | The text displayed when a `bisect` is in progress.                                                               |
-| `am`               | `"AM"`             | The text displayed when an `apply-mailbox` (`git am`) is in progress.                                            |
-| `am_or_rebase`     | `"AM/REBASE"`      | The text displayed when an ambiguous `apply-mailbox` or `rebase` is in progress.                                 |
-| `progress_divider` | `"/"`              | The symbol or text which will separate the current and total progress amounts. (e.g., `" of "`, for `"3 of 10"`) |
-| `style`            | `"bold yellow"`    | The style for the module.                                                                                        |
-| `disabled`         | `false`            | Disables the `git_state` module.                                                                                 |
+| Option         | Default                                                         | Description                                                                      |
+| -------------- | --------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `rebase`       | `"REBASING"`                                                    | The text displayed when a `rebase` is in progress.                               |
+| `merge`        | `"MERGING"`                                                     | The text displayed when a `merge` is in progress.                                |
+| `revert`       | `"REVERTING"`                                                   | The text displayed when a `revert` is in progress.                               |
+| `cherry_pick`  | `"CHERRY-PICKING"`                                              | The text displayed when a `cherry-pick` is in progress.                          |
+| `bisect`       | `"BISECTING"`                                                   | The text displayed when a `bisect` is in progress.                               |
+| `am`           | `"AM"`                                                          | The text displayed when an `apply-mailbox` (`git am`) is in progress.            |
+| `am_or_rebase` | `"AM/REBASE"`                                                   | The text displayed when an ambiguous `apply-mailbox` or `rebase` is in progress. |
+| `style`        | `"bold yellow"`                                                 | The style for the module.                                                        |
+| `format`       | `"[\\($state( $progress_current/$progress_total)\\)]($style) "` | The format for the module.                                                       |
+| `disabled`     | `false`                                                         | Disables the `git_state` module.                                                 |
+
+### Variables
+
+| Variable         | Example    | Description                         |
+| ---------------- | ---------- | ----------------------------------- |
+| state            | `REBASING` | The current state of the repo       |
+| progress_current | `1`        | The current operation progress      |
+| progress_total   | `2`        | The total operation progress        |
+| style\*          |            | Mirrors the value of option `style` |
+
+\*: This variable can only be used as a part of a style string
 
 ### Example
 
@@ -721,7 +732,7 @@ that information will be shown too.
 # ~/.config/starship.toml
 
 [git_state]
-progress_divider = " of "
+format = "[\\($state( $progress_current of $progress_total)\\)]($style) "
 cherry_pick = "🍒 PICKING"
 ```
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -702,18 +702,18 @@ that information will be shown too.
 
 ### Options
 
-| Option         | Default                                                         | Description                                                                      |
-| -------------- | --------------------------------------------------------------- | -------------------------------------------------------------------------------- |
-| `rebase`       | `"REBASING"`                                                    | The text displayed when a `rebase` is in progress.                               |
-| `merge`        | `"MERGING"`                                                     | The text displayed when a `merge` is in progress.                                |
-| `revert`       | `"REVERTING"`                                                   | The text displayed when a `revert` is in progress.                               |
-| `cherry_pick`  | `"CHERRY-PICKING"`                                              | The text displayed when a `cherry-pick` is in progress.                          |
-| `bisect`       | `"BISECTING"`                                                   | The text displayed when a `bisect` is in progress.                               |
-| `am`           | `"AM"`                                                          | The text displayed when an `apply-mailbox` (`git am`) is in progress.            |
-| `am_or_rebase` | `"AM/REBASE"`                                                   | The text displayed when an ambiguous `apply-mailbox` or `rebase` is in progress. |
-| `style`        | `"bold yellow"`                                                 | The style for the module.                                                        |
-| `format`       | `"[\\($state( $progress_current/$progress_total)\\)]($style) "` | The format for the module.                                                       |
-| `disabled`     | `false`                                                         | Disables the `git_state` module.                                                 |
+| Option         | Default                                                         | Description                                                                             |
+| -------------- | --------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| `rebase`       | `"REBASING"`                                                    | A format string displayed when a `rebase` is in progress.                               |
+| `merge`        | `"MERGING"`                                                     | A format string displayed when a `merge` is in progress.                                |
+| `revert`       | `"REVERTING"`                                                   | A format string displayed when a `revert` is in progress.                               |
+| `cherry_pick`  | `"CHERRY-PICKING"`                                              | A format string displayed when a `cherry-pick` is in progress.                          |
+| `bisect`       | `"BISECTING"`                                                   | A format string displayed when a `bisect` is in progress.                               |
+| `am`           | `"AM"`                                                          | A format string displayed when an `apply-mailbox` (`git am`) is in progress.            |
+| `am_or_rebase` | `"AM/REBASE"`                                                   | A format string displayed when an ambiguous `apply-mailbox` or `rebase` is in progress. |
+| `style`        | `"bold yellow"`                                                 | The style for the module.                                                               |
+| `format`       | `"[\\($state( $progress_current/$progress_total)\\)]($style) "` | The format for the module.                                                              |
+| `disabled`     | `false`                                                         | Disables the `git_state` module.                                                        |
 
 ### Variables
 
@@ -733,7 +733,7 @@ that information will be shown too.
 
 [git_state]
 format = "[\\($state( $progress_current of $progress_total)\\)]($style) "
-cherry_pick = "🍒 PICKING"
+cherry_pick = "[🍒 PICKING](bold red)"
 ```
 
 ## Git Status

--- a/src/configs/git_state.rs
+++ b/src/configs/git_state.rs
@@ -1,34 +1,33 @@
-use crate::config::{ModuleConfig, RootModuleConfig, SegmentConfig};
+use crate::config::{ModuleConfig, RootModuleConfig};
 
-use ansi_term::{Color, Style};
 use starship_module_config_derive::ModuleConfig;
 
 #[derive(Clone, ModuleConfig)]
 pub struct GitStateConfig<'a> {
-    pub rebase: SegmentConfig<'a>,
-    pub merge: SegmentConfig<'a>,
-    pub revert: SegmentConfig<'a>,
-    pub cherry_pick: SegmentConfig<'a>,
-    pub bisect: SegmentConfig<'a>,
-    pub am: SegmentConfig<'a>,
-    pub am_or_rebase: SegmentConfig<'a>,
-    pub progress_divider: SegmentConfig<'a>,
-    pub style: Style,
+    pub rebase: &'a str,
+    pub merge: &'a str,
+    pub revert: &'a str,
+    pub cherry_pick: &'a str,
+    pub bisect: &'a str,
+    pub am: &'a str,
+    pub am_or_rebase: &'a str,
+    pub style: &'a str,
+    pub format: &'a str,
     pub disabled: bool,
 }
 
 impl<'a> RootModuleConfig<'a> for GitStateConfig<'a> {
     fn new() -> Self {
         GitStateConfig {
-            rebase: SegmentConfig::new("REBASING"),
-            merge: SegmentConfig::new("MERGING"),
-            revert: SegmentConfig::new("REVERTING"),
-            cherry_pick: SegmentConfig::new("CHERRY-PICKING"),
-            bisect: SegmentConfig::new("BISECTING"),
-            am: SegmentConfig::new("AM"),
-            am_or_rebase: SegmentConfig::new("AM/REBASE"),
-            progress_divider: SegmentConfig::new("/"),
-            style: Color::Yellow.bold(),
+            rebase: "REBASING",
+            merge: "MERGING",
+            revert: "REVERTING",
+            cherry_pick: "CHERRY-PICKING",
+            bisect: "BISECTING",
+            am: "AM",
+            am_or_rebase: "AM/REBASE",
+            style: "bold yellow",
+            format: "[\\($state( $progress_current/$progress_total)\\)]($style) ",
             disabled: false,
         }
     }

--- a/src/modules/git_state.rs
+++ b/src/modules/git_state.rs
@@ -1,8 +1,9 @@
 use git2::RepositoryState;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
-use super::{Context, Module, RootModuleConfig, SegmentConfig};
+use super::{Context, Module, RootModuleConfig};
 use crate::configs::git_state::GitStateConfig;
+use crate::formatter::StringFormatter;
 
 /// Creates a module with the state of the git repository at the current directory
 ///
@@ -12,37 +13,43 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let mut module = context.new_module("git_state");
     let config: GitStateConfig = GitStateConfig::try_load(module.config);
 
-    module.set_style(config.style);
-    module.get_prefix().set_value("(");
-    module.get_suffix().set_value(") ");
-
     let repo = context.get_repo().ok()?;
     let repo_root = repo.root.as_ref()?;
     let repo_state = repo.state?;
 
-    let state_description = get_state_description(repo_state, repo_root, config);
+    let state_description = get_state_description(repo_state, repo_root, &config)?;
 
-    let label = match &state_description {
-        StateDescription::Label(label) => label,
-        StateDescription::LabelAndProgress(label, _) => label,
-        StateDescription::Clean => {
+    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
+        formatter
+            .map_style(|variable| match variable {
+                "style" => Some(Ok(config.style)),
+                _ => None,
+            })
+            .map(|variable| match variable {
+                "state" => Some(Ok(state_description.label)),
+                _ => None,
+            })
+            .map(|variable| match variable {
+                "progress_current" => state_description.current.as_ref().map(Ok),
+                _ => None,
+            })
+            .map(|variable| match variable {
+                "progress_total" => state_description.total.as_ref().map(Ok),
+                _ => None,
+            })
+            .parse(None)
+    });
+
+    module.set_segments(match parsed {
+        Ok(segments) => segments,
+        Err(error) => {
+            log::warn!("Error in module `git_state`:\n{}", error);
             return None;
         }
-    };
+    });
 
-    module.create_segment(label.name, &label.segment);
-
-    if let StateDescription::LabelAndProgress(_, progress) = &state_description {
-        module.create_segment(
-            "progress_current",
-            &SegmentConfig::new(&format!(" {}", progress.current)),
-        );
-        module.create_segment("progress_divider", &SegmentConfig::new("/"));
-        module.create_segment(
-            "progress_total",
-            &SegmentConfig::new(&format!("{}", progress.total)),
-        );
-    }
+    module.get_prefix().set_value("");
+    module.get_suffix().set_value("");
 
     Some(module)
 }
@@ -53,40 +60,57 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 fn get_state_description<'a>(
     state: RepositoryState,
     root: &'a std::path::PathBuf,
-    config: GitStateConfig<'a>,
-) -> StateDescription<'a> {
+    config: &GitStateConfig<'a>,
+) -> Option<StateDescription<'a>> {
     match state {
-        RepositoryState::Clean => StateDescription::Clean,
-        RepositoryState::Merge => StateDescription::Label(StateLabel::new("merge", config.merge)),
-        RepositoryState::Revert => {
-            StateDescription::Label(StateLabel::new("revert", config.revert))
-        }
-        RepositoryState::RevertSequence => {
-            StateDescription::Label(StateLabel::new("revert", config.revert))
-        }
-        RepositoryState::CherryPick => {
-            StateDescription::Label(StateLabel::new("cherry_pick", config.cherry_pick))
-        }
-        RepositoryState::CherryPickSequence => {
-            StateDescription::Label(StateLabel::new("cherry_pick", config.cherry_pick))
-        }
-        RepositoryState::Bisect => {
-            StateDescription::Label(StateLabel::new("bisect", config.bisect))
-        }
-        RepositoryState::ApplyMailbox => StateDescription::Label(StateLabel::new("am", config.am)),
-        RepositoryState::ApplyMailboxOrRebase => {
-            StateDescription::Label(StateLabel::new("am_or_rebase", config.am_or_rebase))
-        }
-        RepositoryState::Rebase => describe_rebase(root, config.rebase),
-        RepositoryState::RebaseInteractive => describe_rebase(root, config.rebase),
-        RepositoryState::RebaseMerge => describe_rebase(root, config.rebase),
+        RepositoryState::Clean => None,
+        RepositoryState::Merge => Some(StateDescription {
+            label: config.merge,
+            current: None,
+            total: None,
+        }),
+        RepositoryState::Revert => Some(StateDescription {
+            label: config.revert,
+            current: None,
+            total: None,
+        }),
+        RepositoryState::RevertSequence => Some(StateDescription {
+            label: config.revert,
+            current: None,
+            total: None,
+        }),
+        RepositoryState::CherryPick => Some(StateDescription {
+            label: config.cherry_pick,
+            current: None,
+            total: None,
+        }),
+        RepositoryState::CherryPickSequence => Some(StateDescription {
+            label: config.cherry_pick,
+            current: None,
+            total: None,
+        }),
+        RepositoryState::Bisect => Some(StateDescription {
+            label: config.bisect,
+            current: None,
+            total: None,
+        }),
+        RepositoryState::ApplyMailbox => Some(StateDescription {
+            label: config.am,
+            current: None,
+            total: None,
+        }),
+        RepositoryState::ApplyMailboxOrRebase => Some(StateDescription {
+            label: config.am_or_rebase,
+            current: None,
+            total: None,
+        }),
+        RepositoryState::Rebase => Some(describe_rebase(root, config.rebase)),
+        RepositoryState::RebaseInteractive => Some(describe_rebase(root, config.rebase)),
+        RepositoryState::RebaseMerge => Some(describe_rebase(root, config.rebase)),
     }
 }
 
-fn describe_rebase<'a>(
-    root: &'a PathBuf,
-    rebase_config: SegmentConfig<'a>,
-) -> StateDescription<'a> {
+fn describe_rebase<'a>(root: &'a PathBuf, rebase_config: &'a str) -> StateDescription<'a> {
     /*
      *  Sadly, libgit2 seems to have some issues with reading the state of
      *  interactive rebases. So, instead, we'll poke a few of the .git files
@@ -98,12 +122,12 @@ fn describe_rebase<'a>(
     let dot_git = root.join(".git");
 
     let has_path = |relative_path: &str| {
-        let path = dot_git.join(Path::new(relative_path));
+        let path = dot_git.join(PathBuf::from(relative_path));
         path.exists()
     };
 
     let file_to_usize = |relative_path: &str| {
-        let path = dot_git.join(Path::new(relative_path));
+        let path = dot_git.join(PathBuf::from(relative_path));
         let contents = crate::utils::read_file(path).ok()?;
         let quantity = contents.trim().parse::<usize>().ok()?;
         Some(quantity)
@@ -112,7 +136,7 @@ fn describe_rebase<'a>(
     let paths_to_progress = |current_path: &str, total_path: &str| {
         let current = file_to_usize(current_path)?;
         let total = file_to_usize(total_path)?;
-        Some(StateProgress { current, total })
+        Some((current, total))
     };
 
     let progress = if has_path("rebase-merge") {
@@ -123,32 +147,15 @@ fn describe_rebase<'a>(
         None
     };
 
-    match progress {
-        None => StateDescription::Label(StateLabel::new("rebase", rebase_config)),
-        Some(progress) => {
-            StateDescription::LabelAndProgress(StateLabel::new("rebase", rebase_config), progress)
-        }
+    StateDescription {
+        label: rebase_config,
+        current: Some(format!("{}", progress.unwrap().0)),
+        total: Some(format!("{}", progress.unwrap().1)),
     }
 }
 
-enum StateDescription<'a> {
-    Clean,
-    Label(StateLabel<'a>),
-    LabelAndProgress(StateLabel<'a>, StateProgress),
-}
-
-struct StateLabel<'a> {
-    name: &'static str,
-    segment: SegmentConfig<'a>,
-}
-
-struct StateProgress {
-    current: usize,
-    total: usize,
-}
-
-impl<'a> StateLabel<'a> {
-    fn new(name: &'static str, segment: SegmentConfig<'a>) -> Self {
-        Self { name, segment }
-    }
+struct StateDescription<'a> {
+    label: &'a str,
+    current: Option<String>,
+    total: Option<String>,
 }

--- a/src/modules/git_state.rs
+++ b/src/modules/git_state.rs
@@ -31,9 +31,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             })
             .map(|variable| match variable {
                 "progress_current" => state_description.current.as_ref().map(Ok),
-                _ => None,
-            })
-            .map(|variable| match variable {
                 "progress_total" => state_description.total.as_ref().map(Ok),
                 _ => None,
             })

--- a/src/modules/git_state.rs
+++ b/src/modules/git_state.rs
@@ -21,12 +21,12 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter
-            .map_style(|variable| match variable {
-                "style" => Some(Ok(config.style)),
+            .map_meta(|variable, _| match variable {
+                "state" => Some(state_description.label),
                 _ => None,
             })
-            .map(|variable| match variable {
-                "state" => Some(Ok(state_description.label)),
+            .map_style(|variable| match variable {
+                "style" => Some(Ok(config.style)),
                 _ => None,
             })
             .map(|variable| match variable {

--- a/tests/testsuite/git_state.rs
+++ b/tests/testsuite/git_state.rs
@@ -1,4 +1,5 @@
 use super::common;
+use ansi_term::Color;
 use std::ffi::OsStr;
 use std::fs::OpenOptions;
 use std::io::{self, Error, ErrorKind, Write};
@@ -20,7 +21,6 @@ fn show_nothing_on_empty_dir() -> io::Result<()> {
 }
 
 #[test]
-#[ignore]
 fn shows_rebasing() -> io::Result<()> {
     let repo_dir = create_repo_with_conflict()?;
     let path = path_str(&repo_dir)?;
@@ -28,16 +28,21 @@ fn shows_rebasing() -> io::Result<()> {
     run_git_cmd(&["rebase", "other-branch"], Some(path), false)?;
 
     let output = common::render_module("git_state")
-        .current_dir(path)
+        .arg("--path")
+        .arg(&path)
         .output()?;
-    let text = String::from_utf8(output.stdout).unwrap();
-    assert!(text.contains("REBASING 1/1"));
+
+    let actual = String::from_utf8(output.stdout).unwrap();
+
+    let mut expected = Color::Yellow.bold().paint("(REBASING 1/1)").to_string();
+    expected.push(' ');
+
+    assert_eq!(expected, actual);
 
     Ok(())
 }
 
 #[test]
-#[ignore]
 fn shows_merging() -> io::Result<()> {
     let repo_dir = create_repo_with_conflict()?;
     let path = path_str(&repo_dir)?;
@@ -45,16 +50,21 @@ fn shows_merging() -> io::Result<()> {
     run_git_cmd(&["merge", "other-branch"], Some(path), false)?;
 
     let output = common::render_module("git_state")
-        .current_dir(path)
+        .arg("--path")
+        .arg(&path)
         .output()?;
-    let text = String::from_utf8(output.stdout).unwrap();
-    assert!(text.contains("MERGING"));
+
+    let actual = String::from_utf8(output.stdout).unwrap();
+
+    let mut expected = Color::Yellow.bold().paint("(MERGING)").to_string();
+    expected.push(' ');
+
+    assert_eq!(expected, actual);
 
     Ok(())
 }
 
 #[test]
-#[ignore]
 fn shows_cherry_picking() -> io::Result<()> {
     let repo_dir = create_repo_with_conflict()?;
     let path = path_str(&repo_dir)?;
@@ -62,16 +72,21 @@ fn shows_cherry_picking() -> io::Result<()> {
     run_git_cmd(&["cherry-pick", "other-branch"], Some(path), false)?;
 
     let output = common::render_module("git_state")
-        .current_dir(path)
+        .arg("--path")
+        .arg(&path)
         .output()?;
-    let text = String::from_utf8(output.stdout).unwrap();
-    assert!(text.contains("CHERRY-PICKING"));
+
+    let actual = String::from_utf8(output.stdout).unwrap();
+
+    let mut expected = Color::Yellow.bold().paint("(CHERRY-PICKING)").to_string();
+    expected.push(' ');
+
+    assert_eq!(expected, actual);
 
     Ok(())
 }
 
 #[test]
-#[ignore]
 fn shows_bisecting() -> io::Result<()> {
     let repo_dir = create_repo_with_conflict()?;
     let path = path_str(&repo_dir)?;
@@ -79,16 +94,21 @@ fn shows_bisecting() -> io::Result<()> {
     run_git_cmd(&["bisect", "start"], Some(path), false)?;
 
     let output = common::render_module("git_state")
-        .current_dir(path)
+        .arg("--path")
+        .arg(&path)
         .output()?;
-    let text = String::from_utf8(output.stdout).unwrap();
-    assert!(text.contains("BISECTING"));
+
+    let actual = String::from_utf8(output.stdout).unwrap();
+
+    let mut expected = Color::Yellow.bold().paint("(BISECTING)").to_string();
+    expected.push(' ');
+
+    assert_eq!(expected, actual);
 
     Ok(())
 }
 
 #[test]
-#[ignore]
 fn shows_reverting() -> io::Result<()> {
     let repo_dir = create_repo_with_conflict()?;
     let path = path_str(&repo_dir)?;
@@ -96,11 +116,16 @@ fn shows_reverting() -> io::Result<()> {
     run_git_cmd(&["revert", "--no-commit", "HEAD~1"], Some(path), false)?;
 
     let output = common::render_module("git_state")
-        .current_dir(path)
+        .arg("--path")
+        .arg(&path)
         .output()?;
-    let text = String::from_utf8(output.stdout).unwrap();
-    assert!(text.contains("REVERTING"));
 
+    let actual = String::from_utf8(output.stdout).unwrap();
+
+    let mut expected = Color::Yellow.bold().paint("(REVERTING)").to_string();
+    expected.push(' ');
+
+    assert_eq!(expected, actual);
     Ok(())
 }
 
@@ -143,7 +168,7 @@ fn create_repo_with_conflict() -> io::Result<tempfile::TempDir> {
         write!(file, "{}", text)
     };
 
-    // Initialise a new git repo
+    // Initialize a new git repo
     run_git_cmd(&["init", "--quiet", path], None, true)?;
 
     // Set local author info


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR deprecates `progress_divider` and `style` keys in the `git_state` module to replace it with the `format` key instead.
It also enables the test that were ignored before.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to issue #1057

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/47182955/82117745-a5af0c80-9772-11ea-8ffa-1ff98cb35f86.png)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
