### PR TITLE
[chore] Update ocaml.rs to support latest ReScript extensions

### DIFF
--- a/src/modules/ocaml.rs
+++ b/src/modules/ocaml.rs
@@ -18,7 +18,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         .try_begin_scan()?
         .set_files(&["dune", "dune-project", "jbuild", "jbuild-ignore", ".merlin"])
         .set_folders(&["_opam", "esy.lock"])
-        .set_extensions(&["opam", "ml", "mli", "re", "rei"])
+        .set_extensions(&["opam", "ml", "mli", "re", "rei", "res", "resi"])
         .is_match();
 
     if !is_ocaml_project {


### PR DESCRIPTION
Support latest ReScript file extensions.

#### Description

The latest updates to BuckleScript/ReScript include a new syntax that works under a new extension (.res/.resi).

#### Motivation and Context

Brings full file extension support for Reason/ReScript.