### PR TITLE
fix(docs): Fix Explore The Starship link in guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@
 - **Easy:** quick to install – start using it in minutes.
 
 <p align="center">
-<a href="https://starship.rs/"><strong>Explore the Starship docs&nbsp;&nbsp;▶</strong></a>
+<a href="https://starship.rs/config/"><strong>Explore the Starship docs&nbsp;&nbsp;▶</strong></a>
 </p>
 
 


### PR DESCRIPTION
Fix Explore the Starship docs link in guide
that redirected to homepage instead of docs.

Fixes: https://github.com/starship/starship/issues/1542

#### Description
Super small fix to one link in starship guide.

#### Motivation and Context
Closes #1542

#### Screenshots (if appropriate):

#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
