### PR TITLE
perf(php): Lazy eval php

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1964,12 +1964,12 @@ The module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Option     | Default                            | Description                                           |
-| ---------- | ---------------------------------- | ----------------------------------------------------- |
-| `format`   | `"via [$symbol$version]($style) "` | The format for the module.                            |
-| `symbol`   | `"🐘 "`                            | The symbol used before displaying the version of PHP. |
-| `style`    | `"147 bold"`                       | The style for the module.                             |
-| `disabled` | `false`                            | Disables the `php` module.                            |
+| Option     | Default                              | Description                                           |
+| ---------- | ------------------------------------ | ----------------------------------------------------- |
+| `format`   | `"via [$symbol($version )]($style)"` | The format for the module.                            |
+| `symbol`   | `"🐘 "`                              | The symbol used before displaying the version of PHP. |
+| `style`    | `"147 bold"`                         | The style for the module.                             |
+| `disabled` | `false`                              | Disables the `php` module.                            |
 
 ### Variables
 

--- a/src/configs/php.rs
+++ b/src/configs/php.rs
@@ -15,7 +15,7 @@ impl<'a> RootModuleConfig<'a> for PhpConfig<'a> {
         PhpConfig {
             symbol: "🐘 ",
             style: "147 bold",
-            format: "via [$symbol$version]($style) ",
+            format: "via [$symbol($version )]($style)",
             disabled: false,
         }
     }

--- a/src/modules/php.rs
+++ b/src/modules/php.rs
@@ -60,7 +60,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     Some(module)
 }
 
-
 fn format_php_version(php_version: &str) -> String {
     format!("v{}", php_version)
 }
@@ -98,8 +97,8 @@ mod tests {
         let actual = ModuleRenderer::new("php").path(dir.path()).collect();
 
         let expected = Some(format!(
-            "via {} ",
-            Color::Fixed(147).bold().paint("🐘 v7.3.8")
+            "via {}",
+            Color::Fixed(147).bold().paint("🐘 v7.3.8 ")
         ));
         assert_eq!(expected, actual);
         dir.close()
@@ -113,8 +112,8 @@ mod tests {
         let actual = ModuleRenderer::new("php").path(dir.path()).collect();
 
         let expected = Some(format!(
-            "via {} ",
-            Color::Fixed(147).bold().paint("🐘 v7.3.8")
+            "via {}",
+            Color::Fixed(147).bold().paint("🐘 v7.3.8 ")
         ));
         assert_eq!(expected, actual);
         dir.close()
@@ -128,8 +127,8 @@ mod tests {
         let actual = ModuleRenderer::new("php").path(dir.path()).collect();
 
         let expected = Some(format!(
-            "via {} ",
-            Color::Fixed(147).bold().paint("🐘 v7.3.8")
+            "via {}",
+            Color::Fixed(147).bold().paint("🐘 v7.3.8 ")
         ));
         assert_eq!(expected, actual);
         dir.close()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
Evaluate php version command lazily and update format string

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Relates to #2111

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
