### PR TITLE
chore: Deprecate affix and module style

### DIFF
--- a/src/module.rs
+++ b/src/module.rs
@@ -112,19 +112,17 @@ impl<'a> Module<'a> {
     }
 
     pub fn ansi_strings_for_shell(&self, shell: Shell) -> Vec<ANSIString> {
-        let mut ansi_strings = self
+        let ansi_strings = self
             .segments
             .iter()
             .map(Segment::ansi_string)
             .collect::<Vec<ANSIString>>();
 
-        ansi_strings = match shell {
+        match shell {
             Shell::Bash => ansi_strings_modified(ansi_strings, shell),
             Shell::Zsh => ansi_strings_modified(ansi_strings, shell),
             _ => ansi_strings,
-        };
-
-        ansi_strings
+        }
     }
 }
 

--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -111,8 +111,5 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         }
     });
 
-    module.get_prefix().set_value("");
-    module.get_suffix().set_value("");
-
     Some(module)
 }

--- a/src/modules/battery.rs
+++ b/src/modules/battery.rs
@@ -56,8 +56,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             match formatter.parse(None) {
                 Ok(format_string) => {
                     module.set_segments(format_string);
-                    module.get_prefix().set_value("");
-                    module.get_suffix().set_value("");
                     Some(module)
                 }
                 Err(e) => {

--- a/src/modules/character.rs
+++ b/src/modules/character.rs
@@ -66,8 +66,5 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         }
     });
 
-    module.get_prefix().set_value("");
-    module.get_suffix().set_value("");
-
     Some(module)
 }

--- a/src/modules/cmd_duration.rs
+++ b/src/modules/cmd_duration.rs
@@ -53,9 +53,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         }
     });
 
-    module.get_prefix().set_value("");
-    module.get_suffix().set_value("");
-
     Some(module)
 }
 

--- a/src/modules/conda.rs
+++ b/src/modules/conda.rs
@@ -46,8 +46,5 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         }
     });
 
-    module.get_prefix().set_value("");
-    module.get_suffix().set_value("");
-
     Some(module)
 }

--- a/src/modules/crystal.rs
+++ b/src/modules/crystal.rs
@@ -50,9 +50,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         }
     });
 
-    module.get_prefix().set_value("");
-    module.get_suffix().set_value("");
-
     Some(module)
 }
 

--- a/src/modules/custom.rs
+++ b/src/modules/custom.rs
@@ -78,9 +78,6 @@ pub fn module<'a>(name: &str, context: &'a Context) -> Option<Module<'a>> {
         }
     });
 
-    module.get_prefix().set_value("");
-    module.get_suffix().set_value("");
-
     Some(module)
 }
 

--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -113,9 +113,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         }
     });
 
-    module.get_prefix().set_value("");
-    module.get_suffix().set_value("");
-
     Some(module)
 }
 

--- a/src/modules/docker_context.rs
+++ b/src/modules/docker_context.rs
@@ -69,9 +69,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                         }
                     });
 
-                    module.get_prefix().set_value("");
-                    module.get_suffix().set_value("");
-
                     Some(module)
                 }
                 _ => None,

--- a/src/modules/dotnet.rs
+++ b/src/modules/dotnet.rs
@@ -86,9 +86,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         }
     });
 
-    module.get_prefix().set_value("");
-    module.get_suffix().set_value("");
-
     Some(module)
 }
 

--- a/src/modules/elixir.rs
+++ b/src/modules/elixir.rs
@@ -51,9 +51,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         }
     });
 
-    module.get_prefix().set_value("");
-    module.get_suffix().set_value("");
-
     Some(module)
 }
 

--- a/src/modules/elm.rs
+++ b/src/modules/elm.rs
@@ -55,9 +55,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         }
     });
 
-    module.get_prefix().set_value("");
-    module.get_suffix().set_value("");
-
     Some(module)
 }
 

--- a/src/modules/env_var.rs
+++ b/src/modules/env_var.rs
@@ -41,8 +41,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             return None;
         }
     });
-    module.get_prefix().set_value("");
-    module.get_suffix().set_value("");
 
     Some(module)
 }

--- a/src/modules/erlang.rs
+++ b/src/modules/erlang.rs
@@ -46,9 +46,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         }
     });
 
-    module.get_prefix().set_value("");
-    module.get_suffix().set_value("");
-
     Some(module)
 }
 

--- a/src/modules/git_branch.rs
+++ b/src/modules/git_branch.rs
@@ -12,9 +12,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let mut module = context.new_module("git_branch");
     let config = GitBranchConfig::try_load(module.config);
 
-    module.get_prefix().set_value("");
-    module.get_suffix().set_value("");
-
     let truncation_symbol = get_first_grapheme(config.truncation_symbol);
 
     // TODO: Once error handling is implemented, warn the user if their config

--- a/src/modules/git_commit.rs
+++ b/src/modules/git_commit.rs
@@ -48,9 +48,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         }
     });
 
-    module.get_prefix().set_value("");
-    module.get_suffix().set_value("");
-
     Some(module)
 }
 

--- a/src/modules/git_state.rs
+++ b/src/modules/git_state.rs
@@ -45,9 +45,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         }
     });
 
-    module.get_prefix().set_value("");
-    module.get_suffix().set_value("");
-
     Some(module)
 }
 

--- a/src/modules/git_status.rs
+++ b/src/modules/git_status.rs
@@ -31,9 +31,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let mut module = context.new_module("git_status");
     let config: GitStatusConfig = GitStatusConfig::try_load(module.config);
 
-    module.get_prefix().set_value("");
-    module.get_suffix().set_value("");
-
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter
             .map_meta(|variable, _| match variable {
@@ -99,9 +96,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             return None;
         }
     });
-
-    module.get_prefix().set_value("");
-    module.get_suffix().set_value("");
 
     Some(module)
 }

--- a/src/modules/golang.rs
+++ b/src/modules/golang.rs
@@ -63,9 +63,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         }
     });
 
-    module.get_prefix().set_value("");
-    module.get_suffix().set_value("");
-
     Some(module)
 }
 

--- a/src/modules/haskell.rs
+++ b/src/modules/haskell.rs
@@ -63,8 +63,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         }
     });
 
-    module.get_prefix().set_value("");
-    module.get_suffix().set_value("");
     Some(module)
 }
 

--- a/src/modules/hg_branch.rs
+++ b/src/modules/hg_branch.rs
@@ -67,9 +67,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         }
     });
 
-    module.get_prefix().set_value("");
-    module.get_suffix().set_value("");
-
     Some(module)
 }
 

--- a/src/modules/hostname.rs
+++ b/src/modules/hostname.rs
@@ -64,8 +64,5 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         }
     });
 
-    module.get_prefix().set_value("");
-    module.get_suffix().set_value("");
-
     Some(module)
 }

--- a/src/modules/java.rs
+++ b/src/modules/java.rs
@@ -51,8 +51,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                     return None;
                 }
             });
-            module.get_prefix().set_value("");
-            module.get_suffix().set_value("");
             Some(module)
         }
         None => None,

--- a/src/modules/jobs.rs
+++ b/src/modules/jobs.rs
@@ -50,8 +50,5 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         }
     });
 
-    module.get_prefix().set_value("");
-    module.get_suffix().set_value("");
-
     Some(module)
 }

--- a/src/modules/julia.rs
+++ b/src/modules/julia.rs
@@ -51,9 +51,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         }
     });
 
-    module.get_prefix().set_value("");
-    module.get_suffix().set_value("");
-
     Some(module)
 }
 

--- a/src/modules/kubernetes.rs
+++ b/src/modules/kubernetes.rs
@@ -100,9 +100,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 }
             });
 
-            module.get_prefix().set_value("");
-            module.get_suffix().set_value("");
-
             Some(module)
         }
         None => None,

--- a/src/modules/line_break.rs
+++ b/src/modules/line_break.rs
@@ -7,9 +7,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
     let mut module = context.new_module("line_break");
 
-    module.get_prefix().set_value("");
-    module.get_suffix().set_value("");
-
     module.set_segments(vec![Segment {
         _name: "line_break".to_string(),
         style: None,

--- a/src/modules/memory_usage.rs
+++ b/src/modules/memory_usage.rs
@@ -84,8 +84,5 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         }
     });
 
-    module.get_prefix().set_value("");
-    module.get_suffix().set_value("");
-
     Some(module)
 }

--- a/src/modules/nim.rs
+++ b/src/modules/nim.rs
@@ -53,9 +53,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         }
     });
 
-    module.get_prefix().set_value("");
-    module.get_suffix().set_value("");
-
     Some(module)
 }
 

--- a/src/modules/nix_shell.rs
+++ b/src/modules/nix_shell.rs
@@ -59,8 +59,5 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         }
     });
 
-    module.get_prefix().set_value("");
-    module.get_suffix().set_value("");
-
     Some(module)
 }

--- a/src/modules/nodejs.rs
+++ b/src/modules/nodejs.rs
@@ -50,9 +50,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         }
     });
 
-    module.get_prefix().set_value("");
-    module.get_suffix().set_value("");
-
     Some(module)
 }
 

--- a/src/modules/ocaml.rs
+++ b/src/modules/ocaml.rs
@@ -55,9 +55,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         }
     });
 
-    module.get_prefix().set_value("");
-    module.get_suffix().set_value("");
-
     Some(module)
 }
 

--- a/src/modules/package.rs
+++ b/src/modules/package.rs
@@ -41,9 +41,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         }
     });
 
-    module.get_prefix().set_value("");
-    module.get_suffix().set_value("");
-
     Some(module)
 }
 

--- a/src/modules/php.rs
+++ b/src/modules/php.rs
@@ -55,8 +55,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                     return None;
                 }
             });
-            module.get_prefix().set_value("");
-            module.get_suffix().set_value("");
 
             Some(module)
         }

--- a/src/modules/purescript.rs
+++ b/src/modules/purescript.rs
@@ -50,9 +50,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         }
     });
 
-    module.get_prefix().set_value("");
-    module.get_suffix().set_value("");
-
     Some(module)
 }
 

--- a/src/modules/python.rs
+++ b/src/modules/python.rs
@@ -76,9 +76,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         }
     });
 
-    module.get_prefix().set_value("");
-    module.get_suffix().set_value("");
-
     Some(module)
 }
 

--- a/src/modules/ruby.rs
+++ b/src/modules/ruby.rs
@@ -49,9 +49,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         }
     });
 
-    module.get_prefix().set_value("");
-    module.get_suffix().set_value("");
-
     Some(module)
 }
 

--- a/src/modules/rust.rs
+++ b/src/modules/rust.rs
@@ -52,9 +52,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         }
     });
 
-    module.get_prefix().set_value("");
-    module.get_suffix().set_value("");
-
     Some(module)
 }
 

--- a/src/modules/singularity.rs
+++ b/src/modules/singularity.rs
@@ -40,8 +40,5 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         }
     });
 
-    module.get_prefix().set_value("");
-    module.get_suffix().set_value("");
-
     Some(module)
 }

--- a/src/modules/terraform.rs
+++ b/src/modules/terraform.rs
@@ -56,9 +56,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         }
     });
 
-    module.get_prefix().set_value("");
-    module.get_suffix().set_value("");
-
     Some(module)
 }
 

--- a/src/modules/time.rs
+++ b/src/modules/time.rs
@@ -62,9 +62,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         }
     });
 
-    module.get_prefix().set_value("");
-    module.get_suffix().set_value("");
-
     Some(module)
 }
 

--- a/src/modules/username.rs
+++ b/src/modules/username.rs
@@ -51,9 +51,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             }
         });
 
-        module.get_prefix().set_value("");
-        module.get_suffix().set_value("");
-
         Some(module)
     } else {
         None

--- a/src/modules/zig.rs
+++ b/src/modules/zig.rs
@@ -52,9 +52,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         }
     });
 
-    module.get_prefix().set_value("");
-    module.get_suffix().set_value("");
-
     Some(module)
 }
 

--- a/src/print.rs
+++ b/src/print.rs
@@ -64,8 +64,6 @@ pub fn get_prompt(context: Context) -> String {
 
     // Creates a root module and prints it.
     let mut root_module = Module::new("Starship Root", "The root module", None);
-    root_module.get_prefix().set_value("");
-    root_module.get_suffix().set_value("");
     root_module.set_segments(
         formatter
             .parse(None)


### PR DESCRIPTION
#### Description
Deprecation of prefix and suffix for all modules.
the `style` member will also be deprecated in preference of `config.style`.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related #1057 

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
