### PR TITLE
fix: restore add_newline configuration

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1,12 +1,5 @@
 # Configuration
 
-::: tip
-
-🔥 Configuration is currently being worked on.
-Many new configuration options will be available in coming releases.
-
-:::
-
 To get started configuring starship, create the following file: `~/.config/starship.toml`.
 
 ```sh
@@ -14,10 +7,9 @@ mkdir -p ~/.config && touch ~/.config/starship.toml
 ```
 
 All configuration for starship is done in this [TOML](https://github.com/toml-lang/toml) file:
-
 ```toml
 # Don't print a new line at the start of the prompt
-format = "$all"
+add_newline = false
 
 # Replace the "❯" symbol in the prompt with "➜"
 [character]                            # The name of the module we are configuring is "character"
@@ -145,6 +137,7 @@ This is the list of prompt-wide configuration options.
 
 | Option         | Default                        | Description                                           |
 | -------------- | ------------------------------ | ----------------------------------------------------- |
+| `add_newline`  | `true` | Add a new line before the start of the prompt. |
 | `format`       | [link](#default-prompt-format) | Configure the format of the prompt.                   |
 | `scan_timeout` | `30`                           | Timeout for starship to scan files (in milliseconds). |
 
@@ -154,7 +147,7 @@ This is the list of prompt-wide configuration options.
 # ~/.config/starship.toml
 
 # Disable the newline at the start of the prompt
-format = "$all"
+add_newline = false
 
 # Use custom format
 format = """
@@ -171,7 +164,7 @@ scan_timeout = 10
 The default `format` is used to define the format of the prompt, if empty or no `format` is provided. The default is as shown:
 
 ```toml
-format = "\n$all"
+format = "$all"
 
 # Which is equivalent to
 format = """

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -6,6 +6,7 @@ use starship_module_config_derive::ModuleConfig;
 pub struct StarshipRootConfig<'a> {
     pub format: &'a str,
     pub scan_timeout: u64,
+    pub add_newline: bool,
 }
 
 // List of default prompt order
@@ -70,8 +71,9 @@ pub const PROMPT_ORDER: &[&str] = &[
 impl<'a> RootModuleConfig<'a> for StarshipRootConfig<'a> {
     fn new() -> Self {
         StarshipRootConfig {
-            format: "\n$all",
+            format: "$all",
             scan_timeout: 30,
+            add_newline: true,
         }
     }
 }

--- a/src/modules/line_break.rs
+++ b/src/modules/line_break.rs
@@ -5,6 +5,11 @@ use crate::segment::Segment;
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     const LINE_ENDING: &str = "\n";
 
+    let show_newline = context.config.get_root_config().add_newline;
+    if show_newline == false {
+        return None;
+    }
+
     let mut module = context.new_module("line_break");
 
     module.set_segments(vec![Segment {

--- a/src/modules/line_break.rs
+++ b/src/modules/line_break.rs
@@ -28,8 +28,7 @@ mod tests {
     #[test]
     fn add_newline_by_default() {
         let expected = Some(String::from("\n"));
-        let actual = ModuleRenderer::new("line_break")
-            .collect();
+        let actual = ModuleRenderer::new("line_break").collect();
         assert_eq!(expected, actual);
     }
 
@@ -39,9 +38,7 @@ mod tests {
         let config = toml::toml! {
             add_newline = false
         };
-        let actual = ModuleRenderer::new("line_break")
-            .config(config)
-            .collect();
+        let actual = ModuleRenderer::new("line_break").config(config).collect();
         assert_eq!(expected, actual);
     }
 }

--- a/src/modules/line_break.rs
+++ b/src/modules/line_break.rs
@@ -6,7 +6,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     const LINE_ENDING: &str = "\n";
 
     let show_newline = context.config.get_root_config().add_newline;
-    if show_newline == false {
+    if !show_newline {
         return None;
     }
 

--- a/src/modules/line_break.rs
+++ b/src/modules/line_break.rs
@@ -20,3 +20,28 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
     Some(module)
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::test::ModuleRenderer;
+
+    #[test]
+    fn add_newline_by_default() {
+        let expected = Some(String::from("\n"));
+        let actual = ModuleRenderer::new("line_break")
+            .collect();
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn dont_add_newline_when_disabled() {
+        let expected = None;
+        let config = toml::toml! {
+            add_newline = false
+        };
+        let actual = ModuleRenderer::new("line_break")
+            .config(config)
+            .collect();
+        assert_eq!(expected, actual);
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Re-implements the `add_newline` root configuration option, along with documentation and tests.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1549 

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
