### PR TITLE
fix(docker_context): enable if either yml or yaml is found

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -710,13 +710,13 @@ The `docker_context` module shows the currently active
 
 ### Options
 
-| Option            | Default                            | Description                                                                             |
-| ----------------- | ---------------------------------- | --------------------------------------------------------------------------------------- |
-| `format`          | `"via [$symbol$context]($style) "` | The format for the module.                                                              |
-| `symbol`          | `"🐳 "`                            | The symbol used before displaying the Docker context.                                   |
-| `style`           | `"blue bold"`                      | The style for the module.                                                               |
-| `only_with_files` | `false`                            | Only show when there's a `docker-compose.yml` or `Dockerfile` in the current directory. |
-| `disabled`        | `true`                             | Disables the `docker_context` module.                                                   |
+| Option            | Default                            | Description                                                                                                     |
+| ----------------- | ---------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `format`          | `"via [$symbol$context]($style) "` | The format for the module.                                                                                      |
+| `symbol`          | `"🐳 "`                            | The symbol used before displaying the Docker context.                                                           |
+| `style`           | `"blue bold"`                      | The style for the module.                                                                                       |
+| `only_with_files` | `false`                            | Only show when there's a `docker-compose.yml`, `docker-compose.yaml`, or `Dockerfile` in the current directory. |
+| `disabled`        | `true`                             | Disables the `docker_context` module.                                                                           |
 
 ### Variables
 

--- a/src/modules/docker_context.rs
+++ b/src/modules/docker_context.rs
@@ -20,7 +20,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     if config.only_with_files
         && !context
             .try_begin_scan()?
-            .set_files(&["docker-compose.yml", "Dockerfile"])
+            .set_files(&["docker-compose.yml", "docker-compose.yaml", "Dockerfile"])
             .is_match()
     {
         return None;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
If `only_with_files = true` is set for the docker_context module, then this prompt is only shown in case a `Dockerfile` or `docker-compose.yml` file is found.
This PR also enables it for `docker-compose.yaml` (notice `yml` vs `yaml`).

#### Motivation and Context
Fixes the prompt for a valid docker-compose yaml file.

#### How Has This Been Tested?
1. Created a docker-compose.yaml file
2. Ran `~/path/to/dev/build/target/starship prompt docker_context`
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.