### PR TITLE
fix(git_state): Handle gitdir indirection when rebasing

### DIFF
--- a/src/modules/git_state.rs
+++ b/src/modules/git_state.rs
@@ -114,6 +114,16 @@ fn describe_rebase<'a>(root: &'a PathBuf, rebase_config: &'a str) -> StateDescri
      */
 
     let dot_git = root.join(".git");
+    let dot_git = if let Ok(conf) = std::fs::read_to_string(&dot_git) {
+        let gitdir_re = regex::Regex::new(r"(?m)^gitdir: (.*)$").unwrap();
+        if let Some(caps) = gitdir_re.captures(&conf) {
+            root.join(caps.get(1).unwrap().as_str())
+        } else {
+            dot_git
+        }
+    } else {
+        dot_git
+    };
 
     let has_path = |relative_path: &str| {
         let path = dot_git.join(PathBuf::from(relative_path));

--- a/src/modules/git_state.rs
+++ b/src/modules/git_state.rs
@@ -140,12 +140,17 @@ fn describe_rebase<'a>(root: &'a PathBuf, rebase_config: &'a str) -> StateDescri
     } else {
         None
     };
-    let progress = progress.unwrap_or((1, 1));
+
+    let (current, total) = if let Some((c, t)) = progress {
+        (Some(format!("{}", c)), Some(format!("{}", t)))
+    } else {
+        (None, None)
+    };
 
     StateDescription {
         label: rebase_config,
-        current: Some(format!("{}", progress.0)),
-        total: Some(format!("{}", progress.1)),
+        current,
+        total,
     }
 }
 


### PR DESCRIPTION
#### Description
The first commit makes rebase status more robust by removing some unwraps in the git_state module.

Those unwraps were triggered by rebasing within git repositories using .git files (not directories) that link to the actual gitdir.

The second commit adds support for gitdir indirection.

#### Motivation and Context
starfish crashed and garbled the terminal when I was rebasing within git submodules.

Fixes #1859

#### How Has This Been Tested?
Tested before/after on local git checkouts.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
