### PR TITLE
fix(readonly): change module to match docs

### DIFF
--- a/src/configs/directory.rs
+++ b/src/configs/directory.rs
@@ -13,8 +13,8 @@ pub struct DirectoryConfig<'a> {
     pub format: &'a str,
     pub style: &'a str,
     pub disabled: bool,
-    pub read_only_symbol: &'a str,
-    pub read_only_symbol_style: &'a str,
+    pub read_only: &'a str,
+    pub read_only_style: &'a str,
 }
 
 impl<'a> RootModuleConfig<'a> for DirectoryConfig<'a> {
@@ -28,8 +28,8 @@ impl<'a> RootModuleConfig<'a> for DirectoryConfig<'a> {
             format: "[$path]($style)[$read_only]($read_only_style) ",
             style: "cyan bold",
             disabled: false,
-            read_only_symbol: "🔒",
-            read_only_symbol_style: "red",
+            read_only: "🔒",
+            read_only_style: "red",
         }
     }
 }

--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -97,13 +97,13 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         String::from("")
     };
     let final_dir_string = format!("{}{}", fish_prefix, truncated_dir_string);
-    let lock_symbol = String::from(config.read_only_symbol);
+    let lock_symbol = String::from(config.read_only);
 
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter
             .map_style(|variable| match variable {
                 "style" => Some(Ok(config.style)),
-                "read_only_style" => Some(Ok(config.read_only_symbol_style)),
+                "read_only_style" => Some(Ok(config.read_only_style)),
                 _ => None,
             })
             .map(|variable| match variable {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
In ce73f6347fc3a2b07d67ae72854f442573296fd9 the docs for the directory module were changed, but `read_only_symbol` and `read_only_symbol_style` were actually used in the module but remapped to `lock_symbol` and `lock_style` when applying to the format string.

This PR removes the remapping and changes the names in the config.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related: #1706

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
