### PR TITLE
refactor(terraform): Use format strings

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1435,7 +1435,7 @@ format = "[📦 \\[$env\\]]($style) "
 
 The `terraform` module shows the currently selected terraform workspace and version.
 By default the terraform version is not shown, since this is slow on current versions of terraform when a lot of plugins are in use.
-I you still want to enable it, [follow the example shown below](#with-version).
+If you still want to enable it, [follow the example shown below](#with-version).
 The module will be shown if any of the following conditions are met:
 
 - The current directory contains a `.terraform` folder

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1435,6 +1435,7 @@ format = "[📦 \\[$env\\]]($style) "
 
 The `terraform` module shows the currently selected terraform workspace and version.
 By default the terraform version is not shown, since this is slow on current versions of terraform when a lot of plugins are in use.
+I you still want to enable it, [follow the example shown below](#with-version).
 The module will be shown if any of the following conditions are met:
 
 - The current directory contains a `.terraform` folder
@@ -1442,12 +1443,12 @@ The module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Variable       | Default                              | Description                                           |
-| -------------- | ------------------------------------ | ----------------------------------------------------- |
-| `format`       | `"via [$symbol$workspace]($style) "` | The format string for the module.                     |
-| `symbol`       | `"💠 "`                              | A format string shown before the terraform workspace. |
-| `style`        | `"bold 105"`                         | The style for the module.                             |
-| `disabled`     | `false`                              | Disables the `terraform` module.                      |
+| Variable   | Default                              | Description                                           |
+| ---------- | ------------------------------------ | ----------------------------------------------------- |
+| `format`   | `"via [$symbol$workspace]($style) "` | The format string for the module.                     |
+| `symbol`   | `"💠 "`                              | A format string shown before the terraform workspace. |
+| `style`    | `"bold 105"`                         | The style for the module.                             |
+| `disabled` | `false`                              | Disables the `terraform` module.                      |
 
 ### Variables
 
@@ -1461,6 +1462,17 @@ The module will be shown if any of the following conditions are met:
 \*: This variable can only be used as a part of a style string
 
 ### Example
+
+#### With Version
+
+```toml
+# ~/.config/starship.toml
+
+[terraform]
+format = "[🏎💨 $version$workspace]($style) "
+```
+
+#### Without version
 
 ```toml
 # ~/.config/starship.toml

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1442,12 +1442,23 @@ The module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Variable       | Default      | Description                                                 |
-| -------------- | ------------ | ----------------------------------------------------------- |
-| `symbol`       | `"💠 "`      | The symbol used before displaying the terraform workspace.  |
-| `show_version` | `false`      | Shows the terraform version. Very slow on large workspaces. |
-| `style`        | `"bold 105"` | The style for the module.                                   |
-| `disabled`     | `false`      | Disables the `terraform` module.                            |
+| Variable       | Default                              | Description                                           |
+| -------------- | ------------------------------------ | ----------------------------------------------------- |
+| `format`       | `"via [$symbol$workspace]($style) "` | The format string for the module.                     |
+| `symbol`       | `"💠 "`                              | A format string shown before the terraform workspace. |
+| `style`        | `"bold 105"`                         | The style for the module.                             |
+| `disabled`     | `false`                              | Disables the `terraform` module.                      |
+
+### Variables
+
+| Variable  | Example    | Description                          |
+| --------- | ---------- | ------------------------------------ |
+| version   | `v0.12.24` | The version of `terraform`           |
+| workspace | `default`  | The current terraform workspace      |
+| symbol    |            | Mirrors the value of option `symbol` |
+| style\*   |            | Mirrors the value of option `style`  |
+
+\*: This variable can only be used as a part of a style string
 
 ### Example
 
@@ -1455,7 +1466,7 @@ The module will be shown if any of the following conditions are met:
 # ~/.config/starship.toml
 
 [terraform]
-symbol = "🏎💨 "
+format = "[🏎💨 $workspace]($style) "
 ```
 
 ## Time

--- a/src/configs/terraform.rs
+++ b/src/configs/terraform.rs
@@ -1,26 +1,21 @@
-use crate::config::{ModuleConfig, RootModuleConfig, SegmentConfig};
+use crate::config::{ModuleConfig, RootModuleConfig};
 
-use ansi_term::{Color, Style};
 use starship_module_config_derive::ModuleConfig;
 
 #[derive(Clone, ModuleConfig)]
 pub struct TerraformConfig<'a> {
-    pub symbol: SegmentConfig<'a>,
-    pub workspace: SegmentConfig<'a>,
-    pub version: SegmentConfig<'a>,
-    pub show_version: bool,
-    pub style: Style,
+    pub format: &'a str,
+    pub symbol: &'a str,
+    pub style: &'a str,
     pub disabled: bool,
 }
 
 impl<'a> RootModuleConfig<'a> for TerraformConfig<'a> {
     fn new() -> Self {
         TerraformConfig {
-            symbol: SegmentConfig::new("💠 "),
-            workspace: SegmentConfig::default(),
-            version: SegmentConfig::default(),
-            show_version: false,
-            style: Color::Fixed(105).bold(),
+            format: "via [$symbol$workspace]($style) ",
+            symbol: "💠 ",
+            style: "bold 105",
             disabled: false,
         }
     }

--- a/src/modules/terraform.rs
+++ b/src/modules/terraform.rs
@@ -1,7 +1,9 @@
 use super::{Context, Module, RootModuleConfig};
 
 use crate::configs::terraform::TerraformConfig;
+use crate::formatter::StringFormatter;
 use crate::utils;
+
 use std::env;
 use std::io;
 use std::path::PathBuf;
@@ -25,20 +27,42 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let mut module = context.new_module("terraform");
     let config: TerraformConfig = TerraformConfig::try_load(module.config);
 
-    module.set_style(config.style);
-    module.create_segment("symbol", &config.symbol);
+    let terraform_version =
+        format_terraform_version(&utils::exec_cmd("terraform", &["version"])?.stdout.as_str());
+    let terraform_workspace = get_terraform_workspace(&context.current_dir);
 
-    if config.show_version {
-        let terraform_version =
-            format_terraform_version(&utils::exec_cmd("terraform", &["version"])?.stdout.as_str())?;
-        module.create_segment("version", &config.version.with_value(&terraform_version));
+    if terraform_version.is_none() && terraform_workspace.is_none() {
+        return None;
     }
 
-    let terraform_workspace = &get_terraform_workspace(&context.current_dir)?;
-    module.create_segment(
-        "workspace",
-        &config.workspace.with_value(&terraform_workspace),
-    );
+    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
+        formatter
+            .map_meta(|variable, _| match variable {
+                "symbol" => Some(config.symbol),
+                _ => None,
+            })
+            .map_style(|variable| match variable {
+                "style" => Some(Ok(config.style)),
+                _ => None,
+            })
+            .map(|variable| match variable {
+                "version" => terraform_version.as_ref().map(Ok),
+                "workspace" => terraform_workspace.as_ref().map(Ok),
+                _ => None,
+            })
+            .parse(None)
+    });
+
+    module.set_segments(match parsed {
+        Ok(segments) => segments,
+        Err(error) => {
+            log::warn!("Error in module `terraform`:\n{}", error);
+            return None;
+        }
+    });
+
+    module.get_prefix().set_value("");
+    module.get_suffix().set_value("");
 
     Some(module)
 }

--- a/tests/testsuite/terraform.rs
+++ b/tests/testsuite/terraform.rs
@@ -46,7 +46,6 @@ fn folder_with_workspace_override() -> io::Result<()> {
     let output = common::render_module("terraform")
         .arg("--path")
         .arg(dir.path())
-        .env_clear()
         .env("TF_WORKSPACE", "development")
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
@@ -70,7 +69,6 @@ fn folder_with_datadir_override() -> io::Result<()> {
     let output = common::render_module("terraform")
         .arg("--path")
         .arg(dir.path())
-        .env_clear()
         .env("TF_DATA_DIR", datadir.path())
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
@@ -132,7 +130,7 @@ fn folder_with_dotterraform_with_version_no_environment() -> io::Result<()> {
         .arg(dir.path())
         .use_config(toml::toml! {
             [terraform]
-            format = "via [$symbol$version$workspace]($style)"
+            format = "via [$symbol$version$workspace]($style) "
         })
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
@@ -160,7 +158,7 @@ fn folder_with_dotterraform_with_version_with_environment() -> io::Result<()> {
         .arg(dir.path())
         .use_config(toml::toml! {
             [terraform]
-            format = "via [$symbol$version$workspace]($style)"
+            format = "via [$symbol$version$workspace]($style) "
         })
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();

--- a/tests/testsuite/terraform.rs
+++ b/tests/testsuite/terraform.rs
@@ -132,7 +132,7 @@ fn folder_with_dotterraform_with_version_no_environment() -> io::Result<()> {
         .arg(dir.path())
         .use_config(toml::toml! {
             [terraform]
-            show_version = true
+            format = "via [$symbol$version$workspace]($style)"
         })
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
@@ -160,7 +160,7 @@ fn folder_with_dotterraform_with_version_with_environment() -> io::Result<()> {
         .arg(dir.path())
         .use_config(toml::toml! {
             [terraform]
-            show_version = true
+            format = "via [$symbol$version$workspace]($style)"
         })
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR deprecates `symbol`, `style` and `show_version` keys in the `terraform` module to replace it with the `format` key instead.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to issue #1057

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
