### PR TITLE
docs: Drop inexistent "number" variable from hostname section

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1275,7 +1275,6 @@ The `hostname` module shows the system hostname.
 
 | Variable | Example | Description                          |
 | -------- | ------- | ------------------------------------ |
-| number   | `1`     | The number of jobs                   |
 | symbol   |         | Mirrors the value of option `symbol` |
 | style\*  |         | Mirrors the value of option `style`  |
 


### PR DESCRIPTION
#### Description

The hostname module does not provide any "number" variable, its presence
in the documentation is likely due to some copy&paste from the jobs
module section, so let's drop it.