### PR TITLE
fix: manage sandboxed version of OCaml

### DIFF
--- a/src/modules/nodejs.rs
+++ b/src/modules/nodejs.rs
@@ -18,7 +18,12 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         .set_folders(&["node_modules"])
         .is_match();
 
-    if !is_js_project {
+    let is_esy_project = context
+        .try_begin_scan()?
+        .set_folders(&["esy.lock"])
+        .is_match();
+
+    if !is_js_project || is_esy_project {
         return None;
     }
 
@@ -59,6 +64,19 @@ mod tests {
 
         let actual = render_module("nodejs", dir.path(), None);
         let expected = Some(format!("via {} ", Color::Green.bold().paint("⬢ v12.0.0")));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn folder_with_package_json_and_esy_lock() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join("package.json"))?.sync_all()?;
+        let esy_lock = dir.path().join("esy.lock");
+        fs::create_dir_all(&esy_lock)?;
+
+        let actual = render_module("nodejs", dir.path(), None);
+        let expected = None;
         assert_eq!(expected, actual);
         dir.close()
     }

--- a/src/modules/ocaml.rs
+++ b/src/modules/ocaml.rs
@@ -29,12 +29,12 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         .set_folders(&["esy.lock"])
         .is_match();
 
-    let ocaml_version =  if is_esy_project {
+    let ocaml_version = if is_esy_project {
         utils::exec_cmd("esy", &["ocaml", "-vnum"])?.stdout
     } else {
         utils::exec_cmd("ocaml", &["-vnum"])?.stdout
     };
-     
+
     let formatted_version = format!("v{}", &ocaml_version);
 
     let mut module = context.new_module("ocaml");
@@ -90,7 +90,10 @@ mod tests {
         let dir = tempfile::tempdir()?;
         fs::create_dir_all(dir.path().join("esy.lock"))?;
         File::create(dir.path().join("package.json"))?.sync_all()?;
-        fs::write(dir.path().join("package.lock"), "{\"dependencies\": {\"ocaml\": \"4.8.1000\"}}")?;
+        fs::write(
+            dir.path().join("package.lock"),
+            "{\"dependencies\": {\"ocaml\": \"4.8.1000\"}}",
+        )?;
         let actual = render_module("ocaml", dir.path(), None);
         let expected = Some(format!("via {} ", Color::Yellow.bold().paint("🐫 v4.08.1")));
         assert_eq!(expected, actual);

--- a/src/modules/ocaml.rs
+++ b/src/modules/ocaml.rs
@@ -24,7 +24,17 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         return None;
     }
 
-    let ocaml_version = utils::exec_cmd("ocaml", &["-vnum"])?.stdout;
+    let is_esy_project = context
+        .try_begin_scan()?
+        .set_folders(&["esy.lock"])
+        .is_match();
+
+    let ocaml_version =  if is_esy_project {
+        utils::exec_cmd("esy", &["ocaml", "-vnum"])?.stdout
+    } else {
+        utils::exec_cmd("ocaml", &["-vnum"])?.stdout
+    };
+     
     let formatted_version = format!("v{}", &ocaml_version);
 
     let mut module = context.new_module("ocaml");
@@ -79,9 +89,10 @@ mod tests {
     fn folder_with_esy_lock_directory() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         fs::create_dir_all(dir.path().join("esy.lock"))?;
-
+        File::create(dir.path().join("package.json"))?.sync_all()?;
+        fs::write(dir.path().join("package.lock"), "{\"dependencies\": {\"ocaml\": \"4.8.1000\"}}")?;
         let actual = render_module("ocaml", dir.path(), None);
-        let expected = Some(format!("via {} ", Color::Yellow.bold().paint("🐫 v4.10.0")));
+        let expected = Some(format!("via {} ", Color::Yellow.bold().paint("🐫 v4.08.1")));
         assert_eq!(expected, actual);
         dir.close()
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -87,6 +87,10 @@ active boot switches: -d:release\n",
             stdout: String::from("4.10.0"),
             stderr: String::default(),
         }),
+        "esy ocaml -vnum" => Some(CommandOutput {
+            stdout: String::from("4.08.1"),
+            stderr: String::default(),
+        }),
         "php -nr echo PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION.'.'.PHP_RELEASE_VERSION;" => {
             Some(CommandOutput {
                 stdout: String::from("7.3.8"),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

- Should not display nodejs info for esy.sh OCaml project
- Should display sandboxed version of OCaml instead of global version if any (should be 4.08 not 4.10)
- display sandboxed version of OCaml when managed with esy.sh without global OCaml installation (should be 4.08 not empty)

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1395

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
