### PR TITLE
docs: Remove newline from beginning of example format config.

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -184,7 +184,6 @@ format = "$all"
 
 # Which is equivalent to
 format = """
-
 $username\
 $hostname\
 $shlvl\


### PR DESCRIPTION
Having a newline there means that an empty newline is printed everytime
the user runs a command or presses Enter, which for short commands
and/or small terminal windows can noticeably decrease the information
density.