### PR TITLE
refactor(nix_shell): Use format strings 

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1160,14 +1160,25 @@ The module will be shown when inside a nix-shell environment.
 
 ### Options
 
-| Variable     | Default       | Description                                       |
-| ------------ | ------------- | ------------------------------------------------- |
-| `use_name`   | `false`       | Display the name of the nix-shell.                |
-| `impure_msg` | `"impure"`    | Customize the "impure" msg.                       |
-| `pure_msg`   | `"pure"`      | Customize the "pure" msg.                         |
-| `symbol`     | `"❄️  "`       | The symbol used before displaying the shell name. |
-| `style`      | `"bold blue"` | The style for the module.                         |
-| `disabled`   | `false`       | Disables the `nix_shell` module.                  |
+| Option       | Default                                        | Description                                           |
+| ------------ | ---------------------------------------------- | ----------------------------------------------------- |
+| `format`     | `"via [$symbol$state( \\($name\\))]($style) "` | The format for the module.                            |
+| `symbol`     | `"❄️  "`                                       | A format string representing the symbol of nix-shell. |
+| `style`      | `"bold blue"`                                  | The style for the module.                             |
+| `impure_msg` | `"impure"`                                     | A format string shown when the shell is impure.       |
+| `pure_msg`   | `"pure"`                                       | A format string shown when the shell is pure.         |
+| `disabled`   | `false`                                        | Disables the `nix_shell` module.                      |
+
+### Variables
+
+| Variable | Example | Description                          |
+| -------- | ------- | ------------------------------------ |
+| state    | `pure`  | The state of the nix-shell           |
+| name     | `lorri` | The name of the nix-shell            |
+| symbol   |         | Mirrors the value of option `symbol` |
+| style\*  |         | Mirrors the value of option `style`  |
+
+\*: This variable can only be used as a part of a style string
 
 ### Example
 
@@ -1176,10 +1187,9 @@ The module will be shown when inside a nix-shell environment.
 
 [nix_shell]
 disabled = true
-use_name = true
-impure_msg = "impure shell"
-pure_msg = "pure shell"
-symbol = "☃️  "
+impure_msg = "[impure shell](bold red)"
+pure_msg = "[pure shell](bold green)"
+format = "via [☃️ $state( \\($name\\))](bold blue) "
 ```
 
 ## NodeJS

--- a/src/configs/nix_shell.rs
+++ b/src/configs/nix_shell.rs
@@ -1,26 +1,25 @@
-use crate::config::{ModuleConfig, RootModuleConfig, SegmentConfig};
+use crate::config::{ModuleConfig, RootModuleConfig};
 
-use ansi_term::{Color, Style};
 use starship_module_config_derive::ModuleConfig;
 
 #[derive(Clone, ModuleConfig)]
 pub struct NixShellConfig<'a> {
-    pub use_name: bool,
-    pub impure_msg: SegmentConfig<'a>,
-    pub pure_msg: SegmentConfig<'a>,
-    pub style: Style,
-    pub symbol: SegmentConfig<'a>,
+    pub format: &'a str,
+    pub symbol: &'a str,
+    pub style: &'a str,
+    pub impure_msg: &'a str,
+    pub pure_msg: &'a str,
     pub disabled: bool,
 }
 
 impl<'a> RootModuleConfig<'a> for NixShellConfig<'a> {
     fn new() -> Self {
         NixShellConfig {
-            use_name: false,
-            impure_msg: SegmentConfig::new("impure"),
-            pure_msg: SegmentConfig::new("pure"),
-            style: Color::Blue.bold(),
-            symbol: SegmentConfig::new("❄️  "),
+            format: "via [$symbol$state( \\($name\\))]($style) ",
+            symbol: "❄️  ",
+            style: "bold blue",
+            impure_msg: "impure",
+            pure_msg: "pure",
             disabled: false,
         }
     }

--- a/tests/testsuite/nix_shell.rs
+++ b/tests/testsuite/nix_shell.rs
@@ -46,13 +46,27 @@ fn impure_shell() -> io::Result<()> {
 }
 
 #[test]
-fn lorri_shell() -> io::Result<()> {
+fn pure_shell_name() -> io::Result<()> {
     let output = common::render_module("nix_shell")
-        .env("IN_NIX_SHELL", "1")
+        .env("IN_NIX_SHELL", "pure")
+        .env("name", "starship")
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
-    let expected = format!("via {} ", Color::Blue.bold().paint("❄️  impure"));
+    let expected = format!("via {} ", Color::Blue.bold().paint("❄️  pure (starship)"));
+    assert_eq!(expected, actual);
+    Ok(())
+}
+
+#[test]
+fn impure_shell_name() -> io::Result<()> {
+    let output = common::render_module("nix_shell")
+        .env("IN_NIX_SHELL", "impure")
+        .env("name", "starship")
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+
+    let expected = format!("via {} ", Color::Blue.bold().paint("❄️  impure (starship)"));
     assert_eq!(expected, actual);
     Ok(())
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR deprecates `symbol`, `style` and `use_name` keys in the `nix_shell` module to replace it with the `format` key instead.
It also removes the exception for `lorri` as it was fixed [here](https://github.com/target/lorri/pull/164).

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to issue #1057

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/47182955/82151910-48908500-985e-11ea-84a2-1120de85f245.png)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
