### PR TITLE
ci: Revert back to actions-rs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,9 +14,11 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup | Rust
-        uses: ATiltedTree/setup-rust@v1
+        uses: actions-rs/toolchain@v1
         with:
-          rust-version: stable
+          toolchain: stable
+          profile: minimal
+          override: true
 
       - name: Build | Publish
         run: cargo publish --token ${{ secrets.CRATES_IO_TOKEN }}
@@ -70,10 +72,12 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Setup | Rust
-        uses: ATiltedTree/setup-rust@v1
+        uses: actions-rs/toolchain@v1
         with:
-          rust-version: stable
-          targets: ${{ matrix.target }}
+          toolchain: stable
+          override: true
+          profile: minimal
+          target: ${{ matrix.target }}
 
       - name: Setup | musl tools
         if: matrix.target == 'x86_64-unknown-linux-musl'

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -19,9 +19,11 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup | Rust
-        uses: ATiltedTree/setup-rust@v1
+        uses: actions-rs/toolchain@v1
         with:
-          rust-version: stable
+          toolchain: stable
+          override: true
+          profile: minimal
           components: rustfmt
 
       - name: Build | Format
@@ -46,13 +48,18 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Setup | Rust
-        uses: ATiltedTree/setup-rust@v1
+        uses: actions-rs/toolchain@v1
         with:
-          rust-version: stable
+          toolchain: stable
+          override: true
+          profile: minimal
           components: clippy
 
       - name: Build | Lint
-        run: cargo clippy --all-targets --all-features -- -D clippy::all
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --all-targets --all-features -- -D clippy::all
 
   # Ensure that the project could be successfully compiled
   cargo_check:
@@ -73,9 +80,11 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Setup | Rust
-        uses: ATiltedTree/setup-rust@v1
+        uses: actions-rs/toolchain@v1
         with:
-          rust-version: stable
+          toolchain: stable
+          profile: minimal
+          override: true
 
       - name: Build | Check
         run: cargo check --all
@@ -106,9 +115,11 @@ jobs:
 
       # Install all the required dependencies for testing
       - name: Setup | Rust
-        uses: ATiltedTree/setup-rust@v1
+        uses: actions-rs/toolchain@v1
         with:
-          rust-version: ${{ matrix.rust }}
+          toolchain: ${{ matrix.rust }}
+          profile: minimal
+          override: true
 
       # Install dotnet at a fixed version
       - name: Setup | DotNet


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Revert the Rust install calls from `ATiltedTree/setup-rust` back to `actions-rs/toolchain`.
This was done as we tried if my action would fix the random test failures but it didn't (as seen here #1456 and in this pr) so this reverts it.
`actions-rs/cargo` is only used in the lint step because otherwise we would get duplicate annotations.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Using a wildly known action was [preferred](https://github.com/starship/starship/pull/1450#discussion_r450992120) if my action didn't fix our failures.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
