### PR TITLE
feat(directory): Add home directory symbol

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -656,6 +656,8 @@ it would have been `nixpkgs/pkgs`.
 | `read_only`         | `"🔒"`                                             | The symbol indicating current directory is read only.                            |
 | `read_only_style`   | `"red"`                                            | The style for the read only symbol.                                              |
 | `truncation_symbol` | `""`                                               | The symbol to prefix to truncated paths. eg: "…/"                                |
+| `home_symbol_enable`  | `true`                                           | Enable to use a symbol when the path is home instead of "~"                      |
+| `home_symbol`       | `"🏠"`                                             | The symbols indicating home directory.                                           |
 
 <details>
 <summary>This module has a few advanced configuration options that control how the directory is displayed.</summary>

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -656,8 +656,7 @@ it would have been `nixpkgs/pkgs`.
 | `read_only`         | `"🔒"`                                             | The symbol indicating current directory is read only.                            |
 | `read_only_style`   | `"red"`                                            | The style for the read only symbol.                                              |
 | `truncation_symbol` | `""`                                               | The symbol to prefix to truncated paths. eg: "…/"                                |
-| `home_symbol_enable`  | `true`                                           | Enable to use a symbol when the path is home instead of "~"                      |
-| `home_symbol`       | `"🏠"`                                             | The symbols indicating home directory.                                           |
+| `home_symbol`       | `"~"`                                              | The symbol indicating home directory.                                           |
 
 <details>
 <summary>This module has a few advanced configuration options that control how the directory is displayed.</summary>

--- a/src/configs/directory.rs
+++ b/src/configs/directory.rs
@@ -17,7 +17,6 @@ pub struct DirectoryConfig<'a> {
     pub read_only_style: &'a str,
     pub truncation_symbol: &'a str,
     pub home_symbol: &'a str,
-    pub show_home_symbol: bool,
 }
 
 impl<'a> RootModuleConfig<'a> for DirectoryConfig<'a> {
@@ -33,9 +32,8 @@ impl<'a> RootModuleConfig<'a> for DirectoryConfig<'a> {
             disabled: false,
             read_only: "🔒",
             read_only_style: "red",
-            home_symbol: "🏠",
-            show_home_symbol: true,
             truncation_symbol: "",
+            home_symbol: "~",
         }
     }
 }

--- a/src/configs/directory.rs
+++ b/src/configs/directory.rs
@@ -16,6 +16,8 @@ pub struct DirectoryConfig<'a> {
     pub read_only: &'a str,
     pub read_only_style: &'a str,
     pub truncation_symbol: &'a str,
+    pub home_symbol: &'a str,
+    pub show_home_symbol: bool,
 }
 
 impl<'a> RootModuleConfig<'a> for DirectoryConfig<'a> {
@@ -31,6 +33,8 @@ impl<'a> RootModuleConfig<'a> for DirectoryConfig<'a> {
             disabled: false,
             read_only: "🔒",
             read_only_style: "red",
+            home_symbol: "🏠",
+            show_home_symbol: true,
             truncation_symbol: "",
         }
     }

--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -16,8 +16,6 @@ use crate::configs::directory::DirectoryConfig;
 use crate::context::Shell;
 use crate::formatter::StringFormatter;
 
-const HOME_SYMBOL: &str = "~";
-
 /// Creates a module with the current directory
 ///
 /// Will perform path contraction, substitution, and truncation.
@@ -25,7 +23,7 @@ const HOME_SYMBOL: &str = "~";
 /// **Contraction**
 ///
 /// - Paths beginning with the home directory or with a git repo right inside
-///   the home directory will be contracted to `~`
+///   the home directory will be contracted to `~`, or the set HOME_SYMBOL
 /// - Paths containing a git repo will contract to begin at the repo root
 ///
 /// **Substitution**
@@ -40,6 +38,8 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let current_dir = &get_current_dir(&context, &config);
 
     let home_dir = context.get_home().unwrap();
+    let home_symbol = String::from(config.home_symbol);
+
     log::debug!("Current directory: {:?}", current_dir);
 
     let repo = &context.get_repo().ok()?;
@@ -48,10 +48,10 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             log::debug!("Repo root: {:?}", repo_root);
             // Contract the path to the git repo root
             contract_repo_path(current_dir, repo_root)
-                .unwrap_or_else(|| contract_path(current_dir, &home_dir, HOME_SYMBOL))
+                .unwrap_or_else(|| contract_path(current_dir, &home_dir, &home_symbol))
         }
         // Contract the path to the home directory
-        _ => contract_path(current_dir, &home_dir, HOME_SYMBOL),
+        _ => contract_path(current_dir, &home_dir, &home_symbol),
     };
     log::debug!("Dir string: {}", dir_string);
 
@@ -60,12 +60,12 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     // Truncate the dir string to the maximum number of path components
     let truncated_dir_string = truncate(substituted_dir, config.truncation_length as usize);
 
-    let prefix = if is_truncated(&truncated_dir_string) {
+    let prefix = if is_truncated(&truncated_dir_string, &home_symbol) {
         // Substitutions could have changed the prefix, so don't allow them and
         // fish-style path contraction together
         if config.fish_style_pwd_dir_length > 0 && config.substitutions.is_empty() {
             // If user is using fish style path, we need to add the segment first
-            let contracted_home_dir = contract_path(&current_dir, &home_dir, HOME_SYMBOL);
+            let contracted_home_dir = contract_path(&current_dir, &home_dir, &home_symbol);
             to_fish_style(
                 config.fish_style_pwd_dir_length as usize,
                 contracted_home_dir,
@@ -80,7 +80,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
     let displayed_path = prefix + &truncated_dir_string;
     let lock_symbol = String::from(config.read_only);
-    let home_symbol = String::from(config.home_symbol);
 
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter
@@ -90,13 +89,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 _ => None,
             })
             .map(|variable| match variable {
-                "path" => {
-                    if config.show_home_symbol && &displayed_path == HOME_SYMBOL {
-                        Some(Ok(&home_symbol))
-                    } else {
-                        Some(Ok(&displayed_path))
-                    }
-                }
+                "path" => Some(Ok(&displayed_path)),
                 "read_only" => {
                     if is_readonly_dir(&context.current_dir) {
                         Some(Ok(&lock_symbol))
@@ -120,8 +113,8 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     Some(module)
 }
 
-fn is_truncated(path: &str) -> bool {
-    !(path.starts_with(HOME_SYMBOL)
+fn is_truncated(path: &str, home_symbol: &str) -> bool {
+    !(path.starts_with(&home_symbol)
         || PathBuf::from(path).has_root()
         || (cfg!(target_os = "windows") && PathBuf::from(String::from(path) + r"\").has_root()))
 }
@@ -556,46 +549,41 @@ mod tests {
     }
 
     #[test]
-    fn home_directory_without_home_symbol() -> io::Result<()> {
+    fn home_directory_default_home_symbol() -> io::Result<()> {
         let actual = ModuleRenderer::new("directory")
             .path(home_dir().unwrap())
-            .config(toml::toml! { // Necessary if homedir is a git repo
-                [directory]
-                truncate_to_repo = false
-                show_home_symbol = false
-            })
             .collect();
         let expected = Some(format!("{} ", Color::Cyan.bold().paint("~")));
 
         assert_eq!(expected, actual);
         Ok(())
     }
+
     #[test]
-    fn home_directory_with_default_home_symbol() -> io::Result<()> {
+    fn home_directory_custom_home_symbol() -> io::Result<()> {
         let actual = ModuleRenderer::new("directory")
             .path(home_dir().unwrap())
             .config(toml::toml! {
                 [directory]
-                show_home_symbol = true
+                home_symbol = "🚀"
             })
             .collect();
-        let expected = Some(format!("{} ", Color::Cyan.bold().paint("🏠")));
+        let expected = Some(format!("{} ", Color::Cyan.bold().paint("🚀")));
 
         assert_eq!(expected, actual);
         Ok(())
     }
 
     #[test]
-    fn home_directory_with_custom_home_symbol() -> io::Result<()> {
+    fn home_directory_custom_home_symbol_subdirectories() -> io::Result<()> {
         let actual = ModuleRenderer::new("directory")
-            .path(home_dir().unwrap())
+            .path(home_dir().unwrap().join("path/subpath"))
             .config(toml::toml! {
                 [directory]
-                show_home_symbol = true
                 home_symbol = "🚀"
             })
             .collect();
-        let expected = Some(format!("{} ", Color::Cyan.bold().paint("🚀")));
+        let expected = Some(format!("{} ", Color::Cyan.bold().paint("🚀/path/subpath")));
 
         assert_eq!(expected, actual);
         Ok(())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
As another prompt libraries, could be good if we can modify and/or add a symbol when the current directoy is home (~). I added the option to enable/disable the symbol (`show_home_symbol`) and also an option to customize it (`home_symbol`), 🏠   by default 

Fixes #1174

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
