### PR TITLE
refactor: Switch from `dirs` to `dirs-next` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,20 +301,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "2.0.2"
+name = "dirs-next"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
+checksum = "1cbcf9241d9e8d106295bd496bbe2e9cffd5fa098f2a8c9e2bbcbf09773c11a8"
 dependencies = [
  "cfg-if",
- "dirs-sys",
+ "dirs-sys-next",
 ]
 
 [[package]]
-name = "dirs-sys"
-version = "0.3.5"
+name = "dirs-sys-next"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a"
+checksum = "9c60f7b8a8953926148223260454befb50c751d3c50e1c178c4fd1ace4083c9a"
 dependencies = [
  "libc",
  "redox_users",
@@ -1121,7 +1121,7 @@ dependencies = [
  "byte-unit",
  "chrono",
  "clap",
- "dirs",
+ "dirs-next",
  "gethostname",
  "git2",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ tls-vendored = ["native-tls/vendored"]
 [dependencies]
 clap = "2.33.1"
 ansi_term = "0.12.1"
-dirs = "2.0.2"
+dirs-next = "1.0.1"
 git2 = { version = "0.13.6", default-features = false, features = [] }
 toml = { version = "0.5.6", features = ["preserve_order"] }
 serde_json = "1.0.55"

--- a/src/bug_report.rs
+++ b/src/bug_report.rs
@@ -168,7 +168,7 @@ fn get_terminal_info() -> TerminalInfo {
 }
 
 fn get_config_path(shell: &str) -> Option<PathBuf> {
-    dirs::home_dir().and_then(|home_dir| {
+    dirs_next::home_dir().and_then(|home_dir| {
         match shell {
             "bash" => Some(".bashrc"),
             "fish" => Some(".config/fish/config.fish"),
@@ -192,7 +192,7 @@ fn get_starship_config() -> String {
         .map(PathBuf::from)
         .ok()
         .or_else(|| {
-            dirs::home_dir().map(|mut home_dir| {
+            dirs_next::home_dir().map(|mut home_dir| {
                 home_dir.push(".config/starship.toml");
                 home_dir
             })

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,7 +6,7 @@ use std::clone::Clone;
 use std::collections::HashMap;
 use std::marker::Sized;
 
-use dirs::home_dir;
+use dirs_next::home_dir;
 use std::env;
 use toml::Value;
 

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -109,7 +109,7 @@ fn get_editor_internal(visual: Option<OsString>, editor: Option<OsString>) -> Os
 fn get_config_path() -> OsString {
     let config_path = env::var_os("STARSHIP_CONFIG").unwrap_or_else(|| "".into());
     if config_path.is_empty() {
-        dirs::home_dir()
+        dirs_next::home_dir()
             .expect("couldn't find home directory")
             .join(".config/starship.toml")
             .as_os_str()

--- a/src/context.rs
+++ b/src/context.rs
@@ -89,7 +89,7 @@ impl<'a> Context<'a> {
     fn expand_tilde(dir: PathBuf) -> PathBuf {
         if dir.starts_with("~") {
             let without_home = dir.strip_prefix("~").unwrap();
-            return dirs::home_dir().unwrap().join(without_home);
+            return dirs_next::home_dir().unwrap().join(without_home);
         }
         dir
     }

--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -5,8 +5,6 @@ use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
 use std::str::FromStr;
 
-use dirs::home_dir;
-
 use super::{Context, Module, RootModuleConfig};
 
 use crate::configs::aws::{AwsConfig, AwsItems};
@@ -19,7 +17,7 @@ fn get_aws_region_from_config(aws_profile: Option<&str>) -> Option<Region> {
         .ok()
         .and_then(|path| PathBuf::from_str(&path).ok())
         .or_else(|| {
-            let mut home = home_dir()?;
+            let mut home = dirs_next::home_dir()?;
             home.push(".aws/config");
             Some(home)
         })?;

--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -55,7 +55,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             .unwrap_or_else(|| &context.current_dir),
     );
 
-    let home_dir = dirs::home_dir().unwrap();
+    let home_dir = dirs_next::home_dir().unwrap();
     log::debug!("Current directory: {:?}", current_dir);
 
     let repo = &context.get_repo().ok()?;

--- a/src/modules/docker_context.rs
+++ b/src/modules/docker_context.rs
@@ -1,5 +1,3 @@
-use dirs::home_dir;
-
 use super::{Context, Module, RootModuleConfig};
 
 use crate::configs::docker_context::DockerContextConfig;
@@ -26,7 +24,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         return None;
     }
 
-    let config_path = home_dir()?.join(DOCKER_CONFIG_FILE);
+    let config_path = dirs_next::home_dir()?.join(DOCKER_CONFIG_FILE);
     let json = utils::read_file(config_path).ok()?;
     let parsed_json = serde_json::from_str(&json).ok()?;
 

--- a/src/modules/kubernetes.rs
+++ b/src/modules/kubernetes.rs
@@ -48,7 +48,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             .filter_map(|filename| parse_kubectl_file(&filename))
             .next(),
         Err(_) => {
-            let filename = dirs::home_dir()?.join(".kube").join("config");
+            let filename = dirs_next::home_dir()?.join(".kube").join("config");
             parse_kubectl_file(&filename)
         }
     };

--- a/tests/testsuite/directory.rs
+++ b/tests/testsuite/directory.rs
@@ -1,5 +1,5 @@
 use ansi_term::Color;
-use dirs::home_dir;
+use dirs_next::home_dir;
 use git2::Repository;
 use std::fs;
 use std::io;
@@ -299,7 +299,7 @@ fn git_repo_root() -> io::Result<()> {
     // TODO: Investigate why git repo related tests fail when the tempdir is within /tmp/...
     // Temporarily making the tempdir within $HOME
     // #[ignore] can be removed after this TODO is addressed
-    let tmp_dir = TempDir::new_in(dirs::home_dir().unwrap())?;
+    let tmp_dir = TempDir::new_in(home_dir().unwrap())?;
     let repo_dir = tmp_dir.path().join("rocket-controls");
     fs::create_dir(&repo_dir)?;
     Repository::init(&repo_dir).unwrap();
@@ -318,7 +318,7 @@ fn git_repo_root() -> io::Result<()> {
 #[test]
 #[ignore]
 fn directory_in_git_repo() -> io::Result<()> {
-    let tmp_dir = TempDir::new_in(dirs::home_dir().unwrap())?;
+    let tmp_dir = TempDir::new_in(home_dir().unwrap())?;
     let repo_dir = tmp_dir.path().join("rocket-controls");
     let dir = repo_dir.join("src");
     fs::create_dir_all(&dir)?;
@@ -338,7 +338,7 @@ fn directory_in_git_repo() -> io::Result<()> {
 #[test]
 #[ignore]
 fn truncated_directory_in_git_repo() -> io::Result<()> {
-    let tmp_dir = TempDir::new_in(dirs::home_dir().unwrap())?;
+    let tmp_dir = TempDir::new_in(home_dir().unwrap())?;
     let repo_dir = tmp_dir.path().join("rocket-controls");
     let dir = repo_dir.join("src/meters/fuel-gauge");
     fs::create_dir_all(&dir)?;
@@ -358,7 +358,7 @@ fn truncated_directory_in_git_repo() -> io::Result<()> {
 #[test]
 #[ignore]
 fn directory_in_git_repo_truncate_to_repo_false() -> io::Result<()> {
-    let tmp_dir = TempDir::new_in(dirs::home_dir().unwrap())?;
+    let tmp_dir = TempDir::new_in(home_dir().unwrap())?;
     let repo_dir = tmp_dir.path().join("above-repo").join("rocket-controls");
     let dir = repo_dir.join("src/meters/fuel-gauge");
     fs::create_dir_all(&dir)?;
@@ -389,7 +389,7 @@ fn directory_in_git_repo_truncate_to_repo_false() -> io::Result<()> {
 #[test]
 #[ignore]
 fn fish_path_directory_in_git_repo_truncate_to_repo_false() -> io::Result<()> {
-    let tmp_dir = TempDir::new_in(dirs::home_dir().unwrap())?;
+    let tmp_dir = TempDir::new_in(home_dir().unwrap())?;
     let repo_dir = tmp_dir.path().join("above-repo").join("rocket-controls");
     let dir = repo_dir.join("src/meters/fuel-gauge");
     fs::create_dir_all(&dir)?;
@@ -421,7 +421,7 @@ fn fish_path_directory_in_git_repo_truncate_to_repo_false() -> io::Result<()> {
 #[test]
 #[ignore]
 fn fish_path_directory_in_git_repo_truncate_to_repo_true() -> io::Result<()> {
-    let tmp_dir = TempDir::new_in(dirs::home_dir().unwrap())?;
+    let tmp_dir = TempDir::new_in(home_dir().unwrap())?;
     let repo_dir = tmp_dir.path().join("above-repo").join("rocket-controls");
     let dir = repo_dir.join("src/meters/fuel-gauge");
     fs::create_dir_all(&dir)?;
@@ -453,7 +453,7 @@ fn fish_path_directory_in_git_repo_truncate_to_repo_true() -> io::Result<()> {
 #[test]
 #[ignore]
 fn directory_in_git_repo_truncate_to_repo_true() -> io::Result<()> {
-    let tmp_dir = TempDir::new_in(dirs::home_dir().unwrap())?;
+    let tmp_dir = TempDir::new_in(home_dir().unwrap())?;
     let repo_dir = tmp_dir.path().join("above-repo").join("rocket-controls");
     let dir = repo_dir.join("src/meters/fuel-gauge");
     fs::create_dir_all(&dir)?;
@@ -485,7 +485,7 @@ fn directory_in_git_repo_truncate_to_repo_true() -> io::Result<()> {
 #[ignore]
 #[cfg(not(target_os = "windows"))]
 fn git_repo_in_home_directory_truncate_to_repo_true() -> io::Result<()> {
-    let tmp_dir = TempDir::new_in(dirs::home_dir().unwrap())?;
+    let tmp_dir = TempDir::new_in(home_dir().unwrap())?;
     let dir = tmp_dir.path().join("src/meters/fuel-gauge");
     fs::create_dir_all(&dir)?;
     Repository::init(&tmp_dir).unwrap();


### PR DESCRIPTION
#### Description
Replaces the `dirs` dependency with the maintained fork `dirs-next`.

#### Motivation and Context
As the `dirs` dependency will be unmaintained for the foreseeable future, switch to the maintained fork `dirs-next`. This change has been suggested in #1319.

Closes #1319.

#### How Has This Been Tested?
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [ ] I have updated the documentation accordingly: Should not be needed since the change of the dependency is not visible to the user.
- [x] I have updated the tests accordingly.
