### PR TITLE
docs(preset): add a Nerd Font icon for "read_only" directories

### DIFF
--- a/docs/presets/README.md
+++ b/docs/presets/README.md
@@ -31,6 +31,9 @@ symbol = " "
 [dart]
 symbol = " "
 
+[directory]
+read_only = " "
+
 [docker]
 symbol = " "
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR adds a Nerd Font padlock icon for the property `read_only` for the `[directory]` module.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It helps those who like me can't figure how to get the emoji working on their setup. This icon was missing in the Nerd Font preset

#### Screenshots (if appropriate):
just a cute padlock
![image](https://user-images.githubusercontent.com/7424845/101284743-4ffa8a00-37c0-11eb-861f-c05be2312b59.png)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
