### PR TITLE
fix(pwsh): stop paths from being interpreted as patterns

### DIFF
--- a/src/init/starship.ps1
+++ b/src/init/starship.ps1
@@ -8,7 +8,7 @@ function global:prompt {
     $jobs = @(Get-Job | Where-Object { $_.State -eq 'Running' }).Count
 
     $env:PWD = $PWD
-    $current_directory = (Convert-Path $PWD)
+    $current_directory = (Convert-Path -LiteralPath $PWD)
 
     if ($lastCmd = Get-History -Count 1) {
         $duration = [math]::Round(($lastCmd.EndExecutionTime - $lastCmd.StartExecutionTime).TotalMilliseconds)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

Currently `Convert-Path` in the powershell prompt script works with `-Path` which interprets paths as wildcard patterns.
Not all valid paths are also valid wildcard patterns, possibly causing the prompt to error (eg `[]*`).
Replace it with `-LiteralPath` that makes `Convert-Path` use the path as-is.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
