### PR TITLE
feat(vagrant): Add support for Vagrant

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -217,6 +217,7 @@ $ruby\
 $rust\
 $swift\
 $terraform\
+$vagrant\
 $zig\
 $nix_shell\
 $conda\
@@ -2282,6 +2283,41 @@ style_root = "black bold"
 format = "user: [$user]($style) "
 disabled = false
 show_always = true
+```
+
+## Vagrant
+
+The `vagrant` module shows the currently installed version of Vagrant.
+The module will be shown if any of the following conditions are met:
+
+- The current directory contains a `Vagrantfile` file
+
+### Options
+
+| Option     | Default                            | Description                                         |
+| ---------- | ---------------------------------- | --------------------------------------------------- |
+| `format`   | `"via [$symbol($version )]($style)"` | The format for the module.                          |
+| `symbol`   | `"⍱ "`                             | A format string representing the symbol of Vagrant. |
+| `style`    | `"cyan bold"`                      | The style for the module.                           |
+| `disabled` | `false`                            | Disables the `Vagrant` module.                      |
+
+### Variables
+
+| Variable | Example          | Description                          |
+| -------- | ---------------- | ------------------------------------ |
+| version  | `Vagrant 2.2.10` | The version of `Vagrant`             |
+| symbol   |                  | Mirrors the value of option `symbol` |
+| style\*  |                  | Mirrors the value of option `style`  |
+
+\*: This variable can only be used as a part of a style string
+
+### Example
+
+```toml
+# ~/.config/starship.toml
+
+[vagrant]
+format = "via [⍱ $version](bold white) "
 ```
 
 ## Zig

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -47,6 +47,7 @@ pub mod swift;
 pub mod terraform;
 pub mod time;
 pub mod username;
+pub mod vagrant;
 pub mod zig;
 
 pub use starship_root::*;

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -49,6 +49,7 @@ pub const PROMPT_ORDER: &[&str] = &[
     "rust",
     "swift",
     "terraform",
+    "vagrant",
     "zig",
     // ↑ Toolchain version modules ↑
     "nix_shell",

--- a/src/configs/vagrant.rs
+++ b/src/configs/vagrant.rs
@@ -1,0 +1,22 @@
+use crate::config::{ModuleConfig, RootModuleConfig};
+
+use starship_module_config_derive::ModuleConfig;
+
+#[derive(Clone, ModuleConfig)]
+pub struct VagrantConfig<'a> {
+    pub format: &'a str,
+    pub symbol: &'a str,
+    pub style: &'a str,
+    pub disabled: bool,
+}
+
+impl<'a> RootModuleConfig<'a> for VagrantConfig<'a> {
+    fn new() -> Self {
+        VagrantConfig {
+            format: "via [$symbol($version )]($style)",
+            symbol: "⍱ ",
+            style: "cyan bold",
+            disabled: false,
+        }
+    }
+}

--- a/src/module.rs
+++ b/src/module.rs
@@ -58,6 +58,7 @@ pub const ALL_MODULES: &[&str] = &[
     "status",
     "time",
     "username",
+    "vagrant",
     "zig",
 ];
 

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -48,6 +48,7 @@ mod terraform;
 mod time;
 mod username;
 mod utils;
+mod vagrant;
 mod zig;
 
 #[cfg(feature = "battery")]
@@ -114,6 +115,7 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
             "time" => time::module(context),
             "crystal" => crystal::module(context),
             "username" => username::module(context),
+            "vagrant" => vagrant::module(context),
             "zig" => zig::module(context),
             _ => {
                 eprintln!("Error: Unknown module {}. Use starship module --list to list out all supported modules.", module);
@@ -185,6 +187,7 @@ pub fn description(module: &str) -> &'static str {
         "terraform" => "The currently selected terraform workspace and version",
         "time" => "The current local time",
         "username" => "The active user's username",
+        "vagrant" => "The currently installed version of Vagrant",
         "zig" => "The currently installed version of Zig",
         _ => "<no description>",
     }

--- a/src/modules/vagrant.rs
+++ b/src/modules/vagrant.rs
@@ -1,0 +1,105 @@
+use super::{Context, Module, RootModuleConfig};
+
+use crate::configs::vagrant::VagrantConfig;
+use crate::formatter::StringFormatter;
+use crate::utils;
+
+/// Creates a module with the current Vagrant version
+///
+/// Will display the Vagrant version if any of the following criteria are met:
+///     - Current directory contains a `Vagrantfile` file
+pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let is_vagrant_project = context
+        .try_begin_scan()?
+        .set_files(&["Vagrantfile"])
+        .is_match();
+
+    if !is_vagrant_project {
+        return None;
+    }
+
+    let mut module = context.new_module("vagrant");
+    let config = VagrantConfig::try_load(module.config);
+    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
+        formatter
+            .map_meta(|var, _| match var {
+                "symbol" => Some(config.symbol),
+                _ => None,
+            })
+            .map_style(|variable| match variable {
+                "style" => Some(Ok(config.style)),
+                _ => None,
+            })
+            .map(|variable| match variable {
+                "version" => format_vagrant_version(
+                    &utils::exec_cmd("vagrant", &["--version"])?.stdout.as_str(),
+                )
+                .map(Ok),
+                _ => None,
+            })
+            .parse(None)
+    });
+
+    module.set_segments(match parsed {
+        Ok(segments) => segments,
+        Err(error) => {
+            log::warn!("Error in module `vagrant`:\n{}", error);
+            return None;
+        }
+    });
+
+    Some(module)
+}
+
+fn format_vagrant_version(vagrant_stdout: &str) -> Option<String> {
+    // `vagrant --version` output looks like this:
+    // Vagrant 2.2.10
+    let version = vagrant_stdout
+        // split into ["Vagrant","2.2.10"]
+        .split_whitespace()
+        // return "2.2.10"
+        .nth(1)?;
+
+    let mut formatted_version = String::with_capacity(version.len() + 1);
+    formatted_version.push('v');
+    formatted_version.push_str(version);
+    Some(formatted_version)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test::ModuleRenderer;
+    use ansi_term::Color;
+    use std::fs::File;
+    use std::io;
+
+    #[test]
+    fn folder_without_vagrant_files() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+
+        let actual = ModuleRenderer::new("vagrant").path(dir.path()).collect();
+
+        let expected = None;
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn folder_with_vagrant_file() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join("Vagrantfile"))?.sync_all()?;
+
+        let actual = ModuleRenderer::new("vagrant").path(dir.path()).collect();
+
+        let expected = Some(format!("via {}", Color::Cyan.bold().paint("⍱ v2.2.10 ")));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn test_format_vagrant_version() {
+        let vagrant = "Vagrant 2.2.10\n";
+        assert_eq!(format_vagrant_version(vagrant), Some("v2.2.10".to_string()));
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -149,6 +149,10 @@ Target: x86_64-apple-darwin19.4.0\n",
             ),
             stderr: String::default(),
         }),
+        "vagrant --version" => Some(CommandOutput {
+            stdout: String::from("Vagrant 2.2.10\n"),
+            stderr: String::default(),
+        }),
         "zig version" => Some(CommandOutput {
             stdout: String::from("0.6.0\n"),
             stderr: String::default(),


### PR DESCRIPTION
Signed-off-by: Dentrax <furkan.turkal@hotmail.com>

#### Description
This PR adds support for [Vagrant](https://www.vagrantup.com/).

#### Motivation and Context
Closes #1792 _(Thanks @developer-guy for the idea!)_

#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [X] I have updated the documentation accordingly.
- [X] I have updated the tests accordingly.

I ran tests but get an error:

```sh
error[E0658]: use of unstable library feature 'str_strip': newly added
   --> src/print.rs:298:41
    |
298 |     } else if let Some(module) = module.strip_prefix("custom.") {
    |                                         ^^^^^^^^^^^^
    |
    = note: see issue #67302 <https://github.com/rust-lang/rust/issues/67302> for more information
```

... but, _vagrant.rs_ unit tests are passing. I'd appreciate if someone who able to build successfully and test it. I couldn't understand exactly what `use of unstable library feature 'str_strip': newly added` error means actually. :)