### PR TITLE
feat: git branch: read from HEAD on newly initialized repo

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -322,7 +322,8 @@ fn get_current_branch(repository: &Repository) -> Option<String> {
                 head_path.push("HEAD");
 
                 // get first line, then last path segment
-                fs::read_to_string(&head_path).ok()?
+                fs::read_to_string(&head_path)
+                    .ok()?
                     .lines()
                     .next()?
                     .trim()

--- a/src/context.rs
+++ b/src/context.rs
@@ -317,8 +317,18 @@ fn get_current_branch(repository: &Repository) -> Option<String> {
         Err(e) => {
             return if e.code() == UnbornBranch {
                 // HEAD should only be an unborn branch if the repository is fresh,
-                // in that case assume "master"
-                Some(String::from("master"))
+                // in that case read directly from `.git/HEAD`
+                let mut head_path = repository.path().to_path_buf();
+                head_path.push("HEAD");
+
+                // get first line, then last path segment
+                fs::read_to_string(&head_path).ok()?
+                    .lines()
+                    .next()?
+                    .trim()
+                    .split('/')
+                    .last()
+                    .map(|r| r.to_owned())
             } else {
                 None
             };

--- a/tests/testsuite/git_branch.rs
+++ b/tests/testsuite/git_branch.rs
@@ -99,11 +99,16 @@ fn test_japanese_truncation() -> io::Result<()> {
 }
 
 #[test]
-fn test_works_with_unborn_master() -> io::Result<()> {
+fn test_works_with_unborn_default_branch() -> io::Result<()> {
     let repo_dir = tempfile::tempdir()?.into_path();
 
     Command::new("git")
         .args(&["init"])
+        .current_dir(&repo_dir)
+        .output()?;
+
+    Command::new("git")
+        .args(&["symbolic-ref", "HEAD", "refs/heads/main"])
         .current_dir(&repo_dir)
         .output()?;
 
@@ -116,7 +121,7 @@ fn test_works_with_unborn_master() -> io::Result<()> {
 
     let expected = format!(
         "on {} ",
-        Color::Purple.bold().paint(format!("\u{e0a0} {}", "master")),
+        Color::Purple.bold().paint(format!("\u{e0a0} {}", "main")),
     );
     assert_eq!(expected, actual);
     remove_dir_all(repo_dir)


### PR DESCRIPTION
#### Description, motivation, context
On a newly initialized git repo, there are no branches created until a
commit is made. Previously, starship handled this by hardcoding a default
value "master" for when branch `head` could not be read.

However, if a user wants to set a different default branch name, that
name won't appear in starship until a commit is made to the branch.

If git2 provides a way to read the default branch name, we can use that,
but at the moment it's not obvious how.

For the moment, we can directly read `.git/HEAD`, which contains the
name of the default branch head reference. This commit implements this
strategy.

Closes #1327

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I've updated the `git_branch::...unborn_master` to `git_branch::...unborn_default_branch`, where the default branch name is set in `.git/HEAD`.

I've also done manual testing on Linux, where I created a new git repo with default branch `main` in `.git/HEAD`, then run the locally built version of starship in that repo as `../starship/target/debug/starship module git_branch`.

- [x] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
