### PR TITLE
docs: alphabetic sorting of configuration subsections

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1744,58 +1744,6 @@ The module will be shown if any of the following conditions are met:
 format = "via [🤖 $version](bold green) "
 ```
 
-## Package Version
-
-The `package` module is shown when the current directory is the repository for a
-package, and shows its current version. The module currently supports `npm`, `cargo`,
-`poetry`, `composer`, `gradle`, `julia`, `mix` and `helm` packages.
-
-- **npm** – The `npm` package version is extracted from the `package.json` present
-  in the current directory
-- **cargo** – The `cargo` package version is extracted from the `Cargo.toml` present
-  in the current directory
-- **poetry** – The `poetry` package version is extracted from the `pyproject.toml` present
-  in the current directory
-- **composer** – The `composer` package version is extracted from the `composer.json` present
-  in the current directory
-- **gradle** – The `gradle` package version is extracted from the `build.gradle` present
-- **julia** - The package version is extracted from the `Project.toml` present
-- **mix** - The `mix` package version is extracted from the `mix.exs` present
-- **helm** - The `helm` chart version is extracted from the `Chart.yaml` present
-- **maven** - The `maven` package version is extracted from the `pom.xml` present
-
-> ⚠️ The version being shown is that of the package whose source code is in your
-> current directory, not your package manager.
-
-### Options
-
-| Option            | Default                            | Description                                                |
-| ----------------- | ---------------------------------- | ---------------------------------------------------------- |
-| `format`          | `"via [$symbol$version]($style) "` | The format for the module.                                 |
-| `symbol`          | `"📦 "`                            | The symbol used before displaying the version the package. |
-| `style`           | `"bold 208"`                       | The style for the module.                                  |
-| `display_private` | `false`                            | Enable displaying version for packages marked as private.  |
-| `disabled`        | `false`                            | Disables the `package` module.                             |
-
-### Variables
-
-| Variable | Example  | Description                          |
-| -------- | -------- | ------------------------------------ |
-| version  | `v1.0.0` | The version of your package          |
-| symbol   |          | Mirrors the value of option `symbol` |
-| style\*  |          | Mirrors the value of option `style`  |
-
-\*: This variable can only be used as a part of a style string
-
-### Example
-
-```toml
-# ~/.config/starship.toml
-
-[package]
-format = "via [🎁 $version](208 bold) "
-```
-
 ## OCaml
 
 The `ocaml` module shows the currently installed version of OCaml.
@@ -1874,6 +1822,58 @@ style = "bold yellow"
 symbol = "☁️ "
 ```
 
+## Package Version
+
+The `package` module is shown when the current directory is the repository for a
+package, and shows its current version. The module currently supports `npm`, `cargo`,
+`poetry`, `composer`, `gradle`, `julia`, `mix` and `helm` packages.
+
+- **npm** – The `npm` package version is extracted from the `package.json` present
+  in the current directory
+- **cargo** – The `cargo` package version is extracted from the `Cargo.toml` present
+  in the current directory
+- **poetry** – The `poetry` package version is extracted from the `pyproject.toml` present
+  in the current directory
+- **composer** – The `composer` package version is extracted from the `composer.json` present
+  in the current directory
+- **gradle** – The `gradle` package version is extracted from the `build.gradle` present
+- **julia** - The package version is extracted from the `Project.toml` present
+- **mix** - The `mix` package version is extracted from the `mix.exs` present
+- **helm** - The `helm` chart version is extracted from the `Chart.yaml` present
+- **maven** - The `maven` package version is extracted from the `pom.xml` present
+
+> ⚠️ The version being shown is that of the package whose source code is in your
+> current directory, not your package manager.
+
+### Options
+
+| Option            | Default                            | Description                                                |
+| ----------------- | ---------------------------------- | ---------------------------------------------------------- |
+| `format`          | `"via [$symbol$version]($style) "` | The format for the module.                                 |
+| `symbol`          | `"📦 "`                            | The symbol used before displaying the version the package. |
+| `style`           | `"bold 208"`                       | The style for the module.                                  |
+| `display_private` | `false`                            | Enable displaying version for packages marked as private.  |
+| `disabled`        | `false`                            | Disables the `package` module.                             |
+
+### Variables
+
+| Variable | Example  | Description                          |
+| -------- | -------- | ------------------------------------ |
+| version  | `v1.0.0` | The version of your package          |
+| symbol   |          | Mirrors the value of option `symbol` |
+| style\*  |          | Mirrors the value of option `style`  |
+
+\*: This variable can only be used as a part of a style string
+
+### Example
+
+```toml
+# ~/.config/starship.toml
+
+[package]
+format = "via [🎁 $version](208 bold) "
+```
+
 ## Perl
 
 The `perl` module shows the currently installed version of Perl.
@@ -1946,6 +1946,42 @@ The module will be shown if any of the following conditions are met:
 
 [php]
 format = "via [🔹 $version](147 bold) "
+```
+
+## PureScript
+
+The `purescript` module shows the currently installed version of PureScript version.
+The module will be shown if any of the following conditions are met:
+
+- The current directory contains a `spago.dhall` file
+- The current directory contains a \*.purs files
+
+### Options
+
+| Option     | Default                            | Description                                                  |
+| ---------- | ---------------------------------- | ------------------------------------------------------------ |
+| `format`   | `"via [$symbol$version]($style) "` | The format for the module.                                   |
+| `symbol`   | `"<=> "`                           | The symbol used before displaying the version of PureScript. |
+| `style`    | `"bold white"`                     | The style for the module.                                    |
+| `disabled` | `false`                            | Disables the `purescript` module.                            |
+
+### Variables
+
+| Variable | Example  | Description                          |
+| -------- | -------- | ------------------------------------ |
+| version  | `0.13.5` | The version of `purescript`          |
+| symbol   |          | Mirrors the value of option `symbol` |
+| style\*  |          | Mirrors the value of option `style`  |
+
+\*: This variable can only be used as a part of a style string
+
+### Example
+
+```toml
+# ~/.config/starship.toml
+
+[purescript]
+format = "via [$symbol$version](bold white)"
 ```
 
 ## Python
@@ -2156,42 +2192,6 @@ and `$SINGULARITY_NAME` is set.
 format = '[📦 \[$env\]]($style) '
 ```
 
-## Swift
-
-The `swift` module shows the currently installed version of Swift.
-The module will be shown if any of the following conditions are met:
-
-- The current directory contains a `Package.swift` file
-- The current directory contains a file with the `.swift` extension
-
-### Options
-
-| Option     | Default                            | Description                                      |
-| ---------- | ---------------------------------- | ------------------------------------------------ |
-| `format`   | `"via [$symbol$version]($style) "` | The format for the module.                       |
-| `symbol`   | `"🐦 "`                            | A format string representing the symbol of Swift |
-| `style`    | `"bold 202"`                       | The style for the module.                        |
-| `disabled` | `false`                            | Disables the `swift` module.                     |
-
-### Variables
-
-| Variable | Example  | Description                          |
-| -------- | -------- | ------------------------------------ |
-| version  | `v5.2.4` | The version of `swift`               |
-| symbol   |          | Mirrors the value of option `symbol` |
-| style\*  |          | Mirrors the value of option `style`  |
-
-\*: This variable can only be used as a part of a style string
-
-### Example
-
-```toml
-# ~/.config/starship.toml
-
-[swift]
-format = "via [🏎  $version](red bold)"
-```
-
 ## Status
 
 The `status` module displays the exit code of the previous command.
@@ -2234,6 +2234,42 @@ symbol = "💣 "
 format = '[\[$symbol$status\]]($style) '
 disabled = false
 
+```
+
+## Swift
+
+The `swift` module shows the currently installed version of Swift.
+The module will be shown if any of the following conditions are met:
+
+- The current directory contains a `Package.swift` file
+- The current directory contains a file with the `.swift` extension
+
+### Options
+
+| Option     | Default                            | Description                                      |
+| ---------- | ---------------------------------- | ------------------------------------------------ |
+| `format`   | `"via [$symbol$version]($style) "` | The format for the module.                       |
+| `symbol`   | `"🐦 "`                            | A format string representing the symbol of Swift |
+| `style`    | `"bold 202"`                       | The style for the module.                        |
+| `disabled` | `false`                            | Disables the `swift` module.                     |
+
+### Variables
+
+| Variable | Example  | Description                          |
+| -------- | -------- | ------------------------------------ |
+| version  | `v5.2.4` | The version of `swift`               |
+| symbol   |          | Mirrors the value of option `symbol` |
+| style\*  |          | Mirrors the value of option `style`  |
+
+\*: This variable can only be used as a part of a style string
+
+### Example
+
+```toml
+# ~/.config/starship.toml
+
+[swift]
+format = "via [🏎  $version](red bold)"
 ```
 
 ## Terraform
@@ -2525,40 +2561,4 @@ format = " transcending [$output]($style)"
 command = "time /T"
 files = ["*.pst"]
 shell = ["pwsh.exe", "-NoProfile", "-Command", "-"]
-```
-
-## PureScript
-
-The `purescript` module shows the currently installed version of PureScript version.
-The module will be shown if any of the following conditions are met:
-
-- The current directory contains a `spago.dhall` file
-- The current directory contains a \*.purs files
-
-### Options
-
-| Option     | Default                            | Description                                                  |
-| ---------- | ---------------------------------- | ------------------------------------------------------------ |
-| `format`   | `"via [$symbol$version]($style) "` | The format for the module.                                   |
-| `symbol`   | `"<=> "`                           | The symbol used before displaying the version of PureScript. |
-| `style`    | `"bold white"`                     | The style for the module.                                    |
-| `disabled` | `false`                            | Disables the `purescript` module.                            |
-
-### Variables
-
-| Variable | Example  | Description                          |
-| -------- | -------- | ------------------------------------ |
-| version  | `0.13.5` | The version of `purescript`          |
-| symbol   |          | Mirrors the value of option `symbol` |
-| style\*  |          | Mirrors the value of option `style`  |
-
-\*: This variable can only be used as a part of a style string
-
-### Example
-
-```toml
-# ~/.config/starship.toml
-
-[purescript]
-format = "via [$symbol$version](bold white)"
 ```


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Reorders the sections in `docs/config/README.md` so that they are in alpahbetical order (except "Prompt", which stays at the first place because it documents the default section in the TOML file)/
