### PR TITLE
refactor(ocaml): Use format strings

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1342,11 +1342,22 @@ The module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Variable   | Default         | Description                                             |
-| ---------- | --------------- | ------------------------------------------------------- |
-| `symbol`   | `"🐫 "`         | The symbol used before displaying the version of OCaml. |
-| `style`    | `"bold yellow"` | The style for the module.                               |
-| `disabled` | `false`         | Disables the `ocaml` module.                            |
+| Option     | Default                            | Description                                             |
+| ---------- | ---------------------------------- | ------------------------------------------------------- |
+| `format`   | `"via [$symbol$version]($style) "` | The format string for the module.                       |
+| `symbol`   | `"🐫 "`                            | The symbol used before displaying the version of OCaml. |
+| `style`    | `"bold yellow"`                    | The style for the module.                               |
+| `disabled` | `false`                            | Disables the `ocaml` module.                            |
+
+### Variables
+
+| Variable | Example   | Description                          |
+| -------- | --------- | ------------------------------------ |
+| version  | `v4.10.0` | The version of `ocaml`               |
+| symbol   |           | Mirrors the value of option `symbol` |
+| style\*  |           | Mirrors the value of option `style`  |
+
+\*: This variable can only be used as a part of a style string
 
 ### Example
 
@@ -1354,7 +1365,7 @@ The module will be shown if any of the following conditions are met:
 # ~/.config/starship.toml
 
 [ocaml]
-symbol = "🐪 "
+format = "via [🐪 $version]($style) "
 ```
 
 ## PHP

--- a/src/configs/ocaml.rs
+++ b/src/configs/ocaml.rs
@@ -1,22 +1,21 @@
-use crate::config::{ModuleConfig, RootModuleConfig, SegmentConfig};
+use crate::config::{ModuleConfig, RootModuleConfig};
 
-use ansi_term::{Color, Style};
 use starship_module_config_derive::ModuleConfig;
 
 #[derive(Clone, ModuleConfig)]
 pub struct OCamlConfig<'a> {
-    pub symbol: SegmentConfig<'a>,
-    pub version: SegmentConfig<'a>,
-    pub style: Style,
+    pub format: &'a str,
+    pub symbol: &'a str,
+    pub style: &'a str,
     pub disabled: bool,
 }
 
 impl<'a> RootModuleConfig<'a> for OCamlConfig<'a> {
     fn new() -> Self {
         OCamlConfig {
-            symbol: SegmentConfig::new("🐫 "),
-            version: SegmentConfig::default(),
-            style: Color::Yellow.bold(),
+            format: "via [$symbol$version]($style) ",
+            symbol: "🐫 ",
+            style: "bold yellow",
             disabled: false,
         }
     }

--- a/src/modules/ocaml.rs
+++ b/src/modules/ocaml.rs
@@ -1,6 +1,7 @@
-use super::{Context, Module, RootModuleConfig, SegmentConfig};
+use super::{Context, Module, RootModuleConfig};
 
 use crate::configs::ocaml::OCamlConfig;
+use crate::formatter::StringFormatter;
 use crate::utils;
 
 /// Creates a module with the current OCaml version
@@ -25,14 +26,37 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     }
 
     let ocaml_version = utils::exec_cmd("ocaml", &["-vnum"])?.stdout;
-    let formatted_version = format!("v{}", &ocaml_version);
 
     let mut module = context.new_module("ocaml");
-    let config = OCamlConfig::try_load(module.config);
-    module.set_style(config.style);
+    let config: OCamlConfig = OCamlConfig::try_load(module.config);
 
-    module.create_segment("symbol", &config.symbol);
-    module.create_segment("version", &SegmentConfig::new(&formatted_version));
+    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
+        formatter
+            .map_meta(|variable, _| match variable {
+                "symbol" => Some(config.symbol),
+                _ => None,
+            })
+            .map_style(|variable| match variable {
+                "style" => Some(Ok(config.style)),
+                _ => None,
+            })
+            .map(|variable| match variable {
+                "version" => Some(Ok(format!("v{}", &ocaml_version))),
+                _ => None,
+            })
+            .parse(None)
+    });
+
+    module.set_segments(match parsed {
+        Ok(segments) => segments,
+        Err(error) => {
+            log::warn!("Error in module `ocaml`: \n{}", error);
+            return None;
+        }
+    });
+
+    module.get_prefix().set_value("");
+    module.get_suffix().set_value("");
 
     Some(module)
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR deprecates `style` and `symbol` keys in the `ocaml` module to replace it with the `format` key instead.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to issue #1057

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
