### PR TITLE
feat: Move cmd_duration after custom module

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -211,8 +211,8 @@ $aws\
 $gcloud\
 $env_var\
 $crystal\
-$cmd_duration\
 $custom\
+$cmd_duration\
 $line_break\
 $jobs\
 $battery\

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -58,8 +58,8 @@ pub const PROMPT_ORDER: &[&str] = &[
     "gcloud",
     "env_var",
     "crystal",
-    "cmd_duration",
     "custom",
+    "cmd_duration",
     "line_break",
     "jobs",
     #[cfg(feature = "battery")]


### PR DESCRIPTION
#### Description

cmd_duration moved after custom by default.

#### Motivation and Context

Closes #1671 

#### Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/11525523/94368752-3402aa00-00e6-11eb-973f-f04be9f9dfab.png)

![image](https://user-images.githubusercontent.com/11525523/94368771-5268a580-00e6-11eb-87a5-e6088a856476.png)

#### How Has This Been Tested?

I launched the current tests with success and build to see the result.

- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:

- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.

No tests seems to fail so I do not know if a test is needed here.
