### PR TITLE
perf(perl): Lazy eval perl

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1929,12 +1929,12 @@ The module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Option     | Default                            | Description                                           |
-| ---------- | ---------------------------------- | ----------------------------------------------------- |
-| `format`   | `"via [$symbol$version]($style) "` | The format string for the module.                     |
-| `symbol`   | `"🐪 "`                            | The symbol used before displaying the version of Perl |
-| `style`    | `"bold 149"`                       | The style for the module.                             |
-| `disabled` | `false`                            | Disables the `perl` module.                           |
+| Option     | Default                              | Description                                           |
+| ---------- | ------------------------------------ | ----------------------------------------------------- |
+| `format`   | `"via [$symbol($version )]($style)"` | The format string for the module.                     |
+| `symbol`   | `"🐪 "`                              | The symbol used before displaying the version of Perl |
+| `style`    | `"bold 149"`                         | The style for the module.                             |
+| `disabled` | `false`                              | Disables the `perl` module.                           |
 
 ### Variables
 

--- a/src/configs/perl.rs
+++ b/src/configs/perl.rs
@@ -15,7 +15,7 @@ impl<'a> RootModuleConfig<'a> for PerlConfig<'a> {
         PerlConfig {
             symbol: "🐪 ",
             style: "149 bold",
-            format: "via [$symbol$version]($style) ",
+            format: "via [$symbol($version )]($style)",
             disabled: false,
         }
     }

--- a/src/modules/perl.rs
+++ b/src/modules/perl.rs
@@ -89,8 +89,8 @@ mod tests {
         let actual = ModuleRenderer::new("perl").path(dir.path()).collect();
 
         let expected = Some(format!(
-            "via {} ",
-            Color::Fixed(149).bold().paint("🐪 v5.26.1")
+            "via {}",
+            Color::Fixed(149).bold().paint("🐪 v5.26.1 ")
         ));
         assert_eq!(expected, actual);
         dir.close()
@@ -104,8 +104,8 @@ mod tests {
         let actual = ModuleRenderer::new("perl").path(dir.path()).collect();
 
         let expected = Some(format!(
-            "via {} ",
-            Color::Fixed(149).bold().paint("🐪 v5.26.1")
+            "via {}",
+            Color::Fixed(149).bold().paint("🐪 v5.26.1 ")
         ));
         assert_eq!(expected, actual);
         dir.close()
@@ -119,8 +119,8 @@ mod tests {
         let actual = ModuleRenderer::new("perl").path(dir.path()).collect();
 
         let expected = Some(format!(
-            "via {} ",
-            Color::Fixed(149).bold().paint("🐪 v5.26.1")
+            "via {}",
+            Color::Fixed(149).bold().paint("🐪 v5.26.1 ")
         ));
         assert_eq!(expected, actual);
         dir.close()
@@ -134,8 +134,8 @@ mod tests {
         let actual = ModuleRenderer::new("perl").path(dir.path()).collect();
 
         let expected = Some(format!(
-            "via {} ",
-            Color::Fixed(149).bold().paint("🐪 v5.26.1")
+            "via {}",
+            Color::Fixed(149).bold().paint("🐪 v5.26.1 ")
         ));
         assert_eq!(expected, actual);
         dir.close()
@@ -149,8 +149,8 @@ mod tests {
         let actual = ModuleRenderer::new("perl").path(dir.path()).collect();
 
         let expected = Some(format!(
-            "via {} ",
-            Color::Fixed(149).bold().paint("🐪 v5.26.1")
+            "via {}",
+            Color::Fixed(149).bold().paint("🐪 v5.26.1 ")
         ));
         assert_eq!(expected, actual);
         dir.close()
@@ -164,8 +164,8 @@ mod tests {
         let actual = ModuleRenderer::new("perl").path(dir.path()).collect();
 
         let expected = Some(format!(
-            "via {} ",
-            Color::Fixed(149).bold().paint("🐪 v5.26.1")
+            "via {}",
+            Color::Fixed(149).bold().paint("🐪 v5.26.1 ")
         ));
         assert_eq!(expected, actual);
         dir.close()
@@ -179,8 +179,8 @@ mod tests {
         let actual = ModuleRenderer::new("perl").path(dir.path()).collect();
 
         let expected = Some(format!(
-            "via {} ",
-            Color::Fixed(149).bold().paint("🐪 v5.26.1")
+            "via {}",
+            Color::Fixed(149).bold().paint("🐪 v5.26.1 ")
         ));
         assert_eq!(expected, actual);
         dir.close()
@@ -194,8 +194,8 @@ mod tests {
         let actual = ModuleRenderer::new("perl").path(dir.path()).collect();
 
         let expected = Some(format!(
-            "via {} ",
-            Color::Fixed(149).bold().paint("🐪 v5.26.1")
+            "via {}",
+            Color::Fixed(149).bold().paint("🐪 v5.26.1 ")
         ));
         assert_eq!(expected, actual);
         dir.close()
@@ -209,8 +209,8 @@ mod tests {
         let actual = ModuleRenderer::new("perl").path(dir.path()).collect();
 
         let expected = Some(format!(
-            "via {} ",
-            Color::Fixed(149).bold().paint("🐪 v5.26.1")
+            "via {}",
+            Color::Fixed(149).bold().paint("🐪 v5.26.1 ")
         ));
         assert_eq!(expected, actual);
         dir.close()
@@ -224,8 +224,8 @@ mod tests {
         let actual = ModuleRenderer::new("perl").path(dir.path()).collect();
 
         let expected = Some(format!(
-            "via {} ",
-            Color::Fixed(149).bold().paint("🐪 v5.26.1")
+            "via {}",
+            Color::Fixed(149).bold().paint("🐪 v5.26.1 ")
         ));
         assert_eq!(expected, actual);
         dir.close()

--- a/src/modules/perl.rs
+++ b/src/modules/perl.rs
@@ -44,7 +44,8 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             })
             .map(|variable| match variable {
                 "version" => {
-                    let perl_version = utils::exec_cmd("perl", &["-e", "printf q#%vd#,$^V;"])?.stdout;
+                    let perl_version =
+                        utils::exec_cmd("perl", &["-e", "printf q#%vd#,$^V;"])?.stdout;
                     Some(Ok(format!("v{}", perl_version)))
                 }
                 _ => None,

--- a/src/modules/perl.rs
+++ b/src/modules/perl.rs
@@ -29,8 +29,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         return None;
     }
 
-    let perl_version = utils::exec_cmd("perl", &["-e", "printf q#%vd#,$^V;"])?.stdout;
-
     let mut module = context.new_module("perl");
     let config: PerlConfig = PerlConfig::try_load(module.config);
 
@@ -45,7 +43,10 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 _ => None,
             })
             .map(|variable| match variable {
-                "version" => Some(Ok(format!("v{}", &perl_version))),
+                "version" => {
+                    let perl_version = utils::exec_cmd("perl", &["-e", "printf q#%vd#,$^V;"])?.stdout;
+                    Some(Ok(format!("v{}", perl_version)))
+                }
                 _ => None,
             })
             .parse(None)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
Evaluate perl version command lazily and update format string

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Relates to #2111

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
