### PR TITLE
feat(username): Try harder to guess if inside ssh

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2399,9 +2399,11 @@ The module will be shown if any of the following conditions are met:
 - The user is currently connected as an SSH session
 - The variable `show_always` is set to true
 
-Note: SSH connection is detected by checking environment variables
+::: tip
+SSH connection is detected by checking environment variables
 `SSH_CONNECTION`, `SSH_CLIENT`, and `SSH_TTY`. If your SSH host does not set up
 these variables, one workaround is to set one of them with a dummy value.
+:::
 
 ### Options
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2399,6 +2399,10 @@ The module will be shown if any of the following conditions are met:
 - The user is currently connected as an SSH session
 - The variable `show_always` is set to true
 
+Note: SSH connection is detected by checking environment variables
+`SSH_CONNECTION`, `SSH_CLIENT`, and `SSH_TTY`. If your SSH host does not set up
+these variables, one workaround is to set one of them with a dummy value.
+
 ### Options
 
 | Option        | Default                 | Description                           |

--- a/src/modules/username.rs
+++ b/src/modules/username.rs
@@ -149,6 +149,18 @@ mod tests {
     }
 
     #[test]
+    fn ssh_connection_client() -> io::Result<()> {
+        let actual = ModuleRenderer::new("username")
+            .env("USER", "astronaut")
+            .env("SSH_CLIENT", "192.168.0.101 39323 22")
+            .collect();
+        let expected = Some(format!("{} in ", Color::Yellow.bold().paint("astronaut")));
+
+        assert_eq!(expected, actual);
+        Ok(())
+    }
+
+    #[test]
     fn show_always() -> io::Result<()> {
         let actual = ModuleRenderer::new("username")
             .env("USER", "astronaut")

--- a/src/modules/username.rs
+++ b/src/modules/username.rs
@@ -13,7 +13,6 @@ use crate::utils;
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let user = context.get_env("USER");
     let logname = context.get_env("LOGNAME");
-    let ssh_connection = context.get_env("SSH_CONNECTION");
 
     const ROOT_UID: Option<u32> = Some(0);
     let user_uid = get_uid();
@@ -21,7 +20,8 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let mut module = context.new_module("username");
     let config: UsernameConfig = UsernameConfig::try_load(module.config);
 
-    if user != logname || ssh_connection.is_some() || user_uid == ROOT_UID || config.show_always {
+    if user != logname || is_ssh_connection(&context) || user_uid == ROOT_UID || config.show_always
+    {
         let username = user?;
         let parsed = StringFormatter::new(config.format).and_then(|formatter| {
             formatter
@@ -53,6 +53,13 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     } else {
         None
     }
+}
+
+fn is_ssh_connection(context: &Context) -> bool {
+    let ssh_env: Vec<&str> = vec!["SSH_CONNECTION", "SSH_CLIENT", "SSH_TTY"];
+    ssh_env
+        .into_iter()
+        .any(|env| context.get_env(env).is_some())
 }
 
 fn get_uid() -> Option<u32> {
@@ -122,6 +129,18 @@ mod tests {
         let actual = ModuleRenderer::new("username")
             .env("USER", "astronaut")
             .env("SSH_CONNECTION", "192.168.223.17 36673 192.168.223.229 22")
+            .collect();
+        let expected = Some(format!("{} in ", Color::Yellow.bold().paint("astronaut")));
+
+        assert_eq!(expected, actual);
+        Ok(())
+    }
+
+    #[test]
+    fn ssh_connection_tty() -> io::Result<()> {
+        let actual = ModuleRenderer::new("username")
+            .env("USER", "astronaut")
+            .env("SSH_TTY", "/dev/pts/0")
             .collect();
         let expected = Some(format!("{} in ", Color::Yellow.bold().paint("astronaut")));
 


### PR DESCRIPTION
#### Description
In addition to `SSH_CONNECTION`, also try other common environment variables set in an ssh connection: `SSH_CLIENT`, `SSH_TTY`.

#### Motivation and Context
Not all servers set `SSH_CONNECTION` in an ssh connection, therefore testing for the existence of `SSH_CONNECTION` is not reliable enough. In fact, testing for `SSH_CLIENT` and `SSH_TTY` is still not good enough, but should be better. Other means (e.g. [link](https://unix.stackexchange.com/questions/9605/how-can-i-detect-if-the-shell-is-controlled-from-ssh)) are beyond my capability.

#### Screenshots (if appropriate):

#### How Has This Been Tested?

- [ ] I have tested using **MacOS**
- [X] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [ ] I have updated the documentation accordingly.
- [X] I have updated the tests accordingly.
