### PR TITLE
docs: Fix typo in contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,7 +106,7 @@ cargo fmt
 
 Testing is critical to making sure starship works as intended on systems big and small. Starship interfaces with many applications and system APIs when generating the prompt, so there's a lot of room for bugs to slip in.
 
-Unit tests are written using the built-in Rust testing library in the same file as the implementation, as is traditionally done in Rust codebases. These tests can be run with `cargo test` and are run on GitHub as part of our GitHub Actions continuous integration to ensure consistend behavior.
+Unit tests are written using the built-in Rust testing library in the same file as the implementation, as is traditionally done in Rust codebases. These tests can be run with `cargo test` and are run on GitHub as part of our GitHub Actions continuous integration to ensure consistent behavior.
 
 All tests that test the rendered output of a module should use `ModuleRenderer`. For Example:
 


### PR DESCRIPTION
#### Description

"consistent" was misspelled in the contributing doc as "consistend". This change fixes that.

#### Motivation and Context

I was interested in contributing and was reading through the contributing doc and noticed the typo.

#### How Has This Been Tested?

This has been tested by a spellchecker and viewing at https://github.com/aduong/starship/blob/contributing/CONTRIBUTING.md

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] (N/A) I have updated the tests accordingly.
