### PR TITLE
fix: broken contribute link on starship.rs

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ If you are interested in helping contribute to starship, please take a look at o
 
 ### Code Contributors
 
-This project exists thanks to all the people who contribute. [[Contribute](CONTRIBUTING.md)].
+This project exists thanks to all the people who contribute. [[Contribute](https://github.com/starship/starship/blob/master/CONTRIBUTING.md)].
 <a href="https://github.com/starship/starship/graphs/contributors"><img src="https://opencollective.com/starship/contributors.svg?width=890&button=false" /></a>
 
 ### Financial Contributors


### PR DESCRIPTION
#### Description
Update relative URL in readme to absolute to fix broken link in docs

#### Motivation and Context
Link to contribute page in guide is causing a 404 on sharship.rs

#### Screenshots (if appropriate):
<img width="604" alt="Screen Shot 2020-06-26 at 3 40 25 PM" src="https://user-images.githubusercontent.com/13108888/85899321-810f7100-b7c3-11ea-8a7d-0cd45a6b04ac.png">

<img width="465" alt="Screen Shot 2020-06-26 at 3 34 17 PM" src="https://user-images.githubusercontent.com/13108888/85899030-07778300-b7c3-11ea-9263-e4e6b36ab93a.png">

#### How Has This Been Tested?
Tested by clicking updated link in readme and making sure it reaches desired destination

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
