### PR TITLE
perf(crystal): Lazily evaluate version command

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -567,12 +567,12 @@ The module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Option     | Default                            | Description                                               |
-| ---------- | ---------------------------------- | --------------------------------------------------------- |
-| `symbol`   | `"🔮 "`                            | The symbol used before displaying the version of crystal. |
-| `style`    | `"bold red"`                       | The style for the module.                                 |
-| `format`   | `"via [$symbol$version]($style) "` | The format for the module.                                |
-| `disabled` | `false`                            | Disables the `crystal` module.                            |
+| Option     | Default                              | Description                                               |
+| ---------- | ------------------------------------ | --------------------------------------------------------- |
+| `symbol`   | `"🔮 "`                              | The symbol used before displaying the version of crystal. |
+| `style`    | `"bold red"`                         | The style for the module.                                 |
+| `format`   | `"via [$symbol($version )]($style)"` | The format for the module.                                |
+| `disabled` | `false`                              | Disables the `crystal` module.                            |
 
 ### Variables
 

--- a/src/configs/crystal.rs
+++ b/src/configs/crystal.rs
@@ -13,7 +13,7 @@ pub struct CrystalConfig<'a> {
 impl<'a> RootModuleConfig<'a> for CrystalConfig<'a> {
     fn new() -> Self {
         CrystalConfig {
-            format: "via [$symbol$version]($style) ",
+            format: "via [$symbol($version )]($style)",
             symbol: "🔮 ",
             style: "bold red",
             disabled: false,

--- a/src/modules/crystal.rs
+++ b/src/modules/crystal.rs
@@ -20,8 +20,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         return None;
     }
 
-    let crystal_version = utils::exec_cmd("crystal", &["--version"])?.stdout;
-
     let mut module = context.new_module("crystal");
     let config: CrystalConfig = CrystalConfig::try_load(module.config);
 
@@ -36,7 +34,10 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 _ => None,
             })
             .map(|variable| match variable {
-                "version" => format_crystal_version(&crystal_version).map(Ok),
+                "version" => format_crystal_version(
+                    utils::exec_cmd("crystal", &["--version"])?.stdout.as_str(),
+                )
+                .map(Ok),
                 _ => None,
             })
             .parse(None)

--- a/src/modules/crystal.rs
+++ b/src/modules/crystal.rs
@@ -90,7 +90,7 @@ mod tests {
         File::create(dir.path().join("shard.yml"))?.sync_all()?;
 
         let actual = ModuleRenderer::new("crystal").path(dir.path()).collect();
-        let expected = Some(format!("via {} ", Color::Red.bold().paint("🔮 v0.35.1")));
+        let expected = Some(format!("via {}", Color::Red.bold().paint("🔮 v0.35.1 ")));
         assert_eq!(expected, actual);
 
         dir.close()
@@ -102,7 +102,7 @@ mod tests {
         File::create(dir.path().join("main.cr"))?.sync_all()?;
 
         let actual = ModuleRenderer::new("crystal").path(dir.path()).collect();
-        let expected = Some(format!("via {} ", Color::Red.bold().paint("🔮 v0.35.1")));
+        let expected = Some(format!("via {}", Color::Red.bold().paint("🔮 v0.35.1 ")));
         assert_eq!(expected, actual);
 
         dir.close()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This updates the module to lazily execute the `crystal --version`
command only when the `version` variable is used in the format string.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to: #2111 

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
