### PR TITLE
feat(shlvl): Add `repeat` option

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2154,6 +2154,7 @@ set to a number and meets or exceeds the specified threshold.
 | `threshold` | `2`                          | Display threshold.                      |
 | `format`    | `"[$symbol$shlvl]($style) "` | The format for the module.              |
 | `symbol`    | `"↕️ "`                      | The symbol used to represent the SHLVL. |
+| `repeat`    | `false`                      | Causes `symbol` to be repeated by the current SHLVL amount. |
 | `style`     | `"bold yellow"`              | The style for the module.               |
 | `disabled`  | `true`                       | Disables the `shlvl` module.            |
 

--- a/src/configs/shlvl.rs
+++ b/src/configs/shlvl.rs
@@ -7,6 +7,7 @@ pub struct ShLvlConfig<'a> {
     pub threshold: i64,
     pub format: &'a str,
     pub symbol: &'a str,
+    pub repeat: bool,
     pub style: &'a str,
     pub disabled: bool,
 }
@@ -17,6 +18,7 @@ impl<'a> RootModuleConfig<'a> for ShLvlConfig<'a> {
             threshold: 2,
             format: "[$symbol$shlvl]($style) ",
             symbol: "↕️  ", // extra space for emoji
+            repeat: false,
             style: "bold yellow",
             disabled: true,
         }

--- a/src/modules/shlvl.rs
+++ b/src/modules/shlvl.rs
@@ -22,8 +22,13 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
     let shlvl_str = &shlvl.to_string();
 
-    let symbol = if config.repeat {
-        Cow::Owned(config.symbol.repeat(shlvl.try_into().unwrap_or(usize::MAX)))
+    let repeat_count = if config.repeat {
+        shlvl.try_into().unwrap_or(1)
+    } else {
+        1
+    };
+    let symbol = if repeat_count != 1 {
+        Cow::Owned(config.symbol.repeat(repeat_count))
     } else {
         Cow::Borrowed(config.symbol)
     };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

Adds an option to the `shlvl` module which causes the `symbol` string to be repeated by the current SHLVL. This enables a nice a visual indicator for SHLVL that in my opinion is more intuitive than just displaying a number.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1878

##### Alternative Implementation

A different approach to adding this, instead of repeating the existing `symbol` string, would be to make the `repeat` option itself a string which is repeated, and you have to include that in your format for it to show up. If messing with `symbol` is something that's generally discouraged in Starship then this would be a good alternative.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [X] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have updated the documentation accordingly.
- [X] I have updated the tests accordingly.
