### PR TITLE
docs: Add note about Crowdin-managed files to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,11 +178,24 @@ Any tests that depend on File I/O should use [`sync_all()`](https://doc.rust-lan
 
 Any tests that use `tempfile::tempdir` should take care to call `dir.close()` after usage to ensure the lifecycle of the directory can be reasoned about. This includes `fixture_repo()` as it returns a TempDir that should be closed.
 
-## Running the Documentation Website Locally
+## Documentation
 
-If you are contributing to the design of Starship's website, the following section will help you get started.
+### Crowdin Translated Pages
 
-### Setup
+Many documentation pages have versions in non-English languages. These
+translated pages are managed by
+[Crowdin](https://crowdin.com/project/starship-prompt). Please do not edit
+these pages directly, even for changes that do not need to be translated (e.g.
+whitespace or emoji changes), since this can cause merges to fail.
+
+If you would like to contribute translations or corrections to the Crowdin
+generated pages, please visit our Crowdin site.
+
+### Running the Documentation Website Locally
+
+Changes to documentation can be viewed in a rendered state from the GitHub PR page
+(go to the CI section at the bottom of the page and look for "deploy preview", then
+click on "details"). If you want to view changes locally as well, follow these steps.
 
 After cloning the project, you can do the following to run the VuePress website on your local machine:
 

--- a/src/init/starship.bash
+++ b/src/init/starship.bash
@@ -32,9 +32,10 @@ starship_precmd() {
     # Save the status, because commands in this pipeline will change $?
     STATUS=$?
 
-    # Evaluate the number of jobs before running the preseved prompt command, so that tools
-    # like z/autojump, which background certain jobs, do not cause spurious background jobs
-    # to be displayed by starship. Also avoids forking to run `wc`, slightly improving perf
+    # Evaluate the number of jobs before running the preseved prompt command, so
+    # that backgrounded jobs in the preserved prompt command like z or autojump
+    # do not cause spurious background jobs. Also do this with a while loop
+    # to avoid having to fork a subshell to call wc.
     NUM_JOBS=$(n=0; while read line; do [[ $line ]] && n=$((n+1));done <<< $(jobs -p) ; echo $n)
 
     # Run the bash precmd function, if it's set. If not set, evaluates to no-op

--- a/src/init/starship.bash
+++ b/src/init/starship.bash
@@ -32,10 +32,9 @@ starship_precmd() {
     # Save the status, because commands in this pipeline will change $?
     STATUS=$?
 
-    # Evaluate the number of jobs before running the preseved prompt command, so
-    # that backgrounded jobs in the preserved prompt command like z or autojump
-    # do not cause spurious background jobs. Also do this with a while loop
-    # to avoid having to fork a subshell to call wc.
+    # Evaluate the number of jobs before running the preseved prompt command, so that tools
+    # like z/autojump, which background certain jobs, do not cause spurious background jobs
+    # to be displayed by starship. Also avoids forking to run `wc`, slightly improving perf
     NUM_JOBS=$(n=0; while read line; do [[ $line ]] && n=$((n+1));done <<< $(jobs -p) ; echo $n)
 
     # Run the bash precmd function, if it's set. If not set, evaluates to no-op


### PR DESCRIPTION
#### Description

Add a note to CONTRIBUTING.md which specifies that Crowdin-generated files should not be changed in PRs.

#### Motivation and Context
Changing Crowdin-translated pages seems to be common point of confusion for PRs (especially those that edit docs in a way that seems like translation should be trivial, e.g. whitespace change or emoji changes). @twpol noted on #1983 that they looked for a note in CONTRIBUTING.md about that and couldn't find one.

This is a bit of a draft, so I'm very open to changing the wording on this.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
Documentation change.

#### Checklist:
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
