### PR TITLE
feat: Switch to dedicated starship logging env var STARSHIP_LOG 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,15 +27,15 @@ Any styling that is applied to a module is inherited by its segments. Module pre
 ## Logging
 
 Debug logging in starship is done with [pretty_env_logger](https://crates.io/crates/pretty_env_logger).
-To run starship with debug logs, set the `RUST_LOG` environment variable to the log level needed.
+To run starship with debug logs, set the `STARSHIP_LOG` environment variable to the log level needed.
 For example, to enable the trace logs, run the following:
 
 ```sh
 # Run installed starship
-RUST_LOG=starship=trace starship
+STARSHIP_LOG=starship=trace starship
 
 # Run with cargo
-RUST_LOG=starship=trace cargo run
+STARSHIP_LOG=starship=trace cargo run
 ```
 
 ## Linting

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ use crate::module::ALL_MODULES;
 use clap::{App, AppSettings, Arg, SubCommand};
 
 fn main() {
-    pretty_env_logger::init();
+    pretty_env_logger::init_custom_env("STARSHIP_LOG");
 
     let status_code_arg = Arg::with_name("status_code")
         .short("s")


### PR DESCRIPTION
#### Description

#### Motivation and Context
As discussed in the issue https://github.com/starship/starship/issues/1277.  I've replaced the default RUST_LOG with STARSHIP_LOG to prevent interference for rust developers.
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
