### PR TITLE
fix(git): prevent tests from using git config

### DIFF
--- a/src/modules/git_state.rs
+++ b/src/modules/git_state.rs
@@ -267,6 +267,8 @@ mod tests {
         let mut command = Command::new("git");
         command
             .args(args)
+            // By setting the home to /dev/null/ we prevent git from using the user's git config.
+            .env("HOME", "/dev/null")
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .stdin(Stdio::null());


### PR DESCRIPTION
#### Description
Rust's process:Command inherits the current process's environment, hence any git command
will use the user's git config. This can lead to tests failing.

By setting the `HOME` env var to `/dev/null` we can prevent git from using the user's config.

#### Motivation and Context
Failing tests prevent successful package builds, e.g. from the AUR. 

Closes #1734 

#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
