### PR TITLE
feat(cmd_duration): custom duration format

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -498,6 +498,7 @@ running `eval $(starship init $0)`, and then proceed as normal.
 | Option               | Default                                                  | Description                                                |
 | -------------------- | -------------------------------------------------------- | ---------------------------------------------------------- |
 | `min_time`           | `2_000`                                                  | Shortest duration to show time for (in milliseconds).      |
+| `show_zero_units`    | `false`                                                  | Display zero time units. (Turns `2h30s` into `2h0m30s`.)   |
 | `show_milliseconds`  | `false`                                                  | Show milliseconds in addition to seconds for the duration. |
 | `format`             | `"took [(${d}d)(${h}h)(${m}m)(${s}s)(${S}ms) ]($style)"` | The format for the module.                                 |
 | `style`              | `"bold yellow"`                                          | The style for the module.                                  |

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -527,7 +527,7 @@ The format string is parsed for token characters, which are replaced with the du
 | s        | `2`     | Second                              |
 | ss       | `02`    | Second (padded with zero)           |
 | S        | `42`    | Millisecond                         |
-| SSS      | `042`   | Millisecond (padded with zero)      |
+| SSS      | `042`   | Millisecond (padded with zeros)     |
 | style\*  |         | Mirrors the value of option `style` |
 
 \*: This variable can only be used as a part of a style string
@@ -539,7 +539,7 @@ The format string is parsed for token characters, which are replaced with the du
 
 [cmd_duration]
 min_time = 500
-format = "underwent took [(${d}d )(${hh}h )(${mm}m )(${ss}s )(${SSS}ms )](bold yellow)"
+format = "underwent [(${d}d )(${hh}h )(${mm}m )(${ss}s )(${SSS}ms )](bold yellow)"
 ```
 
 ## Conda

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -495,15 +495,15 @@ running `eval $(starship init $0)`, and then proceed as normal.
 
 ### Options
 
-| Option              | Default                       | Description                                                |
-| ------------------- | ----------------------------- | ---------------------------------------------------------- |
-| `min_time`          | `2_000`                       | Shortest duration to show time for (in milliseconds).      |
-| `show_milliseconds` | `false`                       | Show milliseconds in addition to seconds for the duration. |
-| `format`            | `"took [$duration]($style) "` | The format for the module.                                 |
-| `style`             | `"bold yellow"`               | The style for the module.                                  |
-| `disabled`          | `false`                       | Disables the `cmd_duration` module.                        |
-| `show_notifications`| `false`                       | Show desktop notifications when command completes.         |
-| `min_time_to_notify`| `45_000`                      | Shortest duration for notification (in milliseconds).      |
+| Option               | Default                                                  | Description                                                |
+| -------------------- | -------------------------------------------------------- | ---------------------------------------------------------- |
+| `min_time`           | `2_000`                                                  | Shortest duration to show time for (in milliseconds).      |
+| `show_milliseconds`  | `false`                                                  | Show milliseconds in addition to seconds for the duration. |
+| `format`             | `"took [(${d}d)(${h}h)(${m}m)(${s}s)(${S}ms) ]($style)"` | The format for the module.                                 |
+| `style`              | `"bold yellow"`                                          | The style for the module.                                  |
+| `disabled`           | `false`                                                  | Disables the `cmd_duration` module.                        |
+| `show_notifications` | `false`                                                  | Show desktop notifications when command completes.         |
+| `min_time_to_notify` | `45_000`                                                 | Shortest duration for notification (in milliseconds).      |
 
 ::: tip
 
@@ -514,10 +514,20 @@ supports notifications by running `STARSHIP_LOG=debug starship module cmd_durati
 
 ### Variables
 
-| Variable | Example  | Description                             |
-| -------- | -------- | --------------------------------------- |
-| duration | `16m40s` | The time it took to execute the command |
-| style\*  |          | Mirrors the value of option `style`     |
+The format string is parsed for token characters, which are replaced with the duration's value for each unit type. The tokens are:
+
+| Variable | Example | Description                         |
+| -------- | ------- | ----------------------------------- |
+| d        | `1`     | Day                                 |
+| h        | `4`     | Hour                                |
+| hh       | `04`    | Hour (padded with zero)             |
+| m        | `3`     | Minute                              |
+| mm       | `03`    | Minute (padded with zero)           |
+| s        | `2`     | Second                              |
+| ss       | `02`    | Second (padded with zero)           |
+| S        | `42`    | Millisecond                         |
+| SSS      | `042`   | Millisecond (padded with zero)      |
+| style\*  |         | Mirrors the value of option `style` |
 
 \*: This variable can only be used as a part of a style string
 
@@ -528,7 +538,7 @@ supports notifications by running `STARSHIP_LOG=debug starship module cmd_durati
 
 [cmd_duration]
 min_time = 500
-format = "underwent [$duration](bold yellow)"
+format = "underwent took [(${d}d )(${hh}h )(${mm}m )(${ss}s )(${SSS}ms )](bold yellow)"
 ```
 
 ## Conda

--- a/src/configs/cmd_duration.rs
+++ b/src/configs/cmd_duration.rs
@@ -18,7 +18,7 @@ impl<'a> Default for CmdDurationConfig<'a> {
     fn default() -> Self {
         CmdDurationConfig {
             min_time: 2_000,
-            format: "took [$duration]($style) ",
+            format: "took [(${d}d)(${h}h)(${m}m)(${s}s)(${S}ms) ]($style)",
             show_milliseconds: false,
             style: "yellow bold",
             disabled: false,

--- a/src/configs/cmd_duration.rs
+++ b/src/configs/cmd_duration.rs
@@ -8,6 +8,7 @@ pub struct CmdDurationConfig<'a> {
     pub min_time: i64,
     pub format: &'a str,
     pub style: &'a str,
+    pub show_zero_units: bool,
     pub show_milliseconds: bool,
     pub disabled: bool,
     pub show_notifications: bool,
@@ -19,6 +20,7 @@ impl<'a> Default for CmdDurationConfig<'a> {
         CmdDurationConfig {
             min_time: 2_000,
             format: "took [(${d}d)(${h}h)(${m}m)(${s}s)(${S}ms) ]($style)",
+            show_zero_units: false,
             show_milliseconds: false,
             style: "yellow bold",
             disabled: false,

--- a/src/modules/cmd_duration.rs
+++ b/src/modules/cmd_duration.rs
@@ -64,19 +64,21 @@ fn render_time(raw_millis: u128, show_millis: bool) -> String {
     let mut rendered_components: Vec<String> = components
         .iter()
         .zip(&suffixes)
-        .map(render_time_component)
+        .filter_map(render_time_component)
         .collect();
     if show_millis || raw_millis < 1000 {
-        rendered_components.push(render_time_component((&millis, &"ms")));
+        if let Some(millis) = render_time_component((&millis, &"ms")) {
+            rendered_components.push(millis);
+        }
     }
-    rendered_components.join("")
+    rendered_components.join(" ")
 }
 
 /// Render a single component of the time string, giving an empty string if component is zero
-fn render_time_component((component, suffix): (&u128, &&str)) -> String {
+fn render_time_component((component, suffix): (&u128, &&str)) -> Option<String> {
     match component {
-        0 => String::new(),
-        n => format!("{}{}", n, suffix),
+        0 => None,
+        n => Some(format!("{}{}", n, suffix)),
     }
 }
 
@@ -133,18 +135,22 @@ mod tests {
     fn test_500ms() {
         assert_eq!(render_time(500_u128, true), "500ms")
     }
+
     #[test]
     fn test_10s() {
         assert_eq!(render_time(10_000_u128, true), "10s")
     }
+
     #[test]
     fn test_90s() {
-        assert_eq!(render_time(90_000_u128, true), "1m30s")
+        assert_eq!(render_time(90_000_u128, true), "1m 30s")
     }
+
     #[test]
     fn test_10110s() {
-        assert_eq!(render_time(10_110_000_u128, true), "2h48m30s")
+        assert_eq!(render_time(10_110_000_u128, true), "2h 48m 30s")
     }
+
     #[test]
     fn test_1d() {
         assert_eq!(render_time(86_400_000_u128, true), "1d")

--- a/src/modules/cmd_duration.rs
+++ b/src/modules/cmd_duration.rs
@@ -242,6 +242,21 @@ mod tests {
     }
 
     #[test]
+    fn config_show_ms_duration_50ms() {
+        let actual = ModuleRenderer::new("cmd_duration")
+            .config(toml::toml! {
+                [cmd_duration]
+                min_time = 10
+                show_milliseconds = true
+            })
+            .cmd_duration(50)
+            .collect();
+
+        let expected = Some(format!("took {}", Color::Yellow.bold().paint("50ms ")));
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
     fn config_show_ms_duration_500ms() {
         let actual = ModuleRenderer::new("cmd_duration")
             .config(toml::toml! {
@@ -383,6 +398,38 @@ mod tests {
             .collect();
 
         let expected = Some(format!("underwent {}", Color::Yellow.bold().paint("5s ")));
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn config_custom_format_duration_5ms() {
+        let actual = ModuleRenderer::new("cmd_duration")
+            .config(toml::toml! {
+                [cmd_duration]
+                min_time = 0
+                show_milliseconds = true
+                format = "took [(${d}d )(${hh}h )(${mm}m )(${ss}s )(${SSS}ms )]($style)"
+            })
+            .cmd_duration(5)
+            .collect();
+
+        let expected = Some(format!("took {}", Color::Yellow.bold().paint("005ms ")));
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn config_custom_format_duration_30ms() {
+        let actual = ModuleRenderer::new("cmd_duration")
+            .config(toml::toml! {
+                [cmd_duration]
+                min_time = 0
+                show_milliseconds = true
+                format = "took [(${d}d )(${hh}h )(${mm}m )(${ss}s )(${SSS}ms )]($style)"
+            })
+            .cmd_duration(30)
+            .collect();
+
+        let expected = Some(format!("took {}", Color::Yellow.bold().paint("030ms ")));
         assert_eq!(expected, actual);
     }
 

--- a/src/modules/cmd_duration.rs
+++ b/src/modules/cmd_duration.rs
@@ -19,34 +19,30 @@ impl Duration {
         }
     }
 
-    fn get_hours(&self, allow_zero: bool) -> Option<&u8> {
-        match (self.hours, allow_zero) {
-            (0, false) => None,
-            (0, true) => self.get_days().and(Some(&self.hours)),
+    fn get_hours(&self) -> Option<&u8> {
+        match self.hours {
+            0 => self.get_days().and(Some(&self.hours)),
             _ => Some(&self.hours),
         }
     }
 
-    fn get_minutes(&self, allow_zero: bool) -> Option<&u8> {
-        match (self.minutes, allow_zero) {
-            (0, false) => None,
-            (0, true) => self.get_hours(true).and(Some(&self.minutes)),
+    fn get_minutes(&self) -> Option<&u8> {
+        match self.minutes {
+            0 => self.get_hours().and(Some(&self.minutes)),
             _ => Some(&self.minutes),
         }
     }
 
-    fn get_seconds(&self, allow_zero: bool) -> Option<&u8> {
-        match (self.seconds, allow_zero) {
-            (0, false) => None,
-            (0, true) => self.get_minutes(true).and(Some(&self.seconds)),
+    fn get_seconds(&self) -> Option<&u8> {
+        match self.seconds {
+            0 => self.get_minutes().and(Some(&self.seconds)),
             _ => Some(&self.seconds),
         }
     }
 
-    fn get_milliseconds(&self, allow_zero: bool) -> Option<&u16> {
-        match (self.millis, allow_zero) {
-            (0, false) => None,
-            (0, true) => self.get_seconds(true).and(Some(&self.millis)),
+    fn get_milliseconds(&self) -> Option<&u16> {
+        match self.millis {
+            0 => self.get_seconds().and(Some(&self.millis)),
             _ => Some(&self.millis),
         }
     }
@@ -102,35 +98,71 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             .map(|variable| match variable {
                 "d" => duration.get_days().map(|days| format!("{}", days)).map(Ok),
                 "hh" => duration
-                    .get_hours(config.show_zero_units)
+                    .get_hours()
+                    .and_then(|hours| match hours {
+                        0 => config.show_zero_units.then(|| 0),
+                        _ => Some(*hours),
+                    })
                     .map(|hours| format!("{:02}", hours))
                     .map(Ok),
                 "h" => duration
-                    .get_hours(config.show_zero_units)
+                    .get_hours()
+                    .and_then(|hours| match hours {
+                        0 => config.show_zero_units.then(|| 0),
+                        _ => Some(*hours),
+                    })
                     .map(|hours| format!("{}", hours))
                     .map(Ok),
-                "mm" => (duration.get_minutes(config.show_zero_units))
+                "mm" => duration
+                    .get_minutes()
+                    .and_then(|minutes| match minutes {
+                        0 => config.show_zero_units.then(|| 0),
+                        _ => Some(*minutes),
+                    })
                     .map(|minutes| format!("{:02}", minutes))
                     .map(Ok),
-                "m" => (duration.get_minutes(config.show_zero_units))
+                "m" => duration
+                    .get_minutes()
+                    .and_then(|minutes| match minutes {
+                        0 => config.show_zero_units.then(|| 0),
+                        _ => Some(*minutes),
+                    })
                     .map(|minutes| format!("{}", minutes))
                     .map(Ok),
-                "ss" => (duration.get_seconds(config.show_zero_units))
+                "ss" => duration
+                    .get_seconds()
+                    .and_then(|seconds| match seconds {
+                        0 => config.show_zero_units.then(|| 0),
+                        _ => Some(*seconds),
+                    })
                     .map(|seconds| format!("{:02}", seconds))
                     .map(Ok),
-                "s" => (duration.get_seconds(config.show_zero_units))
+                "s" => duration
+                    .get_seconds()
+                    .and_then(|seconds| match seconds {
+                        0 => config.show_zero_units.then(|| 0),
+                        _ => Some(*seconds),
+                    })
                     .map(|seconds| format!("{}", seconds))
                     .map(Ok),
                 "SSS" => match config.show_milliseconds {
                     true => duration
-                        .get_milliseconds(config.show_zero_units)
-                        .map(|millis| format!("{:03}", millis))
+                        .get_milliseconds()
+                        .and_then(|millis| match millis {
+                            0 => config.show_zero_units.then(|| 0),
+                            _ => Some(*millis),
+                        })
+                        .map(|millis| format!("{:003}", millis))
                         .map(Ok),
                     _ => None,
                 },
                 "S" => match config.show_milliseconds {
                     true => duration
-                        .get_milliseconds(config.show_zero_units)
+                        .get_milliseconds()
+                        .and_then(|millis| match millis {
+                            0 => config.show_zero_units.then(|| 0),
+                            _ => Some(*millis),
+                        })
                         .map(|millis| format!("{}", millis))
                         .map(Ok),
                     _ => None,

--- a/src/modules/cmd_duration.rs
+++ b/src/modules/cmd_duration.rs
@@ -3,6 +3,32 @@ use super::{Context, Module, RootModuleConfig};
 use crate::configs::cmd_duration::CmdDurationConfig;
 use crate::formatter::StringFormatter;
 
+struct Duration {
+    pub days: u128,
+    pub hours: u8,
+    pub minutes: u8,
+    pub seconds: u8,
+    pub millis: u16,
+}
+
+impl From<u128> for Duration {
+    fn from(raw_millis: u128) -> Self {
+        // Calculate a simple breakdown into days/hours/minutes/seconds/milliseconds
+        let (millis, raw_seconds) = ((raw_millis % 1000) as u16, raw_millis / 1000);
+        let (seconds, raw_minutes) = ((raw_seconds % 60) as u8, raw_seconds / 60);
+        let (minutes, raw_hours) = ((raw_minutes % 60) as u8, raw_minutes / 60);
+        let (hours, days) = ((raw_hours % 24) as u8, raw_hours / 24);
+
+        Self {
+            days,
+            hours,
+            minutes,
+            seconds,
+            millis,
+        }
+    }
+}
+
 /// Outputs the time it took the last command to execute
 ///
 /// Will only print if last command took more than a certain amount of time to
@@ -20,11 +46,11 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     }
 
     let elapsed = context.get_cmd_duration()?;
-    let config_min = config.min_time as u128;
-
-    if elapsed < config_min {
+    if elapsed < config.min_time as u128 {
         return None;
     }
+
+    let duration = Duration::from(elapsed);
 
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter
@@ -33,7 +59,33 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 _ => None,
             })
             .map(|variable| match variable {
-                "duration" => Some(Ok(render_time(elapsed, config.show_milliseconds))),
+                "d" => (duration.days > 0)
+                    .then(|| duration.days.to_string())
+                    .map(Ok),
+                "hh" => (duration.hours > 0)
+                    .then(|| format!("{:02}", duration.hours))
+                    .map(Ok),
+                "h" => (duration.hours > 0)
+                    .then(|| duration.hours.to_string())
+                    .map(Ok),
+                "mm" => (duration.minutes > 0)
+                    .then(|| format!("{:02}", duration.minutes))
+                    .map(Ok),
+                "m" => (duration.minutes > 0)
+                    .then(|| duration.minutes.to_string())
+                    .map(Ok),
+                "ss" => (duration.seconds > 0)
+                    .then(|| format!("{:02}", duration.seconds))
+                    .map(Ok),
+                "s" => (duration.seconds > 0)
+                    .then(|| duration.seconds.to_string())
+                    .map(Ok),
+                "SSS" => (config.show_milliseconds && duration.millis > 0)
+                    .then(|| format!("{:03}", duration.millis))
+                    .map(Ok),
+                "S" => (config.show_milliseconds && duration.millis > 0)
+                    .then(|| duration.millis.to_string())
+                    .map(Ok),
                 _ => None,
             })
             .parse(None)
@@ -48,38 +100,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     });
 
     Some(undistract_me(module, &config, elapsed))
-}
-
-// Render the time into a nice human-readable string
-fn render_time(raw_millis: u128, show_millis: bool) -> String {
-    // Calculate a simple breakdown into days/hours/minutes/seconds/milliseconds
-    let (millis, raw_seconds) = (raw_millis % 1000, raw_millis / 1000);
-    let (seconds, raw_minutes) = (raw_seconds % 60, raw_seconds / 60);
-    let (minutes, raw_hours) = (raw_minutes % 60, raw_minutes / 60);
-    let (hours, days) = (raw_hours % 24, raw_hours / 24);
-
-    let components = [days, hours, minutes, seconds];
-    let suffixes = ["d", "h", "m", "s"];
-
-    let mut rendered_components: Vec<String> = components
-        .iter()
-        .zip(&suffixes)
-        .filter_map(render_time_component)
-        .collect();
-    if show_millis || raw_millis < 1000 {
-        if let Some(millis) = render_time_component((&millis, &"ms")) {
-            rendered_components.push(millis);
-        }
-    }
-    rendered_components.join(" ")
-}
-
-/// Render a single component of the time string, giving an empty string if component is zero
-fn render_time_component((component, suffix): (&u128, &&str)) -> Option<String> {
-    match component {
-        0 => None,
-        n => Some(format!("{}{}", n, suffix)),
-    }
 }
 
 #[cfg(not(feature = "notify-rust"))]
@@ -127,33 +147,32 @@ fn undistract_me<'a, 'b>(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::test::ModuleRenderer;
     use ansi_term::Color;
 
     #[test]
-    fn test_500ms() {
-        assert_eq!(render_time(500_u128, true), "500ms")
+    fn config_blank_duration_500ms() {
+        let actual = ModuleRenderer::new("cmd_duration")
+            .cmd_duration(500)
+            .collect();
+
+        let expected = None;
+        assert_eq!(expected, actual);
     }
 
     #[test]
-    fn test_10s() {
-        assert_eq!(render_time(10_000_u128, true), "10s")
-    }
+    fn config_show_ms_duration_500ms() {
+        let actual = ModuleRenderer::new("cmd_duration")
+            .config(toml::toml! {
+                [cmd_duration]
+                min_time = 500
+                show_milliseconds = true
+            })
+            .cmd_duration(500)
+            .collect();
 
-    #[test]
-    fn test_90s() {
-        assert_eq!(render_time(90_000_u128, true), "1m 30s")
-    }
-
-    #[test]
-    fn test_10110s() {
-        assert_eq!(render_time(10_110_000_u128, true), "2h 48m 30s")
-    }
-
-    #[test]
-    fn test_1d() {
-        assert_eq!(render_time(86_400_000_u128, true), "1d")
+        let expected = Some(format!("took {}", Color::Yellow.bold().paint("500ms ")));
+        assert_eq!(expected, actual);
     }
 
     #[test]
@@ -172,12 +191,52 @@ mod tests {
             .cmd_duration(5000)
             .collect();
 
-        let expected = Some(format!("took {} ", Color::Yellow.bold().paint("5s")));
+        let expected = Some(format!("took {}", Color::Yellow.bold().paint("5s ")));
         assert_eq!(expected, actual);
     }
 
     #[test]
-    fn config_5s_duration_3s() {
+    fn config_blank_duration_90s() {
+        let actual = ModuleRenderer::new("cmd_duration")
+            .cmd_duration(90_000)
+            .collect();
+
+        let expected = Some(format!("took {}", Color::Yellow.bold().paint("1m30s ")));
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn config_blank_duration_7230s() {
+        let actual = ModuleRenderer::new("cmd_duration")
+            .cmd_duration(7_230_000)
+            .collect();
+
+        let expected = Some(format!("took {}", Color::Yellow.bold().paint("2h30s ")));
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn config_blank_duration_10110s() {
+        let actual = ModuleRenderer::new("cmd_duration")
+            .cmd_duration(10_110_000)
+            .collect();
+
+        let expected = Some(format!("took {}", Color::Yellow.bold().paint("2h48m30s ")));
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn config_blank_duration_1d() {
+        let actual = ModuleRenderer::new("cmd_duration")
+            .cmd_duration(86_400_000)
+            .collect();
+
+        let expected = Some(format!("took {}", Color::Yellow.bold().paint("1d ")));
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn config_min_5s_duration_3s() {
         let actual = ModuleRenderer::new("cmd_duration")
             .config(toml::toml! {
                 [cmd_duration]
@@ -191,7 +250,7 @@ mod tests {
     }
 
     #[test]
-    fn config_5s_duration_10s() {
+    fn config_min_5s_duration_10s() {
         let actual = ModuleRenderer::new("cmd_duration")
             .config(toml::toml! {
                 [cmd_duration]
@@ -200,16 +259,16 @@ mod tests {
             .cmd_duration(10000)
             .collect();
 
-        let expected = Some(format!("took {} ", Color::Yellow.bold().paint("10s")));
+        let expected = Some(format!("took {}", Color::Yellow.bold().paint("10s ")));
         assert_eq!(expected, actual);
     }
 
     #[test]
-    fn config_1s_duration_prefix_underwent() {
+    fn config_custom_prefix_duration_1s() {
         let actual = ModuleRenderer::new("cmd_duration")
             .config(toml::toml! {
                 [cmd_duration]
-                format = "underwent [$duration]($style) "
+                format = "underwent [(${d}d)(${h}h)(${m}m)(${s}s)(${S}ms) ]($style)"
             })
             .cmd_duration(1000)
             .collect();
@@ -219,16 +278,30 @@ mod tests {
     }
 
     #[test]
-    fn config_5s_duration_prefix_underwent() {
+    fn config_custom_prefix_duration_5s() {
         let actual = ModuleRenderer::new("cmd_duration")
             .config(toml::toml! {
                 [cmd_duration]
-                format = "underwent [$duration]($style) "
+                format = "underwent [(${d}d)(${h}h)(${m}m)(${s}s)(${S}ms) ]($style)"
             })
             .cmd_duration(5000)
             .collect();
 
-        let expected = Some(format!("underwent {} ", Color::Yellow.bold().paint("5s")));
+        let expected = Some(format!("underwent {}", Color::Yellow.bold().paint("5s ")));
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn config_custom_format_duration_7470s() {
+        let actual = ModuleRenderer::new("cmd_duration")
+            .config(toml::toml! {
+                [cmd_duration]
+                format = "took [(${d}d )(${hh}h )(${mm}m )(${ss}s )(${SSS}ms )]($style)"
+            })
+            .cmd_duration(7_470_000)
+            .collect();
+
+        let expected = Some(format!("took {}", Color::Yellow.bold().paint("02h 04m 30s ")));
         assert_eq!(expected, actual);
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Enable configuring command duration display using a format string with time unit tokens.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Improve command duration output readability. :bowtie: 

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
