### PR TITLE
fix(swift module): parsing swift version

### DIFF
--- a/src/modules/swift.rs
+++ b/src/modules/swift.rs
@@ -78,6 +78,12 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_swift_version_without_org_name() {
+        let input = "Swift version 5.3-dev (LLVM ..., Swift ...)";
+        assert_eq!(parse_swift_version(input), Some(String::from("v5.3-dev")));
+    }
+
+    #[test]
     fn folder_without_swift_files() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("swift.txt"))?.sync_all()?;

--- a/src/modules/swift.rs
+++ b/src/modules/swift.rs
@@ -53,11 +53,12 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 }
 
 fn parse_swift_version(swift_version: &str) -> Option<String> {
-    let version = swift_version
-        // split into ["Apple", "Swift", "version", "5.2.2", ...]
-        .split_whitespace()
-        // return "5.2.2"
-        .nth(3)?;
+    // split into ["Apple", "Swift", "version", "5.2.2", ...] or
+    //            ["Swift", "version", "5.3-dev", ...]
+    let mut splited = swift_version.split_whitespace();
+    let _ = splited.position(|t| t == "version")?;
+    // return "5.2.2" or "5.3-dev"
+    let version = splited.next()?;
 
     Some(format!("v{}", version))
 }


### PR DESCRIPTION
#### Description
I fixed parsing swift version. Originally, the output of `swift --version` was separated space by spaces and then displayed the third value. It now displays the string after the `version`

#### Motivation and Context
Using [tensorflow/swift](https://github.com/tensorflow/swift) toolchains, Starship displays unexpected swift version like `(LLVM`.

#### Screenshots (if appropriate):

`~/GitHub/starship/target/debug/starship` is my version.

<img width="800" alt="Screen Shot" src="https://user-images.githubusercontent.com/29685158/99782039-fa857280-2b5b-11eb-8919-af2d3a74ca68.png">

#### How Has This Been Tested?
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
