### PR TITLE
test: sync filesystem before each test is run

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,17 @@ attohttpc = { version = "0.15.0", optional = true, default-features = false, fea
 native-tls = { version = "0.2", optional = true }
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", features = ["winuser", "securitybaseapi", "processthreadsapi", "handleapi", "impl-default"]}
+winapi = { version = "0.3", features = [
+  "winuser",
+  "securitybaseapi",
+  "processthreadsapi",
+  "handleapi",
+  "fileapi",
+  "errhandlingapi",
+  "winbase",
+  "winnt",
+  "impl-default",
+] }
 
 [target.'cfg(not(windows))'.dependencies]
 nix = "0.18.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,10 +70,7 @@ winapi = { version = "0.3", features = [
   "securitybaseapi",
   "processthreadsapi",
   "handleapi",
-  "fileapi",
-  "errhandlingapi",
   "winbase",
-  "winnt",
   "impl-default",
 ] }
 

--- a/src/modules/utils/test.rs
+++ b/src/modules/utils/test.rs
@@ -1,7 +1,6 @@
 use crate::config::StarshipConfig;
 use crate::context::{Context, Shell};
 use std::path::Path;
-use std::process::Command;
 
 /// Render a specific starship module by name
 pub fn render_module(
@@ -21,6 +20,7 @@ pub fn render_module(
 /// Syncs directory in filesystem to disk to ensure consistent tests
 #[cfg(not(windows))]
 fn fs_sync(path: &Path) {
+    use std::process::Command;
     Command::new("sync").arg(path).status().unwrap();
 }
 

--- a/src/modules/utils/test.rs
+++ b/src/modules/utils/test.rs
@@ -1,12 +1,7 @@
 use crate::config::StarshipConfig;
 use crate::context::{Context, Shell};
-use std::fs::OpenOptions;
 use std::path::Path;
-
-#[cfg(not(windows))]
-use std::os::unix::fs::OpenOptionsExt;
-#[cfg(windows)]
-use std::os::windows::fs::OpenOptionsExt;
+use std::{fs, io};
 
 /// Render a specific starship module by name
 pub fn render_module(
@@ -18,27 +13,30 @@ pub fn render_module(
     context.config = StarshipConfig { config };
     context.shell = Shell::Unknown;
 
-    fs_sync(&path);
+    sync_dir(&path).unwrap();
 
     crate::print::get_module(module_name, context)
 }
 
 /// Syncs directory in filesystem to disk to ensure consistent tests
-fn fs_sync(path: &Path) {
-    let mut opener = OpenOptions::new();
+/// Duplicate defintion in tests/testsuite/common.rs. Always change both!
+fn sync_dir(path: &Path) -> io::Result<()> {
+    let mut opener = fs::OpenOptions::new();
 
     // Fix opening directories
     #[cfg(not(windows))]
     {
+        use std::os::unix::fs::OpenOptionsExt;
         opener.read(true);
         opener.custom_flags(nix::fcntl::OFlag::O_DIRECTORY.bits());
     }
 
     #[cfg(windows)]
     {
+        use std::os::windows::fs::OpenOptionsExt;
         opener.write(true);
         opener.custom_flags(winapi::um::winbase::FILE_FLAG_BACKUP_SEMANTICS);
     }
 
-    opener.open(path).unwrap().sync_all().unwrap();
+    opener.open(path)?.sync_all()
 }

--- a/src/modules/utils/test.rs
+++ b/src/modules/utils/test.rs
@@ -1,6 +1,7 @@
 use crate::config::StarshipConfig;
 use crate::context::{Context, Shell};
 use std::path::Path;
+use std::process::Command;
 
 /// Render a specific starship module by name
 pub fn render_module(
@@ -12,5 +13,16 @@ pub fn render_module(
     context.config = StarshipConfig { config };
     context.shell = Shell::Unknown;
 
+    fs_sync(&path);
+
     crate::print::get_module(module_name, context)
 }
+
+/// Syncs directory in filesystem to disk to ensure consistent tests
+#[cfg(not(windows))]
+fn fs_sync(path: &Path) {
+    Command::new("sync").arg(path).status().unwrap();
+}
+
+#[cfg(windows)]
+fn fs_sync(path: &Path) {}

--- a/src/modules/utils/test.rs
+++ b/src/modules/utils/test.rs
@@ -20,9 +20,56 @@ pub fn render_module(
 /// Syncs directory in filesystem to disk to ensure consistent tests
 #[cfg(not(windows))]
 fn fs_sync(path: &Path) {
-    use std::process::Command;
-    Command::new("sync").arg(path).status().unwrap();
+    use nix::fcntl::{open, OFlag};
+    use nix::sys::stat::Mode;
+    use nix::unistd::fsync;
+    let dir = open(
+        path,
+        OFlag::O_DIRECTORY | OFlag::O_RDONLY | OFlag::O_CLOEXEC,
+        Mode::empty(),
+    )
+    .unwrap();
+    fsync(dir).unwrap();
 }
 
 #[cfg(windows)]
-fn fs_sync(path: &Path) {}
+fn fs_sync(path: &Path) {
+    use std::iter;
+    use std::os::windows::ffi::OsStrExt;
+    use winapi::um::errhandlingapi::GetLastError;
+    use winapi::um::fileapi::{CreateFileW, FlushFileBuffers, OPEN_EXISTING};
+    use winapi::um::handleapi::{CloseHandle, INVALID_HANDLE_VALUE};
+    use winapi::um::winbase::FILE_FLAG_BACKUP_SEMANTICS;
+    use winapi::um::winnt::{
+        FILE_ATTRIBUTE_DIRECTORY, FILE_ATTRIBUTE_NORMAL, FILE_SHARE_DELETE, FILE_SHARE_READ,
+        FILE_SHARE_WRITE, GENERIC_WRITE,
+    };
+
+    let wpath: Vec<u16> = path
+        .as_os_str()
+        .encode_wide()
+        .chain(iter::once(0))
+        .collect();
+
+    let handle = unsafe {
+        CreateFileW(
+            wpath.as_ptr(),
+            GENERIC_WRITE,
+            FILE_SHARE_DELETE | FILE_SHARE_READ | FILE_SHARE_WRITE,
+            std::ptr::null_mut(),
+            OPEN_EXISTING,
+            FILE_ATTRIBUTE_DIRECTORY | FILE_ATTRIBUTE_NORMAL | FILE_FLAG_BACKUP_SEMANTICS,
+            std::ptr::null_mut(),
+        )
+    };
+    if handle == INVALID_HANDLE_VALUE {
+        panic!("Failed to open dir for sync, {}", unsafe { GetLastError() });
+    }
+
+    let r = unsafe { FlushFileBuffers(handle) };
+    if r == 0 {
+        panic!("Failed to flush dir, {}", unsafe { GetLastError() });
+    }
+
+    unsafe { CloseHandle(handle) };
+}

--- a/tests/testsuite/common.rs
+++ b/tests/testsuite/common.rs
@@ -30,6 +30,7 @@ pub fn _render_prompt() -> process::Command {
 
 /// Render a specific starship module by name
 pub fn render_module(module_name: &str) -> process::Command {
+    fs_sync();
     let binary = fs::canonicalize(EXE_PATH).unwrap();
     let mut command = process::Command::new(binary);
 
@@ -85,6 +86,15 @@ fn path_str(repo_dir: &PathBuf) -> io::Result<String> {
         .ok_or_else(|| Error::from(ErrorKind::Other))
         .map(|i| i.replace("\\", "/"))
 }
+
+/// Syncs the filesystem to disk to ensure consistent tests
+#[cfg(not(windows))]
+fn fs_sync() {
+    Command::new("sync").status().unwrap();
+}
+
+#[cfg(windows)]
+fn fs_sync() {}
 
 /// Extends `std::process::Command` with methods for testing
 pub trait TestCommand {

--- a/tests/testsuite/common.rs
+++ b/tests/testsuite/common.rs
@@ -90,9 +90,26 @@ fn path_str(repo_dir: &PathBuf) -> io::Result<String> {
 /// Syncs the filesystem to disk to ensure consistent tests
 #[cfg(not(windows))]
 fn fs_sync() {
+    #[cfg(any(
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "linux",
+        target_os = "netbsd",
+        target_os = "openbsd"
+    ))]
+    nix::unistd::sync();
+
+    #[cfg(not(any(
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "linux",
+        target_os = "netbsd",
+        target_os = "openbsd"
+    )))]
     Command::new("sync").status().unwrap();
 }
 
+// This would require admin in CI
 #[cfg(windows)]
 fn fs_sync() {}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
[Apparently `.sync_all()` might not be enough to ensure new files are visible in the filesystem.](https://github.com/starship/starship/issues/886#issuecomment-667509181)
In the two test module render helpers I found, I added code to sync the filesystem before the modules are rendered. ~~This doesn't work on windows but I don't really remember the failures happening there.~~
I did five ci runs on my fork and they all worked except for unrelated failures reminiscent of #1532  

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#886

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
