### PR TITLE
feat(git): honor `GIT_DIR` environment variable

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -136,7 +136,11 @@ impl<'a> Context<'a> {
     pub fn get_repo(&self) -> Result<&Repo, std::io::Error> {
         self.repo
             .get_or_try_init(|| -> Result<Repo, std::io::Error> {
-                let repository = Repository::discover(&self.current_dir).ok();
+                let repository = if env::var("GIT_DIR").is_ok() {
+                    Repository::open_from_env().ok()
+                } else {
+                    Repository::discover(&self.current_dir).ok()
+                };
                 let branch = repository
                     .as_ref()
                     .and_then(|repo| get_current_branch(repo));

--- a/tests/testsuite/git_branch.rs
+++ b/tests/testsuite/git_branch.rs
@@ -1,6 +1,7 @@
 use ansi_term::Color;
 use remove_dir_all::remove_dir_all;
 use std::io;
+use std::path::Path;
 use std::process::Command;
 
 use crate::common::{self, TestCommand};
@@ -110,6 +111,29 @@ fn test_works_with_unborn_master() -> io::Result<()> {
     let output = common::render_module("git_branch")
         .arg("--path")
         .arg(&repo_dir)
+        .output()
+        .unwrap();
+    let actual = String::from_utf8(output.stdout).unwrap();
+
+    let expected = format!(
+        "on {} ",
+        Color::Purple.bold().paint(format!("\u{e0a0} {}", "master")),
+    );
+    assert_eq!(expected, actual);
+    remove_dir_all(repo_dir)
+}
+
+#[test]
+fn test_git_dir_env_variable() -> io::Result<()> {
+    let repo_dir = tempfile::tempdir()?.into_path();
+
+    Command::new("git")
+        .args(&["init"])
+        .current_dir(&repo_dir)
+        .output()?;
+
+    let output = common::render_module("git_branch")
+        .env("GIT_DIR", Path::new(&repo_dir).join(".git"))
         .output()
         .unwrap();
     let actual = String::from_utf8(output.stdout).unwrap();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Support `GIT_DIR` environment variable (see https://git-scm.com/book/en/v2/Git-Internals-Environment-Variables)

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1108 

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
