### PR TITLE
style: make rustfmt use the default configuration

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,5 @@
+# This file intentionally left almost blank
+#
+# The empty `rustfmt.toml` makes rustfmt use the default configuration,
+# overriding any which may be found in the contributor's home or parent
+# folders.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,7 @@ cargo clippy
 
 ## Formatting
 
-Starship source files are formatted with [rustfmt](https://crates.io/crates/rustfmt-nightly). Rustfmt will be ran as part of CI. Unformatted code will fail a build, so it is suggested that you run rustfmt locally:
+Starship source files are formatted with [rustfmt](https://crates.io/crates/rustfmt-nightly), using the default configuration. Rustfmt will be ran as part of CI. Unformatted code will fail a build, so it is suggested that you run rustfmt locally:
 
 ```sh
 rustup component add rustfmt


### PR DESCRIPTION
#### Description

Add an empty `rustfmt.toml` configuration file to the crate root, making rustfmt use the default configuration for all contributors.

#### Motivation and Context

The Starship project requires user contributions to be formatted, presumably in accordance with the standard Rust [style guide](https://github.com/rust-dev-tools/fmt-rfcs/blob/master/guide/guide.md). However, many contributors will have their own Rustfmt configurations in either $HOME or parent folders, which need to be overridden by a crate-level `rustfmt.toml`.

#### How Has This Been Tested?
- [x] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
