### PR TITLE
fix(install): Detect cygwin_nt as Windows

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -172,6 +172,7 @@ detect_platform() {
 
   case "${platform}" in
     msys_nt*) platform="pc-windows-msvc" ;;
+    cygwin_nt*) platform="pc-windows-msvc";;
     # mingw is Git-Bash
     mingw*) platform="pc-windows-msvc" ;;
     # use the statically compiled musl bins on linux to avoid linking issues.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This fixes the install script by detecting `cygwin_nt*` as Windows.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #985
Closes #2103 

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
