### PR TITLE
docs: update rust icon in preset configuration

### DIFF
--- a/docs/presets/README.md
+++ b/docs/presets/README.md
@@ -86,7 +86,7 @@ symbol = " "
 symbol = " "
 
 [rust]
-symbol = " "
+symbol = " "
 
 [swift]
 symbol = "ﯣ "


### PR DESCRIPTION
#### Description
This changes the suggested nerd font icon for rust from a regular cog to the proper rust icon from devicons (see https://www.nerdfonts.com/cheat-sheet and search for "rust").