### PR TITLE
refactor(conda): Use format strings

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -389,12 +389,23 @@ This does not suppress conda's own prompt modifier, you may want to run `conda c
 
 ### Options
 
-| Variable            | Default        | Description                                                                                                                                                                                                 |
-| ------------------- | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `truncation_length` | `1`            | The number of directories the environment path should be truncated to, if the environment was created via `conda create -p [path]`. `0` means no truncation. Also see the [`directory`](#directory) module. |
-| `symbol`            | `"C "`         | The symbol used before the environment name.                                                                                                                                                                |
-| `style`             | `"bold green"` | The style for the module.                                                                                                                                                                                   |
-| `disabled`          | `false`        | Disables the `conda` module.                                                                                                                                                                                |
+| Option              | Default                            | Description                                                                                                                                                                                                 |
+| ------------------- | ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `truncation_length` | `1`                                | The number of directories the environment path should be truncated to, if the environment was created via `conda create -p [path]`. `0` means no truncation. Also see the [`directory`](#directory) module. |
+| `symbol`            | `"🅒 "`                             | The symbol used before the environment name.                                                                                                                                                                |
+| `style`             | `"bold green"`                     | The style for the module.                                                                                                                                                                                   |
+| `format`            | `"[$symbol$environment]($style) "` | The format for the module.                                                                                                                                                                                   |
+| `disabled`          | `false`                            | Disables the `conda` module.                                                                                                                                                                                |
+
+### Variables
+
+| Variable    | Example      | Description                          |
+| ----------- | ------------ | ------------------------------------ |
+| environment | `astronauts` | The current conda environment        |
+| symbol      |              | Mirrors the value of option `symbol` |
+| style\*     |              | Mirrors the value of option `style`  |
+
+\*: This variable can only be used as a part of a style string
 
 ### Example
 
@@ -402,7 +413,7 @@ This does not suppress conda's own prompt modifier, you may want to run `conda c
 # ~/.config/starship.toml
 
 [conda]
-style = "dimmed green"
+format = "[$symbol$environment](dimmed green) "
 ```
 
 ## Crystal

--- a/src/configs/conda.rs
+++ b/src/configs/conda.rs
@@ -1,14 +1,13 @@
-use crate::config::{ModuleConfig, RootModuleConfig, SegmentConfig};
+use crate::config::{ModuleConfig, RootModuleConfig};
 
-use ansi_term::{Color, Style};
 use starship_module_config_derive::ModuleConfig;
 
 #[derive(Clone, ModuleConfig)]
 pub struct CondaConfig<'a> {
     pub truncation_length: usize,
-    pub symbol: SegmentConfig<'a>,
-    pub environment: SegmentConfig<'a>,
-    pub style: Style,
+    pub format: &'a str,
+    pub symbol: &'a str,
+    pub style: &'a str,
     pub disabled: bool,
 }
 
@@ -16,15 +15,9 @@ impl<'a> RootModuleConfig<'a> for CondaConfig<'a> {
     fn new() -> Self {
         CondaConfig {
             truncation_length: 1,
-            symbol: SegmentConfig {
-                value: "C ",
-                style: None,
-            },
-            environment: SegmentConfig {
-                value: "",
-                style: None,
-            },
-            style: Color::Green.bold(),
+            format: "via [$symbol$environment]($style) ",
+            symbol: "🅒 ",
+            style: "green bold",
             disabled: false,
         }
     }

--- a/src/modules/conda.rs
+++ b/src/modules/conda.rs
@@ -1,10 +1,10 @@
 use std::env;
 
-use super::{Context, Module};
+use super::{Context, Module, RootModuleConfig};
 
 use super::utils::directory::truncate;
-use crate::config::RootModuleConfig;
 use crate::configs::conda::CondaConfig;
+use crate::formatter::StringFormatter;
 
 /// Creates a module with the current Conda environment
 ///
@@ -17,14 +17,37 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     }
 
     let mut module = context.new_module("conda");
-    let config = CondaConfig::try_load(module.config);
+    let config: CondaConfig = CondaConfig::try_load(module.config);
 
     let conda_env = truncate(conda_env, config.truncation_length);
 
-    module.set_style(config.style);
+    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
+        formatter
+            .map_meta(|variable, _| match variable {
+                "symbol" => Some(config.symbol),
+                _ => None,
+            })
+            .map_style(|variable| match variable {
+                "style" => Some(Ok(config.style)),
+                _ => None,
+            })
+            .map(|variable| match variable {
+                "environment" => Some(Ok(conda_env.as_str())),
+                _ => None,
+            })
+            .parse(None)
+    });
 
-    module.create_segment("symbol", &config.symbol);
-    module.create_segment("environment", &config.environment.with_value(&conda_env));
+    module.set_segments(match parsed {
+        Ok(segments) => segments,
+        Err(error) => {
+            log::warn!("Error in module `conda`:\n{}", error);
+            return None;
+        }
+    });
+
+    module.get_prefix().set_value("");
+    module.get_suffix().set_value("");
 
     Some(module)
 }

--- a/tests/testsuite/conda.rs
+++ b/tests/testsuite/conda.rs
@@ -2,15 +2,10 @@ use ansi_term::Color;
 use std::io;
 
 use crate::common;
-use crate::common::TestCommand;
 
 #[test]
 fn not_in_env() -> io::Result<()> {
-    let output = common::render_module("conda")
-        .env_clear()
-        .env("PATH", env!("PATH"))
-        .use_config("".parse().unwrap())
-        .output()?;
+    let output = common::render_module("conda").output()?;
 
     let expected = "";
     let actual = String::from_utf8(output.stdout).unwrap();
@@ -22,12 +17,10 @@ fn not_in_env() -> io::Result<()> {
 #[test]
 fn env_set() -> io::Result<()> {
     let output = common::render_module("conda")
-        .env_clear()
         .env("CONDA_DEFAULT_ENV", "astronauts")
-        .use_config("".parse().unwrap())
         .output()?;
 
-    let expected = format!("via {} ", Color::Green.bold().paint("C astronauts"));
+    let expected = format!("via {} ", Color::Green.bold().paint("🅒 astronauts"));
     let actual = String::from_utf8(output.stdout).unwrap();
 
     assert_eq!(expected, actual);
@@ -37,12 +30,10 @@ fn env_set() -> io::Result<()> {
 #[test]
 fn truncate() -> io::Result<()> {
     let output = common::render_module("conda")
-        .env_clear()
-        .use_config("".parse().unwrap())
         .env("CONDA_DEFAULT_ENV", "/some/really/long/and/really/annoying/path/that/shouldnt/be/displayed/fully/conda/my_env")
         .output()?;
 
-    let expected = format!("via {} ", Color::Green.bold().paint("C my_env"));
+    let expected = format!("via {} ", Color::Green.bold().paint("🅒 my_env"));
     let actual = String::from_utf8(output.stdout).unwrap();
 
     assert_eq!(expected, actual);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR deprecates `symbol` and `style` keys in the `conda` module to replace it with the `format` key instead.
It also changes the default symbol to the reference implementation.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to issue #1057

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/47182955/82127230-3527e000-97b2-11ea-9888-b49adc862efe.png)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
