### PR TITLE
docs: Correct dotnet module default format to match reality

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -779,7 +779,7 @@ when there is a csproj file in the current directory.
 
 | Option      | Default                                   | Description                                              |
 | ----------- | ----------------------------------------- | -------------------------------------------------------- |
-| `format`    | `"v[$symbol$version( 🎯 $tfm)]($style) "` | The format for the module.                               |
+| `format`    | `"[$symbol$version( 🎯 $tfm)]($style) "`  | The format for the module.                               |
 | `symbol`    | `"•NET "`                                 | The symbol used before displaying the version of dotnet. |
 | `heuristic` | `true`                                    | Use faster version detection to keep starship snappy.    |
 | `style`     | `"bold blue"`                             | The style for the module.                                |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
This changes the documentation's default value for the dotnet module's `format` to match what it is in the code.

#### Motivation and Context
I was customising my prompt and noticed that copying the default from the documentation did not replicate the default behaviour.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

I have not attempted to compile the Starship application itself, but did run the development website to verify it picked up the changes using:

* Windows 10 1909
* NodeJS 12.18.4
* NPM 6.14.6
* Microsoft Edge 87.0.664.55

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.

I have read the contributing document and believe I've followed everything relevant but let me know if not.