### PR TITLE
docs: Add FAQ entry on missing symbols

### DIFF
--- a/docs/faq/README.md
+++ b/docs/faq/README.md
@@ -51,3 +51,30 @@ If you get an error like "*version 'GLIBC_2.18' not found (required by starship)
 ```sh
 curl -fsSL https://starship.rs/install.sh | bash -s -- --platform unknown-linux-musl
 ```
+
+## Why don't I see a glyph symbol in my prompt?
+
+The most common cause of this is system misconfiguration. Some Linux distros in
+particular do not come with font support out-of-the-box. You need to ensure that:
+
+  - Your locale is set to a UTF-8 value, like `de_DE.UTF-8` or `ja_JP.UTF-8`). If `LC_ALL` is not a UTF-8 value, 
+    [you will need to change it](https://www.tecmint.com/set-system-locales-in-linux/).
+  - You have an emoji font installed. Most systems come with an emoji font by default, but 
+    some (notably Arch Linux) do not. You can usually install one through your system's
+    package manager--[noto emoji](https://www.google.com/get/noto/help/emoji/) is a popular choice.
+  - You are using a [powerline-patched font](https://github.com/powerline/fonts).
+
+To test your system, run the following commands in a terminal:
+
+```
+echo -e "\xf0\x9f\x90\x8d"
+echo -e "\xee\x82\xa0"
+```
+
+The first line should produce a [snake emoji](https://emojipedia.org/snake/),
+while the second should produce a [powerline branch symbol (e0a0)](https://github.com/ryanoasis/powerline-extra-symbols#glyphs).
+
+If either symbol fails to display correctly, your system is still misconfigured.
+Unfortunately, getting font configuration correct is sometimes difficult. Users
+on the Discord may be able to help. If both symbols display correctly, but
+you still don't see them in starship, [file a bug report!](https://github.com/starship/starship/issues/new/choose)

--- a/docs/faq/README.md
+++ b/docs/faq/README.md
@@ -57,7 +57,7 @@ curl -fsSL https://starship.rs/install.sh | bash -s -- --platform unknown-linux-
 The most common cause of this is system misconfiguration. Some Linux distros in
 particular do not come with font support out-of-the-box. You need to ensure that:
 
-  - Your locale is set to a UTF-8 value, like `de_DE.UTF-8` or `ja_JP.UTF-8`). If `LC_ALL` is not a UTF-8 value, 
+  - Your locale is set to a UTF-8 value, like `de_DE.UTF-8` or `ja_JP.UTF-8`. If `LC_ALL` is not a UTF-8 value, 
     [you will need to change it](https://www.tecmint.com/set-system-locales-in-linux/).
   - You have an emoji font installed. Most systems come with an emoji font by default, but 
     some (notably Arch Linux) do not. You can usually install one through your system's


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

Add an FAQ entry describing common troubleshooting steps for when symbols go missing.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We've had a few people in the Discord and the AUR page have this issue, as well as a (semi-related) issue on [nushell](https://github.com/nushell/nushell/issues/1933) recently. Arguably #1012 could have been fixed by this as well.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
