### PR TITLE
docs: Add link to `fish-async-prompt` plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,8 @@
    starship init fish | source
    ```
 
+   Want to run Starship asynchronously? Install [fish-async-prompt](https://github.com/acomagu/fish-async-prompt) plugin.
+
    #### Zsh
 
    Add the following to the end of `~/.zshrc`:

--- a/docs/README.md
+++ b/docs/README.md
@@ -74,6 +74,8 @@ description: Starship is the minimal, blazing fast, and extremely customizable p
    starship init fish | source
    ```
 
+   Want to run Starship asynchronously? Install [fish-async-prompt](https://github.com/acomagu/fish-async-prompt) plugin.
+
    #### Zsh
 
    Add the following to the end of `~/.zshrc`:


### PR DESCRIPTION
#### Description
Add instructions on how to run Starship asynchronously in fish.

#### Motivation and Context
There is an excellent plugin for fish shell: [fish-async-prompt](https://github.com/acomagu/fish-async-prompt), which allows to run any prompt asynchronously and is extremely useful for Starship. I'm personally using this combination for quite some time and it's a match made in heaven.

This simple PR adds a link to the plugin, so Starship fish users would be aware of its existence and a way to use Starship without prompt slowdown which can be significant.
