### PR TITLE
refactor(character): Use format strings

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -10,7 +10,7 @@ Many new configuration options will be available in coming releases.
 To get started configuring starship, create the following file: `~/.config/starship.toml`.
 
 ```sh
-$ mkdir -p ~/.config && touch ~/.config/starship.toml
+mkdir -p ~/.config && touch ~/.config/starship.toml
 ```
 
 All configuration for starship is done in this [TOML](https://github.com/toml-lang/toml) file:
@@ -20,8 +20,8 @@ All configuration for starship is done in this [TOML](https://github.com/toml-la
 add_newline = false
 
 # Replace the "❯" symbol in the prompt with "➜"
-[character]      # The name of the module we are configuring is "character"
-symbol = "➜"     # The "symbol" segment is being set to "➜"
+[character]                            # The name of the module we are configuring is "character"
+success_symbol = "[➜](bold green)"     # The "success_symbol" segment is being set to "➜" with the color "bold green"
 
 # Disable the package module, hiding it from the prompt completely
 [package]
@@ -29,11 +29,13 @@ disabled = true
 ```
 
 You can change default `starship.toml` file location with `STARSHIP_CONFIG` environment variable:
+
 ```sh
 export STARSHIP_CONFIG=~/.starship
 ```
 
 Equivalently in PowerShell (Windows) would be adding this line to your `$PROFILE`:
+
 ```ps1
 $ENV:STARSHIP_CONFIG = "$HOME\.starship"
 ```
@@ -321,30 +323,59 @@ The `character` module shows a character (usually an arrow) beside where the tex
 is entered in your terminal.
 
 The character will tell you whether the last command was successful or not. It
-can do this in two ways: by changing color (red/green) or by changing its shape
-(❯/✖). The latter will only be done if `use_symbol_for_status` is set to `true`.
+can do this in two ways:
+
+- changing color (`red`/`green`)
+- changing shape (`❯`/`✖`)
+
+By default it only changes color. If you also want to change it's shape take a
+look at [this example](#with-custom-error-shape).
 
 ### Options
 
-| Variable                | Default        | Description                                                                         |
-| ----------------------- | -------------- | ----------------------------------------------------------------------------------- |
-| `symbol`                | `"❯"`          | The symbol used before the text input in the prompt.                                |
-| `error_symbol`          | `"✖"`          | The symbol used before text input if the previous command failed.                   |
-| `use_symbol_for_status` | `false`        | Indicate error status by changing the symbol.                                       |
-| `vicmd_symbol`          | `"❮"`          | The symbol used before the text input in the prompt if shell is in vim normal mode. |
-| `style_success`         | `"bold green"` | The style used if the last command was successful.                                  |
-| `style_failure`         | `"bold red"`   | The style used if the last command failed.                                          |
-| `disabled`              | `false`        | Disables the `character` module.                                                    |
+| Variable         | Default              | Description                                                                      |
+| ---------------- | -------------------- | -------------------------------------------------------------------------------- |
+| `format`         | `"$symbol "`         | The format string used before the text input.                                    |
+| `success_symbol` | `"[❯](bold green)"` | The format string used before the text input if the previous command succeeded.  |
+| `error_symbol`   | `"[❯](bold red)"`   | The format string used before the text input if the previous command failed.     |
+| `vicmd_symbol`   | `"[❮](bold green)"` | The format string used before the text input if the shell is in vim normal mode. |
+| `disabled`       | `false`              | Disables the `character` module.                                                 |
 
-### Example
+### Variables
+
+| Variable | Example | Description                                                           |
+| -------- | ------- | --------------------------------------------------------------------- |
+| symbol   |         | A mirror of either `success_symbol`, `error_symbol` or `vicmd_symbol` |
+
+### Examples
+
+#### With custom error shape
 
 ```toml
 # ~/.config/starship.toml
 
 [character]
-symbol = "➜"
-error_symbol = "✗"
-use_symbol_for_status = true
+success_symbol = "[➜](bold green) "
+error_symbol = "[✗](bold red) "
+```
+
+#### Without custom error shape
+
+```toml
+# ~/.config/starship.toml
+
+[character]
+success_symbol = "[➜](bold green) "
+error_symbol = "[➜](bold red) "
+```
+
+#### With custom vim shape
+
+```toml
+# ~/.config/starship.toml
+
+[character]
+vicmd_symbol = "[V](bold green) "
 ```
 
 ## Command Duration

--- a/src/configs/character.rs
+++ b/src/configs/character.rs
@@ -1,28 +1,23 @@
-use crate::config::{ModuleConfig, RootModuleConfig, SegmentConfig};
+use crate::config::{ModuleConfig, RootModuleConfig};
 
-use ansi_term::{Color, Style};
 use starship_module_config_derive::ModuleConfig;
 
 #[derive(Clone, ModuleConfig)]
 pub struct CharacterConfig<'a> {
-    pub symbol: SegmentConfig<'a>,
-    pub error_symbol: SegmentConfig<'a>,
-    pub vicmd_symbol: SegmentConfig<'a>,
-    pub use_symbol_for_status: bool,
-    pub style_success: Style,
-    pub style_failure: Style,
+    pub format: &'a str,
+    pub success_symbol: &'a str,
+    pub error_symbol: &'a str,
+    pub vicmd_symbol: &'a str,
     pub disabled: bool,
 }
 
 impl<'a> RootModuleConfig<'a> for CharacterConfig<'a> {
     fn new() -> Self {
         CharacterConfig {
-            symbol: SegmentConfig::new("❯"),
-            error_symbol: SegmentConfig::new("✖"),
-            vicmd_symbol: SegmentConfig::new("❮"),
-            use_symbol_for_status: false,
-            style_success: Color::Green.bold(),
-            style_failure: Color::Red.bold(),
+            format: "$symbol ",
+            success_symbol: "[❯](bold green)",
+            error_symbol: "[❯](bold red)",
+            vicmd_symbol: "[❮](bold green)",
             disabled: false,
         }
     }

--- a/src/modules/character.rs
+++ b/src/modules/character.rs
@@ -1,14 +1,15 @@
 use super::{Context, Module, RootModuleConfig, Shell};
 use crate::configs::character::CharacterConfig;
+use crate::formatter::StringFormatter;
 
 /// Creates a module for the prompt character
 ///
-/// The character segment prints an arrow character in a color dependant on the exit-
-/// code of the last executed command:
-/// - If the exit-code was "0", the arrow will be formatted with `style_success`
-/// (green by default)
-/// - If the exit-code was anything else, the arrow will be formatted with
-/// `style_failure` (red by default)
+/// The character segment prints an arrow character in a color dependant on the
+/// exit-code of the last executed command:
+/// - If the exit-code was "0", it will be formatted with `success_symbol`
+///   (green arrow by default)
+/// - If the exit-code was anything else, it will be formatted with
+///   `error_symbol` (red arrow by default)
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     enum ShellEditMode {
         Normal,
@@ -19,12 +20,11 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
     let mut module = context.new_module("character");
     let config: CharacterConfig = CharacterConfig::try_load(module.config);
-    module.get_prefix().set_value("");
 
     let props = &context.properties;
-    let exit_code_default = std::string::String::from("0");
+    let exit_code_default = String::from("0");
     let exit_code = props.get("status_code").unwrap_or(&exit_code_default);
-    let keymap_default = std::string::String::from("viins");
+    let keymap_default = String::from("viins");
     let keymap = props.get("keymap").unwrap_or(&keymap_default);
     let exit_success = exit_code == "0";
 
@@ -38,22 +38,36 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         _ => ASSUMED_MODE,
     };
 
-    if exit_success {
-        module.set_style(config.style_success);
-    } else {
-        module.set_style(config.style_failure);
-    };
-
-    /* If an error symbol is set in the config, use symbols to indicate
-    success/failure, in addition to color */
-    if config.use_symbol_for_status && !exit_success {
-        module.create_segment("error_symbol", &config.error_symbol)
-    } else {
-        match mode {
-            ShellEditMode::Normal => module.create_segment("vicmd_symbol", &config.vicmd_symbol),
-            ShellEditMode::Insert => module.create_segment("symbol", &config.symbol),
+    let symbol = match mode {
+        ShellEditMode::Normal => config.vicmd_symbol,
+        ShellEditMode::Insert => {
+            if exit_success {
+                config.success_symbol
+            } else {
+                config.error_symbol
+            }
         }
     };
+
+    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
+        formatter
+            .map_meta(|variable, _| match variable {
+                "symbol" => Some(symbol),
+                _ => None,
+            })
+            .parse(None)
+    });
+
+    module.set_segments(match parsed {
+        Ok(segments) => segments,
+        Err(error) => {
+            log::warn!("Error in module `character`:\n{}", error);
+            return None;
+        }
+    });
+
+    module.get_prefix().set_value("");
+    module.get_suffix().set_value("");
 
     Some(module)
 }

--- a/tests/testsuite/character.rs
+++ b/tests/testsuite/character.rs
@@ -4,7 +4,7 @@ use std::io;
 use crate::common::{self, TestCommand};
 
 #[test]
-fn char_module_success_status() -> io::Result<()> {
+fn success_status() -> io::Result<()> {
     let expected = format!("{} ", Color::Green.bold().paint("❯"));
 
     // Status code 0
@@ -23,7 +23,7 @@ fn char_module_success_status() -> io::Result<()> {
 }
 
 #[test]
-fn char_module_failure_status() -> io::Result<()> {
+fn failure_status() -> io::Result<()> {
     let expected = format!("{} ", Color::Red.bold().paint("❯"));
 
     let exit_values = ["1", "54321", "-5000"];
@@ -39,9 +39,9 @@ fn char_module_failure_status() -> io::Result<()> {
 }
 
 #[test]
-fn char_module_symbolyes_status() -> io::Result<()> {
+fn custom_symbol() -> io::Result<()> {
     let expected_fail = format!("{} ", Color::Red.bold().paint("✖"));
-    let expected_success = format!("{} ", Color::Green.bold().paint("❯"));
+    let expected_success = format!("{} ", Color::Green.bold().paint("➜"));
 
     let exit_values = ["1", "54321", "-5000"];
 
@@ -51,7 +51,9 @@ fn char_module_symbolyes_status() -> io::Result<()> {
         let output = common::render_module("character")
             .use_config(toml::toml! {
                 [character]
-                use_symbol_for_status = true
+                success_symbol = "[➜](bold green)"
+                error_symbol = "[✖](bold red)"
+
             })
             .arg(arg)
             .output()?;
@@ -63,7 +65,8 @@ fn char_module_symbolyes_status() -> io::Result<()> {
     let output = common::render_module("character")
         .use_config(toml::toml! {
             [character]
-            use_symbol_for_status = true
+            success_symbol = "[➜](bold green)"
+            error_symbol = "[✖](bold red)"
         })
         .arg("--status=0")
         .output()?;
@@ -74,11 +77,10 @@ fn char_module_symbolyes_status() -> io::Result<()> {
 }
 
 #[test]
-fn char_module_zsh_keymap() -> io::Result<()> {
-    let expected_vicmd = "❮";
-    // TODO make this less... well, stupid when ANSI escapes can be mocked out
-    let expected_specified = "I HIGHLY DOUBT THIS WILL SHOW UP IN OTHER OUTPUT";
-    let expected_other = "❯";
+fn zsh_keymap() -> io::Result<()> {
+    let expected_vicmd = format!("{} ", Color::Green.bold().paint("❮"));
+    let expected_specified = format!("{} ", Color::Green.bold().paint("V"));
+    let expected_other = format!("{} ", Color::Green.bold().paint("❯"));
 
     // zle keymap is vicmd
     let output = common::render_module("character")
@@ -86,19 +88,19 @@ fn char_module_zsh_keymap() -> io::Result<()> {
         .arg("--keymap=vicmd")
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
-    assert!(actual.contains(&expected_vicmd));
+    assert_eq!(expected_vicmd, actual);
 
     // specified vicmd character
     let output = common::render_module("character")
         .use_config(toml::toml! {
             [character]
-            vicmd_symbol = "I HIGHLY DOUBT THIS WILL SHOW UP IN OTHER OUTPUT"
+            vicmd_symbol = "[V](bold green)"
         })
         .env("STARSHIP_SHELL", "zsh")
         .arg("--keymap=vicmd")
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
-    assert!(actual.contains(&expected_specified));
+    assert_eq!(expected_specified, actual);
 
     // zle keymap is other
     let output = common::render_module("character")
@@ -106,17 +108,16 @@ fn char_module_zsh_keymap() -> io::Result<()> {
         .arg("--keymap=visual")
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
-    assert!(actual.contains(&expected_other));
+    assert_eq!(expected_other, actual);
 
     Ok(())
 }
 
 #[test]
 fn char_module_fish_keymap() -> io::Result<()> {
-    let expected_vicmd = "❮";
-    // TODO make this less... well, stupid when ANSI escapes can be mocked out
-    let expected_specified = "I HIGHLY DOUBT THIS WILL SHOW UP IN OTHER OUTPUT";
-    let expected_other = "❯";
+    let expected_vicmd = format!("{} ", Color::Green.bold().paint("❮"));
+    let expected_specified = format!("{} ", Color::Green.bold().paint("V"));
+    let expected_other = format!("{} ", Color::Green.bold().paint("❯"));
 
     // fish keymap is default
     let output = common::render_module("character")
@@ -124,19 +125,19 @@ fn char_module_fish_keymap() -> io::Result<()> {
         .arg("--keymap=default")
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
-    assert!(actual.contains(&expected_vicmd));
+    assert_eq!(expected_vicmd, actual);
 
     // specified vicmd character
     let output = common::render_module("character")
         .use_config(toml::toml! {
             [character]
-            vicmd_symbol = "I HIGHLY DOUBT THIS WILL SHOW UP IN OTHER OUTPUT"
+            vicmd_symbol = "[V](bold green)"
         })
         .env("STARSHIP_SHELL", "fish")
         .arg("--keymap=default")
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
-    assert!(actual.contains(&expected_specified));
+    assert_eq!(expected_specified, actual);
 
     // fish keymap is other
     let output = common::render_module("character")
@@ -144,7 +145,7 @@ fn char_module_fish_keymap() -> io::Result<()> {
         .arg("--keymap=visual")
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
-    assert!(actual.contains(&expected_other));
+    assert_eq!(expected_other, actual);
 
     Ok(())
 }

--- a/tests/testsuite/character.rs
+++ b/tests/testsuite/character.rs
@@ -114,7 +114,7 @@ fn zsh_keymap() -> io::Result<()> {
 }
 
 #[test]
-fn char_module_fish_keymap() -> io::Result<()> {
+fn fish_keymap() -> io::Result<()> {
     let expected_vicmd = format!("{} ", Color::Green.bold().paint("❮"));
     let expected_specified = format!("{} ", Color::Green.bold().paint("V"));
     let expected_other = format!("{} ", Color::Green.bold().paint("❯"));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR deprecates `style_failure`, `style_success` and `use_symbol_for_status` keys in the `character` module to replace it with the `format` key instead.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to issue #1057

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
