### PR TITLE
feat(status): Add hex_status & text_status variables

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2278,16 +2278,18 @@ To enable it, set `disabled` to `false` in your configuration file.
 
 ### Variables
 
-| Variable                | Example | Description                                                             |
-| ----------------------- | ------- | ----------------------------------------------------------------------- |
-| status                  | `127`   | The exit code of the last command                                       |
-| int                     | `127`   | The exit code of the last command                                       |
-| common_meaning          | `ERROR` | Meaning of the code if not a signal                                     |
-| signal_number           | `9`     | Signal number corresponding to the exit code, only if signalled         |
-| signal_name             | `KILL`  | Name of the signal corresponding to the exit code, only if signalled    |
-| maybe_int               | `7`     | Contains the exit code number when no meaning has been found            |
-| symbol                  |         | Mirrors the value of option `symbol`                                    |
-| style\*                 |         | Mirrors the value of option `style`                                     |
+| Variable                | Example          | Description                                                                  |
+| ----------------------- | ---------------- | ---------------------------------------------------------------------------- |
+| status                  | `127`            | The exit code of the last command                                            |
+| hex_status              | `0x7F`           | The exit code of the last command in hex                                     |
+| int                     | `127`            | The exit code of the last command                                            |
+| common_meaning          | `ERROR`          | Meaning of the code if not a signal                                          |
+| text_status             | `CONTROL_C_EXIT` | Textual representation of the exit code if available, otherwise empty string |
+| signal_number           | `9`              | Signal number corresponding to the exit code, only if signalled              |
+| signal_name             | `KILL`           | Name of the signal corresponding to the exit code, only if signalled         |
+| maybe_int               | `7`              | Contains the exit code number when no meaning has been found                 |
+| symbol                  |                  | Mirrors the value of option `symbol`                                         |
+| style\*                 |                  | Mirrors the value of option `style`                                          |
 
 \*: This variable can only be used as a part of a style string
 


### PR DESCRIPTION
#### Description

Add hex_status (exit status formatted as hex) and text_status (textual representation of exit code if available) to status module.

text_status is only non-empty on Windows, as UNIX does not really have predefined exit codes, using signals instead.

#### Motivation and Context
Windows exit codes are very large integers which are hard to interpret (see example below).

#### Screenshots
Before:
💥 -1073741510❯
After:
💥 0xC000013A (CONTROL_C_EXIT)❯

#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.