### PR TITLE
refactor(aws): Use format strings

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -219,23 +219,64 @@ is read from the `AWS_VAULT` env var.
 
 ### Options
 
-| Variable          | Default         | Description                                                                 |
-| ----------------- | --------------- | --------------------------------------------------------------------------- |
-| `symbol`          | `"☁️ "`         | The symbol used before displaying the current AWS profile.                  |
-| `displayed_items` | `all`           | Choose which item to display. Possible values: [`all`, `profile`, `region`] |
-| `region_aliases`  |                 | Table of region aliases to display in addition to the AWS name.             |
-| `style`           | `"bold yellow"` | The style for the module.                                                   |
-| `disabled`        | `false`         | Disables the `AWS` module.                                                  |
+| Option           | Default                                          | Description                                                     |
+| ---------------- | ------------------------------------------------ | --------------------------------------------------------------- |
+| `format`         | `"on [$symbol$profile(\\($region\\))]($style) "` | The format for the module.                                      |
+| `symbol`         | `"☁️ "`                                          | The symbol used before displaying the current AWS profile.      |
+| `region_aliases` |                                                  | Table of region aliases to display in addition to the AWS name. |
+| `style`          | `"bold yellow"`                                  | The style for the module.                                       |
+| `disabled`       | `false`                                          | Disables the `AWS` module.                                      |
 
-### Example
+### Variables
+
+| Variable | Example          | Description                          |
+| -------- | ---------------- | ------------------------------------ |
+| region   | `ap-northeast-1` | The current AWS region               |
+| profile  | `astronauts`     | The current AWS profile              |
+| symbol   |                  | Mirrors the value of option `symbol` |
+| style\*  |                  | Mirrors the value of option `style`  |
+
+\*: This variable can only be used as a part of a style string
+
+### Examples
+
+#### Display everything
 
 ```toml
 # ~/.config/starship.toml
 
 [aws]
+format = "on [$symbol$profile(\\($region\\))]($style) "
 style = "bold blue"
 symbol = "🅰 "
-displayed_items = "region"
+[aws.region_aliases]
+ap-southeast-2 = "au"
+us-east-1 = "va"
+```
+
+#### Display region
+
+```toml
+# ~/.config/starship.toml
+
+[aws]
+format = "on [$symbol$region]($style) "
+style = "bold blue"
+symbol = "🅰 "
+[aws.region_aliases]
+ap-southeast-2 = "au"
+us-east-1 = "va"
+```
+
+#### Display profile
+
+```toml
+# ~/.config/starship.toml
+
+[aws]
+format = "on [$symbol$profile]($style) "
+style = "bold blue"
+symbol = "🅰 "
 [aws.region_aliases]
 ap-southeast-2 = "au"
 us-east-1 = "va"

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -277,9 +277,6 @@ us-east-1 = "va"
 format = "on [$symbol$profile]($style) "
 style = "bold blue"
 symbol = "🅰 "
-[aws.region_aliases]
-ap-southeast-2 = "au"
-us-east-1 = "va"
 ```
 
 ## Battery

--- a/src/configs/aws.rs
+++ b/src/configs/aws.rs
@@ -1,48 +1,24 @@
-use crate::config::{ModuleConfig, RootModuleConfig, SegmentConfig};
-use std::collections::HashMap;
-
-use ansi_term::{Color, Style};
+use crate::config::{ModuleConfig, RootModuleConfig};
 use starship_module_config_derive::ModuleConfig;
-
-#[derive(Clone, PartialEq)]
-pub enum AwsItems {
-    All,
-    Region,
-    Profile,
-}
+use std::collections::HashMap;
 
 #[derive(Clone, ModuleConfig)]
 pub struct AwsConfig<'a> {
-    pub symbol: SegmentConfig<'a>,
-    pub profile: SegmentConfig<'a>,
-    pub region: SegmentConfig<'a>,
-    pub style: Style,
+    pub format: &'a str,
+    pub symbol: &'a str,
+    pub style: &'a str,
     pub disabled: bool,
-    pub displayed_items: AwsItems,
     pub region_aliases: HashMap<String, &'a str>,
 }
 
 impl<'a> RootModuleConfig<'a> for AwsConfig<'a> {
     fn new() -> Self {
         AwsConfig {
-            symbol: SegmentConfig::new("☁️  "),
-            profile: SegmentConfig::default(),
-            region: SegmentConfig::default(),
-            style: Color::Yellow.bold(),
+            format: "on [$symbol$profile(\\($region\\))]($style) ",
+            symbol: "☁️  ",
+            style: "bold yellow",
             disabled: false,
-            displayed_items: AwsItems::All,
             region_aliases: HashMap::new(),
-        }
-    }
-}
-
-impl<'a> ModuleConfig<'a> for AwsItems {
-    fn from_config(config: &toml::Value) -> Option<Self> {
-        match config.as_str()? {
-            "all" => Some(AwsItems::All),
-            "region" => Some(AwsItems::Region),
-            "profile" => Some(AwsItems::Profile),
-            _ => None,
         }
     }
 }

--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -77,6 +77,9 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let config: AwsConfig = AwsConfig::try_load(module.config);
 
     let (aws_profile, aws_region) = get_aws_profile_and_region();
+    if aws_profile.is_none() && aws_region.is_none() {
+        return None;
+    }
 
     let mapped_region = if let Some(aws_region) = aws_region {
         Some(alias_region(aws_region, &config.region_aliases))

--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -9,7 +9,8 @@ use dirs::home_dir;
 
 use super::{Context, Module, RootModuleConfig};
 
-use crate::configs::aws::{AwsConfig, AwsItems};
+use crate::configs::aws::AwsConfig;
+use crate::formatter::StringFormatter;
 
 type Profile = String;
 type Region = String;
@@ -53,73 +54,64 @@ fn get_aws_profile_and_region() -> (Option<Profile>, Option<Region>) {
         env::var("AWS_VAULT")
             .or_else(|_| env::var("AWS_PROFILE"))
             .ok(),
-        env::var("AWS_REGION").ok(),
-        env::var("AWS_DEFAULT_REGION").ok(),
+        env::var("AWS_DEFAULT_REGION")
+            .or_else(|_| env::var("AWS_REGION"))
+            .ok(),
     ) {
-        (Some(p), Some(_), Some(dr)) => (Some(p), Some(dr)),
-        (Some(p), Some(r), None) => (Some(p), Some(r)),
-        (None, Some(r), None) => (None, Some(r)),
-        (Some(p), None, Some(dr)) => (Some(p), Some(dr)),
-        (Some(ref p), None, None) => (Some(p.to_owned()), get_aws_region_from_config(Some(p))),
-        (None, None, Some(dr)) => (None, Some(dr)),
-        (None, Some(_), Some(dr)) => (None, Some(dr)),
-        (None, None, None) => (None, get_aws_region_from_config(None)),
+        (Some(p), Some(r)) => (Some(p), Some(r)),
+        (None, Some(r)) => (None, Some(r)),
+        (Some(ref p), None) => (Some(p.to_owned()), get_aws_region_from_config(Some(p))),
+        (None, None) => (None, get_aws_region_from_config(None)),
     }
 }
 
-fn get_aws_region() -> Option<Region> {
-    match (
-        env::var("AWS_REGION").ok(),
-        env::var("AWS_DEFAULT_REGION").ok(),
-    ) {
-        (Some(r), None) => Some(r),
-        (None, Some(dr)) => Some(dr),
-        (Some(_), Some(dr)) => Some(dr),
-        (None, None) => get_aws_region_from_config(None),
-    }
-}
-
-fn alias_region(region: &str, aliases: &HashMap<String, &str>) -> String {
-    match aliases.get(region) {
-        None => region.to_string(),
+fn alias_region(region: String, aliases: &HashMap<String, &str>) -> String {
+    match aliases.get(&region) {
+        None => region,
         Some(alias) => (*alias).to_string(),
     }
 }
 
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
-    const AWS_PREFIX: &str = "on ";
-
     let mut module = context.new_module("aws");
     let config: AwsConfig = AwsConfig::try_load(module.config);
 
-    module.set_style(config.style);
+    let (aws_profile, aws_region) = get_aws_profile_and_region();
 
-    module.get_prefix().set_value(AWS_PREFIX);
-
-    module.create_segment("symbol", &config.symbol);
-    match config.displayed_items {
-        AwsItems::All => {
-            let (aws_profile, aws_region) = get_aws_profile_and_region();
-
-            let aws_segment = match (&aws_profile, &aws_region) {
-                (None, None) => return None,
-                (Some(p), Some(r)) => format!("{}({})", p, alias_region(r, &config.region_aliases)),
-                (Some(p), None) => p.to_string(),
-                (None, Some(r)) => alias_region(r, &config.region_aliases),
-            };
-            module.create_segment("all", &config.region.with_value(&aws_segment));
-        }
-        AwsItems::Profile => {
-            let aws_profile = env::var("AWS_PROFILE").ok()?;
-
-            module.create_segment("profile", &config.profile.with_value(&aws_profile));
-        }
-        AwsItems::Region => {
-            let aws_region = alias_region(&get_aws_region()?, &config.region_aliases);
-
-            module.create_segment("region", &config.region.with_value(&aws_region));
-        }
+    let mapped_region = if let Some(aws_region) = aws_region {
+        Some(alias_region(aws_region, &config.region_aliases))
+    } else {
+        None
     };
+
+    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
+        formatter
+            .map_meta(|variable, _| match variable {
+                "symbol" => Some(config.symbol),
+                _ => None,
+            })
+            .map_style(|variable| match variable {
+                "style" => Some(Ok(config.style)),
+                _ => None,
+            })
+            .map(|variable| match variable {
+                "profile" => aws_profile.as_ref().map(Ok),
+                "region" => mapped_region.as_ref().map(Ok),
+                _ => None,
+            })
+            .parse(None)
+    });
+
+    module.set_segments(match parsed {
+        Ok(segments) => segments,
+        Err(error) => {
+            log::error!("Error in module `aws`: \n{}", error);
+            return None;
+        }
+    });
+
+    module.get_prefix().set_value("");
+    module.get_suffix().set_value("");
 
     Some(module)
 }

--- a/tests/testsuite/aws.rs
+++ b/tests/testsuite/aws.rs
@@ -22,7 +22,7 @@ fn region_set() -> io::Result<()> {
     let output = common::render_module("aws")
         .env("AWS_REGION", "ap-northeast-2")
         .output()?;
-    let expected = format!("on {} ", Color::Yellow.bold().paint("☁️  ap-northeast-2"));
+    let expected = format!("on {} ", Color::Yellow.bold().paint("☁️  (ap-northeast-2)"));
     let actual = String::from_utf8(output.stdout).unwrap();
     assert_eq!(expected, actual);
     Ok(())
@@ -37,7 +37,7 @@ fn region_set_with_alias() -> io::Result<()> {
             ap-southeast-2 = "au"
         })
         .output()?;
-    let expected = format!("on {} ", Color::Yellow.bold().paint("☁️  au"));
+    let expected = format!("on {} ", Color::Yellow.bold().paint("☁️  (au)"));
     let actual = String::from_utf8(output.stdout).unwrap();
     assert_eq!(expected, actual);
     Ok(())
@@ -49,7 +49,7 @@ fn default_region_set() -> io::Result<()> {
         .env("AWS_REGION", "ap-northeast-2")
         .env("AWS_DEFAULT_REGION", "ap-northeast-1")
         .output()?;
-    let expected = format!("on {} ", Color::Yellow.bold().paint("☁️  ap-northeast-1"));
+    let expected = format!("on {} ", Color::Yellow.bold().paint("☁️  (ap-northeast-1)"));
     let actual = String::from_utf8(output.stdout).unwrap();
     assert_eq!(expected, actual);
     Ok(())
@@ -112,7 +112,7 @@ region = us-east-2
     let output = common::render_module("aws")
         .env("AWS_CONFIG_FILE", config_path.to_string_lossy().as_ref())
         .output()?;
-    let expected = format!("on {} ", Color::Yellow.bold().paint("☁️  us-east-1"));
+    let expected = format!("on {} ", Color::Yellow.bold().paint("☁️  (us-east-1)"));
     let actual = String::from_utf8(output.stdout).unwrap();
     assert_eq!(expected, actual);
     dir.close()
@@ -155,10 +155,6 @@ fn profile_and_region_set_with_display_all() -> io::Result<()> {
     let output = common::render_module("aws")
         .env("AWS_PROFILE", "astronauts")
         .env("AWS_REGION", "ap-northeast-1")
-        .use_config(toml::toml! {
-            [aws]
-            displayed_items = "all"
-        })
         .output()?;
     let expected = format!(
         "on {} ",
@@ -173,10 +169,6 @@ fn profile_and_region_set_with_display_all() -> io::Result<()> {
 fn profile_set_with_display_all() -> io::Result<()> {
     let output = common::render_module("aws")
         .env("AWS_PROFILE", "astronauts")
-        .use_config(toml::toml! {
-            [aws]
-            displayed_items = "all"
-        })
         .output()?;
     let expected = format!("on {} ", Color::Yellow.bold().paint("☁️  astronauts"));
     let actual = String::from_utf8(output.stdout).unwrap();
@@ -188,12 +180,8 @@ fn profile_set_with_display_all() -> io::Result<()> {
 fn region_set_with_display_all() -> io::Result<()> {
     let output = common::render_module("aws")
         .env("AWS_REGION", "ap-northeast-1")
-        .use_config(toml::toml! {
-            [aws]
-            displayed_items = "all"
-        })
         .output()?;
-    let expected = format!("on {} ", Color::Yellow.bold().paint("☁️  ap-northeast-1"));
+    let expected = format!("on {} ", Color::Yellow.bold().paint("☁️  (ap-northeast-1)"));
     let actual = String::from_utf8(output.stdout).unwrap();
     assert_eq!(expected, actual);
     Ok(())
@@ -206,7 +194,7 @@ fn profile_and_region_set_with_display_region() -> io::Result<()> {
         .env("AWS_DEFAULT_REGION", "ap-northeast-1")
         .use_config(toml::toml! {
             [aws]
-            displayed_items = "region"
+            format = "on [$symbol$region]($style) "
         })
         .output()?;
     let expected = format!("on {} ", Color::Yellow.bold().paint("☁️  ap-northeast-1"));
@@ -222,7 +210,7 @@ fn profile_and_region_set_with_display_profile() -> io::Result<()> {
         .env("AWS_REGION", "ap-northeast-1")
         .use_config(toml::toml! {
             [aws]
-            displayed_items = "profile"
+            format = "on [$symbol$profile]($style) "
         })
         .output()?;
     let expected = format!("on {} ", Color::Yellow.bold().paint("☁️  astronauts"));
@@ -237,10 +225,10 @@ fn region_set_with_display_profile() -> io::Result<()> {
         .env("AWS_REGION", "ap-northeast-1")
         .use_config(toml::toml! {
             [aws]
-            displayed_items = "profile"
+            format = "on [$symbol$profile]($style) "
         })
         .output()?;
-    let expected = "";
+    let expected = format!("on {} ", Color::Yellow.bold().paint("☁️  "));
     let actual = String::from_utf8(output.stdout).unwrap();
     assert_eq!(expected, actual);
     Ok(())
@@ -252,7 +240,7 @@ fn region_not_set_with_display_region() -> io::Result<()> {
     let output = common::render_module("aws")
         .use_config(toml::toml! {
             [aws]
-            displayed_items = "region"
+            format = "on [$symbol$region]($style) "
         })
         .output()?;
     let expected = "";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR deprecates `symbol`, `style` and `displayed_items` keys in the `aws` module to replace it with the `format` key instead.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to issue #1057

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
