### PR TITLE
docs: Comment about spaces in nix-shell config

### DIFF
--- a/src/configs/nix_shell.rs
+++ b/src/configs/nix_shell.rs
@@ -14,7 +14,7 @@ pub struct NixShellConfig<'a> {
 
 /* The trailing double spaces in `symbol` are needed to work around issues with
 multiwidth emoji support in some shells. Please do not file a PR to change this
-unless you can show that your changes do not affect this workaround. */
+unless you can show that your changes do not affect this workaround.  */
 impl<'a> RootModuleConfig<'a> for NixShellConfig<'a> {
     fn new() -> Self {
         NixShellConfig {

--- a/src/configs/nix_shell.rs
+++ b/src/configs/nix_shell.rs
@@ -12,6 +12,9 @@ pub struct NixShellConfig<'a> {
     pub disabled: bool,
 }
 
+/* The trailing double spaces in `symbol` are needed to work around issues with
+multiwidth emoji support in some shells. Please do not file a PR to change this
+unless you can show that your changes do not affect this workaround. */
 impl<'a> RootModuleConfig<'a> for NixShellConfig<'a> {
     fn new() -> Self {
         NixShellConfig {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
We have had two attempts now to "fix" the two spaces in the nixshell module's default config, which are needed to provide a workaround for rendering of multiwidth emojis. Adds a comment to the code there describing why the spaces are present so that any would-be contributors know that it is not an accident.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
