### PR TITLE
fix(ocaml): Stop new line being included in ocaml version

### DIFF
--- a/src/modules/ocaml.rs
+++ b/src/modules/ocaml.rs
@@ -50,7 +50,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 _ => None,
             })
             .map(|variable| match variable {
-                "version" => Some(Ok(format!("v{}", &ocaml_version))),
+                "version" => Some(Ok(format!("v{}", &ocaml_version.trim()))),
                 _ => None,
             })
             .parse(None)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -84,11 +84,11 @@ active boot switches: -d:release\n",
             stderr: String::default(),
         }),
         "ocaml -vnum" => Some(CommandOutput {
-            stdout: String::from("4.10.0"),
+            stdout: String::from("4.10.0\n"),
             stderr: String::default(),
         }),
         "esy ocaml -vnum" => Some(CommandOutput {
-            stdout: String::from("4.08.1"),
+            stdout: String::from("4.08.1\n"),
             stderr: String::default(),
         }),
         "php -nr echo PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION.'.'.PHP_RELEASE_VERSION;" => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This fixes a regression in the ocaml module that caused the excess whitespace
to not be trimmed from the version.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to #1436 and 

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
