### PR TITLE
feat(kubernetes): Add styling based on current context

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1643,6 +1643,42 @@ disabled = false
 "dev.local.cluster.k8s" = "dev"
 ```
 
+### Kubernetes Display
+
+The `display` configuration option is used to customise what the current Kubernetes context name looks
+like (style) if the name matches defined regular expression.
+If no `display` is provided. The default is as shown:
+
+```toml
+[[kubernetes.display]]
+context_pattern = "prod"
+style = "bold red"
+```
+
+#### Options
+
+The `display` option is an array of the following table.
+
+| Variable            | Description                                                 |
+| ------------------- | ----------------------------------------------------------- |
+| `context_pattern` | Regular expression to match current Kubernetes context name |
+| `style`            | The style used if the display option is in use.             |
+
+#### Example
+
+```toml
+[[kubernetes.display]] # "bold red" style when Kubernetes current context name contains "prod"
+context_pattern = "prod"
+style = "bold red"
+
+[[kubernetes.display]] # "green" style when Kubernetes current context name contains "dev"
+context_pattern = "dev"
+style = "green"
+
+# when Kubernetes current context name doesn't container either "prod" or "dev", the style
+# specified in [kubernetes] will be used.
+```
+
 ## Line Break
 
 The `line_break` module separates the prompt into two lines.

--- a/src/config.rs
+++ b/src/config.rs
@@ -133,6 +133,15 @@ where
     }
 }
 
+impl<'a> ModuleConfig<'a> for regex::Regex {
+    fn from_config(config: &Value) -> Option<Self> {
+        match config {
+            Value::String(value) => regex::Regex::new(value).ok(),
+            _ => None,
+        }
+    }
+}
+
 impl<'a, T, S: ::std::hash::BuildHasher + Default> ModuleConfig<'a> for HashMap<String, T, S>
 where
     T: ModuleConfig<'a>,

--- a/src/configs/kubernetes.rs
+++ b/src/configs/kubernetes.rs
@@ -11,6 +11,7 @@ pub struct KubernetesConfig<'a> {
     pub style: &'a str,
     pub disabled: bool,
     pub context_aliases: HashMap<String, &'a str>,
+    pub display: Vec<KubernetesDisplayConfig<'a>>,
 }
 
 impl<'a> Default for KubernetesConfig<'a> {
@@ -21,6 +22,13 @@ impl<'a> Default for KubernetesConfig<'a> {
             style: "cyan bold",
             disabled: true,
             context_aliases: HashMap::new(),
+            display: vec![],
         }
     }
+}
+
+#[derive(Clone, Default, ModuleConfig, Serialize)]
+pub struct KubernetesDisplayConfig<'a> {
+    pub context_pattern: &'a str,
+    pub style: &'a str,
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Allow granular control of styles based on current Kubernetes context name. The config is inspired by the battery module. Multiple kubernetes.display option can be added with regular expressiones to match the current kubernetes context name. Style of the first matched display option will be used for the final style.

The display option can be extended to allow matching based on context aliases or namespace names, or allow changing the symbol.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #570

#### Screenshots (if appropriate):
![starship-k8s-style](https://user-images.githubusercontent.com/19508/89709969-a696b980-d9c2-11ea-8ed9-b78900b32559.png)


#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
