### PR TITLE
refactor(time): Use format strings

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1697,7 +1697,7 @@ To enable it, set `disabled` to `false` in your configuration file.
 
 ### Options
 
-| Variable          | Default                 | Description                                                                                                            |
+| Option            | Default                 | Description                                                                                                            |
 | ----------------- | ----------------------- | ---------------------------------------------------------------------------------------------------------------------- |
 | `format`          | `"at [$time]($style) "` | The format string for the module.                                                                                      |
 | `use_12hr`        | `false`                 | Enables 12 hour formatting                                                                                             |

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1697,16 +1697,26 @@ To enable it, set `disabled` to `false` in your configuration file.
 
 ### Options
 
-| Variable          | Default         | Description                                                                                                            |
-| ----------------- | --------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| `use_12hr`        | `false`         | Enables 12 hour formatting                                                                                             |
-| `format`          | see below       | The [chrono format string](https://docs.rs/chrono/0.4.7/chrono/format/strftime/index.html) used to format the time.    |
-| `style`           | `"bold yellow"` | The style for the module time                                                                                          |
-| `utc_time_offset` | `"local"`       | Sets the UTC offset to use. Range from -24 &lt; x &lt; 24. Allows floats to accommodate 30/45 minute timezone offsets. |
-| `disabled`        | `true`          | Disables the `time` module.                                                                                            |
+| Variable          | Default                 | Description                                                                                                            |
+| ----------------- | ----------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `format`          | `"at [$time]($style) "` | The format string for the module.                                                                                      |
+| `use_12hr`        | `false`                 | Enables 12 hour formatting                                                                                             |
+| `time_format`     | see below               | The [chrono format string](https://docs.rs/chrono/0.4.7/chrono/format/strftime/index.html) used to format the time.    |
+| `style`           | `"bold yellow"`         | The style for the module time                                                                                          |
+| `utc_time_offset` | `"local"`               | Sets the UTC offset to use. Range from -24 &lt; x &lt; 24. Allows floats to accommodate 30/45 minute timezone offsets. |
+| `disabled`        | `true`                  | Disables the `time` module.                                                                                            |
 
-If `use_12hr` is `true`, then `format` defaults to `"%r"`. Otherwise, it defaults to `"%T"`.
-Manually setting `format` will override the `use_12hr` setting.
+If `use_12hr` is `true`, then `time_format` defaults to `"%r"`. Otherwise, it defaults to `"%T"`.
+Manually setting `time_format` will override the `use_12hr` setting.
+
+### Variables
+
+| Variable | Example    | Description                          |
+| -------- | ---------- | ------------------------------------ |
+| time     | `13:08:10` | The current time.                    |
+| style\*  |            | Mirrors the value of option `style`  |
+
+\*: This variable can only be used as a part of a style string
 
 ### Example
 
@@ -1715,7 +1725,8 @@ Manually setting `format` will override the `use_12hr` setting.
 
 [time]
 disabled = false
-format = "🕙[ %T ]"
+format = "🕙[\\[ $time \\]]($style) "
+time_format = "%T"
 utc_time_offset = "-5"
 ```
 

--- a/src/configs/time.rs
+++ b/src/configs/time.rs
@@ -1,25 +1,26 @@
 use crate::config::{ModuleConfig, RootModuleConfig};
 
-use ansi_term::{Color, Style};
 use starship_module_config_derive::ModuleConfig;
 
 #[derive(Clone, ModuleConfig)]
 pub struct TimeConfig<'a> {
+    pub format: &'a str,
+    pub style: &'a str,
     pub use_12hr: bool,
-    pub format: Option<&'a str>,
-    pub style: Style,
-    pub disabled: bool,
+    pub time_format: Option<&'a str>,
     pub utc_time_offset: &'a str,
+    pub disabled: bool,
 }
 
 impl<'a> RootModuleConfig<'a> for TimeConfig<'a> {
     fn new() -> Self {
         TimeConfig {
+            format: "at [$time]($style) ",
+            style: "bold yellow",
             use_12hr: false,
-            format: None,
-            style: Color::Yellow.bold(),
-            disabled: true,
+            time_format: None,
             utc_time_offset: "local",
+            disabled: true,
         }
     }
 }

--- a/src/modules/time.rs
+++ b/src/modules/time.rs
@@ -1,14 +1,11 @@
 use chrono::{DateTime, FixedOffset, Local, Utc};
 
-use super::{Context, Module};
-
-use crate::config::{RootModuleConfig, SegmentConfig};
+use super::{Context, Module, RootModuleConfig};
 use crate::configs::time::TimeConfig;
+use crate::formatter::StringFormatter;
 
 /// Outputs the current time
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
-    const TIME_PREFIX: &str = "at ";
-
     let mut module = context.new_module("time");
     let config: TimeConfig = TimeConfig::try_load(module.config);
     if config.disabled {
@@ -16,7 +13,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     };
 
     let default_format = if config.use_12hr { "%r" } else { "%T" };
-    let time_format = config.format.unwrap_or(default_format);
+    let time_format = config.time_format.unwrap_or(default_format);
 
     log::trace!(
         "Timer module is enabled with format string: {}",
@@ -37,17 +34,29 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         format_time(&time_format, Local::now())
     };
 
-    module.set_style(config.style);
+    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
+        formatter
+            .map_style(|variable| match variable {
+                "style" => Some(Ok(config.style)),
+                _ => None,
+            })
+            .map(|variable| match variable {
+                "time" => Some(Ok(&formatted_time_string)),
+                _ => None,
+            })
+            .parse(None)
+    });
 
-    module.get_prefix().set_value(TIME_PREFIX);
+    module.set_segments(match parsed {
+        Ok(segments) => segments,
+        Err(error) => {
+            log::warn!("Error in module `time`: \n{}", error);
+            return None;
+        }
+    });
 
-    module.create_segment(
-        "time",
-        &SegmentConfig {
-            value: &formatted_time_string,
-            style: None,
-        },
-    );
+    module.get_prefix().set_value("");
+    module.get_suffix().set_value("");
 
     Some(module)
 }

--- a/tests/testsuite/time.rs
+++ b/tests/testsuite/time.rs
@@ -41,7 +41,8 @@ fn config_check_prefix_and_suffix() -> io::Result<()> {
         .use_config(toml::toml! {
             [time]
             disabled = false
-            format = "[%T]"
+            format = "at [\\[$time\\]]($style) "
+            time_format = "%T"
         })
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
This PR deprecates `style` key in the `time` module to replace it with the `format` key instead.

The old `format` key has been renamed to `time_format` to continue to allow custom time formats while also not conflicting with the new standard `format` key.

#### Motivation and Context
Related to issue #1057

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
