### PR TITLE
feat(terraform): Add hcl extension support to Terraform module 

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2244,7 +2244,7 @@ If you still want to enable it, [follow the example shown below](#with-version).
 The module will be shown if any of the following conditions are met:
 
 - The current directory contains a `.terraform` folder
-- Current directory contains a file with the `.tf` extension
+- Current directory contains a file with the `.tf` or `.hcl` extensions
 
 ### Options
 

--- a/src/modules/terraform.rs
+++ b/src/modules/terraform.rs
@@ -16,7 +16,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let is_terraform_project = context
         .try_begin_scan()?
         .set_folders(&[".terraform"])
-        .set_extensions(&["tf"])
+        .set_extensions(&["tf", "hcl"])
         .is_match();
 
     if !is_terraform_project {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Added `hcl` extension to terraform module to support [different terraform syntax](https://www.terraform.io/docs/configuration/syntax.html) 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When use tools like [Terragrunt](https://terragrunt.gruntwork.io/grunt) Starship doesn't recognize that this repo uses terraform because the terraform files ends with `hcl` extension
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [X] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
