### PR TITLE
fix(directory): Fix path contractions for symlinked git repos

### DIFF
--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -62,6 +62,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
     let dir_string = match &repo.root {
         Some(repo_root) if config.truncate_to_repo && (repo_root != &home_dir) => {
+            log::debug!("Repo root: {:?}", repo_root);
             let repo_folder_name = repo_root.file_name().unwrap().to_str().unwrap();
 
             // Contract the path to the git repo root
@@ -70,6 +71,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         // Contract the path to the home directory
         _ => contract_path(current_dir, &home_dir, HOME_SYMBOL),
     };
+    log::debug!("Dir string: {}", dir_string);
 
     let substituted_dir = substitute_path(dir_string, &config.substitutions);
 

--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -152,10 +152,7 @@ fn contract_repo_path(full_path: &Path, top_level_path: &Path) -> Option<String>
         }
 
         let components: Vec<_> = full_path.components().collect();
-        let repo_name = components[components.len() - i - 1]
-            .as_os_str()
-            .to_str()
-            .unwrap();
+        let repo_name = components[components.len() - i - 1].as_os_str().to_str()?;
 
         if i == 0 {
             return Some(repo_name.to_string());
@@ -166,7 +163,7 @@ fn contract_repo_path(full_path: &Path, top_level_path: &Path) -> Option<String>
             "{repo_name}{separator}{path}",
             repo_name = repo_name,
             separator = "/",
-            path = path.to_slash().unwrap()
+            path = path.to_slash()?
         ));
     }
     None

--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -1,5 +1,6 @@
 use path_slash::PathExt;
 use std::collections::HashMap;
+use std::iter::FromIterator;
 use std::path::{Path, PathBuf};
 use unicode_segmentation::UnicodeSegmentation;
 
@@ -63,10 +64,9 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let dir_string = match &repo.root {
         Some(repo_root) if config.truncate_to_repo && (repo_root != &home_dir) => {
             log::debug!("Repo root: {:?}", repo_root);
-            let repo_folder_name = repo_root.file_name().unwrap().to_str().unwrap();
-
             // Contract the path to the git repo root
-            contract_path(current_dir, repo_root, repo_folder_name)
+            contract_repo_path(current_dir, repo_root)
+                .unwrap_or_else(|| current_dir.to_slash().unwrap())
         }
         // Contract the path to the home directory
         _ => contract_path(current_dir, &home_dir, HOME_SYMBOL),
@@ -134,6 +134,60 @@ fn contract_path(full_path: &Path, top_level_path: &Path, top_level_replacement:
             .to_slash()
             .unwrap()
     )
+}
+
+/// Contract the root component of a path based on the real path
+///
+/// Replaces the `top_level_path` in a given `full_path` with the provided
+/// `top_level_replacement` by walking ancestors and comparing its real path.
+fn contract_repo_path(full_path: &Path, top_level_path: &Path) -> Option<String> {
+    let top_level_real_path = real_path(top_level_path);
+    // Walk ancestors to preserve logical path in `full_path`.
+    // If we'd just `full_real_path.strip_prefix(top_level_real_path)`,
+    // then it wouldn't preserve logical path. It would've returned physical path.
+    for (i, ancestor) in full_path.ancestors().enumerate() {
+        let ancestor_real_path = real_path(ancestor);
+        if ancestor_real_path != top_level_real_path {
+            continue;
+        }
+
+        let components: Vec<_> = full_path.components().collect();
+        let repo_name = components[components.len() - i - 1]
+            .as_os_str()
+            .to_str()
+            .unwrap();
+
+        if i == 0 {
+            return Some(repo_name.to_string());
+        }
+
+        let path = PathBuf::from_iter(&components[components.len() - i..]);
+        return Some(format!(
+            "{repo_name}{separator}{path}",
+            repo_name = repo_name,
+            separator = "/",
+            path = path.to_slash().unwrap()
+        ));
+    }
+    None
+}
+
+fn real_path<P: AsRef<Path>>(path: P) -> PathBuf {
+    let path = path.as_ref();
+    let mut buf = PathBuf::new();
+    for component in path.components() {
+        let next = buf.join(component);
+        if let Ok(realpath) = next.read_link() {
+            if realpath.is_absolute() {
+                buf = realpath;
+            } else {
+                buf.push(realpath);
+            }
+        } else {
+            buf = next;
+        }
+    }
+    buf.canonicalize().unwrap_or_else(|_| path.into())
 }
 
 /// Perform a list of string substitutions on the path

--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -66,7 +66,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             log::debug!("Repo root: {:?}", repo_root);
             // Contract the path to the git repo root
             contract_repo_path(current_dir, repo_root)
-                .unwrap_or_else(|| current_dir.to_slash().unwrap())
+                .unwrap_or_else(|| contract_path(current_dir, &home_dir, HOME_SYMBOL))
         }
         // Contract the path to the home directory
         _ => contract_path(current_dir, &home_dir, HOME_SYMBOL),

--- a/tests/testsuite/directory.rs
+++ b/tests/testsuite/directory.rs
@@ -520,9 +520,9 @@ fn git_repo_in_home_directory_truncate_to_repo_true() -> io::Result<()> {
 fn symlinked_git_repo_root() -> io::Result<()> {
     let tmp_dir = TempDir::new_in(dirs::home_dir().unwrap())?;
     let repo_dir = tmp_dir.path().join("rocket-controls");
+    let symlink_dir = tmp_dir.path().join("rocket-controls-symlink");
     fs::create_dir(&repo_dir)?;
     Repository::init(&repo_dir).unwrap();
-    let symlink_dir = tmp_dir.path().join("rocket-controls-symlink");
     symlink(&repo_dir, &symlink_dir)?;
 
     let output = common::render_module("directory")
@@ -545,15 +545,16 @@ fn symlinked_git_repo_root() -> io::Result<()> {
 fn directory_in_symlinked_git_repo() -> io::Result<()> {
     let tmp_dir = TempDir::new_in(dirs::home_dir().unwrap())?;
     let repo_dir = tmp_dir.path().join("rocket-controls");
-    Repository::init(&repo_dir).unwrap();
+    let src_dir = repo_dir.join("src");
     let symlink_dir = tmp_dir.path().join("rocket-controls-symlink");
+    let symlink_src_dir = symlink_dir.join("src");
+    fs::create_dir_all(&src_dir)?;
+    Repository::init(&repo_dir).unwrap();
     symlink(&repo_dir, &symlink_dir)?;
-    let dir = symlink_dir.join("src");
-    fs::create_dir_all(&dir)?;
 
     let output = common::render_module("directory")
         .arg("--path")
-        .arg(dir)
+        .arg(symlink_src_dir)
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
@@ -571,15 +572,16 @@ fn directory_in_symlinked_git_repo() -> io::Result<()> {
 fn truncated_directory_in_symlinked_git_repo() -> io::Result<()> {
     let tmp_dir = TempDir::new_in(dirs::home_dir().unwrap())?;
     let repo_dir = tmp_dir.path().join("rocket-controls");
-    Repository::init(&repo_dir).unwrap();
+    let src_dir = repo_dir.join("src/meters/fuel-gauge");
     let symlink_dir = tmp_dir.path().join("rocket-controls-symlink");
+    let symlink_src_dir = symlink_dir.join("src/meters/fuel-gauge");
+    fs::create_dir_all(&src_dir)?;
+    Repository::init(&repo_dir).unwrap();
     symlink(&repo_dir, &symlink_dir)?;
-    let dir = symlink_dir.join("src/meters/fuel-gauge");
-    fs::create_dir_all(&dir)?;
 
     let output = common::render_module("directory")
         .arg("--path")
-        .arg(dir)
+        .arg(symlink_src_dir)
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
@@ -594,14 +596,15 @@ fn truncated_directory_in_symlinked_git_repo() -> io::Result<()> {
 fn directory_in_symlinked_git_repo_truncate_to_repo_false() -> io::Result<()> {
     let tmp_dir = TempDir::new_in(dirs::home_dir().unwrap())?;
     let repo_dir = tmp_dir.path().join("above-repo").join("rocket-controls");
-    Repository::init(&repo_dir).unwrap();
+    let src_dir = repo_dir.join("src/meters/fuel-gauge");
     let symlink_dir = tmp_dir
         .path()
         .join("above-repo")
         .join("rocket-controls-symlink");
+    let symlink_src_dir = symlink_dir.join("src/meters/fuel-gauge");
+    fs::create_dir_all(&src_dir)?;
+    Repository::init(&repo_dir).unwrap();
     symlink(&repo_dir, &symlink_dir)?;
-    let dir = symlink_dir.join("src/meters/fuel-gauge");
-    fs::create_dir_all(&dir)?;
 
     let output = common::render_module("directory")
         .use_config(toml::toml! {
@@ -611,7 +614,7 @@ fn directory_in_symlinked_git_repo_truncate_to_repo_false() -> io::Result<()> {
             truncate_to_repo = false
         })
         .arg("--path")
-        .arg(dir)
+        .arg(symlink_src_dir)
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
@@ -631,14 +634,15 @@ fn directory_in_symlinked_git_repo_truncate_to_repo_false() -> io::Result<()> {
 fn fish_path_directory_in_symlinked_git_repo_truncate_to_repo_false() -> io::Result<()> {
     let tmp_dir = TempDir::new_in(dirs::home_dir().unwrap())?;
     let repo_dir = tmp_dir.path().join("above-repo").join("rocket-controls");
-    Repository::init(&repo_dir).unwrap();
+    let src_dir = repo_dir.join("src/meters/fuel-gauge");
     let symlink_dir = tmp_dir
         .path()
         .join("above-repo")
         .join("rocket-controls-symlink");
+    let symlink_src_dir = symlink_dir.join("src/meters/fuel-gauge");
+    fs::create_dir_all(&src_dir)?;
+    Repository::init(&repo_dir).unwrap();
     symlink(&repo_dir, &symlink_dir)?;
-    let dir = symlink_dir.join("src/meters/fuel-gauge");
-    fs::create_dir_all(&dir)?;
 
     let output = common::render_module("directory")
         .use_config(toml::toml! {
@@ -649,7 +653,7 @@ fn fish_path_directory_in_symlinked_git_repo_truncate_to_repo_false() -> io::Res
             fish_style_pwd_dir_length = 1
         })
         .arg("--path")
-        .arg(dir)
+        .arg(symlink_src_dir)
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
@@ -669,14 +673,15 @@ fn fish_path_directory_in_symlinked_git_repo_truncate_to_repo_false() -> io::Res
 fn fish_path_directory_in_symlinked_git_repo_truncate_to_repo_true() -> io::Result<()> {
     let tmp_dir = TempDir::new_in(dirs::home_dir().unwrap())?;
     let repo_dir = tmp_dir.path().join("above-repo").join("rocket-controls");
-    Repository::init(&repo_dir).unwrap();
+    let src_dir = repo_dir.join("src/meters/fuel-gauge");
     let symlink_dir = tmp_dir
         .path()
         .join("above-repo")
         .join("rocket-controls-symlink");
+    let symlink_src_dir = symlink_dir.join("src/meters/fuel-gauge");
+    fs::create_dir_all(&src_dir)?;
+    Repository::init(&repo_dir).unwrap();
     symlink(&repo_dir, &symlink_dir)?;
-    let dir = symlink_dir.join("src/meters/fuel-gauge");
-    fs::create_dir_all(&dir)?;
 
     let output = common::render_module("directory")
         .use_config(toml::toml! {
@@ -687,7 +692,7 @@ fn fish_path_directory_in_symlinked_git_repo_truncate_to_repo_true() -> io::Resu
             fish_style_pwd_dir_length = 1
         })
         .arg("--path")
-        .arg(dir)
+        .arg(symlink_src_dir)
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
@@ -707,14 +712,15 @@ fn fish_path_directory_in_symlinked_git_repo_truncate_to_repo_true() -> io::Resu
 fn directory_in_symlinked_git_repo_truncate_to_repo_true() -> io::Result<()> {
     let tmp_dir = TempDir::new_in(dirs::home_dir().unwrap())?;
     let repo_dir = tmp_dir.path().join("above-repo").join("rocket-controls");
-    Repository::init(&repo_dir).unwrap();
+    let src_dir = repo_dir.join("src/meters/fuel-gauge");
     let symlink_dir = tmp_dir
         .path()
         .join("above-repo")
         .join("rocket-controls-symlink");
+    let symlink_src_dir = symlink_dir.join("src/meters/fuel-gauge");
+    fs::create_dir_all(&src_dir)?;
+    Repository::init(&repo_dir).unwrap();
     symlink(&repo_dir, &symlink_dir)?;
-    let dir = symlink_dir.join("src/meters/fuel-gauge");
-    fs::create_dir_all(&dir)?;
 
     let output = common::render_module("directory")
         .use_config(toml::toml! {
@@ -724,7 +730,7 @@ fn directory_in_symlinked_git_repo_truncate_to_repo_true() -> io::Result<()> {
             truncate_to_repo = true
         })
         .arg("--path")
-        .arg(dir)
+        .arg(symlink_src_dir)
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
@@ -775,11 +781,11 @@ fn symlinked_directory_in_git_repo() -> io::Result<()> {
 fn symlinked_subdirectory_git_repo_out_of_tree() -> io::Result<()> {
     let tmp_dir = TempDir::new_in(dirs::home_dir().unwrap())?;
     let repo_dir = tmp_dir.path().join("above-repo").join("rocket-controls");
-    let dir = repo_dir.join("src/meters/fuel-gauge");
-    fs::create_dir_all(&dir)?;
-    Repository::init(&repo_dir).unwrap();
+    let src_dir = repo_dir.join("src/meters/fuel-gauge");
     let symlink_dir = tmp_dir.path().join("fuel-gauge");
-    symlink(&dir, &symlink_dir)?;
+    fs::create_dir_all(&src_dir)?;
+    Repository::init(&repo_dir).unwrap();
+    symlink(&src_dir, &symlink_dir)?;
 
     let output = common::render_module("directory")
         // Set home directory to the temp repository

--- a/tests/testsuite/directory.rs
+++ b/tests/testsuite/directory.rs
@@ -5,6 +5,8 @@ use std::fs;
 use std::io;
 #[cfg(not(target_os = "windows"))]
 use std::os::unix::fs::symlink;
+#[cfg(target_os = "windows")]
+use std::os::windows::fs::symlink_dir as symlink;
 use std::path::Path;
 use tempfile::TempDir;
 
@@ -516,7 +518,6 @@ fn git_repo_in_home_directory_truncate_to_repo_true() -> io::Result<()> {
 
 #[test]
 #[ignore]
-#[cfg(not(target_os = "windows"))]
 fn symlinked_git_repo_root() -> io::Result<()> {
     let tmp_dir = TempDir::new_in(dirs::home_dir().unwrap())?;
     let repo_dir = tmp_dir.path().join("rocket-controls");
@@ -541,7 +542,6 @@ fn symlinked_git_repo_root() -> io::Result<()> {
 
 #[test]
 #[ignore]
-#[cfg(not(target_os = "windows"))]
 fn directory_in_symlinked_git_repo() -> io::Result<()> {
     let tmp_dir = TempDir::new_in(dirs::home_dir().unwrap())?;
     let repo_dir = tmp_dir.path().join("rocket-controls");
@@ -568,7 +568,6 @@ fn directory_in_symlinked_git_repo() -> io::Result<()> {
 
 #[test]
 #[ignore]
-#[cfg(not(target_os = "windows"))]
 fn truncated_directory_in_symlinked_git_repo() -> io::Result<()> {
     let tmp_dir = TempDir::new_in(dirs::home_dir().unwrap())?;
     let repo_dir = tmp_dir.path().join("rocket-controls");
@@ -592,7 +591,6 @@ fn truncated_directory_in_symlinked_git_repo() -> io::Result<()> {
 
 #[test]
 #[ignore]
-#[cfg(not(target_os = "windows"))]
 fn directory_in_symlinked_git_repo_truncate_to_repo_false() -> io::Result<()> {
     let tmp_dir = TempDir::new_in(dirs::home_dir().unwrap())?;
     let repo_dir = tmp_dir.path().join("above-repo").join("rocket-controls");
@@ -630,7 +628,6 @@ fn directory_in_symlinked_git_repo_truncate_to_repo_false() -> io::Result<()> {
 
 #[test]
 #[ignore]
-#[cfg(not(target_os = "windows"))]
 fn fish_path_directory_in_symlinked_git_repo_truncate_to_repo_false() -> io::Result<()> {
     let tmp_dir = TempDir::new_in(dirs::home_dir().unwrap())?;
     let repo_dir = tmp_dir.path().join("above-repo").join("rocket-controls");
@@ -669,7 +666,6 @@ fn fish_path_directory_in_symlinked_git_repo_truncate_to_repo_false() -> io::Res
 
 #[test]
 #[ignore]
-#[cfg(not(target_os = "windows"))]
 fn fish_path_directory_in_symlinked_git_repo_truncate_to_repo_true() -> io::Result<()> {
     let tmp_dir = TempDir::new_in(dirs::home_dir().unwrap())?;
     let repo_dir = tmp_dir.path().join("above-repo").join("rocket-controls");
@@ -708,7 +704,6 @@ fn fish_path_directory_in_symlinked_git_repo_truncate_to_repo_true() -> io::Resu
 
 #[test]
 #[ignore]
-#[cfg(not(target_os = "windows"))]
 fn directory_in_symlinked_git_repo_truncate_to_repo_true() -> io::Result<()> {
     let tmp_dir = TempDir::new_in(dirs::home_dir().unwrap())?;
     let repo_dir = tmp_dir.path().join("above-repo").join("rocket-controls");
@@ -746,7 +741,6 @@ fn directory_in_symlinked_git_repo_truncate_to_repo_true() -> io::Result<()> {
 
 #[test]
 #[ignore]
-#[cfg(not(target_os = "windows"))]
 fn symlinked_directory_in_git_repo() -> io::Result<()> {
     let tmp_dir = TempDir::new_in(dirs::home_dir().unwrap())?;
     let repo_dir = tmp_dir.path().join("rocket-controls");


### PR DESCRIPTION
#### Description
This PR fixes path contractions
1. when `full_path` contains symlinks (a logical path), and `top_level_path` is given as a physical path.
2. and when git repository's subdirectory is symlinked to outside of the repo tree.

#### Motivation and Context

##### Fix 1
`&repo.root` returns physical path, not the logical path.
`git rev-parse --show-toplevel` returns worktree [path](https://github.com/git/git/blob/v2.27.0/builtin/rev-parse.c#L803), which is [initialized](https://github.com/git/git/blob/v2.27.0/environment.c#L261) with [`strbuf_realpath`](https://github.com/git/git/blob/v2.27.0/abspath.c#L81).
So, it returns a physical path of a repository (there isn't a symlink in its ancestors). I think libgit2 does too so `&repo.root` does.
However, `PWD` and `std::env::current_dir` gives you a logical path (it might contain symlinks in its ancestors).

If I have a following structure of repositories, `starship` mispredict that I'm not inside of the repository since `current_dir` doesn't contain `&repo.root`.
```sh
~/ws> ls -l
... repo
... repo2 -> repo

~/ws> cd ~/ws/repo
repo> echo $(pwd)  $(realpath pwd) $(git rev-parse --show-toplevel)
/home/user/ws/repo /home/user/ws/repo

repo> cd ~/ws/repo2
/home/user/ws/repo2> # note that the prompt is not repo2
/home/user/ws/repo2> echo $(pwd)  $(realpath pwd) $(git rev-parse --show-toplevel)
/home/user/ws/repo2 /home/user/ws/repo /home/user/ws/repo
```

In `repo2`, `$(pwd)` doesn't start with $(git rev-parse --show-toplevel), so the prompt is shown as `/home/user/ws/repo2`, not `repo2`.

So I made a function `realpath` after git's `strbuf_realpath` (they should do the same thing), and `contract_repo_path` walks through ancestors of `full_path` and whether their physical paths are matches with `top_level_path`. Then it trims the matching part.
As I've commented, this will properly handle following case.
```
weird_repo> ls -l src
... src -> ../src
weird_repo> cd src/src/src/src
weird_repo/src/src/src/src>
```
If I'd just applied `strip_prefix`, then it would've been:
```
weird_repo> ls -l src
... src -> ../src
weird_repo> cd src/src/src/src
weird_repo/src>
```

##### Fix 2
When you have a repository at `~/ws/repo`, and you made a symlink `ln -s ~/ws/repo/some/module ~/tmp/module`.
In `~/tmp/module`, You can see that `git rev-parse --show-toplevel` returns `/home/user/ws/repos`.
However, the current version also fails to contract path. It prompts `/home/user/tmp/module> ` again.
It is weird to contract it as `repo/module>`. So when the path is out of the repo tree, it just contracted to `HOME`.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
I've made a repository, and its symlinks like the above scenarios (`ln -s` on Linux, `mklink` on Windows).
- [x] I have tested using **MacOS** (Tested by @nickwb)
- [x] I have tested using **Linux**: I've tested it on WSL1, and Ubuntu 20.04.
- [x] I have tested using **Windows**: I just checked that `git rev-parse --show-toplevel` (and `&repo.root`) returns a logical path, instead of a physical path (Weird 1). Also, It is already failed to recognize a repo root in the scenario of Fix 2 (However, `git rev-parse --show-toplevel` does it well. It might be a libgit2's bug. Weird 2). So there shouldn't be a difference after this PR.

#### Checklist:
- [ ] I have updated the documentation accordingly.
  It is a bug fix. I think updating the documentation isn't needed.
- [x] I have updated the tests accordingly.
  ~It involves `read_link` which requires a real filesystem. Existing tests are pure functions and don't need a real filesystem. I'm not sure how do I add tests.~ Added tests