### PR TITLE
feat(package):  Add Maven pom.xml version support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,10 @@ Cargo.lock
 # Vim swap files
 *.swp
 
+# Emacs
+*~
+\#*\#
+
 # Compiled files for documentation
 docs/node_modules
 docs/.vuepress/dist/

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1629,7 +1629,7 @@ package, and shows its current version. The module currently supports `npm`, `ca
 - **julia** - The package version is extracted from the `Project.toml` present
 - **mix** - The `mix` package version is extracted from the `mix.exs` present
 - **helm** - The `helm` chart version is extracted from the `Chart.yaml` present
-
+- **maven** - The `maven` package version is extracted from the `pom.xml` present
 
 > ⚠️ The version being shown is that of the package whose source code is in your
 > current directory, not your package manager.

--- a/src/modules/package.rs
+++ b/src/modules/package.rs
@@ -5,6 +5,8 @@ use crate::configs::package::PackageConfig;
 use crate::formatter::StringFormatter;
 use crate::utils;
 
+use quick_xml::events::Event as QXEvent;
+use quick_xml::Reader as QXReader;
 use regex::Regex;
 use serde_json as json;
 
@@ -122,6 +124,44 @@ fn extract_mix_version(file_contents: &str) -> Option<String> {
     Some(formatted_version)
 }
 
+fn extract_maven_version(file_contents: &str) -> Option<String> {
+    let mut reader = QXReader::from_str(file_contents);
+    reader.trim_text(true);
+
+    let mut buf = vec![];
+    let mut in_ver = false;
+    let mut depth = 0;
+    loop {
+        match reader.read_event(&mut buf) {
+            Ok(QXEvent::Start(ref e)) => {
+                in_ver = depth == 1 && e.name() == b"version";
+                depth += 1;
+            }
+            Ok(QXEvent::End(_)) => {
+                in_ver = false;
+                depth -= 1;
+            }
+            Ok(QXEvent::Text(t)) if in_ver => {
+                let ver = t.unescape_and_decode(&reader).ok();
+                return match ver {
+                    // Ignore version which is just a property reference
+                    Some(ref v) if !v.starts_with("$") => ver,
+                    _ => None,
+                };
+            }
+            Ok(QXEvent::Eof) => break,
+            Ok(_) => (),
+
+            Err(err) => {
+                log::warn!("Error parsing pom.xml`:\n{}", err);
+                break;
+            }
+        }
+    }
+
+    None
+}
+
 fn get_package_version(base_dir: &PathBuf, config: &PackageConfig) -> Option<String> {
     if let Ok(cargo_toml) = utils::read_file(base_dir.join("Cargo.toml")) {
         extract_cargo_version(&cargo_toml)
@@ -139,6 +179,8 @@ fn get_package_version(base_dir: &PathBuf, config: &PackageConfig) -> Option<Str
         extract_mix_version(&mix_file)
     } else if let Ok(chart_file) = utils::read_file(base_dir.join("Chart.yaml")) {
         extract_helm_package_version(&chart_file)
+    } else if let Ok(pom_file) = utils::read_file(base_dir.join("pom.xml")) {
+        extract_maven_version(&pom_file)
     } else {
         None
     }
@@ -540,6 +582,142 @@ end";
 
         let project_dir = create_project_dir()?;
         fill_config(&project_dir, config_name, Some(&config_content))?;
+        expect_output(&project_dir, None, None)?;
+        project_dir.close()
+    }
+
+    #[test]
+    fn test_extract_maven_version_with_deps() -> io::Result<()> {
+        // pom.xml with common nested tags and dependencies
+        let pom = "
+            <project xmlns=\"http://maven.apache.org/POM/4.0.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd\">
+
+              <modelVersion>4.0.0</modelVersion>
+              <artifactId>parent</artifactId>
+              <packaging>pom</packaging>
+
+              <version>0.3.20-SNAPSHOT</version>
+
+              <name>Test POM</name>
+              <description>Test POM</description>
+
+              <properties>
+                <jdk.version>1.8</jdk.version>
+                <jta.version>2.3.3</jta.version>
+                <woodstox.version>4.13</woodstox.version>
+                <jackson.version>3.3.3</jackson.version>
+              </properties>
+
+              <dependencyManagement>
+                  <dependencies>
+                      <dependency>
+                          <groupId>jta</groupId>
+                          <artifactId>jta</artifactId>
+                          <version>${jta.version}</version>
+                      </dependency>
+                      <dependency>
+                          <groupId>com.fasterxml.woodstox</groupId>
+                          <artifactId>woodstox-core</artifactId>
+                          <version>${woodstox.core.version}</version>
+                      </dependency>
+                      <dependency>
+                          <groupId>com.fasterxml.jackson.dataformat</groupId>
+                          <artifactId>jackson-dataformat-xml</artifactId>
+                          <version>${jackson.version}</version>
+                      </dependency>
+                  </dependencies>
+              </dependencyManagement>
+
+              <build>
+                <plugins>
+                  <plugin>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>${maven.enforcer.version}</version>
+                    <executions>
+                      <execution>
+                        <id>enforce-maven</id>
+                        <goals>
+                          <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                          <rules>
+                            <requireMavenVersion>
+                              <version>3.0.5</version>
+                            </requireMavenVersion>
+                          </rules>
+                        </configuration>
+                      </execution>
+                    </executions>
+                  </plugin>
+                </plugins>
+              </build>
+
+            </project>";
+
+        let project_dir = create_project_dir()?;
+        fill_config(&project_dir, "pom.xml", Some(&pom))?;
+        expect_output(&project_dir, Some("0.3.20-SNAPSHOT"), None)?;
+        project_dir.close()
+    }
+
+    #[test]
+    fn test_extract_maven_version_no_version() -> io::Result<()> {
+        // pom.xml with common nested tags and dependencies
+        let pom = "
+            <project xmlns=\"http://maven.apache.org/POM/4.0.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd\">
+
+              <modelVersion>4.0.0</modelVersion>
+
+              <dependencies>
+                  <dependency>
+                      <groupId>jta</groupId>
+                      <artifactId>jta</artifactId>
+                      <version>1.2.3</version>
+                  </dependency>
+              </dependencies>
+
+            </project>";
+
+        let project_dir = create_project_dir()?;
+        fill_config(&project_dir, "pom.xml", Some(&pom))?;
+        expect_output(&project_dir, None, None)?;
+        project_dir.close()
+    }
+
+    #[test]
+    fn test_extract_maven_version_is_prop() -> io::Result<()> {
+        // pom.xml with common nested tags and dependencies
+        let pom = "
+            <project xmlns=\"http://maven.apache.org/POM/4.0.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd\">
+
+              <modelVersion>4.0.0</modelVersion>
+              <version>${pom.parent.version}</version>
+
+            </project>";
+
+        let project_dir = create_project_dir()?;
+        fill_config(&project_dir, "pom.xml", Some(&pom))?;
+        expect_output(&project_dir, None, None)?;
+        project_dir.close()
+    }
+
+    #[test]
+    fn test_extract_maven_version_no_version_but_deps() -> io::Result<()> {
+        // pom.xml with common nested tags and dependencies
+        let pom = "
+            <project xmlns=\"http://maven.apache.org/POM/4.0.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd\">
+
+              <modelVersion>4.0.0</modelVersion>
+              <artifactId>parent</artifactId>
+              <packaging>pom</packaging>
+
+              <name>Test POM</name>
+              <description>Test POM</description>
+
+            </project>";
+
+        let project_dir = create_project_dir()?;
+        fill_config(&project_dir, "pom.xml", Some(&pom))?;
         expect_output(&project_dir, None, None)?;
         project_dir.close()
     }

--- a/src/modules/package.rs
+++ b/src/modules/package.rs
@@ -145,7 +145,7 @@ fn extract_maven_version(file_contents: &str) -> Option<String> {
                 let ver = t.unescape_and_decode(&reader).ok();
                 return match ver {
                     // Ignore version which is just a property reference
-                    Some(ref v) if !v.starts_with("$") => ver,
+                    Some(ref v) if !v.starts_with('$') => ver,
                     _ => None,
                 };
             }


### PR DESCRIPTION
### Description

Adds ability to extract version information from a Maven pom.xml if present.

#### Motivation and Context

Starship recognises the existence of Maven projects elsewhere (e.g. Java module), but does not extract the version for the package module. This adds that feature.

#### How Has This Been Tested?

Testing is via the inline Rust tests.

- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
