### PR TITLE
fix: bg:none overwrites foreground colour

### DIFF
--- a/docs/advanced-config/README.md
+++ b/docs/advanced-config/README.md
@@ -99,7 +99,7 @@ Style strings are a list of words, separated by whitespace. The words are not ca
 
 where `<color>` is a color specifier (discussed below). `fg:<color>` and `<color>` currently do the same thing , though this may change in the future. The order of words in the string does not matter.
 
-The `none` token overrides all other tokens in a string if it is not part of a `bg:` specifier, so that e.g. `fg:red none fg:blue` will still create a string with no styling. `bg:none` does nothing so `fg:red bg:none` is equivalent to `red` or `fg:red`. It may become an error to use `none` in conjunction with other tokens in the future.
+The `none` token overrides all other tokens in a string if it is not part of a `bg:` specifier, so that e.g. `fg:red none fg:blue` will still create a string with no styling. `bg:none`  sets the background to the default color so `fg:red bg:none` is equivalent to `red` or `fg:red` and `bg:green fg:red bg:none` is also equivalent to `fg:red` or `red`. It may become an error to use `none` in conjunction with other tokens in the future.
 
 A color specifier can be one of the following:
 

--- a/docs/advanced-config/README.md
+++ b/docs/advanced-config/README.md
@@ -99,7 +99,7 @@ Style strings are a list of words, separated by whitespace. The words are not ca
 
 where `<color>` is a color specifier (discussed below). `fg:<color>` and `<color>` currently do the same thing , though this may change in the future. The order of words in the string does not matter.
 
-The `none` token overrides all other tokens in a string if it is not part of a `fg:` or `bg:` specifier, so that e.g. `fg:red none fg:blue` will still create a string with no styling. `bg:none` does nothing so `fg:red bg:none` is equivalent to `red` or `fg:red`. `fg:none` will create a string with no styling. It may become an error to use `none` in conjunction with other tokens in the future.
+The `none` token overrides all other tokens in a string if it is not part of a `bg:` specifier, so that e.g. `fg:red none fg:blue` will still create a string with no styling. `bg:none` does nothing so `fg:red bg:none` is equivalent to `red` or `fg:red`. It may become an error to use `none` in conjunction with other tokens in the future.
 
 A color specifier can be one of the following:
 

--- a/docs/advanced-config/README.md
+++ b/docs/advanced-config/README.md
@@ -99,7 +99,7 @@ Style strings are a list of words, separated by whitespace. The words are not ca
 
 where `<color>` is a color specifier (discussed below). `fg:<color>` and `<color>` currently do the same thing , though this may change in the future. The order of words in the string does not matter.
 
-The `none` token overrides all other tokens in a string, so that e.g. `fg:red none fg:blue` will still create a string with no styling. It may become an error to use `none` in conjunction with other tokens in the future.
+The `none` token overrides all other tokens in a string if it is not part of a `fg:` or `bg:` specifier, so that e.g. `fg:red none fg:blue` will still create a string with no styling. `bg:none` does nothing so `fg:red bg:none` is equivalent to `red` or `fg:red`. `fg:none` will create a string with no styling. It may become an error to use `none` in conjunction with other tokens in the future.
 
 A color specifier can be one of the following:
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -688,6 +688,33 @@ mod tests {
     }
 
     #[test]
+    fn table_get_styles_with_none() {
+        // Test that none on the end will result in None, overriding bg:none
+        let config = Value::from("fg:red bg:none none");
+        assert!(<Style>::from_config(&config).is_none());
+
+        // Test that none in front will result in None, overriding bg:none
+        let config = Value::from("none fg:red bg:none");
+        assert!(<Style>::from_config(&config).is_none());
+
+        // Test that none in the middle will result in None, overriding bg:none
+        let config = Value::from("fg:red none bg:none");
+        assert!(<Style>::from_config(&config).is_none());
+
+        // Test that fg:none will result in None
+        let config = Value::from("fg:none bg:black");
+        assert!(<Style>::from_config(&config).is_none());
+
+        // Test that bg:none will yield a style
+        let config = Value::from("fg:red bg:none");
+        assert_eq!(<Style>::from_config(&config).unwrap(), Color::Red.normal());
+
+        // Test that bg:none will yield a style
+        let config = Value::from("fg:red bg:none bold");
+        assert_eq!(<Style>::from_config(&config).unwrap(), Color::Red.bold());
+    }
+
+    #[test]
     fn table_get_styles_ordered() {
         // Test a background style with inverted order (also test hex + ANSI)
         let config = Value::from("bg:#050505 underline fg:120");

--- a/src/config.rs
+++ b/src/config.rs
@@ -720,7 +720,7 @@ mod tests {
         let config = Value::from("fg:red bg:none bold");
         assert_eq!(<Style>::from_config(&config).unwrap(), Color::Red.bold());
 
-        // Test that bg:none the previous background colour overwrites
+        // Test that bg:none will overwrite the previous background colour
         let config = Value::from("fg:red bg:green bold bg:none");
         assert_eq!(<Style>::from_config(&config).unwrap(), Color::Red.bold());
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -375,16 +375,21 @@ pub fn parse_style_string(style_string: &str) -> Option<ansi_term::Style> {
                     "bold" => Some(style.bold()),
                     "italic" => Some(style.italic()),
                     "dimmed" => Some(style.dimmed()),
+                    // When the string is supposed to be a color:
+                    // Decide if we yield none, reset background or set color.
                     color_string => {
                         if color_string == "none" && col_fg {
-                            None
+                            None // fg:none yields no style.
                         } else {
+                            // Either bg or valid color or both.
                             let parsed = parse_color_string(color_string);
+                            // bg + invalid color = reset the background to default.
                             if !col_fg && parsed.is_none() {
                                 let mut new_style = style;
                                 new_style.background = Option::None;
                                 Some(new_style)
                             } else {
+                                // Valid color, apply color to either bg or fg
                                 parsed.map(|ansi_color| {
                                     if col_fg {
                                         style.fg(ansi_color)

--- a/src/config.rs
+++ b/src/config.rs
@@ -381,7 +381,7 @@ pub fn parse_style_string(style_string: &str) -> Option<ansi_term::Style> {
                         } else {
                             let parsed = parse_color_string(color_string);
                             if !col_fg && parsed.is_none() {
-                                let mut new_style = style.clone();
+                                let mut new_style = style;
                                 new_style.background = Option::None;
                                 Some(new_style)
                             } else {

--- a/src/config.rs
+++ b/src/config.rs
@@ -375,16 +375,19 @@ pub fn parse_style_string(style_string: &str) -> Option<ansi_term::Style> {
                     "bold" => Some(style.bold()),
                     "italic" => Some(style.italic()),
                     "dimmed" => Some(style.dimmed()),
-                    "none" => None,
-
-                    // Try to see if this token parses as a valid color string
-                    color_string => parse_color_string(color_string).map(|ansi_color| {
-                        if col_fg {
-                            style.fg(ansi_color)
-                        } else {
-                            style.on(ansi_color)
+                    color_string => {
+                        if color_string == "none" && col_fg { None }
+                        else {
+                            let parsed = parse_color_string(color_string);
+                            if !col_fg && parsed.is_none() { Some(style) }
+                            else {
+                                parsed.map(|ansi_color|
+                                    if col_fg { style.fg(ansi_color) }
+                                    else { style.on(ansi_color) }
+                                )
+                            }
                         }
-                    }),
+                    },
                 }
             })
         })

--- a/src/config.rs
+++ b/src/config.rs
@@ -381,7 +381,9 @@ pub fn parse_style_string(style_string: &str) -> Option<ansi_term::Style> {
                         } else {
                             let parsed = parse_color_string(color_string);
                             if !col_fg && parsed.is_none() {
-                                Some(style)
+                                let mut new_style = style.clone();
+                                new_style.background = Option::None;
+                                Some(new_style)
                             } else {
                                 parsed.map(|ansi_color| {
                                     if col_fg {
@@ -716,6 +718,10 @@ mod tests {
 
         // Test that bg:none will yield a style
         let config = Value::from("fg:red bg:none bold");
+        assert_eq!(<Style>::from_config(&config).unwrap(), Color::Red.bold());
+
+        // Test that bg:none the previous background colour overwrites
+        let config = Value::from("fg:red bg:green bold bg:none");
         assert_eq!(<Style>::from_config(&config).unwrap(), Color::Red.bold());
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -376,18 +376,23 @@ pub fn parse_style_string(style_string: &str) -> Option<ansi_term::Style> {
                     "italic" => Some(style.italic()),
                     "dimmed" => Some(style.dimmed()),
                     color_string => {
-                        if color_string == "none" && col_fg { None }
-                        else {
+                        if color_string == "none" && col_fg {
+                            None
+                        } else {
                             let parsed = parse_color_string(color_string);
-                            if !col_fg && parsed.is_none() { Some(style) }
-                            else {
-                                parsed.map(|ansi_color|
-                                    if col_fg { style.fg(ansi_color) }
-                                    else { style.on(ansi_color) }
-                                )
+                            if !col_fg && parsed.is_none() {
+                                Some(style)
+                            } else {
+                                parsed.map(|ansi_color| {
+                                    if col_fg {
+                                        style.fg(ansi_color)
+                                    } else {
+                                        style.on(ansi_color)
+                                    }
+                                })
                             }
                         }
-                    },
+                    }
                 }
             })
         })


### PR DESCRIPTION
#### Description
I changed the parsing of styles a bit so that bg:none will not override other fields.

#### Motivation and Context
Background does not have to have a colour. You can do that with `red` or `fg:red` for example. It is confusing if `bg:none` will override foreground just like a standalone `none`.

#### How Has This Been Tested?
This has been tested with some new test cases. I also tested it in a Fish shell in a suckless st terminal on Artix Linux 5.9.6.
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
