### PR TITLE
Do not try to analyze write permissions on network locations

### DIFF
--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -107,7 +107,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             .map(|variable| match variable {
                 "path" => Some(Ok(&final_dir_string)),
                 "read_only" => {
-                    if is_readonly_dir(current_dir.to_str()?) {
+                    if is_readonly_dir(context.current_dir.to_str()?) {
                         Some(Ok(&lock_symbol))
                     } else {
                         None

--- a/src/modules/utils/directory_win.rs
+++ b/src/modules/utils/directory_win.rs
@@ -28,6 +28,10 @@ pub fn is_write_allowed(folder_path: &str) -> std::result::Result<bool, &'static
         .collect();
 
     if is_network_path(&folder_name) {
+        log::info!(
+            "Directory '{:?}' is a network drive, unable to check write permissions. See #1506 for details",
+            folder_path
+        );
         return Ok(true);
     }
 
@@ -122,6 +126,7 @@ pub fn is_write_allowed(folder_path: &str) -> std::result::Result<bool, &'static
     Ok(result != 0)
 }
 
+#[link(name = "Shlwapi")]
 extern "system" {
     fn PathIsNetworkPathW(pszPath: LPCWSTR) -> BOOLEAN;
 }

--- a/src/modules/utils/directory_win.rs
+++ b/src/modules/utils/directory_win.rs
@@ -10,21 +10,27 @@ use winapi::um::handleapi;
 use winapi::um::processthreadsapi;
 use winapi::um::securitybaseapi;
 use winapi::um::winnt::{
-    SecurityImpersonation, DACL_SECURITY_INFORMATION, FILE_ALL_ACCESS, FILE_GENERIC_EXECUTE,
-    FILE_GENERIC_READ, FILE_GENERIC_WRITE, GENERIC_MAPPING, GROUP_SECURITY_INFORMATION, HANDLE,
-    OWNER_SECURITY_INFORMATION, PRIVILEGE_SET, PSECURITY_DESCRIPTOR, STANDARD_RIGHTS_READ,
-    TOKEN_DUPLICATE, TOKEN_IMPERSONATE, TOKEN_QUERY,
+    SecurityImpersonation, BOOLEAN, DACL_SECURITY_INFORMATION, FILE_ALL_ACCESS,
+    FILE_GENERIC_EXECUTE, FILE_GENERIC_READ, FILE_GENERIC_WRITE, GENERIC_MAPPING,
+    GROUP_SECURITY_INFORMATION, HANDLE, LPCWSTR, OWNER_SECURITY_INFORMATION, PRIVILEGE_SET,
+    PSECURITY_DESCRIPTOR, STANDARD_RIGHTS_READ, TOKEN_DUPLICATE, TOKEN_IMPERSONATE, TOKEN_QUERY,
 };
 
 /// Checks if the current user has write access right to the `folder_path`
 ///
 /// First, the function extracts DACL from the given directory and then calls `AccessCheck` against
 /// the current process access token and directory's security descriptor.
+/// Does not work for network drives and always returns true
 pub fn is_write_allowed(folder_path: &str) -> std::result::Result<bool, &'static str> {
     let folder_name: Vec<u16> = OsStr::new(folder_path)
         .encode_wide()
         .chain(iter::once(0))
         .collect();
+
+    if is_network_path(&folder_name) {
+        return Ok(true);
+    }
+
     let mut length: DWORD = 0;
 
     let rc = unsafe {
@@ -114,4 +120,12 @@ pub fn is_write_allowed(folder_path: &str) -> std::result::Result<bool, &'static
     }
 
     Ok(result != 0)
+}
+
+extern "system" {
+    fn PathIsNetworkPathW(pszPath: LPCWSTR) -> BOOLEAN;
+}
+
+fn is_network_path(folder_path: &Vec<u16>) -> bool {
+    return unsafe { PathIsNetworkPathW(folder_path.as_ptr()) } == 1;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
Do not try to analyze if the current process can write network location on Windows.

#### Motivation and Context
Unfortunately, there's no way on Windows to tell if we can write a network location because it's not being controlled by the OS itself. Thus now the lock symbol is never shown on network locations.
This PR introduces a new unsafe call.
Closes #1476

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [X] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
