### PR TITLE
fix: Add a fallback prompt under TERM=dumb

### DIFF
--- a/src/print.rs
+++ b/src/print.rs
@@ -26,6 +26,15 @@ pub fn get_prompt(context: Context) -> String {
     let config = context.config.get_root_config();
     let mut buf = String::new();
 
+    match std::env::var_os("TERM") {
+        Some(term) if term == "dumb" => {
+            log::error!("Under a 'dumb' terminal (TERM=dumb).");
+            buf.push_str("Starship disabled due to TERM=dumb > ");
+            return buf;
+        }
+        _ => {}
+    }
+
     // A workaround for a fish bug (see #739,#279). Applying it to all shells
     // breaks things (see #808,#824,#834). Should only be printed in fish.
     if let Shell::Fish = context.shell {


### PR DESCRIPTION
#### Description

This fallback is the quick-fix for #1588

#### Motivation and Context

See https://github.com/starship/starship/issues/1588#issuecomment-674568040

#### How Has This Been Tested?

Ran it under `env`, `env 'TERM=dumb` and `env 'TERM=dumber`.

- [ ] I have tested using **MacOS**
- [X] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:

So far this is missing tests and documentation changes.
I'm not sure how to write the test for it (new to rust and this project), nor whether
should this behavior be documented nor where.

- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
