### PR TITLE
fix(bash): init breaks if PROMPT_COMMAND includes starship_precmd as an intermediate command

### DIFF
--- a/src/init/starship.bash
+++ b/src/init/starship.bash
@@ -71,7 +71,7 @@ else
     # add multiple instances of the starship function and keep other user functions if any.
     if [[ -z "$PROMPT_COMMAND" ]]; then
         PROMPT_COMMAND="starship_precmd"
-    elif [[ "$PROMPT_COMMAND" != *"starship_precmd" ]]; then
+    elif [[ "$PROMPT_COMMAND" != *"starship_precmd"* ]]; then
         # Appending to PROMPT_COMMAND breaks exit status ($?) checking.
         # Prepending to PROMPT_COMMAND breaks "command duration" module.
         # So, we are preserving the existing PROMPT_COMMAND


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
If `PROMPT_COMMAND` includes `starship_precmd` as an intermediate command and `eval "$(starship init bash)` is executed again, then `PROMPT_COMMAND` enters an infinite loop of `starship_precmd` executions. This happens when other tools also hook into the shell using `PROMPT_COMMAND`. In particular this happens with [z](https://github.com/rupa/z/). For example,

```sh
❯ echo $PROMPT_COMMAND
_direnv_hook;starship_precmd
_z --add "$(command pwd -P 2>/dev/null)" 2>/dev/null;
```

#### Motivation and Context
Ideally the bash init would be idempotent so that the user can run `eval "$(starship init bash)"` without worrying about crashing the shell. It's possible I'm missing some context and the condition is intentionally checking for `starship_precmd` to be last in `PROMPT_COMMAND`.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
