### PR TITLE
feat(task_warrior): introduce task_warrior module

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2343,7 +2343,7 @@ format = "via [🏎  $version](red bold)"
 ```
 
 ## Task Warrior
-The `Task Warrior` module shows the current started task in the Task Warrior and a symbol indicating if there are due tasks.
+The `task_warrior` module shows the current started task in the Task Warrior and a symbol indicating if there are due tasks.
 The module is only shown when there's a `.task` folder in the home directory.
 Symbol priority: `overdue` > `today` > `week`, meaning when there's an overdue task has higher priority and is shown even if there's a task due today. Only one symbol is displayed.
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2342,6 +2342,44 @@ The module will be shown if any of the following conditions are met:
 format = "via [🏎  $version](red bold)"
 ```
 
+## Task Warrior
+The `Task Warrior` module shows the current started task in the Task Warrior and a symbol indicating if there are due tasks.
+The module is only shown when there's a `.task` folder in the home directory.
+Symbol priority: `overdue` > `today` > `week`, meaning when there's an overdue task has higher priority and is shown even if there's a task due today. Only one symbol is displayed.
+
+::: tip
+
+This module is disabled by default.
+To enable it, set `disabled` to `false` in your configuration file.
+:::
+
+### Options
+| Option                  | Default                                                           | Description                                             |
+| ----------------------- | ----------------------------------------------------------------- | ------------------------------------------------------- |
+| `format`                | `"[$symbol]($symbol_style)[$current_task]($current_task_style) "` | The format for the module.                              |
+| `current_task_style`    | `"white"`                                                         | The style for current task text.                        |
+| `no_tasks_symbol`       | `"✓"`                                                             | The symbol displayed when there's no task due.          |
+| `no_tasks_symbol_style` | `"green"`                                                         | The style for `no_tasks_symbol`.                        |
+| `today_symbol`          | `"⚡"`                                                            | The symbol displayed when there's a task due today.     |
+| `today_symbol_style`    | `"cyan"`                                                          | The style for `today_symbol`.                           |
+| `week_symbol`           | `"📅"`                                                            | The symbol displayed when there's a task due this week. |
+| `week_symbol_style`     | `"green"`                                                         | The style for `week_symbol`.                            |
+| `overdue_symbol`        | `"❌"`                                                            | The symbol displayed when there's an overdue task.      |
+| `overdue_symbol_style`  | `"bold red"`                                                      | The style for `overdue_symbol`.                         |
+| `disabled`              | `true`                                                            | Disables the `task_warrior` module.                     |
+
+### Variables
+
+| Variable             | Example              | Description                                                          |
+| -------------------- | -------------------- | -------------------------------------------------------------------- |
+| symbol               | `⚡`                 | Displayed symbol (one of overdue/today/etc).                         |
+| symbol_style\*       |                      | Displayed symbol style (set with appropriate `*_symbol_style` var).  |
+| current_task         | `Finish the project` | The active task  (the first one in the `task +ACTIVE` list).         |
+| current_task_style\* |                      | The style for the current task.                                      |
+
+\*: This variable can only be used as a part of a style string
+
+
 ## Terraform
 
 The `terraform` module shows the currently selected terraform workspace and version.

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -47,6 +47,7 @@ pub mod singularity;
 mod starship_root;
 pub mod status;
 pub mod swift;
+pub mod task_warrior;
 pub mod terraform;
 pub mod time;
 pub mod username;

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -64,6 +64,7 @@ pub const PROMPT_ORDER: &[&str] = &[
     "custom",
     "cmd_duration",
     "line_break",
+    "task_warrior",
     "jobs",
     #[cfg(feature = "battery")]
     "battery",

--- a/src/configs/task_warrior.rs
+++ b/src/configs/task_warrior.rs
@@ -1,0 +1,35 @@
+use crate::config::{ModuleConfig, RootModuleConfig};
+use starship_module_config_derive::ModuleConfig;
+
+#[derive(Clone, ModuleConfig)]
+pub struct TaskWarriorConfig<'a> {
+    pub format: &'a str,
+    pub current_task_style: &'a str,
+    pub no_tasks_symbol: &'a str,
+    pub no_tasks_symbol_style: &'a str,
+    pub today_symbol: &'a str,
+    pub today_symbol_style: &'a str,
+    pub week_symbol: &'a str,
+    pub week_symbol_style: &'a str,
+    pub overdue_symbol: &'a str,
+    pub overdue_symbol_style: &'a str,
+    pub disabled: bool,
+}
+
+impl<'a> RootModuleConfig<'a> for TaskWarriorConfig<'a> {
+    fn new() -> Self {
+        TaskWarriorConfig {
+            format: "[$symbol]($symbol_style)[$current_task]($current_task_style) ",
+            current_task_style: "white",
+            no_tasks_symbol: "✓",
+            no_tasks_symbol_style: "green",
+            today_symbol: "⚡",
+            today_symbol_style: "cyan",
+            week_symbol: "📅",
+            week_symbol_style: "green",
+            overdue_symbol: "❌",
+            overdue_symbol_style: "bold red",
+            disabled: true,
+        }
+    }
+}

--- a/src/module.rs
+++ b/src/module.rs
@@ -55,6 +55,7 @@ pub const ALL_MODULES: &[&str] = &[
     "rust",
     "php",
     "swift",
+    "task_warrior",
     "terraform",
     "shlvl",
     "singularity",

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -47,6 +47,7 @@ mod shlvl;
 mod singularity;
 mod status;
 mod swift;
+mod task_warrior;
 mod terraform;
 mod time;
 mod username;
@@ -116,6 +117,7 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
             "singularity" => singularity::module(context),
             "swift" => swift::module(context),
             "status" => status::module(context),
+            "task_warrior" => task_warrior::module(context),
             "terraform" => terraform::module(context),
             "time" => time::module(context),
             "crystal" => crystal::module(context),
@@ -191,6 +193,7 @@ pub fn description(module: &str) -> &'static str {
         "swift" => "The currently installed version of Swift",
         "shlvl" => "The current value of SHLVL",
         "status" => "The status of the last command",
+        "task_warrior" => "The status of Task Warrior tasks",
         "terraform" => "The currently selected terraform workspace and version",
         "time" => "The current local time",
         "username" => "The active user's username",

--- a/src/modules/task_warrior.rs
+++ b/src/modules/task_warrior.rs
@@ -1,0 +1,108 @@
+use super::{Context, Module};
+use crate::config::RootModuleConfig;
+use crate::configs::task_warrior::TaskWarriorConfig;
+use crate::formatter::StringFormatter;
+use crate::utils;
+use std::path::Path;
+
+pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    if !task_warrior_installed() {
+        log::debug!("Task warrior is not installed");
+        return None;
+    }
+
+    let mut module = context.new_module("task_warrior");
+    let config: TaskWarriorConfig = TaskWarriorConfig::try_load(module.config);
+    if config.disabled {
+        return None;
+    }
+
+    let current_task = get_current_task();
+
+    let mut symbol = String::from(config.no_tasks_symbol);
+    let mut symbol_style = String::from(config.no_tasks_symbol_style);
+
+    let result = utils::exec_cmd("task", &["+OVERDUE"]);
+    if result.is_some() {
+        symbol = String::from(config.overdue_symbol);
+        symbol_style = String::from(config.overdue_symbol_style);
+    } else {
+        let result = utils::exec_cmd("task", &["+DUETODAY"]);
+        if result.is_some() {
+            symbol = String::from(config.today_symbol);
+            symbol_style = String::from(config.today_symbol_style);
+        } else {
+            let result = utils::exec_cmd("task", &["+WEEK"]);
+            if result.is_some() {
+                symbol = String::from(config.week_symbol);
+                symbol_style = String::from(config.week_symbol_style);
+            }
+        }
+    }
+
+    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
+        formatter
+            .map_style(|variable| match variable {
+                "symbol_style" => Some(Ok(symbol_style.as_str())),
+                "current_task_style" => Some(Ok(config.current_task_style)),
+                _ => None,
+            })
+            .map(|variable| match variable {
+                "symbol" => Some(Ok(&symbol)),
+                "current_task" => match &current_task {
+                    Some(task) => Some(Ok(&task)),
+                    None => None,
+                },
+                _ => None,
+            })
+            .parse(None)
+    });
+
+    module.set_segments(match parsed {
+        Ok(segments) => segments,
+        Err(error) => {
+            log::warn!("Error in module `task warrior`:\n{}", error);
+            return None;
+        }
+    });
+
+    Some(module)
+}
+
+fn task_warrior_installed() -> bool {
+    let home_dir = dirs_next::home_dir().unwrap();
+    let task_dir = Path::new(&home_dir).join(".task");
+    task_dir.exists()
+}
+
+fn get_current_task() -> Option<String> {
+    let result = utils::exec_cmd("task", &["+ACTIVE", "uuids"])?;
+    let uuid = result.stdout.lines().next()?.split(' ').next()?;
+    let arg = String::from(uuid) + ".description";
+    let result = utils::exec_cmd("task", &["_get", arg.as_str()])?;
+    Some(String::from(result.stdout.trim()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test::ModuleRenderer;
+    use std::io;
+
+    #[test]
+    fn disabled_by_default() -> io::Result<()> {
+        let expected = None;
+
+        let actual = ModuleRenderer::new("task_warrior").collect();
+        assert_eq!(expected, actual);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_current_task() {
+        let expected = String::from("Task Warrior test task");
+        let actual = get_current_task().unwrap();
+        assert_eq!(expected, actual);
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -196,6 +196,18 @@ CMake suite maintained and supported by Kitware (kitware.com/cmake).\n",
             stdout: String::from("22.1.3\n"),
             stderr: String::default(),
         }),
+        "task +OVERDUE" => Some(CommandOutput {
+            stdout: String::from("[task next ( +OVERDUE )]"),
+            stderr: String::default(),
+        }),
+        "task +ACTIVE uuids" => Some(CommandOutput {
+            stdout: String::from("d0ea68e3-ca95-4da1-8ed5-0a569d9f7f73"),
+            stderr: String::default(),
+        }),
+        "task _get d0ea68e3-ca95-4da1-8ed5-0a569d9f7f73.description" => Some(CommandOutput {
+            stdout: String::from("Task Warrior test task\n"),
+            stderr: String::default(),
+        }),
         // If we don't have a mocked command fall back to executing the command
         _ => internal_exec_cmd(&cmd, &args),
     }


### PR DESCRIPTION
#### Description
Introduce 'task_warrior' module. It shows various icons depending on due tasks (overdue/due today/this week/no due) and current active task.
The module is disabled by default.

#### Motivation and Context
Closes #1296

#### Screenshots (if appropriate):
![Screenshot from 2021-01-12 21-04-23](https://user-images.githubusercontent.com/2017002/104360479-c99d3a80-5519-11eb-838b-0c8fe2b555d1.png)

#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [X] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [X] I have updated the documentation accordingly.
- [X] I have updated the tests accordingly.
