### PR TITLE
fix(nodejs): Change nodejs symbol to the nerd-font nodejs one

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1814,7 +1814,7 @@ By default the module will be shown if any of the following conditions are met:
 | Option              | Default                              | Description                                        |
 | ------------------- | ------------------------------------ | -------------------------------------------------- |
 | `format`            | `"via [$symbol($version )]($style)"` | The format for the module.                         |
-| `symbol`            | `"⬢ "`                               | A format string representing the symbol of NodeJS. |
+| `symbol`            | `" "`                               | A format string representing the symbol of NodeJS. |
 | `detect_extensions` | `["js", "mjs", "cjs", "ts"]`         | Which extensions should trigger this moudle.       |
 | `detect_files`      | `["package.json", ".node-version"]`  | Which filenames should trigger this module.        |
 | `detect_folders`    | `["node_modules"]`                   | Which folders should trigger this module.          |

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -85,7 +85,7 @@ In the second part, which is enclosed in a `()`, is a [style string](#style-stri
 For example:
 
 - `[on](red bold)` will print a string `on` with bold text colored red.
-- `[⬢ $version](bold green)` will print a symbol `⬢ ` followed by the content of variable `version`, with bold text colored green.
+- `[⌘ $version](bold green)` will print a symbol `⌘ ` followed by the content of variable `version`, with bold text colored green.
 - `[a [b](red) c](green)` will print `a b c` with `b` red, and `a` and `c` green.
 
 #### Style Strings

--- a/src/configs/nodejs.rs
+++ b/src/configs/nodejs.rs
@@ -18,7 +18,7 @@ impl<'a> RootModuleConfig<'a> for NodejsConfig<'a> {
     fn new() -> Self {
         NodejsConfig {
             format: "via [$symbol($version )]($style)",
-            symbol: "⬢ ",
+            symbol: " ",
             style: "bold green",
             disabled: false,
             not_capable_style: "bold red",

--- a/src/modules/nodejs.rs
+++ b/src/modules/nodejs.rs
@@ -130,7 +130,7 @@ mod tests {
         File::create(dir.path().join("package.json"))?.sync_all()?;
 
         let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Green.bold().paint("⬢ v12.0.0 ")));
+        let expected = Some(format!("via {}", Color::Green.bold().paint(" v12.0.0 ")));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -154,7 +154,7 @@ mod tests {
         File::create(dir.path().join(".node-version"))?.sync_all()?;
 
         let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Green.bold().paint("⬢ v12.0.0 ")));
+        let expected = Some(format!("via {}", Color::Green.bold().paint(" v12.0.0 ")));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -165,7 +165,7 @@ mod tests {
         File::create(dir.path().join("index.js"))?.sync_all()?;
 
         let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Green.bold().paint("⬢ v12.0.0 ")));
+        let expected = Some(format!("via {}", Color::Green.bold().paint(" v12.0.0 ")));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -176,7 +176,7 @@ mod tests {
         File::create(dir.path().join("index.mjs"))?.sync_all()?;
 
         let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Green.bold().paint("⬢ v12.0.0 ")));
+        let expected = Some(format!("via {}", Color::Green.bold().paint(" v12.0.0 ")));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -187,7 +187,7 @@ mod tests {
         File::create(dir.path().join("index.cjs"))?.sync_all()?;
 
         let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Green.bold().paint("⬢ v12.0.0 ")));
+        let expected = Some(format!("via {}", Color::Green.bold().paint(" v12.0.0 ")));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -198,7 +198,7 @@ mod tests {
         File::create(dir.path().join("index.ts"))?.sync_all()?;
 
         let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Green.bold().paint("⬢ v12.0.0 ")));
+        let expected = Some(format!("via {}", Color::Green.bold().paint(" v12.0.0 ")));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -210,7 +210,7 @@ mod tests {
         fs::create_dir_all(&node_modules)?;
 
         let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Green.bold().paint("⬢ v12.0.0 ")));
+        let expected = Some(format!("via {}", Color::Green.bold().paint(" v12.0.0 ")));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -229,7 +229,7 @@ mod tests {
         file.sync_all()?;
 
         let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Green.bold().paint("⬢ v12.0.0 ")));
+        let expected = Some(format!("via {}", Color::Green.bold().paint(" v12.0.0 ")));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -248,7 +248,7 @@ mod tests {
         file.sync_all()?;
 
         let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Red.bold().paint("⬢ v12.0.0 ")));
+        let expected = Some(format!("via {}", Color::Red.bold().paint(" v12.0.0 ")));
         assert_eq!(expected, actual);
         dir.close()
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
Replace unicode hexagon with nodejs-specific nerd-font icon

#### Motivation and Context
The unicode hexagon symbol does not actually fit into a single column with a fixed-width font. [ (nf-mdi-nodejs)](https://www.nerdfonts.com/cheat-sheet?set=nf-mdi-nodejs) does. As starship requires a nerd font as a prerequisite, it's safe to assume that this symbol is available.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
Visually checked on Linux, with FiraCode Nerd Font Mono at multiple sizes. 
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
