### PR TITLE
Disable AWS by default

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -254,7 +254,7 @@ is read from the `AWS_VAULT` env var.
 | `symbol`         | `"☁️ "`                                        | The symbol used before displaying the current AWS profile.      |
 | `region_aliases` |                                                | Table of region aliases to display in addition to the AWS name. |
 | `style`          | `"bold yellow"`                                | The style for the module.                                       |
-| `disabled`       | `false`                                        | Disables the `AWS` module.                                      |
+| `disabled`       | `true`                                        | Disables the `AWS` module.                                      |
 
 ### Variables
 

--- a/src/configs/aws.rs
+++ b/src/configs/aws.rs
@@ -17,7 +17,7 @@ impl<'a> RootModuleConfig<'a> for AwsConfig<'a> {
             format: "on [$symbol$profile(\\($region\\))]($style) ",
             symbol: "☁️  ",
             style: "bold yellow",
-            disabled: false,
+            disabled: true,
             region_aliases: HashMap::new(),
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
Disables the AWS config

#### Motivation and Context
Not everybody uses AWS so it makes sense to me to have this be an opt-in feature.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

Ran the tests on windows, there were only 2 failures that look unrelated
```
---- modules::directory::tests::root_directory stdout ----
thread 'modules::directory::tests::root_directory' panicked at 'assertion failed: `(left == right)`
  left: `Some("\u{1b}[1;36m/\u{1b}[0m ")`,
 right: `Some("\u{1b}[1;36m/\u{1b}[0m\u{1b}[31m🔒\u{1b}[0m ")`', src\modules\directory.rs:721:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- modules::custom::tests::command_returns_right_string stdout ----
thread 'modules::custom::tests::command_returns_right_string' panicked at 'assertion failed: `(left == right)`
  left: `Some("?????\r\n")`,
 right: `Some("강남스타일\r\n")`', src\modules\custom.rs:284:9
```

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly (no tests for that config).

