### PR TITLE
fix: Fixed a typo: permission -> permissions

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -152,7 +152,7 @@ install() {
     sudo=""
     msg="Installing Starship, please wait…"
   else
-    warn "Escalated permission are required to install to ${BIN_DIR}"
+    warn "Escalated permissions are required to install to ${BIN_DIR}"
     elevate_priv
     sudo="sudo"
     msg="Installing Starship as root, please wait…"


### PR DESCRIPTION
Fixed a typo: permission -> permissions, just as in the title. Nothing more.

#### Motivation and Context
The current installation script prints "Escalated **permission are** required", but it should be "Escalated **permissions are** required".

#### Screenshots (if appropriate):

#### How Has This Been Tested?
Ran `install/install.sh` and `cargo test`.
- [ ] I have tested using **MacOS**
- [X] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [ ] I have updated the documentation accordingly. - **Irrelevant**
- [ ] I have updated the tests accordingly.
