### PR TITLE
fix(git-state): Fix discrepancy between v0.44.0 and master

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1075,7 +1075,7 @@ that information will be shown too.
 | `am`           | `"AM"`                                                          | A format string displayed when an `apply-mailbox` (`git am`) is in progress.            |
 | `am_or_rebase` | `"AM/REBASE"`                                                   | A format string displayed when an ambiguous `apply-mailbox` or `rebase` is in progress. |
 | `style`        | `"bold yellow"`                                                 | The style for the module.                                                               |
-| `format`       | `"[\\($state( $progress_current/$progress_total)\\)]($style) "` | The format for the module.                                                              |
+| `format`       | `"\\([$state( $progress_current/$progress_total)]($style)\\) "` | The format for the module.                                                              |
 | `disabled`     | `false`                                                         | Disables the `git_state` module.                                                        |
 
 ### Variables

--- a/src/configs/git_state.rs
+++ b/src/configs/git_state.rs
@@ -27,7 +27,7 @@ impl<'a> RootModuleConfig<'a> for GitStateConfig<'a> {
             am: "AM",
             am_or_rebase: "AM/REBASE",
             style: "bold yellow",
-            format: "[\\($state( $progress_current/$progress_total)\\)]($style) ",
+            format: "\\([$state( $progress_current/$progress_total)]($style)\\) ",
             disabled: false,
         }
     }

--- a/src/modules/git_state.rs
+++ b/src/modules/git_state.rs
@@ -190,7 +190,7 @@ mod tests {
 
         let actual = ModuleRenderer::new("git_state").path(path).collect();
 
-        let expected = Some(format!("{} ", Color::Yellow.bold().paint("(REBASING 1/1)")));
+        let expected = Some(format!("({}) ", Color::Yellow.bold().paint("REBASING 1/1")));
 
         assert_eq!(expected, actual);
         repo_dir.close()
@@ -205,7 +205,7 @@ mod tests {
 
         let actual = ModuleRenderer::new("git_state").path(path).collect();
 
-        let expected = Some(format!("{} ", Color::Yellow.bold().paint("(MERGING)")));
+        let expected = Some(format!("({}) ", Color::Yellow.bold().paint("MERGING")));
 
         assert_eq!(expected, actual);
         repo_dir.close()
@@ -221,8 +221,8 @@ mod tests {
         let actual = ModuleRenderer::new("git_state").path(path).collect();
 
         let expected = Some(format!(
-            "{} ",
-            Color::Yellow.bold().paint("(CHERRY-PICKING)")
+            "({}) ",
+            Color::Yellow.bold().paint("CHERRY-PICKING")
         ));
 
         assert_eq!(expected, actual);
@@ -238,7 +238,7 @@ mod tests {
 
         let actual = ModuleRenderer::new("git_state").path(path).collect();
 
-        let expected = Some(format!("{} ", Color::Yellow.bold().paint("(BISECTING)")));
+        let expected = Some(format!("({}) ", Color::Yellow.bold().paint("BISECTING")));
 
         assert_eq!(expected, actual);
         repo_dir.close()
@@ -253,7 +253,7 @@ mod tests {
 
         let actual = ModuleRenderer::new("git_state").path(path).collect();
 
-        let expected = Some(format!("{} ", Color::Yellow.bold().paint("(REVERTING)")));
+        let expected = Some(format!("({}) ", Color::Yellow.bold().paint("REVERTING")));
 
         assert_eq!(expected, actual);
         repo_dir.close()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Fixes a discrepancy between v0.44.0 and master:
On 0.44.0 the brackets in the `git_status` module weren't styled but they were on master. 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Minimize breaking changes

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
