### PR TITLE
fix(user): Fix username detection on Windows

### DIFF
--- a/src/modules/username.rs
+++ b/src/modules/username.rs
@@ -23,7 +23,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
     let user_uid = get_uid();
 
-    let is_not_login = logname.is_some() && username != logname.unwrap_or_default();
+    let is_not_login = logname.is_some() && username != logname.unwrap();
     let is_root = user_uid == ROOT_UID;
 
     let mut module = context.new_module("username");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This switches Windows to use the env var `USERNAME` rather than `USER`
for getting the username of the current user. I have also done some minor
refactoring to simplify some of the code and make the checks to see if
the user is root or another user a bit more robust.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1554
Closes #1579
Closes #1350
Closes #1157

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

**Note** - I have not tested this on Windows the changes were made after checking the docs and looking at the related issues.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
