### PR TITLE
Fix compiling for iOS targets

### DIFF
--- a/src/modules/utils/directory_nix.rs
+++ b/src/modules/utils/directory_nix.rs
@@ -32,7 +32,7 @@ pub fn is_write_allowed(folder_path: &Path) -> Result<bool, &'static str> {
     }
 }
 
-#[cfg(all(unix, not(target_os = "macos")))]
+#[cfg(all(unix, not(any(target_os = "macos", target_os = "ios"))))]
 fn get_supplementary_groups() -> Vec<u32> {
     match nix::unistd::getgroups() {
         Err(_) => Vec::new(),
@@ -40,7 +40,7 @@ fn get_supplementary_groups() -> Vec<u32> {
     }
 }
 
-#[cfg(all(unix, target_os = "macos"))]
+#[cfg(all(unix, any(target_os = "macos", target_os = "ios")))]
 fn get_supplementary_groups() -> Vec<u32> {
     // at the moment nix crate does not provide it for macOS
     Vec::new()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
`nix` also doesn't provide `getgroups` for iOS, leading to a compile error.

#### How Has This Been Tested?
- [N/A] I have tested using **MacOS**
- [N/A] I have tested using **Linux**
- [N/A] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [N/A] I have updated the documentation accordingly.
- [N/A] I have updated the tests accordingly.
