### PR TITLE
refactor(nim): Use format string

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1323,11 +1323,20 @@ The module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Variable   | Default         | Description                                            |
-| ---------- | --------------- | ------------------------------------------------------ |
-| `symbol`   | `"👑 "`         | The symbol used before displaying the version of Nim.  |
-| `style`    | `"bold yellow"` | The style for the module.                              |
-| `disabled` | `false`         | Disables the `nim` module.                             |
+| Variable   | Default                            | Description                                           |
+|------------|------------------------------------|-------------------------------------------------------|
+| `format`   | `"via [$symbol$version]($style) "` | The format for the module                             |
+| `symbol`   | `"👑 "`                            | The symbol used before displaying the version of Nim. |
+| `style`    | `"bold yellow"`                    | The style for the module.                             |
+| `disabled` | `false`                            | Disables the `nim` module.                            |
+
+### Variables
+
+| Variable | Example  | Description                          |
+|----------|----------|--------------------------------------|
+| version  | `v1.2.0` | The version of `nimc`                |
+| symbol   |          | Mirrors the value of option `symbol` |
+| style\*  |          | Mirrors the value of option `style`  |
 
 ### Example
 

--- a/src/configs/nim.rs
+++ b/src/configs/nim.rs
@@ -1,22 +1,21 @@
-use crate::config::{ModuleConfig, RootModuleConfig, SegmentConfig};
+use crate::config::{ModuleConfig, RootModuleConfig};
 
-use ansi_term::{Color, Style};
 use starship_module_config_derive::ModuleConfig;
 
 #[derive(Clone, ModuleConfig)]
 pub struct NimConfig<'a> {
-    pub symbol: SegmentConfig<'a>,
-    pub version: SegmentConfig<'a>,
-    pub style: Style,
+    pub format: &'a str,
+    pub symbol: &'a str,
+    pub style: &'a str,
     pub disabled: bool,
 }
 
 impl<'a> RootModuleConfig<'a> for NimConfig<'a> {
     fn new() -> Self {
         NimConfig {
-            symbol: SegmentConfig::new("👑 "),
-            version: SegmentConfig::default(),
-            style: Color::Yellow.bold(),
+            format:  "via [$symbol$version]($style) ",
+            symbol: "👑 ",
+            style: "yellow bold",
             disabled: false,
         }
     }

--- a/src/configs/nim.rs
+++ b/src/configs/nim.rs
@@ -13,7 +13,7 @@ pub struct NimConfig<'a> {
 impl<'a> RootModuleConfig<'a> for NimConfig<'a> {
     fn new() -> Self {
         NimConfig {
-            format:  "via [$symbol$version]($style) ",
+            format: "via [$symbol$version]($style) ",
             symbol: "👑 ",
             style: "yellow bold",
             disabled: false,


### PR DESCRIPTION
#### Description
This PR refactors module `nim` to use format string.

#### Motivation and Context
Related #1057

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
