### PR TITLE
fix(directory): preserve substitution order

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,15 +438,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91b62f79061a0bc2e046024cb7ba44b08419ed238ecbd9adbd787434b9e8c25"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
@@ -487,12 +478,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b45e59b16c76b11bf9738fd5d38879d3bd28ad292d7b313608becb17ae2df9"
+checksum = "55e2e4c765aa53a0424761bf9f41aa7a6ac1efa87238f59560640e27fca028f2"
 dependencies = [
  "autocfg",
- "hashbrown 0.8.2",
+ "hashbrown",
 ]
 
 [[package]]
@@ -818,7 +809,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87a6df8506c2d359d5105344891f283e8e7ef81a7c6a542d516f8707e4a09b6b"
 dependencies = [
  "dlv-list",
- "hashbrown 0.9.1",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1183,6 +1174,7 @@ dependencies = [
  "dirs-next",
  "gethostname",
  "git2",
+ "indexmap",
  "log",
  "native-tls",
  "nix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ term_size = "0.3.2"
 quick-xml = "0.19.0"
 rand = "0.7.3"
 serde_derive = "1.0.115"
+indexmap = "1.6.0"
 notify-rust = { version = "4.0.0", optional = true }
 
 # Optional/http:

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,7 @@
 use crate::configs::StarshipRootConfig;
 use crate::utils;
 use ansi_term::{Color, Style};
+use indexmap::IndexMap;
 
 use std::clone::Clone;
 use std::collections::HashMap;
@@ -143,6 +144,22 @@ where
         }
 
         Some(hm)
+    }
+}
+
+impl<'a, T, S: ::std::hash::BuildHasher + Default> ModuleConfig<'a> for IndexMap<String, T, S>
+where
+    T: ModuleConfig<'a>,
+    S: Clone,
+{
+    fn from_config(config: &'a Value) -> Option<Self> {
+        let mut im = IndexMap::default();
+
+        for (x, y) in config.as_table()?.iter() {
+            im.insert(x.clone(), T::from_config(y)?);
+        }
+
+        Some(im)
     }
 }
 

--- a/src/configs/directory.rs
+++ b/src/configs/directory.rs
@@ -1,5 +1,5 @@
 use crate::config::{ModuleConfig, RootModuleConfig};
-use std::collections::HashMap;
+use indexmap::IndexMap;
 
 use starship_module_config_derive::ModuleConfig;
 
@@ -7,7 +7,7 @@ use starship_module_config_derive::ModuleConfig;
 pub struct DirectoryConfig<'a> {
     pub truncation_length: i64,
     pub truncate_to_repo: bool,
-    pub substitutions: HashMap<String, &'a str>,
+    pub substitutions: IndexMap<String, &'a str>,
     pub fish_style_pwd_dir_length: i64,
     pub use_logical_path: bool,
     pub format: &'a str,
@@ -24,7 +24,7 @@ impl<'a> RootModuleConfig<'a> for DirectoryConfig<'a> {
             truncation_length: 3,
             truncate_to_repo: true,
             fish_style_pwd_dir_length: 0,
-            substitutions: HashMap::new(),
+            substitutions: IndexMap::new(),
             use_logical_path: true,
             format: "[$path]($style)[$read_only]($read_only_style) ",
             style: "cyan bold",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Use `IndexMap` instead of `HashMap` to store directory substitutions in order to preserve the insertion order.

The extra crate dependency should be fine because it's already an indirect dependency.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1765

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
