### PR TITLE
fix: use suffixes for modules before directory

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -7,6 +7,7 @@ mkdir -p ~/.config && touch ~/.config/starship.toml
 ```
 
 All configuration for starship is done in this [TOML](https://github.com/toml-lang/toml) file:
+
 ```toml
 # Don't print a new line at the start of the prompt
 add_newline = false
@@ -38,7 +39,7 @@ $ENV:STARSHIP_CONFIG = "$HOME\.starship"
 
 **Variable**: Smaller sub-components that contains information provided by the module. For example, the "version" variable in the "nodejs" module contains the current version of NodeJS.
 
-By convention, most modules have a prefix of default terminal color (e.g. `via ` in "nodejs") and an empty space as a suffix.
+By convention, most modules have a prefix of default terminal color (e.g. `via` in "nodejs") and an empty space as a suffix.
 
 ### Format Strings
 
@@ -69,7 +70,7 @@ In the second part, which is enclosed in a `()`, is a [style string](#style-stri
 For example:
 
 - `[on](red bold)` will print a string `on` with bold text colored red.
-- `[⬢ $version](bold green)` will print a symbol `⬢ ` followed by the content of variable `version`, with bold text colored green.
+- `[⬢ $version](bold green)` will print a symbol `⬢` followed by the content of variable `version`, with bold text colored green.
 - `[a [b](red) c](green)` will print `a b c` with `b` red, and `a` and `c` green.
 
 #### Style Strings
@@ -93,7 +94,7 @@ For example:
 
 - `(@$region)` will show nothing if the variable `region` is `None`, otherwise `@` followed by the value of region.
 - `(some text)` will always show nothing since there are no variables wrapped in the braces.
-- When `$all` is a shortcut for `\[$a$b\] `, `($all)` will show nothing only if `$a` and `$b` are both `None`.
+- When `$all` is a shortcut for `\[$a$b\]`, `($all)` will show nothing only if `$a` and `$b` are both `None`.
   This works the same as `(\[$a$b\] )`.
 
 #### Escapable characters
@@ -101,7 +102,7 @@ For example:
 The following symbols have special usage in a format string.
 If you want to print the following symbols, you have to escape them with a backslash (`\`).
 
-- $
+- \$
 - \\
 - [
 - ]
@@ -874,7 +875,7 @@ The module will be shown only if any of the following conditions are met:
 
 | Variable  | Example                                     | Description                                |
 | --------- | ------------------------------------------- | ------------------------------------------ |
-| env_value | `Windows NT` (if *variable* would be `$OS`) | The environment value of option `variable` |
+| env_value | `Windows NT` (if _variable_ would be `$OS`) | The environment value of option `variable` |
 | symbol    |                                             | Mirrors the value of option `symbol`       |
 | style\*   | `black bold dimmed`                         | Mirrors the value of option `style`        |
 
@@ -902,7 +903,7 @@ The module will be shown if any of the following conditions are met:
 
 | Option     | Default                            | Description                                              |
 | ---------- | ---------------------------------- | -------------------------------------------------------- |
-| `symbol`   | `"🖧 "`                            | The symbol used before displaying the version of erlang. |
+| `symbol`   | `"🖧 "`                             | The symbol used before displaying the version of erlang. |
 | `style`    | `"bold red"`                       | The style for the module.                                |
 | `format`   | `"via [$symbol$version]($style) "` | The format for the module.                               |
 | `disabled` | `false`                            | Disables the `erlang` module.                            |
@@ -933,13 +934,13 @@ This is based on the `~/.config/gcloud/active_config` file and the `~/.config/gc
 
 ### Options
 
-| Variable          | Default                                           | Description                                                                 |
-| ----------------- | ------------------------------------------------- | --------------------------------------------------------------------------- |
-| `format`          | `"on [$symbol$account(\\($region\\))]($style) "`  | The format for the module.                                                  |
-| `symbol`          | `"☁️ "`                                            | The symbol used before displaying the current GCP profile.                  |
-| `region_aliases`  |                                                   | Table of region aliases to display in addition to the GCP name.             |
-| `style`           | `"bold blue"`                                     | The style for the module.                                                   |
-| `disabled`        | `false`                                           | Disables the `gcloud` module.                                               |
+| Variable         | Default                                          | Description                                                     |
+| ---------------- | ------------------------------------------------ | --------------------------------------------------------------- |
+| `format`         | `"on [$symbol$account(\\($region\\))]($style) "` | The format for the module.                                      |
+| `symbol`         | `"☁️ "`                                          | The symbol used before displaying the current GCP profile.      |
+| `region_aliases` |                                                  | Table of region aliases to display in addition to the GCP name. |
+| `style`          | `"bold blue"`                                    | The style for the module.                                       |
+| `disabled`       | `false`                                          | Disables the `gcloud` module.                                   |
 
 ### Variables
 
@@ -995,7 +996,7 @@ The `git_branch` module shows the active branch of the repo in your current dire
 
 | Option              | Default                          | Description                                                                              |
 | ------------------- | -------------------------------- | ---------------------------------------------------------------------------------------- |
-| `format`            | `"on [$symbol$branch]($style) "` | The format for the module.  Use `"$branch"` to refer to the current branch name.         |
+| `format`            | `"on [$symbol$branch]($style) "` | The format for the module. Use `"$branch"` to refer to the current branch name.          |
 | `symbol`            | `" "`                           | A format string representing the symbol of git branch.                                   |
 | `style`             | `"bold purple"`                  | The style for the module.                                                                |
 | `truncation_length` | `2^63 - 1`                       | Truncates a git branch to X graphemes.                                                   |
@@ -1131,12 +1132,12 @@ The following variables can be used in `format`:
 | `all_status`   | Shortcut for`$conflicted$stashed$deleted$renamed$modified$staged$untracked`                   |
 | `ahead_behind` | Displays `diverged` `ahead` or `behind` format string based on the current status of the repo |
 | `conflicted`   | Displays `conflicted` when this branch has merge conflicts.                                   |
-| `untracked`    | Displays `untracked`  when there are untracked files in the working directory.                |
-| `stashed`      | Displays `stashed`    when a stash exists for the local repository.                           |
-| `modified`     | Displays `modified`   when there are file modifications in the working directory.             |
-| `staged`       | Displays `staged`     when a new file has been added to the staging area.                     |
-| `renamed`      | Displays `renamed`    when a renamed file has been added to the staging area.                 |
-| `deleted`      | Displays `deleted`    when a file's deletion has been added to the staging area.              |
+| `untracked`    | Displays `untracked` when there are untracked files in the working directory.                 |
+| `stashed`      | Displays `stashed` when a stash exists for the local repository.                              |
+| `modified`     | Displays `modified` when there are file modifications in the working directory.               |
+| `staged`       | Displays `staged` when a new file has been added to the staging area.                         |
+| `renamed`      | Displays `renamed` when a renamed file has been added to the staging area.                    |
+| `deleted`      | Displays `deleted` when a file's deletion has been added to the staging area.                 |
 | style\*        | Mirrors the value of option `style`                                                           |
 
 \*: This variable can only be used as a part of a style string
@@ -1224,20 +1225,20 @@ The module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Option     | Default                            | Description                                    |
-| ---------- | ---------------------------------- | ---------------------------------------------- |
-| `format`   | `"via [$symbol$version]($style) "` | The format for the module.                     |
-| `symbol`   | `"⎈ "`                            | A format string representing the symbol of Helm. |
-| `style`    | `"bold white"`                      | The style for the module.                      |
-| `disabled` | `false`                            | Disables the `helm` module.                  |
+| Option     | Default                            | Description                                      |
+| ---------- | ---------------------------------- | ------------------------------------------------ |
+| `format`   | `"via [$symbol$version]($style) "` | The format for the module.                       |
+| `symbol`   | `"⎈ "`                             | A format string representing the symbol of Helm. |
+| `style`    | `"bold white"`                     | The style for the module.                        |
+| `disabled` | `false`                            | Disables the `helm` module.                      |
 
 ### Variables
 
-| Variable | Example   | Description                          |
-| -------- | --------- | ------------------------------------ |
-| version  | `v3.1.1` | The version of `helm`                  |
-| symbol   |           | Mirrors the value of option `symbol` |
-| style\*  |           | Mirrors the value of option `style`  |
+| Variable | Example  | Description                          |
+| -------- | -------- | ------------------------------------ |
+| version  | `v3.1.1` | The version of `helm`                |
+| symbol   |          | Mirrors the value of option `symbol` |
+| style\*  |          | Mirrors the value of option `style`  |
 
 \*: This variable can only be used as a part of a style string
 
@@ -1256,13 +1257,13 @@ The `hostname` module shows the system hostname.
 
 ### Options
 
-| Option     | Default                     | Description                                                                                                                          |
-| ---------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `ssh_only` | `true`                      | Only show hostname when connected to an SSH session.                                                                                 |
-| `trim_at`  | `"."`                       | String that the hostname is cut off at, after the first match. `"."` will stop after the first dot. `""` will disable any truncation |
-| `format`   | `"on [$hostname]($style) "` | The format for the module.                                                                                                           |
-| `style`    | `"bold dimmed green"`       | The style for the module.                                                                                                            |
-| `disabled` | `false`                     | Disables the `hostname` module.                                                                                                      |
+| Option     | Default                    | Description                                                                                                                          |
+| ---------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `ssh_only` | `true`                     | Only show hostname when connected to an SSH session.                                                                                 |
+| `trim_at`  | `"."`                      | String that the hostname is cut off at, after the first match. `"."` will stop after the first dot. `""` will disable any truncation |
+| `format`   | `"[$hostname]($style) on "` | The format for the module.                                                                                                           |
+| `style`    | `"bold dimmed green"`      | The style for the module.                                                                                                            |
+| `disabled` | `false`                    | Disables the `hostname` module.                                                                                                      |
 
 ### Variables
 
@@ -1411,14 +1412,14 @@ To enable it, set `disabled` to `false` in your configuration file.
 
 ### Options
 
-| Option                  | Default                                              | Description                                                           |
-| ----------------------- | ---------------------------------------------------- | --------------------------------------------------------------------- |
+| Option                  | Default                                             | Description                                                           |
+| ----------------------- | --------------------------------------------------- | --------------------------------------------------------------------- |
 | `symbol`                | `"☸ "`                                              | A format string representing the symbol displayed before the Cluster. |
-| `format`                | `"on [$symbol$context( \\($namespace\\))]($style) "` | The format for the module.                                            |
-| `style`                 | `"cyan bold"`                                        | The style for the module.                                             |
-| `namespace_spaceholder` | `none`                                               | The value to display if no namespace was found.                       |
-| `context_aliases`       |                                                      | Table of context aliases to display.                                  |
-| `disabled`              | `true`                                               | Disables the `kubernetes` module.                                     |
+| `format`                | `"[$symbol$context( \\($namespace\\))]($style) on "` | The format for the module.                                            |
+| `style`                 | `"cyan bold"`                                       | The style for the module.                                             |
+| `namespace_spaceholder` | `none`                                              | The value to display if no namespace was found.                       |
+| `context_aliases`       |                                                     | Table of context aliases to display.                                  |
+| `disabled`              | `true`                                              | Disables the `kubernetes` module.                                     |
 
 ### Variables
 
@@ -1487,14 +1488,14 @@ To enable it, set `disabled` to `false` in your configuration file.
 
 ### Variables
 
-| Variable    | Example       | Description                                                        |
-| ----------- | ------------- | ------------------------------------------------------------------ |
-| ram         | `31GiB/65GiB` | The usage/total RAM of the current system memory.                  |
-| ram_pct     | `48%`         | The percentage of the current system memory.                       |
-| swap\**     | `1GiB/4GiB`   | The swap memory size of the current system swap memory file.       |
-| swap_pct\** | `77%`         | The swap memory percentage of the current system swap memory file. |
-| symbol      | `🐏`          | Mirrors the value of option `symbol`                               |
-| style\*     |               | Mirrors the value of option `style`                                |
+| Variable     | Example       | Description                                                        |
+| ------------ | ------------- | ------------------------------------------------------------------ |
+| ram          | `31GiB/65GiB` | The usage/total RAM of the current system memory.                  |
+| ram_pct      | `48%`         | The percentage of the current system memory.                       |
+| swap\*\*     | `1GiB/4GiB`   | The swap memory size of the current system swap memory file.       |
+| swap_pct\*\* | `77%`         | The swap memory percentage of the current system swap memory file. |
+| symbol       | `🐏`          | Mirrors the value of option `symbol`                               |
+| style\*      |               | Mirrors the value of option `style`                                |
 
 \*: This variable can only be used as a part of a style string
 \*\*: The SWAP file information is only displayed if detected on the current system
@@ -1599,7 +1600,7 @@ The module will be shown when inside a nix-shell environment.
 | Option       | Default                                        | Description                                           |
 | ------------ | ---------------------------------------------- | ----------------------------------------------------- |
 | `format`     | `"via [$symbol$state( \\($name\\))]($style) "` | The format for the module.                            |
-| `symbol`     | `"❄️  "`                                       | A format string representing the symbol of nix-shell. |
+| `symbol`     | `"❄️ "`                                        | A format string representing the symbol of nix-shell. |
 | `style`      | `"bold blue"`                                  | The style for the module.                             |
 | `impure_msg` | `"impure"`                                     | A format string shown when the shell is impure.       |
 | `pure_msg`   | `"pure"`                                       | A format string shown when the shell is pure.         |
@@ -1759,7 +1760,6 @@ The module will be shown if any of the following conditions are met:
 format = "via [🐪 $version]($style) "
 ```
 
-
 ## Perl
 
 The `perl` module shows the currently installed version of Perl.
@@ -1774,8 +1774,8 @@ The module will be shown if any of the following conditions are met:
 ### Options
 
 | Variable   | Default                            | Description                                           |
-| ---------- |----------------------------------- | ----------------------------------------------------- |
-| `format`   | `"via [$symbol$version]($style) "` | The format string for the module.|
+| ---------- | ---------------------------------- | ----------------------------------------------------- |
+| `format`   | `"via [$symbol$version]($style) "` | The format string for the module.                     |
 | `symbol`   | `"🐪 "`                            | The symbol used before displaying the version of Perl |
 | `style`    | `"bold 149"`                       | The style for the module.                             |
 | `disabled` | `false`                            | Disables the `perl` module.                           |
@@ -1796,7 +1796,6 @@ The module will be shown if any of the following conditions are met:
 [perl]
 format = "via [🦪 $version]($style) "
 ```
-
 
 ## PHP
 
@@ -1985,21 +1984,21 @@ set to a number and meets or exceeds the specified threshold.
 
 ### Options
 
-| Variable    | Default                      | Description                                      |
-| ----------- | ---------------------------- | ------------------------------------------------ |
-| `threshold` | `2`                          | Display threshold.                               |
-| `format`    | `"[$symbol$shlvl]($style) "` | The format for the module.                       |
-| `symbol`    | `"↕️ "`                       | The symbol used to represent the SHLVL.          |
-| `style`     | `"bold yellow"`              | The style for the module.                        |
-| `disabled`  | `true`                       | Disables the `shlvl` module.                     |
+| Variable    | Default                      | Description                             |
+| ----------- | ---------------------------- | --------------------------------------- |
+| `threshold` | `2`                          | Display threshold.                      |
+| `format`    | `"[$symbol$shlvl]($style) "` | The format for the module.              |
+| `symbol`    | `"↕️ "`                      | The symbol used to represent the SHLVL. |
+| `style`     | `"bold yellow"`              | The style for the module.               |
+| `disabled`  | `true`                       | Disables the `shlvl` module.            |
 
 ### Variables
 
-| Variable | Example   | Description                          |
-| -------- | --------- | ------------------------------------ |
-| shlvl    | `3`       | The current value of SHLVL           |
-| symbol   |           | Mirrors the value of option `symbol` |
-| style\*  |           | Mirrors the value of option `style`  |
+| Variable | Example | Description                          |
+| -------- | ------- | ------------------------------------ |
+| shlvl    | `3`     | The current value of SHLVL           |
+| symbol   |         | Mirrors the value of option `symbol` |
+| style\*  |         | Mirrors the value of option `style`  |
 
 \*: This variable can only be used as a part of a style string
 
@@ -2194,13 +2193,13 @@ The module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Option        | Default                  | Description                           |
-| ------------- | ------------------------ | ------------------------------------- |
-| `style_root`  | `"bold red"`             | The style used when the user is root. |
-| `style_user`  | `"bold yellow"`          | The style used for non-root users.    |
-| `format`      | `"via [$user]($style) "` | The format for the module.            |
-| `show_always` | `false`                  | Always shows the `username` module.   |
-| `disabled`    | `false`                  | Disables the `username` module.       |
+| Option        | Default                | Description                           |
+| ------------- | ---------------------- | ------------------------------------- |
+| `style_root`  | `"bold red"`           | The style used when the user is root. |
+| `style_user`  | `"bold yellow"`        | The style used for non-root users.    |
+| `format`      | `"[$user]($style) on "` | The format for the module.            |
+| `show_always` | `false`                | Always shows the `username` module.   |
+| `disabled`    | `false`                | Disables the `username` module.       |
 
 ### Variables
 
@@ -2276,8 +2275,8 @@ Multiple custom modules can be defined by using a `.`.
 
 ::: tip
 
-The order in which custom modules are shown can be individually set by including 
-`${custom.foo}` in the top level `format` (as it includes a dot, you need to use `${...}`). 
+The order in which custom modules are shown can be individually set by including
+`${custom.foo}` in the top level `format` (as it includes a dot, you need to use `${...}`).
 By default, the `custom` module will simply show all custom modules in the order they were defined.
 
 :::

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1257,13 +1257,13 @@ The `hostname` module shows the system hostname.
 
 ### Options
 
-| Option     | Default                    | Description                                                                                                                          |
-| ---------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `ssh_only` | `true`                     | Only show hostname when connected to an SSH session.                                                                                 |
-| `trim_at`  | `"."`                      | String that the hostname is cut off at, after the first match. `"."` will stop after the first dot. `""` will disable any truncation |
+| Option     | Default                     | Description                                                                                                                          |
+| ---------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `ssh_only` | `true`                      | Only show hostname when connected to an SSH session.                                                                                 |
+| `trim_at`  | `"."`                       | String that the hostname is cut off at, after the first match. `"."` will stop after the first dot. `""` will disable any truncation |
 | `format`   | `"[$hostname]($style) in "` | The format for the module.                                                                                                           |
-| `style`    | `"bold dimmed green"`      | The style for the module.                                                                                                            |
-| `disabled` | `false`                    | Disables the `hostname` module.                                                                                                      |
+| `style`    | `"bold dimmed green"`       | The style for the module.                                                                                                            |
+| `disabled` | `false`                     | Disables the `hostname` module.                                                                                                      |
 
 ### Variables
 
@@ -1412,14 +1412,14 @@ To enable it, set `disabled` to `false` in your configuration file.
 
 ### Options
 
-| Option                  | Default                                             | Description                                                           |
-| ----------------------- | --------------------------------------------------- | --------------------------------------------------------------------- |
-| `symbol`                | `"☸ "`                                              | A format string representing the symbol displayed before the Cluster. |
+| Option                  | Default                                              | Description                                                           |
+| ----------------------- | ---------------------------------------------------- | --------------------------------------------------------------------- |
+| `symbol`                | `"☸ "`                                               | A format string representing the symbol displayed before the Cluster. |
 | `format`                | `"[$symbol$context( \\($namespace\\))]($style) in "` | The format for the module.                                            |
-| `style`                 | `"cyan bold"`                                       | The style for the module.                                             |
-| `namespace_spaceholder` | `none`                                              | The value to display if no namespace was found.                       |
-| `context_aliases`       |                                                     | Table of context aliases to display.                                  |
-| `disabled`              | `true`                                              | Disables the `kubernetes` module.                                     |
+| `style`                 | `"cyan bold"`                                        | The style for the module.                                             |
+| `namespace_spaceholder` | `none`                                               | The value to display if no namespace was found.                       |
+| `context_aliases`       |                                                      | Table of context aliases to display.                                  |
+| `disabled`              | `true`                                               | Disables the `kubernetes` module.                                     |
 
 ### Variables
 
@@ -2193,13 +2193,13 @@ The module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Option        | Default                | Description                           |
-| ------------- | ---------------------- | ------------------------------------- |
-| `style_root`  | `"bold red"`           | The style used when the user is root. |
-| `style_user`  | `"bold yellow"`        | The style used for non-root users.    |
+| Option        | Default                 | Description                           |
+| ------------- | ----------------------- | ------------------------------------- |
+| `style_root`  | `"bold red"`            | The style used when the user is root. |
+| `style_user`  | `"bold yellow"`         | The style used for non-root users.    |
 | `format`      | `"[$user]($style) in "` | The format for the module.            |
-| `show_always` | `false`                | Always shows the `username` module.   |
-| `disabled`    | `false`                | Disables the `username` module.       |
+| `show_always` | `false`                 | Always shows the `username` module.   |
+| `disabled`    | `false`                 | Disables the `username` module.       |
 
 ### Variables
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1261,7 +1261,7 @@ The `hostname` module shows the system hostname.
 | ---------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
 | `ssh_only` | `true`                     | Only show hostname when connected to an SSH session.                                                                                 |
 | `trim_at`  | `"."`                      | String that the hostname is cut off at, after the first match. `"."` will stop after the first dot. `""` will disable any truncation |
-| `format`   | `"[$hostname]($style) on "` | The format for the module.                                                                                                           |
+| `format`   | `"[$hostname]($style) in "` | The format for the module.                                                                                                           |
 | `style`    | `"bold dimmed green"`      | The style for the module.                                                                                                            |
 | `disabled` | `false`                    | Disables the `hostname` module.                                                                                                      |
 
@@ -1415,7 +1415,7 @@ To enable it, set `disabled` to `false` in your configuration file.
 | Option                  | Default                                             | Description                                                           |
 | ----------------------- | --------------------------------------------------- | --------------------------------------------------------------------- |
 | `symbol`                | `"☸ "`                                              | A format string representing the symbol displayed before the Cluster. |
-| `format`                | `"[$symbol$context( \\($namespace\\))]($style) on "` | The format for the module.                                            |
+| `format`                | `"[$symbol$context( \\($namespace\\))]($style) in "` | The format for the module.                                            |
 | `style`                 | `"cyan bold"`                                       | The style for the module.                                             |
 | `namespace_spaceholder` | `none`                                              | The value to display if no namespace was found.                       |
 | `context_aliases`       |                                                     | Table of context aliases to display.                                  |
@@ -2197,7 +2197,7 @@ The module will be shown if any of the following conditions are met:
 | ------------- | ---------------------- | ------------------------------------- |
 | `style_root`  | `"bold red"`           | The style used when the user is root. |
 | `style_user`  | `"bold yellow"`        | The style used for non-root users.    |
-| `format`      | `"[$user]($style) on "` | The format for the module.            |
+| `format`      | `"[$user]($style) in "` | The format for the module.            |
 | `show_always` | `false`                | Always shows the `username` module.   |
 | `disabled`    | `false`                | Disables the `username` module.       |
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -39,7 +39,7 @@ $ENV:STARSHIP_CONFIG = "$HOME\.starship"
 
 **Variable**: Smaller sub-components that contains information provided by the module. For example, the "version" variable in the "nodejs" module contains the current version of NodeJS.
 
-By convention, most modules have a prefix of default terminal color (e.g. `via` in "nodejs") and an empty space as a suffix.
+By convention, most modules have a prefix of default terminal color (e.g. `via ` in "nodejs") and an empty space as a suffix.
 
 ### Format Strings
 
@@ -70,7 +70,7 @@ In the second part, which is enclosed in a `()`, is a [style string](#style-stri
 For example:
 
 - `[on](red bold)` will print a string `on` with bold text colored red.
-- `[⬢ $version](bold green)` will print a symbol `⬢` followed by the content of variable `version`, with bold text colored green.
+- `[⬢ $version](bold green)` will print a symbol `⬢ ` followed by the content of variable `version`, with bold text colored green.
 - `[a [b](red) c](green)` will print `a b c` with `b` red, and `a` and `c` green.
 
 #### Style Strings
@@ -94,7 +94,7 @@ For example:
 
 - `(@$region)` will show nothing if the variable `region` is `None`, otherwise `@` followed by the value of region.
 - `(some text)` will always show nothing since there are no variables wrapped in the braces.
-- When `$all` is a shortcut for `\[$a$b\]`, `($all)` will show nothing only if `$a` and `$b` are both `None`.
+- When `$all` is a shortcut for `\[$a$b\] `, `($all)` will show nothing only if `$a` and `$b` are both `None`.
   This works the same as `(\[$a$b\] )`.
 
 #### Escapable characters

--- a/src/configs/hostname.rs
+++ b/src/configs/hostname.rs
@@ -16,7 +16,7 @@ impl<'a> RootModuleConfig<'a> for HostnameConfig<'a> {
         HostnameConfig {
             ssh_only: true,
             trim_at: ".",
-            format: "[$hostname]($style) on ",
+            format: "[$hostname]($style) in ",
             style: "green dimmed bold",
             disabled: false,
         }

--- a/src/configs/hostname.rs
+++ b/src/configs/hostname.rs
@@ -16,7 +16,7 @@ impl<'a> RootModuleConfig<'a> for HostnameConfig<'a> {
         HostnameConfig {
             ssh_only: true,
             trim_at: ".",
-            format: "on [$hostname]($style) ",
+            format: "[$hostname]($style) on",
             style: "green dimmed bold",
             disabled: false,
         }

--- a/src/configs/hostname.rs
+++ b/src/configs/hostname.rs
@@ -16,7 +16,7 @@ impl<'a> RootModuleConfig<'a> for HostnameConfig<'a> {
         HostnameConfig {
             ssh_only: true,
             trim_at: ".",
-            format: "[$hostname]($style) on",
+            format: "[$hostname]($style) on ",
             style: "green dimmed bold",
             disabled: false,
         }

--- a/src/configs/kubernetes.rs
+++ b/src/configs/kubernetes.rs
@@ -16,7 +16,7 @@ impl<'a> RootModuleConfig<'a> for KubernetesConfig<'a> {
     fn new() -> Self {
         KubernetesConfig {
             symbol: "☸ ",
-            format: "[$symbol$context( \\($namespace\\))]($style) on ",
+            format: "[$symbol$context( \\($namespace\\))]($style) in ",
             style: "cyan bold",
             disabled: true,
             context_aliases: HashMap::new(),

--- a/src/configs/kubernetes.rs
+++ b/src/configs/kubernetes.rs
@@ -16,7 +16,7 @@ impl<'a> RootModuleConfig<'a> for KubernetesConfig<'a> {
     fn new() -> Self {
         KubernetesConfig {
             symbol: "☸ ",
-            format: "[$symbol$context( \\($namespace\\))]($style) on",
+            format: "[$symbol$context( \\($namespace\\))]($style) on ",
             style: "cyan bold",
             disabled: true,
             context_aliases: HashMap::new(),

--- a/src/configs/kubernetes.rs
+++ b/src/configs/kubernetes.rs
@@ -16,7 +16,7 @@ impl<'a> RootModuleConfig<'a> for KubernetesConfig<'a> {
     fn new() -> Self {
         KubernetesConfig {
             symbol: "☸ ",
-            format: "on [$symbol$context( \\($namespace\\))]($style) ",
+            format: "[$symbol$context( \\($namespace\\))]($style) on",
             style: "cyan bold",
             disabled: true,
             context_aliases: HashMap::new(),

--- a/src/configs/username.rs
+++ b/src/configs/username.rs
@@ -14,7 +14,7 @@ pub struct UsernameConfig<'a> {
 impl<'a> RootModuleConfig<'a> for UsernameConfig<'a> {
     fn new() -> Self {
         UsernameConfig {
-            format: "[$user]($style) on ",
+            format: "[$user]($style) in ",
             style_root: "red bold",
             style_user: "yellow bold",
             show_always: false,

--- a/src/configs/username.rs
+++ b/src/configs/username.rs
@@ -14,7 +14,7 @@ pub struct UsernameConfig<'a> {
 impl<'a> RootModuleConfig<'a> for UsernameConfig<'a> {
     fn new() -> Self {
         UsernameConfig {
-            format: "[$user]($style) on",
+            format: "[$user]($style) on ",
             style_root: "red bold",
             style_user: "yellow bold",
             show_always: false,

--- a/src/configs/username.rs
+++ b/src/configs/username.rs
@@ -14,7 +14,7 @@ pub struct UsernameConfig<'a> {
 impl<'a> RootModuleConfig<'a> for UsernameConfig<'a> {
     fn new() -> Self {
         UsernameConfig {
-            format: "via [$user]($style) ",
+            format: "[$user]($style) on",
             style_root: "red bold",
             style_user: "yellow bold",
             show_always: false,

--- a/src/module.rs
+++ b/src/module.rs
@@ -6,7 +6,7 @@ use std::fmt;
 
 // List of all modules
 // Keep these ordered alphabetically.
-// Default ordering is handled in configs/mod.rs
+// Default ordering is handled in configs/starship_root.rs
 pub const ALL_MODULES: &[&str] = &[
     "aws",
     #[cfg(feature = "battery")]

--- a/src/modules/hostname.rs
+++ b/src/modules/hostname.rs
@@ -95,7 +95,7 @@ mod tests {
                 trim_at = ""
             })
             .collect();
-        let expected = Some(format!("{} on ", style().paint(hostname)));
+        let expected = Some(format!("{} in ", style().paint(hostname)));
 
         assert_eq!(expected, actual);
         Ok(())
@@ -126,7 +126,7 @@ mod tests {
             })
             .env("SSH_CONNECTION", "something")
             .collect();
-        let expected = Some(format!("{} on ", style().paint(hostname)));
+        let expected = Some(format!("{} in ", style().paint(hostname)));
 
         assert_eq!(expected, actual);
         Ok(())
@@ -142,7 +142,7 @@ mod tests {
                 trim_at = ""
             })
             .collect();
-        let expected = Some(format!("{} on ", style().paint(hostname)));
+        let expected = Some(format!("{} in ", style().paint(hostname)));
 
         assert_eq!(expected, actual);
         Ok(())
@@ -159,7 +159,7 @@ mod tests {
                 trim_at = trim_at
             })
             .collect();
-        let expected = Some(format!("{} on ", style().paint(remainder)));
+        let expected = Some(format!("{} in ", style().paint(remainder)));
 
         assert_eq!(expected, actual);
         Ok(())

--- a/src/modules/hostname.rs
+++ b/src/modules/hostname.rs
@@ -95,7 +95,7 @@ mod tests {
                 trim_at = ""
             })
             .collect();
-        let expected = Some(format!("on {} ", style().paint(hostname)));
+        let expected = Some(format!("{} on", style().paint(hostname)));
 
         assert_eq!(expected, actual);
         Ok(())
@@ -126,7 +126,7 @@ mod tests {
             })
             .env("SSH_CONNECTION", "something")
             .collect();
-        let expected = Some(format!("on {} ", style().paint(hostname)));
+        let expected = Some(format!("{} on", style().paint(hostname)));
 
         assert_eq!(expected, actual);
         Ok(())
@@ -142,7 +142,7 @@ mod tests {
                 trim_at = ""
             })
             .collect();
-        let expected = Some(format!("on {} ", style().paint(hostname)));
+        let expected = Some(format!("{} on", style().paint(hostname)));
 
         assert_eq!(expected, actual);
         Ok(())
@@ -159,7 +159,7 @@ mod tests {
                 trim_at = trim_at
             })
             .collect();
-        let expected = Some(format!("on {} ", style().paint(remainder)));
+        let expected = Some(format!("{} on", style().paint(remainder)));
 
         assert_eq!(expected, actual);
         Ok(())

--- a/src/modules/hostname.rs
+++ b/src/modules/hostname.rs
@@ -95,7 +95,7 @@ mod tests {
                 trim_at = ""
             })
             .collect();
-        let expected = Some(format!("{} on", style().paint(hostname)));
+        let expected = Some(format!("{} on ", style().paint(hostname)));
 
         assert_eq!(expected, actual);
         Ok(())
@@ -126,7 +126,7 @@ mod tests {
             })
             .env("SSH_CONNECTION", "something")
             .collect();
-        let expected = Some(format!("{} on", style().paint(hostname)));
+        let expected = Some(format!("{} on ", style().paint(hostname)));
 
         assert_eq!(expected, actual);
         Ok(())
@@ -142,7 +142,7 @@ mod tests {
                 trim_at = ""
             })
             .collect();
-        let expected = Some(format!("{} on", style().paint(hostname)));
+        let expected = Some(format!("{} on ", style().paint(hostname)));
 
         assert_eq!(expected, actual);
         Ok(())
@@ -159,7 +159,7 @@ mod tests {
                 trim_at = trim_at
             })
             .collect();
-        let expected = Some(format!("{} on", style().paint(remainder)));
+        let expected = Some(format!("{} on ", style().paint(remainder)));
 
         assert_eq!(expected, actual);
         Ok(())

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -59,7 +59,7 @@ use crate::module::Module;
 pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
     match module {
         // Keep these ordered alphabetically.
-        // Default ordering is handled in configs/mod.rs
+        // Default ordering is handled in configs/starship_root.rs
         "aws" => aws::module(context),
         #[cfg(feature = "battery")]
         "battery" => battery::module(context),

--- a/src/modules/username.rs
+++ b/src/modules/username.rs
@@ -123,7 +123,7 @@ mod tests {
             .env("USER", "astronaut")
             .env("SSH_CONNECTION", "192.168.223.17 36673 192.168.223.229 22")
             .collect();
-        let expected = Some(format!("via {} ", Color::Yellow.bold().paint("astronaut")));
+        let expected = Some(format!("{} on", Color::Yellow.bold().paint("astronaut")));
 
         assert_eq!(expected, actual);
         Ok(())
@@ -138,7 +138,7 @@ mod tests {
                 show_always = true
             })
             .collect();
-        let expected = Some(format!("via {} ", Color::Yellow.bold().paint("astronaut")));
+        let expected = Some(format!("{} on", Color::Yellow.bold().paint("astronaut")));
 
         assert_eq!(expected, actual);
         Ok(())

--- a/src/modules/username.rs
+++ b/src/modules/username.rs
@@ -123,7 +123,7 @@ mod tests {
             .env("USER", "astronaut")
             .env("SSH_CONNECTION", "192.168.223.17 36673 192.168.223.229 22")
             .collect();
-        let expected = Some(format!("{} on", Color::Yellow.bold().paint("astronaut")));
+        let expected = Some(format!("{} on ", Color::Yellow.bold().paint("astronaut")));
 
         assert_eq!(expected, actual);
         Ok(())
@@ -138,7 +138,7 @@ mod tests {
                 show_always = true
             })
             .collect();
-        let expected = Some(format!("{} on", Color::Yellow.bold().paint("astronaut")));
+        let expected = Some(format!("{} on ", Color::Yellow.bold().paint("astronaut")));
 
         assert_eq!(expected, actual);
         Ok(())

--- a/src/modules/username.rs
+++ b/src/modules/username.rs
@@ -111,7 +111,7 @@ mod tests {
             .env("LOGNAME", "astronaut")
             .env("USER", "cosmonaut")
             .collect();
-        let expected = Some(format!("via {} ", Color::Yellow.bold().paint("cosmonaut")));
+        let expected = Some(format!("{} on ", Color::Yellow.bold().paint("cosmonaut")));
 
         assert_eq!(expected, actual);
         Ok(())

--- a/src/modules/username.rs
+++ b/src/modules/username.rs
@@ -111,7 +111,7 @@ mod tests {
             .env("LOGNAME", "astronaut")
             .env("USER", "cosmonaut")
             .collect();
-        let expected = Some(format!("{} on ", Color::Yellow.bold().paint("cosmonaut")));
+        let expected = Some(format!("{} in ", Color::Yellow.bold().paint("cosmonaut")));
 
         assert_eq!(expected, actual);
         Ok(())
@@ -123,7 +123,7 @@ mod tests {
             .env("USER", "astronaut")
             .env("SSH_CONNECTION", "192.168.223.17 36673 192.168.223.229 22")
             .collect();
-        let expected = Some(format!("{} on ", Color::Yellow.bold().paint("astronaut")));
+        let expected = Some(format!("{} in ", Color::Yellow.bold().paint("astronaut")));
 
         assert_eq!(expected, actual);
         Ok(())
@@ -138,7 +138,7 @@ mod tests {
                 show_always = true
             })
             .collect();
-        let expected = Some(format!("{} on ", Color::Yellow.bold().paint("astronaut")));
+        let expected = Some(format!("{} in ", Color::Yellow.bold().paint("astronaut")));
 
         assert_eq!(expected, actual);
         Ok(())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

Previously, all modules would have prefixes, which lead to the first
module having a dangling prefix. This change ensures that the first
few modules would instead have suffixes so that we don't start or
end with a prefix or suffix.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1607 

#### Screenshots (if appropriate):

**Before**
![image](https://user-images.githubusercontent.com/4658208/92418242-8169a800-f134-11ea-8989-6651d3832a3d.png)


**After**
![image](https://user-images.githubusercontent.com/4658208/92419053-1f5f7180-f139-11ea-9f42-8cb4e23922b1.png)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
