### PR TITLE
fix(config): log as error if failure to read config wasn't caused by NotFound

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,7 @@ use indexmap::IndexMap;
 
 use std::clone::Clone;
 use std::collections::HashMap;
+use std::io::ErrorKind;
 use std::marker::Sized;
 
 use std::env;
@@ -236,7 +237,13 @@ impl StarshipConfig {
                 Some(content)
             }
             Err(e) => {
-                log::debug!("Unable to read config file content: {}", &e);
+                let level = if e.kind() == ErrorKind::NotFound {
+                    log::Level::Debug
+                } else {
+                    log::Level::Error
+                };
+
+                log::log!(level, "Unable to read config file content: {}", &e);
                 None
             }
         }?;


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Until now all log messages related to failure to read config file contents as a string were not visible by default. The case of a missing config file is innocuous but I think other errors like invalid unicode are worth showing to the user.

This PR increases the log level from `debug` to `error` if the source of the error is not `ErrorKind::NotFound`.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
