### PR TITLE
docs: Update document for installing on windows

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -86,7 +86,7 @@ description: Starship is the minimal, blazing fast, and extremely customizable p
 
    #### Powershell
 
-   Add the following to the end of `Microsoft.PowerShell_profile.ps1`. The location of this file can be checked with the `$PROFILE` command on PowerShell.
+   Add the following to the end of `~\Documents\PowerShell\Microsoft.PowerShell_profile.ps1` (or `~/.config/powershell/Microsoft.PowerShell_profile.ps1` on -Nix):
 
    ```sh
    # ~\Documents\PowerShell\Profile.ps1

--- a/docs/README.md
+++ b/docs/README.md
@@ -86,7 +86,7 @@ description: Starship is the minimal, blazing fast, and extremely customizable p
 
    #### Powershell
 
-   Add the following to the end of `Microsoft.PowerShell_profile.ps1`. You can check the location of this ps1 file with `$PROFILE` command in PowerShell (typically the path is `~\Documents\PowerShell\Microsoft.PowerShell_profile.ps1` or `~\.config\powershell\Microsoft.PowerShell_profile.ps1` on -Nix)
+   Add the following to the end of `Microsoft.PowerShell_profile.ps1`. You can check the location of this file by querying `$PROFILE` variable in PowerShell. Typically the path is `~\Documents\PowerShell\Microsoft.PowerShell_profile.ps1` or `~\.config\powershell\Microsoft.PowerShell_profile.ps1` on -Nix.
 
    ```sh
    # ~\Documents\PowerShell\Profile.ps1

--- a/docs/README.md
+++ b/docs/README.md
@@ -86,7 +86,7 @@ description: Starship is the minimal, blazing fast, and extremely customizable p
 
    #### Powershell
 
-   Add the following to the end of `~\Documents\PowerShell\Microsoft.PowerShell_profile.ps1` (or `~/.config/powershell/Microsoft.PowerShell_profile.ps1` on -Nix):
+   Add the following to the end of `Microsoft.PowerShell_profile.ps1`. The location of this file can be checked with the `$PROFILE` command on PowerShell.
 
    ```sh
    # ~\Documents\PowerShell\Profile.ps1

--- a/docs/README.md
+++ b/docs/README.md
@@ -86,7 +86,7 @@ description: Starship is the minimal, blazing fast, and extremely customizable p
 
    #### Powershell
 
-   Add the following to the end of `~\Documents\PowerShell\Microsoft.PowerShell_profile.ps1` (or `~/.config/powershell/Microsoft.PowerShell_profile.ps1` on -Nix):
+   Add the following to the end of `Microsoft.PowerShell_profile.ps1`. You can check the location of this ps1 file with `$PROFILE` command in PowerShell (typically the path is `~\Documents\PowerShell\Microsoft.PowerShell_profile.ps1` or `~\.config\powershell\Microsoft.PowerShell_profile.ps1` on -Nix)
 
    ```sh
    # ~\Documents\PowerShell\Profile.ps1

--- a/docs/README.md
+++ b/docs/README.md
@@ -86,7 +86,7 @@ description: Starship is the minimal, blazing fast, and extremely customizable p
 
    #### Powershell
 
-   Add the following to the end of `Microsoft.PowerShell_profile.ps1`. You can check the location of this file by querying `$PROFILE` variable in PowerShell. Typically the path is `~\Documents\PowerShell\Microsoft.PowerShell_profile.ps1` or `~\.config\powershell\Microsoft.PowerShell_profile.ps1` on -Nix.
+   Add the following to the end of `Microsoft.PowerShell_profile.ps1`. You can check the location of this file by querying the `$PROFILE` variable in PowerShell. Typically the path is `~\Documents\PowerShell\Microsoft.PowerShell_profile.ps1` or `~\.config\powershell\Microsoft.PowerShell_profile.ps1` on -Nix.
 
    ```sh
    # ~\Documents\PowerShell\Profile.ps1

--- a/docs/ja-JP/README.md
+++ b/docs/ja-JP/README.md
@@ -94,7 +94,7 @@ description: Starship はミニマルで、非常に高速で、カスタマイ�
 
    #### Powershell
 
-   `Microsoft.PowerShell_profile.ps1` の末尾に以下を追加してください。このファイルの置き場所は PowerShell で `$PROFILE` コマンドを実行することで確認することができます。
+   `~\Documents\PowerShell\Microsoft.PowerShell_profile.ps1` (それか Nix上の `~/.config/powershell/Microsoft.PowerShell_profile.ps1` )の末尾に以下を追加してください。
 
    ```sh
    # ~\Documents\PowerShell\Profile.ps1

--- a/docs/ja-JP/README.md
+++ b/docs/ja-JP/README.md
@@ -94,7 +94,7 @@ description: Starship はミニマルで、非常に高速で、カスタマイ�
 
    #### Powershell
 
-   `~\Documents\PowerShell\Microsoft.PowerShell_profile.ps1` (それか Nix上の `~/.config/powershell/Microsoft.PowerShell_profile.ps1` )の末尾に以下を追加してください。
+   `Microsoft.PowerShell_profile.ps1` の末尾に以下を追加してください。このファイルの置き場所は PowerShell で `$PROFILE` コマンドを実行することで確認することができます。
 
    ```sh
    # ~\Documents\PowerShell\Profile.ps1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
In present documents, it writes

> Add the following to the end of ~\Documents\PowerShell\Microsoft.PowerShell_profile.ps1 (or ~/.config/powershell/Microsoft.PowerShell_profile.ps1 on -Nix):

for installing on windows. But the location of this file depends on the version of the Windows, so I updated the document for telling users to check the correct path of ps1 file with `$PROFILE` command on PowerShell.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1753 

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
