### PR TITLE
Switch to install the musl binaries by default

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -170,20 +170,14 @@ detect_platform() {
   local platform
   platform="$(uname -s | tr '[:upper:]' '[:lower:]')"
 
-  # check for MUSL
-  if [ "${platform}" = "linux" ]; then
-    if ldd /bin/sh | grep -i musl >/dev/null; then
-      platform=unknown-linux-musl
-    fi
-  fi
-
   # mingw is Git-Bash
   if echo "${platform}" | grep -i mingw >/dev/null; then
     platform=pc-windows-msvc
   fi
 
   if [ "${platform}" = "linux" ]; then
-    platform=unknown-linux-gnu
+    # use the statically compiled musl bins on linux to avoid linking issues.
+    platform=unknown-linux-musl
   fi
 
   if [ "${platform}" = "darwin" ]; then


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
We have had a few issues where users haave run the install script and
have ended up with a non-functioning version of starship because their
system doesn't have a required lib that we link against. To avoid these
problems it seems the easiest solution is to default to using the
statically compiled musl binaries. If a user knows that they are doing
they can use the non-statically compiled binaries by supplying the `-p`
argument to the installer. Note this is what other rust based tools such
as ripgrep do.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1528 
Closes #1091

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
