### PR TITLE
fix(format-string): Forward conditional wrapper to meta variables

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -101,6 +101,8 @@ For example:
 
 - `(@$region)` will show nothing if the variable `region` is `None`, otherwise `@` followed by the value of region.
 - `(some text)` will always show nothing since there are no variables wrapped in the braces.
+- When `$all` is a shortcut for `\[$a$b\] `, `($all)` will show nothing only if `$a` and `$b` are both `None`.
+  This works the same as `(\[$a$b\] )`.
 
 #### Escapable characters
 

--- a/src/formatter/model.rs
+++ b/src/formatter/model.rs
@@ -55,6 +55,15 @@ impl<'a> VariableHolder<Cow<'a, str>> for Vec<FormatElement<'a>> {
     }
 }
 
+impl<'a> VariableHolder<Cow<'a, str>> for &[FormatElement<'a>] {
+    fn get_variables(&self) -> BTreeSet<Cow<'a, str>> {
+        self.iter().fold(BTreeSet::new(), |mut acc, el| {
+            acc.extend(el.get_variables());
+            acc
+        })
+    }
+}
+
 impl<'a> StyleVariableHolder<Cow<'a, str>> for StyleElement<'a> {
     fn get_style_variables(&self) -> BTreeSet<Cow<'a, str>> {
         match self {

--- a/src/formatter/string_formatter.rs
+++ b/src/formatter/string_formatter.rs
@@ -296,7 +296,7 @@ impl<'a> StringFormatter<'a> {
                             // Show the conditional format string if all the variables inside are not
                             // none.
                             fn _should_show_elements<'a>(
-                                format_elements: &Vec<FormatElement>,
+                                format_elements: &[FormatElement],
                                 variables: &'a VariableMapType<'a>,
                             ) -> bool {
                                 format_elements.get_variables().iter().any(|var| {

--- a/src/formatter/string_formatter.rs
+++ b/src/formatter/string_formatter.rs
@@ -295,12 +295,40 @@ impl<'a> StringFormatter<'a> {
                         FormatElement::Conditional(format) => {
                             // Show the conditional format string if all the variables inside are not
                             // none.
-                            let should_show: bool = format.get_variables().iter().any(|var| {
-                                variables
-                                    .get(var.as_ref())
-                                    .map(|segments| segments.is_some())
-                                    .unwrap_or(false)
-                            });
+                            fn _should_show_elements<'a>(
+                                format_elements: &Vec<FormatElement>,
+                                variables: &'a VariableMapType<'a>,
+                            ) -> bool {
+                                format_elements.get_variables().iter().any(|var| {
+                                    variables
+                                        .get(var.as_ref())
+                                        .map(|map_result| {
+                                            let map_result = map_result.as_ref();
+                                            map_result
+                                                .and_then(|result| result.as_ref().ok())
+                                                .map(|result| match result {
+                                                    // If the variable is a meta variable, also
+                                                    // check the format string inside it.
+                                                    VariableValue::Meta(meta_elements) => {
+                                                        let meta_variables =
+                                                            _clone_without_meta(variables);
+                                                        _should_show_elements(
+                                                            &meta_elements,
+                                                            &meta_variables,
+                                                        )
+                                                    }
+                                                    _ => true,
+                                                })
+                                                // The variable is None or Err, or a meta variable
+                                                // that shouldn't show
+                                                .unwrap_or(false)
+                                        })
+                                        // Can't find the variable in format string
+                                        .unwrap_or(false)
+                                })
+                            }
+
+                            let should_show: bool = _should_show_elements(&format, variables);
 
                             if should_show {
                                 _parse_format(format, style, variables, style_variables)
@@ -591,6 +619,21 @@ mod tests {
         match_next!(result_iter, " and ", None);
         match_next!(result_iter, " ", None);
         match_next!(result_iter, "$some", None);
+    }
+
+    #[test]
+    fn test_conditional_meta_variable() {
+        const FORMAT_STR: &str = r"(\[$all\]) ";
+
+        let formatter = StringFormatter::new(FORMAT_STR)
+            .unwrap()
+            .map_meta(|var, _| match var {
+                "all" => Some("$some"),
+                _ => None,
+            });
+        let result = formatter.parse(None).unwrap();
+        let mut result_iter = result.iter();
+        match_next!(result_iter, " ", None);
     }
 
     #[test]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
When mapping meta variable `$all` to `\[$a$b\]`, a conditional format string `($all)` will always render, no matter if both `$a` and `$b` are `None`.

This PR will make `($all)` work the same as `(\[$a$b\])`.


#### Motivation and Context

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
