### PR TITLE
perf(ocaml): lazy eval OCaml

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1799,12 +1799,12 @@ The module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Option     | Default                            | Description                                             |
-| ---------- | ---------------------------------- | ------------------------------------------------------- |
-| `format`   | `"via [$symbol$version]($style) "` | The format string for the module.                       |
-| `symbol`   | `"🐫 "`                            | The symbol used before displaying the version of OCaml. |
-| `style`    | `"bold yellow"`                    | The style for the module.                               |
-| `disabled` | `false`                            | Disables the `ocaml` module.                            |
+| Option     | Default                              | Description                                             |
+| ---------- | ------------------------------------ | ------------------------------------------------------- |
+| `format`   | `"via [$symbol($version )]($style)"` | The format string for the module.                       |
+| `symbol`   | `"🐫 "`                              | The symbol used before displaying the version of OCaml. |
+| `style`    | `"bold yellow"`                      | The style for the module.                               |
+| `disabled` | `false`                              | Disables the `ocaml` module.                            |
 
 ### Variables
 

--- a/src/configs/ocaml.rs
+++ b/src/configs/ocaml.rs
@@ -13,7 +13,7 @@ pub struct OCamlConfig<'a> {
 impl<'a> RootModuleConfig<'a> for OCamlConfig<'a> {
     fn new() -> Self {
         OCamlConfig {
-            format: "via [$symbol$version]($style) ",
+            format: "via [$symbol($version )]($style)",
             symbol: "🐫 ",
             style: "bold yellow",
             disabled: false,

--- a/src/modules/ocaml.rs
+++ b/src/modules/ocaml.rs
@@ -25,17 +25,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         return None;
     }
 
-    let is_esy_project = context
-        .try_begin_scan()?
-        .set_folders(&["esy.lock"])
-        .is_match();
-
-    let ocaml_version = if is_esy_project {
-        utils::exec_cmd("esy", &["ocaml", "-vnum"])?.stdout
-    } else {
-        utils::exec_cmd("ocaml", &["-vnum"])?.stdout
-    };
-
     let mut module = context.new_module("ocaml");
     let config: OCamlConfig = OCamlConfig::try_load(module.config);
 
@@ -50,7 +39,19 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 _ => None,
             })
             .map(|variable| match variable {
-                "version" => Some(Ok(format!("v{}", &ocaml_version.trim()))),
+                "version" => {
+                    let is_esy_project = context
+                        .try_begin_scan()?
+                        .set_folders(&["esy.lock"])
+                        .is_match();
+
+                    let ocaml_version = if is_esy_project {
+                        utils::exec_cmd("esy", &["ocaml", "-vnum"])?.stdout
+                    } else {
+                        utils::exec_cmd("ocaml", &["-vnum"])?.stdout
+                    };
+                    Some(Ok(format!("v{}", &ocaml_version.trim())))
+                }
                 _ => None,
             })
             .parse(None)
@@ -89,7 +90,7 @@ mod tests {
         File::create(dir.path().join("any.opam"))?.sync_all()?;
 
         let actual = ModuleRenderer::new("ocaml").path(dir.path()).collect();
-        let expected = Some(format!("via {} ", Color::Yellow.bold().paint("🐫 v4.10.0")));
+        let expected = Some(format!("via {}", Color::Yellow.bold().paint("🐫 v4.10.0 ")));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -100,7 +101,7 @@ mod tests {
         fs::create_dir_all(dir.path().join("_opam"))?;
 
         let actual = ModuleRenderer::new("ocaml").path(dir.path()).collect();
-        let expected = Some(format!("via {} ", Color::Yellow.bold().paint("🐫 v4.10.0")));
+        let expected = Some(format!("via {}", Color::Yellow.bold().paint("🐫 v4.10.0 ")));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -115,7 +116,7 @@ mod tests {
             "{\"dependencies\": {\"ocaml\": \"4.8.1000\"}}",
         )?;
         let actual = ModuleRenderer::new("ocaml").path(dir.path()).collect();
-        let expected = Some(format!("via {} ", Color::Yellow.bold().paint("🐫 v4.08.1")));
+        let expected = Some(format!("via {}", Color::Yellow.bold().paint("🐫 v4.08.1 ")));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -126,7 +127,7 @@ mod tests {
         File::create(dir.path().join("dune"))?.sync_all()?;
 
         let actual = ModuleRenderer::new("ocaml").path(dir.path()).collect();
-        let expected = Some(format!("via {} ", Color::Yellow.bold().paint("🐫 v4.10.0")));
+        let expected = Some(format!("via {}", Color::Yellow.bold().paint("🐫 v4.10.0 ")));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -137,7 +138,7 @@ mod tests {
         File::create(dir.path().join("dune-project"))?.sync_all()?;
 
         let actual = ModuleRenderer::new("ocaml").path(dir.path()).collect();
-        let expected = Some(format!("via {} ", Color::Yellow.bold().paint("🐫 v4.10.0")));
+        let expected = Some(format!("via {}", Color::Yellow.bold().paint("🐫 v4.10.0 ")));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -148,7 +149,7 @@ mod tests {
         File::create(dir.path().join("jbuild"))?.sync_all()?;
 
         let actual = ModuleRenderer::new("ocaml").path(dir.path()).collect();
-        let expected = Some(format!("via {} ", Color::Yellow.bold().paint("🐫 v4.10.0")));
+        let expected = Some(format!("via {}", Color::Yellow.bold().paint("🐫 v4.10.0 ")));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -159,7 +160,7 @@ mod tests {
         File::create(dir.path().join("jbuild-ignore"))?.sync_all()?;
 
         let actual = ModuleRenderer::new("ocaml").path(dir.path()).collect();
-        let expected = Some(format!("via {} ", Color::Yellow.bold().paint("🐫 v4.10.0")));
+        let expected = Some(format!("via {}", Color::Yellow.bold().paint("🐫 v4.10.0 ")));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -170,7 +171,7 @@ mod tests {
         File::create(dir.path().join(".merlin"))?.sync_all()?;
 
         let actual = ModuleRenderer::new("ocaml").path(dir.path()).collect();
-        let expected = Some(format!("via {} ", Color::Yellow.bold().paint("🐫 v4.10.0")));
+        let expected = Some(format!("via {}", Color::Yellow.bold().paint("🐫 v4.10.0 ")));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -181,7 +182,7 @@ mod tests {
         File::create(dir.path().join("any.ml"))?.sync_all()?;
 
         let actual = ModuleRenderer::new("ocaml").path(dir.path()).collect();
-        let expected = Some(format!("via {} ", Color::Yellow.bold().paint("🐫 v4.10.0")));
+        let expected = Some(format!("via {}", Color::Yellow.bold().paint("🐫 v4.10.0 ")));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -192,7 +193,7 @@ mod tests {
         File::create(dir.path().join("any.mli"))?.sync_all()?;
 
         let actual = ModuleRenderer::new("ocaml").path(dir.path()).collect();
-        let expected = Some(format!("via {} ", Color::Yellow.bold().paint("🐫 v4.10.0")));
+        let expected = Some(format!("via {}", Color::Yellow.bold().paint("🐫 v4.10.0 ")));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -203,7 +204,7 @@ mod tests {
         File::create(dir.path().join("any.re"))?.sync_all()?;
 
         let actual = ModuleRenderer::new("ocaml").path(dir.path()).collect();
-        let expected = Some(format!("via {} ", Color::Yellow.bold().paint("🐫 v4.10.0")));
+        let expected = Some(format!("via {}", Color::Yellow.bold().paint("🐫 v4.10.0 ")));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -214,7 +215,7 @@ mod tests {
         File::create(dir.path().join("any.rei"))?.sync_all()?;
 
         let actual = ModuleRenderer::new("ocaml").path(dir.path()).collect();
-        let expected = Some(format!("via {} ", Color::Yellow.bold().paint("🐫 v4.10.0")));
+        let expected = Some(format!("via {}", Color::Yellow.bold().paint("🐫 v4.10.0 ")));
         assert_eq!(expected, actual);
         dir.close()
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
Evaluate ocaml version command lazily and update format string

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Relates to #2111

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
