### PR TITLE
fix: bash-preexec detection and implementation

### DIFF
--- a/src/init/starship.bash
+++ b/src/init/starship.bash
@@ -56,7 +56,7 @@ starship_precmd() {
 
 # If the user appears to be using https://github.com/rcaloras/bash-preexec,
 # then hook our functions into their framework.
-if [[ "${__bp_imported:-}" == "defined" ]]; then
+if [[ "${__bp_imported:-}" == "defined" || $preexec_functions || $precmd_functions ]]; then
     # bash-preexec needs a single function--wrap the args into a closure and pass
     starship_preexec_all(){ starship_preexec "$_"; }
     preexec_functions+=(starship_preexec_all)

--- a/src/init/starship.bash
+++ b/src/init/starship.bash
@@ -56,8 +56,10 @@ starship_precmd() {
 
 # If the user appears to be using https://github.com/rcaloras/bash-preexec,
 # then hook our functions into their framework.
-if [[ $preexec_functions ]]; then
-    preexec_functions+=('starship_preexec "$_"')
+if [[ "${__bp_imported:-}" == "defined" ]]; then
+    # bash-preexec needs a single function--wrap the args into a closure and pass
+    starship_preexec_all(){ starship_preexec "$_"; }
+    preexec_functions+=(starship_preexec_all)
     precmd_functions+=(starship_precmd)
 else
     # We want to avoid destroying an existing DEBUG hook. If we detect one, create


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
Change detection and implementation for bash-preexec: now checks for a preexec variable in case bash-preexec is installed at a system level (and so necessarily sourced before anything the user does).

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes an issue found in discussion on #2039 

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
