### PR TITLE
fix(nix_shell): remove extra whitespace of symbol

### DIFF
--- a/src/configs/nix_shell.rs
+++ b/src/configs/nix_shell.rs
@@ -16,7 +16,7 @@ impl<'a> RootModuleConfig<'a> for NixShellConfig<'a> {
     fn new() -> Self {
         NixShellConfig {
             format: "via [$symbol$state( \\($name\\))]($style) ",
-            symbol: "❄️  ",
+            symbol: "❄️ ",
             style: "bold blue",
             impure_msg: "impure",
             pure_msg: "pure",

--- a/src/modules/nix_shell.rs
+++ b/src/modules/nix_shell.rs
@@ -91,7 +91,7 @@ mod tests {
         let actual = ModuleRenderer::new("nix_shell")
             .env("IN_NIX_SHELL", "pure")
             .collect();
-        let expected = Some(format!("via {} ", Color::Blue.bold().paint("❄️  pure")));
+        let expected = Some(format!("via {} ", Color::Blue.bold().paint("❄️ pure")));
 
         assert_eq!(expected, actual);
         Ok(())
@@ -102,7 +102,7 @@ mod tests {
         let actual = ModuleRenderer::new("nix_shell")
             .env("IN_NIX_SHELL", "impure")
             .collect();
-        let expected = Some(format!("via {} ", Color::Blue.bold().paint("❄️  impure")));
+        let expected = Some(format!("via {} ", Color::Blue.bold().paint("❄️ impure")));
 
         assert_eq!(expected, actual);
         Ok(())
@@ -116,7 +116,7 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "via {} ",
-            Color::Blue.bold().paint("❄️  pure (starship)")
+            Color::Blue.bold().paint("❄️ pure (starship)")
         ));
 
         assert_eq!(expected, actual);
@@ -131,7 +131,7 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "via {} ",
-            Color::Blue.bold().paint("❄️  impure (starship)")
+            Color::Blue.bold().paint("❄️ impure (starship)")
         ));
 
         assert_eq!(expected, actual);


### PR DESCRIPTION
Documents don't need to change because they have only one whitespace.

<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
