### PR TITLE
feat: Add gcloud module

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -893,8 +893,8 @@ format = "via [e $version](bold red) "
 
 ## Gcloud
 
-The `gcloud` module shows the current GCP region and profile for [`gcloud`](https://cloud.google.com/sdk/gcloud) CLI.
-This is based on `~/.config/gcloud/active_config` file and `~/.config/gcloud/configurations/config_{CONFIG NAME}` file.
+The `gcloud` module shows the current configuration for [`gcloud`](https://cloud.google.com/sdk/gcloud) CLI.
+This is based on the `~/.config/gcloud/active_config` file and the `~/.config/gcloud/configurations/config_{CONFIG NAME}` file and the `CLOUDSDK_CONFIG` env var.
 
 ### Options
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -901,7 +901,7 @@ This is based on the `~/.config/gcloud/active_config` file and the `~/.config/gc
 | Variable          | Default                                           | Description                                                                 |
 | ----------------- | ------------------------------------------------- | --------------------------------------------------------------------------- |
 | `format`          | `"on [$symbol$account(\\($region\\))]($style) "`  | The format for the module.                                                  |
-| `symbol`          | `"🇬️ "`                                            | The symbol used before displaying the current GCP profile.                  |
+| `symbol`          | `"☁️ "`                                            | The symbol used before displaying the current GCP profile.                  |
 | `region_aliases`  |                                                   | Table of region aliases to display in addition to the GCP name.             |
 | `style`           | `"bold blue"`                                     | The style for the module.                                                   |
 | `disabled`        | `false`                                           | Disables the `gcloud` module.                                               |
@@ -946,7 +946,7 @@ style = "bold yellow"
 # ~/.config/starship.toml
 
 [gcloud]
-symbol = "️☁️ "
+symbol = "️🇬️ "
 [gcloud.region_aliases]
 us-central1 = "uc1"
 asia-northeast1 = "an1"

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -210,6 +210,7 @@ $nix_shell\
 $conda\
 $memory_usage\
 $aws\
+$gcloud\
 $env_var\
 $crystal\
 $cmd_duration\
@@ -888,6 +889,67 @@ The module will be shown if any of the following conditions are met:
 
 [erlang]
 format = "via [e $version](bold red) "
+```
+
+## Gcloud
+
+The `gcloud` module shows the current GCP region and profile for [`gcloud`](https://cloud.google.com/sdk/gcloud) CLI.
+This is based on `~/.config/gcloud/active_config` file and `~/.config/gcloud/configurations/config_{CONFIG NAME}` file.
+
+### Options
+
+| Variable          | Default                                           | Description                                                                 |
+| ----------------- | ------------------------------------------------- | --------------------------------------------------------------------------- |
+| `format`          | `"on [$symbol$account(\\($region\\))]($style) "`  | The format for the module.                                                  |
+| `symbol`          | `"🇬️ "`                                            | The symbol used before displaying the current GCP profile.                  |
+| `region_aliases`  |                                                   | Table of region aliases to display in addition to the GCP name.             |
+| `style`           | `"bold blue"`                                     | The style for the module.                                                   |
+| `disabled`        | `false`                                           | Disables the `gcloud` module.                                               |
+
+### Variables
+
+| Variable | Example           | Description                                                        |
+| -------- | ----------------- | ------------------------------------------------------------------ |
+| region   | `us-central1`     | The current GCP region                                             |
+| account  | `foo@example.com` | The current GCP profile                                            |
+| project  |                   | The current GCP project                                            |
+| active   | `default`         | The active config name written in `~/.config/gcloud/active_config` |
+| symbol   |                   | Mirrors the value of option `symbol`                               |
+| style\*  |                   | Mirrors the value of option `style`                                |
+
+\*: This variable can only be used as a part of a style string
+
+### Examples
+
+#### Display account and project
+
+```toml
+# ~/.config/starship.toml
+
+[gcloud]
+format = "on [$symbol$account(\\($project\\))]($style) "
+```
+
+#### Display active config name only
+
+```toml
+# ~/.config/starship.toml
+
+[gcloud]
+format = "[$symbol$active]($style) "
+style = "bold yellow"
+```
+
+#### Display account and aliased region
+
+```toml
+# ~/.config/starship.toml
+
+[gcloud]
+symbol = "️☁️ "
+[gcloud.region_aliases]
+us-central1 = "uc1"
+asia-northeast1 = "an1"
 ```
 
 ## Git Branch

--- a/src/configs/gcloud.rs
+++ b/src/configs/gcloud.rs
@@ -1,0 +1,24 @@
+use crate::config::{ModuleConfig, RootModuleConfig};
+use starship_module_config_derive::ModuleConfig;
+use std::collections::HashMap;
+
+#[derive(Clone, ModuleConfig)]
+pub struct GcloudConfig<'a> {
+    pub format: &'a str,
+    pub symbol: &'a str,
+    pub style: &'a str,
+    pub disabled: bool,
+    pub region_aliases: HashMap<String, &'a str>,
+}
+
+impl<'a> RootModuleConfig<'a> for GcloudConfig<'a> {
+    fn new() -> Self {
+        GcloudConfig {
+            format: "on [$symbol$account(\\($region\\))]($style) ",
+            symbol: "🇬️ ",
+            style: "bold blue",
+            disabled: false,
+            region_aliases: HashMap::new(),
+        }
+    }
+}

--- a/src/configs/gcloud.rs
+++ b/src/configs/gcloud.rs
@@ -15,7 +15,7 @@ impl<'a> RootModuleConfig<'a> for GcloudConfig<'a> {
     fn new() -> Self {
         GcloudConfig {
             format: "on [$symbol$account(\\($region\\))]($style) ",
-            symbol: "🇬️ ",
+            symbol: "☁️ ",
             style: "bold blue",
             disabled: false,
             region_aliases: HashMap::new(),

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -13,6 +13,7 @@ pub mod elixir;
 pub mod elm;
 pub mod env_var;
 pub mod erlang;
+pub mod gcloud;
 pub mod git_branch;
 pub mod git_commit;
 pub mod git_state;

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -11,7 +11,7 @@ pub struct StarshipRootConfig<'a> {
 // List of default prompt order
 // NOTE: If this const value is changed then Default prompt order subheading inside
 // prompt heading of config docs needs to be updated according to changes made here.
-pub const PROMPT_ORDER: [&str; 44] = [
+pub const PROMPT_ORDER: [&str; 45] = [
     "username",
     "hostname",
     "singularity",
@@ -50,6 +50,7 @@ pub const PROMPT_ORDER: [&str; 44] = [
     "conda",
     "memory_usage",
     "aws",
+    "gcloud",
     "env_var",
     "crystal",
     "cmd_duration",

--- a/src/module.rs
+++ b/src/module.rs
@@ -22,6 +22,7 @@ pub const ALL_MODULES: &[&str] = &[
     "elm",
     "erlang",
     "env_var",
+    "gcloud",
     "git_branch",
     "git_commit",
     "git_state",

--- a/src/modules/gcloud.rs
+++ b/src/modules/gcloud.rs
@@ -1,0 +1,151 @@
+use std::collections::HashMap;
+use std::env;
+use std::fs::File;
+use std::io::{BufRead, BufReader, Error, ErrorKind};
+use std::path::PathBuf;
+use std::str::FromStr;
+
+use super::{Context, Module, RootModuleConfig};
+
+use crate::configs::gcloud::GcloudConfig;
+use crate::formatter::StringFormatter;
+
+type Account = String;
+type Project = String;
+type Region = String;
+type Active = String;
+
+fn get_gcloud_account_from_config(current_config: &PathBuf) -> Option<Account> {
+    let file = File::open(&current_config).ok()?;
+    let reader = BufReader::new(file);
+    let lines = reader.lines().filter_map(Result::ok);
+    let account_line = lines
+        .skip_while(|line| line != "[core]")
+        .skip(1)
+        .take_while(|line| !line.starts_with('['))
+        .find(|line| line.starts_with("account"))?;
+    let account = account_line.split('=').nth(1)?.trim();
+    Some(account.to_string())
+}
+
+fn get_gcloud_project_from_config(current_config: &PathBuf) -> Option<Project> {
+    let file = File::open(&current_config).ok()?;
+    let reader = BufReader::new(file);
+    let lines = reader.lines().filter_map(Result::ok);
+    let project_line = lines
+        .skip_while(|line| line != "[core]")
+        .skip(1)
+        .take_while(|line| !line.starts_with('['))
+        .find(|line| line.starts_with("project"))?;
+    let project = project_line.split('=').nth(1)?.trim();
+    Some(project.to_string())
+}
+
+fn get_gcloud_region_from_config(current_config: &PathBuf) -> Option<Region> {
+    let file = File::open(&current_config).ok()?;
+    let reader = BufReader::new(file);
+    let lines = reader.lines().filter_map(Result::ok);
+    let region_line = lines
+        .skip_while(|line| line != "[compute]")
+        .skip(1)
+        .take_while(|line| !line.starts_with('['))
+        .find(|line| line.starts_with("region"))?;
+    let region = region_line.split('=').nth(1)?.trim();
+    Some(region.to_string())
+}
+
+fn get_active_config(config_root: &PathBuf) -> Option<String> {
+    let path = config_root.join("active_config");
+    let file = File::open(&path).ok()?;
+    let reader = BufReader::new(file);
+    let first_line = match reader.lines().next() {
+        Some(res) => res,
+        None => Err(Error::new(ErrorKind::NotFound, "empty")),
+    };
+    match first_line {
+        Ok(c) => Some(c),
+        Err(_) => None,
+    }
+}
+
+fn get_current_config_path() -> Option<PathBuf> {
+    let config_dir = get_config_dir()?;
+    let active_config = get_active_config(&config_dir)?;
+    let current_config = config_dir.join(format!("configurations/config_{}", active_config));
+    Some(current_config)
+}
+
+fn get_config_dir() -> Option<PathBuf> {
+    let config_dir = env::var("CLOUDSDK_CONFIG")
+        .ok()
+        .and_then(|path| PathBuf::from_str(&path).ok())
+        .or_else(|| {
+            let mut home = dirs_next::home_dir()?;
+            home.push(".config/gcloud");
+            Some(home)
+        })?;
+    Some(config_dir)
+}
+
+fn alias_region(region: String, aliases: &HashMap<String, &str>) -> String {
+    match aliases.get(&region) {
+        None => region.to_string(),
+        Some(alias) => (*alias).to_string(),
+    }
+}
+
+pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let mut module = context.new_module("gcloud");
+    let config: GcloudConfig = GcloudConfig::try_load(module.config);
+
+    let config_path = get_current_config_path()?;
+    let gcloud_account = get_gcloud_account_from_config(&config_path);
+    let gcloud_project = get_gcloud_project_from_config(&config_path);
+    let gcloud_region = get_gcloud_region_from_config(&config_path);
+    let config_dir = get_config_dir()?;
+    let gcloud_active: Option<Active> = get_active_config(&config_dir);
+
+    if gcloud_account.is_none()
+        && gcloud_project.is_none()
+        && gcloud_region.is_none()
+        && gcloud_active.is_none()
+    {
+        return None;
+    }
+
+    let mapped_region = if let Some(gcloud_region) = gcloud_region {
+        Some(alias_region(gcloud_region, &config.region_aliases))
+    } else {
+        None
+    };
+
+    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
+        formatter
+            .map_meta(|variable, _| match variable {
+                "symbol" => Some(config.symbol),
+                _ => None,
+            })
+            .map_style(|variable| match variable {
+                "style" => Some(Ok(config.style)),
+                _ => None,
+            })
+            .map(|variable| match variable {
+                "account" => gcloud_account.as_ref().map(Ok),
+                "project" => gcloud_project.as_ref().map(Ok),
+                "region" => mapped_region.as_ref().map(Ok),
+                "active" => gcloud_active.as_ref().map(Ok),
+                _ => None,
+            })
+            .parse(None)
+    });
+
+    module.set_segments(match parsed {
+        Ok(segments) => segments,
+        Err(error) => {
+            log::error!("Error in module `gcloud`: \n{}", error);
+            return None;
+        }
+    });
+
+    Some(module)
+}

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -13,6 +13,7 @@ mod elixir;
 mod elm;
 mod env_var;
 mod erlang;
+mod gcloud;
 mod git_branch;
 mod git_commit;
 mod git_state;
@@ -69,6 +70,7 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
         "elm" => elm::module(context),
         "erlang" => erlang::module(context),
         "env_var" => env_var::module(context),
+        "gcloud" => gcloud::module(context),
         "git_branch" => git_branch::module(context),
         "git_commit" => git_commit::module(context),
         "git_state" => git_state::module(context),
@@ -122,6 +124,7 @@ pub fn description(module: &str) -> &'static str {
         "dotnet" => "The relevant version of the .NET Core SDK for the current directory",
         "env_var" => "Displays the current value of a selected environment variable",
         "erlang" => "Current OTP version",
+        "gcloud" => "The current GCP client configuration",
         "git_branch" => "The active branch of the repo in your current directory",
         "git_commit" => "The active commit of the repo in your current directory",
         "git_state" => "The current git operation, and it's progress",

--- a/tests/testsuite/gcloud.rs
+++ b/tests/testsuite/gcloud.rs
@@ -1,0 +1,159 @@
+use std::fs::{create_dir, File};
+use std::io::{self, Write};
+
+use ansi_term::Color;
+
+use crate::common::{self, TestCommand};
+
+#[test]
+fn account_set() -> io::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let active_config_path = dir.path().join("active_config");
+    let mut active_config_file = File::create(&active_config_path)?;
+    active_config_file.write_all(b"default")?;
+
+    create_dir(dir.path().join("configurations"))?;
+    let config_default_path = dir.path().join("configurations/config_default");
+    let mut config_default_file = File::create(&config_default_path)?;
+    config_default_file.write_all(
+        b"[core]
+account = foo@example.com
+",
+    )?;
+
+    let output = common::render_module("gcloud")
+        .env("CLOUDSDK_CONFIG", dir.path().to_string_lossy().as_ref())
+        .output()?;
+    let expected = format!("on {} ", Color::Blue.bold().paint("🇬️ foo@example.com"));
+    let actual = String::from_utf8(output.stdout).unwrap();
+    assert_eq!(actual, expected);
+    dir.close()
+}
+
+#[test]
+fn account_and_region_set() -> io::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let active_config_path = dir.path().join("active_config");
+    let mut active_config_file = File::create(&active_config_path)?;
+    active_config_file.write_all(b"default")?;
+
+    create_dir(dir.path().join("configurations"))?;
+    let config_default_path = dir.path().join("configurations/config_default");
+    let mut config_default_file = File::create(&config_default_path)?;
+    config_default_file.write_all(
+        b"[core]
+account = foo@example.com
+
+[compute]
+region = us-central1
+",
+    )?;
+
+    let output = common::render_module("gcloud")
+        .env("CLOUDSDK_CONFIG", dir.path().to_string_lossy().as_ref())
+        .output()?;
+    let expected = format!(
+        "on {} ",
+        Color::Blue.bold().paint("🇬️ foo@example.com(us-central1)")
+    );
+    let actual = String::from_utf8(output.stdout).unwrap();
+    assert_eq!(actual, expected);
+    dir.close()
+}
+
+#[test]
+fn account_and_region_set_with_alias() -> io::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let active_config_path = dir.path().join("active_config");
+    let mut active_config_file = File::create(&active_config_path)?;
+    active_config_file.write_all(b"default")?;
+
+    create_dir(dir.path().join("configurations"))?;
+    let config_default_path = dir.path().join("configurations/config_default");
+    let mut config_default_file = File::create(&config_default_path)?;
+    config_default_file.write_all(
+        b"[core]
+account = foo@example.com
+
+[compute]
+region = us-central1
+",
+    )?;
+
+    let output = common::render_module("gcloud")
+        .env("CLOUDSDK_CONFIG", dir.path().to_string_lossy().as_ref())
+        .use_config(toml::toml! {
+            [gcloud.region_aliases]
+            us-central1 = "uc1"
+        })
+        .output()?;
+    let expected = format!("on {} ", Color::Blue.bold().paint("🇬️ foo@example.com(uc1)"));
+    let actual = String::from_utf8(output.stdout).unwrap();
+    assert_eq!(actual, expected);
+    dir.close()
+}
+
+#[test]
+fn active_set() -> io::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let active_config_path = dir.path().join("active_config");
+    let mut active_config_file = File::create(&active_config_path)?;
+    active_config_file.write_all(b"default1")?;
+
+    let output = common::render_module("gcloud")
+        .env("CLOUDSDK_CONFIG", dir.path().to_string_lossy().as_ref())
+        .use_config(toml::toml! {
+            [gcloud]
+            format = "on [$symbol$active]($style) "
+        })
+        .output()?;
+    let expected = format!("on {} ", Color::Blue.bold().paint("🇬️ default1"));
+    let actual = String::from_utf8(output.stdout).unwrap();
+    assert_eq!(actual, expected);
+    dir.close()
+}
+
+#[test]
+fn project_set() -> io::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let active_config_path = dir.path().join("active_config");
+    let mut active_config_file = File::create(&active_config_path)?;
+    active_config_file.write_all(b"default")?;
+
+    create_dir(dir.path().join("configurations"))?;
+    let config_default_path = dir.path().join("configurations/config_default");
+    let mut config_default_file = File::create(&config_default_path)?;
+    config_default_file.write_all(
+        b"[core]
+project = abc
+",
+    )?;
+
+    let output = common::render_module("gcloud")
+        .env("CLOUDSDK_CONFIG", dir.path().to_string_lossy().as_ref())
+        .use_config(toml::toml! {
+            [gcloud]
+            format = "on [$symbol$project]($style) "
+        })
+        .output()?;
+    let expected = format!("on {} ", Color::Blue.bold().paint("🇬️ abc"));
+    let actual = String::from_utf8(output.stdout).unwrap();
+    assert_eq!(actual, expected);
+    dir.close()
+}
+
+#[test]
+fn region_not_set_with_display_region() -> io::Result<()> {
+    let dir = tempfile::tempdir()?;
+    let output = common::render_module("gcloud")
+        .env("CLOUDSDK_CONFIG", dir.path().to_string_lossy().as_ref())
+        .use_config(toml::toml! {
+            [gcloud]
+            format = "on [$symbol$region]($style) "
+        })
+        .output()?;
+    let expected = "";
+    let actual = String::from_utf8(output.stdout).unwrap();
+    assert_eq!(expected, actual);
+    dir.close()
+}

--- a/tests/testsuite/gcloud.rs
+++ b/tests/testsuite/gcloud.rs
@@ -24,7 +24,7 @@ account = foo@example.com
     let output = common::render_module("gcloud")
         .env("CLOUDSDK_CONFIG", dir.path().to_string_lossy().as_ref())
         .output()?;
-    let expected = format!("on {} ", Color::Blue.bold().paint("🇬️ foo@example.com"));
+    let expected = format!("on {} ", Color::Blue.bold().paint("☁️ foo@example.com"));
     let actual = String::from_utf8(output.stdout).unwrap();
     assert_eq!(actual, expected);
     dir.close()
@@ -54,7 +54,7 @@ region = us-central1
         .output()?;
     let expected = format!(
         "on {} ",
-        Color::Blue.bold().paint("🇬️ foo@example.com(us-central1)")
+        Color::Blue.bold().paint("☁️ foo@example.com(us-central1)")
     );
     let actual = String::from_utf8(output.stdout).unwrap();
     assert_eq!(actual, expected);
@@ -87,7 +87,7 @@ region = us-central1
             us-central1 = "uc1"
         })
         .output()?;
-    let expected = format!("on {} ", Color::Blue.bold().paint("🇬️ foo@example.com(uc1)"));
+    let expected = format!("on {} ", Color::Blue.bold().paint("☁️ foo@example.com(uc1)"));
     let actual = String::from_utf8(output.stdout).unwrap();
     assert_eq!(actual, expected);
     dir.close()
@@ -107,7 +107,7 @@ fn active_set() -> io::Result<()> {
             format = "on [$symbol$active]($style) "
         })
         .output()?;
-    let expected = format!("on {} ", Color::Blue.bold().paint("🇬️ default1"));
+    let expected = format!("on {} ", Color::Blue.bold().paint("☁️ default1"));
     let actual = String::from_utf8(output.stdout).unwrap();
     assert_eq!(actual, expected);
     dir.close()
@@ -136,7 +136,7 @@ project = abc
             format = "on [$symbol$project]($style) "
         })
         .output()?;
-    let expected = format!("on {} ", Color::Blue.bold().paint("🇬️ abc"));
+    let expected = format!("on {} ", Color::Blue.bold().paint("☁️ abc"));
     let actual = String::from_utf8(output.stdout).unwrap();
     assert_eq!(actual, expected);
     dir.close()

--- a/tests/testsuite/main.rs
+++ b/tests/testsuite/main.rs
@@ -7,6 +7,7 @@ mod configuration;
 mod directory;
 mod dotnet;
 mod env_var;
+mod gcloud;
 mod git_branch;
 mod git_commit;
 mod git_state;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

Add a module for displaying the current `gcloud` profile based on the followings:

- `~/.config/gcloud/active_config`
- `~/.config/gcloud/configurations/config_$(cat ~/.config/gcloud/active_config)`
- `CLOUDSDK_CONFIG` env var

This module is based on the AWS module.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #901

#### Screenshots (if appropriate):

![gcloud-module](https://user-images.githubusercontent.com/1369554/87881016-5797dd00-ca31-11ea-85cc-f8c107a76128.png)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
