### PR TITLE
perf(elixir): evaluate version lazily

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -808,12 +808,12 @@ The module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Option     | Default                                                 | Description                                                     |
-| ---------- | ------------------------------------------------------- | --------------------------------------------------------------- |
-| `symbol`   | `"💧 "`                                                 | The symbol used before displaying the version of Elixir/Erlang. |
-| `style`    | `"bold purple"`                                         | The style for the module.                                       |
-| `format`   | `'via [$symbol$version \(OTP $otp_version\)]($style) '` | The format for the module elixir.                               |
-| `disabled` | `false`                                                 | Disables the `elixir` module.                                   |
+| Option     | Default                                                   | Description                                                     |
+| ---------- | --------------------------------------------------------- | --------------------------------------------------------------- |
+| `symbol`   | `"💧 "`                                                   | The symbol used before displaying the version of Elixir/Erlang. |
+| `style`    | `"bold purple"`                                           | The style for the module.                                       |
+| `format`   | `'via [$symbol($version \(OTP $otp_version\) )]($style)'` | The format for the module elixir.                               |
+| `disabled` | `false`                                                   | Disables the `elixir` module.                                   |
 
 ### Variables
 

--- a/src/configs/elixir.rs
+++ b/src/configs/elixir.rs
@@ -13,7 +13,7 @@ pub struct ElixirConfig<'a> {
 impl<'a> RootModuleConfig<'a> for ElixirConfig<'a> {
     fn new() -> Self {
         ElixirConfig {
-            format: "via [$symbol$version \\(OTP $otp_version\\)]($style) ",
+            format: "via [$symbol($version \\(OTP $otp_version\\) )]($style)",
             symbol: "💧 ",
             style: "bold purple",
             disabled: false,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

This updates the module to lazily execute the `elixir --version` command only when the `$version` or `$otp_version` variables are used in the format string.

Because the output of the command is used to provide both `$version` and `$otp_version` I wrapped the call to `get_elixir_version` with `once_cell::sync::Lazy`.

I also updated the format string to better accommodate a missing `elixir` command.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to: #2111

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
