### PR TITLE
perf(init): Use random for session-key instead of invoking starship session

### DIFF
--- a/src/init/starship.bash
+++ b/src/init/starship.bash
@@ -86,4 +86,6 @@ STARSHIP_START_TIME=$(::STARSHIP:: time)
 export STARSHIP_SHELL="bash"
 
 # Set up the session key that will be used to store logs
-export STARSHIP_SESSION_KEY=$(::STARSHIP:: session)
+STARSHIP_SESSION_KEY="$RANDOM$RANDOM$RANDOM$RANDOM$RANDOM"; # Random generates a number b/w 0 - 32767
+STARSHIP_SESSION_KEY="${STARSHIP_SESSION_KEY}0000000000000000" # Pad it to 16+ chars.
+export STARSHIP_SESSION_KEY=${STARSHIP_SESSION_KEY:0:16}; # Trim to 16-digits if excess.

--- a/src/init/starship.zsh
+++ b/src/init/starship.zsh
@@ -78,4 +78,6 @@ STARSHIP_START_TIME=$(::STARSHIP:: time)
 export STARSHIP_SHELL="zsh"
 
 # Set up the session key that will be used to store logs
-export STARSHIP_SESSION_KEY=$(::STARSHIP:: session)
+STARSHIP_SESSION_KEY="$RANDOM$RANDOM$RANDOM$RANDOM$RANDOM"; # Random generates a number b/w 0 - 32767
+STARSHIP_SESSION_KEY="${STARSHIP_SESSION_KEY}0000000000000000" # Pad it to 16+ chars.
+export STARSHIP_SESSION_KEY=${STARSHIP_SESSION_KEY:0:16}; # Trim to 16-digits if excess.


### PR DESCRIPTION
#### Description
We currently invoke `starship session` in a sub-shell to generate the session-key, which is non-performant. By using $RANDOM instead, we can avoid this and generate the session-key quicker. This commit provides this optimization for ZSH (tested on 5.8 and 4.3) and bash-3.2.

#### Motivation and Context
Improves the performance of shell startup.

```
### With `starship session`
~ ❯ benchmark_zsh
Benchmark #1: zsh -i -c exit;
  Time (mean ± σ):      69.0 ms ±   4.6 ms    [User: 33.7 ms, System: 27.2 ms]
  Range (min … max):    65.1 ms …  88.7 ms    50 runs

  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet PC without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.

### With `$RANDOM`
~ ❯ benchmark_zsh
Benchmark #1: zsh -i -c exit;
  Time (mean ± σ):      60.2 ms ±   2.3 ms    [User: 30.5 ms, System: 23.4 ms]
  Range (min … max):    57.6 ms …  69.2 ms    50 runs

### With starship not enabled.
~ ❯ benchmark_zsh
Benchmark #1: zsh -i -c exit;
  Time (mean ± σ):      58.4 ms ±   3.1 ms    [User: 29.7 ms, System: 22.2 ms]
  Range (min … max):    56.2 ms …  75.5 ms    50 runs

  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet PC without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.
```

#### How Has This Been Tested?
Verified that the snippet in question works on zsh-5.8, zsh-4.3 and bash-3.2. Also verified that the prompt works correctly using zsh-5.8

- [x] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
