### PR TITLE
fix(test/dir): make lock thread-safe

### DIFF
--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -430,7 +430,7 @@ mod tests {
         #[test]
         #[ignore]
         fn symlinked_subdirectory_git_repo_out_of_tree() -> io::Result<()> {
-            while LOCK.swap(true, Ordering::Relaxed) {}
+            while LOCK.swap(true, Ordering::Acquire) {}
             let tmp_dir = TempDir::new_in(home_dir().unwrap().as_path())?;
             let repo_dir = tmp_dir.path().join("above-repo").join("rocket-controls");
             let src_dir = repo_dir.join("src/meters/fuel-gauge");
@@ -451,7 +451,7 @@ mod tests {
 
             assert_eq!(expected, actual);
 
-            LOCK.store(false, Ordering::Relaxed);
+            LOCK.store(false, Ordering::Release);
 
             tmp_dir.close()
         }
@@ -459,7 +459,7 @@ mod tests {
         #[test]
         #[ignore]
         fn git_repo_in_home_directory_truncate_to_repo_true() -> io::Result<()> {
-            while LOCK.swap(true, Ordering::Relaxed) {}
+            while LOCK.swap(true, Ordering::Acquire) {}
             let tmp_dir = TempDir::new_in(home_dir().unwrap().as_path())?;
             let dir = tmp_dir.path().join("src/fuel-gauge");
             fs::create_dir_all(&dir)?;
@@ -485,7 +485,7 @@ mod tests {
 
             assert_eq!(expected, actual);
 
-            LOCK.store(false, Ordering::Relaxed);
+            LOCK.store(false, Ordering::Release);
 
             tmp_dir.close()
         }

--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -430,8 +430,7 @@ mod tests {
         #[test]
         #[ignore]
         fn symlinked_subdirectory_git_repo_out_of_tree() -> io::Result<()> {
-            while LOCK.load(Ordering::Relaxed) {}
-            LOCK.store(true, Ordering::Relaxed);
+            while LOCK.swap(true, Ordering::Relaxed) {}
             let tmp_dir = TempDir::new_in(home_dir().unwrap().as_path())?;
             let repo_dir = tmp_dir.path().join("above-repo").join("rocket-controls");
             let src_dir = repo_dir.join("src/meters/fuel-gauge");
@@ -460,8 +459,7 @@ mod tests {
         #[test]
         #[ignore]
         fn git_repo_in_home_directory_truncate_to_repo_true() -> io::Result<()> {
-            while LOCK.load(Ordering::Relaxed) {}
-            LOCK.store(true, Ordering::Relaxed);
+            while LOCK.swap(true, Ordering::Relaxed) {}
             let tmp_dir = TempDir::new_in(home_dir().unwrap().as_path())?;
             let dir = tmp_dir.path().join("src/fuel-gauge");
             fs::create_dir_all(&dir)?;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
I replaced the seperate spin and lock with a single atomic swap and made the ordering stronger.

I kept the spinlock but `Mutex` might be cleaner.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I had a lot of test failures in #1573 in a row.

In the previous version this could have happend:

```
T1: while LOCK.load(Ordering::Relaxed) {}
T2: while LOCK.load(Ordering::Relaxed) {}
T1: LOCK.store(true, Ordering::Relaxed);
T2: LOCK.store(true, Ordering::Relaxed);
```

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**
- [x] I have tested using **CI**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
