### PR TITLE
refactor(zig): Use format strings

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1657,11 +1657,20 @@ The module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Variable   | Default      | Description                                            |
-| ---------- | ------------ | ------------------------------------------------------ |
-| `symbol`   | `"↯ "`      | The symbol used before displaying the version of Zig. |
-| `style`    | `"bold yellow"` | The style for the module.                              |
-| `disabled` | `false`      | Disables the `zig` module.                            |
+| Variable   | Default                            | Description                                            |
+| ---------- | ---------------------------------- | ------------------------------------------------------ |
+| `symbol`   | `"↯ "`                             | The symbol used before displaying the version of Zig.  |
+| `style`    | `"bold yellow"`                    | The style for the module.                              |
+| `format`   | `"via [$symbol$version]($style) "` | The format for the module.                             |
+| `disabled` | `false`                            | Disables the `zig` module.                             |
+
+### Variables
+
+| Variable | Example  | Description                          |
+| -------- | -------- | ------------------------------------ |
+| version  | `v0.6.0` | The version of `zig`                 |
+| symbol   |          | Mirrors the value of option `symbol` |
+| style\*  |          | Mirrors the value of option `style`  |
 
 ### Example
 

--- a/src/configs/zig.rs
+++ b/src/configs/zig.rs
@@ -13,7 +13,7 @@ pub struct ZigConfig<'a> {
 impl<'a> RootModuleConfig<'a> for ZigConfig<'a> {
     fn new() -> Self {
         ZigConfig {
-            format: "via [$symbol$version]($style)",
+            format: "via [$symbol$version]($style) ",
             symbol: "↯ ",
             style: "bold yellow",
             disabled: false,

--- a/src/configs/zig.rs
+++ b/src/configs/zig.rs
@@ -1,22 +1,21 @@
-use crate::config::{ModuleConfig, RootModuleConfig, SegmentConfig};
+use crate::config::{ModuleConfig, RootModuleConfig};
 
-use ansi_term::{Color, Style};
 use starship_module_config_derive::ModuleConfig;
 
 #[derive(Clone, ModuleConfig)]
 pub struct ZigConfig<'a> {
-    pub symbol: SegmentConfig<'a>,
-    pub version: SegmentConfig<'a>,
-    pub style: Style,
+    pub format: &'a str,
+    pub symbol: &'a str,
+    pub style: &'a str,
     pub disabled: bool,
 }
 
 impl<'a> RootModuleConfig<'a> for ZigConfig<'a> {
     fn new() -> Self {
         ZigConfig {
-            symbol: SegmentConfig::new("↯ "),
-            version: SegmentConfig::default(),
-            style: Color::Yellow.bold(),
+            format: "via [$symbol$version]($style)",
+            symbol: "↯ ",
+            style: "bold yellow",
             disabled: false,
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR deprecates `symbol` and `style` keys in the `zig` module to replace it with the `format` key instead. Heavily based on #1224.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to issue #1057.

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
