### PR TITLE
fix(install): improve supported target detection

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -33,6 +33,8 @@ BLUE="$(tput setaf 4 2>/dev/null || echo '')"
 MAGENTA="$(tput setaf 5 2>/dev/null || echo '')"
 NO_COLOR="$(tput sgr0 2>/dev/null || echo '')"
 
+SUPPORTED_TARGETS="x86_64-unknown-linux-gnu x86_64-unknown-linux-musl i686-unknown-linux-musl x86_64-apple-darwin x86_64-pc-windows-msvc"
+
 info() {
   printf "%s\n" "${BOLD}${GREY}>${NO_COLOR} $*"
 }
@@ -250,7 +252,8 @@ is_build_available() {
   local good
   
   good=$(
-    for t in x86_64-unknown-linux-gnu x86_64-unknown-linux-musl i686-unknown-linux-musl x86_64-apple-darwin x86_64-pc-windows-msvc; do
+    IFS=" "
+    for t in $SUPPORTED_TARGETS; do
       if [ "${t}" == "${target}" ]; then
         echo 1
         break

--- a/install/install.sh
+++ b/install/install.sh
@@ -192,7 +192,7 @@ detect_arch() {
 
   # `uname -m` in some cases mis-reports 32-bit OS as 64-bit, so double check
   if [ "${arch}" = "x64" ] && [ "$(getconf LONG_BIT)" -eq 32 ]; then
-    arch=i386
+    arch=i686
   fi
 
   echo "${arch}"
@@ -239,6 +239,33 @@ check_bin_dir() {
 
   if [ "${good}" != "1" ]; then
     warn "Bin directory ${bin_dir} is not in your \$PATH"
+  fi
+}
+
+is_build_available() {
+  local arch="$1"
+  local platform="$2"
+
+  local target="${arch}-${platform}"
+  local good
+  
+  good=$(
+    for t in x86_64-unknown-linux-gnu x86_64-unknown-linux-musl i686-unknown-linux-musl x86_64-apple-darwin x86_64-pc-windows-msvc; do
+      if [ "${t}" == "${target}" ]; then
+        echo 1
+        break
+      fi
+    done
+  )
+
+  if [ "${good}" != "1" ]; then
+    error "${arch} builds for ${platform} are not yet available for Starship"
+    printf "\n" >&2
+    info "If you would like to see a build for your configuration,"
+    info "please create an issue requesting a build for ${MAGENTA}${target}${NO_COLOR}:"
+    info "${BOLD}${UNDERLINE}https://github.com/starship/starship/issues/new/${NO_COLOR}"
+    printf "\n"
+    exit 1
   fi
 }
 
@@ -320,13 +347,7 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 
-if [ "${ARCH}" = "i386" ]; then
-  error "i386 builds are not yet available for Starship\n"
-  info "If you would like to see a build for your configuration,"
-  info "please create an issue requesting a build for ${MAGENTA}${ARCH}-${PLATFORM}${NO_COLOR}:"
-  info "${BOLD}${UNDERLINE}https://github.com/starship/starship/issues/new/${NO_COLOR}\n"
-  exit 1
-fi
+is_build_available "${ARCH}" "${PLATFORM}"
 
 printf "  %s\n" "${UNDERLINE}Configuration${NO_COLOR}"
 info "${BOLD}Bin directory${NO_COLOR}: ${GREEN}${BIN_DIR}${NO_COLOR}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Improve detection of supported platforms. Previously there was only a check to see if the install was on `i386` (this still isn't supported but `i686` now is), instead check against a list of supported install targets.
In addition:
- Detect fake `x64` as `i686` instead of `i386`
- Replace `\n` in `info` and `error` with `printf "\n"`

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
