### PR TITLE
fix: ensure trailing line_break gets printed

### DIFF
--- a/src/print.rs
+++ b/src/print.rs
@@ -34,6 +34,7 @@ pub fn get_prompt(context: Context) -> String {
 
     let modules = compute_modules(&context);
 
+    let mut last = "";
     let mut print_without_prefix = true;
     let printable = modules.iter();
 
@@ -47,7 +48,13 @@ pub fn get_prompt(context: Context) -> String {
             write!(buf, "{}", ANSIStrings(&module)).unwrap();
         }
 
-        print_without_prefix = module.get_name() == "line_break"
+        last = module.get_name();
+        print_without_prefix = last == "line_break";
+    }
+
+    // Ensure trailing newline doesn't get trimmed
+    if last == "line_break" {
+        buf.push_str("\x1b[0m");
     }
 
     buf


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Prevent shell from trimming trailing newline by appending reset sequence.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1042 
Closes #4168

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
