### PR TITLE
fix(init): pass verbatim invocation between phases

### DIFF
--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -23,9 +23,13 @@ struct StarshipPath {
 }
 impl StarshipPath {
     fn init() -> io::Result<Self> {
-        Ok(Self {
-            native_path: env::current_exe()?,
-        })
+        let argv0_path = env::args().next().map(PathBuf::from);
+        let native_path = match argv0_path {
+            Some(path) => path,
+            None => env::current_exe()?,
+        };
+
+        Ok(Self { native_path })
     }
     fn str_path(&self) -> io::Result<&str> {
         let current_exe = self
@@ -91,6 +95,9 @@ impl StarshipPath {
 init code. The stub produces the main init script, then evaluates it with
 `source` and process substitution */
 pub fn init_stub(shell_name: &str) -> io::Result<()> {
+    let starship = path_to_starship();
+
+    log::debug!("Starship: {}", starship);
     log::debug!("Shell name: {}", shell_name);
 
     let shell_basename = Path::new(shell_name)

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -95,17 +95,15 @@ impl StarshipPath {
 init code. The stub produces the main init script, then evaluates it with
 `source` and process substitution */
 pub fn init_stub(shell_name: &str) -> io::Result<()> {
-    let starship = path_to_starship();
-
-    log::debug!("Starship: {}", starship);
-    log::debug!("Shell name: {}", shell_name);
+    let starship = StarshipPath::init()?;
 
     let shell_basename = Path::new(shell_name)
         .file_stem()
         .and_then(OsStr::to_str)
         .unwrap_or(shell_name);
 
-    let starship = StarshipPath::init()?;
+    log::debug!("Starship path: {:?}", starship.str_path());
+    log::debug!("Shell name: {}", shell_name);
 
     match shell_basename {
         "bash" => print!(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Alter 2-phase init so the first phase takes original invocation and passes it to the second phase without any modifications being made.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #910 

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
