### PR TITLE
perf(async): Introduce async and timeout support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ If you spot anywhere that we could trim some time or reduce the prompt's workloa
 
 ## Architecture
 
-The project begins in [`main.rs`](src/main.rs), where the appropriate `print::` method is called based on which arguments are given to [clap](https://crates.io/crates/clap). When printing the full prompt, we use [rayon](https://crates.io/crates/rayon) to parallelize the computation of modules.
+The project begins in [`main.rs`](src/main.rs), where the appropriate `print::` method is called based on which arguments are given to [clap](https://crates.io/crates/clap). When printing the full prompt, we use [async_std](https://crates.io/crates/async_std) to parallelize the computation of modules and time out operations that take too long.
 
 Any styling that is applied to a module is inherited by its segments. Module prefixes and suffixes by default don't have any styling applied to them.
 
@@ -39,7 +39,7 @@ use crate::configs::php::PhpConfig;
 use crate::formatter::StringFormatter;
 
 
-pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+pub async fn module<'a>(context: &'a Context<'a>) -> Option<Module<'a>> {
    // Here `my_env_var` will be either the contents of the var or the function
    // will exit if the variable is not set.
    let my_env_var = context.get_env("MY_VAR")?;
@@ -59,10 +59,10 @@ use crate::configs::php::PhpConfig;
 use crate::formatter::StringFormatter;
 
 
-pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+pub async fn module<'a>(context: &'a Context<'a>) -> Option<Module<'a>> {
    // Here `output` will be either the stdout of the called command or the function
    // will exit if the called program was not installed or could not be run.
-   let output = context.exec_cmd("my_command", &["first_arg", "second_arg"])?.stdout;
+   let output = context.exec_cmd("my_command", &["first_arg", "second_arg"]).await?.stdout;
 
    // Then you can happily use the output
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1687,6 +1687,7 @@ dependencies = [
  "chrono",
  "clap",
  "dirs-next",
+ "futures",
  "gethostname",
  "git2",
  "indexmap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,16 +435,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
-dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1329,17 +1319,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "process_control"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72770c250bec5862264169dc3a2f7baa46ff6fa52f72d793e15904c5aa3adb7f"
-dependencies = [
- "crossbeam-channel",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "quick-xml"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1737,7 +1716,6 @@ dependencies = [
  "path-slash",
  "pest",
  "pest_derive",
- "process_control",
  "quick-xml",
  "rand 0.8.3",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,6 +46,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "async-channel"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2114d64672151c0c5eaa5e131ec84a74f06e1e559830dabba01ca30605d66319"
+dependencies = [
+ "concurrent-queue",
+ "event-listener",
+ "futures-core",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb877970c7b440ead138f6321a3b5395d6061183af779340b65e20c0fede9146"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "once_cell",
+ "vec-arena",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9586ec52317f36de58453159d48351bc244bc24ced3effc1fce22f3d48664af6"
+dependencies = [
+ "async-channel",
+ "async-executor",
+ "async-io",
+ "async-mutex",
+ "blocking",
+ "futures-lite",
+ "num_cpus",
+ "once_cell",
+]
+
+[[package]]
 name = "async-io"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -64,6 +105,63 @@ dependencies = [
  "waker-fn",
  "winapi",
 ]
+
+[[package]]
+name = "async-lock"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1996609732bde4a9988bc42125f55f2af5f3c36370e27c778d5191a4a1b63bfb"
+dependencies = [
+ "event-listener",
+]
+
+[[package]]
+name = "async-mutex"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479db852db25d9dbf6204e6cb6253698f175c15726470f78af0d918e99d6156e"
+dependencies = [
+ "event-listener",
+]
+
+[[package]]
+name = "async-std"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9f06685bad74e0570f5213741bea82158279a4103d988e57bfada11ad230341"
+dependencies = [
+ "async-channel",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "num_cpus",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-task"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91831deabf0d6d7ec49552e489aed63b7456a7a3c46cff62adad428110b0af0"
+
+[[package]]
+name = "atomic-waker"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "065374052e7df7ee4047b1160cca5e1467a12351a40b3da123c870ba0b8eda2a"
 
 [[package]]
 name = "attohttpc"
@@ -170,6 +268,26 @@ checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
 dependencies = [
  "byte-tools",
 ]
+
+[[package]]
+name = "blocking"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5e170dbede1f740736619b776d7251cb1b9095c435c34d8ca9f57fcd2f335e9"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "atomic-waker",
+ "fastrand",
+ "futures-lite",
+ "once_cell",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63396b8a4b9de3f4fdfb320ab6080762242f66a8ef174c49d8e19b674db4cdbe"
 
 [[package]]
 name = "byte-tools"
@@ -322,6 +440,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8f45d9ad417bcef4817d614a501ab55cdd96a6fdb24f49aab89a54acfd66b19"
+dependencies = [
+ "quote 1.0.8",
+ "syn 1.0.60",
+]
+
+[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -408,6 +536,12 @@ dependencies = [
  "quote 1.0.8",
  "syn 1.0.60",
 ]
+
+[[package]]
+name = "event-listener"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
 
 [[package]]
 name = "fake-simd"
@@ -617,6 +751,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "gloo-timers"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47204a46aaff920a1ea58b11d03dec6f704287d27561724a4631e450654a891f"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -691,6 +838,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "js-sys"
+version = "0.3.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc9f84f9b115ce7843d60706df1422a916680bfdfcbdb0447c5614ff9d7e4d78"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -745,6 +910,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
  "cfg-if 1.0.0",
+ "value-bag",
 ]
 
 [[package]]
@@ -891,6 +1057,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -1504,6 +1680,7 @@ name = "starship"
 version = "0.50.0"
 dependencies = [
  "ansi_term 0.12.1",
+ "async-std",
  "attohttpc",
  "battery",
  "byte-unit",
@@ -1805,6 +1982,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9071ac216321a4470a69fb2b28cfc68dcd1a39acd877c8be8e014df6772d8efa"
 
 [[package]]
+name = "value-bag"
+version = "1.0.0-alpha.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b676010e055c99033117c2343b33a40a30b91fecd6c49055ac9cd2d6c305ab1"
+dependencies = [
+ "ctor",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1845,6 +2031,82 @@ name = "wasi"
 version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ee1280240b7c461d6a0071313e08f34a60b0365f14260362e5a2b17d1d31aa7"
+dependencies = [
+ "cfg-if 1.0.0",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b7d8b6942b8bb3a9b0e73fc79b98095a27de6fa247615e59d096754a3bc2aa8"
+dependencies = [
+ "bumpalo",
+ "lazy_static",
+ "log",
+ "proc-macro2",
+ "quote 1.0.8",
+ "syn 1.0.60",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e67a5806118af01f0d9045915676b22aaebecf4178ae7021bc171dab0b897ab"
+dependencies = [
+ "cfg-if 1.0.0",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ac38da8ef716661f0f36c0d8320b89028efe10c7c0afde65baffb496ce0d3b"
+dependencies = [
+ "quote 1.0.8",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc053ec74d454df287b9374ee8abb36ffd5acb95ba87da3ba5b7d3fe20eb401e"
+dependencies = [
+ "proc-macro2",
+ "quote 1.0.8",
+ "syn 1.0.60",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d6f8ec44822dd71f5f221a5847fb34acd9060535c1211b70a05844c0f6383b1"
+
+[[package]]
+name = "web-sys"
+version = "0.3.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec600b26223b2948cedfde2a0aa6756dcf1fef616f43d7b3097aaf53a6c4d92b"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "wepoll-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,12 +263,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const_fn"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b9d6de7f49e22cf97ad17fc4036ece69300032f45f78f30b4a4482cdc3f4a6"
-
-[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -314,31 +308,6 @@ checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
-dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1aaa739f95311c2c7887a76863f500026092fb1dce0161dab577e559ef3569d"
-dependencies = [
- "cfg-if 1.0.0",
- "const_fn",
- "crossbeam-utils",
- "lazy_static",
- "memoffset",
- "scopeguard",
 ]
 
 [[package]]
@@ -418,12 +387,6 @@ name = "dtoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88d7ed2934d741c6b37e33e3832298e8850b53fd2d2bea03873375596c7cea4e"
-
-[[package]]
-name = "either"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "enumflags2"
@@ -833,15 +796,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
-name = "memoffset"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "157b4208e3059a8f9e78d559edc658e13df41410cb3ae03979c83130067fdd87"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "native-tls"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -937,16 +891,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
-dependencies = [
- "hermit-abi",
- "libc",
 ]
 
 [[package]]
@@ -1309,31 +1253,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rayon"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b0d8e0819fadc20c74ea8373106ead0600e3a67ef1fe8da56e39b9ae7275674"
-dependencies = [
- "autocfg",
- "crossbeam-deque",
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-utils",
- "lazy_static",
- "num_cpus",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1439,12 +1358,6 @@ name = "scoped-tls"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
-
-[[package]]
-name = "scopeguard"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "security-framework"
@@ -1613,7 +1526,6 @@ dependencies = [
  "process_control",
  "quick-xml",
  "rand 0.8.3",
- "rayon",
  "regex",
  "rust-ini",
  "semver",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,6 +125,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-process"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef37b86e2fa961bae5a4d212708ea0154f904ce31d1a4a7f47e1bbc33a0c040b"
+dependencies = [
+ "async-io",
+ "blocking",
+ "cfg-if 1.0.0",
+ "event-listener",
+ "futures-lite",
+ "once_cell",
+ "signal-hook",
+ "winapi",
+]
+
+[[package]]
 name = "async-std"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -794,9 +810,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
+checksum = "de910d521f7cc3135c4de8db1cb910e0b5ed1dc6f57c381cd07e8e661ce10094"
 dependencies = [
  "matches",
  "unicode-bidi",
@@ -869,9 +885,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.84"
+version = "0.2.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cca32fa0182e8c0989459524dc356b8f2b5c10f1b9eb521b7d182c03cf8c5ff"
+checksum = "7ccac4b00700875e6a07c6cde370d44d32fa01c5a65cdd2fca6858c479d28bb3"
 
 [[package]]
 name = "libgit2-sys"
@@ -1659,6 +1675,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fa3938c99da4914afedd13bf3d79bcb6c277d1b2c398d23257a304d9e1b074"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "780f5e3fe0c66f67197236097d89de1e86216f1f6fdeaf47c442f854ab46c240"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16f1d0fef1604ba8f7a073c7e701f213e056707210e9020af4528e0101ce11a6"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1680,6 +1715,7 @@ name = "starship"
 version = "0.50.0"
 dependencies = [
  "ansi_term 0.12.1",
+ "async-process",
  "async-std",
  "attohttpc",
  "battery",
@@ -1851,9 +1887,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8208a331e1cb318dd5bd76951d2b8fc48ca38a69f5f4e4af1b6a9f8c6236915"
+checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
 dependencies = [
  "once_cell",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,6 +46,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "async-attributes"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
+dependencies = [
+ "quote 1.0.8",
+ "syn 1.0.60",
+]
+
+[[package]]
 name = "async-channel"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,6 +156,7 @@ version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9f06685bad74e0570f5213741bea82158279a4103d988e57bfada11ad230341"
 dependencies = [
+ "async-attributes",
  "async-channel",
  "async-global-executor",
  "async-io",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ git2 = { version = "0.13.17", default-features = false }
 toml = { version = "0.5.8", features = ["preserve_order"] }
 rust-ini = "0.16.1"
 serde_json = "1.0.64"
-rayon = "1.5.0"
 log = { version = "0.4.14", features = ["std"] }
 # battery is optional (on by default) because the crate doesn't currently build for Termux
 # see: https://github.com/svartalf/rust-battery/issues/33

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ notify-rust = { version = "4.3.0", optional = true }
 semver = "0.11.0"
 which = "4.0.2"
 shadow-rs = "0.5.24"
-async-std = "1.9.0"
+async-std = { version= "1.9.0", features = ["attributes"] }
 async-process = "1.0.2"
 futures = "0.3.13"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ which = "4.0.2"
 shadow-rs = "0.5.24"
 
 process_control = { version = "3.0.1", features = ["crossbeam-channel"] }
+async-std = "1.9.0"
 
 # Optional/http:
 attohttpc = { version = "0.16.3", optional = true, default-features = false, features = ["tls", "form"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,8 +65,6 @@ notify-rust = { version = "4.3.0", optional = true }
 semver = "0.11.0"
 which = "4.0.2"
 shadow-rs = "0.5.24"
-
-process_control = { version = "3.0.1", features = ["crossbeam-channel"] }
 async-std = "1.9.0"
 async-process = "1.0.2"
 futures = "0.3.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ shadow-rs = "0.5.24"
 
 process_control = { version = "3.0.1", features = ["crossbeam-channel"] }
 async-std = "1.9.0"
+async-process = "1.0.2"
 futures = "0.3.13"
 
 # Optional/http:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ shadow-rs = "0.5.24"
 
 process_control = { version = "3.0.1", features = ["crossbeam-channel"] }
 async-std = "1.9.0"
+futures = "0.3.13"
 
 # Optional/http:
 attohttpc = { version = "0.16.3", optional = true, default-features = false, features = ["tls", "form"] }

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2747,7 +2747,7 @@ If you have an interesting example not covered there, feel free to share it ther
 
 ### Options
 
-| Option        | Default                       | Description                                                                                                                |
+| Option        | Default                         | Description                                                                                                                |
 | ------------- | ------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
 | `command`     |                                 | The command whose output should be printed. The command will be passed on stdin to the shell.                              |
 | `when`        |                                 | A shell command used as a condition to show the module. The module will be shown if the command returns a `0` status code. |
@@ -2759,7 +2759,10 @@ If you have an interesting example not covered there, feel free to share it ther
 | `symbol`      | `""`                            | The symbol used before displaying the command output.                                                                      |
 | `style`       | `"bold green"`                  | The style for the module.                                                                                                  |
 | `format`      | `"[$symbol($output )]($style)"` | The format for the module.                                                                                                 |
+| `timeout`*    |                                 | The timeout (in milliseconds) for the module.                                                                              |
 | `disabled`    | `false`                         | Disables this `custom` module.                                                                                             |
+
+\*: a per-module `timeout` always takes precedence over `prompt_timeout`, even when `timeout` is longer
 
 ### Variables
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -151,11 +151,12 @@ This is the list of prompt-wide configuration options.
 
 ### Options
 
-| Option         | Default                        | Description                                           |
-| -------------- | ------------------------------ | ----------------------------------------------------- |
-| `format`       | [link](#default-prompt-format) | Configure the format of the prompt.                   |
-| `scan_timeout` | `30`                           | Timeout for starship to scan files (in milliseconds). |
-| `add_newline`  | `true`                         | Inserts blank line between shell prompts.               |
+| Option           | Default                        | Description                                                |
+| --------------   | ------------------------------ | -----------------------------------------------------      |
+| `format`         | [link](#default-prompt-format) | Configure the format of the prompt.                        |
+| `scan_timeout`   | `30`                           | Timeout for starship to scan files (in milliseconds).      |
+| `add_newline`    | `true`                         | Inserts blank line between shell prompts.                  |
+| `prompt_timeout` | `700`                          | Timeout for starship to show the prompt (in milliseconds). |
 
 ### Example
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,7 @@
 use crate::configs::StarshipRootConfig;
 use crate::utils;
 use ansi_term::{Color, Style};
+use async_std::task::block_on;
 use indexmap::IndexMap;
 
 use std::clone::Clone;
@@ -231,7 +232,7 @@ impl StarshipConfig {
             config_path_str
         };
 
-        let toml_content = match utils::read_file(&file_path) {
+        let toml_content = match block_on(utils::read_file(&file_path)) {
             Ok(content) => {
                 log::trace!("Config file content: \"\n{}\"", &content);
                 Some(content)

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -6,7 +6,6 @@ use starship_module_config_derive::ModuleConfig;
 pub struct StarshipRootConfig<'a> {
     pub format: &'a str,
     pub scan_timeout: u64,
-    pub command_timeout: u64,
     pub prompt_timeout: u64,
     pub add_newline: bool,
 }
@@ -81,7 +80,6 @@ impl<'a> RootModuleConfig<'a> for StarshipRootConfig<'a> {
         StarshipRootConfig {
             format: "$all",
             scan_timeout: 30,
-            command_timeout: 500,
             prompt_timeout: 700,
             add_newline: true,
         }

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -7,6 +7,7 @@ pub struct StarshipRootConfig<'a> {
     pub format: &'a str,
     pub scan_timeout: u64,
     pub command_timeout: u64,
+    pub prompt_timeout: u64,
     pub add_newline: bool,
 }
 
@@ -81,6 +82,7 @@ impl<'a> RootModuleConfig<'a> for StarshipRootConfig<'a> {
             format: "$all",
             scan_timeout: 30,
             command_timeout: 500,
+            prompt_timeout: 700,
             add_newline: true,
         }
     }

--- a/src/context.rs
+++ b/src/context.rs
@@ -54,6 +54,9 @@ pub struct Context<'a> {
 
     /// Timeout for the execution of commands
     cmd_timeout: Duration,
+
+    /// Timeout for returning the prompt
+    pub prompt_timeout: Duration,
 }
 
 impl<'a> Context<'a> {
@@ -112,6 +115,7 @@ impl<'a> Context<'a> {
         let logical_dir = logical_path;
 
         let cmd_timeout = Duration::from_millis(config.get_root_config().command_timeout);
+        let prompt_timeout = Duration::from_millis(config.get_root_config().prompt_timeout);
 
         Context {
             config,
@@ -126,6 +130,7 @@ impl<'a> Context<'a> {
             #[cfg(test)]
             cmd: HashMap::new(),
             cmd_timeout,
+            prompt_timeout,
         }
     }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,6 +1,7 @@
 use crate::config::StarshipConfig;
 use crate::module::Module;
 use crate::utils::{exec_cmd, CommandOutput};
+use std::process::ExitStatus;
 use std::sync::Arc;
 
 use crate::modules;
@@ -292,6 +293,15 @@ impl<'a> Context<'a> {
             return out;
         }
         crate::utils::async_exec_cmd(cmd, args).await
+    }
+
+    /// Execute a command and return the exit code and output on stdout and stderr
+    pub async fn exec_cmd_status(
+        &self,
+        cmd: &str,
+        args: &[&str],
+    ) -> Option<(ExitStatus, CommandOutput)> {
+        crate::utils::exec_cmd_status(cmd, args).await
     }
 
     #[cfg(test)]

--- a/src/context.rs
+++ b/src/context.rs
@@ -8,6 +8,7 @@ use dirs_next::home_dir;
 use git2::{ErrorCode::UnbornBranch, Repository, RepositoryState};
 use once_cell::sync::OnceCell;
 use std::collections::{HashMap, HashSet};
+use std::convert::TryFrom;
 use std::env;
 use std::ffi::OsString;
 use std::fs;
@@ -194,6 +195,15 @@ impl<'a> Context<'a> {
         let disabled = Some(config).and_then(|table| table.as_table()?.get("disabled")?.as_bool());
 
         Some(disabled == Some(true))
+    }
+
+    /// Return the timeout duration specified for this module, or None if none was given
+    pub fn module_timeout(&self, name: &str) -> Option<Duration> {
+        let config = self.config.get_module_config(name)?;
+
+        let int = config.as_table()?.get("timeout")?.as_integer()?;
+
+        u64::try_from(int).map(Duration::from_millis).ok()
     }
 
     // returns a new ScanDir struct with reference to current dir_files of context

--- a/src/context.rs
+++ b/src/context.rs
@@ -304,6 +304,18 @@ impl<'a> Context<'a> {
         crate::utils::exec_cmd_status(cmd, args).await
     }
 
+    /// Execute a command and return the exit code and output on stdout and stderr.
+    /// If the command spawns successfully, write all data to its stdin before reading the output.
+    /// Otherwise return None.
+    pub async fn exec_cmd_with_stdin(
+        &self,
+        cmd: &str,
+        args: &[&str],
+        stdin: &str,
+    ) -> Option<(ExitStatus, CommandOutput)> {
+        crate::utils::exec_cmd_with_stdin(cmd, args, stdin).await
+    }
+
     #[cfg(test)]
     fn try_cmd_mock(&self, cmd: &str, args: &[&str]) -> Option<Option<CommandOutput>> {
         let command = match args.len() {

--- a/src/formatter/string_formatter.rs
+++ b/src/formatter/string_formatter.rs
@@ -1,6 +1,5 @@
 use ansi_term::Style;
 use pest::error::Error as PestError;
-use rayon::prelude::*;
 use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet};
 use std::error::Error;
@@ -106,7 +105,7 @@ impl<'a> StringFormatter<'a> {
         M: Fn(&str) -> Option<Result<T, StringFormatterError>> + Sync,
     {
         self.variables
-            .par_iter_mut()
+            .iter_mut()
             .filter(|(_, value)| value.is_none())
             .for_each(|(key, value)| {
                 *value = mapper(key).map(|var| var.map(|var| VariableValue::Plain(var.into())));
@@ -166,7 +165,7 @@ impl<'a> StringFormatter<'a> {
         M: Fn(&str) -> Option<Result<Vec<Segment>, StringFormatterError>> + Sync,
     {
         self.variables
-            .par_iter_mut()
+            .iter_mut()
             .filter(|(_, value)| value.is_none())
             .for_each(|(key, value)| {
                 *value = mapper(key).map(|var| var.map(VariableValue::Styled));
@@ -183,7 +182,7 @@ impl<'a> StringFormatter<'a> {
         M: Fn(&str) -> Option<Result<T, StringFormatterError>> + Sync,
     {
         self.style_variables
-            .par_iter_mut()
+            .iter_mut()
             .filter(|(_, value)| value.is_none())
             .for_each(|(key, value)| {
                 *value = mapper(key).map(|var| var.map(|var| var.into()));

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -75,6 +75,13 @@ impl log::Log for StarshipLogger {
     }
 
     fn log(&self, record: &Record) {
+        if !record
+            .module_path()
+            .map_or(false, |s| s.contains("starship"))
+        {
+            return;
+        }
+
         let to_print = format!(
             "[{}] - ({}): {}",
             record.level(),

--- a/src/modules/cmake.rs
+++ b/src/modules/cmake.rs
@@ -32,7 +32,7 @@ pub async fn module<'a>(context: &'a Context<'a>) -> Option<Module<'a>> {
             .async_map(|variable| async move {
                 match variable.as_ref() {
                     "version" => context
-                        .async_exec_cmd("cmake", &["--version"])
+                        .exec_cmd("cmake", &["--version"])
                         .await
                         .and_then(|output| format_cmake_version(&output.stdout))
                         .map(Ok),

--- a/src/modules/cmake.rs
+++ b/src/modules/cmake.rs
@@ -4,7 +4,7 @@ use crate::configs::cmake::CMakeConfig;
 use crate::formatter::StringFormatter;
 
 /// Creates a module with the current CMake version
-pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+pub async fn module<'a>(context: &'a Context<'a>) -> Option<Module<'a>> {
     let mut module = context.new_module("cmake");
     let config = CMakeConfig::try_load(module.config);
 
@@ -19,8 +19,8 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         return None;
     }
 
-    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
-        formatter
+    let parsed = match StringFormatter::new(config.format) {
+        Ok(formatter) => formatter
             .map_meta(|variable, _| match variable {
                 "symbol" => Some(config.symbol),
                 _ => None,
@@ -29,16 +29,20 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 "style" => Some(Ok(config.style)),
                 _ => None,
             })
-            .map(|variable| match variable {
-                "version" => context
-                    .exec_cmd("cmake", &["--version"])
-                    .map(|output| format_cmake_version(&output.stdout))
-                    .flatten()
-                    .map(Ok),
-                _ => None,
+            .async_map(|variable| async move {
+                match variable.as_ref() {
+                    "version" => context
+                        .async_exec_cmd("cmake", &["--version"])
+                        .await
+                        .and_then(|output| format_cmake_version(&output.stdout))
+                        .map(Ok),
+                    _ => None,
+                }
             })
-            .parse(None)
-    });
+            .await
+            .parse(None),
+        Err(e) => Err(e),
+    };
 
     module.set_segments(match parsed {
         Ok(segments) => segments,

--- a/src/modules/crystal.rs
+++ b/src/modules/crystal.rs
@@ -4,7 +4,7 @@ use crate::configs::crystal::CrystalConfig;
 use crate::formatter::StringFormatter;
 
 /// Creates a module with the current Crystal version
-pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+pub async fn module<'a>(context: &'a Context<'a>) -> Option<Module<'a>> {
     let mut module = context.new_module("crystal");
     let config: CrystalConfig = CrystalConfig::try_load(module.config);
 
@@ -19,8 +19,8 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         return None;
     }
 
-    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
-        formatter
+    let parsed = match StringFormatter::new(config.format) {
+        Ok(formatter) => formatter
             .map_meta(|variable, _| match variable {
                 "symbol" => Some(config.symbol),
                 _ => None,
@@ -29,15 +29,23 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 "style" => Some(Ok(config.style)),
                 _ => None,
             })
-            .map(|variable| match variable {
-                "version" => format_crystal_version(
-                    context.exec_cmd("crystal", &["--version"])?.stdout.as_str(),
-                )
-                .map(Ok),
-                _ => None,
+            .async_map(|variable| {
+                let context = &context;
+                async move {
+                    match variable.as_str() {
+                        "version" => context
+                            .async_exec_cmd("crystal", &["--version"])
+                            .await
+                            .and_then(|ver| format_crystal_version(&ver.stdout))
+                            .map(Ok),
+                        _ => None,
+                    }
+                }
             })
-            .parse(None)
-    });
+            .await
+            .parse(None),
+        Err(e) => Err(e),
+    };
 
     module.set_segments(match parsed {
         Ok(segments) => segments,

--- a/src/modules/crystal.rs
+++ b/src/modules/crystal.rs
@@ -34,7 +34,7 @@ pub async fn module<'a>(context: &'a Context<'a>) -> Option<Module<'a>> {
                 async move {
                     match variable.as_str() {
                         "version" => context
-                            .async_exec_cmd("crystal", &["--version"])
+                            .exec_cmd("crystal", &["--version"])
                             .await
                             .and_then(|ver| format_crystal_version(&ver.stdout))
                             .map(Ok),

--- a/src/modules/custom.rs
+++ b/src/modules/custom.rs
@@ -1,5 +1,5 @@
-use std::io::Write;
-use std::process::{Command, Output, Stdio};
+use crate::utils::CommandOutput;
+use std::process::ExitStatus;
 use std::time::Instant;
 
 use super::{Context, Module, RootModuleConfig};
@@ -13,7 +13,7 @@ use crate::{configs::custom::CustomConfig, formatter::StringFormatter};
 /// command can be run -- if its result is 0, the module will be shown.
 ///
 /// Finally, the content of the module itself is also set by a command.
-pub fn module<'a>(name: &str, context: &'a Context) -> Option<Module<'a>> {
+pub async fn module<'a>(name: &str, context: &'a Context<'a>) -> Option<Module<'a>> {
     let start: Instant = Instant::now();
     let toml_config = context.config.get_custom_module_config(name).expect(
         "modules::custom::module should only be called after ensuring that the module exists",
@@ -36,7 +36,7 @@ pub fn module<'a>(name: &str, context: &'a Context) -> Option<Module<'a>> {
 
     if !is_match {
         if let Some(when) = config.when {
-            is_match = exec_when(when, &config.shell.0);
+            is_match = exec_command(context, when, &config.shell.0).await.is_some();
         }
 
         if !is_match {
@@ -46,8 +46,8 @@ pub fn module<'a>(name: &str, context: &'a Context) -> Option<Module<'a>> {
 
     let mut module = Module::new(name, config.description, Some(toml_config));
 
-    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
-        formatter
+    let parsed = match StringFormatter::new(config.format) {
+        Ok(formatter) => formatter
             .map_meta(|var, _| match var {
                 "symbol" => Some(config.symbol),
                 _ => None,
@@ -56,21 +56,29 @@ pub fn module<'a>(name: &str, context: &'a Context) -> Option<Module<'a>> {
                 "style" => Some(Ok(config.style)),
                 _ => None,
             })
-            .map(|variable| match variable {
-                "output" => {
-                    let output = exec_command(config.command, &config.shell.0)?;
-                    let trimmed = output.trim();
+            .async_map(|variable| {
+                let config = &config;
+                async move {
+                    match variable.as_ref() {
+                        "output" => {
+                            let output =
+                                exec_command(context, config.command, &config.shell.0).await?;
+                            let trimmed = output.trim();
 
-                    if trimmed.is_empty() {
-                        None
-                    } else {
-                        Some(Ok(trimmed.to_string()))
+                            if trimmed.is_empty() {
+                                None
+                            } else {
+                                Some(Ok(trimmed.to_string()))
+                            }
+                        }
+                        _ => None,
                     }
                 }
-                _ => None,
             })
-            .parse(None)
-    });
+            .await
+            .parse(None),
+        Err(e) => Err(e),
+    };
 
     match parsed {
         Ok(segments) => module.set_segments(segments),
@@ -98,44 +106,36 @@ fn get_shell<'a, 'b>(shell_args: &'b [&'a str]) -> (std::borrow::Cow<'a, str>, &
 
 /// Attempt to run the given command in a shell by passing it as `stdin` to `get_shell()`
 #[cfg(not(windows))]
-fn shell_command(cmd: &str, shell_args: &[&str]) -> Option<Output> {
+async fn shell_command(
+    context: &Context<'_>,
+    cmd: &str,
+    shell_args: &[&str],
+) -> Option<(ExitStatus, CommandOutput)> {
     let (shell, shell_args) = get_shell(shell_args);
-    let mut command = Command::new(shell.as_ref());
 
-    command
-        .args(shell_args)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
+    let shell = shell.as_ref();
+    let shell_args = adjust_args_for_powershell(shell, shell_args);
 
-    handle_powershell(&mut command, &shell, shell_args);
+    if let Some(ret) = context.exec_cmd_with_stdin(shell, shell_args, cmd).await {
+        return Some(ret);
+    }
 
-    let mut child = match command.spawn() {
-        Ok(command) => command,
-        Err(err) => {
-            log::trace!("Error executing command: {:?}", err);
-            log::debug!(
-                "Could not launch command with given shell or STARSHIP_SHELL env variable, retrying with /usr/bin/env sh"
-            );
-
-            Command::new("/usr/bin/env")
-                .arg("sh")
-                .stdin(Stdio::piped())
-                .stdout(Stdio::piped())
-                .stderr(Stdio::piped())
-                .spawn()
-                .ok()?
-        }
-    };
-
-    child.stdin.as_mut()?.write_all(cmd.as_bytes()).ok()?;
-    child.wait_with_output().ok()
+    log::debug!(
+        "Could not launch command with given shell or STARSHIP_SHELL env variable, retrying with /usr/bin/env sh"
+    );
+    context
+        .exec_cmd_with_stdin("/usr/bin/env", &["sh"], cmd)
+        .await
 }
 
 /// Attempt to run the given command in a shell by passing it as `stdin` to `get_shell()`,
 /// or by invoking cmd.exe /C.
 #[cfg(windows)]
-fn shell_command(cmd: &str, shell_args: &[&str]) -> Option<Output> {
+async fn shell_command(
+    context: &Context<'_>,
+    cmd: &str,
+    shell_args: &[&str],
+) -> Option<(ExitStatus, CommandOutput)> {
     let (shell, shell_args) = if !shell_args.is_empty() {
         (
             Some(std::borrow::Cow::Borrowed(shell_args[0])),
@@ -148,20 +148,14 @@ fn shell_command(cmd: &str, shell_args: &[&str]) -> Option<Output> {
     };
 
     if let Some(forced_shell) = shell {
-        let mut command = Command::new(forced_shell.as_ref());
+        let forced_shell = forced_shell.as_ref();
+        let shell_args = adjust_args_for_powershell(forced_shell, shell_args);
 
-        command
-            .args(shell_args)
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
-
-        handle_powershell(&mut command, &forced_shell, shell_args);
-
-        if let Ok(mut child) = command.spawn() {
-            child.stdin.as_mut()?.write_all(cmd.as_bytes()).ok()?;
-
-            return child.wait_with_output().ok();
+        if let Some(ret) = context
+            .exec_cmd_with_stdin(forced_shell, shell_args, cmd)
+            .await
+        {
+            return Some(ret);
         }
 
         log::debug!(
@@ -169,61 +163,22 @@ fn shell_command(cmd: &str, shell_args: &[&str]) -> Option<Output> {
         );
     }
 
-    let command = Command::new("cmd.exe")
-        .arg("/C")
-        .arg(cmd)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn();
-
-    command.ok()?.wait_with_output().ok()
-}
-
-/// Execute the given command capturing all output, and return whether it return 0
-fn exec_when(cmd: &str, shell_args: &[&str]) -> bool {
-    log::trace!("Running '{}'", cmd);
-
-    if let Some(output) = shell_command(cmd, shell_args) {
-        if !output.status.success() {
-            log::trace!("non-zero exit code '{:?}'", output.status.code());
-            log::trace!(
-                "stdout: {}",
-                std::str::from_utf8(&output.stdout).unwrap_or("<invalid utf8>")
-            );
-            log::trace!(
-                "stderr: {}",
-                std::str::from_utf8(&output.stderr).unwrap_or("<invalid utf8>")
-            );
-        }
-
-        output.status.success()
-    } else {
-        log::debug!("Cannot start command");
-
-        false
-    }
+    context.exec_cmd_status("cmd.exe", &["/C", cmd]).await
 }
 
 /// Execute the given command, returning its output on success
-fn exec_command(cmd: &str, shell_args: &[&str]) -> Option<String> {
+async fn exec_command(context: &Context<'_>, cmd: &str, shell_args: &[&str]) -> Option<String> {
     log::trace!("Running '{}'", cmd);
 
-    if let Some(output) = shell_command(cmd, shell_args) {
-        if !output.status.success() {
-            log::trace!("Non-zero exit code '{:?}'", output.status.code());
-            log::trace!(
-                "stdout: {}",
-                std::str::from_utf8(&output.stdout).unwrap_or("<invalid utf8>")
-            );
-            log::trace!(
-                "stderr: {}",
-                std::str::from_utf8(&output.stderr).unwrap_or("<invalid utf8>")
-            );
+    if let Some((status, output)) = shell_command(context, cmd, shell_args).await {
+        if !status.success() {
+            log::trace!("Non-zero exit code '{:?}'", status.code());
+            log::trace!("stdout: {}", output.stdout);
+            log::trace!("stderr: {}", output.stderr);
             return None;
         }
 
-        Some(String::from_utf8_lossy(&output.stdout).into())
+        Some(output.stdout)
     } else {
         None
     }
@@ -231,20 +186,21 @@ fn exec_command(cmd: &str, shell_args: &[&str]) -> Option<String> {
 
 /// If the specified shell refers to PowerShell, adds the arguments "-Command -" to the
 /// given command.
-fn handle_powershell(command: &mut Command, shell: &str, shell_args: &[&str]) {
+fn adjust_args_for_powershell<'a>(shell: &str, shell_args: &'a [&'a str]) -> &'a [&'a str] {
     let is_powershell = shell.ends_with("pwsh.exe")
         || shell.ends_with("powershell.exe")
         || shell.ends_with("pwsh")
         || shell.ends_with("powershell");
 
     if is_powershell && shell_args.is_empty() {
-        command.arg("-NoProfile").arg("-Command").arg("-");
+        &["-NoProfile", "-Command", "-"]
+    } else {
+        shell_args
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
 
     #[cfg(not(windows))]
     const SHELL: &[&str] = &["/bin/sh"];
@@ -258,15 +214,30 @@ mod tests {
 
     const UNKNOWN_COMMAND: &str = "ydelsyiedsieudleylse dyesdesl";
 
+    fn exec_command(cmd: &str, shell_args: &[&str]) -> Option<String> {
+        use crate::config::StarshipConfig;
+        use crate::modules::{Context, Shell};
+        use std::path::PathBuf;
+
+        let mut context = Context::new_with_shell_and_path(
+            clap::ArgMatches::default(),
+            Shell::Unknown,
+            PathBuf::new(),
+            PathBuf::new(),
+        );
+        context.config = StarshipConfig { config: None };
+        async_std::task::block_on(super::exec_command(&context, cmd, shell_args))
+    }
+
     #[test]
     fn when_returns_right_value() {
-        assert!(exec_when("echo hello", SHELL));
-        assert!(!exec_when(FAILING_COMMAND, SHELL));
+        assert!(exec_command("echo hello", SHELL).is_some());
+        assert!(!exec_command(FAILING_COMMAND, SHELL).is_some());
     }
 
     #[test]
     fn when_returns_false_if_invalid_command() {
-        assert!(!exec_when(UNKNOWN_COMMAND, SHELL));
+        assert!(!exec_command(UNKNOWN_COMMAND, SHELL).is_some());
     }
 
     #[test]

--- a/src/modules/dart.rs
+++ b/src/modules/dart.rs
@@ -32,8 +32,7 @@ pub async fn module<'a>(context: &'a Context<'a>) -> Option<Module<'a>> {
             .async_map(|variable| async move {
                 match variable.as_ref() {
                     "version" => {
-                        let dart_version =
-                            context.async_exec_cmd("dart", &["--version"]).await?.stderr;
+                        let dart_version = context.exec_cmd("dart", &["--version"]).await?.stderr;
                         parse_dart_version(&dart_version).map(Ok)
                     }
                     _ => None,

--- a/src/modules/dart.rs
+++ b/src/modules/dart.rs
@@ -4,7 +4,7 @@ use crate::configs::dart::DartConfig;
 use crate::formatter::StringFormatter;
 
 /// Creates a module with the current Dart version
-pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+pub async fn module<'a>(context: &'a Context<'a>) -> Option<Module<'a>> {
     let mut module = context.new_module("dart");
     let config: DartConfig = DartConfig::try_load(module.config);
 
@@ -19,8 +19,8 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         return None;
     }
 
-    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
-        formatter
+    let parsed = match StringFormatter::new(config.format) {
+        Ok(formatter) => formatter
             .map_meta(|var, _| match var {
                 "symbol" => Some(config.symbol),
                 _ => None,
@@ -29,15 +29,20 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 "style" => Some(Ok(config.style)),
                 _ => None,
             })
-            .map(|variable| match variable {
-                "version" => {
-                    let dart_version = context.exec_cmd("dart", &["--version"])?.stderr;
-                    parse_dart_version(&dart_version).map(Ok)
+            .async_map(|variable| async move {
+                match variable.as_ref() {
+                    "version" => {
+                        let dart_version =
+                            context.async_exec_cmd("dart", &["--version"]).await?.stderr;
+                        parse_dart_version(&dart_version).map(Ok)
+                    }
+                    _ => None,
                 }
-                _ => None,
             })
-            .parse(None)
-    });
+            .await
+            .parse(None),
+        Err(e) => Err(e),
+    };
 
     module.set_segments(match parsed {
         Ok(segments) => segments,

--- a/src/modules/docker_context.rs
+++ b/src/modules/docker_context.rs
@@ -39,7 +39,7 @@ pub async fn module<'a>(context: &'a Context<'a>) -> Option<Module<'a>> {
         return None;
     }
 
-    let json = utils::async_read_file(docker_config).await.ok()?;
+    let json = utils::read_file(docker_config).await.ok()?;
     let parsed_json: serde_json::Value = serde_json::from_str(&json).ok()?;
 
     let ctx = parsed_json.get("currentContext")?.as_str()?;

--- a/src/modules/dotnet.rs
+++ b/src/modules/dotnet.rs
@@ -284,12 +284,12 @@ fn map_str_to_lower(value: Option<&OsStr>) -> Option<String> {
 }
 
 async fn get_version_from_cli(context: &Context<'_>) -> Option<Version> {
-    let version_output = context.async_exec_cmd("dotnet", &["--version"]).await?;
+    let version_output = context.exec_cmd("dotnet", &["--version"]).await?;
     Some(Version(format!("v{}", version_output.stdout.trim())))
 }
 
 async fn get_latest_sdk_from_cli(context: &Context<'_>) -> Option<Version> {
-    match context.async_exec_cmd("dotnet", &["--list-sdks"]).await {
+    match context.exec_cmd("dotnet", &["--list-sdks"]).await {
         Some(sdks_output) => {
             fn parse_failed<T>() -> Option<T> {
                 log::warn!("Unable to parse the output from `dotnet --list-sdks`.");

--- a/src/modules/dotnet.rs
+++ b/src/modules/dotnet.rs
@@ -103,7 +103,7 @@ async fn find_current_tfm(files: &[DotNetFile]) -> Option<String> {
 }
 
 async fn get_tfm_from_project_file(path: &Path) -> Option<String> {
-    let project_file = utils::async_read_file(path).await.ok()?;
+    let project_file = utils::read_file(path).await.ok()?;
     let mut reader = Reader::from_str(&project_file);
     reader.trim_text(true);
 
@@ -231,7 +231,7 @@ async fn check_directory_for_global_json(path: &Path) -> Option<Version> {
 }
 
 async fn get_pinned_sdk_version_from_file(path: &Path) -> Option<Version> {
-    let json_text = utils::async_read_file(path).await.ok()?;
+    let json_text = utils::read_file(path).await.ok()?;
     log::debug!(
         "Checking if .NET SDK version is pinned in: {}",
         path.display()

--- a/src/modules/elixir.rs
+++ b/src/modules/elixir.rs
@@ -74,10 +74,7 @@ pub async fn module<'a>(context: &'a Context<'a>) -> Option<Module<'a>> {
 }
 
 async fn get_elixir_version<'a>(context: &'a Context<'a>) -> Option<(String, String)> {
-    let output = context
-        .async_exec_cmd("elixir", &["--version"])
-        .await?
-        .stdout;
+    let output = context.exec_cmd("elixir", &["--version"]).await?.stdout;
 
     parse_elixir_version(&output)
 }

--- a/src/modules/elm.rs
+++ b/src/modules/elm.rs
@@ -32,8 +32,7 @@ pub async fn module<'a>(context: &'a Context<'a>) -> Option<Module<'a>> {
             .async_map(|variable| async move {
                 match variable.as_ref() {
                     "version" => {
-                        let elm_version =
-                            context.async_exec_cmd("elm", &["--version"]).await?.stdout;
+                        let elm_version = context.exec_cmd("elm", &["--version"]).await?.stdout;
                         let module_version = Some(format!("v{}", elm_version.trim()))?;
                         Some(Ok(module_version))
                     }

--- a/src/modules/erlang.rs
+++ b/src/modules/erlang.rs
@@ -52,7 +52,7 @@ pub async fn module<'a>(context: &'a Context<'a>) -> Option<Module<'a>> {
 }
 
 async fn get_erlang_version(context: &Context<'_>) -> Option<String> {
-    Some(context.async_exec_cmd(
+    Some(context.exec_cmd(
         "erl",
         &[
             "-noshell",

--- a/src/modules/git_state.rs
+++ b/src/modules/git_state.rs
@@ -132,7 +132,7 @@ fn describe_rebase<'a>(root: &'a Path, rebase_config: &'a str) -> StateDescripti
 
     let file_to_usize = |relative_path: &str| {
         let path = dot_git.join(PathBuf::from(relative_path));
-        let contents = crate::utils::read_file(path).ok()?;
+        let contents = std::fs::read_to_string(path).ok()?;
         let quantity = contents.trim().parse::<usize>().ok()?;
         Some(quantity)
     };

--- a/src/modules/golang.rs
+++ b/src/modules/golang.rs
@@ -31,7 +31,7 @@ pub async fn module<'a>(context: &'a Context<'a>) -> Option<Module<'a>> {
             .async_map(|variable| async move {
                 match variable.as_ref() {
                     "version" => {
-                        format_go_version(&context.async_exec_cmd("go", &["version"]).await?.stdout)
+                        format_go_version(&context.exec_cmd("go", &["version"]).await?.stdout)
                             .map(Ok)
                     }
                     _ => None,

--- a/src/modules/helm.rs
+++ b/src/modules/helm.rs
@@ -33,7 +33,7 @@ pub async fn module<'a>(context: &'a Context<'a>) -> Option<Module<'a>> {
                 match variable.as_ref() {
                     "version" => format_helm_version(
                         &context
-                            .async_exec_cmd("helm", &["version", "--short", "--client"])
+                            .exec_cmd("helm", &["version", "--short", "--client"])
                             .await?
                             .stdout,
                     )

--- a/src/modules/java.rs
+++ b/src/modules/java.rs
@@ -61,7 +61,7 @@ async fn get_java_version<'a>(context: &'a Context<'a>) -> Option<String> {
     };
 
     let output = context
-        .async_exec_cmd(&java_command.as_str(), &["-Xinternalversion"])
+        .exec_cmd(&java_command.as_str(), &["-Xinternalversion"])
         .await?;
     let java_version = if output.stdout.is_empty() {
         output.stderr

--- a/src/modules/java.rs
+++ b/src/modules/java.rs
@@ -7,7 +7,7 @@ use regex::Regex;
 const JAVA_VERSION_PATTERN: &str = "(?P<version>[\\d\\.]+)[^\\s]*\\s(?:built|from)";
 
 /// Creates a module with the current Java version
-pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+pub async fn module<'a>(context: &'a Context<'a>) -> Option<Module<'a>> {
     let mut module = context.new_module("java");
     let config: JavaConfig = JavaConfig::try_load(module.config);
 
@@ -22,8 +22,8 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         return None;
     }
 
-    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
-        formatter
+    let parsed = match StringFormatter::new(config.format) {
+        Ok(formatter) => formatter
             .map_meta(|var, _| match var {
                 "symbol" => Some(config.symbol),
                 _ => None,
@@ -32,15 +32,16 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 "style" => Some(Ok(config.style)),
                 _ => None,
             })
-            .map(|variable| match variable {
-                "version" => {
-                    let java_version = get_java_version(context)?;
-                    Some(Ok(java_version))
+            .async_map(|variable| async move {
+                match variable.as_ref() {
+                    "version" => get_java_version(context).await.map(Ok),
+                    _ => None,
                 }
-                _ => None,
             })
-            .parse(None)
-    });
+            .await
+            .parse(None),
+        Err(e) => Err(e),
+    };
 
     module.set_segments(match parsed {
         Ok(segments) => segments,
@@ -53,13 +54,15 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     Some(module)
 }
 
-fn get_java_version(context: &Context) -> Option<String> {
+async fn get_java_version<'a>(context: &'a Context<'a>) -> Option<String> {
     let java_command = match context.get_env("JAVA_HOME") {
         Some(java_home) => format!("{}/bin/java", java_home),
         None => String::from("java"),
     };
 
-    let output = context.exec_cmd(&java_command.as_str(), &["-Xinternalversion"])?;
+    let output = context
+        .async_exec_cmd(&java_command.as_str(), &["-Xinternalversion"])
+        .await?;
     let java_version = if output.stdout.is_empty() {
         output.stderr
     } else {

--- a/src/modules/julia.rs
+++ b/src/modules/julia.rs
@@ -32,10 +32,7 @@ pub async fn module<'a>(context: &'a Context<'a>) -> Option<Module<'a>> {
             .async_map(|variable| async move {
                 match variable.as_ref() {
                     "version" => format_julia_version(
-                        &context
-                            .async_exec_cmd("julia", &["--version"])
-                            .await?
-                            .stdout,
+                        &context.exec_cmd("julia", &["--version"]).await?.stdout,
                     )
                     .map(Ok),
                     _ => None,

--- a/src/modules/julia.rs
+++ b/src/modules/julia.rs
@@ -4,7 +4,7 @@ use crate::configs::julia::JuliaConfig;
 use crate::formatter::StringFormatter;
 
 /// Creates a module with the current Julia version
-pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+pub async fn module<'a>(context: &'a Context<'a>) -> Option<Module<'a>> {
     let mut module = context.new_module("julia");
     let config = JuliaConfig::try_load(module.config);
 
@@ -19,8 +19,8 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         return None;
     }
 
-    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
-        formatter
+    let parsed = match StringFormatter::new(config.format) {
+        Ok(formatter) => formatter
             .map_meta(|var, _| match var {
                 "symbol" => Some(config.symbol),
                 _ => None,
@@ -29,15 +29,22 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 "style" => Some(Ok(config.style)),
                 _ => None,
             })
-            .map(|variable| match variable {
-                "version" => format_julia_version(
-                    &context.exec_cmd("julia", &["--version"])?.stdout.as_str(),
-                )
-                .map(Ok),
-                _ => None,
+            .async_map(|variable| async move {
+                match variable.as_ref() {
+                    "version" => format_julia_version(
+                        &context
+                            .async_exec_cmd("julia", &["--version"])
+                            .await?
+                            .stdout,
+                    )
+                    .map(Ok),
+                    _ => None,
+                }
             })
-            .parse(None)
-    });
+            .await
+            .parse(None),
+        Err(e) => Err(e),
+    };
 
     module.set_segments(match parsed {
         Ok(segments) => segments,

--- a/src/modules/kotlin.rs
+++ b/src/modules/kotlin.rs
@@ -63,7 +63,7 @@ pub async fn module<'a>(context: &'a Context<'a>) -> Option<Module<'a>> {
 }
 
 async fn get_kotlin_version(context: &Context<'_>, kotlin_binary: &str) -> Option<String> {
-    let output = context.async_exec_cmd(kotlin_binary, &["-version"]).await?;
+    let output = context.exec_cmd(kotlin_binary, &["-version"]).await?;
     if output.stdout.is_empty() {
         Some(output.stderr)
     } else {

--- a/src/modules/kubernetes.rs
+++ b/src/modules/kubernetes.rs
@@ -11,7 +11,7 @@ use crate::formatter::StringFormatter;
 use crate::utils;
 
 async fn get_kube_context(filename: path::PathBuf) -> Option<String> {
-    let contents = utils::async_read_file(filename).await.ok()?;
+    let contents = utils::read_file(filename).await.ok()?;
 
     let yaml_docs = YamlLoader::load_from_str(&contents).ok()?;
     if yaml_docs.is_empty() {
@@ -28,7 +28,7 @@ async fn get_kube_context(filename: path::PathBuf) -> Option<String> {
 }
 
 async fn get_kube_ns(filename: path::PathBuf, current_ctx: String) -> Option<String> {
-    let contents = utils::async_read_file(filename).await.ok()?;
+    let contents = utils::read_file(filename).await.ok()?;
 
     let yaml_docs = YamlLoader::load_from_str(&contents).ok()?;
     if yaml_docs.is_empty() {

--- a/src/modules/lua.rs
+++ b/src/modules/lua.rs
@@ -63,7 +63,7 @@ pub async fn module<'a>(context: &'a Context<'a>) -> Option<Module<'a>> {
 }
 
 async fn get_lua_version(context: &Context<'_>, lua_binary: &str) -> Option<String> {
-    let output = context.async_exec_cmd(lua_binary, &["-v"]).await?;
+    let output = context.exec_cmd(lua_binary, &["-v"]).await?;
     if output.stdout.is_empty() {
         Some(output.stderr)
     } else {

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -108,7 +108,7 @@ pub async fn handle<'a>(
             "memory_usage" => memory_usage::module(context),
             "nim" => nim::module(context),
             "nix_shell" => nix_shell::module(context),
-            "nodejs" => nodejs::module(context),
+            "nodejs" => nodejs::module(context).await,
             "ocaml" => ocaml::module(context),
             "openstack" => openstack::module(context),
             "package" => package::module(context),

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -89,7 +89,7 @@ pub async fn handle<'a>(module: &str, context: &'a Context<'a>) -> Option<Module
             "git_branch" => git_branch::module(context),
             "git_commit" => git_commit::module(context),
             "git_state" => git_state::module(context),
-            "git_status" => git_status::module(context),
+            "git_status" => git_status::module(context).await,
             "golang" => golang::module(context),
             "helm" => helm::module(context),
             "hg_branch" => hg_branch::module(context),

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -128,7 +128,7 @@ pub async fn handle<'a>(
             "crystal" => crystal::module(context).await,
             "username" => username::module(context),
             "vagrant" => vagrant::module(context).await,
-            "zig" => zig::module(context),
+            "zig" => zig::module(context).await,
             _ => {
                 eprintln!("Error: Unknown module {}. Use starship module --list to list out all supported modules.", module);
                 None

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -83,7 +83,7 @@ pub async fn handle<'a>(
             "conda" => conda::module(context),
             "dart" => dart::module(context),
             "directory" => directory::module(context),
-            "docker_context" => docker_context::module(context),
+            "docker_context" => docker_context::module(context).await,
             "dotnet" => dotnet::module(context),
             "elixir" => elixir::module(context).await,
             "elm" => elm::module(context),

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -121,7 +121,7 @@ pub async fn handle<'a>(
             "shell" => shell::module(context),
             "shlvl" => shlvl::module(context),
             "singularity" => singularity::module(context),
-            "swift" => swift::module(context),
+            "swift" => swift::module(context).await,
             "status" => status::module(context),
             "terraform" => terraform::module(context).await,
             "time" => time::module(context),

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -87,7 +87,7 @@ pub async fn handle<'a>(
             "dotnet" => dotnet::module(context).await,
             "elixir" => elixir::module(context).await,
             "elm" => elm::module(context),
-            "erlang" => erlang::module(context),
+            "erlang" => erlang::module(context).await,
             "env_var" => env_var::module(context),
             "gcloud" => gcloud::module(context),
             "git_branch" => git_branch::module(context),

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -123,7 +123,7 @@ pub async fn handle<'a>(
             "singularity" => singularity::module(context),
             "swift" => swift::module(context),
             "status" => status::module(context),
-            "terraform" => terraform::module(context),
+            "terraform" => terraform::module(context).await,
             "time" => time::module(context),
             "crystal" => crystal::module(context).await,
             "username" => username::module(context),

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -104,7 +104,7 @@ pub async fn handle<'a>(
             "kotlin" => kotlin::module(context).await,
             "kubernetes" => kubernetes::module(context),
             "line_break" => line_break::module(context),
-            "lua" => lua::module(context),
+            "lua" => lua::module(context).await,
             "memory_usage" => memory_usage::module(context),
             "nim" => nim::module(context).await,
             "nix_shell" => nix_shell::module(context),

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -110,7 +110,7 @@ pub async fn handle<'a>(
             "nix_shell" => nix_shell::module(context),
             "nodejs" => nodejs::module(context).await,
             "ocaml" => ocaml::module(context),
-            "openstack" => openstack::module(context),
+            "openstack" => openstack::module(context).await,
             "package" => package::module(context).await,
             "perl" => perl::module(context),
             "php" => php::module(context),

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -106,7 +106,7 @@ pub async fn handle<'a>(
             "line_break" => line_break::module(context),
             "lua" => lua::module(context),
             "memory_usage" => memory_usage::module(context),
-            "nim" => nim::module(context),
+            "nim" => nim::module(context).await,
             "nix_shell" => nix_shell::module(context),
             "nodejs" => nodejs::module(context).await,
             "ocaml" => ocaml::module(context),

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -98,7 +98,7 @@ pub async fn handle<'a>(
             "helm" => helm::module(context),
             "hg_branch" => hg_branch::module(context),
             "hostname" => hostname::module(context),
-            "java" => java::module(context),
+            "java" => java::module(context).await,
             "jobs" => jobs::module(context),
             "julia" => julia::module(context),
             "kotlin" => kotlin::module(context),

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -85,7 +85,7 @@ pub async fn handle<'a>(
             "directory" => directory::module(context),
             "docker_context" => docker_context::module(context),
             "dotnet" => dotnet::module(context),
-            "elixir" => elixir::module(context),
+            "elixir" => elixir::module(context).await,
             "elm" => elm::module(context),
             "erlang" => erlang::module(context),
             "env_var" => env_var::module(context),

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -111,7 +111,7 @@ pub async fn handle<'a>(
             "nodejs" => nodejs::module(context).await,
             "ocaml" => ocaml::module(context),
             "openstack" => openstack::module(context),
-            "package" => package::module(context),
+            "package" => package::module(context).await,
             "perl" => perl::module(context),
             "php" => php::module(context),
             "purescript" => purescript::module(context),

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -116,7 +116,7 @@ pub async fn handle<'a>(
             "php" => php::module(context),
             "purescript" => purescript::module(context).await,
             "python" => python::module(context).await,
-            "ruby" => ruby::module(context),
+            "ruby" => ruby::module(context).await,
             "rust" => rust::module(context).await,
             "shell" => shell::module(context),
             "shlvl" => shlvl::module(context),

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -102,7 +102,7 @@ pub async fn handle<'a>(
             "jobs" => jobs::module(context),
             "julia" => julia::module(context).await,
             "kotlin" => kotlin::module(context).await,
-            "kubernetes" => kubernetes::module(context),
+            "kubernetes" => kubernetes::module(context).await,
             "line_break" => line_break::module(context),
             "lua" => lua::module(context).await,
             "memory_usage" => memory_usage::module(context),

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -78,7 +78,7 @@ pub async fn handle<'a>(
             #[cfg(feature = "battery")]
             "battery" => battery::module(context),
             "character" => character::module(context),
-            "cmake" => cmake::module(context),
+            "cmake" => cmake::module(context).await,
             "cmd_duration" => cmd_duration::module(context),
             "conda" => conda::module(context),
             "dart" => dart::module(context),

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -114,7 +114,7 @@ pub async fn handle<'a>(
             "package" => package::module(context).await,
             "perl" => perl::module(context),
             "php" => php::module(context),
-            "purescript" => purescript::module(context),
+            "purescript" => purescript::module(context).await,
             "python" => python::module(context).await,
             "ruby" => ruby::module(context),
             "rust" => rust::module(context).await,

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -101,7 +101,7 @@ pub async fn handle<'a>(
             "java" => java::module(context).await,
             "jobs" => jobs::module(context),
             "julia" => julia::module(context).await,
-            "kotlin" => kotlin::module(context),
+            "kotlin" => kotlin::module(context).await,
             "kubernetes" => kubernetes::module(context),
             "line_break" => line_break::module(context),
             "lua" => lua::module(context),

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -109,7 +109,7 @@ pub async fn handle<'a>(
             "nim" => nim::module(context).await,
             "nix_shell" => nix_shell::module(context),
             "nodejs" => nodejs::module(context).await,
-            "ocaml" => ocaml::module(context),
+            "ocaml" => ocaml::module(context).await,
             "openstack" => openstack::module(context).await,
             "package" => package::module(context).await,
             "perl" => perl::module(context).await,

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -94,7 +94,7 @@ pub async fn handle<'a>(
             "git_commit" => git_commit::module(context),
             "git_state" => git_state::module(context),
             "git_status" => git_status::module(context).await,
-            "golang" => golang::module(context),
+            "golang" => golang::module(context).await,
             "helm" => helm::module(context),
             "hg_branch" => hg_branch::module(context),
             "hostname" => hostname::module(context),

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -115,7 +115,7 @@ pub async fn handle<'a>(
             "perl" => perl::module(context),
             "php" => php::module(context),
             "purescript" => purescript::module(context),
-            "python" => python::module(context),
+            "python" => python::module(context).await,
             "ruby" => ruby::module(context),
             "rust" => rust::module(context).await,
             "shell" => shell::module(context),

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -63,7 +63,7 @@ use crate::context::{Context, Shell};
 use crate::module::Module;
 use std::time::Instant;
 
-pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
+pub async fn handle<'a>(module: &str, context: &'a Context<'a>) -> Option<Module<'a>> {
     let start: Instant = Instant::now();
 
     let mut m: Option<Module> = {

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -112,7 +112,7 @@ pub async fn handle<'a>(
             "ocaml" => ocaml::module(context),
             "openstack" => openstack::module(context).await,
             "package" => package::module(context).await,
-            "perl" => perl::module(context),
+            "perl" => perl::module(context).await,
             "php" => php::module(context),
             "purescript" => purescript::module(context).await,
             "python" => python::module(context).await,

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -95,7 +95,7 @@ pub async fn handle<'a>(
             "git_state" => git_state::module(context),
             "git_status" => git_status::module(context).await,
             "golang" => golang::module(context).await,
-            "helm" => helm::module(context),
+            "helm" => helm::module(context).await,
             "hg_branch" => hg_branch::module(context),
             "hostname" => hostname::module(context),
             "java" => java::module(context).await,

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -81,7 +81,7 @@ pub async fn handle<'a>(
             "cmake" => cmake::module(context).await,
             "cmd_duration" => cmd_duration::module(context),
             "conda" => conda::module(context),
-            "dart" => dart::module(context),
+            "dart" => dart::module(context).await,
             "directory" => directory::module(context),
             "docker_context" => docker_context::module(context).await,
             "dotnet" => dotnet::module(context).await,

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -100,7 +100,7 @@ pub async fn handle<'a>(
             "hostname" => hostname::module(context),
             "java" => java::module(context).await,
             "jobs" => jobs::module(context),
-            "julia" => julia::module(context),
+            "julia" => julia::module(context).await,
             "kotlin" => kotlin::module(context),
             "kubernetes" => kubernetes::module(context),
             "line_break" => line_break::module(context),

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -86,7 +86,7 @@ pub async fn handle<'a>(
             "docker_context" => docker_context::module(context).await,
             "dotnet" => dotnet::module(context).await,
             "elixir" => elixir::module(context).await,
-            "elm" => elm::module(context),
+            "elm" => elm::module(context).await,
             "erlang" => erlang::module(context).await,
             "env_var" => env_var::module(context),
             "gcloud" => gcloud::module(context),

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -84,7 +84,7 @@ pub async fn handle<'a>(
             "dart" => dart::module(context),
             "directory" => directory::module(context),
             "docker_context" => docker_context::module(context).await,
-            "dotnet" => dotnet::module(context),
+            "dotnet" => dotnet::module(context).await,
             "elixir" => elixir::module(context).await,
             "elm" => elm::module(context),
             "erlang" => erlang::module(context),

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -113,7 +113,7 @@ pub async fn handle<'a>(
             "openstack" => openstack::module(context).await,
             "package" => package::module(context).await,
             "perl" => perl::module(context).await,
-            "php" => php::module(context),
+            "php" => php::module(context).await,
             "purescript" => purescript::module(context).await,
             "python" => python::module(context).await,
             "ruby" => ruby::module(context).await,

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -127,7 +127,7 @@ pub async fn handle<'a>(
             "time" => time::module(context),
             "crystal" => crystal::module(context).await,
             "username" => username::module(context),
-            "vagrant" => vagrant::module(context),
+            "vagrant" => vagrant::module(context).await,
             "zig" => zig::module(context),
             _ => {
                 eprintln!("Error: Unknown module {}. Use starship module --list to list out all supported modules.", module);

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -125,7 +125,7 @@ pub async fn handle<'a>(
             "status" => status::module(context),
             "terraform" => terraform::module(context),
             "time" => time::module(context),
-            "crystal" => crystal::module(context),
+            "crystal" => crystal::module(context).await,
             "username" => username::module(context),
             "vagrant" => vagrant::module(context),
             "zig" => zig::module(context),

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -113,7 +113,7 @@ pub async fn handle<'a>(module: &str, context: &'a Context<'a>) -> Option<Module
             "purescript" => purescript::module(context),
             "python" => python::module(context),
             "ruby" => ruby::module(context),
-            "rust" => rust::module(context),
+            "rust" => rust::module(context).await,
             "shell" => shell::module(context),
             "shlvl" => shlvl::module(context),
             "singularity" => singularity::module(context),

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -74,7 +74,7 @@ pub async fn handle<'a>(
         match module {
             // Keep these ordered alphabetically.
             // Default ordering is handled in configs/starship_root.rs
-            "aws" => aws::module(context),
+            "aws" => aws::module(context).await,
             #[cfg(feature = "battery")]
             "battery" => battery::module(context),
             "character" => character::module(context),

--- a/src/modules/nim.rs
+++ b/src/modules/nim.rs
@@ -31,7 +31,7 @@ pub async fn module<'a>(context: &'a Context<'a>) -> Option<Module<'a>> {
             .async_map(|variable| async move {
                 match variable.as_ref() {
                     "version" => context
-                        .async_exec_cmd("nim", &["--version"])
+                        .exec_cmd("nim", &["--version"])
                         .await
                         .map(|command_output| command_output.stdout)
                         .and_then(|nim_version_output| {

--- a/src/modules/nodejs.rs
+++ b/src/modules/nodejs.rs
@@ -33,7 +33,7 @@ pub async fn module<'a>(context: &'a Context<'a>) -> Option<Module<'a>> {
 
     let nodejs_version = async {
         context
-            .async_exec_cmd("node", &["--version"])
+            .exec_cmd("node", &["--version"])
             .await
             .map(|cmd| cmd.stdout)
     }

--- a/src/modules/nodejs.rs
+++ b/src/modules/nodejs.rs
@@ -99,9 +99,7 @@ pub async fn module<'a>(context: &'a Context<'a>) -> Option<Module<'a>> {
 }
 
 async fn get_engines_version(base_dir: &Path) -> Option<String> {
-    let json_str = utils::async_read_file(base_dir.join("package.json"))
-        .await
-        .ok()?;
+    let json_str = utils::read_file(base_dir.join("package.json")).await.ok()?;
     let package_json: json::Value = json::from_str(&json_str).ok()?;
     let raw_version = package_json.get("engines")?.get("node")?.as_str()?;
     Some(raw_version.to_string())

--- a/src/modules/ocaml.rs
+++ b/src/modules/ocaml.rs
@@ -37,12 +37,9 @@ pub async fn module<'a>(context: &'a Context<'a>) -> Option<Module<'a>> {
                             .is_match();
 
                         let ocaml_version = if is_esy_project {
-                            context
-                                .async_exec_cmd("esy", &["ocaml", "-vnum"])
-                                .await?
-                                .stdout
+                            context.exec_cmd("esy", &["ocaml", "-vnum"]).await?.stdout
                         } else {
-                            context.async_exec_cmd("ocaml", &["-vnum"]).await?.stdout
+                            context.exec_cmd("ocaml", &["-vnum"]).await?.stdout
                         };
                         Some(Ok(format!("v{}", &ocaml_version.trim())))
                     }

--- a/src/modules/openstack.rs
+++ b/src/modules/openstack.rs
@@ -32,7 +32,7 @@ async fn get_osp_project_from_config(context: &Context<'_>, osp_cloud: &str) -> 
 }
 
 async fn get_osp_project_from_file(file: Option<&str>, osp_cloud: &str) -> Option<Project> {
-    let config = utils::async_read_file(file?).await.ok()?;
+    let config = utils::read_file(file?).await.ok()?;
     let clouds = YamlLoader::load_from_str(config.as_str()).ok()?;
     let s = clouds.get(0)?["clouds"][osp_cloud]["auth"]["project_name"].as_str()?;
     if !s.is_empty() {

--- a/src/modules/package.rs
+++ b/src/modules/package.rs
@@ -174,7 +174,7 @@ fn extract_meson_version(file_contents: &str) -> Option<String> {
 }
 
 async fn get_package_version<'a>(base_dir: &Path, config: &'a PackageConfig<'a>) -> Option<String> {
-    use utils::async_read_file as load;
+    use utils::read_file as load;
 
     if let Ok(cargo_toml) = load(base_dir.join("Cargo.toml")).await {
         extract_cargo_version(&cargo_toml)

--- a/src/modules/perl.rs
+++ b/src/modules/perl.rs
@@ -32,7 +32,7 @@ pub async fn module<'a>(context: &'a Context<'a>) -> Option<Module<'a>> {
                 match variable.as_ref() {
                     "version" => {
                         let perl_version = context
-                            .async_exec_cmd("perl", &["-e", "printf q#%vd#,$^V;"])
+                            .exec_cmd("perl", &["-e", "printf q#%vd#,$^V;"])
                             .await?
                             .stdout;
                         Some(Ok(format!("v{}", perl_version)))

--- a/src/modules/php.rs
+++ b/src/modules/php.rs
@@ -31,7 +31,7 @@ pub async fn module<'a>(context: &'a Context<'a>) -> Option<Module<'a>> {
             .async_map(|variable| async move {
                 match variable.as_ref() {
                     "version" => {
-                        let php_cmd_output = context.async_exec_cmd(
+                        let php_cmd_output = context.exec_cmd(
                             "php",
                             &[
                                 "-nr",

--- a/src/modules/purescript.rs
+++ b/src/modules/purescript.rs
@@ -31,8 +31,7 @@ pub async fn module<'a>(context: &'a Context<'a>) -> Option<Module<'a>> {
             .async_map(|variable| async move {
                 match variable.as_ref() {
                     "version" => {
-                        let purs_version =
-                            context.async_exec_cmd("purs", &["--version"]).await?.stdout;
+                        let purs_version = context.exec_cmd("purs", &["--version"]).await?.stdout;
                         Some(Ok(format!("v{}", purs_version.trim())))
                     }
                     _ => None,

--- a/src/modules/python.rs
+++ b/src/modules/python.rs
@@ -1,12 +1,12 @@
 use ini::Ini;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use super::{Context, Module, RootModuleConfig};
 use crate::configs::python::PythonConfig;
 use crate::formatter::StringFormatter;
 
 /// Creates a module with the current Python version and, if active, virtual environment.
-pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+pub async fn module<'a>(context: &'a Context<'a>) -> Option<Module<'a>> {
     let mut module = context.new_module("python");
     let config: PythonConfig = PythonConfig::try_load(module.config);
 
@@ -29,8 +29,8 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         ""
     };
 
-    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
-        formatter
+    let parsed = match StringFormatter::new(config.format) {
+        Ok(formatter) => formatter
             .map_meta(|var, _| match var {
                 "symbol" => Some(config.symbol),
                 _ => None,
@@ -39,20 +39,27 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 "style" => Some(Ok(config.style)),
                 _ => None,
             })
-            .map(|variable| match variable {
-                "version" => {
-                    let version = get_python_version(context, &config)?;
-                    Some(Ok(version.trim().to_string()))
+            .async_map(|variable| {
+                let config = &config;
+                async move {
+                    match variable.as_ref() {
+                        "version" => {
+                            let version = get_python_version(context, &config).await?;
+                            Some(Ok(version.trim().to_string()))
+                        }
+                        "virtualenv" => {
+                            let virtual_env = get_python_virtual_env(context).await;
+                            virtual_env.as_ref().map(|e| Ok(e.trim().to_string()))
+                        }
+                        "pyenv_prefix" => Some(Ok(pyenv_prefix.to_string())),
+                        _ => None,
+                    }
                 }
-                "virtualenv" => {
-                    let virtual_env = get_python_virtual_env(context);
-                    virtual_env.as_ref().map(|e| Ok(e.trim().to_string()))
-                }
-                "pyenv_prefix" => Some(Ok(pyenv_prefix.to_string())),
-                _ => None,
             })
-            .parse(None)
-    });
+            .await
+            .parse(None),
+        Err(e) => Err(e),
+    };
 
     module.set_segments(match parsed {
         Ok(segments) => segments,
@@ -65,23 +72,31 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     Some(module)
 }
 
-fn get_python_version(context: &Context, config: &PythonConfig) -> Option<String> {
+async fn get_python_version<'a>(
+    context: &'a Context<'a>,
+    config: &'a PythonConfig<'a>,
+) -> Option<String> {
     if config.pyenv_version_name {
-        return Some(context.exec_cmd("pyenv", &["version-name"])?.stdout);
+        return Some(
+            context
+                .async_exec_cmd("pyenv", &["version-name"])
+                .await?
+                .stdout,
+        );
     };
-    let version = config.python_binary.0.iter().find_map(|binary| {
-        match context.exec_cmd(binary, &["--version"]) {
-            Some(output) => {
-                if output.stdout.is_empty() {
-                    Some(output.stderr)
-                } else {
-                    Some(output.stdout)
-                }
-            }
-            None => None,
+
+    for binary in &config.python_binary.0 {
+        if let Some(output) = context.async_exec_cmd(binary, &["--version"]).await {
+            let version = if output.stdout.is_empty() {
+                output.stderr
+            } else {
+                output.stdout
+            };
+            return Some(format_python_version(&version));
         }
-    })?;
-    Some(format_python_version(&version))
+    }
+
+    None
 }
 
 fn format_python_version(python_stdout: &str) -> String {
@@ -94,21 +109,29 @@ fn format_python_version(python_stdout: &str) -> String {
     )
 }
 
-fn get_python_virtual_env(context: &Context) -> Option<String> {
-    context.get_env("VIRTUAL_ENV").and_then(|venv| {
-        get_prompt_from_venv(Path::new(&venv)).or_else(|| {
-            Path::new(&venv)
-                .file_name()
-                .map(|filename| String::from(filename.to_str().unwrap_or("")))
-        })
+async fn get_python_virtual_env<'a>(context: &'a Context<'a>) -> Option<String> {
+    let venv = context.get_env("VIRTUAL_ENV")?;
+
+    let venv_path = PathBuf::from(venv);
+
+    get_prompt_from_venv(&venv_path).await.or_else(|| {
+        venv_path
+            .file_name()
+            .map(|filename| String::from(filename.to_str().unwrap_or("")))
     })
 }
-fn get_prompt_from_venv(venv_path: &Path) -> Option<String> {
-    Ini::load_from_file(venv_path.join("pyvenv.cfg"))
-        .ok()?
-        .general_section()
-        .get("prompt")
-        .map(String::from)
+
+async fn get_prompt_from_venv(venv_path: &Path) -> Option<String> {
+    // spawning and waiting since Ini does not support async
+    let venv_path = venv_path.to_owned();
+    async_std::task::spawn(async move {
+        Ini::load_from_file(venv_path.join("pyvenv.cfg"))
+            .ok()?
+            .general_section()
+            .get("prompt")
+            .map(String::from)
+    })
+    .await
 }
 
 #[cfg(test)]

--- a/src/modules/python.rs
+++ b/src/modules/python.rs
@@ -77,16 +77,11 @@ async fn get_python_version<'a>(
     config: &'a PythonConfig<'a>,
 ) -> Option<String> {
     if config.pyenv_version_name {
-        return Some(
-            context
-                .async_exec_cmd("pyenv", &["version-name"])
-                .await?
-                .stdout,
-        );
+        return Some(context.exec_cmd("pyenv", &["version-name"]).await?.stdout);
     };
 
     for binary in &config.python_binary.0 {
-        if let Some(output) = context.async_exec_cmd(binary, &["--version"]).await {
+        if let Some(output) = context.exec_cmd(binary, &["--version"]).await {
             let version = if output.stdout.is_empty() {
                 output.stderr
             } else {

--- a/src/modules/ruby.rs
+++ b/src/modules/ruby.rs
@@ -36,7 +36,7 @@ pub async fn module<'a>(context: &'a Context<'a>) -> Option<Module<'a>> {
             .async_map(|variable| async move {
                 match variable.as_ref() {
                     "version" => {
-                        format_ruby_version(&context.async_exec_cmd("ruby", &["-v"]).await?.stdout)
+                        format_ruby_version(&context.exec_cmd("ruby", &["-v"]).await?.stdout)
                             .map(Ok)
                     }
                     _ => None,

--- a/src/modules/rust.rs
+++ b/src/modules/rust.rs
@@ -114,7 +114,7 @@ fn env_rustup_toolchain(context: &Context) -> Option<String> {
 
 async fn execute_rustup_override_list(context: &Context<'_>) -> Option<String> {
     let stdout = context
-        .async_exec_cmd("rustup", &["override", "list"])
+        .exec_cmd("rustup", &["override", "list"])
         .await?
         .stdout;
     extract_toolchain_from_rustup_override_list(&stdout, &context.current_dir)
@@ -215,7 +215,7 @@ fn extract_toolchain_from_rustup_run_rustc_version(
 
 async fn execute_rustc_version(context: &Context<'_>) -> Option<String> {
     context
-        .async_exec_cmd("rustc", &["--version"])
+        .exec_cmd("rustc", &["--version"])
         .await
         .map(|output| output.stdout)
 }

--- a/src/modules/swift.rs
+++ b/src/modules/swift.rs
@@ -32,10 +32,7 @@ pub async fn module<'a>(context: &'a Context<'a>) -> Option<Module<'a>> {
             .async_map(|variable| async move {
                 match variable.as_ref() {
                     "version" => {
-                        let swift_version = context
-                            .async_exec_cmd("swift", &["--version"])
-                            .await?
-                            .stdout;
+                        let swift_version = context.exec_cmd("swift", &["--version"]).await?.stdout;
                         parse_swift_version(&swift_version).map(Ok)
                     }
                     _ => None,

--- a/src/modules/terraform.rs
+++ b/src/modules/terraform.rs
@@ -36,10 +36,7 @@ pub async fn module<'a>(context: &'a Context<'a>) -> Option<Module<'a>> {
             .async_map(|variable| async move {
                 match variable.as_ref() {
                     "version" => format_terraform_version(
-                        &context
-                            .async_exec_cmd("terraform", &["version"])
-                            .await?
-                            .stdout,
+                        &context.exec_cmd("terraform", &["version"]).await?.stdout,
                     )
                     .map(Ok),
                     "workspace" => get_terraform_workspace(context).await.map(Ok),

--- a/src/modules/terraform.rs
+++ b/src/modules/terraform.rs
@@ -72,7 +72,7 @@ async fn get_terraform_workspace(context: &Context<'_>) -> Option<String> {
         Some(s) => PathBuf::from(s),
         None => context.current_dir.join(".terraform"),
     };
-    match utils::async_read_file(datadir.join("environment")).await {
+    match utils::read_file(datadir.join("environment")).await {
         Err(ref e) if e.kind() == io::ErrorKind::NotFound => Some("default".to_string()),
         Ok(s) => Some(s),
         _ => None,

--- a/src/modules/vagrant.rs
+++ b/src/modules/vagrant.rs
@@ -4,10 +4,9 @@ use crate::configs::vagrant::VagrantConfig;
 use crate::formatter::StringFormatter;
 
 /// Creates a module with the current Vagrant version
-pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+pub async fn module<'a>(context: &'a Context<'a>) -> Option<Module<'a>> {
     let mut module = context.new_module("vagrant");
     let config = VagrantConfig::try_load(module.config);
-
     let is_vagrant_project = context
         .try_begin_scan()?
         .set_files(&config.detect_files)
@@ -19,8 +18,8 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         return None;
     }
 
-    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
-        formatter
+    let parsed = match StringFormatter::new(config.format) {
+        Ok(formatter) => formatter
             .map_meta(|var, _| match var {
                 "symbol" => Some(config.symbol),
                 _ => None,
@@ -29,15 +28,22 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 "style" => Some(Ok(config.style)),
                 _ => None,
             })
-            .map(|variable| match variable {
-                "version" => format_vagrant_version(
-                    &context.exec_cmd("vagrant", &["--version"])?.stdout.as_str(),
-                )
-                .map(Ok),
-                _ => None,
+            .async_map(|variable| async move {
+                match variable.as_ref() {
+                    "version" => format_vagrant_version(
+                        &context
+                            .async_exec_cmd("vagrant", &["--version"])
+                            .await?
+                            .stdout,
+                    )
+                    .map(Ok),
+                    _ => None,
+                }
             })
-            .parse(None)
-    });
+            .await
+            .parse(None),
+        Err(e) => Err(e),
+    };
 
     module.set_segments(match parsed {
         Ok(segments) => segments,

--- a/src/modules/vagrant.rs
+++ b/src/modules/vagrant.rs
@@ -31,10 +31,7 @@ pub async fn module<'a>(context: &'a Context<'a>) -> Option<Module<'a>> {
             .async_map(|variable| async move {
                 match variable.as_ref() {
                     "version" => format_vagrant_version(
-                        &context
-                            .async_exec_cmd("vagrant", &["--version"])
-                            .await?
-                            .stdout,
+                        &context.exec_cmd("vagrant", &["--version"]).await?.stdout,
                     )
                     .map(Ok),
                     _ => None,

--- a/src/modules/zig.rs
+++ b/src/modules/zig.rs
@@ -33,7 +33,7 @@ pub async fn module<'a>(context: &'a Context<'a>) -> Option<Module<'a>> {
                 match variable.as_ref() {
                     "version" => {
                         let zig_version_output =
-                            context.async_exec_cmd("zig", &["version"]).await?.stdout;
+                            context.exec_cmd("zig", &["version"]).await?.stdout;
                         let zig_version = format!("v{}", zig_version_output.trim());
                         Some(Ok(zig_version))
                     }

--- a/src/modules/zig.rs
+++ b/src/modules/zig.rs
@@ -4,7 +4,7 @@ use crate::configs::zig::ZigConfig;
 use crate::formatter::StringFormatter;
 
 /// Creates a module with the current Zig version
-pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+pub async fn module<'a>(context: &'a Context<'a>) -> Option<Module<'a>> {
     let mut module = context.new_module("zig");
     let config = ZigConfig::try_load(module.config);
 
@@ -19,8 +19,8 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         return None;
     }
 
-    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
-        formatter
+    let parsed = match StringFormatter::new(config.format) {
+        Ok(formatter) => formatter
             .map_meta(|variable, _| match variable {
                 "symbol" => Some(config.symbol),
                 _ => None,
@@ -29,16 +29,21 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 "style" => Some(Ok(config.style)),
                 _ => None,
             })
-            .map(|variable| match variable {
-                "version" => {
-                    let zig_version_output = context.exec_cmd("zig", &["version"])?.stdout;
-                    let zig_version = format!("v{}", zig_version_output.trim());
-                    Some(Ok(zig_version))
+            .async_map(|variable| async move {
+                match variable.as_ref() {
+                    "version" => {
+                        let zig_version_output =
+                            context.async_exec_cmd("zig", &["version"]).await?.stdout;
+                        let zig_version = format!("v{}", zig_version_output.trim());
+                        Some(Ok(zig_version))
+                    }
+                    _ => None,
                 }
-                _ => None,
             })
-            .parse(None)
-    });
+            .await
+            .parse(None),
+        Err(e) => Err(e),
+    };
 
     module.set_segments(match parsed {
         Ok(segments) => segments,

--- a/src/print.rs
+++ b/src/print.rs
@@ -1,6 +1,5 @@
 use ansi_term::ANSIStrings;
 use clap::ArgMatches;
-use rayon::prelude::*;
 use std::collections::BTreeSet;
 use std::fmt::{self, Debug, Write as FmtWrite};
 use std::io::{self, Write};
@@ -54,7 +53,7 @@ pub fn get_prompt(context: Context) -> String {
         // Make $all display all modules
         if module == "all" {
             Some(Ok(PROMPT_ORDER
-                .par_iter()
+                .iter()
                 .flat_map(|module| {
                     handle_module(module, &context, &modules)
                         .into_iter()

--- a/src/print.rs
+++ b/src/print.rs
@@ -342,20 +342,17 @@ async fn handle_module<'a>(
     } else if module == "custom" {
         // Write out all custom modules, except for those that are explicitly set
         if let Some(custom_modules) = context.config.get_custom_modules() {
-            let custom_modules = custom_modules.iter().filter_map(|(custom_module, config)| {
+            for (custom_module, config) in custom_modules {
                 if should_add_implicit_custom_module(custom_module, config, &module_list) {
-                    modules::custom::module(custom_module, &context)
-                } else {
-                    None
+                    modules.extend(modules::custom::module(custom_module, &context).await);
                 }
-            });
-            modules.extend(custom_modules);
+            }
         }
     } else if let Some(module) = module.strip_prefix("custom.") {
         // Write out a custom module if it isn't disabled (and it exists...)
         match context.is_custom_module_disabled_in_config(&module) {
             Some(true) => (), // Module is disabled, we don't add it to the prompt
-            Some(false) => modules.extend(modules::custom::module(&module, &context)),
+            Some(false) => modules.extend(modules::custom::module(&module, &context).await),
             None => match context.config.get_custom_modules() {
                 Some(modules) => log::debug!(
                     "top level format contains custom module \"{}\", but no configuration was provided. Configuration for the following modules were provided: {:?}",

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -19,6 +19,11 @@ pub fn read_file<P: AsRef<Path>>(file_name: P) -> Result<String> {
     Ok(data)
 }
 
+#[inline(always)]
+pub async fn async_read_file<P: AsRef<Path>>(file_name: P) -> Result<String> {
+    async_std::fs::read_to_string(file_name.as_ref()).await
+}
+
 #[derive(Debug, Clone)]
 pub struct CommandOutput {
     pub stdout: String,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,26 +1,17 @@
 use async_process::{Command, Stdio};
 use async_std::io::prelude::WriteExt;
 use futures::stream::{self, Stream, StreamExt};
-use std::fs::File;
 use std::future::Future;
-use std::io::{Read, Result};
+use std::io::Result;
 use std::path::Path;
 use std::process::ExitStatus;
 use std::time::Instant;
 
 use crate::context::Shell;
 
-/// Return the string contents of a file
-pub fn read_file<P: AsRef<Path>>(file_name: P) -> Result<String> {
-    let mut file = File::open(file_name)?;
-    let mut data = String::new();
-
-    file.read_to_string(&mut data)?;
-    Ok(data)
-}
-
 #[inline(always)]
-pub async fn async_read_file<P: AsRef<Path>>(file_name: P) -> Result<String> {
+/// Return the string contents of a file
+pub async fn read_file<P: AsRef<Path>>(file_name: P) -> Result<String> {
     async_std::fs::read_to_string(file_name.as_ref()).await
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,6 @@
 use process_control::{ChildExt, Timeout};
 use std::fs::File;
+use std::future::Future;
 use std::io::{Read, Result};
 use std::path::Path;
 use std::process::{Command, Stdio};
@@ -333,6 +334,19 @@ fn internal_exec_cmd(cmd: &str, args: &[&str], time_limit: Duration) -> Option<C
             None
         }
     }
+}
+
+pub async fn parallel_map<I, F, U, T, Fut>(items: I, f: F) -> Vec<U>
+where
+    I: IntoIterator<Item = T>,
+    F: Fn(T) -> Fut,
+    Fut: Future<Output = U>,
+{
+    let mut v = vec![];
+    for x in items {
+        v.push(f(x).await);
+    }
+    v
 }
 
 #[cfg(test)]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
Currently, this will:
* replace rayon with async_std
* adds support for specifying a per-module "timeout" key in config
* adds support for specifying a global "prompt_timeout" key in config, used for all modules that don't have a "timeout" explicitly given
* changes all modules to execute subprocesses and file reads asynchronously, and library calls on a different future, so the timeouts work
* report an exceeded timeout value when running `timings`

A quick measurement shows no visible performance impact https://github.com/starship/starship/issues/312#issuecomment-767142122

Feedback welcome as to exactly how to deal with timeouts, and when they should be silent or not. The current version is geared for debugging, so it's immediately obvious which module is causing the prompt to hang.

#### Motivation and Context
Async allows pervasive and simple handling of timeouts for virtually any code. There are multiple open issues related to responsiveness, and this approach with allow timeout control with arbitrary granularity, while maintaining parallelism.

<!--- If it fixes an open issue, please link to the issue here. -->
Closes #312, #597, #891, #940, #1551
Will possibly close a few others once fully implemented.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
