### PR TITLE
test(terraform): Move tests which do not require env vars

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -121,12 +121,6 @@ jobs:
         if: matrix.os == 'macOS-latest'
         run: pip3 install mercurial
 
-      # Install Terraform at a fixed version
-      - name: Setup | Terraform
-        uses: volcano-coffee-company/setup-terraform@v1
-        with:
-          version: "0.12.14"
-
       # Run the ignored tests that expect the above setup
       - name: Build | Test
         run: cargo test -- -Z unstable-options --include-ignored

--- a/src/modules/terraform.rs
+++ b/src/modules/terraform.rs
@@ -144,7 +144,6 @@ is 0.12.14. You can update by downloading from www.terraform.io/downloads.html
     }
 
     #[test]
-    #[ignore]
     fn folder_with_dotterraform_with_version_no_environment() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         let tf_dir = dir.path().join(".terraform");
@@ -168,7 +167,6 @@ is 0.12.14. You can update by downloading from www.terraform.io/downloads.html
     }
 
     #[test]
-    #[ignore]
     fn folder_with_dotterraform_with_version_with_environment() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         let tf_dir = dir.path().join(".terraform");

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -123,6 +123,10 @@ active boot switches: -d:release\n",
             stdout: String::from("0.6.0"),
             stderr: String::default(),
         }),
+        "terraform version" => Some(CommandOutput {
+            stdout: String::from("Terraform v0.12.14"),
+            stderr: String::default(),
+        }),
         s if s.starts_with("erl") => Some(CommandOutput {
             stdout: String::from("22.1.3"),
             stderr: String::default(),

--- a/tests/testsuite/terraform.rs
+++ b/tests/testsuite/terraform.rs
@@ -3,7 +3,6 @@ use std::fs::{self, File};
 use std::io::{self, Write};
 
 use crate::common;
-use crate::common::TestCommand;
 
 #[test]
 fn folder_without_dotterraform() -> io::Result<()> {
@@ -114,59 +113,6 @@ fn folder_with_dotterraform_with_environment() -> io::Result<()> {
     let actual = String::from_utf8(output.stdout).unwrap();
 
     let expected = format!("via {} ", Color::Fixed(105).bold().paint("💠 development"));
-    assert_eq!(expected, actual);
-    Ok(())
-}
-
-#[test]
-#[ignore]
-fn folder_with_dotterraform_with_version_no_environment() -> io::Result<()> {
-    let dir = tempfile::tempdir()?;
-    let tf_dir = dir.path().join(".terraform");
-    fs::create_dir(&tf_dir)?;
-
-    let output = common::render_module("terraform")
-        .arg("--path")
-        .arg(dir.path())
-        .use_config(toml::toml! {
-            [terraform]
-            format = "via [$symbol$version$workspace]($style) "
-        })
-        .output()?;
-    let actual = String::from_utf8(output.stdout).unwrap();
-
-    let expected = format!(
-        "via {} ",
-        Color::Fixed(105).bold().paint("💠 v0.12.14 default")
-    );
-    assert_eq!(expected, actual);
-    Ok(())
-}
-
-#[test]
-#[ignore]
-fn folder_with_dotterraform_with_version_with_environment() -> io::Result<()> {
-    let dir = tempfile::tempdir()?;
-    let tf_dir = dir.path().join(".terraform");
-    fs::create_dir(&tf_dir)?;
-    let mut file = File::create(tf_dir.join("environment"))?;
-    file.write_all(b"development")?;
-    file.sync_all()?;
-
-    let output = common::render_module("terraform")
-        .arg("--path")
-        .arg(dir.path())
-        .use_config(toml::toml! {
-            [terraform]
-            format = "via [$symbol$version$workspace]($style) "
-        })
-        .output()?;
-    let actual = String::from_utf8(output.stdout).unwrap();
-
-    let expected = format!(
-        "via {} ",
-        Color::Fixed(105).bold().paint("💠 v0.12.14 development")
-    );
     assert_eq!(expected, actual);
     Ok(())
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Moves terraform's tests which do not require env vars into unit tests allowing for version mocking and removing another install step from our CI.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Reduces our CI runtime even further and get a little bit closed to moving all test to unit test.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
