### PR TITLE
perf(memory_usage): replace sysinfo with sys-info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,12 +390,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "doc-comment"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
-
-[[package]]
 name = "dtoa"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -704,15 +698,6 @@ dependencies = [
  "dbus",
  "mac-notification-sys",
  "winrt-notification",
-]
-
-[[package]]
-name = "ntapi"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a31937dea023539c72ddae0e3571deadc1414b300483fa7aaec176168cfa9d2"
-dependencies = [
- "winapi",
 ]
 
 [[package]]
@@ -1229,7 +1214,7 @@ dependencies = [
  "serde_json",
  "shell-words",
  "starship_module_config_derive",
- "sysinfo",
+ "sys-info",
  "tempfile",
  "term_size",
  "toml",
@@ -1303,18 +1288,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "sysinfo"
-version = "0.15.3"
+name = "sys-info"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67330cbee3b2a819e3365a773f05e884a136603687f812bf24db5b6c3d76b696"
+checksum = "e5cfbd84f86389198ade41b439f72a5b1b3a8ba728e61cd589e1720d0df44c39"
 dependencies = [
- "cfg-if 0.1.10",
- "doc-comment",
+ "cc",
  "libc",
- "ntapi",
- "once_cell",
- "rayon",
- "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ unicode-segmentation = "1.6.0"
 gethostname = "0.2.1"
 once_cell = "1.5.2"
 chrono = "0.4"
-sysinfo = "0.15.3"
+sys-info = "0.7.0"
 byte-unit = "4.0.9"
 starship_module_config_derive = { version = "0.1.2", path = "starship_module_config_derive" }
 yaml-rust = "0.4"

--- a/src/modules/memory_usage.rs
+++ b/src/modules/memory_usage.rs
@@ -38,15 +38,13 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         return None;
     }
 
-    let system = sys_info::mem_info();
-    if system.is_err() {
-        log::warn!(
-            "Unable to access memory usage information:\n{}",
-            system.unwrap_err()
-        );
-        return None;
-    }
-    let system = system.unwrap();
+    let system = match sys_info::mem_info() {
+        Ok(info) => info,
+        Err(err) => {
+            log::warn!("Unable to access memory usage information:\n{}", err);
+            return None;
+        }
+    };
 
     // avail includes reclaimable memory, but isn't supported on all platforms
     let avail_memory_kib = match system.avail {

--- a/src/modules/memory_usage.rs
+++ b/src/modules/memory_usage.rs
@@ -40,7 +40,10 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
     let system = sys_info::mem_info();
     if system.is_err() {
-        log::warn!("Unable to access memory usage information:\n{}", system.unwrap_err());
+        log::warn!(
+            "Unable to access memory usage information:\n{}",
+            system.unwrap_err()
+        );
         return None;
     }
     let system = system.unwrap();

--- a/src/modules/memory_usage.rs
+++ b/src/modules/memory_usage.rs
@@ -1,5 +1,4 @@
 use byte_unit::{Byte, ByteUnit};
-use sysinfo::{RefreshKind, SystemExt};
 
 use super::{Context, Module, RootModuleConfig, Shell};
 
@@ -39,9 +38,20 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         return None;
     }
 
-    let system = sysinfo::System::new_with_specifics(RefreshKind::new().with_memory());
-    let used_memory_kib = system.get_used_memory();
-    let total_memory_kib = system.get_total_memory();
+    let system = sys_info::mem_info();
+    if system.is_err() {
+        log::warn!("Unable to access memory usage information:\n{}", system.unwrap_err());
+        return None;
+    }
+    let system = system.unwrap();
+
+    // avail includes reclaimable memory, but isn't supported on all platforms
+    let avail_memory_kib = match system.avail {
+        0 => system.free,
+        _ => system.avail,
+    };
+    let used_memory_kib = system.total - avail_memory_kib;
+    let total_memory_kib = system.total;
     let ram_used = (used_memory_kib as f64 / total_memory_kib as f64) * 100.;
     let ram_pct = format_pct(ram_used, pct_sign);
 
@@ -51,8 +61,8 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     }
 
     let ram = format_usage_total(used_memory_kib, total_memory_kib);
-    let total_swap_kib = system.get_total_swap();
-    let used_swap_kib = system.get_used_swap();
+    let total_swap_kib = system.swap_total;
+    let used_swap_kib = system.swap_total - system.swap_free;
     let percent_swap_used = (used_swap_kib as f64 / total_swap_kib as f64) * 100.;
     let swap_pct = format_pct(percent_swap_used, pct_sign);
     let swap = format_usage_total(used_swap_kib, total_swap_kib);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Sysinfo is slow to get memory usage information both on windows (#1564) and linux (#1879).
This PR replaces it with the `sys-info` library.

### Potential issues
Right now `sys-info` calculates swap incorrectly on windows, but I already made a PR for that (FillZpp/sys-info-rs#73)


#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1879
Closes #1573
Closes #1564

#### Screenshots (if appropriate):
Benchmark (windows):
| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `starship module memory_usage` | 336.9 ± 7.3 | 325.6 | 346.5 | 17.87 ± 5.43 |
| `target/release/starship module memory_usage` | 18.9 ± 5.7 | 16.9 | 78.6 | 1.00 |

Benchmark (linux):
| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `starship module memory_usage` | 5.9 ± 1.4 | 4.8 | 31.2 | 1.76 ± 0.58 |
| `target/release/starship module memory_usage` | 3.4 ± 0.8 | 2.6 | 21.9 | 1.00 |

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
