### PR TITLE
fix: Allow configuration of root keys from cli

### DIFF
--- a/src/configure.rs
+++ b/src/configure.rs
@@ -64,27 +64,25 @@ pub fn update_configuration(name: &str, value: &str) {
 
             config_str = toml::to_string_pretty(&table).expect("Failed to serialize the config to string");
         }
-    } else {
-        if let Some(table) = config.as_table_mut() {
-            if value.parse::<bool>().is_ok() {
-                table.insert(
-                    key.to_string(),
-                    Value::Boolean(value.parse::<bool>().unwrap()),
-                );
-            } else if value.parse::<i64>().is_ok() {
-                table.insert(
-                    key.to_string(),
-                    Value::Integer(value.parse::<i64>().unwrap()),
-                );
-            } else {
-                table.insert(
-                    key.to_string(),
-                    Value::String(value.to_string()),
-                );
-            }
-
-            config_str = toml::to_string_pretty(&table).expect("Failed to serialize the config to string");
+    } else if let Some(table) = config.as_table_mut() {
+        if value.parse::<bool>().is_ok() {
+            table.insert(
+                key.to_string(),
+                Value::Boolean(value.parse::<bool>().unwrap()),
+            );
+        } else if value.parse::<i64>().is_ok() {
+            table.insert(
+                key.to_string(),
+                Value::Integer(value.parse::<i64>().unwrap()),
+            );
+        } else {
+            table.insert(
+                key.to_string(),
+                Value::String(value.to_string()),
+            );
         }
+
+        config_str = toml::to_string_pretty(&table).expect("Failed to serialize the config to string");
     }
 
     File::create(&config_path)

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -62,8 +62,7 @@ pub fn update_configuration(name: &str, value: &str) {
                 table.insert(key_table.to_string(), Value::Table(updated_values));
             }
 
-            config_str = 
-                toml::to_string_pretty(&table).expect("Failed to serialize the config to string");
+            config_str = toml::to_string_pretty(&table).expect("Failed to serialize the config to string");
         }
     } else {
         if let Some(table) = config.as_table_mut() {
@@ -84,8 +83,7 @@ pub fn update_configuration(name: &str, value: &str) {
                 );
             }
 
-            config_str = 
-                toml::to_string_pretty(&table).expect("Failed to serialize the config to string");
+            config_str = toml::to_string_pretty(&table).expect("Failed to serialize the config to string");
         }
     }
 


### PR DESCRIPTION
#### Description
This fork resolves bug #1199; the bug was as such: If no table is specified (using a period) holding the value in the command `starship config [value] [key]`, an error is returned. This bug-fix permits changing table-less values. Additionally, the function `update_configuration(name: &str, value: &str)` is made somewhat more verbose.

#### Motivation and Context
Closes #1199 

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
I have run a test as follows:

1. Execute `cargo test`; no failed runs
2. Execute `starship config key value`; creates a table-less index "key" with value "value" in config file starship.toml
3. Execute `starship config table.key value`; works as above, with "key" under the table "table"
4. Perform the above two on already-existing TOML variables; correctly replaces the current value without adding a new one.
- [x] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
(Neither are applicable)