### PR TITLE
feat(conda): add ignore_base option

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -519,6 +519,7 @@ This does not suppress conda's own prompt modifier, you may want to run `conda c
 | `symbol`            | `"🅒 "`                             | The symbol used before the environment name.                                                                                                                                                                |
 | `style`             | `"bold green"`                     | The style for the module.                                                                                                                                                                                   |
 | `format`            | `"[$symbol$environment]($style) "` | The format for the module.                                                                                                                                                                                  |
+| `ignore_base`       | `false`                            | Ignores `base` environment when activated.                                                                                                                                                                  |
 | `disabled`          | `false`                            | Disables the `conda` module.                                                                                                                                                                                |
 
 ### Variables

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -519,7 +519,7 @@ This does not suppress conda's own prompt modifier, you may want to run `conda c
 | `symbol`            | `"🅒 "`                             | The symbol used before the environment name.                                                                                                                                                                |
 | `style`             | `"bold green"`                     | The style for the module.                                                                                                                                                                                   |
 | `format`            | `"[$symbol$environment]($style) "` | The format for the module.                                                                                                                                                                                  |
-| `ignore_base`       | `false`                            | Ignores `base` environment when activated.                                                                                                                                                                  |
+| `ignore_base`       | `true`                             | Ignores `base` environment when activated.                                                                                                                                                                  |
 | `disabled`          | `false`                            | Disables the `conda` module.                                                                                                                                                                                |
 
 ### Variables

--- a/src/configs/conda.rs
+++ b/src/configs/conda.rs
@@ -8,6 +8,7 @@ pub struct CondaConfig<'a> {
     pub format: &'a str,
     pub symbol: &'a str,
     pub style: &'a str,
+    pub ignore_base: bool,
     pub disabled: bool,
 }
 
@@ -18,6 +19,7 @@ impl<'a> RootModuleConfig<'a> for CondaConfig<'a> {
             format: "via [$symbol$environment]($style) ",
             symbol: "🅒 ",
             style: "green bold",
+            ignore_base: false,
             disabled: false,
         }
     }

--- a/src/configs/conda.rs
+++ b/src/configs/conda.rs
@@ -19,7 +19,7 @@ impl<'a> RootModuleConfig<'a> for CondaConfig<'a> {
             format: "via [$symbol$environment]($style) ",
             symbol: "🅒 ",
             style: "green bold",
-            ignore_base: false,
+            ignore_base: true,
             disabled: false,
         }
     }

--- a/src/modules/conda.rs
+++ b/src/modules/conda.rs
@@ -19,6 +19,10 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let mut module = context.new_module("conda");
     let config: CondaConfig = CondaConfig::try_load(module.config);
 
+    if config.ignore_base && conda_env == "base" {
+        return None;
+    }
+
     let conda_env = truncate(conda_env, config.truncation_length);
 
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {

--- a/tests/testsuite/conda.rs
+++ b/tests/testsuite/conda.rs
@@ -1,11 +1,28 @@
 use ansi_term::Color;
 use std::io;
 
-use crate::common;
+use crate::common::{self, TestCommand};
 
 #[test]
 fn not_in_env() -> io::Result<()> {
     let output = common::render_module("conda").output()?;
+
+    let expected = "";
+    let actual = String::from_utf8(output.stdout).unwrap();
+
+    assert_eq!(expected, actual);
+    Ok(())
+}
+
+#[test]
+fn ignore_base() -> io::Result<()> {
+    let output = common::render_module("conda")
+        .env("CONDA_DEFAULT_ENV", "base")
+        .use_config(toml::toml! {
+            [conda]
+            ignore_base = true
+        })
+        .output()?;
 
     let expected = "";
     let actual = String::from_utf8(output.stdout).unwrap();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
Adds an `ignore_base` option to the `conda` module so that the `base` environment is not shown when activated. Defaulted to `true`.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1536

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
