### PR TITLE
test(aws): Ignore tests that check .aws files

### DIFF
--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -124,6 +124,7 @@ mod tests {
     use std::io::{self, Write};
 
     #[test]
+    #[ignore]
     fn no_region_set() -> io::Result<()> {
         let actual = ModuleRenderer::new("aws").collect();
         let expected = None;
@@ -377,6 +378,7 @@ region = us-east-2
     }
 
     #[test]
+    #[ignore]
     fn region_not_set_with_display_region() -> io::Result<()> {
         let actual = ModuleRenderer::new("aws")
             .config(toml::toml! {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
When running the AWS module it will parse the AWS config found in
`~/.aws/config` to get the region. This means that tests that expect no
region to be set will fail if there exists a default profile with a
region set, which is probably true for most AWS users. To avoid this
have set the AWS tests that depend on the non-existance of a
`.aws/config` to be ignored.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1773 

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
