### PR TITLE
fix: restore the `pyenv_prefix` option to python

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1856,23 +1856,25 @@ The module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Option               | Default                                                    | Description                                                                |
-| -------------------- | ---------------------------------------------------------- | -------------------------------------------------------------------------- |
-| `format`             | `"via [${symbol}${version}( \\($virtualenv\\))]($style) "` | The format for the module.                                                 |
-| `symbol`             | `"🐍 "`                                                    | A format string representing the symbol of Python                          |
-| `style`              | `"yellow bold"`                                            | The style for the module.                                                  |
-| `pyenv_version_name` | `false`                                                    | Use pyenv to get Python version                                            |
-| `scan_for_pyfiles`   | `true`                                                     | If false, Python files in the current directory will not show this module. |
-| `disabled`           | `false`                                                    | Disables the `python` module.                                              |
+| Option               | Default                                                                   | Description                                                                |
+| -------------------- | ------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| `format`             | `"via [${symbol}${pyenv_prefix}${version}( \\($virtualenv\\))]($style) "` | The format for the module.                                                 |
+| `symbol`             | `"🐍 "`                                                                   | A format string representing the symbol of Python                          |
+| `style`              | `"yellow bold"`                                                           | The style for the module.                                                  |
+| `pyenv_version_name` | `false`                                                                   | Use pyenv to get Python version                                            |
+| `pyenv_prefix`       | `pyenv `                                                                  | Prefix before pyenv version display, only used if pyenv is used            |
+| `scan_for_pyfiles`   | `true`                                                                    | If false, Python files in the current directory will not show this module. |
+| `disabled`           | `false`                                                                   | Disables the `python` module.                                              |
 
 ### Variables
 
-| Variable   | Example         | Description                          |
-| ---------- | --------------- | ------------------------------------ |
-| version    | `"v3.8.1"`      | The version of `python`              |
-| symbol     | `"🐍 "`         | Mirrors the value of option `symbol` |
-| style      | `"yellow bold"` | Mirrors the value of option `style`  |
-| virtualenv | `"venv"`        | The current `virtualenv` name        |
+| Variable     | Example         | Description                                |
+| ------------ | --------------- | ------------------------------------------ |
+| version      | `"v3.8.1"`      | The version of `python`                    |
+| symbol       | `"🐍 "`         | Mirrors the value of option `symbol`       |
+| style        | `"yellow bold"` | Mirrors the value of option `style`        |
+| pyenv_prefix | `"pyenv "`      | Mirrors the value of option `pyenv_prefix` |
+| virtualenv   | `"venv"`        | The current `virtualenv` name              |
 
 <details>
 <summary>This module has some advanced configuration options.</summary>

--- a/src/configs/python.rs
+++ b/src/configs/python.rs
@@ -5,6 +5,7 @@ use starship_module_config_derive::ModuleConfig;
 #[derive(Clone, ModuleConfig)]
 pub struct PythonConfig<'a> {
     pub pyenv_version_name: bool,
+    pub pyenv_prefix: &'a str,
     pub python_binary: &'a str,
     pub scan_for_pyfiles: bool,
     pub format: &'a str,
@@ -17,9 +18,10 @@ impl<'a> RootModuleConfig<'a> for PythonConfig<'a> {
     fn new() -> Self {
         PythonConfig {
             pyenv_version_name: false,
+            pyenv_prefix: "pyenv ",
             python_binary: "python",
             scan_for_pyfiles: true,
-            format: "via [$symbol$version( \\($virtualenv\\))]($style) ",
+            format: "via [${symbol}${pyenv_prefix}${version}( \\($virtualenv\\))]($style) ",
             style: "yellow bold",
             symbol: "🐍 ",
             disabled: false,

--- a/src/modules/python.rs
+++ b/src/modules/python.rs
@@ -48,6 +48,11 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         format_python_version(&version)
     };
     let virtual_env = get_python_virtual_env(context);
+    let pyenv_prefix = if config.pyenv_version_name {
+        config.pyenv_prefix
+    } else {
+        ""
+    };
 
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter
@@ -62,6 +67,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             .map(|variable| match variable {
                 "version" => Some(Ok(python_version.trim())),
                 "virtualenv" => virtual_env.as_ref().map(|e| Ok(e.trim())),
+                "pyenv_prefix" => Some(Ok(pyenv_prefix)),
                 _ => None,
             })
             .parse(None)
@@ -146,6 +152,7 @@ mod tests {
 
         check_python2_renders(&dir, None);
         check_python3_renders(&dir, None);
+        check_pyenv_renders(&dir, None);
         dir.close()
     }
 
@@ -156,6 +163,7 @@ mod tests {
 
         check_python2_renders(&dir, None);
         check_python3_renders(&dir, None);
+        check_pyenv_renders(&dir, None);
         dir.close()
     }
 
@@ -166,6 +174,7 @@ mod tests {
 
         check_python2_renders(&dir, None);
         check_python3_renders(&dir, None);
+        check_pyenv_renders(&dir, None);
         dir.close()
     }
 
@@ -176,6 +185,7 @@ mod tests {
 
         check_python2_renders(&dir, None);
         check_python3_renders(&dir, None);
+        check_pyenv_renders(&dir, None);
         dir.close()
     }
 
@@ -186,6 +196,7 @@ mod tests {
 
         check_python2_renders(&dir, None);
         check_python3_renders(&dir, None);
+        check_pyenv_renders(&dir, None);
         dir.close()
     }
 
@@ -196,6 +207,7 @@ mod tests {
 
         check_python2_renders(&dir, None);
         check_python3_renders(&dir, None);
+        check_pyenv_renders(&dir, None);
         dir.close()
     }
 
@@ -206,6 +218,7 @@ mod tests {
 
         check_python2_renders(&dir, None);
         check_python3_renders(&dir, None);
+        check_pyenv_renders(&dir, None);
         dir.close()
     }
 
@@ -216,6 +229,7 @@ mod tests {
 
         check_python2_renders(&dir, None);
         check_python3_renders(&dir, None);
+        check_pyenv_renders(&dir, None);
         dir.close()
     }
 
@@ -257,6 +271,13 @@ mod tests {
 
         check_python3_renders(&dir, Some(config_python3));
 
+        let config_pyenv = toml::toml! {
+            [python]
+            pyenv_version_name = true
+            pyenv_prefix = "test_pyenv "
+            scan_for_pyfiles = false
+        };
+        check_pyenv_renders(&dir, Some(config_pyenv));
         dir.close()
     }
 
@@ -323,6 +344,25 @@ mod tests {
             .collect();
 
         let expected = Some(format!("via {} ", Color::Yellow.bold().paint("🐍 v3.8.0")));
+        assert_eq!(expected, actual);
+    }
+
+    fn check_pyenv_renders(dir: &tempfile::TempDir, starship_config: Option<toml::Value>) {
+        let config = starship_config.unwrap_or(toml::toml! {
+             [python]
+             pyenv_version_name = true
+             pyenv_prefix = "test_pyenv "
+        });
+
+        let actual = ModuleRenderer::new("python")
+            .path(dir.path())
+            .config(config)
+            .collect();
+
+        let expected = Some(format!(
+            "via {} ",
+            Color::Yellow.bold().paint("🐍 test_pyenv system")
+        ));
         assert_eq!(expected, actual);
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -125,6 +125,10 @@ active boot switches: -d:release\n",
             stdout: String::from("0.13.5\n"),
             stderr: String::default(),
         }),
+        "pyenv version-name" => Some(CommandOutput {
+            stdout: String::from("system\n"),
+            stderr: String::default(),
+        }),
         "python --version" => Some(CommandOutput {
             stdout: String::default(),
             stderr: String::from("Python 2.7.17\n"),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Have restored the `pyenv_prefix` option to the python module. This is
added as a new variable that will only be shown if `pyenv` is being used
to determine the version of python that is being used.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes a regression introduced in the format-strings release

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
