### PR TITLE
fix(git_state) panic on interactive git rebase

### DIFF
--- a/src/modules/git_state.rs
+++ b/src/modules/git_state.rs
@@ -133,8 +133,10 @@ fn describe_rebase<'a>(root: &'a PathBuf, rebase_config: &'a str) -> StateDescri
         Some((current, total))
     };
 
-    let progress = if has_path("rebase-merge") {
+    let progress = if has_path("rebase-merge/msgnum") {
         paths_to_progress("rebase-merge/msgnum", "rebase-merge/end")
+    } else if has_path("rebase-merge/onto") {
+        Some((1, 1))
     } else if has_path("rebase-apply") {
         paths_to_progress("rebase-apply/next", "rebase-apply/last")
     } else {


### PR DESCRIPTION
#### Description
This pr will fix a panic in the git_state module when doing a `git rebase`.  It is possibly an edge case and might possibly only happen when the rebase only has one command.

I've not done more testing regarding the cause but so far it has only triggered on rebase with one command thus I chose to return (1, 1) as progress. 

#### Motivation and Context
Execute `git rebase -i` and put the editor in background (ctrl-z) or dropping to shell will result in
```
thread '<unnamed>' panicked at 'called `Option::unwrap()` on a `None` value', src/modules/git_state.rs:146:37
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

#### Screenshots (if appropriate):

#### How Has This Been Tested?
I've recompiled `starship`using `cargo build --release --no-default-features` and verified it will resolve the panic.
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
