### PR TITLE
perf: evaluate swift version lazily

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2316,12 +2316,12 @@ The module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Option     | Default                            | Description                                      |
-| ---------- | ---------------------------------- | ------------------------------------------------ |
-| `format`   | `"via [$symbol$version]($style) "` | The format for the module.                       |
-| `symbol`   | `"🐦 "`                            | A format string representing the symbol of Swift |
-| `style`    | `"bold 202"`                       | The style for the module.                        |
-| `disabled` | `false`                            | Disables the `swift` module.                     |
+| Option     | Default                              | Description                                      |
+| ---------- | ------------------------------------ | ------------------------------------------------ |
+| `format`   | `"via [$symbol($version )]($style)"` | The format for the module.                       |
+| `symbol`   | `"🐦 "`                              | A format string representing the symbol of Swift |
+| `style`    | `"bold 202"`                         | The style for the module.                        |
+| `disabled` | `false`                              | Disables the `swift` module.                     |
 
 ### Variables
 

--- a/src/configs/swift.rs
+++ b/src/configs/swift.rs
@@ -13,7 +13,7 @@ pub struct SwiftConfig<'a> {
 impl<'a> RootModuleConfig<'a> for SwiftConfig<'a> {
     fn new() -> Self {
         SwiftConfig {
-            format: "via [$symbol$version]($style) ",
+            format: "via [$symbol($version )]($style)",
             symbol: "🐦 ",
             style: "bold 202",
             disabled: false,

--- a/src/modules/swift.rs
+++ b/src/modules/swift.rs
@@ -100,8 +100,8 @@ mod tests {
         File::create(dir.path().join("Package.swift"))?.sync_all()?;
         let actual = ModuleRenderer::new("swift").path(dir.path()).collect();
         let expected = Some(format!(
-            "via {} ",
-            Color::Fixed(202).bold().paint("🐦 v5.2.2")
+            "via {}",
+            Color::Fixed(202).bold().paint("🐦 v5.2.2 ")
         ));
         assert_eq!(expected, actual);
         dir.close()
@@ -113,8 +113,8 @@ mod tests {
         File::create(dir.path().join("main.swift"))?.sync_all()?;
         let actual = ModuleRenderer::new("swift").path(dir.path()).collect();
         let expected = Some(format!(
-            "via {} ",
-            Color::Fixed(202).bold().paint("🐦 v5.2.2")
+            "via {}",
+            Color::Fixed(202).bold().paint("🐦 v5.2.2 ")
         ));
         assert_eq!(expected, actual);
         dir.close()

--- a/src/modules/swift.rs
+++ b/src/modules/swift.rs
@@ -19,8 +19,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         return None;
     }
 
-    let swift_version = utils::exec_cmd("swift", &["--version"])?.stdout;
-
     let mut module = context.new_module("swift");
     let config: SwiftConfig = SwiftConfig::try_load(module.config);
 
@@ -35,7 +33,10 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 _ => None,
             })
             .map(|variable| match variable {
-                "version" => parse_swift_version(&swift_version).map(Ok),
+                "version" => {
+                    let swift_version = utils::exec_cmd("swift", &["--version"])?.stdout;
+                    parse_swift_version(&swift_version).map(Ok)
+                }
                 _ => None,
             })
             .parse(None)


### PR DESCRIPTION
#### Description

This updates the module to lazily execute the swift --version
command only when the version variable is used in the format string.

#### Motivation and Context

Related to: #2111

#### How Has This Been Tested?

- [x] I have tested using MacOS
- [ ] I have tested using Linux
- [ ] I have tested using Windows

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.