### PR TITLE
fix(directory): use physical path instead of logical for lock

### DIFF
--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -107,7 +107,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             .map(|variable| match variable {
                 "path" => Some(Ok(&final_dir_string)),
                 "read_only" => {
-                    if is_readonly_dir(current_dir.to_str()?) {
+                    if is_readonly_dir(context.current_dir.to_str()?) {
                         Some(Ok(&lock_symbol))
                     } else {
                         None


### PR DESCRIPTION
Co-Authored-By: Alexey Chernyshov <eiden127@gmail.com>

<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

The directory lock read-only test was done with the logical path instead of the physical path.
This caused checks for SMB shares on windows to use `Microsoft.PowerShell.Core\FileSystem::\\NAS\MY-SHARE`  (`PWD` env var)  instead of the proper `\\NAS\MY-SHARE`  (`--path` arg or `env::current_dir`) path. This used to cause these directories to incorrectly appear as read-only.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1506
Closes #1476

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
