### PR TITLE
fix: replace emoji for CMake and Erlang with NerdFonts

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -452,7 +452,7 @@ The `cmake` module shows the currently installed version of CMake if:
 | Option     | Default                            | Description                                  |
 | ---------- | ---------------------------------- | -------------------------------------------- |
 | `format`   | `"via [$symbol$version]($style) "` | The format for the module.                   |
-| `symbol`   | `"🛆 "`                             | The symbol used before the version of cmake. |
+| `symbol`   | `"喝 "`                             | The symbol used before the version of cmake. |
 | `style`    | `"bold blue"`                      | The style for the module.                    |
 | `disabled` | `false`                            | Disables the `cmake` module.                 |
 
@@ -920,7 +920,7 @@ The module will be shown if any of the following conditions are met:
 
 | Option     | Default                            | Description                                              |
 | ---------- | ---------------------------------- | -------------------------------------------------------- |
-| `symbol`   | `"🖧 "`                             | The symbol used before displaying the version of erlang. |
+| `symbol`   | `" "`                             | The symbol used before displaying the version of erlang. |
 | `style`    | `"bold red"`                       | The style for the module.                                |
 | `format`   | `"via [$symbol$version]($style) "` | The format for the module.                               |
 | `disabled` | `false`                            | Disables the `erlang` module.                            |

--- a/src/configs/cmake.rs
+++ b/src/configs/cmake.rs
@@ -14,7 +14,7 @@ impl<'a> RootModuleConfig<'a> for CMakeConfig<'a> {
     fn new() -> Self {
         CMakeConfig {
             format: "via [$symbol$version]($style) ",
-            symbol: "🛆 ",
+            symbol: "喝 ",
             style: "bold blue",
             disabled: false,
         }

--- a/src/configs/erlang.rs
+++ b/src/configs/erlang.rs
@@ -14,7 +14,7 @@ impl<'a> RootModuleConfig<'a> for ErlangConfig<'a> {
     fn new() -> Self {
         ErlangConfig {
             format: "via [$symbol$version]($style) ",
-            symbol: "🖧 ",
+            symbol: " ",
             style: "bold red",
             disabled: false,
         }

--- a/src/modules/cmake.rs
+++ b/src/modules/cmake.rs
@@ -77,7 +77,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("CMakeLists.txt"))?.sync_all()?;
         let actual = ModuleRenderer::new("cmake").path(dir.path()).collect();
-        let expected = Some(format!("via {} ", Color::Blue.bold().paint("🛆 v3.17.3")));
+        let expected = Some(format!("via {} ", Color::Blue.bold().paint("喝 v3.17.3")));
         assert_eq!(expected, actual);
         dir.close()
     }

--- a/src/modules/erlang.rs
+++ b/src/modules/erlang.rs
@@ -89,7 +89,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("rebar.config"))?.sync_all()?;
 
-        let expected = Some(format!("via {} ", Color::Red.bold().paint("🖧 22.1.3")));
+        let expected = Some(format!("via {} ", Color::Red.bold().paint(" 22.1.3")));
         let output = ModuleRenderer::new("erlang").path(dir.path()).collect();
 
         assert_eq!(output, expected);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
The emoji used for the CMake and Erlang modules appear to have little font support, as is shown on the emojipedia entries for the respective emoji:
https://emojipedia.org/triangle-with-rounded-corners/
https://emojipedia.org/three-networked-computers/

This PR replaces the emoji used with NerdFont icons for "Triangle Outline" and "Erlang".

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
