### PR TITLE
feat(directory): fix #1162 add ellipsis to truncated paths

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -651,6 +651,7 @@ it would have been `nixpkgs/pkgs`.
 | `disabled`          | `false`                                            | Disables the `directory` module.                                                 |
 | `read_only`         | `"🔒"`                                             | The symbol indicating current directory is read only.                            |
 | `read_only_style`   | `"red"`                                            | The style for the read only symbol.                                              |
+| `truncation_symbol` | `""`                                               | The symbol to prefix to truncated paths. eg: "…/"                                |
 
 <details>
 <summary>This module has a few advanced configuration options that control how the directory is displayed.</summary>
@@ -694,6 +695,7 @@ a single character. For `fish_style_pwd_dir_length = 2`, it would be `/bu/th/ci/
 
 [directory]
 truncation_length = 8
+truncation_symbol = "…/"
 ```
 
 ## Docker Context

--- a/src/configs/directory.rs
+++ b/src/configs/directory.rs
@@ -15,6 +15,7 @@ pub struct DirectoryConfig<'a> {
     pub disabled: bool,
     pub read_only: &'a str,
     pub read_only_style: &'a str,
+    pub truncation_symbol: &'a str,
 }
 
 impl<'a> RootModuleConfig<'a> for DirectoryConfig<'a> {
@@ -30,6 +31,7 @@ impl<'a> RootModuleConfig<'a> for DirectoryConfig<'a> {
             disabled: false,
             read_only: "🔒",
             read_only_style: "red",
+            truncation_symbol: "",
         }
     }
 }

--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -36,36 +36,12 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let mut module = context.new_module("directory");
     let config: DirectoryConfig = DirectoryConfig::try_load(module.config);
 
-    // Using environment PWD is the standard approach for determining logical path
-    // If this is None for any reason, we fall back to reading the os-provided path
-    let physical_current_dir = if config.use_logical_path {
-        match context.get_env("PWD") {
-            Some(x) => Some(PathBuf::from(x)),
-            None => {
-                log::debug!("Error getting PWD environment variable!");
-                None
-            }
-        }
-    } else {
-        match std::env::current_dir() {
-            Ok(x) => Some(x),
-            Err(e) => {
-                log::debug!("Error getting physical current directory: {}", e);
-                None
-            }
-        }
-    };
-    let current_dir = Path::new(
-        physical_current_dir
-            .as_ref()
-            .unwrap_or_else(|| &context.current_dir),
-    );
+    let current_dir = &get_current_dir(&context, &config);
 
     let home_dir = dirs_next::home_dir().unwrap();
     log::debug!("Current directory: {:?}", current_dir);
 
     let repo = &context.get_repo().ok()?;
-
     let dir_string = match &repo.root {
         Some(repo_root) if config.truncate_to_repo && (repo_root != &home_dir) => {
             log::debug!("Repo root: {:?}", repo_root);
@@ -129,6 +105,33 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     });
 
     Some(module)
+}
+
+fn get_current_dir(context: &Context, config: &DirectoryConfig) -> Path {
+    // Using environment PWD is the standard approach for determining logical path
+    // If this is None for any reason, we fall back to reading the os-provided path
+    let physical_current_dir = if config.use_logical_path {
+        match context.get_env("PWD") {
+            Some(x) => Some(PathBuf::from(x)),
+            None => {
+                log::debug!("Error getting PWD environment variable!");
+                None
+            }
+        }
+    } else {
+        match std::env::current_dir() {
+            Ok(x) => Some(x),
+            Err(e) => {
+                log::debug!("Error getting physical current directory: {}", e);
+                None
+            }
+        }
+    };
+    let current_dir = Path::new(
+        physical_current_dir
+            .as_ref()
+            .unwrap_or_else(|| &context.current_dir),
+    );
 }
 
 fn is_readonly_dir(path: &Path) -> bool {


### PR DESCRIPTION
#### Description
Adds ellipsis in front of truncated paths: …/
Configurable through new config option: directory.truncation_symbol
~~On~~ Off by default (default is empty string)

#### Motivation and Context
Better visual indication of when the path has been truncated
Closes #1162 
Fixes #1626 

#### Screenshots (if appropriate):
![Screenshot from 2020-08-07 00-08-10](https://user-images.githubusercontent.com/53842233/89619422-cacb8c80-d842-11ea-816b-e8de51405c86.png)

#### How Has This Been Tested?
~~Updated existing tests~~ No longer needed since default is empty symbol.  Default behaviour is the same as before.
Ran `cargo test && cargo test --tests directory:: -- --ignored`
Added test for new config option: directory.truncation_symbol
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
