### PR TITLE
feat(config): Add support for config composition using `$STARSHIP_CONFIG`

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -42,6 +42,9 @@ Or for Cmd (Windows) would be adding this line to your `starship.lua`:
 os.setenv('STARSHIP_CONFIG', 'C:\\Users\\user\\example\\non\\default\\path\\starship.toml')
 ```
 
+The `STARSHIP_CONFIG` environment variable may point towards multiple files separated by the OS's PATH-like separator; `:` on MacOS and Linux and `;` on Windows.
+The first mention of a value wins; the first file has precedence over the following files. Typically the default, or catch-all, config should be last.
+
 ### Logging
 
 By default starship logs warnings and errors into a file named `~/.cache/starship/session_${STARSHIP_SESSION_KEY}.log`, where the session key is corresponding to a instance of your terminal.

--- a/src/bug_report.rs
+++ b/src/bug_report.rs
@@ -208,17 +208,15 @@ fn get_config_path(shell: &str) -> Option<PathBuf> {
 }
 
 fn get_starship_config() -> String {
-    std::env::var("STARSHIP_CONFIG")
-        .map(PathBuf::from)
-        .ok()
-        .or_else(|| {
-            utils::home_dir().map(|mut home_dir| {
-                home_dir.push(".config/starship.toml");
-                home_dir
-            })
-        })
-        .and_then(|config_path| fs::read_to_string(config_path).ok())
-        .unwrap_or_else(|| UNKNOWN_CONFIG.to_string())
+    let configs = crate::config::get_config_path()
+        .map(crate::config::read_configs)
+        .unwrap_or_else(Vec::new);
+
+    if configs.is_empty() {
+        UNKNOWN_CONFIG.to_string()
+    } else {
+        configs.join("\n---\n")
+    }
 }
 
 fn get_shell_version(shell: &str) -> String {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->
Hi👋

This PR introduces support for config composition. By setting `$STARSHIP_CONFIG` to multiple paths separated by whatever your OS uses for PATH-like separation (most commonly `:`), the first mention of a value wins. This mimics the resolution logic as seen in [kubectl](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/#merging-kubeconfig-files).

#### Motivation and Context

The motivation for config composition is to allow for conditional prompt modules while reusing the same basic config.

Conditional prompt setup is already possible by changing `$STARSHIP_CONFIG` via some external mechanism - such as dotenv. That, however, does not allow for reusing default configuration, and as such the config would need to be replicated across each separate config file.

By allowing `$STARSHIP_CONFIG` to point towards multiple config files, the problem of having repeated config is solved. This follows the precedence of other tools, maybe most noteworthy of which is kubectl, that reads all files in a config variable and concatenates them into one effective config.

There are effectively no changes to the regular code path of having just the one config in `$STARSHIP_CONFIG` and as such there should be no performance impact for that use case. Having multiple config files does not noticeably affect performance in my testing (20 files on the path).

While this doesn't directly solve any of the many tickets on conditional configuration, it may probably be used in conjunction with shell-based scripting (like hooking into the `fish_prompt` event in fish) to conditionally change only a small set of variables and might be good enough for some of the use cases. Here are some of the tickets I found on this topic:
#607 #680 #1001 #1081 #1235

Closes #2684

#### Screenshots (if appropriate):

N/A

#### How Has This Been Tested?

I've tested it with fish on WSL2 running Ubuntu on Windows 10. Even pointing `$STARSHIP_CONFIG` to files on the Windows disk (which is infamously slow for WSL2), there is still no noticeable performance impact with 20 files. And realistically I don't see people using more than a couple files for their config.

I've tested it with Powershell on Windows 10 where the separator for PATH-like variables is `;`, and that works as expected.

I've tested the same things with fish in MacOS and it works as expected there as well.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
I've updated the documentation in English. What's the process is for documentation in other languages?

- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
