### PR TITLE
build: add builds for various targets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,7 +64,7 @@ jobs:
             os: macOS-latest
             name: starship-x86_64-apple-darwin.tar.gz
           
-          # TODO: switch to acOS-latest once it reaches 11.0
+          # TODO: switch to macOS-latest once it reaches 11.0
           - target: aarch64-apple-darwin
             os: macos-11.0
             name: starship-aarch64-apple-darwin.tar.gz

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,13 +52,30 @@ jobs:
             os: ubuntu-latest
             name: starship-i686-unknown-linux-musl.tar.gz
 
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-latest
+            name: starship-aarch64-unknown-linux-musl.tar.gz
+
+          - target: arm-unknown-linux-musleabihf
+            os: ubuntu-latest
+            name: starship-arm-unknown-linux-musleabihf.tar.gz
+
           - target: x86_64-apple-darwin
             os: macOS-latest
             name: starship-x86_64-apple-darwin.tar.gz
+          
+          # TODO: switch to acOS-latest once it reaches 11.0
+          - target: aarch64-apple-darwin
+            os: macos-11.0
+            name: starship-aarch64-apple-darwin.tar.gz
 
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             name: starship-x86_64-pc-windows-msvc.zip
+          
+          - target: i686-pc-windows-msvc
+            os: windows-latest
+            name: starship-i686-pc-windows-msvc.zip
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -101,7 +118,8 @@ jobs:
         if: matrix.os != 'windows-latest'
         run: |
           cd target/${{ matrix.target }}/release
-          strip starship
+          # TODO: investigate better cross platform stripping
+          strip starship || true
           tar czvf ../../../${{ matrix.name }} starship
           cd -
 

--- a/install/install.sh
+++ b/install/install.sh
@@ -33,7 +33,11 @@ BLUE="$(tput setaf 4 2>/dev/null || echo '')"
 MAGENTA="$(tput setaf 5 2>/dev/null || echo '')"
 NO_COLOR="$(tput sgr0 2>/dev/null || echo '')"
 
-SUPPORTED_TARGETS="x86_64-unknown-linux-gnu x86_64-unknown-linux-musl i686-unknown-linux-musl x86_64-apple-darwin x86_64-pc-windows-msvc"
+SUPPORTED_TARGETS="x86_64-unknown-linux-gnu x86_64-unknown-linux-musl \
+                  i686-unknown-linux-musl aarch64-unknown-linux-musl \
+                  arm-unknown-linux-musleabihf x86_64-apple-darwin \
+                  aarch64-apple-darwin x86_64-pc-windows-msvc \
+                  i686-pc-windows-msvc"
 
 info() {
   printf "%s\n" "${BOLD}${GREY}>${NO_COLOR} $*"
@@ -192,13 +196,33 @@ detect_arch() {
   local arch
   arch="$(uname -m | tr '[:upper:]' '[:lower:]')"
 
+  case "${arch}" in
+    armv*) arch="arm" ;;
+    arm64) arch="aarch64" ;;
+  esac
+
   # `uname -m` in some cases mis-reports 32-bit OS as 64-bit, so double check
   if [ "${arch}" = "x64" ] && [ "$(getconf LONG_BIT)" -eq 32 ]; then
     arch=i686
+  elif [ "${arch}" = "aarch64" ] && [ "$(getconf LONG_BIT)" -eq 32 ]; then
+    arch=arm
   fi
 
   echo "${arch}"
 }
+
+detect_target() {
+  local arch="$1"
+  local platform="$2"
+  local target="$arch-$platform"
+
+  if [ "${target}" = "arm-unknown-linux-musl" ]; then
+    target="${target}eabihf"
+  fi
+
+  echo "${target}"
+}
+
 
 confirm() {
   if [ -z "${FORCE-}" ]; then
@@ -247,8 +271,8 @@ check_bin_dir() {
 is_build_available() {
   local arch="$1"
   local platform="$2"
+  local target="$3"
 
-  local target="${arch}-${platform}"
   local good
   
   good=$(
@@ -350,7 +374,9 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 
-is_build_available "${ARCH}" "${PLATFORM}"
+TARGET="$(detect_target "${ARCH}" "${PLATFORM}")"
+
+is_build_available "${ARCH}" "${PLATFORM}" "${TARGET}"
 
 printf "  %s\n" "${UNDERLINE}Configuration${NO_COLOR}"
 info "${BOLD}Bin directory${NO_COLOR}: ${GREEN}${BIN_DIR}${NO_COLOR}"
@@ -372,7 +398,7 @@ if [ "${PLATFORM}" = "pc-windows-msvc" ]; then
   EXT=zip
 fi
 
-URL="${BASE_URL}/latest/download/starship-${ARCH}-${PLATFORM}.${EXT}"
+URL="${BASE_URL}/latest/download/starship-${TARGET}.${EXT}"
 info "Tarball URL: ${UNDERLINE}${BLUE}${URL}${NO_COLOR}"
 confirm "Install Starship ${GREEN}latest${NO_COLOR} to ${BOLD}${GREEN}${BIN_DIR}${NO_COLOR}?"
 check_bin_dir "${BIN_DIR}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Add release build targets for:

- `aarch64-unknown-linux-musl` (Pi 3/4)
- `arm-unknown-linux-musleabihf` (I think that still covers the first Pi?)
- `aarch64-apple-darwin` (M1)
- `i686-pc-windows-msvc`

I didn't add `armv7-unknown-linux-musleabihf` because the performance difference to `arm-unknown-linux-musleabihf` was negligible in a quick test on my Pi 3. The ARM targets without `hf` (FPU) didn't build.

FreeBSD didn't build and windows aarch64 is blocked on the next `sys-info` release.

I tested all the binaries and they seem to work fine.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #315
Closes #1736
Closes #1901
Closes #1923
Closes #1074

Partial fix for #1175 

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **CI**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
