### PR TITLE
fix(bash): Fix number of background jobs

### DIFF
--- a/src/init/starship.bash
+++ b/src/init/starship.bash
@@ -28,8 +28,11 @@ starship_preexec() {
 
 # Will be run before the prompt is drawn
 starship_precmd() {
+    local NUM_JOBS
     # Save the status, because commands in this pipeline will change $?
     STATUS=$?
+
+    NUM_JOBS=$(n=0; while read line; do [[ $line ]] && n=$((n+1));done <<< $(jobs -p) ; echo $n)
 
     # Run the bash precmd function, if it's set. If not set, evaluates to no-op
     "${starship_precmd_user_func-:}"
@@ -40,10 +43,10 @@ starship_precmd() {
     if [[ $STARSHIP_START_TIME ]]; then
         STARSHIP_END_TIME=$(::STARSHIP:: time)
         STARSHIP_DURATION=$((STARSHIP_END_TIME - STARSHIP_START_TIME))
-        PS1="$(::STARSHIP:: prompt --status=$STATUS --jobs="$(jobs -p | wc -l)" --cmd-duration=$STARSHIP_DURATION)"
+        PS1="$(::STARSHIP:: prompt --status=$STATUS --jobs="$NUM_JOBS" --cmd-duration=$STARSHIP_DURATION)"
         unset STARSHIP_START_TIME
     else
-        PS1="$(::STARSHIP:: prompt --status=$STATUS --jobs="$(jobs -p | wc -l)")"
+        PS1="$(::STARSHIP:: prompt --status=$STATUS --jobs="$NUM_JOBS")"
     fi
     PREEXEC_READY=true  # Signal that we can safely restart the timer
 }


### PR DESCRIPTION
Without this patch, I always get the indicator for background jobs.
Also it does not rely on `wc` to count.

<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1776 

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
