### PR TITLE
feat(git_branch): show remote name

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1036,12 +1036,13 @@ The `git_branch` module shows the active branch of the repo in your current dire
 
 ### Variables
 
-| Variable | Example  | Description                                                                                          |
-| -------- | -------- | ---------------------------------------------------------------------------------------------------- |
-| branch   | `master` | The current branch name, falls back to `HEAD` if there's no current branch (e.g. git detached HEAD). |
-| remote   | `master` | The remote branch name.                                                                              |
-| symbol   |          | Mirrors the value of option `symbol`                                                                 |
-| style\*  |          | Mirrors the value of option `style`                                                                  |
+| Variable        | Example  | Description                                                                                          |
+| ----------------| -------- | ---------------------------------------------------------------------------------------------------- |
+| branch          | `master` | The current branch name, falls back to `HEAD` if there's no current branch (e.g. git detached HEAD). |
+| remote_name     | `origin` | The remote name.                                                                                     |
+| remote_branch   | `master` | The name of the branch tracked on `remote_name`.                                                     |
+| symbol          |          | Mirrors the value of option `symbol`                                                                 |
+| style\*         |          | Mirrors the value of option `style`                                                                  |
 
 \*: This variable can only be used as a part of a style string
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1031,7 +1031,7 @@ The `git_branch` module shows the active branch of the repo in your current dire
 | `style`             | `"bold purple"`                  | The style for the module.                                                                |
 | `truncation_length` | `2^63 - 1`                       | Truncates a git branch to X graphemes.                                                   |
 | `truncation_symbol` | `"…"`                            | The symbol used to indicate a branch name was truncated. You can use `""` for no symbol. |
-| `only_attached`      | `false`                                         | Only show the branch name when not in a detached HEAD state. |
+| `only_attached`     | `false`                         | Only show the branch name when not in a detached HEAD state.                             |
 | `disabled`          | `false`                          | Disables the `git_branch` module.                                                        |
 
 ### Variables

--- a/src/context.rs
+++ b/src/context.rs
@@ -171,7 +171,9 @@ impl<'a> Context<'a> {
                     .as_ref()
                     .and_then(|repo| repo.workdir().map(Path::to_path_buf));
                 let state = repository.as_ref().map(|repo| repo.state());
-                let remote = repository.as_ref().and_then(|repo| get_remote_branch(repo));
+                let remote = repository
+                    .as_ref()
+                    .and_then(|repo| get_remote_repository_info(repo));
                 Ok(Repo {
                     branch,
                     root,
@@ -312,8 +314,14 @@ pub struct Repo {
     /// State
     pub state: Option<RepositoryState>,
 
-    /// Remote branch name
-    pub remote: Option<String>,
+    /// Remote repository
+    pub remote: Option<Remote>,
+}
+
+/// Remote repository
+pub struct Remote {
+    pub branch: Option<String>,
+    pub name: Option<String>,
 }
 
 // A struct of Criteria which will be used to verify current PathBuf is
@@ -380,7 +388,7 @@ fn get_current_branch(repository: &Repository) -> Option<String> {
     shorthand.map(std::string::ToString::to_string)
 }
 
-fn get_remote_branch(repository: &Repository) -> Option<String> {
+fn get_remote_repository_info(repository: &Repository) -> Option<Remote> {
     if let Ok(head) = repository.head() {
         if let Some(local_branch_ref) = head.name() {
             let remote_ref = match repository.branch_upstream_name(local_branch_ref) {
@@ -388,8 +396,13 @@ fn get_remote_branch(repository: &Repository) -> Option<String> {
                 Err(_) => return None,
             };
 
-            let remote = remote_ref.split('/').last().map(|r| r.to_owned())?;
-            return Some(remote);
+            let v = &mut remote_ref.rsplit('/').collect::<Vec<&str>>().into_iter();
+            let remote_branch = v.next()?.to_owned();
+            let remote_name = v.next()?.to_owned();
+            return Some(Remote {
+                branch: Some(remote_branch),
+                name: Some(remote_name),
+            });
         }
     }
     None

--- a/src/context.rs
+++ b/src/context.rs
@@ -396,9 +396,10 @@ fn get_remote_repository_info(repository: &Repository) -> Option<Remote> {
                 Err(_) => return None,
             };
 
-            let v = &mut remote_ref.rsplit('/').collect::<Vec<&str>>().into_iter();
-            let remote_branch = v.next()?.to_owned();
-            let remote_name = v.next()?.to_owned();
+            let mut v = remote_ref.splitn(4, "/");
+            let remote_name = v.nth(2)?.to_owned();
+            let remote_branch = v.last()?.to_owned();
+
             return Some(Remote {
                 branch: Some(remote_branch),
                 name: Some(remote_name),

--- a/src/context.rs
+++ b/src/context.rs
@@ -396,7 +396,7 @@ fn get_remote_repository_info(repository: &Repository) -> Option<Remote> {
                 Err(_) => return None,
             };
 
-            let mut v = remote_ref.splitn(4, "/");
+            let mut v = remote_ref.splitn(4, '/');
             let remote_name = v.nth(2)?.to_owned();
             let remote_branch = v.last()?.to_owned();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Git Branch module now provides two variables for remote repository:
- remote_name: name of the remote (as set by `git remote add` command)
- remote branch: name of the tracked branch on the remote

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1971 

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [X] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
