### PR TITLE
docs(cmd_duration): Document cmd_duration notifications

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -494,6 +494,11 @@ running `eval $(starship init $0)`, and then proceed as normal.
 | `format`            | `"took [$duration]($style) "` | The format for the module.                                 |
 | `style`             | `"bold yellow"`               | The style for the module.                                  |
 | `disabled`          | `false`                       | Disables the `cmd_duration` module.                        |
+| `show_notifications`| `false`                       | Show desktop notifications when command completes.         |
+| `min_time_to_notify`| `45_000`                      | Shortest duration for notification (in milliseconds).      |
+
+Showing desktop notifications requires starship to be built with `rust-notify` support. You check if your starship
+supports notifications by running `STARSHIP_LOG=debug starship module cmd_duration -d 60_000`.
 
 ### Variables
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -497,8 +497,12 @@ running `eval $(starship init $0)`, and then proceed as normal.
 | `show_notifications`| `false`                       | Show desktop notifications when command completes.         |
 | `min_time_to_notify`| `45_000`                      | Shortest duration for notification (in milliseconds).      |
 
+::: tip
+
 Showing desktop notifications requires starship to be built with `rust-notify` support. You check if your starship
-supports notifications by running `STARSHIP_LOG=debug starship module cmd_duration -d 60_000`.
+supports notifications by running `STARSHIP_LOG=debug starship module cmd_duration -d 60000` when `show_notifications` is set to `true`.
+
+:::
 
 ### Variables
 


### PR DESCRIPTION
Added in #1019

<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
Adds documentation for new config options.

#### Motivation and Context
This is new and not yet enabled by default in binaries available e.g. via homebrew (see #1830 ). I'm not sure what the best approach is to 
1. document the minimum version required for options
2. whether to document options that many users are unlikely to have available yet (unless they build from source with `--features rust-notify`)

Fixes: #1597

#### Screenshots (if appropriate):
n/a

#### How Has This Been Tested?
Documented based on source changed in #1019 .

- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- n/a I have updated the tests accordingly.
