### PR TITLE
fix: Honor gitconfig for default branch

### DIFF
--- a/src/modules/git_status.rs
+++ b/src/modules/git_status.rs
@@ -127,7 +127,19 @@ impl<'a> GitStatusInfo<'a> {
         self.repo
             .branch
             .clone()
-            .unwrap_or_else(|| String::from("master"))
+            .unwrap_or_else(|| self.get_default_branch_name())
+    }
+
+    fn get_default_branch_name(&self) -> String {
+        const DEFAULT_BRANCH_NAME: &str = "master";
+
+        match git2::Config::open_default() {
+            Ok(config) => config
+                .get_str("init.defaultBranch")
+                .unwrap_or(DEFAULT_BRANCH_NAME)
+                .to_string(),
+            Err(_) => String::from(DEFAULT_BRANCH_NAME),
+        }
     }
 
     fn get_repository(&self) -> Option<Repository> {

--- a/tests/testsuite/git_branch.rs
+++ b/tests/testsuite/git_branch.rs
@@ -193,9 +193,24 @@ fn test_git_dir_env_variable() -> io::Result<()> {
         .unwrap();
     let actual = String::from_utf8(output.stdout).unwrap();
 
+    const DEFAULT_BRANCH_NAME: &str = "master";
+    let default_branch_name = match git2::Config::open_default() {
+        Ok(config) => {
+            dbg!("bla");
+            dbg!(config.get_str("init.defaultBranch"))
+                .unwrap_or(DEFAULT_BRANCH_NAME)
+                .to_string()
+        }
+        Err(_) => String::from(DEFAULT_BRANCH_NAME),
+    };
+
+    dbg!(&default_branch_name);
+
     let expected = format!(
         "on {} ",
-        Color::Purple.bold().paint(format!("\u{e0a0} {}", "master")),
+        Color::Purple
+            .bold()
+            .paint(format!("\u{e0a0} {}", default_branch_name)),
     );
     assert_eq!(expected, actual);
     remove_dir_all(repo_dir)

--- a/tests/testsuite/git_branch.rs
+++ b/tests/testsuite/git_branch.rs
@@ -193,18 +193,22 @@ fn test_git_dir_env_variable() -> io::Result<()> {
         .unwrap();
     let actual = String::from_utf8(output.stdout).unwrap();
 
-    const DEFAULT_BRANCH_NAME: &str = "master";
-    let default_branch_name = match git2::Config::open_default() {
-        Ok(config) => {
-            dbg!("bla");
-            dbg!(config.get_str("init.defaultBranch"))
-                .unwrap_or(DEFAULT_BRANCH_NAME)
-                .to_string()
-        }
-        Err(_) => String::from(DEFAULT_BRANCH_NAME),
-    };
+    let default_branch_name = {
+        const DEFAULT_BRANCH_NAME: &str = "master";
 
-    dbg!(&default_branch_name);
+        let output = Command::new("git")
+            .args(&["config", "--global", "init.defaultBranch"])
+            .output()
+            .unwrap();
+
+        let default = String::from_utf8(output.stdout).unwrap().trim().to_string();
+
+        if default.is_empty() {
+            DEFAULT_BRANCH_NAME.to_string()
+        } else {
+            default
+        }
+    };
 
     let expected = format!(
         "on {} ",


### PR DESCRIPTION
#### Description
Use gitconfig "init.defaultBranch" if present for git default branch display.

With git 2.28 there is a new configuration option for the default branch
when using git init.

This change checks if the default branch name has been changed in the git
configuration and uses that to display the current branch when no branch has
been created yet in a new git repository.

If `init.defaultBranch` has not been defined and no branch exists it falls back
to "master" like before.

* Highlights from Git 2.28: https://github.blog/2020-07-27-highlights-from-git-2-28/#introducing-init-defaultbranch
* Git 2.28 Release Notes: https://lore.kernel.org/git/xmqq5za8hpir.fsf@gitster.c.googlers.com/

#### Motivation and Context
Currently the configuration option is not honored. That can lead to confusing
behavior when the configuration option is changed. The change will not be
reflected by starship which falls back to "master" by default.

#### How Has This Been Tested?
I recompiled starship with the changes and created a new repository after
changing `init.defaultBranch` to `main` in my gitconfig file.

Starship now shows the value defined in `init.defaultBranch` instead of using
master.

I also ran the tests with the changes. There are problems now as the test
`git_branch::test_git_dir_env_variable` doesnt honor the configuration option.

I tried to fix it but i ran into a bug in the git library apparently: https://github.com/rust-lang/git2-rs/issues/474

When using the following code in the test

```
    const DEFAULT_BRANCH_NAME: &str = "master";
    let default_branch_name = match git2::Config::open_default() {
        Ok(config) => { dbg!("bla"); dbg!(config.get_str("init.defaultBranch")).unwrap_or(DEFAULT_BRANCH_NAME).to_string() }
        Err(_) => String::from(DEFAULT_BRANCH_NAME),
    };

    dbg!(&default_branch_name);
```

I included the updated test so maybe we can fix that somehow. It would be nice
to fix the test as well as git behaves now differently when `init.defaultBranch`
is set.

- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

I'm not totally sure if this could have performance penalties but form my testing it seemed fine.

#### Checklist:
I updated the test but ran into a bug apparently. See above for explanation.

- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.