### PR TITLE
fix(nodejs): Remove accidental line break from version string

### DIFF
--- a/src/modules/nodejs.rs
+++ b/src/modules/nodejs.rs
@@ -30,6 +30,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
     let mut module = context.new_module("nodejs");
     let config = NodejsConfig::try_load(module.config);
+    let nodejs_version = utils::exec_cmd("node", &["--version"])?.stdout;
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter
             .map_meta(|var, _| match var {
@@ -41,7 +42,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 _ => None,
             })
             .map(|variable| match variable {
-                "version" => Some(Ok(utils::exec_cmd("node", &["--version"])?.stdout)),
+                "version" => Some(Ok(nodejs_version.trim())),
                 _ => None,
             })
             .parse(None)


### PR DESCRIPTION
#### Description
A recent refactor of modules to use format strings accidentally got rid
of the `trim()` on the NodeJS version string. This just adds it back so
that the prompt doesn't include an unnecessary line break when
showing node version.

#### Motivation and Context
This is the change from 2 days ago where it seems the call to `trim()` was removed:
https://github.com/starship/starship/commit/ec76fafff08933f6f31fb99ea974bdb5ae97a0af#diff-c01cecd829b03f2f92c8c68c12409c18L37

Fixes #1465

#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
This is my first time writing any Rust code so I pretty much just copied what was done in
similar modules. I wasn't sure how to add a test for this and if such a test is necessary it
should probably be added to most modules.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
