### PR TITLE
fix: Pass `--no-gpg-sign` to `git commit` in tests

### DIFF
--- a/src/modules/git_state.rs
+++ b/src/modules/git_state.rs
@@ -324,13 +324,17 @@ mod tests {
         // Write a file on master and commit it
         write_file("Version A")?;
         run_git_cmd(&["add", "the_file"], Some(path), true)?;
-        run_git_cmd(&["commit", "--message", "Commit A"], Some(path), true)?;
+        run_git_cmd(
+            &["commit", "--message", "Commit A", "--no-gpg-sign"],
+            Some(path),
+            true,
+        )?;
 
         // Switch to another branch, and commit a change to the file
         run_git_cmd(&["checkout", "-b", "other-branch"], Some(path), true)?;
         write_file("Version B")?;
         run_git_cmd(
-            &["commit", "--all", "--message", "Commit B"],
+            &["commit", "--all", "--message", "Commit B", "--no-gpg-sign"],
             Some(path),
             true,
         )?;
@@ -339,7 +343,7 @@ mod tests {
         run_git_cmd(&["checkout", "master"], Some(path), true)?;
         write_file("Version C")?;
         run_git_cmd(
-            &["commit", "--all", "--message", "Commit C"],
+            &["commit", "--all", "--message", "Commit C", "--no-gpg-sign"],
             Some(path),
             true,
         )?;

--- a/src/modules/git_status.rs
+++ b/src/modules/git_status.rs
@@ -813,7 +813,7 @@ mod tests {
             .current_dir(&repo_dir.path())
             .output()?;
         Command::new("git")
-            .args(&["commit", "-m", "add new files"])
+            .args(&["commit", "-m", "add new files", "--no-gpg-sign"])
             .current_dir(&repo_dir.path())
             .output()?;
 
@@ -842,7 +842,7 @@ mod tests {
         File::create(repo_dir.join("readme.md"))?.sync_all()?;
 
         Command::new("git")
-            .args(&["commit", "-am", "Update readme"])
+            .args(&["commit", "-am", "Update readme", "--no-gpg-sign"])
             .current_dir(&repo_dir)
             .output()?;
         barrier();
@@ -870,7 +870,7 @@ mod tests {
         fs::write(repo_dir.join("Cargo.toml"), " ")?;
 
         Command::new("git")
-            .args(&["commit", "-am", "Update readme"])
+            .args(&["commit", "-am", "Update readme", "--no-gpg-sign"])
             .current_dir(repo_dir)
             .output()?;
         barrier();
@@ -894,7 +894,7 @@ mod tests {
         barrier();
 
         Command::new("git")
-            .args(&["commit", "-m", "Change readme"])
+            .args(&["commit", "-m", "Change readme", "--no-gpg-sign"])
             .current_dir(repo_dir)
             .output()?;
         barrier();


### PR DESCRIPTION
#### Description
Pass `--no-gpg-sign` to all instances of `git commit` in tests. This prevents the potential need for user interaction for those who have `commit.gpgSign` set to `true`, and in some cases, outright test failure.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Some users have `commit.gpgSign` set to `true` in their global git config, causing tests which run `git commit` to fail if the configured `user.signingKey` is not present, as is often the case with PGP smart cards or other methods of offline PGP key storage (for smart cards the commit may not outright fail, but bring up a dialog box asking for the user's PIN. However, this is also undesirable because tests shouldn't require user interaction).

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I ran `cargo test --all-features -- -Z unstable-options --include-ignored` with a signing PGP subkey configured. This key is on a PGP smart card and is not present on the testing device.

Relevant portion of `$HOME/.gitconfig`:
```
[user]
    signingKey = XXXX
[commit]
    gpgSign = true
```

- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
