### PR TITLE
proof of concept for showing the exit status

### DIFF
--- a/src/configs/character.rs
+++ b/src/configs/character.rs
@@ -4,20 +4,18 @@ use starship_module_config_derive::ModuleConfig;
 
 #[derive(Clone, ModuleConfig)]
 pub struct CharacterConfig<'a> {
-    pub format: &'a str,
-    pub success_symbol: &'a str,
-    pub error_symbol: &'a str,
-    pub vicmd_symbol: &'a str,
+    pub success_format: &'a str,
+    pub error_format: &'a str,
+    pub vicmd_format: &'a str,
     pub disabled: bool,
 }
 
 impl<'a> RootModuleConfig<'a> for CharacterConfig<'a> {
     fn new() -> Self {
         CharacterConfig {
-            format: "$symbol ",
-            success_symbol: "[❯](bold green)",
-            error_symbol: "[❯](bold red)",
-            vicmd_symbol: "[❮](bold green)",
+            success_format: "[❯](bold green) ",
+            error_format: "[❯](bold red) ",
+            vicmd_format: "[❮](bold green) ",
             disabled: false,
         }
     }

--- a/src/modules/character.rs
+++ b/src/modules/character.rs
@@ -38,21 +38,21 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         _ => ASSUMED_MODE,
     };
 
-    let symbol = match mode {
-        ShellEditMode::Normal => config.vicmd_symbol,
+    let format = match mode {
+        ShellEditMode::Normal => config.vicmd_format,
         ShellEditMode::Insert => {
             if exit_success {
-                config.success_symbol
+                config.success_format
             } else {
-                config.error_symbol
+                config.error_format
             }
         }
     };
 
-    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
+    let parsed = StringFormatter::new(format).and_then(|formatter| {
         formatter
             .map_meta(|variable, _| match variable {
-                "symbol" => Some(symbol),
+                "code" => Some(exit_code),
                 _ => None,
             })
             .parse(None)


### PR DESCRIPTION
I'd like a way to automatically print the exit status of failed
commands, in addition to the fact that they failed. Here's an initial
stab at enabling something like this. (I haven't updated tests yet, so
for now this change causes failures.) With this change, I add this to my
config:

    [character]
    error_format = "[$code](red) [❯](bold red) "

Then my prompt looks like this:

![image](https://user-images.githubusercontent.com/860932/87482667-e5be2e80-c5ff-11ea-965a-4df7e19f1cd5.png)

I'm not sure if this is the best approach, either design-wise or
implementation-wise, but I wanted to put something up to get
suggestions. Another option would be to print an extra line above the
prompt containing the status; that might make is clearer that it's
associated with the previous command too.