### PR TITLE
perf(nodejs): evaluate nodejs format string lazily

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1760,7 +1760,7 @@ The module will be shown if any of the following conditions are met:
 
 | Option     | Default                            | Description                                        |
 | ---------- | ---------------------------------- | -------------------------------------------------- |
-| `format`   | `"via [$symbol$version]($style) "` | The format for the module.                         |
+| `format`   | `"via [$symbol($version )]($style)"` | The format for the module.                         |
 | `symbol`   | `"⬢ "`                             | A format string representing the symbol of NodeJS. |
 | `style`    | `"bold green"`                     | The style for the module.                          |
 | `disabled` | `false`                            | Disables the `nodejs` module.                      |

--- a/src/configs/nodejs.rs
+++ b/src/configs/nodejs.rs
@@ -14,7 +14,7 @@ pub struct NodejsConfig<'a> {
 impl<'a> RootModuleConfig<'a> for NodejsConfig<'a> {
     fn new() -> Self {
         NodejsConfig {
-            format: "via [$symbol$version]($style) ",
+            format: "via [$symbol($version )]($style)",
             symbol: "⬢ ",
             style: "bold green",
             disabled: false,

--- a/src/modules/nodejs.rs
+++ b/src/modules/nodejs.rs
@@ -125,7 +125,7 @@ mod tests {
         File::create(dir.path().join("package.json"))?.sync_all()?;
 
         let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
-        let expected = Some(format!("via {} ", Color::Green.bold().paint("⬢ v12.0.0")));
+        let expected = Some(format!("via {}", Color::Green.bold().paint("⬢ v12.0.0 ")));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -149,7 +149,7 @@ mod tests {
         File::create(dir.path().join(".node-version"))?.sync_all()?;
 
         let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
-        let expected = Some(format!("via {} ", Color::Green.bold().paint("⬢ v12.0.0")));
+        let expected = Some(format!("via {}", Color::Green.bold().paint("⬢ v12.0.0 ")));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -160,7 +160,7 @@ mod tests {
         File::create(dir.path().join("index.js"))?.sync_all()?;
 
         let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
-        let expected = Some(format!("via {} ", Color::Green.bold().paint("⬢ v12.0.0")));
+        let expected = Some(format!("via {}", Color::Green.bold().paint("⬢ v12.0.0 ")));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -171,7 +171,7 @@ mod tests {
         File::create(dir.path().join("index.mjs"))?.sync_all()?;
 
         let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
-        let expected = Some(format!("via {} ", Color::Green.bold().paint("⬢ v12.0.0")));
+        let expected = Some(format!("via {}", Color::Green.bold().paint("⬢ v12.0.0 ")));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -182,7 +182,7 @@ mod tests {
         File::create(dir.path().join("index.cjs"))?.sync_all()?;
 
         let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
-        let expected = Some(format!("via {} ", Color::Green.bold().paint("⬢ v12.0.0")));
+        let expected = Some(format!("via {}", Color::Green.bold().paint("⬢ v12.0.0 ")));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -193,7 +193,7 @@ mod tests {
         File::create(dir.path().join("index.ts"))?.sync_all()?;
 
         let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
-        let expected = Some(format!("via {} ", Color::Green.bold().paint("⬢ v12.0.0")));
+        let expected = Some(format!("via {}", Color::Green.bold().paint("⬢ v12.0.0 ")));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -205,7 +205,7 @@ mod tests {
         fs::create_dir_all(&node_modules)?;
 
         let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
-        let expected = Some(format!("via {} ", Color::Green.bold().paint("⬢ v12.0.0")));
+        let expected = Some(format!("via {}", Color::Green.bold().paint("⬢ v12.0.0 ")));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -224,7 +224,7 @@ mod tests {
         file.sync_all()?;
 
         let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
-        let expected = Some(format!("via {} ", Color::Green.bold().paint("⬢ v12.0.0")));
+        let expected = Some(format!("via {}", Color::Green.bold().paint("⬢ v12.0.0 ")));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -243,7 +243,7 @@ mod tests {
         file.sync_all()?;
 
         let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
-        let expected = Some(format!("via {} ", Color::Red.bold().paint("⬢ v12.0.0")));
+        let expected = Some(format!("via {}", Color::Red.bold().paint("⬢ v12.0.0 ")));
         assert_eq!(expected, actual);
         dir.close()
     }

--- a/src/modules/nodejs.rs
+++ b/src/modules/nodejs.rs
@@ -38,7 +38,8 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
     let mut module = context.new_module("nodejs");
     let config = NodejsConfig::try_load(module.config);
-    let nodejs_version = Lazy::new(|| utils::exec_cmd("node", &["--version"]).map(|cmd| cmd.stdout));
+    let nodejs_version =
+        Lazy::new(|| utils::exec_cmd("node", &["--version"]).map(|cmd| cmd.stdout));
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter
             .map_meta(|var, _| match var {
@@ -48,7 +49,8 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             .map_style(|variable| match variable {
                 "style" => {
                     let engines_version = get_engines_version(&context.current_dir);
-                    let in_engines_range = check_engines_version(nodejs_version.deref().as_ref()?, engines_version);
+                    let in_engines_range =
+                        check_engines_version(nodejs_version.deref().as_ref()?, engines_version);
                     if in_engines_range {
                         Some(Ok(config.style))
                     } else {


### PR DESCRIPTION
#### Description
Update Format string. Does not do lazy loading since the version is also needed for determining the style, so version has to be evaluated at least once.

#### Motivation and Context
Relates to #2111

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
