### PR TITLE
style(init): Tidy-up init scripts

### DIFF
--- a/src/init/starship.bash
+++ b/src/init/starship.bash
@@ -22,7 +22,7 @@ starship_preexec() {
         PREEXEC_READY=false
         STARSHIP_START_TIME=$(::STARSHIP:: time)
     fi
-    
+
     : "$PREV_LAST_ARG"
 }
 
@@ -52,9 +52,9 @@ if [[ $preexec_functions ]]; then
     preexec_functions+=('starship_preexec "$_"')
     precmd_functions+=(starship_precmd)
 else
-# We want to avoid destroying an existing DEBUG hook. If we detect one, create
-# a new function that runs both the existing function AND our function, then
-# re-trap DEBUG to use this new function. This prevents a trap clobber.
+    # We want to avoid destroying an existing DEBUG hook. If we detect one, create
+    # a new function that runs both the existing function AND our function, then
+    # re-trap DEBUG to use this new function. This prevents a trap clobber.
     dbg_trap="$(trap -p DEBUG | cut -d' ' -f3 | tr -d \')"
     if [[ -z "$dbg_trap" ]]; then
         trap 'starship_preexec "$_"' DEBUG
@@ -64,8 +64,8 @@ else
         }
         trap 'starship_preexec_all "$_"' DEBUG
     fi
- 
-    # Finally, prepare the precmd function and set up the start time. We will avoid to 
+
+    # Finally, prepare the precmd function and set up the start time. We will avoid to
     # add multiple instances of the starship function and keep other user functions if any.
     if [[ -z "$PROMPT_COMMAND" ]]; then
         PROMPT_COMMAND="starship_precmd"

--- a/src/init/starship.bash
+++ b/src/init/starship.bash
@@ -59,7 +59,7 @@ else
     if [[ -z "$dbg_trap" ]]; then
         trap 'starship_preexec "$_"' DEBUG
     elif [[ "$dbg_trap" != 'starship_preexec "$_"' && "$dbg_trap" != 'starship_preexec_all "$_"' ]]; then
-        function starship_preexec_all(){
+        starship_preexec_all() {
             local PREV_LAST_ARG=$1 ; $dbg_trap; starship_preexec; : "$PREV_LAST_ARG";
         }
         trap 'starship_preexec_all "$_"' DEBUG

--- a/src/init/starship.bash
+++ b/src/init/starship.bash
@@ -43,7 +43,7 @@ starship_precmd() {
     else
         PS1="$(::STARSHIP:: prompt --status=$STATUS --jobs="$(jobs -p | wc -l)")"
     fi
-    PREEXEC_READY=true;  # Signal that we can safely restart the timer
+    PREEXEC_READY=true  # Signal that we can safely restart the timer
 }
 
 # If the user appears to be using https://github.com/rcaloras/bash-preexec,

--- a/src/init/starship.zsh
+++ b/src/init/starship.zsh
@@ -18,7 +18,7 @@ starship_precmd() {
     # quotes so we set it here and then use the value later on.
     NUM_JOBS=$#jobstates
     # Compute cmd_duration, if we have a time to consume
-    if [[ ! -z "${STARSHIP_START_TIME+1}" ]]; then
+    if [[ -n "${STARSHIP_START_TIME+1}" ]]; then
         STARSHIP_END_TIME=$(::STARSHIP:: time)
         STARSHIP_DURATION=$((STARSHIP_END_TIME - STARSHIP_START_TIME))
         PROMPT="$(::STARSHIP:: prompt --status=$STATUS --cmd-duration=$STARSHIP_DURATION --jobs="$NUM_JOBS")"

--- a/src/init/starship.zsh
+++ b/src/init/starship.zsh
@@ -16,7 +16,7 @@ starship_precmd() {
 
     # Use length of jobstates array as number of jobs. Expansion fails inside
     # quotes so we set it here and then use the value later on.
-    NUM_JOBS=$#jobstates  
+    NUM_JOBS=$#jobstates
     # Compute cmd_duration, if we have a time to consume
     if [[ ! -z "${STARSHIP_START_TIME+1}" ]]; then
         STARSHIP_END_TIME=$(::STARSHIP:: time)
@@ -27,7 +27,7 @@ starship_precmd() {
         PROMPT="$(::STARSHIP:: prompt --status=$STATUS --jobs="$NUM_JOBS")"
     fi
 }
-starship_preexec(){
+starship_preexec() {
     STARSHIP_START_TIME=$(::STARSHIP:: time)
 }
 

--- a/src/init/starship.zsh
+++ b/src/init/starship.zsh
@@ -47,9 +47,8 @@ if [[ ${preexec_functions[(ie)starship_preexec]} -gt ${#preexec_functions} ]]; t
 fi
 
 # Set up a function to redraw the prompt if the user switches vi modes
-function zle-keymap-select
-{
-    PROMPT=$(::STARSHIP:: prompt --keymap=$KEYMAP --jobs="$(jobs | wc -l)")
+zle-keymap-select() {
+    PROMPT=$(::STARSHIP:: prompt --keymap="$KEYMAP" --jobs="$(jobs | wc -l)")
     zle reset-prompt
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
This PR fixes whitespace and indentation issues inside `bash`/`zsh` init script. Additionally, consistent function definition style is enforced and scripts are examined using `shellcheck`.
<!--- Describe your changes in detail -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Idea is to keep things tidy, consistent and bug-free by running `shellcheck`.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
