### PR TITLE
feat: Make git_branch and kubernetes prefixes configurable

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -993,14 +993,15 @@ The `git_branch` module shows the active branch of the repo in your current dire
 
 ### Options
 
-| Option              | Default                          | Description                                                                              |
-| ------------------- | -------------------------------- | ---------------------------------------------------------------------------------------- |
-| `format`            | `"on [$symbol$branch]($style) "` | The format for the module.  Use `"$branch"` to refer to the current branch name.         |
-| `symbol`            | `" "`                           | A format string representing the symbol of git branch.                                   |
-| `style`             | `"bold purple"`                  | The style for the module.                                                                |
-| `truncation_length` | `2^63 - 1`                       | Truncates a git branch to X graphemes.                                                   |
-| `truncation_symbol` | `"…"`                            | The symbol used to indicate a branch name was truncated. You can use `""` for no symbol. |
-| `disabled`          | `false`                          | Disables the `git_branch` module.                                                        |
+| Option              | Default                              | Description                                                                              |
+| ------------------- | ------------------------------------ | ---------------------------------------------------------------------------------------- |
+| `format`            | `"$prefix[$symbol$branch]($style) "` | The format for the module.  Use `"$branch"` to refer to the current branch name.         |
+| `symbol`            | `" "`                               | A format string representing the symbol of git branch.                                   |
+| `style`             | `"bold purple"`                      | The style for the module.                                                                |
+| `prefix`            | `"on "`                              | The prefix for the module                                                                |
+| `truncation_length` | `2^63 - 1`                           | Truncates a git branch to X graphemes.                                                   |
+| `truncation_symbol` | `"…"`                                | The symbol used to indicate a branch name was truncated. You can use `""` for no symbol. |
+| `disabled`          | `false`                              | Disables the `git_branch` module.                                                        |
 
 ### Variables
 
@@ -1411,14 +1412,15 @@ To enable it, set `disabled` to `false` in your configuration file.
 
 ### Options
 
-| Option                  | Default                                              | Description                                                           |
-| ----------------------- | ---------------------------------------------------- | --------------------------------------------------------------------- |
-| `symbol`                | `"☸ "`                                              | A format string representing the symbol displayed before the Cluster. |
-| `format`                | `"on [$symbol$context( \\($namespace\\))]($style) "` | The format for the module.                                            |
-| `style`                 | `"cyan bold"`                                        | The style for the module.                                             |
-| `namespace_spaceholder` | `none`                                               | The value to display if no namespace was found.                       |
-| `context_aliases`       |                                                      | Table of context aliases to display.                                  |
-| `disabled`              | `true`                                               | Disables the `kubernetes` module.                                     |
+| Option                  | Default                                                  | Description                                                           |
+| ----------------------- | -------------------------------------------------------- | --------------------------------------------------------------------- |
+| `format`                | `"$prefix[$symbol$context( \\($namespace\\))]($style) "` | The format for the module.                                            |
+| `symbol`                | `"☸ "`                                                   | A format string representing the symbol displayed before the Cluster. |
+| `prefix`                | `"on "`                                                  | The prefix for the module.                                            |
+| `style`                 | `"cyan bold"`                                            | The style for the module.                                             |
+| `namespace_spaceholder` | `none`                                                   | The value to display if no namespace was found.                       |
+| `context_aliases`       |                                                          | Table of context aliases to display.                                  |
+| `disabled`              | `true`                                                   | Disables the `kubernetes` module.                                     |
 
 ### Variables
 

--- a/src/configs/git_branch.rs
+++ b/src/configs/git_branch.rs
@@ -7,6 +7,7 @@ pub struct GitBranchConfig<'a> {
     pub format: &'a str,
     pub symbol: &'a str,
     pub style: &'a str,
+    pub prefix: &'a str,
     pub truncation_length: i64,
     pub truncation_symbol: &'a str,
     pub disabled: bool,
@@ -15,9 +16,10 @@ pub struct GitBranchConfig<'a> {
 impl<'a> RootModuleConfig<'a> for GitBranchConfig<'a> {
     fn new() -> Self {
         GitBranchConfig {
-            format: "on [$symbol$branch]($style) ",
+            format: "$prefix[$symbol$branch]($style) ",
             symbol: " ",
             style: "bold purple",
+            prefix: "on ",
             truncation_length: std::i64::MAX,
             truncation_symbol: "…",
             disabled: false,

--- a/src/configs/kubernetes.rs
+++ b/src/configs/kubernetes.rs
@@ -6,6 +6,7 @@ use std::collections::HashMap;
 #[derive(Clone, ModuleConfig)]
 pub struct KubernetesConfig<'a> {
     pub symbol: &'a str,
+    pub prefix: &'a str,
     pub format: &'a str,
     pub style: &'a str,
     pub disabled: bool,
@@ -16,7 +17,8 @@ impl<'a> RootModuleConfig<'a> for KubernetesConfig<'a> {
     fn new() -> Self {
         KubernetesConfig {
             symbol: "☸ ",
-            format: "on [$symbol$context( \\($namespace\\))]($style) ",
+            prefix: "on ",
+            format: "$prefix[$symbol$context( \\($namespace\\))]($style) ",
             style: "cyan bold",
             disabled: true,
             context_aliases: HashMap::new(),

--- a/src/modules/git_branch.rs
+++ b/src/modules/git_branch.rs
@@ -288,6 +288,7 @@ mod tests {
             truncate_length,
             expected_name,
             truncation_symbol,
+            "on ",
             "",
         )
     }
@@ -297,6 +298,7 @@ mod tests {
         truncate_length: i64,
         expected_name: &str,
         truncation_symbol: &str,
+        prefix: &str,
         config_options: &str,
     ) -> io::Result<()> {
         let repo_dir = fixture_repo(FixtureProvider::GIT)?;
@@ -312,9 +314,10 @@ mod tests {
                     "
                     [git_branch]
                         truncation_length = {}
+                        prefix = {}
                         {}
                 ",
-                    truncate_length, config_options
+                    truncate_length, prefix, config_options
                 ))
                 .unwrap(),
             )

--- a/src/modules/git_branch.rs
+++ b/src/modules/git_branch.rs
@@ -288,8 +288,7 @@ mod tests {
             truncate_length,
             expected_name,
             truncation_symbol,
-            "on ",
-            "",
+            "prefix = \"on \"",
         )
     }
 
@@ -298,7 +297,6 @@ mod tests {
         truncate_length: i64,
         expected_name: &str,
         truncation_symbol: &str,
-        prefix: &str,
         config_options: &str,
     ) -> io::Result<()> {
         let repo_dir = fixture_repo(FixtureProvider::GIT)?;
@@ -314,10 +312,9 @@ mod tests {
                     "
                     [git_branch]
                         truncation_length = {}
-                        prefix = {}
                         {}
                 ",
-                    truncate_length, prefix, config_options
+                    truncate_length, config_options
                 ))
                 .unwrap(),
             )

--- a/src/modules/git_branch.rs
+++ b/src/modules/git_branch.rs
@@ -288,7 +288,7 @@ mod tests {
             truncate_length,
             expected_name,
             truncation_symbol,
-            "prefix = \"on \"",
+            "",
         )
     }
 
@@ -311,6 +311,7 @@ mod tests {
                 toml::from_str(&format!(
                     "
                     [git_branch]
+                        prefix = \"on\"
                         truncation_length = {}
                         {}
                 ",

--- a/src/modules/git_branch.rs
+++ b/src/modules/git_branch.rs
@@ -52,6 +52,10 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 "branch" => Some(Ok(graphemes.concat())),
                 _ => None,
             })
+            .map(|variable| match variable {
+                "prefix" => Some(Ok(config.prefix)),
+                _ => None,
+            })
             .parse(None)
     });
 
@@ -311,7 +315,7 @@ mod tests {
                 toml::from_str(&format!(
                     "
                     [git_branch]
-                        prefix = \"on\"
+                        prefix = \"on \"
                         truncation_length = {}
                         {}
                 ",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
I _think_ I did this right.

I want to remove `on` from the the `git_branch` indicator. This will allow me to customize the prefix, but keeps the current behavior as default.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
let me know what I need to do here...
- [x] I have updated the tests accordingly.
ditto