### PR TITLE
build(deps): disabled logs in release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ toml = { version = "0.5.6", features = ["preserve_order"] }
 serde_json = "1.0.53"
 rayon = "1.3.0"
 pretty_env_logger = "0.4.0"
-log = "0.4.8"
+log = { version = "0.4.8", features = ["release_max_level_off"] }
 # battery is optional (on by default) because the crate doesn't currently build for Termux
 # see: https://github.com/svartalf/rust-battery/issues/33
 battery = { version = "0.7.5", optional = true }


### PR DESCRIPTION
#### Description
Setting RUST_LOG prints debug messages to the console, in startship release binary mode.

#### Motivation and Context
Related to issue https://github.com/starship/starship/issues/1277

#### How Has This Been Tested?
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**