### PR TITLE
fix(explain): align table correctly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,7 +198,7 @@ dependencies = [
  "atty",
  "bitflags",
  "strsim",
- "textwrap 0.11.0",
+ "textwrap",
  "unicode-width",
  "vec_map",
 ]
@@ -1183,7 +1183,6 @@ dependencies = [
  "sysinfo",
  "tempfile",
  "term_size",
- "textwrap 0.12.1",
  "toml",
  "unicode-segmentation",
  "unicode-width",
@@ -1277,15 +1276,6 @@ name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "203008d98caf094106cfaba70acfed15e18ed3ddb7d94e49baec153a2b462789"
 dependencies = [
  "unicode-width",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,6 @@ os_info = "2.0.6"
 urlencoding = "1.1.1"
 open = "1.4.0"
 unicode-width = "0.1.8"
-textwrap = "0.12.1"
 term_size = "0.3.2"
 quick-xml = "0.18.1"
 

--- a/src/print.rs
+++ b/src/print.rs
@@ -5,7 +5,7 @@ use std::collections::BTreeSet;
 use std::fmt::{self, Debug, Write as FmtWrite};
 use std::io::{self, Write};
 use unicode_segmentation::UnicodeSegmentation;
-use unicode_width::UnicodeWidthStr;
+use unicode_width::UnicodeWidthChar;
 
 use crate::configs::PROMPT_ORDER;
 use crate::context::{Context, Shell};
@@ -288,13 +288,15 @@ fn better_width(s: &str) -> usize {
     s.graphemes(true).map(grapheme_width).sum()
 }
 
-// Assume that graphemes have a width of at most 2 to work around unicode-width not working on the grapheme level
+// Assume that graphemes have width of the first character in the grapheme
 fn grapheme_width(g: &str) -> usize {
-    std::cmp::min(2, g.width())
+    g.chars().next().and_then(|i| i.width()).unwrap_or(0)
 }
 
 #[test]
 fn test_grapheme_aware_better_width() {
     // UnicodeWidthStr::width would return 8
-    assert_eq!(2, better_width("👩‍👩‍👦‍👦"))
+    assert_eq!(2, better_width("👩‍👩‍👦‍👦"));
+    assert_eq!(1, better_width("Ü"));
+    assert_eq!(11, better_width("normal text"));
 }

--- a/src/print.rs
+++ b/src/print.rs
@@ -143,7 +143,7 @@ pub fn explain(args: ArgMatches) {
                 // Handle normal wrapping
                 current_pos += grapheme_width(g);
                 // Wrap when hitting max width or newline
-                if g == "\n" || current_pos - 1 >= desc_width {
+                if g == "\n" || current_pos > desc_width {
                     // trim spaces on linebreak
                     if g == " " && desc_width > 1 {
                         continue;

--- a/src/print.rs
+++ b/src/print.rs
@@ -115,6 +115,10 @@ pub fn explain(args: ArgMatches) {
 
     let desc_width = term_size::dimensions()
         .map(|(w, _)| w)
+        // In addition to the module width itself there are also 6 padding characters in each line.
+        // This needs to be updated here and later in the function on line formatting changes.
+        // Overall a line looks like this: " {module name}  -  {description}".
+        // Add padding length to module length to avoid text overflow. This line also assures desc_width >= 0.
         .map(|width| width - std::cmp::min(width, max_module_width + 6));
 
     println!("\n Here's a breakdown of your prompt:");

--- a/src/print.rs
+++ b/src/print.rs
@@ -113,13 +113,14 @@ pub fn explain(args: ArgMatches) {
 
     let max_module_width = modules.iter().map(|i| i.value_len).max().unwrap_or(0);
 
+    // In addition to the module width itself there are also 6 padding characters in each line.
+    // Overall a line looks like this: " {module name}  -  {description}".
+    const PADDING_WIDTH: usize = 6;
+
     let desc_width = term_size::dimensions()
         .map(|(w, _)| w)
-        // In addition to the module width itself there are also 6 padding characters in each line.
-        // This needs to be updated here and later in the function on line formatting changes.
-        // Overall a line looks like this: " {module name}  -  {description}".
         // Add padding length to module length to avoid text overflow. This line also assures desc_width >= 0.
-        .map(|width| width - std::cmp::min(width, max_module_width + 6));
+        .map(|width| width - std::cmp::min(width, max_module_width + PADDING_WIDTH));
 
     println!("\n Here's a breakdown of your prompt:");
     for info in modules {
@@ -153,7 +154,7 @@ pub fn explain(args: ArgMatches) {
                         continue;
                     }
 
-                    print!("\n{}", " ".repeat(max_module_width + 6));
+                    print!("\n{}", " ".repeat(max_module_width + PADDING_WIDTH));
                     if g == "\n" {
                         current_pos = 0;
                         continue;

--- a/src/print.rs
+++ b/src/print.rs
@@ -119,8 +119,7 @@ pub fn explain(args: ArgMatches) {
     println!("\n Here's a breakdown of your prompt:");
     for info in modules {
         if let Some(desc_width) = desc_width {
-            let wrapped = textwrap::fill(&info.desc, desc_width);
-            let mut lines = wrapped.split('\n');
+            let mut lines = textwrap::wrap_iter(&info.desc, desc_width);
             println!(
                 " {}{}  -  {}",
                 info.value,

--- a/src/print.rs
+++ b/src/print.rs
@@ -114,7 +114,7 @@ pub fn explain(args: ArgMatches) {
 
     let desc_width = term_size::dimensions()
         .map(|(w, _)| w)
-        .map(|width| width - std::cmp::min(width, max_module_width));
+        .map(|width| width - std::cmp::min(width, max_module_width + 6));
 
     println!("\n Here's a breakdown of your prompt:");
     for info in modules {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

The table in `explain` wasn't aligned correctly. I think this happens because since v0.12.0 textwrap doesn't count ANSI escape sequences anymore. This also means `max_ansi_width` is no longer needed.
I couldn't get `{:width$}` to work the way I wanted so I replaced it with `" ".repeat(width)`.
~Also by using `UnicodeWidthStr::width` the width calculation itself should be a bit better because it can work on the level of graphemes instead of characters.~ Sadly both `UnicodeWidthStr::width` and `UnicodeWidthStr::width` appear to fail at this. I replaced them with a custom textwrapper.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1480 

#### Screenshots (if appropriate):
Before:
```
starship on  master [!?] is 📦 v0.44.0 via 🦀 v1.44.1
❯ starship explain

 Here's a breakdown of your prompt:
 starship          -  The current working directory
  master          -  The active branch of the repo in your current directory
 !?                -  Symbol representing the state of the repo
 📦 v0.44.0  -  The package version of the current directory's project
 🦀 v1.44.1        -  The currently installed version of Rust
```

After (this does not look aligned here but it does in my terminal):
```
 Here's a breakdown of your prompt:
 starship         -  The current working directory
 on  master      -  The active branch of the repo in your current directory
 [!?]             -  Symbol representing the state of the repo
 is 📦 v0.44.0    -  The package version of the current directory's project
 via 🦀 v1.44.1   -  The currently installed version of Rust
 ❯                -  A character (usually an arrow) beside where the text is entered in your terminal

```

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
