### PR TITLE
fix(pwsh): fix crash on error in shell with old pwsh

### DIFF
--- a/src/init/starship.ps1
+++ b/src/init/starship.ps1
@@ -19,12 +19,12 @@ function global:prompt {
     [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
     if ($lastCmd = Get-History -Count 1) {
         # In case we have a False on the Dollar hook, we know there's an error.
-        if( -not $origDollarQuestion){
-          # We retrieve the InvocationInfo from the most recent error.
-          $lastCmdletError = Get-Error |  Where-Object {$_ -ne $null} | Select-Object -expand InvocationInfo
-          # We check if the las command executed matches the line that caused the last error , in which case we know
-          # it was an internal Powershell command, otherwise, there MUST be an error code.
-          $lastExitCodeForPrompt = if($lastCmd.CommandLine -eq $lastCmdletError.Line){1} else {$origLastExitCode}
+        if (-not $origDollarQuestion) {
+            # We retrieve the InvocationInfo from the most recent error.
+            $lastCmdletError = try { Get-Error |  Where-Object { $_ -ne $null } | Select-Object -expand InvocationInfo } catch { $null }
+            # We check if the las command executed matches the line that caused the last error , in which case we know
+            # it was an internal Powershell command, otherwise, there MUST be an error code.
+            $lastExitCodeForPrompt = if ($null -ne $lastCmdletError -and $lastCmd.CommandLine -eq $lastCmdletError.Line) { 1 } else { $origLastExitCode }
         }
 
         $duration = [math]::Round(($lastCmd.EndExecutionTime - $lastCmd.StartExecutionTime).TotalMilliseconds)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Older powershell versions don't have `Get-Error`. Handle missing `Get-Error` gracefully.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

#### Screenshots (if appropriate):

Before on Powershell 5:
```
~
❯ Write-Error '' -ErrorAction 'Ignore'

PS>
```
After:
```
~
❯ Write-Error '' -ErrorAction 'Ignore'

~
❯ 
```

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
