### PR TITLE
fix(config): don't panic when hex color is too short

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -384,9 +384,13 @@ fn parse_color_string(color_string: &str) -> Option<ansi_term::Color> {
             "Attempting to read hexadecimal color string: {}",
             color_string
         );
-        let r: u8 = u8::from_str_radix(&color_string.get(1..3)?, 16).ok()?;
-        let g: u8 = u8::from_str_radix(&color_string.get(3..5)?, 16).ok()?;
-        let b: u8 = u8::from_str_radix(&color_string.get(5..7)?, 16).ok()?;
+        if color_string.len() != 7 {
+            log::debug!("Could not parse hexadecimal string: {}", color_string);
+            return None;
+        }
+        let r: u8 = u8::from_str_radix(&color_string[1..3], 16).ok()?;
+        let g: u8 = u8::from_str_radix(&color_string[3..5], 16).ok()?;
+        let b: u8 = u8::from_str_radix(&color_string[5..7], 16).ok()?;
         log::trace!("Read RGB color string: {},{},{}", r, g, b);
         return Some(Color::RGB(r, g, b));
     }
@@ -596,7 +600,13 @@ mod tests {
         let config = Value::from("#00000");
         assert_eq!(<Style>::from_config(&config), None);
 
-        let config = Value::from("#A12BCD");
+        let config = Value::from("#0000000");
+        assert_eq!(<Style>::from_config(&config), None);
+
+        let config = Value::from("#NOTHEX");
+        assert_eq!(<Style>::from_config(&config), None);
+
+        let config = Value::from("#a12BcD");
         assert_eq!(
             <Style>::from_config(&config).unwrap(),
             Color::RGB(0xA1, 0x2B, 0xCD).into()

--- a/src/config.rs
+++ b/src/config.rs
@@ -384,9 +384,9 @@ fn parse_color_string(color_string: &str) -> Option<ansi_term::Color> {
             "Attempting to read hexadecimal color string: {}",
             color_string
         );
-        let r: u8 = u8::from_str_radix(&color_string[1..3], 16).ok()?;
-        let g: u8 = u8::from_str_radix(&color_string[3..5], 16).ok()?;
-        let b: u8 = u8::from_str_radix(&color_string[5..7], 16).ok()?;
+        let r: u8 = u8::from_str_radix(&color_string.get(1..3)?, 16).ok()?;
+        let g: u8 = u8::from_str_radix(&color_string.get(3..5)?, 16).ok()?;
+        let b: u8 = u8::from_str_radix(&color_string.get(5..7)?, 16).ok()?;
         log::trace!("Read RGB color string: {},{},{}", r, g, b);
         return Some(Color::RGB(r, g, b));
     }
@@ -589,6 +589,18 @@ mod tests {
     fn test_from_style() {
         let config = Value::from("red bold");
         assert_eq!(<Style>::from_config(&config).unwrap(), Color::Red.bold());
+    }
+
+    #[test]
+    fn test_from_hex_color_style() {
+        let config = Value::from("#00000");
+        assert_eq!(<Style>::from_config(&config), None);
+
+        let config = Value::from("#A12BCD");
+        assert_eq!(
+            <Style>::from_config(&config).unwrap(),
+            Color::RGB(0xA1, 0x2B, 0xCD).into()
+        );
     }
 
     #[test]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
When the user gives a hex color that is shorter than expected it caused an out of bounds error. This PR works around this ~by using checked array indexing~ by checking the length of the hex color string beforehand. 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1467

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
