### PR TITLE
fix(pwsh): disable builtin venv prompt

### DIFF
--- a/src/init/starship.ps1
+++ b/src/init/starship.ps1
@@ -63,6 +63,9 @@ function global:prompt {
     }
 }
 
+# Disable virtualenv prompt, it breaks starship
+$ENV:VIRTUAL_ENV_DISABLE_PROMPT=1
+
 $ENV:STARSHIP_SHELL = "powershell"
 
 # Set up the session key that will be used to store logs


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

To prevent duplicate venv entries in the prompt, disable the builtin venv prompt. The `python` module can serve as the replacement.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #2087

Context #551

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
