### PR TITLE
fix(git_commit): show last created tag on current commit

### DIFF
--- a/src/modules/git_commit.rs
+++ b/src/modules/git_commit.rs
@@ -339,4 +339,71 @@ mod tests {
         assert_eq!(expected, actual);
         Ok(())
     }
+
+    #[test]
+    fn test_latest_tag_shown_with_tag_enabled() -> io::Result<()> {
+        let repo_dir = fixture_repo(FixtureProvider::GIT)?;
+
+        let mut git_commit = Command::new("git")
+            .args(&["rev-parse", "HEAD"])
+            .current_dir(&repo_dir.path())
+            .output()?
+            .stdout;
+        git_commit.truncate(7);
+        let commit_output = str::from_utf8(&git_commit).unwrap().trim();
+
+        Command::new("git")
+            .args(&["tag", "v1", "-m", "Testing tags v1"])
+            .current_dir(&repo_dir.path())
+            .output()?;
+
+        Command::new("git")
+            .args(&["tag", "v0", "-m", "Testing tags v0", "HEAD~1"])
+            .current_dir(&repo_dir.path())
+            .output()?;
+
+        Command::new("git")
+            .args(&["tag", "v2", "-m", "Testing tags v2"])
+            .current_dir(&repo_dir.path())
+            .output()?;
+
+        let git_tag = Command::new("git")
+            .args(&[
+                "for-each-ref",
+                "--contains",
+                "HEAD",
+                "--sort=-taggerdate",
+                "--count=1",
+                "--format",
+                "%(refname:short)",
+                "refs/tags",
+            ])
+            .current_dir(&repo_dir.path())
+            .output()?
+            .stdout;
+        let tag_output = str::from_utf8(&git_tag).unwrap().trim();
+
+        let expected_output = format!("{} {}", commit_output, tag_output);
+
+        let actual = ModuleRenderer::new("git_commit")
+            .config(toml::toml! {
+                [git_commit]
+                    only_detached = false
+                    tag_disabled = false
+                    tag_symbol = ""
+            })
+            .path(&repo_dir.path())
+            .collect();
+
+        let expected = Some(format!(
+            "{} ",
+            Color::Green
+                .bold()
+                .paint(format!("({})", expected_output.trim()))
+                .to_string()
+        ));
+
+        assert_eq!(expected, actual);
+        Ok(())
+    }
 }

--- a/src/modules/git_commit.rs
+++ b/src/modules/git_commit.rs
@@ -342,6 +342,8 @@ mod tests {
 
     #[test]
     fn test_latest_tag_shown_with_tag_enabled() -> io::Result<()> {
+        use std::{thread, time};
+
         let repo_dir = fixture_repo(FixtureProvider::GIT)?;
 
         let mut git_commit = Command::new("git")
@@ -353,9 +355,12 @@ mod tests {
         let commit_output = str::from_utf8(&git_commit).unwrap().trim();
 
         Command::new("git")
-            .args(&["tag", "v1", "-m", "Testing tags v1"])
+            .args(&["tag", "v2", "-m", "Testing tags v2"])
             .current_dir(&repo_dir.path())
             .output()?;
+
+        // Wait one second between tags
+        thread::sleep(time::Duration::from_millis(1000));
 
         Command::new("git")
             .args(&["tag", "v0", "-m", "Testing tags v0", "HEAD~1"])
@@ -363,7 +368,7 @@ mod tests {
             .output()?;
 
         Command::new("git")
-            .args(&["tag", "v2", "-m", "Testing tags v2"])
+            .args(&["tag", "v1", "-m", "Testing tags v1"])
             .current_dir(&repo_dir.path())
             .output()?;
 

--- a/src/modules/git_commit.rs
+++ b/src/modules/git_commit.rs
@@ -56,14 +56,12 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         });
 
         let mut tag_name = String::new();
-        let mut oldest = Time::new(0,0);
+        let mut oldest = Time::new(0, 0);
         // Let's check if HEAD has some tag. If several, gets last created one...
         for (name, timestamp, reference) in tag_and_refs.rev() {
-            if commit_oid == reference.peel_to_commit().ok()?.id() {
-                if timestamp > oldest {
-                    tag_name = name;
-                    oldest = timestamp;
-                }
+            if commit_oid == reference.peel_to_commit().ok()?.id() && timestamp > oldest {
+                tag_name = name;
+                oldest = timestamp;
             }
         }
         // If we have tag...


### PR DESCRIPTION
### Description
If option to show tag is enabled, it now shows last created tag on current commit.

#### Motivation and Context
Fix / improve behavior of `git_commit` module. It makes sense to show latest created tag pointing to current commit instead of oldest one. 

#### How Has This Been Tested?
- [X] I have tested using **MacOS**
- [X] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [X] I have updated the documentation accordingly.
- [X] I have updated the tests accordingly.
