### PR TITLE
build: add x86_64 freebsd build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -81,6 +81,10 @@ jobs:
             os: windows-latest
             name: starship-aarch64-pc-windows-msvc.zip
 
+          - target: x86_64-unknown-freebsd
+            os: ubuntu-latest
+            name: starship-x86_64-unknown-freebsd.tar.gz
+
     runs-on: ${{ matrix.os }}
     steps:
       - name: Setup | Checkout

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,2 @@
+[target.x86_64-unknown-freebsd]
+image = "docker.io/rustembedded/cross:x86_64-unknown-freebsd"

--- a/install/install.sh
+++ b/install/install.sh
@@ -37,7 +37,8 @@ SUPPORTED_TARGETS="x86_64-unknown-linux-gnu x86_64-unknown-linux-musl \
                   i686-unknown-linux-musl aarch64-unknown-linux-musl \
                   arm-unknown-linux-musleabihf x86_64-apple-darwin \
                   aarch64-apple-darwin x86_64-pc-windows-msvc \
-                  i686-pc-windows-msvc aarch64-pc-windows-msvc"
+                  i686-pc-windows-msvc aarch64-pc-windows-msvc \
+                  x86_64-unknown-freebsd"
 
 info() {
   printf "%s\n" "${BOLD}${GREY}>${NO_COLOR} $*"
@@ -172,6 +173,7 @@ install() {
 #   - darwin
 #   - linux
 #   - linux_musl (Alpine)
+#   - freebsd
 detect_platform() {
   local platform
   platform="$(uname -s | tr '[:upper:]' '[:lower:]')"
@@ -184,6 +186,7 @@ detect_platform() {
     # use the statically compiled musl bins on linux to avoid linking issues.
     linux) platform="unknown-linux-musl" ;;
     darwin) platform="apple-darwin" ;;
+    freebsd) platform="unknown-freebsd" ;;
   esac
 
   echo "${platform}"
@@ -197,6 +200,7 @@ detect_arch() {
   arch="$(uname -m | tr '[:upper:]' '[:lower:]')"
 
   case "${arch}" in
+    amd64) arch="x86_64" ;;
     armv*) arch="arm" ;;
     arm64) arch="aarch64" ;;
   esac


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
It looks like `cross` doesn't have the FreeBSD docker image whitelisted, which is why builds for FreeBSD in CI where failing and not using `cross`. This PR adds a `Cross.toml` file that points to the official `cross` FreeBSD image, adds the `x86_64-unknown-freebsd` target to `install.sh` and `deploy.yml` and adds support for FreeBSD in `detect_platform` and `detect-arch` in `install.sh`

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #828

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**
- [x] I have tested using **FreeBSD VM**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
