### PR TITLE
feat(battery): make module behaviour more obvious

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -315,26 +315,17 @@ The module is only visible when the device's battery is below 10%.
 
 ### Options
 
-| Option               | Default                           | Description                                       |
-| -------------------- | --------------------------------- | ------------------------------------------------- |
-| `full_symbol`        | `"•"`                             | The symbol shown when the battery is full.        |
-| `charging_symbol`    | `"⇡"`                             | The symbol shown when the battery is charging.    |
-| `discharging_symbol` | `"⇣"`                             | The symbol shown when the battery is discharging. |
-| `format`             | `"[$symbol$percentage]($style) "` | The format for the module.                        |
-| `display`            | [link](#battery-display)          | Display threshold and style for the module.       |
-| `disabled`           | `false`                           | Disables the `battery` module.                    |
+| Option               | Default                           | Description                                         |
+| -------------------- | --------------------------------- | --------------------------------------------------- |
+| `full_symbol`        | `""`                             | The symbol shown when the battery is full.          |
+| `charging_symbol`    | `""`                             | The symbol shown when the battery is charging.      |
+| `discharging_symbol` | `""`                             | The symbol shown when the battery is discharging.   |
+| `unknown_symbol`     | `""`                             | The symbol shown when the battery state is unknown. |
+| `empty_symbol`       | `""`                             | The symbol shown when the battery state is empty.   |
+| `format`             | `"[$symbol$percentage]($style) "` | The format for the module.                          |
+| `display`            | [link](#battery-display)          | Display threshold and style for the module.         |
+| `disabled`           | `false`                           | Disables the `battery` module.                      |
 
-<details>
-<summary>There are also options for some uncommon battery states.</summary>
-
-| Variable         | Description                                         |
-| ---------------- | --------------------------------------------------- |
-| `unknown_symbol` | The symbol shown when the battery state is unknown. |
-| `empty_symbol`   | The symbol shown when the battery state is empty.   |
-
-Note: Battery indicator will be hidden if the status is `unknown` or `empty` unless you specify the option in the config.
-
-</details>
 
 ### Example
 

--- a/docs/presets/README.md
+++ b/docs/presets/README.md
@@ -20,11 +20,6 @@ If emojis aren't your thing, this might catch your eye!
 [aws]
 symbol = " "
 
-[battery]
-full_symbol = ""
-charging_symbol = ""
-discharging_symbol = ""
-
 [conda]
 symbol = " "
 

--- a/src/configs/battery.rs
+++ b/src/configs/battery.rs
@@ -7,8 +7,8 @@ pub struct BatteryConfig<'a> {
     pub full_symbol: &'a str,
     pub charging_symbol: &'a str,
     pub discharging_symbol: &'a str,
-    pub unknown_symbol: Option<&'a str>,
-    pub empty_symbol: Option<&'a str>,
+    pub unknown_symbol: &'a str,
+    pub empty_symbol: &'a str,
     pub display: Vec<BatteryDisplayConfig<'a>>,
     pub disabled: bool,
     pub format: &'a str,
@@ -17,11 +17,11 @@ pub struct BatteryConfig<'a> {
 impl<'a> RootModuleConfig<'a> for BatteryConfig<'a> {
     fn new() -> Self {
         BatteryConfig {
-            full_symbol: "•",
-            charging_symbol: "↑",
-            discharging_symbol: "↓",
-            unknown_symbol: None,
-            empty_symbol: None,
+            full_symbol: "",
+            charging_symbol: "",
+            discharging_symbol: "",
+            unknown_symbol: "",
+            empty_symbol: "",
             format: "[$symbol$percentage]($style) ",
             display: vec![BatteryDisplayConfig {
                 threshold: 10,

--- a/src/modules/battery.rs
+++ b/src/modules/battery.rs
@@ -35,8 +35,8 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                         battery::State::Full => Some(config.full_symbol),
                         battery::State::Charging => Some(config.charging_symbol),
                         battery::State::Discharging => Some(config.discharging_symbol),
-                        battery::State::Unknown => config.unknown_symbol,
-                        battery::State::Empty => config.empty_symbol,
+                        battery::State::Unknown => Some(config.unknown_symbol),
+                        battery::State::Empty => Some(config.empty_symbol),
                         _ => {
                             log::debug!("Unhandled battery state `{}`", state);
                             None
@@ -85,7 +85,12 @@ fn get_battery_status() -> Option<BatteryStatus> {
                 })
             }
             Err(e) => {
-                log::warn!("Unable to access battery information:\n{}", &e);
+                let level = if cfg!(target_os = "linux") {
+                    log::Level::Info
+                } else {
+                    log::Level::Warn
+                };
+                log::log!(level, "Unable to access battery information:\n{}", &e);
                 None
             }
         })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Because there have been a number of bug reports, mainly from linux users, the log level of the message about the failure to get battery information is reduced for those users.

The default icons in the module are replaced with their nerd font counterparts, to make it more obvious battery information is being displayed by the module. I also added icons for the unknown and dead states to ensure a battery related icon is always visible. Because these have default values now I also moved their docs into the main section of the battery module.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes #1940
fixes #1932
fixes #1803
fixes #2035

#### Screenshots (if appropriate):
Old: full / charging / discharging / unknown (or dead)
![Bildschirmfoto vom 2020-12-01 17-39-11](https://user-images.githubusercontent.com/835177/100770005-0e9f5e80-33fd-11eb-996d-427ea974c234.png)
New: full / charging / discharging / unknown / dead
![Bildschirmfoto vom 2020-12-01 17-44-05](https://user-images.githubusercontent.com/835177/100770023-13fca900-33fd-11eb-9d99-0f4faf6db78e.png)


#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
