### PR TITLE
feat: prefix STATUS and PREEXEC_READY shell vars with STARSHIP_

### DIFF
--- a/src/init/starship.bash
+++ b/src/init/starship.bash
@@ -8,9 +8,9 @@
 # data for commands like `slow | slow | fast`, since the timer starts at the start
 # of the "fast" command.
 
-# To solve this, we set a flag `PREEXEC_READY` when the prompt is drawn, and only
-# start the timer if this flag is present. That way, timing is for the entire command,
-# and not just a portion of it.
+# To solve this, we set a flag `STARSHIP_PREEXEC_READY` when the prompt is
+# drawn, and only start the timer if this flag is present. That way, timing is
+# for the entire command, and not just a portion of it.
 
 # Will be run before *every* command (even ones in pipes!)
 starship_preexec() {
@@ -18,8 +18,8 @@ starship_preexec() {
     local PREV_LAST_ARG=$1
 
     # Avoid restarting the timer for commands in the same pipeline
-    if [ "$PREEXEC_READY" = "true" ]; then
-        PREEXEC_READY=false
+    if [ "$STARSHIP_PREEXEC_READY" = "true" ]; then
+        STARSHIP_PREEXEC_READY=false
         STARSHIP_START_TIME=$(::STARSHIP:: time)
     fi
 
@@ -30,7 +30,7 @@ starship_preexec() {
 starship_precmd() {
     local NUM_JOBS
     # Save the status, because commands in this pipeline will change $?
-    STATUS=$?
+    STARSHIP_CMD_STATUS=$?
 
     # Evaluate the number of jobs before running the preseved prompt command, so that tools
     # like z/autojump, which background certain jobs, do not cause spurious background jobs
@@ -46,12 +46,12 @@ starship_precmd() {
     if [[ $STARSHIP_START_TIME ]]; then
         STARSHIP_END_TIME=$(::STARSHIP:: time)
         STARSHIP_DURATION=$((STARSHIP_END_TIME - STARSHIP_START_TIME))
-        PS1="$(::STARSHIP:: prompt --status=$STATUS --jobs="$NUM_JOBS" --cmd-duration=$STARSHIP_DURATION)"
+        PS1="$(::STARSHIP:: prompt --status=$STARSHIP_CMD_STATUS --jobs="$NUM_JOBS" --cmd-duration=$STARSHIP_DURATION)"
         unset STARSHIP_START_TIME
     else
-        PS1="$(::STARSHIP:: prompt --status=$STATUS --jobs="$NUM_JOBS")"
+        PS1="$(::STARSHIP:: prompt --status=$STARSHIP_CMD_STATUS --jobs="$NUM_JOBS")"
     fi
-    PREEXEC_READY=true  # Signal that we can safely restart the timer
+    STARSHIP_PREEXEC_READY=true  # Signal that we can safely restart the timer
 }
 
 # If the user appears to be using https://github.com/rcaloras/bash-preexec,

--- a/src/init/starship.zsh
+++ b/src/init/starship.zsh
@@ -13,13 +13,13 @@ starship_render() {
     # Use length of jobstates array as number of jobs. Expansion fails inside
     # quotes so we set it here and then use the value later on.
     NUM_JOBS=$#jobstates
-    PROMPT="$(::STARSHIP:: prompt --keymap="${KEYMAP-}" --status=$STATUS --cmd-duration=${STARSHIP_DURATION-} --jobs="$NUM_JOBS")"
+    PROMPT="$(::STARSHIP:: prompt --keymap="${KEYMAP-}" --status=$STARSHIP_CMD_STATUS --cmd-duration=${STARSHIP_DURATION-} --jobs="$NUM_JOBS")"
 }
 
 # Will be run before every prompt draw
 starship_precmd() {
     # Save the status, because commands in this pipeline will change $?
-    STATUS=$?
+    STARSHIP_CMD_STATUS=$?
 
     # Compute cmd_duration, if we have a time to consume, otherwise clear the
     # previous duration


### PR DESCRIPTION
#### Description
I was surprised to see the STATUS and PREEXEC_READY variables being set in my shell. I think
it's better to have them in the STARSHIP_ "namespace". (Actually, STATUS
got the new name STARSHIP_CMD_STATUS.)

#### Motivation and Context
For cleanliness :-) And it's unfortunate if users try to use the generic name `STATUS` for themself, not knowing starship will overwrite the variable. 

#### Screenshots (if appropriate):

#### How Has This Been Tested?
* I ran `cargo test`:
  - on master: `test result: FAILED. 440 passed; 52 failed; 28 ignored; 0 measured; 0 filtered out`
  - on this PR: `test result: FAILED. 440 passed; 52 failed; 28 ignored; 0 measured; 0 filtered out`
  (So no change.)
* I installed starship from this PR onto my system (with bash).
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly. (I didn't see any documentation regarding to these variables, I think they are an implementation detail. The remaining uses of `STATUS` in the repo seem unrelated to this change, so I left it alone.)
- [x] I have updated the tests accordingly. (AFAICS, no tests need updating.)
