### PR TITLE
fix(windows): configure console to enable ANSI support

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,9 @@ use starship::module::ALL_MODULES;
 use starship::*;
 
 fn main() {
+    // Configure the current terminal on windows to support ANSI escape sequences.
+    #[cfg(windows)]
+    let _ = ansi_term::enable_ansi_support();
     logger::init();
 
     let status_code_arg = Arg::with_name("status_code")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

Consoles on WIndows don't always have support for ANSI sequences enabled.
Call `ansi_term::enable_ansi_support` to configure the current console to enable support for ANSI sequences.

Potential problems:
`enable_ansi_support` only supports Windows 10, not sure what happens on Windows <10 with this change.
Maybe ANSI support should be disabled again after rendering the prompt?

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Might close #1533

#### Screenshots (if appropriate):

#### How Has This Been Tested?
I tried testing it in the windows console in legacy mode, but it didn't work with that.
My normal shell already has ANSI support enabled so I wasn't able to test it with a configuration that didn't work previously, but it didn't break anything.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
