### PR TITLE
ci(deploy): Fix failing Linux GNU builds

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,28 +39,32 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target:
-          - x86_64-unknown-linux-gnu
-          - x86_64-unknown-linux-musl
-          - i686-unknown-linux-musl
-          - x86_64-apple-darwin
-          - x86_64-pc-windows-msvc
         include:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             name: starship-x86_64-unknown-linux-gnu.tar.gz
+            flags: "--features tls-vendored"
+
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
             name: starship-x86_64-unknown-linux-musl.tar.gz
+            flags: "--features tls-vendored"
+
           - target: i686-unknown-linux-musl
             os: ubuntu-latest
             name: starship-i686-unknown-linux-musl.tar.gz
+            flags: "--features tls-vendored"
+
           - target: x86_64-apple-darwin
             os: macOS-latest
             name: starship-x86_64-apple-darwin.tar.gz
+            flags: ""
+
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             name: starship-x86_64-pc-windows-msvc.zip
+            flags: ""
+
     runs-on: ${{ matrix.os }}
     steps:
       - name: Setup | Checkout
@@ -83,27 +87,14 @@ jobs:
           profile: minimal
           target: ${{ matrix.target }}
 
-      - name: Setup | musl tools
-        if: contains(matrix.target, 'musl')
-        run: sudo apt install -y musl-tools
-
       - name: Build | Build
-        if: "! contains(matrix.target, 'musl')"
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release --target ${{ matrix.target }}
+          args: --release ${{ matrix.flags }} --target ${{ matrix.target }}
           use-cross: true
 
-      - name: Build | Build [musl]
-        if: contains(matrix.target, 'musl')
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --features tls-vendored --target ${{ matrix.target }}
-          use-cross: true
-
-      - name: Post Setup | Prepare artifacts [Windows]
+      - name: Post Build | Prepare artifacts [Windows]
         if: matrix.os == 'windows-latest'
         run: |
           cd target/${{ matrix.target }}/release
@@ -111,7 +102,7 @@ jobs:
           7z a ../../../${{ matrix.name }} starship.exe
           cd -
 
-      - name: Post Setup | Prepare artifacts [-nix]
+      - name: Post Build | Prepare artifacts [-nix]
         if: matrix.os != 'windows-latest'
         run: |
           cd target/${{ matrix.target }}/release
@@ -119,7 +110,7 @@ jobs:
           tar czvf ../../../${{ matrix.name }} starship
           cd -
 
-      - name: Post Setup | Upload artifacts
+      - name: Deploy | Upload artifacts
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.name }}
@@ -159,6 +150,7 @@ jobs:
           body_path: RELEASE.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   aur_release:
     runs-on: ubuntu-latest
     name: Create AUR release

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,27 +43,22 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
             name: starship-x86_64-unknown-linux-gnu.tar.gz
-            flags: "--features tls-vendored"
 
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
             name: starship-x86_64-unknown-linux-musl.tar.gz
-            flags: "--features tls-vendored"
 
           - target: i686-unknown-linux-musl
             os: ubuntu-latest
             name: starship-i686-unknown-linux-musl.tar.gz
-            flags: "--features tls-vendored"
 
           - target: x86_64-apple-darwin
             os: macOS-latest
             name: starship-x86_64-apple-darwin.tar.gz
-            flags: ""
 
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             name: starship-x86_64-pc-windows-msvc.zip
-            flags: ""
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -91,8 +86,8 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release ${{ matrix.flags }} --target ${{ matrix.target }}
-          use-cross: true
+          args: --release --features tls-vendored --target ${{ matrix.target }}
+          use-cross: contains(matrix.target, 'linux')
 
       - name: Post Build | Prepare artifacts [Windows]
         if: matrix.os == 'windows-latest'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This fixes the failing Linux 64 bit builds that are linking to GNU libc
that are failing because cross doesn't compile openssl-sys. The fix is
simply to enable the vendored-tls feature so that we get the rust
vendored SSL rather than the system SSL. Have also done a little bit of
refactoring to the deploy script. Now rather than have a matrix of
targets have just included each target individually (this may be
something we want to revisit in the future as the number of platforms
increases). I have also removed the installation of the musl tools since
this is no longer needed when using cross for compilation.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
