### PR TITLE
docs: show current directory in terminal window title

### DIFF
--- a/docs/advanced-config/README.md
+++ b/docs/advanced-config/README.md
@@ -75,6 +75,16 @@ precmd_functions+=(set_win_title)
 If you like the result, add these lines to your shell configuration file 
 (`~/.bashrc` or `~/.zsrhc`) to make it permanent.
 
+For example, If you want to display your current directory in your terminal tab title,
+Just add this code in `~/.bashrc` like below:
+
+```bash
+function set_win_title(){
+    echo -ne "\033]0; ${PWD##*/} \007"
+}
+starship_precmd_user_func="set_win_title"
+```
+
 ## Style Strings
 
 Style strings are a list of words, separated by whitespace. The words are not case sensitive (i.e. `bold` and `BoLd` are considered the same string). Each word can be one of the following:

--- a/docs/advanced-config/README.md
+++ b/docs/advanced-config/README.md
@@ -73,14 +73,14 @@ precmd_functions+=(set_win_title)
 ```
 
 If you like the result, add these lines to your shell configuration file 
-(`~/.bashrc` or `~/.zsrhc`) to make it permanent.
+(`~/.bashrc` or `~/.zshrc`) to make it permanent.
 
-For example, If you want to display your current directory in your terminal tab title,
-Just add this code in `~/.bashrc` like below:
+For example, if you want to display your current directory in your terminal tab title,
+add the following snippet to your `~/.bashrc` or `~/.zshrc`:
 
 ```bash
 function set_win_title(){
-    echo -ne "\033]0; ${PWD##*/} \007"
+    echo -ne "\033]0; $(basename $PWD) \007"
 }
 starship_precmd_user_func="set_win_title"
 ```


### PR DESCRIPTION
### Tested on Gnome Terminal Ubuntu 20.04
![image](https://user-images.githubusercontent.com/41269045/86113449-1758d500-baeb-11ea-9b0c-f4ce614b13fb.png)
