### PR TITLE
perf(git_status): add option to use windows starship.exe to render in wsl

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1457,25 +1457,33 @@ format = '[+$added]($added_style)/[-$deleted]($deleted_style) '
 The `git_status` module shows symbols representing the state of the repo in your
 current directory.
 
+::: tip
+
+The Git Status module is very slow in Windows directories (for example under `/mnt/c/`) when in a WSL environment.
+You can disable the module or use the `windows_starship` option to use a Windows-native Starship executable to compute `git_status` for those paths.
+
+:::
+
 ### Options
 
-| Option              | Default                                       | Description                         |
-| ------------------- | --------------------------------------------- | ----------------------------------- |
-| `format`            | `'([\[$all_status$ahead_behind\]]($style) )'` | The default format for `git_status` |
-| `conflicted`        | `"="`                                         | This branch has merge conflicts.    |
-| `ahead`             | `"⇡"`                                         | The format of `ahead`               |
-| `behind`            | `"⇣"`                                         | The format of `behind`              |
-| `diverged`          | `"⇕"`                                         | The format of `diverged`            |
-| `up_to_date`        | `""`                                          | The format of `up_to_date`          |
-| `untracked`         | `"?"`                                         | The format of `untracked`           |
-| `stashed`           | `"$"`                                         | The format of `stashed`             |
-| `modified`          | `"!"`                                         | The format of `modified`            |
-| `staged`            | `"+"`                                         | The format of `staged`              |
-| `renamed`           | `"»"`                                         | The format of `renamed`             |
-| `deleted`           | `"✘"`                                         | The format of `deleted`             |
-| `style`             | `"bold red"`                                  | The style for the module.           |
-| `ignore_submodules` | `false`                                       | Ignore changes to submodules.       |
-| `disabled`          | `false`                                       | Disables the `git_status` module.   |
+| Option              | Default                                       | Description                                                                                                 |
+| ------------------- | --------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `format`            | `'([\[$all_status$ahead_behind\]]($style) )'` | The default format for `git_status`                                                                         |
+| `conflicted`        | `"="`                                         | This branch has merge conflicts.                                                                            |
+| `ahead`             | `"⇡"`                                         | The format of `ahead`                                                                                       |
+| `behind`            | `"⇣"`                                         | The format of `behind`                                                                                      |
+| `diverged`          | `"⇕"`                                         | The format of `diverged`                                                                                    |
+| `up_to_date`        | `""`                                          | The format of `up_to_date`                                                                                  |
+| `untracked`         | `"?"`                                         | The format of `untracked`                                                                                   |
+| `stashed`           | `"$"`                                         | The format of `stashed`                                                                                     |
+| `modified`          | `"!"`                                         | The format of `modified`                                                                                    |
+| `staged`            | `"+"`                                         | The format of `staged`                                                                                      |
+| `renamed`           | `"»"`                                         | The format of `renamed`                                                                                     |
+| `deleted`           | `"✘"`                                         | The format of `deleted`                                                                                     |
+| `style`             | `"bold red"`                                  | The style for the module.                                                                                   |
+| `ignore_submodules` | `false`                                       | Ignore changes to submodules.                                                                               |
+| `disabled`          | `false`                                       | Disables the `git_status` module.                                                                           |
+| `windows_starship`  |                                               | Use this (Linux) path to a Windows Starship executable to render `git_status` when on Windows paths in WSL. |
 
 ### Variables
 
@@ -1537,6 +1545,15 @@ Show ahead/behind count of the branch being tracked
 ahead = "⇡${count}"
 diverged = "⇕⇡${ahead_count}⇣${behind_count}"
 behind = "⇣${count}"
+```
+
+Use Windows Starship executable on Windows paths in WSL
+
+```toml
+# ~/.config/starship.toml
+
+[git_status]
+windows_starship = '/mnt/c/Users/username/scoop/apps/starship/current/starship.exe'
 ```
 
 ## Go

--- a/src/config.rs
+++ b/src/config.rs
@@ -225,6 +225,21 @@ pub struct StarshipConfig {
     pub config: Option<Value>,
 }
 
+pub fn get_config_path() -> Option<String> {
+    if let Ok(path) = env::var("STARSHIP_CONFIG") {
+        // Use $STARSHIP_CONFIG as the config path if available
+        log::debug!("STARSHIP_CONFIG is set: {}", &path);
+        Some(path)
+    } else {
+        // Default to using ~/.config/starship.toml
+        log::debug!("STARSHIP_CONFIG is not set");
+        let config_path = utils::home_dir()?.join(".config/starship.toml");
+        let config_path_str = config_path.to_str()?.to_owned();
+        log::debug!("Using default config path: {}", config_path_str);
+        Some(config_path_str)
+    }
+}
+
 impl StarshipConfig {
     /// Initialize the Config struct
     pub fn initialize() -> Self {
@@ -241,18 +256,7 @@ impl StarshipConfig {
 
     /// Create a config from a starship configuration file
     fn config_from_file() -> Option<Value> {
-        let file_path = if let Ok(path) = env::var("STARSHIP_CONFIG") {
-            // Use $STARSHIP_CONFIG as the config path if available
-            log::debug!("STARSHIP_CONFIG is set: {}", &path);
-            path
-        } else {
-            // Default to using ~/.config/starship.toml
-            log::debug!("STARSHIP_CONFIG is not set");
-            let config_path = utils::home_dir()?.join(".config/starship.toml");
-            let config_path_str = config_path.to_str()?.to_owned();
-            log::debug!("Using default config path: {}", config_path_str);
-            config_path_str
-        };
+        let file_path = get_config_path()?;
 
         let toml_content = match utils::read_file(&file_path) {
             Ok(content) => {

--- a/src/configs/git_status.rs
+++ b/src/configs/git_status.rs
@@ -20,6 +20,8 @@ pub struct GitStatusConfig<'a> {
     pub untracked: &'a str,
     pub ignore_submodules: bool,
     pub disabled: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub windows_starship: Option<&'a str>,
 }
 
 impl<'a> Default for GitStatusConfig<'a> {
@@ -40,6 +42,7 @@ impl<'a> Default for GitStatusConfig<'a> {
             untracked: "?",
             ignore_submodules: false,
             disabled: false,
+            windows_starship: None,
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Because I/O is slow on Windows paths with WSL, add the option to render `git_status` with a Windows `starship.exe`. This is 10x faster. This still uses the linux starship config.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **WSL1**
- [x] I have tested using **WSL2**


#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
