### PR TITLE
feat: Make git_branch prefix configurable

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -618,6 +618,7 @@ The `git_branch` module shows the active branch of the repo in your current dire
 | `symbol`            | `" "`          | The symbol used before the branch name of the repo in your current directory.         |
 | `truncation_length` | `2^63 - 1`      | Truncates a git branch to X graphemes                                                 |
 | `truncation_symbol` | `"…"`           | The symbol used to indicate a branch name was truncated. You can use "" for no symbol |
+| `prefix`            | `"on "`         | Prefix to display immediately before git branch.                                      |
 | `style`             | `"bold purple"` | The style for the module.                                                             |
 | `disabled`          | `false`         | Disables the `git_branch` module.                                                     |
 

--- a/src/configs/git_branch.rs
+++ b/src/configs/git_branch.rs
@@ -9,6 +9,7 @@ pub struct GitBranchConfig<'a> {
     pub truncation_length: i64,
     pub truncation_symbol: &'a str,
     pub branch_name: SegmentConfig<'a>,
+    pub prefix: &'a str,
     pub style: Style,
     pub disabled: bool,
 }
@@ -20,6 +21,7 @@ impl<'a> RootModuleConfig<'a> for GitBranchConfig<'a> {
             truncation_length: std::i64::MAX,
             truncation_symbol: "…",
             branch_name: SegmentConfig::default(),
+            prefix: "on ",
             style: Color::Purple.bold(),
             disabled: false,
         }

--- a/src/modules/git_branch.rs
+++ b/src/modules/git_branch.rs
@@ -12,7 +12,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let config = GitBranchConfig::try_load(module.config);
     module.set_style(config.style);
 
-    module.get_prefix().set_value("on ");
+    module.get_prefix().set_value(config.prefix);
 
     let truncation_symbol = get_graphemes(config.truncation_symbol, 1);
     module.create_segment("symbol", &config.symbol);


### PR DESCRIPTION
#### Description
Allows the `prefix` symbol for the `git_branch` module to be configured

#### Motivation and Context
Provides functionality that is commonly available in other modules

#### How Has This Been Tested?
I ran `cargo build` and ran `target/debug/starship prompt`. It defaults to the previous `prefix` value, `"on "`, but now also supports a configured prefix in the `~/.config/starship` file.

- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
