### PR TITLE
fix(zsh): Ensure existing keymap change functions are not overriden

### DIFF
--- a/src/init/starship.zsh
+++ b/src/init/starship.zsh
@@ -54,13 +54,27 @@ if [[ -z ${preexec_function[(re)starship_preexec]} ]]; then
 fi
 
 # Set up a function to redraw the prompt if the user switches vi modes
-zle-keymap-select() {
+starship_zle-keymap-select() {
     starship_render
     zle reset-prompt
 }
 
+## Check for existing keymap-select widget.
+local existing_keymap_select_fn=$widgets[zle-keymap-select];
+# zle-keymap-select is a special widget so it'll be "user:fnName" or nothing. Let's get fnName only.
+existing_keymap_select_fn=${existing_keymap_select_fn//user:};
+if [[ -z ${existing_keymap_select_fn} ]]; then
+    zle -N zle-keymap-select starship_zle-keymap-select;
+else
+    # Define a wrapper fn to call the original widget fn and then Starship's.
+    starship_zle-keymap-select-wrapped() {
+        ${existing_keymap_select_fn} "$@";
+        starship_zle-keymap-select "$@";
+    }
+    zle -N zle-keymap-select starship_zle-keymap-select-wrapped;
+fi
+
 STARSHIP_START_TIME=$(::STARSHIP:: time)
-zle -N zle-keymap-select
 export STARSHIP_SHELL="zsh"
 
 # Set up the session key that will be used to store logs


### PR DESCRIPTION
#### Description
The current zsh-wrapper overwrites `zle-keymap-select` if it exists already. These changes will ensure that we just append our behaviour to the existing function.

#### Motivation and Context
For zsh users who already have `zle-keymap-select` defined, we are currently overriding their configuration. This will fix that.
Closes #1804 

#### How Has This Been Tested?
Verified the behaviour on zsh-5.8 (MacOS) and zsh-4.3 (EC2 running Amazon Linux/Redhat).
 
- [x] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

###### Steps To Reproduce:
1. Add the following snippet in `zshrc` **BEFORE** sourcing starship.
    ```
    echo -ne '\e[5 q';    # Line Cursor
    function myfoo() {
            echo -ne '\e[1 q';   # Block Cursor
    }
    zle -N zle-keymap-select myfoo;
    ```
1. On starting shell, verify that a line cursor is present.
1. Change keymap mode after starting shell. (eg: ^X^V will trigger vi-mode)

Success Criteria: The cursor will become a block.

#### Checklist:
<Not applicable>

- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
