### PR TITLE
feat(git_branch): add remote branch name if different than local branch

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1025,6 +1025,7 @@ The `git_branch` module shows the active branch of the repo in your current dire
 
 | Option              | Default                          | Description                                                                              |
 | ------------------- | -------------------------------- | ---------------------------------------------------------------------------------------- |
+| `always_show_remote`| `false`                          | Shows the remote tracking branch name, even if it is equal to the local branch name.     |
 | `format`            | `"on [$symbol$branch]($style) "` | The format for the module. Use `"$branch"` to refer to the current branch name.          |
 | `symbol`            | `" "`                           | A format string representing the symbol of git branch.                                   |
 | `style`             | `"bold purple"`                  | The style for the module.                                                                |
@@ -1039,6 +1040,7 @@ The `git_branch` module shows the active branch of the repo in your current dire
 | Variable | Example  | Description                                                                                          |
 | -------- | -------- | ---------------------------------------------------------------------------------------------------- |
 | branch   | `master` | The current branch name, falls back to `HEAD` if there's no current branch (e.g. git detached HEAD). |
+| remote   | `master` | The remote branch name.                                                                              |
 | symbol   |          | Mirrors the value of option `symbol`                                                                 |
 | style\*  |          | Mirrors the value of option `style`                                                                  |
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1031,6 +1031,7 @@ The `git_branch` module shows the active branch of the repo in your current dire
 | `truncation_length` | `2^63 - 1`                       | Truncates a git branch to X graphemes.                                                   |
 | `truncation_symbol` | `"…"`                            | The symbol used to indicate a branch name was truncated. You can use `""` for no symbol. |
 | `only_attached`      | `false`                                         | Only show the branch name when not in a detached HEAD state. |
+| `show_remote`       | `true`                           | Shows the remote tracking branch name if it is different than the local branch name.     |
 | `disabled`          | `false`                          | Disables the `git_branch` module.                                                        |
 
 ### Variables

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1032,7 +1032,6 @@ The `git_branch` module shows the active branch of the repo in your current dire
 | `truncation_length` | `2^63 - 1`                       | Truncates a git branch to X graphemes.                                                   |
 | `truncation_symbol` | `"…"`                            | The symbol used to indicate a branch name was truncated. You can use `""` for no symbol. |
 | `only_attached`      | `false`                                         | Only show the branch name when not in a detached HEAD state. |
-| `show_remote`       | `true`                           | Shows the remote tracking branch name if it is different than the local branch name.     |
 | `disabled`          | `false`                          | Disables the `git_branch` module.                                                        |
 
 ### Variables

--- a/src/configs/git_branch.rs
+++ b/src/configs/git_branch.rs
@@ -10,7 +10,6 @@ pub struct GitBranchConfig<'a> {
     pub truncation_length: i64,
     pub truncation_symbol: &'a str,
     pub only_attached: bool,
-    pub show_remote: bool,
     pub always_show_remote: bool,
     pub disabled: bool,
 }

--- a/src/configs/git_branch.rs
+++ b/src/configs/git_branch.rs
@@ -11,19 +11,21 @@ pub struct GitBranchConfig<'a> {
     pub truncation_symbol: &'a str,
     pub only_attached: bool,
     pub show_remote: bool,
+    pub always_show_remote: bool,
     pub disabled: bool,
 }
 
 impl<'a> RootModuleConfig<'a> for GitBranchConfig<'a> {
     fn new() -> Self {
         GitBranchConfig {
-            format: "on [$symbol$branch]($style) ",
+            format: "on [$symbol$branch]($style)(:[$remote]($style)) ",
             symbol: " ",
             style: "bold purple",
             truncation_length: std::i64::MAX,
             truncation_symbol: "…",
             only_attached: false,
             show_remote: true,
+            always_show_remote: true,
             disabled: false,
         }
     }

--- a/src/configs/git_branch.rs
+++ b/src/configs/git_branch.rs
@@ -24,8 +24,7 @@ impl<'a> RootModuleConfig<'a> for GitBranchConfig<'a> {
             truncation_length: std::i64::MAX,
             truncation_symbol: "…",
             only_attached: false,
-            show_remote: true,
-            always_show_remote: true,
+            always_show_remote: false,
             disabled: false,
         }
     }

--- a/src/configs/git_branch.rs
+++ b/src/configs/git_branch.rs
@@ -10,6 +10,7 @@ pub struct GitBranchConfig<'a> {
     pub truncation_length: i64,
     pub truncation_symbol: &'a str,
     pub only_attached: bool,
+    pub show_remote: bool,
     pub disabled: bool,
 }
 
@@ -22,6 +23,7 @@ impl<'a> RootModuleConfig<'a> for GitBranchConfig<'a> {
             truncation_length: std::i64::MAX,
             truncation_symbol: "…",
             only_attached: false,
+            show_remote: true,
             disabled: false,
         }
     }

--- a/src/context.rs
+++ b/src/context.rs
@@ -171,7 +171,7 @@ impl<'a> Context<'a> {
                     .as_ref()
                     .and_then(|repo| repo.workdir().map(Path::to_path_buf));
                 let state = repository.as_ref().map(|repo| repo.state());
-                let remote = repository.as_ref().and_then(|repo| get_remote(repo));
+                let remote = repository.as_ref().and_then(|repo| get_remote_branch(repo));
                 Ok(Repo {
                     branch,
                     root,
@@ -380,7 +380,7 @@ fn get_current_branch(repository: &Repository) -> Option<String> {
     shorthand.map(std::string::ToString::to_string)
 }
 
-fn get_remote(repository: &Repository) -> Option<String> {
+fn get_remote_branch(repository: &Repository) -> Option<String> {
     if let Ok(head) = repository.head() {
         if let Some(local_branch_ref) = head.name() {
             let remote_ref = match repository.branch_upstream_name(local_branch_ref) {

--- a/src/modules/git_branch.rs
+++ b/src/modules/git_branch.rs
@@ -56,6 +56,9 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         remote_graphemes.truncate(trunc_len + 1);
     }
 
+    let show_remote = config.always_show_remote
+        || (!graphemes.eq(&remote_graphemes) && !remote_graphemes.is_empty());
+
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter
             .map_meta(|var, _| match var {
@@ -69,7 +72,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             .map(|variable| match variable {
                 "branch" => Some(Ok(graphemes.concat())),
                 "remote" => {
-                    if !remote_graphemes.is_empty() {
+                    if show_remote {
                         Some(Ok(remote_graphemes.concat()))
                     } else {
                         None

--- a/src/modules/git_branch.rs
+++ b/src/modules/git_branch.rs
@@ -45,6 +45,15 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         graphemes.truncate(trunc_len + 1)
     }
 
+    if config.show_remote {
+        if let Some(r) = repo.remote.as_ref() {
+            if !branch_name.eq(r) {
+                graphemes.push(":");
+                r.graphemes(true).for_each(|g| graphemes.push(g));
+            }
+        }
+    }
+
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter
             .map_meta(|var, _| match var {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Show the remote tracking branch in case the current branch is named differently than the remote tracking one.

The remote branch name is appended to the branch name, separated by a `:`, as stated in the issue linked below.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1757

#### Screenshots (if appropriate):
Before
![image](https://user-images.githubusercontent.com/8809698/99858556-1bff5200-2b8e-11eb-94cb-815906ef4838.png)

After
![image](https://user-images.githubusercontent.com/8809698/99858497-fbcf9300-2b8d-11eb-9c00-15352c5d3b14.png)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [X] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
