### PR TITLE
test: avoid setting $HOME

### DIFF
--- a/src/bug_report.rs
+++ b/src/bug_report.rs
@@ -254,10 +254,10 @@ mod tests {
     #[test]
     #[cfg(not(windows))]
     fn test_get_config_path() {
-        env::set_var("HOME", "/test/home");
-
         let config_path = get_config_path("bash");
-        assert_eq!("/test/home/.bashrc", config_path.unwrap().to_str().unwrap());
-        env::remove_var("HOME");
+        assert_eq!(
+            dirs_next::home_dir().unwrap().join(".bashrc"),
+            config_path.unwrap()
+        );
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -91,6 +91,7 @@ impl<'a> Context<'a> {
         }
     }
 
+    // Tries to retrieve home directory from a table in testing mode or else retrieves it from the os
     pub fn get_home(&self) -> Option<PathBuf> {
         if cfg!(test) {
             return self.get_env("HOME").map(PathBuf::from).or_else(home_dir);

--- a/src/context.rs
+++ b/src/context.rs
@@ -3,6 +3,7 @@ use crate::module::Module;
 
 use crate::modules;
 use clap::ArgMatches;
+use dirs_next::home_dir;
 use git2::{ErrorCode::UnbornBranch, Repository, RepositoryState};
 use once_cell::sync::OnceCell;
 use std::collections::{HashMap, HashSet};
@@ -88,6 +89,14 @@ impl<'a> Context<'a> {
             shell,
             env: HashMap::new(),
         }
+    }
+
+    pub fn get_home(&self) -> Option<PathBuf> {
+        if cfg!(test) {
+            return self.get_env("HOME").map(PathBuf::from).or_else(home_dir);
+        }
+
+        home_dir()
     }
 
     // Retrives a environment variable from the os or from a table if in testing mode

--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -17,7 +17,7 @@ fn get_aws_region_from_config(context: &Context, aws_profile: Option<&str>) -> O
         .get_env("AWS_CONFIG_FILE")
         .and_then(|path| PathBuf::from_str(&path).ok())
         .or_else(|| {
-            let mut home = dirs_next::home_dir()?;
+            let mut home = context.get_home()?;
             home.push(".aws/config");
             Some(home)
         })?;

--- a/src/modules/docker_context.rs
+++ b/src/modules/docker_context.rs
@@ -28,7 +28,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let docker_config = PathBuf::from(
         &context
             .get_env_os("DOCKER_CONFIG")
-            .unwrap_or(dirs_next::home_dir()?.join(".docker").into_os_string()),
+            .unwrap_or(context.get_home()?.join(".docker").into_os_string()),
     )
     .join("config.json");
 

--- a/src/modules/gcloud.rs
+++ b/src/modules/gcloud.rs
@@ -82,7 +82,7 @@ fn get_config_dir(context: &Context) -> Option<PathBuf> {
         .get_env("CLOUDSDK_CONFIG")
         .and_then(|path| PathBuf::from_str(&path).ok())
         .or_else(|| {
-            let mut home = dirs_next::home_dir()?;
+            let mut home = context.get_home()?;
             home.push(".config/gcloud");
             Some(home)
         })?;

--- a/src/modules/kubernetes.rs
+++ b/src/modules/kubernetes.rs
@@ -59,7 +59,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         return None;
     };
 
-    let default_config_file = dirs_next::home_dir()?.join(".kube").join("config");
+    let default_config_file = context.get_home()?.join(".kube").join("config");
 
     let kube_cfg = context
         .get_env("KUBECONFIG")

--- a/src/modules/openstack.rs
+++ b/src/modules/openstack.rs
@@ -14,7 +14,7 @@ fn get_osp_project_from_config(context: &Context, osp_cloud: &str) -> Option<Pro
     // 1st = $PWD/clouds.yaml, 2nd = $HOME/.config/openstack/clouds.yaml, 3rd = /etc/openstack/clouds.yaml
     let config = [
         context.get_env("PWD").map(|pwd| pwd + "/clouds.yaml"),
-        dirs_next::home_dir().map(|home| {
+        context.get_home().map(|home| {
             home.join(".config/openstack/clouds.yaml")
                 .display()
                 .to_string()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Add a method to `Context` to get the home directory that first attempts to read `$HOME` with mocked environment variables  from `self.get_env` during testing.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to #886 might fix to some extent
https://github.com/starship/starship/issues/886#issuecomment-761162673

Beyond what's described in that comment `$HOME` was also being set in `test_get_config_path`.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
