### PR TITLE
refactor(hg_branch): Use format strings

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1139,13 +1139,24 @@ The `hg_branch` module shows the active branch of the repo in your current direc
 
 ### Options
 
-| Variable            | Default         | Description                                                                                  |
-| ------------------- | --------------- | -------------------------------------------------------------------------------------------- |
-| `symbol`            | `" "`          | The symbol used before the hg bookmark or branch name of the repo in your current directory. |
-| `truncation_length` | `2^63 - 1`      | Truncates the hg branch name to X graphemes                                                  |
-| `truncation_symbol` | `"…"`           | The symbol used to indicate a branch name was truncated.                                     |
-| `style`             | `"bold purple"` | The style for the module.                                                                    |
-| `disabled`          | `true`          | Disables the `hg_branch` module.                                                             |
+| Option              | Default                          | Description                                                                                  |
+| ------------------- | -------------------------------- | -------------------------------------------------------------------------------------------- |
+| `symbol`            | `" "`                           | The symbol used before the hg bookmark or branch name of the repo in your current directory. |
+| `style`             | `"bold purple"`                  | The style for the module.                                                                    |
+| `format`            | `"on [$symbol$branch]($style) "` | The format for the module.                                                                   |
+| `truncation_length` | `2^63 - 1`                       | Truncates the hg branch name to X graphemes                                                  |
+| `truncation_symbol` | `"…"`                            | The symbol used to indicate a branch name was truncated.                                     |
+| `disabled`          | `true`                           | Disables the `hg_branch` module.                                                             |
+
+### Variables
+
+| Variable | Example  | Description                          |
+| -------- | -------- | ------------------------------------ |
+| branch   | `master` | The active mercurial branch          |
+| symbol   |          | Mirrors the value of option `symbol` |
+| style\*  |          | Mirrors the value of option `style`  |
+
+\*: This variable can only be used as a part of a style string
 
 ### Example
 
@@ -1153,7 +1164,7 @@ The `hg_branch` module shows the active branch of the repo in your current direc
 # ~/.config/starship.toml
 
 [hg_branch]
-symbol = "🌱 "
+format = "on [🌱 $branch](bold purple)"
 truncation_length = 4
 truncation_symbol = ""
 ```

--- a/src/configs/hg_branch.rs
+++ b/src/configs/hg_branch.rs
@@ -1,26 +1,25 @@
-use crate::config::{ModuleConfig, RootModuleConfig, SegmentConfig};
+use crate::config::{ModuleConfig, RootModuleConfig};
 
-use ansi_term::{Color, Style};
 use starship_module_config_derive::ModuleConfig;
 
 #[derive(Clone, ModuleConfig)]
 pub struct HgBranchConfig<'a> {
-    pub symbol: SegmentConfig<'a>,
+    pub symbol: &'a str,
+    pub style: &'a str,
+    pub format: &'a str,
     pub truncation_length: i64,
     pub truncation_symbol: &'a str,
-    pub branch_name: SegmentConfig<'a>,
-    pub style: Style,
     pub disabled: bool,
 }
 
 impl<'a> RootModuleConfig<'a> for HgBranchConfig<'a> {
     fn new() -> Self {
         HgBranchConfig {
-            symbol: SegmentConfig::new(" "),
+            symbol: " ",
+            style: "bold purple",
+            format: "on [$symbol$branch]($style) ",
             truncation_length: std::i64::MAX,
             truncation_symbol: "…",
-            branch_name: SegmentConfig::default(),
-            style: Color::Purple.bold(),
             disabled: true,
         }
     }

--- a/src/modules/hg_branch.rs
+++ b/src/modules/hg_branch.rs
@@ -3,6 +3,7 @@ use unicode_segmentation::UnicodeSegmentation;
 use super::{Context, Module, RootModuleConfig};
 
 use crate::configs::hg_branch::HgBranchConfig;
+use crate::formatter::StringFormatter;
 
 /// Creates a module with the Hg bookmark or branch in the current directory
 ///
@@ -15,12 +16,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     }
 
     let mut module = context.new_module("hg_branch");
-    let config = HgBranchConfig::try_load(module.config);
-    module.set_style(config.style);
-
-    module.get_prefix().set_value("on ");
-
-    module.create_segment("symbol", &config.symbol);
+    let config: HgBranchConfig = HgBranchConfig::try_load(module.config);
 
     // TODO: Once error handling is implemented, warn the user if their config
     // truncation length is nonsensical
@@ -46,10 +42,33 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         truncated_graphemes
     };
 
-    module.create_segment(
-        "name",
-        &config.branch_name.with_value(&truncated_and_symbol),
-    );
+    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
+        formatter
+            .map_meta(|variable, _| match variable {
+                "symbol" => Some(config.symbol),
+                _ => None,
+            })
+            .map_style(|variable| match variable {
+                "style" => Some(Ok(config.style)),
+                _ => None,
+            })
+            .map(|variable| match variable {
+                "branch" => Some(Ok(truncated_and_symbol.as_str())),
+                _ => None,
+            })
+            .parse(None)
+    });
+
+    module.set_segments(match parsed {
+        Ok(segments) => segments,
+        Err(error) => {
+            log::warn!("Error in module `hg_branch`:\n{}", error);
+            return None;
+        }
+    });
+
+    module.get_prefix().set_value("");
+    module.get_suffix().set_value("");
 
     Some(module)
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR deprecates `symbol` and `style` keys in the `hg_branch` module to replace it with the `format` key instead.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to issue #1057

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
