### PR TITLE
fix: remove extra space for nix-shell segment

### DIFF
--- a/src/configs/nix_shell.rs
+++ b/src/configs/nix_shell.rs
@@ -20,7 +20,7 @@ impl<'a> RootModuleConfig<'a> for NixShellConfig<'a> {
             impure_msg: SegmentConfig::new("impure"),
             pure_msg: SegmentConfig::new("pure"),
             style: Color::Blue.bold(),
-            symbol: SegmentConfig::new("❄️  "),
+            symbol: SegmentConfig::new("❄️ "),
             disabled: false,
         }
     }

--- a/tests/testsuite/nix_shell.rs
+++ b/tests/testsuite/nix_shell.rs
@@ -28,7 +28,7 @@ fn pure_shell() -> io::Result<()> {
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
-    let expected = format!("via {} ", Color::Blue.bold().paint("❄️  pure"));
+    let expected = format!("via {} ", Color::Blue.bold().paint("❄️ pure"));
     assert_eq!(expected, actual);
     Ok(())
 }
@@ -40,7 +40,7 @@ fn impure_shell() -> io::Result<()> {
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
-    let expected = format!("via {} ", Color::Blue.bold().paint("❄️  impure"));
+    let expected = format!("via {} ", Color::Blue.bold().paint("❄️ impure"));
     assert_eq!(expected, actual);
     Ok(())
 }
@@ -52,7 +52,7 @@ fn lorri_shell() -> io::Result<()> {
         .output()?;
     let actual = String::from_utf8(output.stdout).unwrap();
 
-    let expected = format!("via {} ", Color::Blue.bold().paint("❄️  impure"));
+    let expected = format!("via {} ", Color::Blue.bold().paint("❄️ impure"));
     assert_eq!(expected, actual);
     Ok(())
 }


### PR DESCRIPTION
Now matches documentation

#### Motivation and Context
Removes unnecessary and unsymmetrical extra space

#### Screenshots (if appropriate):

#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly. --> Match present document
- [ ] I have updated the tests accordingly.
