### PR TITLE
test: fix mocked commands

### DIFF
--- a/src/modules/crystal.rs
+++ b/src/modules/crystal.rs
@@ -55,9 +55,9 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
 fn format_crystal_version(crystal_version: &str) -> Option<String> {
     let version = crystal_version
-        // split into ["Crystal", "0.32.1", ...]
+        // split into ["Crystal", "0.35.1", ...]
         .split_whitespace()
-        // return "0.32.1"
+        // return "0.35.1"
         .nth(1)?;
 
     let mut formatted_version = String::with_capacity(version.len() + 1);
@@ -89,7 +89,7 @@ mod tests {
         File::create(dir.path().join("shard.yml"))?.sync_all()?;
 
         let actual = render_module("crystal", dir.path(), None);
-        let expected = Some(format!("via {} ", Color::Red.bold().paint("🔮 v0.32.1")));
+        let expected = Some(format!("via {} ", Color::Red.bold().paint("🔮 v0.35.1")));
         assert_eq!(expected, actual);
 
         dir.close()
@@ -101,7 +101,7 @@ mod tests {
         File::create(dir.path().join("main.cr"))?.sync_all()?;
 
         let actual = render_module("crystal", dir.path(), None);
-        let expected = Some(format!("via {} ", Color::Red.bold().paint("🔮 v0.32.1")));
+        let expected = Some(format!("via {} ", Color::Red.bold().paint("🔮 v0.35.1")));
         assert_eq!(expected, actual);
 
         dir.close()

--- a/src/modules/erlang.rs
+++ b/src/modules/erlang.rs
@@ -57,10 +57,10 @@ fn get_erlang_version() -> Option<String> {
         &[
             "-noshell",
             "-eval",
-            "Fn=filename:join([code:root_dir(),\"releases\",erlang:system_info(otp_release),\"OTP_VERSION\"]),\
+            "'Fn=filename:join([code:root_dir(),\"releases\",erlang:system_info(otp_release),\"OTP_VERSION\"]),\
              {ok,Content}=file:read_file(Fn),\
              io:format(\"~s\",[Content]),\
-             halt(0)."
+             halt(0).'"
         ]
     )?.stdout.trim().to_string())
 }

--- a/src/modules/php.rs
+++ b/src/modules/php.rs
@@ -24,7 +24,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         "php",
         &[
             "-nr",
-            "echo PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION.'.'.PHP_RELEASE_VERSION;",
+            "'echo PHP_MAJOR_VERSION.\".\".PHP_MINOR_VERSION.\".\".PHP_RELEASE_VERSION;'",
         ],
     ) {
         Some(php_cmd_output) => {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -40,36 +40,42 @@ pub fn exec_cmd(cmd: &str, args: &[&str]) -> Option<CommandOutput> {
     };
     match command.as_str() {
         "crystal --version" => Some(CommandOutput {
-            stdout: String::from("Crystal 0.32.1 (2019-12-18)"),
+            stdout: String::from(
+                "\
+Crystal 0.35.1 (2020-06-19)
+
+LLVM: 10.0.0
+Default target: x86_64-apple-macosx\n",
+            ),
             stderr: String::default(),
         }),
         "dummy_command" => Some(CommandOutput {
-            stdout: String::from("stdout ok!"),
-            stderr: String::from("stderr ok!"),
+            stdout: String::from("stdout ok!\n"),
+            stderr: String::from("stderr ok!\n"),
         }),
         "elixir --version" => Some(CommandOutput {
             stdout: String::from(
                 "\
 Erlang/OTP 22 [erts-10.6.4] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1] [hipe]
 
-Elixir 1.10 (compiled with Erlang/OTP 22)",
+Elixir 1.10 (compiled with Erlang/OTP 22)\n",
             ),
             stderr: String::default(),
         }),
         "elm --version" => Some(CommandOutput {
-            stdout: String::from("0.19.1"),
+            stdout: String::from("0.19.1\n"),
             stderr: String::default(),
         }),
         "go version" => Some(CommandOutput {
-            stdout: String::from("go version go1.12.1 linux/amd64"),
+            stdout: String::from("go version go1.12.1 linux/amd64\n"),
             stderr: String::default(),
         }),
         "helm version --short --client" => Some(CommandOutput {
-            stdout: String::from("v3.1.1+gafe7058"),
+            stdout: String::from("v3.1.1+gafe7058\n"),
             stderr: String::default(),
         }),
         "julia --version" => Some(CommandOutput {
-            stdout: String::from("julia version 1.4.0"),
+            stdout: String::from("julia version 1.4.0\n"),
             stderr: String::default(),
         }),
         "nim --version" => Some(CommandOutput {
@@ -84,7 +90,7 @@ active boot switches: -d:release\n",
             stderr: String::default(),
         }),
         "node --version" => Some(CommandOutput {
-            stdout: String::from("v12.0.0"),
+            stdout: String::from("v12.0.0\n"),
             stderr: String::default(),
         }),
         "ocaml -vnum" => Some(CommandOutput {
@@ -95,36 +101,30 @@ active boot switches: -d:release\n",
             stdout: String::from("4.08.1\n"),
             stderr: String::default(),
         }),
-        "php -nr echo PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION.'.'.PHP_RELEASE_VERSION;" => {
+        "php -nr 'echo PHP_MAJOR_VERSION.\".\".PHP_MINOR_VERSION.\".\".PHP_RELEASE_VERSION;'" => {
             Some(CommandOutput {
                 stdout: String::from("7.3.8"),
                 stderr: String::default(),
             })
         }
         "purs --version" => Some(CommandOutput {
-            stdout: String::from("0.13.5"),
+            stdout: String::from("0.13.5\n"),
             stderr: String::default(),
         }),
         "python --version" => Some(CommandOutput {
-            stdout: String::from("Python 2.7.17"),
-            stderr: String::default(),
+            stdout: String::default(),
+            stderr: String::from("Python 2.7.17\n"),
         }),
         "python3 --version" => Some(CommandOutput {
-            stdout: String::from("Python 3.8.0"),
+            stdout: String::from("Python 3.8.0\n"),
             stderr: String::default(),
         }),
         "ruby -v" => Some(CommandOutput {
-            stdout: String::from("ruby 2.5.1p57 (2018-03-29 revision 63029) [x86_64-linux-gnu]"),
+            stdout: String::from("ruby 2.5.1p57 (2018-03-29 revision 63029) [x86_64-linux-gnu]\n"),
             stderr: String::default(),
         }),
-        "stack --no-install-ghc --lock-file read-only ghc -- --numeric-version" => {
-            Some(CommandOutput {
-                stdout: String::from("8.6.5"),
-                stderr: String::default(),
-            })
-        }
         "zig version" => Some(CommandOutput {
-            stdout: String::from("0.6.0"),
+            stdout: String::from("0.6.0\n"),
             stderr: String::default(),
         }),
         "cmake --version" => Some(CommandOutput {
@@ -137,11 +137,11 @@ CMake suite maintained and supported by Kitware (kitware.com/cmake).\n",
             stderr: String::default(),
         }),
         "terraform version" => Some(CommandOutput {
-            stdout: String::from("Terraform v0.12.14"),
+            stdout: String::from("Terraform v0.12.14\n"),
             stderr: String::default(),
         }),
-        s if s.starts_with("erl") => Some(CommandOutput {
-            stdout: String::from("22.1.3"),
+        s if s.starts_with("erl -noshell -eval") => Some(CommandOutput {
+            stdout: String::from("22.1.3\n"),
             stderr: String::default(),
         }),
         // If we don't have a mocked command fall back to executing the command
@@ -234,8 +234,8 @@ mod tests {
     fn exec_mocked_command() {
         let result = exec_cmd("dummy_command", &[]);
         let expected = Some(CommandOutput {
-            stdout: String::from("stdout ok!"),
-            stderr: String::from("stderr ok!"),
+            stdout: String::from("stdout ok!\n"),
+            stderr: String::from("stderr ok!\n"),
         });
 
         assert_eq!(result, expected)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Ensure that output of mocked commands faithfully replicates output of actual commands including any trailing whitespace.

##### Todo list:

- [x] `crystal --version`
- [x] `dummy_command`
- [x] `elixir --version`
- [x] `elm --version`
- [x] `go version`
- [x] `helm version --short --client`
- [x] `julia --version`
- [x] `nim --version`
- [x] `node --version`
- [x] `ocaml -vnum`
- [x] `esy ocaml -vnum`
- [x] `php -nr 'echo PHP_MAJOR_VERSION.".".PHP_MINOR_VERSION.".".PHP_RELEASE_VERSION;'`
- [x] `purs --version`
- [x] `python --version` (python2)
- [x] `python3 --version`
- [x] `ruby -v`
- [ ] ~`stack --no-install-ghc --lock-file read-only ghc -- --numeric-version`~ (removed in #1418)
- [x] `zig version`
- [x] `cmake --version`
- [x] `terraform version`
- [x] `erl -noshell -eval...` (erlang)

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1484 

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
