### PR TITLE
feat(git_branch): add 'only_attached' config bool

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1030,6 +1030,7 @@ The `git_branch` module shows the active branch of the repo in your current dire
 | `style`             | `"bold purple"`                  | The style for the module.                                                                |
 | `truncation_length` | `2^63 - 1`                       | Truncates a git branch to X graphemes.                                                   |
 | `truncation_symbol` | `"…"`                            | The symbol used to indicate a branch name was truncated. You can use `""` for no symbol. |
+| `only_attached`      | `false`                                         | Only show the branch name when not in a detached HEAD state. |
 | `disabled`          | `false`                          | Disables the `git_branch` module.                                                        |
 
 ### Variables

--- a/src/configs/git_branch.rs
+++ b/src/configs/git_branch.rs
@@ -9,6 +9,7 @@ pub struct GitBranchConfig<'a> {
     pub style: &'a str,
     pub truncation_length: i64,
     pub truncation_symbol: &'a str,
+    pub only_attached: bool,
     pub disabled: bool,
 }
 
@@ -20,6 +21,7 @@ impl<'a> RootModuleConfig<'a> for GitBranchConfig<'a> {
             style: "bold purple",
             truncation_length: std::i64::MAX,
             truncation_symbol: "…",
+            only_attached: false,
             disabled: false,
         }
     }

--- a/src/modules/git_branch.rs
+++ b/src/modules/git_branch.rs
@@ -274,7 +274,9 @@ mod tests {
 
         let expected = Some(format!(
             "on {} ",
-            Color::Purple.bold().paint(format!("\u{e0a0} {}", "test_branch")),
+            Color::Purple
+                .bold()
+                .paint(format!("\u{e0a0} {}", "test_branch")),
         ));
 
         assert_eq!(expected, actual);


### PR DESCRIPTION
#### Description
This adds a new boolean, `only_attached`, to the configuration for
the `git_branch` module. This mirrors the `only_detached` config
value for the `git_commit` module: setting the value to true causes
the module to suppress its output when the user is not on a branch.
For the sake of backwards compatibility, this new config value
defaults to false.

#### Motivation and Context
This allows users to have either a branch name or a commit hash in
their prompt, as opposed to having either a branch name or the
overly-wordy "HEAD (sha1)", using a config such as:

```toml
[git_branch]
  symbol = ""
  only_attached = true
[git_commit]
  format = "(at [$hash]($style) )"
  only_detached = true
```

Closes #1905

#### How Has This Been Tested?
Adds two new tests to the `git_branch` module, which confirm that
the output of the module is unchanged when the config value is set
to true and the repository has a branch checked out, and that the
output of the module is suppressed when the config value is set
to true and the repository is in a detached HEAD state.

I have also tested manually by replacing my local starship binary
with one produced from this version of the code.

- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
