### PR TITLE
fix(cmake): Fix spacing with missing variable

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -444,12 +444,12 @@ The `cmake` module shows the currently installed version of CMake if any of the 
 
 ### Options
 
-| Option     | Default                            | Description                                  |
-| ---------- | ---------------------------------- | -------------------------------------------- |
-| `format`   | `"via [$symbol$version]($style) "` | The format for the module.                   |
-| `symbol`   | `"喝 "`                             | The symbol used before the version of cmake. |
-| `style`    | `"bold blue"`                      | The style for the module.                    |
-| `disabled` | `false`                            | Disables the `cmake` module.                 |
+| Option     | Default                              | Description                                  |
+| ---------- | ------------------------------------ | -------------------------------------------- |
+| `format`   | `"via [$symbol($version )]($style)"` | The format for the module.                   |
+| `symbol`   | `"喝 "`                              | The symbol used before the version of cmake. |
+| `style`    | `"bold blue"`                        | The style for the module.                    |
+| `disabled` | `false`                              | Disables the `cmake` module.                 |
 
 ### Variables
 

--- a/src/configs/cmake.rs
+++ b/src/configs/cmake.rs
@@ -13,7 +13,7 @@ pub struct CMakeConfig<'a> {
 impl<'a> RootModuleConfig<'a> for CMakeConfig<'a> {
     fn new() -> Self {
         CMakeConfig {
-            format: "via [$symbol$version]($style) ",
+            format: "via [$symbol($version )]($style)",
             symbol: "喝 ",
             style: "bold blue",
             disabled: false,

--- a/src/modules/cmake.rs
+++ b/src/modules/cmake.rs
@@ -7,7 +7,7 @@ use crate::utils;
 /// Creates a module with the current CMake version
 ///
 /// Will display the CMake version if any of the following criteria are met:
-///     - The current directory contains a `CMakeLists.txt` file
+///     - The current directory contains a `CMakeLists.txt` or `CMakeCache.txt`
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let is_cmake_project = context
         .try_begin_scan()?
@@ -77,7 +77,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("CMakeLists.txt"))?.sync_all()?;
         let actual = ModuleRenderer::new("cmake").path(dir.path()).collect();
-        let expected = Some(format!("via {} ", Color::Blue.bold().paint("喝 v3.17.3")));
+        let expected = Some(format!("via {}", Color::Blue.bold().paint("喝 v3.17.3 ")));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -87,7 +87,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("CMakeCache.txt"))?.sync_all()?;
         let actual = ModuleRenderer::new("cmake").path(dir.path()).collect();
-        let expected = Some(format!("via {} ", Color::Blue.bold().paint("喝 v3.17.3")));
+        let expected = Some(format!("via {}", Color::Blue.bold().paint("喝 v3.17.3 ")));
         assert_eq!(expected, actual);
         dir.close()
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This fixes the additional space when the `version` variable can't be
populated.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to #2111

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
