### PR TITLE
build: add aarch64 windows build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,6 +76,10 @@ jobs:
           - target: i686-pc-windows-msvc
             os: windows-latest
             name: starship-i686-pc-windows-msvc.zip
+          
+          - target: aarch64-pc-windows-msvc
+            os: windows-latest
+            name: starship-aarch64-pc-windows-msvc.zip
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/install/install.sh
+++ b/install/install.sh
@@ -37,7 +37,7 @@ SUPPORTED_TARGETS="x86_64-unknown-linux-gnu x86_64-unknown-linux-musl \
                   i686-unknown-linux-musl aarch64-unknown-linux-musl \
                   arm-unknown-linux-musleabihf x86_64-apple-darwin \
                   aarch64-apple-darwin x86_64-pc-windows-msvc \
-                  i686-pc-windows-msvc"
+                  i686-pc-windows-msvc aarch64-pc-windows-msvc"
 
 info() {
   printf "%s\n" "${BOLD}${GREY}>${NO_COLOR} $*"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR adds `aarch64-pc-windows-msvc` to the release matrix and lists it as a supported target in `install.sh`.

Now that sys-info has released a new version this finally builds fine. I tested a build and it worked in a VM.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1175

#### Screenshots (if appropriate):
<img width="984" alt="image" src="https://user-images.githubusercontent.com/835177/105870684-cbc2c700-5ff8-11eb-91b7-72311371d7ee.png">

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
