### PR TITLE
fix(cmd_duration): Add spaces between units of time

### DIFF
--- a/src/modules/cmd_duration.rs
+++ b/src/modules/cmd_duration.rs
@@ -143,11 +143,11 @@ mod tests {
     }
     #[test]
     fn test_90s() {
-        assert_eq!(render_time(90_000 as u128, true), "1m30s")
+        assert_eq!(render_time(90_000 as u128, true), "1m 30s")
     }
     #[test]
     fn test_10110s() {
-        assert_eq!(render_time(10_110_000 as u128, true), "2h48m30s")
+        assert_eq!(render_time(10_110_000 as u128, true), "2h 48m 30s")
     }
     #[test]
     fn test_1d() {

--- a/src/modules/cmd_duration.rs
+++ b/src/modules/cmd_duration.rs
@@ -71,7 +71,8 @@ fn render_time(raw_millis: u128, show_millis: bool) -> String {
     if show_millis || raw_millis < 1000 {
         rendered_components.push(render_time_component((&millis, &"ms")));
     }
-    rendered_components.join("")
+    rendered_components.retain(|val| !val.is_empty());
+    rendered_components.join(" ")
 }
 
 /// Render a single component of the time string, giving an empty string if component is zero


### PR DESCRIPTION
#### Description
Adds spaces between individual units of time in the Command Duration module.
Achieved by trimming empty strings from `rendered_components` vector then joining them with a space instead of an empty string.

#### Motivation and Context
I believe the Command Duration module's clarity and appearance is improved with spaces.

#### Screenshots (if appropriate):
![screenshot](https://user-images.githubusercontent.com/32436504/90017627-b99bd900-dca3-11ea-9032-e0708dce3e2a.png)

#### How Has This Been Tested?
Edited `cmd_module` tests to reflect new formatting.
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.