### PR TITLE
fix(python): Add a missing ' ' to the end of the python prompt

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2128,7 +2128,7 @@ By default the module will be shown if any of the following conditions are met:
 
 | Option               | Default                                                                                                      | Description                                                                            |
 | -------------------- | ------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- |
-| `format`             | `'via [${symbol}${pyenv_prefix}(${version} )(\($virtualenv\))]($style)'`                                     | The format for the module.                                                             |
+| `format`             | `'via [${symbol}${pyenv_prefix}(${version} )(\($virtualenv\) )]($style)'`                                    | The format for the module.                                                             |
 | `symbol`             | `"🐍 "`                                                                                                      | A format string representing the symbol of Python                                      |
 | `style`              | `"yellow bold"`                                                                                              | The style for the module.                                                              |
 | `pyenv_version_name` | `false`                                                                                                      | Use pyenv to get Python version                                                        |

--- a/src/configs/python.rs
+++ b/src/configs/python.rs
@@ -22,7 +22,7 @@ impl<'a> Default for PythonConfig<'a> {
             pyenv_version_name: false,
             pyenv_prefix: "pyenv ",
             python_binary: VecOr(vec!["python", "python3", "python2"]),
-            format: "via [${symbol}${pyenv_prefix}(${version} )(\\($virtualenv\\))]($style)",
+            format: "via [${symbol}${pyenv_prefix}(${version} )(\\($virtualenv\\) )]($style)",
             style: "yellow bold",
             symbol: "🐍 ",
             disabled: false,

--- a/src/modules/python.rs
+++ b/src/modules/python.rs
@@ -313,7 +313,7 @@ mod tests {
 
         let expected = Some(format!(
             "via {}",
-            Color::Yellow.bold().paint("🐍 v3.8.0 (my_venv)")
+            Color::Yellow.bold().paint("🐍 v3.8.0 (my_venv) ")
         ));
 
         assert_eq!(actual, expected);
@@ -331,7 +331,7 @@ mod tests {
 
         let expected = Some(format!(
             "via {}",
-            Color::Yellow.bold().paint("🐍 v3.8.0 (my_venv)")
+            Color::Yellow.bold().paint("🐍 v3.8.0 (my_venv) ")
         ));
 
         assert_eq!(actual, expected);
@@ -358,7 +358,7 @@ prompt = 'foo'
 
         let expected = Some(format!(
             "via {}",
-            Color::Yellow.bold().paint("🐍 v3.8.0 (foo)")
+            Color::Yellow.bold().paint("🐍 v3.8.0 (foo) ")
         ));
 
         assert_eq!(actual, expected);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description

After upgrading from 0.47 to 0.49 I noticed that there was a missing ' ' between
the python format section and the one that comes after that.

#### Motivation and Context
Fixes #2342

#### Screenshots (if appropriate):

```
# this is with 0.49 release
~/p/ideas on  master [$?] via ⬢ v15.3.0 via 🐍 v3.9.1 (python-3.9.1)via 💠 default on ☁️  me(pdx) on ☁️   8 🐟
❯ ../starship/target/debug/starship prompt

# this is with this patch
~/p/ideas on  master [$?] via ⬢ v15.3.0 via 🐍 v3.9.1 (python-3.9.1) via 💠 default on ☁️  me(pdx) on ☁️   8 🐟
❯ ⏎

```

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
