### PR TITLE
fix(git_status): Remove renames_index_to_workdir() option from git status

### DIFF
--- a/src/modules/git_status.rs
+++ b/src/modules/git_status.rs
@@ -260,7 +260,6 @@ fn get_repo_status(repository: &mut Repository) -> Result<RepoStatus, git2::Erro
     status_options
         .renames_from_rewrites(true)
         .renames_head_to_index(true)
-        .renames_index_to_workdir(true)
         .include_unmodified(true);
 
     let statuses = repository.statuses(Some(&mut status_options))?;

--- a/tests/testsuite/git_status.rs
+++ b/tests/testsuite/git_status.rs
@@ -503,48 +503,6 @@ fn shows_deleted_file_with_count() -> io::Result<()> {
     remove_dir_all(repo_dir)
 }
 
-#[test]
-#[ignore]
-fn prefix() -> io::Result<()> {
-    let repo_dir = common::create_fixture_repo()?;
-    File::create(repo_dir.join("prefix"))?.sync_all()?;
-    let output = common::render_module("git_status")
-        .arg("--path")
-        .arg(&repo_dir)
-        .env_clear()
-        .use_config(toml::toml! {
-            [git_status]
-            prefix = "("
-            style = ""
-        })
-        .output()?;
-    let actual = String::from_utf8(output.stdout).unwrap();
-    let expected = "(";
-    assert!(actual.starts_with(&expected));
-    remove_dir_all(repo_dir)
-}
-
-#[test]
-#[ignore]
-fn suffix() -> io::Result<()> {
-    let repo_dir = common::create_fixture_repo()?;
-    File::create(repo_dir.join("suffix"))?.sync_all()?;
-    let output = common::render_module("git_status")
-        .arg("--path")
-        .arg(&repo_dir)
-        .env_clear()
-        .use_config(toml::toml! {
-            [git_status]
-            suffix = ")"
-            style = ""
-        })
-        .output()?;
-    let actual = String::from_utf8(output.stdout).unwrap();
-    let expected = ")";
-    assert!(actual.ends_with(&expected));
-    remove_dir_all(repo_dir)
-}
-
 // Whenever a file is manually renamed, git itself ('git status') does not treat such file as renamed,
 // but as untracked instead. The following test checks if manually deleted and manually renamed
 // files are tracked by git_status module in the same way 'git status' does.
@@ -579,12 +537,15 @@ fn ignore_manually_renamed() -> io::Result<()> {
             ahead = "A"
             deleted = "D"
             untracked = "U"
+            renamed = "R"
         })
         .output()?;
 
     let actual = String::from_utf8(output.stdout).unwrap();
-    let expected = "ADU";
-    assert_eq!(actual, expected);
+    assert!(actual.contains('A'));
+    assert!(actual.contains('D'));
+    assert!(actual.contains('U'));
+    assert!(!actual.contains('R'));
 
     remove_dir_all(repo_dir)
 }


### PR DESCRIPTION
This option causes advanced files rename detection which causes inconsistency between `git status` and Starship reports.
Closes #1371
#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [X] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [X] I have updated the tests accordingly.
