### PR TITLE
feat(directory): Show lock symbol if current directory is read only

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1150,6 +1150,7 @@ dependencies = [
  "dirs-next",
  "gethostname",
  "git2",
+ "libc",
  "log",
  "native-tls",
  "nom",
@@ -1174,6 +1175,7 @@ dependencies = [
  "unicode-segmentation",
  "unicode-width",
  "urlencoding",
+ "winapi",
  "yaml-rust",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,7 +88,7 @@ dependencies = [
  "lazycell",
  "libc",
  "mach",
- "nix",
+ "nix 0.15.0",
  "num-traits",
  "uom",
  "winapi",
@@ -652,6 +652,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50e4785f2c3b7589a0d0c1dd60285e1188adac4006e8abd6dd578e1567027363"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if",
+ "libc",
+ "void",
+]
+
+[[package]]
 name = "nom"
 version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1150,9 +1163,9 @@ dependencies = [
  "dirs-next",
  "gethostname",
  "git2",
- "libc",
  "log",
  "native-tls",
+ "nix 0.17.0",
  "nom",
  "once_cell",
  "open",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ native-tls = { version = "0.2", optional = true }
 winapi = { version = "0.3", features = ["winuser", "securitybaseapi", "processthreadsapi", "handleapi", "impl-default"]}
 
 [target.'cfg(not(windows))'.dependencies]
-libc = "0.2"
+nix = "0.17.0"
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,12 @@ quick-xml = "0.18.1"
 attohttpc = { version = "0.15.0", optional = true, default-features = false, features = ["tls", "form"] }
 native-tls = { version = "0.2", optional = true }
 
+[target.'cfg(windows)'.dependencies]
+winapi = { version = "0.3", features = ["winuser", "securitybaseapi", "processthreadsapi", "handleapi", "impl-default"]}
+
+[target.'cfg(not(windows))'.dependencies]
+libc = "0.2"
+
 [dev-dependencies]
 tempfile = "3.1.0"
 # More realiable than std::fs version on Windows

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -589,13 +589,15 @@ it would have been `nixpkgs/pkgs`.
 
 ### Options
 
-| Option              | Default              | Description                                                                      |
-| ------------------- | -------------------- | -------------------------------------------------------------------------------- |
-| `truncation_length` | `3`                  | The number of parent folders that the current directory should be truncated to.  |
-| `truncate_to_repo`  | `true`               | Whether or not to truncate to the root of the git repo that you're currently in. |
-| `format`            | `"[$path]($style) "` | The format for the module.                                                       |
-| `style`             | `"bold cyan"`        | The style for the module.                                                        |
-| `disabled`          | `false`              | Disables the `directory` module.                                                 |
+| Variable                 | Default              | Description                                                                      |
+| ------------------------ | -------------------- | -------------------------------------------------------------------------------- |
+| `truncation_length`      | `3`                  | The number of parent folders that the current directory should be truncated to.  |
+| `truncate_to_repo`       | `true`               | Whether or not to truncate to the root of the git repo that you're currently in. |
+| `format`                 | `"[$path]($style) "` | The format for the module.                                                       |
+| `style`                  | `"bold cyan"`        | The style for the module.                                                        |
+| `disabled`               | `false`              | Disables the `directory` module.                                                 |
+| `read_only_symbol`       | `"🔒"`               | The symbol indicating current directory is read only.                            |
+| `read_only_symbol_style` | `"red normal"`       | The style for the read only symbol.                                              |
 
 <details>
 <summary>This module has a few advanced configuration options that control how the directory is displayed.</summary>

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -589,15 +589,15 @@ it would have been `nixpkgs/pkgs`.
 
 ### Options
 
-| Variable                 | Default              | Description                                                                      |
-| ------------------------ | -------------------- | -------------------------------------------------------------------------------- |
-| `truncation_length`      | `3`                  | The number of parent folders that the current directory should be truncated to.  |
-| `truncate_to_repo`       | `true`               | Whether or not to truncate to the root of the git repo that you're currently in. |
-| `format`                 | `"[$path]($style) "` | The format for the module.                                                       |
-| `style`                  | `"bold cyan"`        | The style for the module.                                                        |
-| `disabled`               | `false`              | Disables the `directory` module.                                                 |
-| `read_only_symbol`       | `"🔒"`               | The symbol indicating current directory is read only.                            |
-| `read_only_symbol_style` | `"red normal"`       | The style for the read only symbol.                                              |
+| Variable                 | Default                                         | Description                                                                      |
+| ------------------------ | ----------------------------------------------- | -------------------------------------------------------------------------------- |
+| `truncation_length`      | `3`                                             | The number of parent folders that the current directory should be truncated to.  |
+| `truncate_to_repo`       | `true`                                          | Whether or not to truncate to the root of the git repo that you're currently in. |
+| `format`                 | `"[$path]($style)[$lock_symbol]($lock_style) "` | The format for the module.                                                       |
+| `style`                  | `"bold cyan"`                                   | The style for the module.                                                        |
+| `disabled`               | `false`                                         | Disables the `directory` module.                                                 |
+| `read_only_symbol`       | `"🔒"`                                          | The symbol indicating current directory is read only.                            |
+| `read_only_symbol_style` | `"red"`                                         | The style for the read only symbol.                                              |
 
 <details>
 <summary>This module has a few advanced configuration options that control how the directory is displayed.</summary>

--- a/src/configs/directory.rs
+++ b/src/configs/directory.rs
@@ -1,4 +1,4 @@
-use crate::config::{ModuleConfig, RootModuleConfig};
+use crate::config::{ModuleConfig, RootModuleConfig, SegmentConfig};
 use std::collections::HashMap;
 
 use starship_module_config_derive::ModuleConfig;
@@ -13,6 +13,8 @@ pub struct DirectoryConfig<'a> {
     pub format: &'a str,
     pub style: &'a str,
     pub disabled: bool,
+    pub read_only_symbol: SegmentConfig<'a>,
+    pub read_only_symbol_style: Style,
 }
 
 impl<'a> RootModuleConfig<'a> for DirectoryConfig<'a> {
@@ -23,9 +25,11 @@ impl<'a> RootModuleConfig<'a> for DirectoryConfig<'a> {
             fish_style_pwd_dir_length: 0,
             substitutions: HashMap::new(),
             use_logical_path: true,
-            format: "[$path]($style) ",
+            format: "[$path]($style) [$read_only]($read_only_style)",
             style: "cyan bold",
             disabled: false,
+            read_only_symbol: SegmentConfig::new("🔒"),
+            read_only_symbol_style: Color::Red.normal(),
         }
     }
 }

--- a/src/configs/directory.rs
+++ b/src/configs/directory.rs
@@ -1,4 +1,4 @@
-use crate::config::{ModuleConfig, RootModuleConfig, SegmentConfig};
+use crate::config::{ModuleConfig, RootModuleConfig};
 use std::collections::HashMap;
 
 use starship_module_config_derive::ModuleConfig;
@@ -13,8 +13,8 @@ pub struct DirectoryConfig<'a> {
     pub format: &'a str,
     pub style: &'a str,
     pub disabled: bool,
-    pub read_only_symbol: SegmentConfig<'a>,
-    pub read_only_symbol_style: Style,
+    pub read_only_symbol: &'a str,
+    pub read_only_symbol_style: &'a str,
 }
 
 impl<'a> RootModuleConfig<'a> for DirectoryConfig<'a> {
@@ -25,11 +25,11 @@ impl<'a> RootModuleConfig<'a> for DirectoryConfig<'a> {
             fish_style_pwd_dir_length: 0,
             substitutions: HashMap::new(),
             use_logical_path: true,
-            format: "[$path]($style) [$read_only]($read_only_style)",
+            format: "[$path]($style)[$read_only]($read_only_style) ",
             style: "cyan bold",
             disabled: false,
-            read_only_symbol: SegmentConfig::new("🔒"),
-            read_only_symbol_style: Color::Red.normal(),
+            read_only_symbol: "🔒",
+            read_only_symbol_style: "red",
         }
     }
 }

--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -95,6 +95,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         String::from("")
     };
     let final_dir_string = format!("{}{}", fish_prefix, truncated_dir_string);
+    let lock_symbol = String::from(config.read_only_symbol);
 
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter
@@ -107,7 +108,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 "path" => Some(Ok(&final_dir_string)),
                 "read_only" => {
                     if is_readonly_dir(current_dir.to_str()?) {
-                        Some(Ok(config.read_only_symbol))
+                        Some(Ok(&lock_symbol))
                     } else {
                         None
                     }

--- a/src/modules/utils/directory_nix.rs
+++ b/src/modules/utils/directory_nix.rs
@@ -2,7 +2,7 @@ use nix::sys::stat::Mode;
 use nix::unistd;
 use nix::unistd::{Gid, Uid};
 use std::fs;
-use std::os::linux::fs::MetadataExt;
+use std::os::unix::fs::MetadataExt;
 use std::os::unix::fs::PermissionsExt;
 
 const USER_WRITE_BIT: u32 = Mode::S_IWUSR.bits();
@@ -17,10 +17,10 @@ pub fn is_write_allowed(folder_path: &str) -> Result<bool, &'static str> {
     if euid.is_root() {
         return Ok(true);
     }
-    if meta.st_uid() == euid.as_raw() {
+    if meta.uid() == euid.as_raw() {
         Ok(perms & USER_WRITE_BIT != 0)
-    } else if (meta.st_gid() == Gid::effective().as_raw())
-        || (get_supplementary_groups().contains(&meta.st_gid()))
+    } else if (meta.gid() == Gid::effective().as_raw())
+        || (get_supplementary_groups().contains(&meta.gid()))
     {
         Ok(perms & GROUP_WRITE_BIT != 0)
     } else {

--- a/src/modules/utils/directory_nix.rs
+++ b/src/modules/utils/directory_nix.rs
@@ -1,0 +1,60 @@
+extern crate libc;
+#[cfg(all(unix, not(target_os = "macos")))]
+use libc::gid_t;
+use std::ffi::CString;
+
+pub fn is_write_allowed(folder_path: &str) -> std::result::Result<bool, &'static str> {
+    let c_string = CString::new(folder_path).unwrap();
+    unsafe {
+        let mut buf: Vec<u8> = Vec::with_capacity(std::mem::size_of::<libc::stat>());
+        let res = libc::stat(c_string.as_ptr(), buf.as_mut_ptr() as *mut libc::stat);
+
+        if res != 0 {
+            return Err("Unable to stat() directory");
+        }
+
+        let stat_struct: *const libc::stat = buf.as_ptr() as *const libc::stat;
+        let mode = (*stat_struct).st_mode;
+        if (*stat_struct).st_uid == libc::geteuid() {
+            return Ok(mode & libc::S_IWUSR != 0);
+        }
+        if (*stat_struct).st_gid == libc::getgid() {
+            return Ok(mode & libc::S_IWGRP != 0);
+        }
+
+        let num_groups = libc::getgroups(0, ::std::ptr::null_mut());
+        if num_groups == -1 {
+            return Err("Unable to get suplementary groups for the current process");
+        }
+        #[cfg(all(unix, target_os = "macos"))]
+        let mut groups: Vec<u32> = vec![0; 1024];
+        #[cfg(all(unix, not(target_os = "macos")))]
+        let mut groups: Vec<gid_t> = vec![0; 1024];
+        let res = libc::getgroups(num_groups, groups.as_mut_ptr());
+        if res == -1 {
+            return Err("Unable to get suplementary groups for the current process");
+        }
+
+        for i in 0..num_groups {
+            if groups[i as usize] == (*stat_struct).st_gid {
+                return Ok(mode & libc::S_IWGRP != 0);
+            }
+        }
+
+        Ok(mode & libc::S_IWOTH != 0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn read_only_test() {
+        assert_eq!(is_write_allowed("/etc"), Ok(false));
+        assert_eq!(
+            is_write_allowed("/i_dont_exist"),
+            Err("Unable to stat() directory")
+        );
+    }
+}

--- a/src/modules/utils/directory_nix.rs
+++ b/src/modules/utils/directory_nix.rs
@@ -1,47 +1,45 @@
-extern crate libc;
-#[cfg(all(unix, not(target_os = "macos")))]
-use libc::gid_t;
-use std::ffi::CString;
+use nix::sys::stat::Mode;
+use nix::unistd;
+use nix::unistd::{Gid, Uid};
+use std::fs;
+use std::os::linux::fs::MetadataExt;
+use std::os::unix::fs::PermissionsExt;
 
-pub fn is_write_allowed(folder_path: &str) -> std::result::Result<bool, &'static str> {
-    let c_string = CString::new(folder_path).unwrap();
-    unsafe {
-        let mut stat: libc::stat = std::mem::zeroed();
-        let res = libc::stat(c_string.as_ptr(), &mut stat);
+const USER_WRITE_BIT: u32 = Mode::S_IWUSR.bits();
+const GROUP_WRITE_BIT: u32 = Mode::S_IWGRP.bits();
+const OTHER_WRITE_BIT: u32 = Mode::S_IWOTH.bits();
 
-        if res != 0 {
-            return Err("Unable to stat() directory");
-        }
+pub fn is_write_allowed(folder_path: &str) -> Result<bool, &'static str> {
+    let meta = fs::metadata(folder_path).map_err(|_| "Unable to stat() directory")?;
+    let perms = meta.permissions().mode();
 
-        let mode = stat.st_mode;
-        if stat.st_uid == libc::geteuid() {
-            return Ok(mode & libc::S_IWUSR != 0);
-        }
-        if stat.st_gid == libc::getgid() {
-            return Ok(mode & libc::S_IWGRP != 0);
-        }
-
-        let num_groups = libc::getgroups(0, ::std::ptr::null_mut());
-        if num_groups == -1 {
-            return Err("Unable to get suplementary groups for the current process");
-        }
-        #[cfg(all(unix, target_os = "macos"))]
-        let mut groups: Vec<u32> = vec![0; 1024];
-        #[cfg(all(unix, not(target_os = "macos")))]
-        let mut groups: Vec<gid_t> = vec![0; 1024];
-        let res = libc::getgroups(num_groups, groups.as_mut_ptr());
-        if res == -1 {
-            return Err("Unable to get suplementary groups for the current process");
-        }
-
-        for i in 0..num_groups {
-            if groups[i as usize] == stat.st_gid {
-                return Ok(mode & libc::S_IWGRP != 0);
-            }
-        }
-
-        Ok(mode & libc::S_IWOTH != 0)
+    let euid = Uid::effective();
+    if euid.is_root() {
+        return Ok(true);
     }
+    if meta.st_uid() == euid.as_raw() {
+        Ok(perms & USER_WRITE_BIT != 0)
+    } else if (meta.st_gid() == Gid::effective().as_raw())
+        || (get_supplementary_groups().contains(&meta.st_gid()))
+    {
+        Ok(perms & GROUP_WRITE_BIT != 0)
+    } else {
+        Ok(perms & OTHER_WRITE_BIT != 0)
+    }
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn get_supplementary_groups() -> Vec<u32> {
+    match unistd::getgroups() {
+        Err(_) => Vec::new(),
+        Ok(v) => v.into_iter().map(|i| i.as_raw()).collect(),
+    }
+}
+
+#[cfg(all(unix, target_os = "macos"))]
+fn get_supplementary_groups() -> Vec<u32> {
+    // at the moment nix crate does not provide it for macOS
+    Vec::new()
 }
 
 #[cfg(test)]

--- a/src/modules/utils/directory_nix.rs
+++ b/src/modules/utils/directory_nix.rs
@@ -1,13 +1,8 @@
 use nix::sys::stat::Mode;
-use nix::unistd;
 use nix::unistd::{Gid, Uid};
 use std::fs;
 use std::os::unix::fs::MetadataExt;
 use std::os::unix::fs::PermissionsExt;
-
-const USER_WRITE_BIT: u32 = Mode::S_IWUSR.bits();
-const GROUP_WRITE_BIT: u32 = Mode::S_IWGRP.bits();
-const OTHER_WRITE_BIT: u32 = Mode::S_IWOTH.bits();
 
 pub fn is_write_allowed(folder_path: &str) -> Result<bool, &'static str> {
     let meta = fs::metadata(folder_path).map_err(|_| "Unable to stat() directory")?;
@@ -18,19 +13,19 @@ pub fn is_write_allowed(folder_path: &str) -> Result<bool, &'static str> {
         return Ok(true);
     }
     if meta.uid() == euid.as_raw() {
-        Ok(perms & USER_WRITE_BIT != 0)
+        Ok(perms & Mode::S_IWUSR.bits() as u32 != 0)
     } else if (meta.gid() == Gid::effective().as_raw())
         || (get_supplementary_groups().contains(&meta.gid()))
     {
-        Ok(perms & GROUP_WRITE_BIT != 0)
+        Ok(perms & Mode::S_IWGRP.bits() as u32 != 0)
     } else {
-        Ok(perms & OTHER_WRITE_BIT != 0)
+        Ok(perms & Mode::S_IWOTH.bits() as u32 != 0)
     }
 }
 
 #[cfg(all(unix, not(target_os = "macos")))]
 fn get_supplementary_groups() -> Vec<u32> {
-    match unistd::getgroups() {
+    match nix::unistd::getgroups() {
         Err(_) => Vec::new(),
         Ok(v) => v.into_iter().map(|i| i.as_raw()).collect(),
     }

--- a/src/modules/utils/directory_nix.rs
+++ b/src/modules/utils/directory_nix.rs
@@ -4,6 +4,14 @@ use std::fs;
 use std::os::unix::fs::MetadataExt;
 use std::os::unix::fs::PermissionsExt;
 
+/// Checks if the current user can write to the `folder_path`.
+///
+/// It extracts Unix access rights from the directory and checks whether
+/// 1) the current user is the owner of the directory and whether it has the write access
+/// 2) the current user's primary group is the directory group owner whether if it has write access
+/// 2a) (not implemented on macOS) one of the supplementary groups of the current user is the
+/// directory group owner and whether it has write access
+/// 3) 'others' part of the access mask has the write access
 pub fn is_write_allowed(folder_path: &str) -> Result<bool, &'static str> {
     let meta = fs::metadata(folder_path).map_err(|_| "Unable to stat() directory")?;
     let perms = meta.permissions().mode();
@@ -42,6 +50,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[ignore]
     fn read_only_test() {
         assert_eq!(is_write_allowed("/etc"), Ok(false));
         assert_eq!(

--- a/src/modules/utils/directory_win.rs
+++ b/src/modules/utils/directory_win.rs
@@ -1,0 +1,124 @@
+extern crate winapi;
+
+use std::ffi::OsStr;
+use std::iter;
+use std::mem;
+use std::os::windows::ffi::OsStrExt;
+use winapi::ctypes::c_void;
+use winapi::shared::minwindef::{BOOL, DWORD};
+use winapi::um::handleapi;
+use winapi::um::processthreadsapi;
+use winapi::um::securitybaseapi;
+use winapi::um::winnt::{
+    SecurityImpersonation, DACL_SECURITY_INFORMATION, FILE_ALL_ACCESS, FILE_GENERIC_EXECUTE,
+    FILE_GENERIC_READ, FILE_GENERIC_WRITE, GENERIC_MAPPING, GROUP_SECURITY_INFORMATION, HANDLE,
+    OWNER_SECURITY_INFORMATION, PRIVILEGE_SET, PSECURITY_DESCRIPTOR, STANDARD_RIGHTS_READ,
+    TOKEN_DUPLICATE, TOKEN_IMPERSONATE, TOKEN_QUERY,
+};
+
+pub fn is_write_allowed(folder_path: &str) -> std::result::Result<bool, &'static str> {
+    let folder_name: Vec<u16> = OsStr::new(folder_path)
+        .encode_wide()
+        .chain(iter::once(0))
+        .collect();
+    let mut length: DWORD = 0;
+
+    unsafe {
+        let rc = securitybaseapi::GetFileSecurityW(
+            folder_name.as_ptr(),
+            OWNER_SECURITY_INFORMATION | GROUP_SECURITY_INFORMATION | DACL_SECURITY_INFORMATION,
+            std::ptr::null_mut(),
+            0,
+            &mut length,
+        );
+
+        if rc != 0 {
+            return Err(
+                "GetFileSecurityW returned non-zero when asked for the security descriptor size",
+            );
+        }
+
+        let mut buf: Vec<u8> = Vec::with_capacity(length as usize);
+
+        let rc = securitybaseapi::GetFileSecurityW(
+            folder_name.as_ptr(),
+            OWNER_SECURITY_INFORMATION | GROUP_SECURITY_INFORMATION | DACL_SECURITY_INFORMATION,
+            buf.as_mut_ptr() as *mut c_void,
+            length,
+            &mut length,
+        );
+
+        if rc != 1 {
+            return Err("GetFileSecurityW failed to retrieve the security descriptor");
+        }
+
+        let mut token: HANDLE = 0 as HANDLE;
+        let rc = processthreadsapi::OpenProcessToken(
+            processthreadsapi::GetCurrentProcess(),
+            TOKEN_IMPERSONATE | TOKEN_QUERY | TOKEN_DUPLICATE | STANDARD_RIGHTS_READ,
+            &mut token,
+        );
+        if rc != 1 {
+            return Err("OpenProcessToken failed to retrieve current process' security token");
+        }
+
+        let mut impersonated_token: HANDLE = 0 as HANDLE;
+        let rc =
+            securitybaseapi::DuplicateToken(token, SecurityImpersonation, &mut impersonated_token);
+
+        if rc != 1 {
+            handleapi::CloseHandle(token);
+            return Err("DuplicateToken failed");
+        }
+
+        let mut mapping: GENERIC_MAPPING = GENERIC_MAPPING {
+            GenericRead: FILE_GENERIC_READ,
+            GenericWrite: FILE_GENERIC_WRITE,
+            GenericExecute: FILE_GENERIC_EXECUTE,
+            GenericAll: FILE_ALL_ACCESS,
+        };
+
+        let mut priviledges: PRIVILEGE_SET = PRIVILEGE_SET::default();
+        let mut priv_size = mem::size_of::<PRIVILEGE_SET>() as DWORD;
+        let mut granted_access: DWORD = 0;
+        let mut access_rights: DWORD = FILE_GENERIC_WRITE;
+        securitybaseapi::MapGenericMask(&mut access_rights, &mut mapping);
+        let mut result: BOOL = 0 as BOOL;
+        let rc = securitybaseapi::AccessCheck(
+            buf.as_mut_ptr() as PSECURITY_DESCRIPTOR,
+            impersonated_token,
+            access_rights,
+            &mut mapping,
+            &mut priviledges,
+            &mut priv_size,
+            &mut granted_access,
+            &mut result,
+        );
+
+        handleapi::CloseHandle(impersonated_token);
+        handleapi::CloseHandle(token);
+
+        if rc != 1 {
+            return Err("AccessCheck failed");
+        }
+
+        Ok(result != 0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn read_only_test() {
+        assert_eq!(
+            is_write_allowed(&std::env::var("windir").unwrap()),
+            Ok(false)
+        );
+        assert_eq!(
+            is_write_allowed(&std::env::var("USERPROFILE").unwrap()),
+            Ok(true)
+        );
+    }
+}

--- a/src/modules/utils/directory_win.rs
+++ b/src/modules/utils/directory_win.rs
@@ -23,68 +23,73 @@ pub fn is_write_allowed(folder_path: &str) -> std::result::Result<bool, &'static
         .collect();
     let mut length: DWORD = 0;
 
-    unsafe {
-        let rc = securitybaseapi::GetFileSecurityW(
+    let rc = unsafe {
+        securitybaseapi::GetFileSecurityW(
             folder_name.as_ptr(),
             OWNER_SECURITY_INFORMATION | GROUP_SECURITY_INFORMATION | DACL_SECURITY_INFORMATION,
             std::ptr::null_mut(),
             0,
             &mut length,
+        )
+    };
+    if rc != 0 {
+        return Err(
+            "GetFileSecurityW returned non-zero when asked for the security descriptor size",
         );
+    }
 
-        if rc != 0 {
-            return Err(
-                "GetFileSecurityW returned non-zero when asked for the security descriptor size",
-            );
-        }
+    let mut buf: Vec<u8> = Vec::with_capacity(length as usize);
 
-        let mut buf: Vec<u8> = Vec::with_capacity(length as usize);
-
-        let rc = securitybaseapi::GetFileSecurityW(
+    let rc = unsafe {
+        securitybaseapi::GetFileSecurityW(
             folder_name.as_ptr(),
             OWNER_SECURITY_INFORMATION | GROUP_SECURITY_INFORMATION | DACL_SECURITY_INFORMATION,
             buf.as_mut_ptr() as *mut c_void,
             length,
             &mut length,
-        );
+        )
+    };
 
-        if rc != 1 {
-            return Err("GetFileSecurityW failed to retrieve the security descriptor");
-        }
+    if rc != 1 {
+        return Err("GetFileSecurityW failed to retrieve the security descriptor");
+    }
 
-        let mut token: HANDLE = 0 as HANDLE;
-        let rc = processthreadsapi::OpenProcessToken(
+    let mut token: HANDLE = 0 as HANDLE;
+    let rc = unsafe {
+        processthreadsapi::OpenProcessToken(
             processthreadsapi::GetCurrentProcess(),
             TOKEN_IMPERSONATE | TOKEN_QUERY | TOKEN_DUPLICATE | STANDARD_RIGHTS_READ,
             &mut token,
-        );
-        if rc != 1 {
-            return Err("OpenProcessToken failed to retrieve current process' security token");
-        }
+        )
+    };
+    if rc != 1 {
+        return Err("OpenProcessToken failed to retrieve current process' security token");
+    }
 
-        let mut impersonated_token: HANDLE = 0 as HANDLE;
-        let rc =
-            securitybaseapi::DuplicateToken(token, SecurityImpersonation, &mut impersonated_token);
+    let mut impersonated_token: HANDLE = 0 as HANDLE;
+    let rc = unsafe {
+        securitybaseapi::DuplicateToken(token, SecurityImpersonation, &mut impersonated_token)
+    };
+    if rc != 1 {
+        unsafe { handleapi::CloseHandle(token) };
+        return Err("DuplicateToken failed");
+    }
 
-        if rc != 1 {
-            handleapi::CloseHandle(token);
-            return Err("DuplicateToken failed");
-        }
+    let mut mapping: GENERIC_MAPPING = GENERIC_MAPPING {
+        GenericRead: FILE_GENERIC_READ,
+        GenericWrite: FILE_GENERIC_WRITE,
+        GenericExecute: FILE_GENERIC_EXECUTE,
+        GenericAll: FILE_ALL_ACCESS,
+    };
 
-        let mut mapping: GENERIC_MAPPING = GENERIC_MAPPING {
-            GenericRead: FILE_GENERIC_READ,
-            GenericWrite: FILE_GENERIC_WRITE,
-            GenericExecute: FILE_GENERIC_EXECUTE,
-            GenericAll: FILE_ALL_ACCESS,
-        };
-
-        let mut priviledges: PRIVILEGE_SET = PRIVILEGE_SET::default();
-        let mut priv_size = mem::size_of::<PRIVILEGE_SET>() as DWORD;
-        let mut granted_access: DWORD = 0;
-        let mut access_rights: DWORD = FILE_GENERIC_WRITE;
-        securitybaseapi::MapGenericMask(&mut access_rights, &mut mapping);
-        let mut result: BOOL = 0 as BOOL;
-        let rc = securitybaseapi::AccessCheck(
+    let mut priviledges: PRIVILEGE_SET = PRIVILEGE_SET::default();
+    let mut priv_size = mem::size_of::<PRIVILEGE_SET>() as DWORD;
+    let mut granted_access: DWORD = 0;
+    let mut access_rights: DWORD = FILE_GENERIC_WRITE;
+    let mut result: BOOL = 0 as BOOL;
+    unsafe { securitybaseapi::MapGenericMask(&mut access_rights, &mut mapping) };
+    let rc = unsafe {
+        securitybaseapi::AccessCheck(
             buf.as_mut_ptr() as PSECURITY_DESCRIPTOR,
             impersonated_token,
             access_rights,
@@ -93,15 +98,16 @@ pub fn is_write_allowed(folder_path: &str) -> std::result::Result<bool, &'static
             &mut priv_size,
             &mut granted_access,
             &mut result,
-        );
-
+        )
+    };
+    unsafe {
         handleapi::CloseHandle(impersonated_token);
         handleapi::CloseHandle(token);
-
-        if rc != 1 {
-            return Err("AccessCheck failed");
-        }
-
-        Ok(result != 0)
     }
+
+    if rc != 1 {
+        return Err("AccessCheck failed");
+    }
+
+    Ok(result != 0)
 }

--- a/src/modules/utils/directory_win.rs
+++ b/src/modules/utils/directory_win.rs
@@ -105,20 +105,3 @@ pub fn is_write_allowed(folder_path: &str) -> std::result::Result<bool, &'static
         Ok(result != 0)
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn read_only_test() {
-        assert_eq!(
-            is_write_allowed(&std::env::var("windir").unwrap()),
-            Ok(false)
-        );
-        assert_eq!(
-            is_write_allowed(&std::env::var("USERPROFILE").unwrap()),
-            Ok(true)
-        );
-    }
-}

--- a/src/modules/utils/directory_win.rs
+++ b/src/modules/utils/directory_win.rs
@@ -16,6 +16,10 @@ use winapi::um::winnt::{
     TOKEN_DUPLICATE, TOKEN_IMPERSONATE, TOKEN_QUERY,
 };
 
+/// Checks if the current user has write access right to the `folder_path`
+///
+/// First, the function extracts DACL from the given directory and then calls `AccessCheck` against
+/// the current process access token and directory's security descriptor.
 pub fn is_write_allowed(folder_path: &str) -> std::result::Result<bool, &'static str> {
     let folder_name: Vec<u16> = OsStr::new(folder_path)
         .encode_wide()

--- a/src/modules/utils/mod.rs
+++ b/src/modules/utils/mod.rs
@@ -1,5 +1,11 @@
 pub mod directory;
 pub mod java_version_parser;
 
+#[cfg(target_os = "windows")]
+pub mod directory_win;
+
+#[cfg(not(target_os = "windows"))]
+pub mod directory_nix;
+
 #[cfg(test)]
 pub mod test;

--- a/tests/testsuite/directory.rs
+++ b/tests/testsuite/directory.rs
@@ -138,11 +138,14 @@ fn root_directory() -> io::Result<()> {
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
+    #[cfg(not(target_os = "windows"))]
     let expected = format!(
         "in {}{} ",
         Color::Cyan.bold().paint("/"),
         Color::Red.normal().paint("🔒")
     );
+    #[cfg(target_os = "windows")]
+    let expected = format!("in {} ", Color::Cyan.bold().paint("/"),);
     assert_eq!(expected, actual);
     Ok(())
 }
@@ -158,11 +161,14 @@ fn test_prefix() -> io::Result<()> {
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
+    #[cfg(not(target_os = "windows"))]
     let expected = format!(
         "sample {}{} ",
         Color::Cyan.bold().paint("/"),
         Color::Red.normal().paint("🔒")
     );
+    #[cfg(target_os = "windows")]
+    let expected = format!("sample {} ", Color::Cyan.bold().paint("/"),);
     assert_eq!(expected, actual);
     Ok(())
 }

--- a/tests/testsuite/directory.rs
+++ b/tests/testsuite/directory.rs
@@ -138,7 +138,31 @@ fn root_directory() -> io::Result<()> {
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
-    let expected = format!("{} ", Color::Cyan.bold().paint("/"));
+    let expected = format!(
+        "in {}{} ",
+        Color::Cyan.bold().paint("/"),
+        Color::Red.normal().paint("🔒")
+    );
+    assert_eq!(expected, actual);
+    Ok(())
+}
+
+#[test]
+fn test_prefix() -> io::Result<()> {
+    let output = common::render_module("directory")
+        .arg("--path=/")
+        .use_config(toml::toml! {
+            [directory]
+            prefix = "sample "
+        })
+        .output()?;
+    let actual = String::from_utf8(output.stdout).unwrap();
+
+    let expected = format!(
+        "sample {}{} ",
+        Color::Cyan.bold().paint("/"),
+        Color::Red.normal().paint("🔒")
+    );
     assert_eq!(expected, actual);
     Ok(())
 }
@@ -151,7 +175,11 @@ fn directory_in_root() -> io::Result<()> {
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
-    let expected = format!("{} ", Color::Cyan.bold().paint("/etc"));
+    let expected = format!(
+        "in {}{} ",
+        Color::Cyan.bold().paint("/etc"),
+        Color::Red.normal().paint("🔒")
+    );
     assert_eq!(expected, actual);
     Ok(())
 }

--- a/tests/testsuite/directory.rs
+++ b/tests/testsuite/directory.rs
@@ -145,7 +145,7 @@ fn root_directory() -> io::Result<()> {
         Color::Red.normal().paint("🔒")
     );
     #[cfg(target_os = "windows")]
-    let expected = format!("in {} ", Color::Cyan.bold().paint("/"),);
+    let expected = format!("{} ", Color::Cyan.bold().paint("/"),);
     assert_eq!(expected, actual);
     Ok(())
 }

--- a/tests/testsuite/directory.rs
+++ b/tests/testsuite/directory.rs
@@ -140,35 +140,12 @@ fn root_directory() -> io::Result<()> {
 
     #[cfg(not(target_os = "windows"))]
     let expected = format!(
-        "in {}{} ",
+        "{}{} ",
         Color::Cyan.bold().paint("/"),
         Color::Red.normal().paint("🔒")
     );
     #[cfg(target_os = "windows")]
     let expected = format!("in {} ", Color::Cyan.bold().paint("/"),);
-    assert_eq!(expected, actual);
-    Ok(())
-}
-
-#[test]
-fn test_prefix() -> io::Result<()> {
-    let output = common::render_module("directory")
-        .arg("--path=/")
-        .use_config(toml::toml! {
-            [directory]
-            prefix = "sample "
-        })
-        .output()?;
-    let actual = String::from_utf8(output.stdout).unwrap();
-
-    #[cfg(not(target_os = "windows"))]
-    let expected = format!(
-        "sample {}{} ",
-        Color::Cyan.bold().paint("/"),
-        Color::Red.normal().paint("🔒")
-    );
-    #[cfg(target_os = "windows")]
-    let expected = format!("sample {} ", Color::Cyan.bold().paint("/"),);
     assert_eq!(expected, actual);
     Ok(())
 }
@@ -182,7 +159,7 @@ fn directory_in_root() -> io::Result<()> {
     let actual = String::from_utf8(output.stdout).unwrap();
 
     let expected = format!(
-        "in {}{} ",
+        "{}{} ",
         Color::Cyan.bold().paint("/etc"),
         Color::Red.normal().paint("🔒")
     );


### PR DESCRIPTION
The directory module shows little 'lock' symbol when the current directory can't be written by the current user.

#### Description
It was requested to Starship have the similar feature as zsh does -- showing a special symbol whenever the current directory can't be written by the current user.
The *nix implementation is straightforward: it uses a built-in sh feature to determine the matter. Windows implementation is complex involving Windows Security API to perform an `AccessCheck`.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1041

#### Screenshots (if appropriate):
![Annotation 2020-06-06 194759](https://user-images.githubusercontent.com/2017002/83950786-f24bac00-a835-11ea-8804-5be72c782318.png)
![Screenshot from 2020-06-06 20-12-35](https://user-images.githubusercontent.com/2017002/83950802-0c858a00-a836-11ea-85e5-a7bcac8e932e.png)

#### How Has This Been Tested?
- [X] I have tested using **MacOS**
- [X] I have tested using **Linux**
- [X] I have tested using **Windows**

#### Checklist:
- [X] I have updated the documentation accordingly.
- [X] I have updated the tests accordingly.
