### PR TITLE
perf(kotlin): Lazy eval kotlin

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1443,13 +1443,13 @@ The module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Option          | Default                            | Description                                                                   |
-| --------------- | ---------------------------------- | ----------------------------------------------------------------------------- |
-| `format`        | `"via [$symbol$version]($style) "` | The format for the module.                                                    |
-| `symbol`        | `"🅺 "`                            | A format string representing the symbol of Kotlin.                            |
-| `style`         | `"bold blue"`                      | The style for the module.                                                     |
-| `kotlin_binary` | `"kotlin"`                         | Configures the kotlin binary that Starship executes when getting the version. |
-| `disabled`      | `false`                            | Disables the `kotlin` module.                                                 |
+| Option          | Default                              | Description                                                                   |
+| --------------- | ------------------------------------ | ----------------------------------------------------------------------------- |
+| `format`        | `"via [$symbol($version )]($style)"` | The format for the module.                                                    |
+| `symbol`        | `"🅺 "`                              | A format string representing the symbol of Kotlin.                            |
+| `style`         | `"bold blue"`                        | The style for the module.                                                     |
+| `kotlin_binary` | `"kotlin"`                           | Configures the kotlin binary that Starship executes when getting the version. |
+| `disabled`      | `false`                              | Disables the `kotlin` module.                                                 |
 
 ### Variables
 

--- a/src/configs/kotlin.rs
+++ b/src/configs/kotlin.rs
@@ -14,7 +14,7 @@ pub struct KotlinConfig<'a> {
 impl<'a> RootModuleConfig<'a> for KotlinConfig<'a> {
     fn new() -> Self {
         KotlinConfig {
-            format: "via [$symbol$version]($style) ",
+            format: "via [$symbol($version )]($style)",
             symbol: "🅺 ",
             style: "bold blue",
             kotlin_binary: "kotlin",

--- a/src/modules/kotlin.rs
+++ b/src/modules/kotlin.rs
@@ -23,7 +23,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
     let mut module = context.new_module("kotlin");
     let config = KotlinConfig::try_load(module.config);
-    let kotlin_version = format_kotlin_version(&get_kotlin_version(&config.kotlin_binary)?)?;
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter
             .map_meta(|var, _| match var {
@@ -35,7 +34,11 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 _ => None,
             })
             .map(|variable| match variable {
-                "version" => Some(Ok(&kotlin_version)),
+                "version" => {
+                    let kotlin_version =
+                        format_kotlin_version(&get_kotlin_version(&config.kotlin_binary)?)?;
+                    Some(Ok(kotlin_version))
+                }
                 _ => None,
             })
             .parse(None)

--- a/src/modules/kotlin.rs
+++ b/src/modules/kotlin.rs
@@ -102,7 +102,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("main.kt"))?.sync_all()?;
         let actual = ModuleRenderer::new("kotlin").path(dir.path()).collect();
-        let expected = Some(format!("via {} ", Color::Blue.bold().paint("🅺 v1.4.21")));
+        let expected = Some(format!("via {}", Color::Blue.bold().paint("🅺 v1.4.21 ")));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -112,7 +112,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("main.kts"))?.sync_all()?;
         let actual = ModuleRenderer::new("kotlin").path(dir.path()).collect();
-        let expected = Some(format!("via {} ", Color::Blue.bold().paint("🅺 v1.4.21")));
+        let expected = Some(format!("via {}", Color::Blue.bold().paint("🅺 v1.4.21 ")));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -132,7 +132,7 @@ mod tests {
             .config(config)
             .collect();
 
-        let expected = Some(format!("via {} ", Color::Blue.bold().paint("🅺 v1.4.21")));
+        let expected = Some(format!("via {}", Color::Blue.bold().paint("🅺 v1.4.21 ")));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -152,7 +152,7 @@ mod tests {
             .config(config)
             .collect();
 
-        let expected = Some(format!("via {} ", Color::Blue.bold().paint("🅺 v1.4.21")));
+        let expected = Some(format!("via {}", Color::Blue.bold().paint("🅺 v1.4.21 ")));
         assert_eq!(expected, actual);
         dir.close()
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
Evaluate version string for kotlin lazily and update format string

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #2111

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
