### PR TITLE
feat(status): Convert known status code to their meaning

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2211,20 +2211,14 @@ To enable it, set `disabled` to `false` in your configuration file.
 | Option                    | Default                     | Description                                            |
 | ------------------------- | --------------------------- | ------------------------------------------------------ |
 | `format`                  | `[$symbol$status]($style) ` | The format of the module                               |
-| `program_error_symbol`    | `"🔴"`                       | The symbol displayed on program error                  |
+| `symbol`                  | `"✖"`                       | The symbol displayed on program error                  |
 | `not_executable_symbol`   | `"🚫"`                       | The symbol displayed when file isn't executable        |
 | `not_found_symbol`        | `"🔍"`                       | The symbol displayed when the command can't be found   |
 | `sigint_symbol`           | `"🧱"`                       | The symbol displayed on SIGINT (Ctrl + c)              |
 | `signal_symbol`           | `"⚡"`                       | The symbol displayed on any signal |
 | `style`                   | `"bold red"`                | The style for the module.                              |
+| `map_symbol`              | `false`                     | Enable symbols mapping from exit code                  |
 | `disabled`                | `true`                      | Disables the `status` module.                          |
-
-
-                    "status" => Some(Ok(exit_code)),
-                    "status_int" => Some(Ok(exit_code)),
-                    "status_common_meaning" => Ok(status_common_meaning(exit_code_int)).transpose(),
-                    "status_signal_number" => Ok(status_signal_int(exit_code_int)).transpose(),
-                    "status_signal_name" => Ok(status_signal_name(exit_code_int)).transpose(),
 
 ### Variables
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2242,8 +2242,9 @@ To enable it, set `disabled` to `false` in your configuration file.
 
 [status]
 style = "bg:blue"
-symbol = "💣 "
-format = '[\[$symbol$status\]]($style) '
+symbol = "🔴"
+format = '[\[$symbol $status_common_meaning$status_signal_name\]]($style) '
+map_symbol = true
 disabled = false
 
 ```

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2229,6 +2229,7 @@ To enable it, set `disabled` to `false` in your configuration file.
 | status_common_meaning   | `ERROR` | Meaning of the code if not a signal                                     |
 | status_signal_number    | `9`     | Signal number corresponding to the exit code, only if signalled         |
 | status_signal_name      | `KILL`  | Name of the signal corresponding to the exit code, only if signalled    |
+| status_maybe_int        | `7`     | Contains the exit code number when no meaning has been found            |
 | symbol                  |         | Mirrors the value of option `symbol`                                    |
 | style\*                 |         | Mirrors the value of option `style`                                     |
 
@@ -2243,7 +2244,7 @@ To enable it, set `disabled` to `false` in your configuration file.
 [status]
 style = "bg:blue"
 symbol = "🔴"
-format = '[\[$symbol $status_common_meaning$status_signal_name\]]($style) '
+format = '[\[$symbol $status_common_meaning$status_signal_name$status_maybe_int\]]($style) '
 map_symbol = true
 disabled = false
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2217,6 +2217,7 @@ To enable it, set `disabled` to `false` in your configuration file.
 | `sigint_symbol`           | `"🧱"`                       | The symbol displayed on SIGINT (Ctrl + c)              |
 | `signal_symbol`           | `"⚡"`                       | The symbol displayed on any signal |
 | `style`                   | `"bold red"`                | The style for the module.                              |
+| `recognize_signal_code`   | `true`                      | Enable signal mapping from exit code                   |
 | `map_symbol`              | `false`                     | Enable symbols mapping from exit code                  |
 | `disabled`                | `true`                      | Disables the `status` module.                          |
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2213,6 +2213,7 @@ To enable it, set `disabled` to `false` in your configuration file.
 | `format`   | `[$symbol$status]($style) ` | The format of the module                               |
 | `symbol`   | `"✖"`                       | A format string representing the symbol for the status |
 | `style`    | `"bold red"`                | The style for the module.                              |
+| `meaning`  | `false`                     | Display code meaing instead of value                   |
 | `disabled` | `true`                      | Disables the `status` module.                          |
 
 ### Variables

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2226,11 +2226,11 @@ To enable it, set `disabled` to `false` in your configuration file.
 | Variable                | Example | Description                                                             |
 | ----------------------- | ------- | ----------------------------------------------------------------------- |
 | status                  | `127`   | The exit code of the last command                                       |
-| status_int              | `127`   | The exit code of the last command                                       |
-| status_common_meaning   | `ERROR` | Meaning of the code if not a signal                                     |
-| status_signal_number    | `9`     | Signal number corresponding to the exit code, only if signalled         |
-| status_signal_name      | `KILL`  | Name of the signal corresponding to the exit code, only if signalled    |
-| status_maybe_int        | `7`     | Contains the exit code number when no meaning has been found            |
+| int                     | `127`   | The exit code of the last command                                       |
+| common_meaning          | `ERROR` | Meaning of the code if not a signal                                     |
+| signal_number           | `9`     | Signal number corresponding to the exit code, only if signalled         |
+| signal_name             | `KILL`  | Name of the signal corresponding to the exit code, only if signalled    |
+| maybe_int               | `7`     | Contains the exit code number when no meaning has been found            |
 | symbol                  |         | Mirrors the value of option `symbol`                                    |
 | style\*                 |         | Mirrors the value of option `style`                                     |
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2208,21 +2208,35 @@ To enable it, set `disabled` to `false` in your configuration file.
 
 ### Options
 
-| Option     | Default                     | Description                                            |
-| ---------- | --------------------------- | ------------------------------------------------------ |
-| `format`   | `[$symbol$status]($style) ` | The format of the module                               |
-| `symbol`   | `"✖"`                       | A format string representing the symbol for the status |
-| `style`    | `"bold red"`                | The style for the module.                              |
-| `meaning`  | `false`                     | Display code meaing instead of value                   |
-| `disabled` | `true`                      | Disables the `status` module.                          |
+| Option                    | Default                     | Description                                            |
+| ------------------------- | --------------------------- | ------------------------------------------------------ |
+| `format`                  | `[$symbol$status]($style) ` | The format of the module                               |
+| `program_error_symbol`    | `"🔴"`                       | The symbol displayed on program error                  |
+| `not_executable_symbol`   | `"🚫"`                       | The symbol displayed when file isn't executable        |
+| `not_found_symbol`        | `"🔍"`                       | The symbol displayed when the command can't be found   |
+| `sigint_symbol`           | `"🧱"`                       | The symbol displayed on SIGINT (Ctrl + c)              |
+| `signal_symbol`           | `"⚡"`                       | The symbol displayed on any signal |
+| `style`                   | `"bold red"`                | The style for the module.                              |
+| `disabled`                | `true`                      | Disables the `status` module.                          |
+
+
+                    "status" => Some(Ok(exit_code)),
+                    "status_int" => Some(Ok(exit_code)),
+                    "status_common_meaning" => Ok(status_common_meaning(exit_code_int)).transpose(),
+                    "status_signal_number" => Ok(status_signal_int(exit_code_int)).transpose(),
+                    "status_signal_name" => Ok(status_signal_name(exit_code_int)).transpose(),
 
 ### Variables
 
-| Variable | Example | Description                          |
-| -------- | ------- | ------------------------------------ |
-| status   | `127`   | The exit code of the last command    |
-| symbol   |         | Mirrors the value of option `symbol` |
-| style\*  |         | Mirrors the value of option `style`  |
+| Variable                | Example | Description                                                             |
+| ----------------------- | ------- | ----------------------------------------------------------------------- |
+| status                  | `127`   | The exit code of the last command                                       |
+| status_int              | `127`   | The exit code of the last command                                       |
+| status_common_meaning   | `ERROR` | Meaning of the code if not a signal                                     |
+| status_signal_number    | `9`     | Signal number corresponding to the exit code, only if signalled         |
+| status_signal_name      | `KILL`  | Name of the signal corresponding to the exit code, only if signalled    |
+| symbol                  |         | Mirrors the value of option `symbol`                                    |
+| style\*                 |         | Mirrors the value of option `style`                                     |
 
 \*: This variable can only be used as a part of a style string
 

--- a/src/configs/status.rs
+++ b/src/configs/status.rs
@@ -5,9 +5,12 @@ use starship_module_config_derive::ModuleConfig;
 #[derive(Clone, ModuleConfig)]
 pub struct StatusConfig<'a> {
     pub format: &'a str,
-    pub symbol: &'a str,
+    pub program_error_symbol: &'a str,
+    pub not_executable_symbol: &'a str,
+    pub not_found_symbol: &'a str,
+    pub sigint_symbol: &'a str,
+    pub signal_symbol: &'a str,
     pub style: &'a str,
-    pub meaning: bool,
     pub disabled: bool,
 }
 
@@ -15,9 +18,12 @@ impl<'a> RootModuleConfig<'a> for StatusConfig<'a> {
     fn new() -> Self {
         StatusConfig {
             format: "[$symbol$status]($style) ",
-            symbol: "✖",
+            program_error_symbol: "🔴",
+            not_executable_symbol: "🚫",
+            not_found_symbol: "🔍",
+            sigint_symbol: "🧱",
+            signal_symbol: "⚡",
             style: "bold red",
-            meaning: false,
             disabled: true,
         }
     }

--- a/src/configs/status.rs
+++ b/src/configs/status.rs
@@ -7,6 +7,7 @@ pub struct StatusConfig<'a> {
     pub format: &'a str,
     pub symbol: &'a str,
     pub style: &'a str,
+    pub meaning: bool,
     pub disabled: bool,
 }
 
@@ -16,6 +17,7 @@ impl<'a> RootModuleConfig<'a> for StatusConfig<'a> {
             format: "[$symbol$status]($style) ",
             symbol: "✖",
             style: "bold red",
+            meaning: false,
             disabled: true,
         }
     }

--- a/src/configs/status.rs
+++ b/src/configs/status.rs
@@ -5,12 +5,13 @@ use starship_module_config_derive::ModuleConfig;
 #[derive(Clone, ModuleConfig)]
 pub struct StatusConfig<'a> {
     pub format: &'a str,
-    pub program_error_symbol: &'a str,
+    pub symbol: &'a str,
     pub not_executable_symbol: &'a str,
     pub not_found_symbol: &'a str,
     pub sigint_symbol: &'a str,
     pub signal_symbol: &'a str,
     pub style: &'a str,
+    pub map_symbol: bool,
     pub disabled: bool,
 }
 
@@ -18,12 +19,13 @@ impl<'a> RootModuleConfig<'a> for StatusConfig<'a> {
     fn new() -> Self {
         StatusConfig {
             format: "[$symbol$status]($style) ",
-            program_error_symbol: "🔴",
+            symbol: "✖",
             not_executable_symbol: "🚫",
             not_found_symbol: "🔍",
             sigint_symbol: "🧱",
             signal_symbol: "⚡",
             style: "bold red",
+            map_symbol: false,
             disabled: true,
         }
     }

--- a/src/configs/status.rs
+++ b/src/configs/status.rs
@@ -12,6 +12,7 @@ pub struct StatusConfig<'a> {
     pub signal_symbol: &'a str,
     pub style: &'a str,
     pub map_symbol: bool,
+    pub recognize_signal_code: bool,
     pub disabled: bool,
 }
 
@@ -26,6 +27,7 @@ impl<'a> RootModuleConfig<'a> for StatusConfig<'a> {
             signal_symbol: "⚡",
             style: "bold red",
             map_symbol: false,
+            recognize_signal_code: true,
             disabled: true,
         }
     }

--- a/src/modules/status.rs
+++ b/src/modules/status.rs
@@ -24,14 +24,25 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             return None;
         };
 
-        let exit_code_str = match config.meaning {
-            true => signal_name_from_exit_code(exit_code),
-            false => exit_code,
+        let exit_code_int: u32 = match exit_code.parse() {
+            Ok(i) => i,
+            Err(_) => return None,
         };
+
+        let scm = status_common_meaning(exit_code_int);
+        let ssname = status_signal_int(exit_code_int);
+        let ssnumber = status_signal_name(exit_code_int);
+
         let parsed = StringFormatter::new(config.format).and_then(|formatter| {
             formatter
                 .map_meta(|var, _| match var {
-                    "symbol" => Some(config.symbol),
+                    "symbol" => match exit_code_int {
+                        126 => Some(config.not_executable_symbol),
+                        127 => Some(config.not_found_symbol),
+                        130 => Some(config.sigint_symbol),
+                        x if x > 128 && x < 256 => Some(config.signal_symbol),
+                        _ => Some(config.program_error_symbol),
+                    },
                     _ => None,
                 })
                 .map_style(|variable| match variable {
@@ -39,7 +50,11 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                     _ => None,
                 })
                 .map(|variable| match variable {
-                    "status" => Some(Ok(exit_code_str)),
+                    "status" => Some(Ok(exit_code)),
+                    "status_int" => Some(Ok(exit_code)),
+                    "status_common_meaning" => Ok(scm.as_deref()).transpose(),
+                    "status_signal_number" => Ok(ssname.as_deref()).transpose(),
+                    "status_signal_name" => Ok(ssnumber.as_deref()).transpose(),
                     _ => None,
                 })
                 .parse(None)
@@ -56,36 +71,58 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     }
 }
 
-fn signal_name_from_exit_code(exit_code: &str) -> &str {
-    match exit_code {
-        "1" => "ERROR",
-        "2" => "USAGE",
-        "126" => "NOPERM",
-        "127" => "NOTFOUND",
-        "129" => "SIGHUP",    // 128 + 1
-        "130" => "SIGINT",    // 128 + 2
-        "131" => "SIGQUIT",   // 128 + 3
-        "132" => "SIGILL",    // 128 + 4
-        "133" => "SIGTRAP",   // 128 + 5
-        "134" => "SIGIOT",    // 128 + 6
-        "135" => "SIGBUS",    // 128 + 7
-        "136" => "SIGFPE",    // 128 + 8
-        "137" => "SIGKILL",   // 128 + 9
-        "138" => "SIGUSR1",   // 128 + 10
-        "139" => "SIGSEGV",   // 128 + 11
-        "140" => "SIGUSR2",   // 128 + 12
-        "141" => "SIGPIPE",   // 128 + 13
-        "142" => "SIGALRM",   // 128 + 14
-        "143" => "SIGTERM",   // 128 + 15
-        "144" => "SIGSTKFLT", // 128 + 16
-        "145" => "SIGCHLD",   // 128 + 17
-        "146" => "SIGCONT",   // 128 + 18
-        "147" => "SIGSTOP",   // 128 + 19
-        "148" => "SIGTSTP",   // 128 + 20
-        "149" => "SIGTTIN",   // 128 + 21
-        "150" => "SIGTTOU",   // 128 + 22
-        _ => exit_code,
+fn status_common_meaning(ex: u32) -> Option<String> {
+    // Over 128 are Signal exit code
+    if ex > 128 {
+        return None;
     }
+    Some(match ex {
+        1 => "ERROR".to_string(),
+        2 => "USAGE".to_string(),
+        126 => "NOPERM".to_string(),
+        127 => "NOTFOUND".to_string(),
+        _ => ex.to_string(),
+    })
+}
+
+fn status_signal_int(ex: u32) -> Option<String> {
+    if ex < 129 {
+        return None;
+    }
+    let ex = ex - 128;
+    Some(ex.to_string())
+}
+
+fn status_signal_name(ex: u32) -> Option<String> {
+    if ex < 129 {
+        return None;
+    }
+    let ex = ex - 128;
+    Some(match ex {
+        1 => "HUP".to_string(),     // 128 + 1
+        2 => "INT".to_string(),     // 128 + 2
+        3 => "QUIT".to_string(),    // 128 + 3
+        4 => "ILL".to_string(),     // 128 + 4
+        5 => "TRAP".to_string(),    // 128 + 5
+        6 => "IOT".to_string(),     // 128 + 6
+        7 => "BUS".to_string(),     // 128 + 7
+        8 => "FPE".to_string(),     // 128 + 8
+        9 => "KILL".to_string(),    // 128 + 9
+        10 => "USR1".to_string(),   // 128 + 10
+        11 => "SEGV".to_string(),   // 128 + 11
+        12 => "USR2".to_string(),   // 128 + 12
+        13 => "PIPE".to_string(),   // 128 + 13
+        14 => "ALRM".to_string(),   // 128 + 14
+        15 => "TERM".to_string(),   // 128 + 15
+        16 => "STKFLT".to_string(), // 128 + 16
+        17 => "CHLD".to_string(),   // 128 + 17
+        18 => "CONT".to_string(),   // 128 + 18
+        19 => "STOP".to_string(),   // 128 + 19
+        20 => "TSTP".to_string(),   // 128 + 20
+        21 => "TTIN".to_string(),   // 128 + 21
+        22 => "TTOU".to_string(),   // 128 + 22
+        _ => ex.to_string(),
+    })
 }
 
 #[cfg(test)]
@@ -142,6 +179,11 @@ mod tests {
             let actual = ModuleRenderer::new("status")
                 .config(toml::toml! {
                     [status]
+                    program_error_symbol = "✖"
+                    not_executable_symbol = "✖"
+                    not_found_symbol = "✖"
+                    sigint_symbol = "✖"
+                    signal_symbol = "✖"
                     disabled = false
                 })
                 .status(*status)
@@ -155,15 +197,41 @@ mod tests {
     #[test]
     fn signal_name_enabled() -> io::Result<()> {
         let exit_values = [1, 2, 126, 127, 130, 101];
-        let exit_values_name = ["ERROR", "USAGE", "NOPERM", "NOTFOUND", "SIGINT", "101"];
+        let exit_values_name = ["ERROR", "USAGE", "NOPERM", "NOTFOUND", "INT", "101"];
 
         for (status, name) in exit_values.iter().zip(exit_values_name.iter()) {
             let expected = Some(name.to_string());
             let actual = ModuleRenderer::new("status")
                 .config(toml::toml! {
                     [status]
-                    format = "$status"
+                    format = "$status_common_meaning$status_signal_name"
                     meaning = true
+                    disabled = false
+                })
+                .status(*status)
+                .collect();
+            assert_eq!(expected, actual);
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn special_symbols() -> io::Result<()> {
+        let exit_values = [1, 126, 127, 130, 131];
+        let exit_values_name = ["🔴", "🚫", "🔍", "🧱", "⚡"];
+
+        for (status, name) in exit_values.iter().zip(exit_values_name.iter()) {
+            let expected = Some(name.to_string());
+            let actual = ModuleRenderer::new("status")
+                .config(toml::toml! {
+                    [status]
+                    format = "$symbol"
+                    program_error_symbol = "🔴"
+                    not_executable_symbol = "🚫"
+                    not_found_symbol = "🔍"
+                    sigint_symbol = "🧱"
+                    signal_symbol = "⚡"
                     disabled = false
                 })
                 .status(*status)


### PR DESCRIPTION
#### Description
User is able to choose if their want to display the meaning of
known status code in place of number.

Inspired by  go-powerline
https://github.com/justjanne/powerline-go/blob/master/segment-exitcode.go#L9

#### Motivation and Context
Having a number doesn't give a lot of information, status number of above 128 give the corresponding signal number of why a program exited 
Closes #1821

#### Screenshots (if appropriate):

#### How Has This Been Tested?
There is one unit tests, I successfully use it on my prompt on linux
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
