### PR TITLE
feat(package): Add support for Helm charts

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1575,7 +1575,7 @@ format = "via [🤖 $version](bold green) "
 
 The `package` module is shown when the current directory is the repository for a
 package, and shows its current version. The module currently supports `npm`, `cargo`,
-`poetry`, `composer`, `gradle`, `julia` and `mix` packages.
+`poetry`, `composer`, `gradle`, `julia`, `mix` and `helm` packages.
 
 - **npm** – The `npm` package version is extracted from the `package.json` present
   in the current directory
@@ -1588,6 +1588,8 @@ package, and shows its current version. The module currently supports `npm`, `ca
 - **gradle** – The `gradle` package version is extracted from the `build.gradle` present
 - **julia** - The package version is extracted from the `Project.toml` present
 - **mix** - The `mix` package version is extracted from the `mix.exs` present
+- **helm** - The `helm` chart version is extracted from the `Chart.yaml` present
+
 
 > ⚠️ The version being shown is that of the package whose source code is in your
 > current directory, not your package manager.


### PR DESCRIPTION
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
Parses a `Chart.yaml` file in the current directory and uses that as the current package version

#### Motivation and Context
Closes #1487

#### Screenshots (if appropriate):

#### How Has This Been Tested?
I added a unit test.
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
