### PR TITLE
fix(pwsh): preserve original console encondings

### DIFF
--- a/src/init/starship.ps1
+++ b/src/init/starship.ps1
@@ -1,7 +1,5 @@
 #!/usr/bin/env pwsh
 
-# Starship assumes UTF-8
-[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 function global:prompt {
     $origDollarQuestion = $global:?
     $origLastExitCode = $global:LASTEXITCODE
@@ -18,6 +16,9 @@ function global:prompt {
     # doesn't show the last command as a failure (because it had a non-zero exit code).
     $lastExitCodeForPrompt = if ($origLastExitCode) { $origLastExitCode } else { 0 }
 
+    # Save old output encoding and set it to UTF-8
+    $origOutputEncoding = [Console]::OutputEncoding
+    [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
     if ($lastCmd = Get-History -Count 1) {
         $duration = [math]::Round(($lastCmd.EndExecutionTime - $lastCmd.StartExecutionTime).TotalMilliseconds)
         # & ensures the path is interpreted as something to execute
@@ -25,6 +26,8 @@ function global:prompt {
     } else {
         $out = @(&::STARSHIP:: prompt "--path=$current_directory" --status=$lastExitCodeForPrompt --jobs=$jobs)
     }
+    # Restore old output encoding
+    [Console]::OutputEncoding = $origOutputEncoding
 
     # Convert stdout (array of lines) to expected return type string
     # `n is an escaped newline


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

Instead of forcing the whole shell to use utf-8 only change the `[Console]::OutputEncoding` before `starship prompt` is run and restore the old value afterwards.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1801

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
