### PR TITLE
test(git-state): tests failing when git init.defaultBranch set

### DIFF
--- a/src/modules/git_state.rs
+++ b/src/modules/git_state.rs
@@ -321,6 +321,16 @@ mod tests {
             true,
         )?;
 
+        // Ensure on the expected branch.
+        // If build environment has `init.defaultBranch` global set
+        // it will default to an unknown branch, so neeed to make & change branch
+        run_git_cmd(
+            &["checkout", "-b", "master"],
+            Some(path),
+            // command expected to fail if already on the expected branch
+            false,
+        )?;
+
         // Write a file on master and commit it
         write_file("Version A")?;
         run_git_cmd(&["add", "the_file"], Some(path), true)?;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

The tests for git-state can fail since they assume the default branch is always `master`.

On machines with the global option `init.defaultBranch` set will cause the tests to fail

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Currently when trying to install `starship` from [AUR](https://aur.archlinux.org/packages/starship) it runs tests as apart of the package build process. On my machines I have set `init.defaultBranch` & found that the package fails to pass tests.

<!--- If it fixes an open issue, please link to the issue here. -->
```
---- modules::git_state::tests::shows_bisecting stdout ----
Error: Kind(Other)
thread 'modules::git_state::tests::shows_bisecting' panicked at 'assertion failed: `(left == right)`
  left: `1`,
 right: `0`: the test returned a termination value with a non-zero status code (1) which indicates a failure', /home/drb/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src/libstd/macros.rs:16:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- modules::git_state::tests::shows_merging stdout ----
Error: Kind(Other)
thread 'modules::git_state::tests::shows_merging' panicked at 'assertion failed: `(left == right)`
  left: `1`,
 right: `0`: the test returned a termination value with a non-zero status code (1) which indicates a failure', /home/drb/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src/libstd/macros.rs:16:9

---- modules::git_state::tests::shows_cherry_picking stdout ----
Error: Kind(Other)
thread 'modules::git_state::tests::shows_cherry_picking' panicked at 'assertion failed: `(left == right)`
  left: `1`,
 right: `0`: the test returned a termination value with a non-zero status code (1) which indicates a failure', /home/drb/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src/libstd/macros.rs:16:9

---- modules::git_state::tests::shows_rebasing stdout ----
Error: Kind(Other)
thread 'modules::git_state::tests::shows_rebasing' panicked at 'assertion failed: `(left == right)`
  left: `1`,
 right: `0`: the test returned a termination value with a non-zero status code (1) which indicates a failure', /home/drb/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src/libstd/macros.rs:16:9

---- modules::git_state::tests::shows_reverting stdout ----
Error: Kind(Other)
thread 'modules::git_state::tests::shows_reverting' panicked at 'assertion failed: `(left == right)`
  left: `1`,
 right: `0`: the test returned a termination value with a non-zero status code (1) which indicates a failure', /home/drb/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src/libstd/macros.rs:16:9


failures:
    modules::git_state::tests::shows_bisecting
    modules::git_state::tests::shows_cherry_picking
    modules::git_state::tests::shows_merging
    modules::git_state::tests::shows_rebasing
    modules::git_state::tests::shows_reverting

test result: FAILED. 445 passed; 5 failed; 26 ignored; 0 measured; 0 filtered out
```

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

Changes tested by
 * running tests when default branch differs from expected branch in tests
 * running tests when default branch is the same as expected branch in tests

<!--- Include details of your testing environment, tests ran to see how -->

Testing environment
 * Linux machine
 * git version 2.28
 * rustc 1.46

<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
