### PR TITLE
feat: Error messaging

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,16 +72,18 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
 ## Logging
 
-Debug logging in starship is done with [pretty_env_logger](https://crates.io/crates/pretty_env_logger).
-To run starship with debug logs, set the `STARSHIP_LOG` environment variable to the log level needed.
-For example, to enable the trace logs, run the following:
+Debug logging in starship is done with our custom logger implementation.
+To see the debug logs of the current starship session execute the following command:
 
 ```sh
 # Run installed starship
-STARSHIP_LOG=trace starship
+starship prompt
 
 # Run with cargo
-STARSHIP_LOG=trace cargo run
+cargo run prompt
+
+# Read the log file
+cat /tmp/starship/session_$(STARSHIP_SESSION_KEY).log
 ```
 
 ## Linting

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,7 @@ starship prompt
 cargo run prompt
 
 # Read the log file
-cat /tmp/starship/session_$(STARSHIP_SESSION_KEY).log
+cat ~/.cache/starship/session_${STARSHIP_SESSION_KEY}.log
 ```
 
 ## Linting

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,17 +73,15 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 ## Logging
 
 Debug logging in starship is done with our custom logger implementation.
-To see the debug logs of the current starship session execute the following command:
+To run starship with debug logs, set the `STARSHIP_LOG` environment variable to the log level needed.
+For example, to enable the trace logs, run the following:
 
 ```sh
 # Run installed starship
-starship prompt
+STARSHIP_LOG=trace starship
 
 # Run with cargo
-cargo run prompt
-
-# Read the log file
-cat ~/.cache/starship/session_${STARSHIP_SESSION_KEY}.log
+STARSHIP_LOG=trace cargo run
 ```
 
 ## Linting

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,19 +335,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 
 [[package]]
-name = "env_logger"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
 name = "fake-simd"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,15 +431,6 @@ dependencies = [
  "bytes",
  "fnv",
  "itoa",
-]
-
-[[package]]
-name = "humantime"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
-dependencies = [
- "quick-error",
 ]
 
 [[package]]
@@ -814,16 +792,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea"
 
 [[package]]
-name = "pretty_env_logger"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "926d36b9553851b8b0005f1275891b392ee4d2d833852c417ed025477350fb9d"
-dependencies = [
- "env_logger",
- "log",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -831,12 +799,6 @@ checksum = "04f5f085b5d71e2188cb8271e5da0161ad52c3f227a661a3c135fdf28e258b12"
 dependencies = [
  "unicode-xid",
 ]
-
-[[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
@@ -1100,7 +1062,6 @@ dependencies = [
  "path-slash",
  "pest",
  "pest_derive",
- "pretty_env_logger",
  "quick-xml",
  "rayon",
  "regex",
@@ -1180,15 +1141,6 @@ checksum = "1e4129646ca0ed8f45d09b929036bafad5377103edd06e50bf574b353d2b08d9"
 dependencies = [
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
-dependencies = [
- "winapi-util",
 ]
 
 [[package]]
@@ -1355,15 +1307,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1173,6 +1173,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "quick-xml",
+ "rand",
  "rayon",
  "regex",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,7 @@ git2 = { version = "0.13.8", default-features = false }
 toml = { version = "0.5.6", features = ["preserve_order"] }
 serde_json = "1.0.57"
 rayon = "1.3.1"
-pretty_env_logger = "0.4.0"
-log = "0.4.11"
+log = { version = "0.4.11", features = ["std"] }
 # battery is optional (on by default) because the crate doesn't currently build for Termux
 # see: https://github.com/svartalf/rust-battery/issues/33
 battery = { version = "0.7.5", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ open = "1.4.0"
 unicode-width = "0.1.8"
 term_size = "0.3.2"
 quick-xml = "0.18.1"
+rand = "0.7.3"
 notify-rust = { version = "4.0.0", optional = true }
 
 # Optional/http:

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -35,7 +35,7 @@ $ENV:STARSHIP_CONFIG = "$HOME\.starship"
 
 ### Logging
 
-By default starship logs everything it does into a log file named `~/.cache/starship/session_${STARSHIP_SESSION_KEY}.log`, where the session key is corresponding to a instance of your terminal.
+By default starship logs warnings and errors into a file named `~/.cache/starship/session_${STARSHIP_SESSION_KEY}.log`, where the session key is corresponding to a instance of your terminal.
 This, however can be changed using the `STARSHIP_CACHE` environment variable:
 
 ```sh

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -33,6 +33,21 @@ Equivalently in PowerShell (Windows) would be adding this line to your `$PROFILE
 $ENV:STARSHIP_CONFIG = "$HOME\.starship"
 ```
 
+### Logging
+
+By default starship logs everything it does into a log file named `~/.cache/starship/session_${STARSHIP_SESSION_KEY}.log`, where the session key is corresponding to a instance of your terminal.
+This, however can be changed using the `STARSHIP_CACHE` environment variable:
+
+```sh
+export STARSHIP_CACHE=~/.starship/cache
+```
+
+Equivalently in PowerShell (Windows) would be adding this line to your `$PROFILE`:
+
+```ps1
+$ENV:STARSHIP_CACHE = "$HOME\AppData\Local\Temp"
+```
+
 ### Terminology
 
 **Module**: A component in the prompt giving information based on contextual information from your OS. For example, the "nodejs" module shows the version of NodeJS that is currently installed on your computer, if your current directory is a NodeJS project.

--- a/src/config.rs
+++ b/src/config.rs
@@ -199,7 +199,7 @@ impl StarshipConfig {
     fn config_from_file() -> Option<Value> {
         let file_path = if let Ok(path) = env::var("STARSHIP_CONFIG") {
             // Use $STARSHIP_CONFIG as the config path if available
-            log::debug!("STARSHIP_CONFIG is set: \n{}", &path);
+            log::debug!("STARSHIP_CONFIG is set: {}", &path);
             path
         } else {
             // Default to using ~/.config/starship.toml
@@ -212,22 +212,22 @@ impl StarshipConfig {
 
         let toml_content = match utils::read_file(&file_path) {
             Ok(content) => {
-                log::trace!("Config file content: \n{}", &content);
+                log::trace!("Config file content: \"\n{}\"", &content);
                 Some(content)
             }
             Err(e) => {
-                log::debug!("Unable to read config file content: \n{}", &e);
+                log::debug!("Unable to read config file content: {}", &e);
                 None
             }
         }?;
 
         match toml::from_str(&toml_content) {
             Ok(parsed) => {
-                log::debug!("Config parsed: \n{:?}", &parsed);
+                log::debug!("Config parsed: {:?}", &parsed);
                 Some(parsed)
             }
             Err(error) => {
-                log::debug!("Unable to parse the config file: {}", error);
+                log::error!("Unable to parse the config file: {}", error);
                 None
             }
         }
@@ -238,7 +238,7 @@ impl StarshipConfig {
         let module_config = self.get_config(&[module_name]);
         if module_config.is_some() {
             log::debug!(
-                "Config found for \"{}\": \n{:?}",
+                "Config found for \"{}\": {:?}",
                 &module_name,
                 &module_config
             );
@@ -302,7 +302,7 @@ impl StarshipConfig {
         let module_config = self.get_config(&["custom", module_name]);
         if module_config.is_some() {
             log::debug!(
-                "Custom config found for \"{}\": \n{:?}",
+                "Custom config found for \"{}\": {:?}",
                 &module_name,
                 &module_config
             );

--- a/src/configs/custom.rs
+++ b/src/configs/custom.rs
@@ -52,7 +52,7 @@ impl<'a> ModuleConfig<'a> for Files<'a> {
             if let Some(file) = item.as_str() {
                 files.push(file);
             } else {
-                log::debug!("Unexpected file {:?}", item);
+                log::warn!("Unexpected file {:?}", item);
             }
         }
 
@@ -68,7 +68,7 @@ impl<'a> ModuleConfig<'a> for Extensions<'a> {
             if let Some(file) = item.as_str() {
                 extensions.push(file);
             } else {
-                log::debug!("Unexpected extension {:?}", item);
+                log::warn!("Unexpected extension {:?}", item);
             }
         }
 
@@ -84,7 +84,7 @@ impl<'a> ModuleConfig<'a> for Directories<'a> {
             if let Some(file) = item.as_str() {
                 directories.push(file);
             } else {
-                log::debug!("Unexpected directory {:?}", item);
+                log::warn!("Unexpected directory {:?}", item);
             }
         }
 

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -77,12 +77,12 @@ pub fn edit_configuration() {
         Ok(_) => (),
         Err(error) => match error.kind() {
             ErrorKind::NotFound => {
-                eprintln!(
-                    "Error: editor {:?} was not found. Did you set your $EDITOR or $VISUAL \
-                    environment variables correctly?",
-                    editor
+                log::error!(
+                    "Editor {:?} was not found. Did you set your $EDITOR or $VISUAL \
+                    environment variables correctly?\n Full error: {:?}",
+                    editor,
+                    error
                 );
-                eprintln!("Full error: {:?}", error);
                 std::process::exit(1)
             }
             other_error => panic!("failed to open file: {:?}", other_error),

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -75,7 +75,7 @@ pub fn edit_configuration() {
         Ok(_) => (),
         Err(error) => match error.kind() {
             ErrorKind::NotFound => {
-               eprintln!(
+                eprintln!(
                     "Error: editor {:?} was not found. Did you set your $EDITOR or $VISUAL \
                     environment variables correctly?",
                     editor_cmd

--- a/src/init/starship.bash
+++ b/src/init/starship.bash
@@ -87,5 +87,5 @@ export STARSHIP_SHELL="bash"
 
 # Set up the session key that will be used to store logs
 if [ -c /dev/urandom ]; then
-    export STARSHIP_SESSION_KEY=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 16 | head -n 1)
+    export STARSHIP_SESSION_KEY=$(::STARSHIP:: session)
 fi

--- a/src/init/starship.bash
+++ b/src/init/starship.bash
@@ -86,6 +86,4 @@ STARSHIP_START_TIME=$(::STARSHIP:: time)
 export STARSHIP_SHELL="bash"
 
 # Set up the session key that will be used to store logs
-if [ -c /dev/urandom ]; then
-    export STARSHIP_SESSION_KEY=$(::STARSHIP:: session)
-fi
+export STARSHIP_SESSION_KEY=$(::STARSHIP:: session)

--- a/src/init/starship.bash
+++ b/src/init/starship.bash
@@ -84,3 +84,8 @@ fi
 # Set up the start time and STARSHIP_SHELL, which controls shell-specific sequences
 STARSHIP_START_TIME=$(::STARSHIP:: time)
 export STARSHIP_SHELL="bash"
+
+# Set up the session key that will be used to store logs
+if [ -c /dev/urandom ]; then
+    export STARSHIP_SESSION_KEY=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 16 | head -n 1)
+fi

--- a/src/init/starship.fish
+++ b/src/init/starship.fish
@@ -18,6 +18,4 @@ function fish_mode_prompt; end
 export STARSHIP_SHELL="fish"
 
 # Set up the session key that will be used to store logs
-if test -c /dev/urandom
-    export STARSHIP_SESSION_KEY=(::STARSHIP:: session)
-end
+export STARSHIP_SESSION_KEY=(::STARSHIP:: session)

--- a/src/init/starship.fish
+++ b/src/init/starship.fish
@@ -19,5 +19,5 @@ export STARSHIP_SHELL="fish"
 
 # Set up the session key that will be used to store logs
 if test -c /dev/urandom
-    export STARSHIP_SESSION_KEY=(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 16 | head -n 1)
+    export STARSHIP_SESSION_KEY=(::STARSHIP:: session)
 end

--- a/src/init/starship.fish
+++ b/src/init/starship.fish
@@ -16,3 +16,8 @@ set VIRTUAL_ENV_DISABLE_PROMPT 1
 
 function fish_mode_prompt; end
 export STARSHIP_SHELL="fish"
+
+# Set up the session key that will be used to store logs
+if test -c /dev/urandom
+    export STARSHIP_SESSION_KEY=(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 16 | head -n 1)
+end

--- a/src/init/starship.ion
+++ b/src/init/starship.ion
@@ -17,6 +17,4 @@ end
 export STARSHIP_SHELL="ion"
 
 # Set up the session key that will be used to store logs
-if test -c /dev/urandom
-    export STARSHIP_SESSION_KEY=$(::STARSHIP:: session)
-end
+export STARSHIP_SESSION_KEY=$(::STARSHIP:: session)

--- a/src/init/starship.ion
+++ b/src/init/starship.ion
@@ -15,3 +15,8 @@ end
 
 # Export the correct name of the shell
 export STARSHIP_SHELL="ion"
+
+# Set up the session key that will be used to store logs
+if test -c /dev/urandom
+    export STARSHIP_SESSION_KEY=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 16 | head -n 1)
+end

--- a/src/init/starship.ion
+++ b/src/init/starship.ion
@@ -18,5 +18,5 @@ export STARSHIP_SHELL="ion"
 
 # Set up the session key that will be used to store logs
 if test -c /dev/urandom
-    export STARSHIP_SESSION_KEY=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 16 | head -n 1)
+    export STARSHIP_SESSION_KEY=$(::STARSHIP:: session)
 end

--- a/src/init/starship.ps1
+++ b/src/init/starship.ps1
@@ -26,4 +26,4 @@ function global:prompt {
 $ENV:STARSHIP_SHELL = "powershell"
 
 # Set up the session key that will be used to store logs
-$ENV:STARSHIP_SESSION_KEY = -join (('a'..'z') + ('A'..'Z') + ('0'..'9') | Get-Random -Count 16)
+$ENV:STARSHIP_SESSION_KEY = $(::STARSHIP:: session) 

--- a/src/init/starship.ps1
+++ b/src/init/starship.ps1
@@ -26,4 +26,4 @@ function global:prompt {
 $ENV:STARSHIP_SHELL = "powershell"
 
 # Set up the session key that will be used to store logs
-$ENV:STARSHIP_SESSION_KEY = $(::STARSHIP:: session) 
+$ENV:STARSHIP_SESSION_KEY = $(::STARSHIP:: session)

--- a/src/init/starship.ps1
+++ b/src/init/starship.ps1
@@ -26,4 +26,4 @@ function global:prompt {
 $ENV:STARSHIP_SHELL = "powershell"
 
 # Set up the session key that will be used to store logs
-$ENV:STARSHIP_SESSION_KEY = -join ( (65..90) + (97..122) | Get-Random -Count 16 | % {[char]$_})
+$ENV:STARSHIP_SESSION_KEY = -join (('a'..'z') + ('A'..'Z') + ('0'..'9') | Get-Random -Count 16)

--- a/src/init/starship.ps1
+++ b/src/init/starship.ps1
@@ -24,3 +24,6 @@ function global:prompt {
 }
 
 $ENV:STARSHIP_SHELL = "powershell"
+
+# Set up the session key that will be used to store logs
+$ENV:STARSHIP_SESSION_KEY = -join ( (65..90) + (97..122) | Get-Random -Count 16 | % {[char]$_})

--- a/src/init/starship.zsh
+++ b/src/init/starship.zsh
@@ -65,5 +65,5 @@ export STARSHIP_SHELL="zsh"
 
 # Set up the session key that will be used to store logs
 if [ -c /dev/urandom ]; then
-    export STARSHIP_SESSION_KEY=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 16 | head -n 1)
+    export STARSHIP_SESSION_KEY=$(::STARSHIP:: session)
 fi

--- a/src/init/starship.zsh
+++ b/src/init/starship.zsh
@@ -64,6 +64,4 @@ zle -N zle-keymap-select
 export STARSHIP_SHELL="zsh"
 
 # Set up the session key that will be used to store logs
-if [ -c /dev/urandom ]; then
-    export STARSHIP_SESSION_KEY=$(::STARSHIP:: session)
-fi
+export STARSHIP_SESSION_KEY=$(::STARSHIP:: session)

--- a/src/init/starship.zsh
+++ b/src/init/starship.zsh
@@ -62,3 +62,8 @@ zle-keymap-select() {
 STARSHIP_START_TIME=$(::STARSHIP:: time)
 zle -N zle-keymap-select
 export STARSHIP_SHELL="zsh"
+
+# Set up the session key that will be used to store logs
+if [ -c /dev/urandom ]; then
+    export STARSHIP_SESSION_KEY=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 16 | head -n 1)
+fi

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod config;
 pub mod configs;
 pub mod context;
 pub mod formatter;
+pub mod logger;
 pub mod module;
 pub mod modules;
 pub mod print;

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,0 +1,87 @@
+use ansi_term::Color;
+use log::{Level, LevelFilter, Metadata, Record};
+use std::{
+    env,
+    fs::{self, File, OpenOptions},
+    io::Write,
+    sync::{Arc, Mutex},
+};
+
+pub struct StarshipLogger {
+    log_file: Arc<Mutex<File>>,
+    log_file_content: Arc<String>,
+}
+
+impl StarshipLogger {
+    fn new() -> Self {
+        let log_dir = env::temp_dir().join("starship");
+
+        fs::create_dir_all(log_dir.clone()).expect("Unable to create log dir!");
+        let session_log_file = log_dir.join(format!(
+            "session_{}.log",
+            env::var("STARSHIP_SESSION_KEY").unwrap_or_default()
+        ));
+
+        Self {
+            log_file_content: Arc::new(
+                fs::read_to_string(session_log_file.clone()).unwrap_or_default(),
+            ),
+            log_file: Arc::new(Mutex::new(
+                OpenOptions::new()
+                    .create(true)
+                    .append(true)
+                    .open(session_log_file)
+                    .unwrap(),
+            )),
+        }
+    }
+}
+
+impl<'a> log::Log for StarshipLogger {
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        metadata.level() <= Level::Warn
+    }
+
+    fn log(&self, record: &Record) {
+        let to_print = format!(
+            "[{}] - ({}): {}",
+            record.level(),
+            record.module_path().unwrap_or_default(),
+            record.args()
+        );
+
+        self.log_file
+            .lock()
+            .map(|mut file| writeln!(file, "{}", to_print))
+            .expect("Log file mutex was poisoned!")
+            .expect("Unable to write to the log file!");
+
+        if self.enabled(record.metadata()) && !self.log_file_content.contains(&to_print) {
+            eprintln!(
+                "[{}] - ({}): {}",
+                match record.level() {
+                    Level::Trace => Color::Black.dimmed().paint(format!("{}", record.level())),
+                    Level::Debug => Color::Black.paint(format!("{}", record.level())),
+                    Level::Info => Color::White.paint(format!("{}", record.level())),
+                    Level::Warn => Color::Yellow.paint(format!("{}", record.level())),
+                    Level::Error => Color::Red.paint(format!("{}", record.level())),
+                },
+                record.module_path().unwrap_or_default(),
+                record.args()
+            );
+        }
+    }
+
+    fn flush(&self) {
+        self.log_file
+            .lock()
+            .map(|mut file| file.flush())
+            .expect("Log file mutex was poisoned!")
+            .expect("Unable to flush the log file!");
+    }
+}
+
+pub fn init() {
+    log::set_boxed_logger(Box::new(StarshipLogger::new())).unwrap();
+    log::set_max_level(LevelFilter::Trace);
+}

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -5,6 +5,7 @@ use std::{
     env,
     fs::{self, File, OpenOptions},
     io::Write,
+    path::PathBuf,
     sync::{Arc, Mutex},
 };
 
@@ -15,7 +16,13 @@ pub struct StarshipLogger {
 
 impl StarshipLogger {
     fn new() -> Self {
-        let log_dir = env::temp_dir().join("starship");
+        let log_dir = env::var_os("STARSHIP_CACHE")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| {
+                dirs_next::home_dir()
+                    .expect("Unable to find home directory")
+                    .join(".cache/starship")
+            });
 
         fs::create_dir_all(log_dir.clone()).expect("Unable to create log dir!");
         let session_log_file = log_dir.join(format!(

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -4,12 +4,12 @@ use std::{
     collections::HashSet,
     env,
     fs::{self, File, OpenOptions},
-    io::{BufWriter, Write},
+    io::Write,
     sync::{Arc, Mutex},
 };
 
 pub struct StarshipLogger {
-    log_file: Arc<Mutex<BufWriter<File>>>,
+    log_file: Arc<Mutex<File>>,
     log_file_content: Arc<HashSet<String>>,
 }
 
@@ -31,13 +31,13 @@ impl StarshipLogger {
                     .map(|line| line.to_string())
                     .collect(),
             ),
-            log_file: Arc::new(Mutex::new(BufWriter::new(
+            log_file: Arc::new(Mutex::new(
                 OpenOptions::new()
                     .create(true)
                     .append(true)
                     .open(session_log_file)
                     .unwrap(),
-            ))),
+            )),
         }
     }
 }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -73,6 +73,14 @@ impl log::Log for StarshipLogger {
             record.args()
         );
 
+        if record.metadata().level() <= Level::Warn {
+            self.log_file
+                .lock()
+                .map(|mut file| writeln!(file, "{}", to_print))
+                .expect("Log file writer mutex was poisoned!")
+                .expect("Unable to write to the log file!");
+        }
+
         if self.enabled(record.metadata()) && !self.log_file_content.contains(to_print.as_str()) {
             eprintln!(
                 "[{}] - ({}): {}",
@@ -86,11 +94,6 @@ impl log::Log for StarshipLogger {
                 record.module_path().unwrap_or_default(),
                 record.args()
             );
-            self.log_file
-                .lock()
-                .map(|mut file| writeln!(file, "{}", to_print))
-                .expect("Log file writer mutex was poisoned!")
-                .expect("Unable to write to the log file!");
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,8 @@ mod test;
 
 use crate::module::ALL_MODULES;
 use clap::{App, AppSettings, Arg, Shell, SubCommand};
+use rand::distributions::Alphanumeric;
+use rand::Rng;
 
 fn main() {
     logger::init();
@@ -152,7 +154,8 @@ fn main() {
                             .required(true)
                             .env("STARSHIP_SHELL"),
                     ),
-            );
+            )
+            .subcommand(SubCommand::with_name("session").about("Generate random session key"));
 
     let matches = app.clone().get_matches();
 
@@ -207,6 +210,13 @@ fn main() {
 
             app.gen_completions_to("starship", shell, &mut io::stdout().lock());
         }
+        ("session", _) => println!(
+            "{}",
+            rand::thread_rng()
+                .sample_iter(&Alphanumeric)
+                .take(16)
+                .collect::<String>()
+        ),
         (command, _) => unreachable!("Invalid subcommand: {}", command),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod configure;
 mod context;
 mod formatter;
 mod init;
+mod logger;
 mod module;
 mod modules;
 mod print;
@@ -22,7 +23,7 @@ use crate::module::ALL_MODULES;
 use clap::{App, AppSettings, Arg, Shell, SubCommand};
 
 fn main() {
-    pretty_env_logger::init_custom_env("STARSHIP_LOG");
+    logger::init();
 
     let status_code_arg = Arg::with_name("status_code")
         .short("s")

--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -108,7 +108,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::error!("Error in module `aws`: \n{}", error);
+            log::warn!("Error in module `aws`: \n{}", error);
             return None;
         }
     });

--- a/src/modules/battery.rs
+++ b/src/modules/battery.rs
@@ -85,7 +85,7 @@ fn get_battery_status() -> Option<BatteryStatus> {
                 })
             }
             Err(e) => {
-                log::debug!("Unable to access battery information:\n{}", &e);
+                log::warn!("Unable to access battery information:\n{}", &e);
                 None
             }
         })

--- a/src/modules/cmd_duration.rs
+++ b/src/modules/cmd_duration.rs
@@ -18,11 +18,9 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         .parse::<u128>()
         .ok()?;
 
-    /* TODO: Once error handling is implemented, warn the user if their config
-    min time is nonsensical */
     if config.min_time < 0 {
-        log::debug!(
-            "[WARN]: min_time in [cmd_duration] ({}) was less than zero",
+        log::warn!(
+            "min_time in [cmd_duration] ({}) was less than zero",
             config.min_time
         );
         return None;

--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -136,7 +136,7 @@ fn is_readonly_dir(path: &Path) -> bool {
         Ok(res) => !res,
         Err(e) => {
             log::debug!(
-                "Failed to detemine read only status of directory '{:?}': {}",
+                "Failed to determine read only status of directory '{:?}': {}",
                 path,
                 e
             );

--- a/src/modules/dotnet.rs
+++ b/src/modules/dotnet.rs
@@ -321,7 +321,7 @@ fn get_latest_sdk_from_cli() -> Option<Version> {
         None => {
             // Older versions of the dotnet cli do not support the --list-sdks command
             // So, if the status code indicates failure, fall back to `dotnet --version`
-            log::warn!(
+            log::debug!(
                 "Received a non-success exit code from `dotnet --list-sdks`. \
                  Falling back to `dotnet --version`.",
             );

--- a/src/modules/git_branch.rs
+++ b/src/modules/git_branch.rs
@@ -14,8 +14,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
     let truncation_symbol = get_first_grapheme(config.truncation_symbol);
 
-    // TODO: Once error handling is implemented, warn the user if their config
-    //       truncation length is nonsensical
     let len = if config.truncation_length <= 0 {
         log::warn!(
             "\"truncation_length\" should be a positive value, found {}",

--- a/src/modules/git_status.rs
+++ b/src/modules/git_status.rs
@@ -144,7 +144,7 @@ impl<'a> GitStatusInfo<'a> {
                 return match result.as_ref() {
                     Ok(ahead_behind) => Some(*ahead_behind),
                     Err(error) => {
-                        log::warn!("Warn: get_ahead_behind: {}", error);
+                        log::debug!("get_ahead_behind: {}", error);
                         None
                     }
                 };
@@ -159,7 +159,7 @@ impl<'a> GitStatusInfo<'a> {
             match data.as_ref().unwrap() {
                 Ok(ahead_behind) => Some(*ahead_behind),
                 Err(error) => {
-                    log::warn!("Warn: get_ahead_behind: {}", error);
+                    log::debug!("get_ahead_behind: {}", error);
                     None
                 }
             }
@@ -173,7 +173,7 @@ impl<'a> GitStatusInfo<'a> {
                 return match result.as_ref() {
                     Ok(repo_status) => Some(*repo_status),
                     Err(error) => {
-                        log::warn!("Warn: get_repo_status: {}", error);
+                        log::debug!("get_repo_status: {}", error);
                         None
                     }
                 };
@@ -187,7 +187,7 @@ impl<'a> GitStatusInfo<'a> {
             match data.as_ref().unwrap() {
                 Ok(repo_status) => Some(*repo_status),
                 Err(error) => {
-                    log::warn!("Warn: get_repo_status: {}", error);
+                    log::debug!(" get_repo_status: {}", error);
                     None
                 }
             }
@@ -201,7 +201,7 @@ impl<'a> GitStatusInfo<'a> {
                 return match result.as_ref() {
                     Ok(stashed_count) => Some(*stashed_count),
                     Err(error) => {
-                        log::warn!("Warn: get_stashed_count: {}", error);
+                        log::debug!("get_stashed_count: {}", error);
                         None
                     }
                 };
@@ -215,7 +215,7 @@ impl<'a> GitStatusInfo<'a> {
             match data.as_ref().unwrap() {
                 Ok(stashed_count) => Some(*stashed_count),
                 Err(error) => {
-                    log::warn!("Warn: get_stashed_count: {}", error);
+                    log::debug!("get_stashed_count: {}", error);
                     None
                 }
             }
@@ -356,7 +356,7 @@ where
             .parse(None)
             .ok()
     } else {
-        log::error!("Error parsing format string `{}`", &config_path);
+        log::warn!("Error parsing format string `{}`", &config_path);
         None
     }
 }

--- a/src/modules/hg_branch.rs
+++ b/src/modules/hg_branch.rs
@@ -18,8 +18,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let mut module = context.new_module("hg_branch");
     let config: HgBranchConfig = HgBranchConfig::try_load(module.config);
 
-    // TODO: Once error handling is implemented, warn the user if their config
-    // truncation length is nonsensical
     let len = if config.truncation_length <= 0 {
         log::warn!(
             "\"truncation_length\" should be a positive value, found {}",

--- a/src/modules/hostname.rs
+++ b/src/modules/hostname.rs
@@ -24,7 +24,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let host = match os_hostname.into_string() {
         Ok(host) => host,
         Err(bad) => {
-            log::debug!("hostname is not valid UTF!\n{:?}", bad);
+            log::warn!("hostname is not valid UTF!\n{:?}", bad);
             return None;
         }
     };

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -110,7 +110,10 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
         "username" => username::module(context),
         "zig" => zig::module(context),
         _ => {
-            eprintln!("Error: Unknown module {}. Use starship module --list to list out all supported modules.", module);
+            log::error!(
+                "Unknown module {}. Use starship module --list to list out all supported modules.",
+                module
+            );
             None
         }
     }

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -110,8 +110,8 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
         "username" => username::module(context),
         "zig" => zig::module(context),
         _ => {
-            log::error!(
-                "Unknown module {}. Use starship module --list to list out all supported modules.",
+            eprintln!(
+                "Error: Unknown module {}. Use starship module --list to list out all supported modules.",
                 module
             );
             None

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -249,7 +249,7 @@ fn internal_exec_cmd(cmd: &str, args: &[&str]) -> Option<CommandOutput> {
             })
         }
         Err(error) => {
-            log::trace!("Executing command {:?} failed by: {:?}", cmd, error);
+            log::warn!("Executing command {:?} failed by: {:?}", cmd, error);
             None
         }
     }

--- a/starship_module_config_derive/src/lib.rs
+++ b/starship_module_config_derive/src/lib.rs
@@ -20,12 +20,6 @@ fn impl_module_config(dinput: DeriveInput) -> proc_macro::TokenStream {
             let mut load_tokens = quote! {};
             let mut from_tokens = quote! {};
 
-            let check_migrations = quote! {
-                if config.get("prefix").is_some() || config.get("suffix").is_some() {
-                    log::warn!("You're using the outdated config format! Migrate your config here: https://starship.rs/migrating-to-0.45.0/")
-                }
-            };
-
             for field in fields_named.named.iter() {
                 let ident = field.ident.as_ref().unwrap();
                 let ty = &field.ty;
@@ -53,7 +47,9 @@ fn impl_module_config(dinput: DeriveInput) -> proc_macro::TokenStream {
                 fn load_config(&self, config: &'a toml::Value) -> Self {
                     let mut new_module_config = self.clone();
                     if let toml::Value::Table(config) = config {
-                        #check_migrations
+                        if config.get("prefix").is_some() || config.get("suffix").is_some() {
+                            log::warn!("You're using the outdated config format! Migrate your config here: https://starship.rs/migrating-to-0.45.0/")
+                        }
                         #load_tokens
                     }
                     new_module_config


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
Implements error messaging.
This take a bit of a different approach than #1416.
This creates a custom logger for the `log` crate which logs everything to a file (`/tmp/starship/session_$STARSHIP_SESSION_KEY.log`) and it logs everything above `Warn` to stderr but only if the log file does not contain the line that should be logged resulting in an error or warning to be only logged at the first starship invocation after opening the shell.
I choose the temp dir for storing logs as they can become quite large and most temp dir are cleared at reboot.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1075

#### Screenshots (if appropriate):
Wrong format string:
![image](https://user-images.githubusercontent.com/47182955/89935573-a7be2580-dc12-11ea-9b58-1c613f95ef7b.png)

Broken config:
![image](https://user-images.githubusercontent.com/47182955/89935622-befd1300-dc12-11ea-9fad-b4f987eaffd5.png)


#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
