### PR TITLE
docs: Improvements in docs for custom modules

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2282,6 +2282,13 @@ By default, the `custom` module will simply show all custom modules in the order
 
 :::
 
+::: tip
+
+[Issue #1252](https://github.com/starship/starship/discussions/1252) contains examples of custom modules.
+If you have an interesting example not covered there, feel free to share it there!
+
+:::
+
 ### Options
 
 | Option        | Default                       | Description                                                                                                                |

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2276,9 +2276,9 @@ Multiple custom modules can be defined by using a `.`.
 
 ::: tip
 
-The order in which custom modules are shown can be individually set
-by setting `custom.foo` in `prompt_order`. By default, the `custom` module
-will simply show all custom modules in the order they were defined.
+The order in which custom modules are shown can be individually set by including 
+`${custom.foo}` in `prompt_order` (as it includes a dot, you need to use `${...}`). 
+By default, the `custom` module will simply show all custom modules in the order they were defined.
 
 :::
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2277,7 +2277,7 @@ Multiple custom modules can be defined by using a `.`.
 ::: tip
 
 The order in which custom modules are shown can be individually set by including 
-`${custom.foo}` in `prompt_order` (as it includes a dot, you need to use `${...}`). 
+`${custom.foo}` in the top level `format` (as it includes a dot, you need to use `${...}`). 
 By default, the `custom` module will simply show all custom modules in the order they were defined.
 
 :::

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2286,7 +2286,7 @@ will simply show all custom modules in the order they were defined.
 
 | Option        | Default                       | Description                                                                                                                |
 | ------------- | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `command`     |                               | The command whose output should be printed.                                                                                |
+| `command`     |                               | The command whose output should be printed. The command will be passed on stdin to the shell.                              |
 | `when`        |                               | A shell command used as a condition to show the module. The module will be shown if the command returns a `0` status code. |
 | `shell`       |                               | [See below](#custom-command-shell)                                                                                         |
 | `description` | `"<custom module>"`           | The description of the module that is shown when running `starship explain`.                                               |
@@ -2316,6 +2316,8 @@ will simply show all custom modules in the order they were defined.
 - Other following arguments are passed to the shell.
 
 If unset, it will fallback to STARSHIP_SHELL and then to "sh" on Linux, and "cmd /C" on Windows.
+
+The `command` will be passed in on stdin.
 
 If `shell` is not given or only contains one element and Starship detects PowerShell will be used,
 the following arguments will automatically be added: `-NoProfile -Command -`.

--- a/docs/faq/README.md
+++ b/docs/faq/README.md
@@ -10,11 +10,11 @@
   - **Configuration**: [matchai's Dotfiles](https://github.com/matchai/dotfiles/blob/b6c6a701d0af8d145a8370288c00bb9f0648b5c2/.config/fish/config.fish)
   - **Prompt**: [Starship](https://starship.rs/)
 
-## Do `prompt_order` and `<module>.disabled` do the same thing?
+## Do top level `format` and `<module>.disabled` do the same thing?
 
 Yes, they can both be used to disable modules in the prompt. If all you plan to do is disable modules, `<module>.disabled` is the preferred way to do so for these reasons:
 
-- Disabling modules is more explicit than omitting them from the prompt_order
+- Disabling modules is more explicit than omitting them from the top level `format`
 - Newly created modules will be added to the prompt as Starship is updated
 
 ## The docs say Starship is cross-shell, but it doesn't support X shell. Why?

--- a/src/print.rs
+++ b/src/print.rs
@@ -249,19 +249,19 @@ fn handle_module<'a>(
             Some(false) => modules.push(modules::custom::module(&module[7..], &context)),
             None => match context.config.get_custom_modules() {
                 Some(modules) => log::debug!(
-                    "prompt_order contains custom module \"{}\", but no configuration was provided. Configuration for the following modules were provided: {:?}",
+                    "top level format contains custom module \"{}\", but no configuration was provided. Configuration for the following modules were provided: {:?}",
                     module,
                     DebugCustomModules(modules),
                     ),
                 None => log::debug!(
-                    "prompt_order contains custom module \"{}\", but no configuration was provided.",
+                    "top level format contains custom module \"{}\", but no configuration was provided.",
                     module,
                     ),
             },
         }
     } else {
         log::debug!(
-            "Expected prompt_order to contain value from {:?}. Instead received {}",
+            "Expected top level format to contain value from {:?}. Instead received {}",
             ALL_MODULES,
             module,
         );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description

* Document that commands are passed in as stdin (so don't use `/usr/bin/zsh -c` as shell as I did for 2 hours without figuring out whats going on...).
* Document that you need curly braces arround individual custom modules in when setting prompt_order
* Add link to #1252 


#### Motivation and Context
It took me about 2 hours to figure out how to do this and this is what I would have liked to see in the docs.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
