### PR TITLE
fix: remove errant whitespace which broke tar command

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -114,7 +114,7 @@ fetch_and_unpack() {
   # I'd like to separate this into a fetch() and unpack() function, but I can't
   # figure out how to get bash functions to read STDIN/STDOUT from pipes
   if [ "${EXT}" = "tar.gz" ]; then
-    fetch "${URL}" | ${sudo} tar xzf "${VERBOSE}" - -C "${BIN_DIR}"
+    fetch "${URL}" | ${sudo} tar xz"${VERBOSE}"f - -C "${BIN_DIR}"
   elif [ "${EXT}" = "zip" ]; then
     # According to https://unix.stackexchange.com/q/2690, zip files cannot be read
     # through a pipe. We'll have to do our own file-based setup.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

HOTFIX: curl installer will be broken until this is merged.

There was a space added to a tar command in #1305. While it seems innocuous, it causes tar to either try to extract the file `"v"` or the file `""` instead of reading from stdin like we want. This reverts that change by putting the `VERBOSE` invocation in the middle of the command string, hopefully making it more obvious if it breaks in the future.

Curiously, this did *not* break the script when executing it directly (`./install.sh`) but *did* break it when running it in a new shell (`bash install.sh`). I've determined that that has something to do with the environment, but haven't worked out anything deeper than that.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1313

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
