### PR TITLE
perf(init/pwsh): use get-random for session-key instead of invoking starship session

### DIFF
--- a/src/init/starship.ps1
+++ b/src/init/starship.ps1
@@ -66,4 +66,4 @@ function global:prompt {
 $ENV:STARSHIP_SHELL = "powershell"
 
 # Set up the session key that will be used to store logs
-$ENV:STARSHIP_SESSION_KEY = (& ::STARSHIP:: session)
+$ENV:STARSHIP_SESSION_KEY = -join ((48..57) + (65..90) + (97..122) | Get-Random -Count 16 | ForEach-Object { [char]$_ })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

Use powershell builtins instead of `starship session` because it's faster. Based on the work in #1576.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

#1755

Benchmark:
```
~
❯ Measure-Command {-join ((48..57) + (65..90) + (97..122) | Get-Random -Count 16 | ForEach-Object { [char]$_ })}


Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 0
Milliseconds      : 7
Ticks             : 70925
TotalDays         : 8.20891203703704E-08
TotalHours        : 1.97013888888889E-06
TotalMinutes      : 0.000118208333333333
TotalSeconds      : 0.0070925
TotalMilliseconds : 7.0925

~
❯ Measure-Command {starship session}


Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 0
Milliseconds      : 19
Ticks             : 198315
TotalDays         : 2.2953125E-07
TotalHours        : 5.50875E-06
TotalMinutes      : 0.000330525
TotalSeconds      : 0.0198315
TotalMilliseconds : 19.8315

```

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
