### PR TITLE
perf(git_status): Improved git_status module performance

### DIFF
--- a/src/formatter/string_formatter.rs
+++ b/src/formatter/string_formatter.rs
@@ -229,7 +229,7 @@ impl<'a> StringFormatter<'a> {
                     StyleElement::Variable(name) => {
                         let variable = variables.get(name.as_ref()).unwrap_or(&None);
                         match variable {
-                            Some(style_string) => style_string.clone().map(|string| string),
+                            Some(style_string) => style_string.clone(),
                             None => Ok("".into()),
                         }
                     }

--- a/src/modules/git_status.rs
+++ b/src/modules/git_status.rs
@@ -152,9 +152,9 @@ impl<'a> GitStatusInfo<'a> {
         }
 
         {
+            let mut data = self.ahead_behind.write().unwrap();
             let repo = self.get_repository()?;
             let branch_name = self.get_branch_name();
-            let mut data = self.ahead_behind.write().unwrap();
             *data = Some(get_ahead_behind(&repo, &branch_name));
             match data.as_ref().unwrap() {
                 Ok(ahead_behind) => Some(*ahead_behind),
@@ -181,8 +181,8 @@ impl<'a> GitStatusInfo<'a> {
         }
 
         {
-            let mut repo = self.get_repository()?;
             let mut data = self.repo_status.write().unwrap();
+            let mut repo = self.get_repository()?;
             *data = Some(get_repo_status(&mut repo));
             match data.as_ref().unwrap() {
                 Ok(repo_status) => Some(*repo_status),
@@ -209,8 +209,8 @@ impl<'a> GitStatusInfo<'a> {
         }
 
         {
-            let mut repo = self.get_repository()?;
             let mut data = self.stashed_count.write().unwrap();
+            let mut repo = self.get_repository()?;
             *data = Some(get_stashed_count(&mut repo));
             match data.as_ref().unwrap() {
                 Ok(stashed_count) => Some(*stashed_count),
@@ -249,6 +249,7 @@ impl<'a> GitStatusInfo<'a> {
 
 /// Gets the number of files in various git states (staged, modified, deleted, etc...)
 fn get_repo_status(repository: &mut Repository) -> Result<RepoStatus, git2::Error> {
+    log::debug!("New repo status created");
     let mut status_options = git2::StatusOptions::new();
 
     let mut repo_status = RepoStatus::default();


### PR DESCRIPTION
#### Description
There is a race condition that happens between https://github.com/starship/starship/blob/9044f9e14ca36a70d748810a0c4eda89d3f18391/src/modules/git_status.rs#L171
and 
https://github.com/starship/starship/blob/9044f9e14ca36a70d748810a0c4eda89d3f18391/src/modules/git_status.rs#L185
because
https://github.com/starship/starship/blob/9044f9e14ca36a70d748810a0c4eda89d3f18391/src/modules/git_status.rs#L184
takes some time to process. While line 184 is executing line 171 executes of the other maps and returns a `None`. To avoid this I moved the write lock to the earliest point possible. **This is not a long term solution** a race condition can still happen if the processor switches context to a different thread at the wrong point. The real solution would be to pre initialize the `RepoStatus` object.

#### Motivation and Context
Fixes bug with `RepoStatus` being created more than once.

#### Screenshots (if appropriate):
Preformace diff: (the first one is with the fix)
![Screenshot from 2020-10-12 15-19-15](https://user-images.githubusercontent.com/35749450/95796825-c2f4f200-0ca2-11eb-879c-2ad8ab5b05d6.png)

#### How Has This Been Tested?
Doesn't change any platform dependent code.
- [x] Ran the tests on linux

