### PR TITLE
perf(memory_usage): speed up on windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,6 @@ winapi = { version = "0.3", features = [
   "processthreadsapi",
   "handleapi",
   "sysinfoapi",
-  "errhandlingapi",
   "impl-default",
 ] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,6 @@ unicode-segmentation = "1.6.0"
 gethostname = "0.2.1"
 once_cell = "1.4.0"
 chrono = "0.4"
-sysinfo = "0.15.1"
 byte-unit = "4.0.9"
 starship_module_config_derive = { version = "0.1.0", path = "starship_module_config_derive" }
 yaml-rust = "0.4"
@@ -70,11 +69,14 @@ winapi = { version = "0.3", features = [
   "securitybaseapi",
   "processthreadsapi",
   "handleapi",
+  "sysinfoapi",
+  "errhandlingapi",
   "impl-default",
 ] }
 
 [target.'cfg(not(windows))'.dependencies]
 nix = "0.18.0"
+sysinfo = "0.15.1"
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/src/modules/memory_usage.rs
+++ b/src/modules/memory_usage.rs
@@ -72,10 +72,10 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             return None;
         }
 
-        used_memory_kb = mem_info.ullAvailPhys / 1_000;
+        used_memory_kb = (mem_info.ullTotalPhys - mem_info.ullAvailPhys) / 1_000;
         total_memory_kb = mem_info.ullTotalPhys / 1_000;
         total_swap_kb = (mem_info.ullTotalPageFile - mem_info.ullTotalPhys) / 1_000;
-        used_swap_kb = mem_info.ullAvailPageFile / 1_000;
+        used_swap_kb = total_swap_kb - (mem_info.ullAvailPageFile - mem_info.ullAvailPhys) / 1_000;
     }
 
     let ram_used = (used_memory_kb as f64 / total_memory_kb as f64) * 100.;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
The `memory_usage` module was very slow in windows. This PR cuts module rendering time from 400ms to 20ms for me.
`sysinfo` is replaced in this PR with direct calls to `winapi` (equivalent to how `sysinfo` did it).

Also the module was assuming returned memory is in KiB even though sysinfo returns memory in KB, I also made the module use the correct unit.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1564

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
