### PR TITLE
feat(command): add 'toggle' command

### DIFF
--- a/src/configure.rs
+++ b/src/configure.rs
@@ -8,6 +8,7 @@ use crate::config::StarshipConfig;
 use std::fs::File;
 use std::io::Write;
 use toml::map::Map;
+use toml::value::Table;
 use toml::Value;
 
 #[cfg(not(windows))]
@@ -16,20 +17,13 @@ const STD_EDITOR: &str = "vi";
 const STD_EDITOR: &str = "notepad.exe";
 
 pub fn update_configuration(name: &str, value: &str) {
-    let config_path = get_config_path();
-
     let keys: Vec<&str> = name.split('.').collect();
     if keys.len() != 2 {
         log::error!("Please pass in a config key with a '.'");
         process::exit(1);
     }
 
-    let starship_config = StarshipConfig::initialize();
-    let mut config = starship_config
-        .config
-        .expect("Failed to load starship config");
-
-    if let Some(table) = config.as_table_mut() {
+    if let Some(table) = get_configuration().as_table_mut() {
         if !table.contains_key(keys[0]) {
             table.insert(keys[0].to_string(), Value::Table(Map::new()));
         }
@@ -54,12 +48,66 @@ pub fn update_configuration(name: &str, value: &str) {
             table.insert(keys[0].to_string(), Value::Table(updated_values));
         }
 
-        let config_str =
-            toml::to_string_pretty(&table).expect("Failed to serialize the config to string");
-        File::create(&config_path)
-            .and_then(|mut file| file.write_all(config_str.as_ref()))
-            .expect("Error writing starship config");
+        write_configuration(table);
     }
+}
+
+pub fn toggle_configuration(name: &str, key: &str) {
+    if let Some(table) = get_configuration().as_table_mut() {
+        match table.get(name) {
+            Some(v) => {
+                if let Some(values) = v.as_table() {
+                    let mut updated_values = values.clone();
+
+                    let current: bool = match updated_values.get(key) {
+                        Some(v) => match v.as_bool() {
+                            Some(b) => b,
+                            _ => {
+                                log::error!(
+                                    "Given config key '{}' must be in 'boolean' format",
+                                    key
+                                );
+                                process::exit(1);
+                            }
+                        },
+                        _ => {
+                            log::error!("Given config key '{}' must be exist in config file", key);
+                            process::exit(1);
+                        }
+                    };
+
+                    updated_values.insert(key.to_string(), Value::Boolean(!current));
+
+                    table.insert(name.to_string(), Value::Table(updated_values));
+
+                    write_configuration(table);
+                }
+            }
+            _ => {
+                log::error!("Given module '{}' not found in config file", name);
+                process::exit(1);
+            }
+        };
+    }
+}
+
+pub fn get_configuration() -> Value {
+    let starship_config = StarshipConfig::initialize();
+
+    starship_config
+        .config
+        .expect("Failed to load starship config")
+}
+
+pub fn write_configuration(table: &mut Table) {
+    let config_path = get_config_path();
+
+    let config_str =
+        toml::to_string_pretty(&table).expect("Failed to serialize the config to string");
+
+    File::create(&config_path)
+        .and_then(|mut file| file.write_all(config_str.as_ref()))
+        .expect("Error writing starship config");
 }
 
 pub fn edit_configuration() {
@@ -119,7 +167,6 @@ mod tests {
     use super::*;
 
     // This is every possible permutation, 3² = 9.
-
     #[test]
     fn visual_set_editor_set() {
         let actual = get_editor_internal(Some("foo".into()), Some("bar".into()));

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,11 +29,11 @@ fn main() {
         .takes_value(true);
 
     let shell_arg = Arg::with_name("shell")
-        .value_name("SHELL")
-        .help(
-            "The name of the currently running shell\nCurrently supported options: bash, zsh, fish, powershell, ion",
-        )
-        .required(true);
+		.value_name("SHELL")
+		.help(
+			"The name of the currently running shell\nCurrently supported options: bash, zsh, fish, powershell, ion",
+		)
+		.required(true);
 
     let cmd_duration_arg = Arg::with_name("cmd_duration")
         .short("d")
@@ -118,6 +118,21 @@ fn main() {
                 .arg(Arg::with_name("value").help("Value to place into that key")),
         )
         .subcommand(
+            SubCommand::with_name("toggle")
+                .about("Toggle a given starship module")
+                .arg(
+                    Arg::with_name("name")
+                        .help("The name of the module to be toggled")
+                        .required(true),
+                )
+                .arg(
+                    Arg::with_name("key")
+                        .help("The key of the config to be toggled")
+                        .required(false)
+                        .required_unless("name"),
+                ),
+        )
+        .subcommand(
             SubCommand::with_name("bug-report").about(
                 "Create a pre-populated GitHub issue with information about your configuration",
             ),
@@ -177,6 +192,15 @@ fn main() {
                 }
             } else {
                 configure::edit_configuration()
+            }
+        }
+        ("toggle", Some(sub_m)) => {
+            if let Some(name) = sub_m.value_of("name") {
+                if let Some(value) = sub_m.value_of("key") {
+                    configure::toggle_configuration(name, value)
+                } else {
+                    configure::toggle_configuration(name, "disabled")
+                }
             }
         }
         ("bug-report", Some(_)) => bug_report::create(),


### PR DESCRIPTION
Closes #894

Signed-off-by: Dentrax <furkan.turkal@hotmail.com>

#### Description
See the given issue in order to get more description about the `toggle` feature.

#### Motivation and Context
As requested at #894 and #1873, this PR adds brand new `toggle` command.

#### Screenshots (if appropriate):
[![asciicast](https://asciinema.org/a/374476.svg)](https://asciinema.org/a/374476)

#### How Has This Been Tested?
* Given module name and flag key exist without arg:
```sh
$ dasel select -f ~/.config/starship.toml -p toml -m '.kubernetes.disabled' # returns 'true'
$ cargo run toggle kubernetes
$ dasel select -f ~/.config/starship.toml -p toml -m '.kubernetes.disabled' # returns 'false'
```
* Given module name and flag key exist with arg:
```sh
$ dasel select -f ~/.config/starship.toml -p toml -m '.kubernetes.disabled' # returns 'true'
$ cargo run toggle kubernetes disabled
$ dasel select -f ~/.config/starship.toml -p toml -m '.kubernetes.disabled' # returns 'false'
```
* Given module name exist but flag key not exist with arg:
```sh
$ cargo run toggle kubernetes show_namespace
```
_See the error:_ `[ERROR] - (starship::configure): Given config key 'show_namespace' must be exist in config file`
* Given module name and `non-boolean` flag key exist with arg:
```sh
$ cargo run toggle kubernetes format
```
_See the error:_ `[ERROR] - (starship::configure): Given config key 'format' must be in 'boolean' format`
* Given module name not exist:
```sh
$ cargo run toggle winamp
```
This will panic-ed, it works the same as the `update_configuration()` function. We just ignored the `None` case, by using this: `table.get(keys[0]).unwrap()`. Shouldn't we cover the case of `None`? What about adding a new fatal message like: ``[ERROR] - (starship::configure): Given module 'winamp' not found in config file``
* Given module name and flag key not exist:
```sh
$ cargo run toggle winamp volume
```
Same as above.

- [X] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
_Some help wanted here too! :)_
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.

**Happy aliases, you astronauts! **

`alias k8s!='cargo run toggle kubernetes'`