### PR TITLE
refactor(custom): Use format string

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1918,20 +1918,29 @@ will simply show all custom modules in the order they were defined.
 
 ### Options
 
-| Variable      | Default             | Description                                                                  |
-| ------------- | ------------------- | ---------------------------------------------------------------------------- |
-| `command`     |                     | The command whose output should be printed.                                  |
-| `when`        |                     | A shell command used as a condition to show the module. The module will be shown if the command returns a `0` status code. |
-| `shell`       |                     | [See below](#custom-command-shell)                                           |
-| `description` | `"<custom module>"` | The description of the module that is shown when running `starship explain`. |
-| `files`       | `[]`                | The files that will be searched in the working directory for a match.        |
-| `directories` | `[]`                | The directories that will be searched in the working directory for a match.  |
-| `extensions`  | `[]`                | The extensions that will be searched in the working directory for a match.   |
-| `symbol`      | `""`                | The symbol used before displaying the command output.                        |
-| `style`       | `"bold green"`      | The style for the module.                                                    |
-| `prefix`      | `""`                | Prefix to display immediately before the command output.                     |
-| `suffix`      | `""`                | Suffix to display immediately after the command output.                      |
-| `disabled`    | `false`             | Disables this `custom` module.                                               |
+| Variable      | Default                       | Description                                                                                                                |
+|---------------|-------------------------------|----------------------------------------------------------------------------------------------------------------------------|
+| `command`     |                               | The command whose output should be printed.                                                                                |
+| `when`        |                               | A shell command used as a condition to show the module. The module will be shown if the command returns a `0` status code. |
+| `shell`       |                               | [See below](#custom-command-shell)                                                                                         |
+| `description` | `"<custom module>"`           | The description of the module that is shown when running `starship explain`.                                               |
+| `files`       | `[]`                          | The files that will be searched in the working directory for a match.                                                      |
+| `directories` | `[]`                          | The directories that will be searched in the working directory for a match.                                                |
+| `extensions`  | `[]`                          | The extensions that will be searched in the working directory for a match.                                                 |
+| `symbol`      | `""`                          | The symbol used before displaying the command output.                                                                      |
+| `style`       | `"bold green"`                | The style for the module.                                                                                                  |
+| `format`      | `"[$symbol$output]($style) "` | The format for the module.                                                                                                 |
+| `disabled`    | `false`                       | Disables this `custom` module.                                                                                             |
+
+### Variables
+
+| Variable | Description                            |
+|----------|----------------------------------------|
+| output   | The output of shell command in `shell` |
+| symbol   | Mirrors the value of option `symbol`   |
+| style\*  | Mirrors the value of option `style`    |
+
+\*: This variable can only be used as a part of a style string
 
 #### Custom command shell
 

--- a/src/configs/custom.rs
+++ b/src/configs/custom.rs
@@ -1,6 +1,5 @@
-use crate::config::{ModuleConfig, RootModuleConfig, SegmentConfig, VecOr};
+use crate::config::{ModuleConfig, RootModuleConfig, VecOr};
 
-use ansi_term::Style;
 use starship_module_config_derive::ModuleConfig;
 
 #[derive(Clone, Default, PartialEq)]
@@ -14,15 +13,14 @@ pub struct Directories<'a>(pub Vec<&'a str>);
 
 #[derive(Clone, ModuleConfig)]
 pub struct CustomConfig<'a> {
-    pub symbol: Option<SegmentConfig<'a>>,
+    pub format: &'a str,
+    pub symbol: &'a str,
     pub command: &'a str,
     pub when: Option<&'a str>,
     pub shell: VecOr<&'a str>,
     pub description: &'a str,
-    pub style: Option<Style>,
+    pub style: &'a str,
     pub disabled: bool,
-    pub prefix: Option<&'a str>,
-    pub suffix: Option<&'a str>,
     pub files: Files<'a>,
     pub extensions: Extensions<'a>,
     pub directories: Directories<'a>,
@@ -31,15 +29,14 @@ pub struct CustomConfig<'a> {
 impl<'a> RootModuleConfig<'a> for CustomConfig<'a> {
     fn new() -> Self {
         CustomConfig {
-            symbol: None,
+            format: "[$symbol$output]($style) ",
+            symbol: "",
             command: "",
             when: None,
             shell: VecOr::default(),
             description: "<custom config>",
-            style: None,
+            style: "green bold",
             disabled: false,
-            prefix: None,
-            suffix: None,
             files: Files::default(),
             extensions: Extensions::default(),
             directories: Directories::default(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
This PR refactors `custom` module to use format string.

#### Motivation and Context
Related to #1057

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
