### PR TITLE
fix(custom): Fix fallback shell not working on macOS

### DIFF
--- a/src/modules/custom.rs
+++ b/src/modules/custom.rs
@@ -106,10 +106,10 @@ fn shell_command(cmd: &str, shell_args: &[&str]) -> Option<Output> {
         Err(err) => {
             log::trace!("Error executing command: {:?}", err);
             log::debug!(
-                "Could not launch command with given shell or STARSHIP_SHELL env variable, retrying with /bin/env sh"
+                "Could not launch command with given shell or STARSHIP_SHELL env variable, retrying with /usr/bin/env sh"
             );
 
-            Command::new("/bin/env")
+            Command::new("/usr/bin/env")
                 .arg("sh")
                 .stdin(Stdio::piped())
                 .stdout(Stdio::piped())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Have switched the fallback shell used when the custom module can't use
the default to use `/usr/bin/env sh` rather than `/bin/env` since
`/usr/bin/env` is more commonly available.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1347

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
