### PR TITLE
perf(init): Use random for session-key in fish

### DIFF
--- a/src/init/starship.fish
+++ b/src/init/starship.fish
@@ -18,4 +18,4 @@ function fish_mode_prompt; end
 export STARSHIP_SHELL="fish"
 
 # Set up the session key that will be used to store logs
-export STARSHIP_SESSION_KEY=(string sub -s1 -l16 (random)(random)(random)(random)(random)0000000000000000)
+export STARSHIP_SESSION_KEY=(random 10000000000000 9999999999999999)

--- a/src/init/starship.fish
+++ b/src/init/starship.fish
@@ -18,4 +18,4 @@ function fish_mode_prompt; end
 export STARSHIP_SHELL="fish"
 
 # Set up the session key that will be used to store logs
-export STARSHIP_SESSION_KEY=(::STARSHIP:: session)
+export STARSHIP_SESSION_KEY=(string sub -s1 -l16 (random)(random)(random)(random)(random)0000000000000000)


### PR DESCRIPTION
#### Description
Same as #1755 but for fish users

#### Motivation and Context
Improves the performance of shell startup

With `starship session`:
```
❯ hyperfine -r500 "fish -i -c exit"
Benchmark #1: fish -i -c exit
  Time (mean ± σ):      13.3 ms ±   3.9 ms    [User: 9.8 ms, System: 3.8 ms]
  Range (min … max):     5.5 ms …  20.4 ms    500 runs
 
```

With `random`:
```
❯ hyperfine -r500 "fish -i -c exit"
Benchmark #1: fish -i -c exit
  Time (mean ± σ):      10.2 ms ±   2.9 ms    [User: 7.7 ms, System: 2.7 ms]
  Range (min … max):     4.1 ms …  15.6 ms    500 runs
 
  Warning: Command took less than 5 ms to complete. Results might be inaccurate.
```

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [X] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
