### PR TITLE
docs(config/README.md): Remove removed options from Memory example (fix #1799)

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1533,11 +1533,8 @@ To enable it, set `disabled` to `false` in your configuration file.
 
 [memory_usage]
 disabled = false
-show_percentage = true
-show_swap = true
 threshold = -1
 symbol = " "
-separator = "/"
 style = "bold dimmed green"
 ```
 


### PR DESCRIPTION
docs(config/README.md): Remove removed options from Memory example (fix #1799)

Remove the following options (unsupported since ec76faf & v0.45.0):
[memory_usage]
show_percentage = true
show_swap = true
separator = "/"

#### Description
See commit message above.

#### Motivation and Context
Fix #1799 

#### How Has This Been Tested?
N/A
Change to documentation only.

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
