### PR TITLE
feat(nodejs): support additional file patterns

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1081,7 +1081,8 @@ The module will be shown if any of the following conditions are met:
 - The current directory contains a `package.json` file
 - The current directory contains a `.node-version` file
 - The current directory contains a `node_modules` directory
-- The current directory contains a file with the `.js` extension
+- The current directory contains a file with the `.js`, `.mjs` or `.cjs` extension
+- The current directory contains a file with the `.ts` extension
 
 ### Options
 

--- a/src/modules/nodejs.rs
+++ b/src/modules/nodejs.rs
@@ -6,14 +6,15 @@ use crate::utils;
 /// Creates a module with the current Node.js version
 ///
 /// Will display the Node.js version if any of the following criteria are met:
-///     - Current directory contains a `.js` file
+///     - Current directory contains a `.js`, `.mjs` or `.cjs` file
+///     - Current directory contains a `.ts` file
 ///     - Current directory contains a `package.json` or `.node-version` file
 ///     - Current directory contains a `node_modules` directory
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let is_js_project = context
         .try_begin_scan()?
         .set_files(&["package.json", ".node-version"])
-        .set_extensions(&["js"])
+        .set_extensions(&["js", "mjs", "cjs", "ts"])
         .set_folders(&["node_modules"])
         .is_match();
 
@@ -77,6 +78,37 @@ mod tests {
     fn folder_with_js_file() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("index.js"))?.sync_all()?;
+
+        let actual = render_module("nodejs", dir.path(), None);
+        let expected = Some(format!("via {} ", Color::Green.bold().paint("⬢ v12.0.0")));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn folder_with_mjs_file() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join("index.mjs"))?.sync_all()?;
+
+        let actual = render_module("nodejs", dir.path(), None);
+        let expected = Some(format!("via {} ", Color::Green.bold().paint("⬢ v12.0.0")));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    fn folder_with_cjs_file() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join("index.cjs"))?.sync_all()?;
+
+        let actual = render_module("nodejs", dir.path(), None);
+        let expected = Some(format!("via {} ", Color::Green.bold().paint("⬢ v12.0.0")));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    fn folder_with_ts_file() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join("index.ts"))?.sync_all()?;
 
         let actual = render_module("nodejs", dir.path(), None);
         let expected = Some(format!("via {} ", Color::Green.bold().paint("⬢ v12.0.0")));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Extend nodejs module support by recognizing additional file patterns.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1304 Note that `.jsx` and `.tsx` are left out of this. ⚠️ 

#### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1170440/84302920-651a9700-ab56-11ea-8cc0-0e1d75bcc902.png)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
