### PR TITLE
fix(bug-report): verify exit code of open, always print url

### DIFF
--- a/src/bug_report.rs
+++ b/src/bug_report.rs
@@ -19,19 +19,19 @@ pub fn create() {
     };
 
     let link = make_github_issue_link(crate_version!(), environment);
+    let short_link = shorten_link(&link);
 
     if open::that(&link)
         .map(|status| status.success())
         .unwrap_or(false)
     {
-        print!("Take a look at your browser. A GitHub issue has been populated with your configuration")
+        println!("Take a look at your browser. A GitHub issue has been populated with your configuration.");
+        println!("If your browser has failed to open, please click this link:\n");
     } else {
-        let link = shorten_link(&link).unwrap_or(link);
-        println!(
-            "Click this link to create a GitHub issue populated with your configuration:\n\n  {}",
-            link
-        );
+        println!("Click this link to create a GitHub issue populated with your configuration:\n");
     }
+
+    println!(" {}", short_link.unwrap_or(link));
 }
 
 #[cfg(feature = "http")]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

`open::that` returns an `io::Result<ExitCode>` but only the `Result` was checked, not if the `ExitCode` indicated failure. This PR makes it verify both.

To prevent issues like #1838 in the future it might make sense to always print the URL. Should I add this to this PR too?

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1838

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
