### PR TITLE
feat(rust): Support new rust-toolchain format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1122,18 +1122,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.116"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96fe57af81d28386a513cbc6858332abc6117cfdb5999647c6444b8f43a370a5"
+checksum = "b88fa983de7720629c9387e9f517353ed404164b1e482c970a90c1a4aaf7dc1a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.116"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f630a6370fd8e457873b4bd2ffdae75408bc291ba72be773772a4c2a065d9ae8"
+checksum = "cbd1ae72adb44aab48f325a02444a5fc079349a8d804c1fc922aed3f7454c74e"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
@@ -1210,7 +1210,7 @@ dependencies = [
  "rayon",
  "regex",
  "rust-ini",
- "serde_derive",
+ "serde",
  "serde_json",
  "shell-words",
  "starship_module_config_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ ansi_term = "0.12.1"
 dirs-next = "2.0.0"
 git2 = { version = "0.13.12", default-features = false }
 toml = { version = "0.5.7", features = ["preserve_order"] }
-rust-ini = "0.16" 
+rust-ini = "0.16"
 serde_json = "1.0.59"
 rayon = "1.5.0"
 log = { version = "0.4.11", features = ["std"] }
@@ -59,7 +59,7 @@ unicode-width = "0.1.8"
 term_size = "0.3.2"
 quick-xml = "0.20.0"
 rand = "0.7.3"
-serde_derive = "1.0.115"
+serde = { version = "1.0.117", features = ["derive"] }
 indexmap = "1.6.0"
 notify-rust = { version = "4.0.0", optional = true }
 

--- a/src/modules/rust.rs
+++ b/src/modules/rust.rs
@@ -144,7 +144,7 @@ fn find_rust_toolchain_file(context: &Context) -> Option<String> {
 
         match contents.lines().count() {
             0 => None,
-            1 => Some(contents.trim().to_owned()),
+            1 => Some(contents),
             _ => Some(
                 toml::from_str::<OverrideFile>(&contents)
                     .ok()?
@@ -152,6 +152,8 @@ fn find_rust_toolchain_file(context: &Context) -> Option<String> {
                     .channel?,
             ),
         }
+        .filter(|c| !c.trim().is_empty())
+        .map(|c| c.trim().to_owned())
     }
 
     if let Ok(true) = context

--- a/src/modules/rust.rs
+++ b/src/modules/rust.rs
@@ -145,12 +145,12 @@ fn find_rust_toolchain_file(context: &Context) -> Option<String> {
         match contents.lines().count() {
             0 => None,
             1 => Some(contents),
-            _ => Some(
+            _ => {
                 toml::from_str::<OverrideFile>(&contents)
                     .ok()?
                     .toolchain
-                    .channel?,
-            ),
+                    .channel
+            }
         }
         .filter(|c| !c.trim().is_empty())
         .map(|c| c.trim().to_owned())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This changes the extraction of the currently used Rust version from the `rust-toolchain` file to support the [new format](https://blog.rust-lang.org/2020/11/27/Rustup-1.23.0.html#new-format-for-rust-toolchain) as well. It reads the first line as before but checks for `[toolchain]` in the resulting string to detect the new TOML format. In that case it parses the whole file as TOML file and extracts the version from the `toolchain.channel` value. In case the first line is empty the TOML parsing is triggered as well, as a TOML file can contain potential empty lines before the `[toolchain]` section.

I added test cases for both versions as well.

Old format (still valid):
```txt
1.34.0
```

New format:
```toml
[toolchain]
channel = "1.34.0"
```

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
A new version of rustup was released yesterday, introducing an optional new TOML format for the `rust-toolchain` file that allows to provide additional _components_ and _targets_ that rustup will auto-install if missing.

The current implementation in starship simply reads the first line to extract the currently used Rust version. This works fine with the old format but creates an empty version output (in my case) with the new format.

Closes #1935

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.

#### Considerations & ideas

Currently the extraction will fail if there are some other sections in the TOML version before the `[toolchain]` section as it will fail to trigger the TOML parsing. There is in my opinion no reason to put anything else in there as it has no use to `rustup` but it is technically possible or people maybe like to put a comment at the top of the file.

Therefore, it may be a good choice to try TOML parsing first and then fall back to reading the first line. I left the current order intact as there are probably not many TOML versions of `rust-toolchain` around yet and it is simply faster than trying to parse the TOML format first.