### PR TITLE
 refactor(directory/lock): fix clippy, replace str with Path

### DIFF
--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -107,7 +107,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             .map(|variable| match variable {
                 "path" => Some(Ok(&final_dir_string)),
                 "read_only" => {
-                    if is_readonly_dir(context.current_dir.to_str()?) {
+                    if is_readonly_dir(&context.current_dir) {
                         Some(Ok(&lock_symbol))
                     } else {
                         None
@@ -129,12 +129,12 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     Some(module)
 }
 
-fn is_readonly_dir(path: &str) -> bool {
+fn is_readonly_dir(path: &Path) -> bool {
     match directory_utils::is_write_allowed(path) {
         Ok(res) => !res,
         Err(e) => {
             log::debug!(
-                "Failed to detemine read only status of directory '{}': {}",
+                "Failed to detemine read only status of directory '{:?}': {}",
                 path,
                 e
             );

--- a/src/modules/utils/directory_nix.rs
+++ b/src/modules/utils/directory_nix.rs
@@ -3,6 +3,7 @@ use nix::unistd::{Gid, Uid};
 use std::fs;
 use std::os::unix::fs::MetadataExt;
 use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
 
 /// Checks if the current user can write to the `folder_path`.
 ///
@@ -12,7 +13,7 @@ use std::os::unix::fs::PermissionsExt;
 /// 2a) (not implemented on macOS) one of the supplementary groups of the current user is the
 /// directory group owner and whether it has write access
 /// 3) 'others' part of the access mask has the write access
-pub fn is_write_allowed(folder_path: &str) -> Result<bool, &'static str> {
+pub fn is_write_allowed(folder_path: &Path) -> Result<bool, &'static str> {
     let meta = fs::metadata(folder_path).map_err(|_| "Unable to stat() directory")?;
     let perms = meta.permissions().mode();
 
@@ -52,9 +53,9 @@ mod tests {
     #[test]
     #[ignore]
     fn read_only_test() {
-        assert_eq!(is_write_allowed("/etc"), Ok(false));
+        assert_eq!(is_write_allowed(Path::new("/etc")), Ok(false));
         assert_eq!(
-            is_write_allowed("/i_dont_exist"),
+            is_write_allowed(Path::new("/i_dont_exist")),
             Err("Unable to stat() directory")
         );
     }

--- a/src/modules/utils/directory_win.rs
+++ b/src/modules/utils/directory_win.rs
@@ -1,9 +1,9 @@
 extern crate winapi;
 
-use std::ffi::OsStr;
 use std::iter;
 use std::mem;
 use std::os::windows::ffi::OsStrExt;
+use std::path::Path;
 use winapi::ctypes::c_void;
 use winapi::shared::minwindef::{BOOL, DWORD};
 use winapi::um::handleapi;
@@ -21,8 +21,9 @@ use winapi::um::winnt::{
 /// First, the function extracts DACL from the given directory and then calls `AccessCheck` against
 /// the current process access token and directory's security descriptor.
 /// Does not work for network drives and always returns true
-pub fn is_write_allowed(folder_path: &str) -> std::result::Result<bool, &'static str> {
-    let folder_name: Vec<u16> = OsStr::new(folder_path)
+pub fn is_write_allowed(folder_path: &Path) -> std::result::Result<bool, &'static str> {
+    let folder_name: Vec<u16> = folder_path
+        .as_os_str()
         .encode_wide()
         .chain(iter::once(0))
         .collect();
@@ -131,6 +132,6 @@ extern "system" {
     fn PathIsNetworkPathW(pszPath: LPCWSTR) -> BOOLEAN;
 }
 
-fn is_network_path(folder_path: &Vec<u16>) -> bool {
-    return unsafe { PathIsNetworkPathW(folder_path.as_ptr()) } == 1;
+fn is_network_path(folder_path: &[u16]) -> bool {
+    unsafe { PathIsNetworkPathW(folder_path.as_ptr()) == 1 }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
I noticed the recent changes to the directory module in #1506 introduced some clippy errors on windows.
When reviewing I didn't run `cargo clippy` because I thought CI would catch clippy errors, but they weren't caught there because clippy isn't running on windows in CI.

I also replaced the use of `str` in the directory lock helpers with `Path` because the module work with `Path`/`OsStr` internally anyway. This avoids coversion to UTF-8 and back and allows it to work on directories that aren't valid unicode.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
