### PR TITLE
refactor: Changes to how String ownership is acquired in native types for faster compile times

### DIFF
--- a/src/bug_report.rs
+++ b/src/bug_report.rs
@@ -144,22 +144,22 @@ fn get_shell_info() -> ShellInfo {
     let shell = std::env::var("STARSHIP_SHELL");
     if shell.is_err() {
         return ShellInfo {
-            name: UNKNOWN_SHELL.to_string(),
-            version: UNKNOWN_VERSION.to_string(),
-            config: UNKNOWN_CONFIG.to_string(),
+            name: UNKNOWN_SHELL.to_owned(),
+            version: UNKNOWN_VERSION.to_owned(),
+            config: UNKNOWN_CONFIG.to_owned(),
         };
     }
 
     let shell = shell.unwrap();
 
     let version = exec_cmd(&shell, &["--version"])
-        .map(|output| output.stdout.trim().to_string())
-        .unwrap_or_else(|| UNKNOWN_VERSION.to_string());
+        .map(|output| output.stdout.trim().to_owned())
+        .unwrap_or_else(|| UNKNOWN_VERSION.to_owned());
 
     let config = get_config_path(&shell)
         .and_then(|config_path| fs::read_to_string(config_path).ok())
-        .map(|config| config.trim().to_string())
-        .unwrap_or_else(|| UNKNOWN_CONFIG.to_string());
+        .map(|config| config.trim().to_owned())
+        .unwrap_or_else(|| UNKNOWN_CONFIG.to_owned());
 
     ShellInfo {
         name: shell,
@@ -177,11 +177,11 @@ struct TerminalInfo {
 fn get_terminal_info() -> TerminalInfo {
     let terminal = std::env::var("TERM_PROGRAM")
         .or_else(|_| std::env::var("LC_TERMINAL"))
-        .unwrap_or_else(|_| UNKNOWN_TERMINAL.to_string());
+        .unwrap_or_else(|_| UNKNOWN_TERMINAL.to_owned());
 
     let version = std::env::var("TERM_PROGRAM_VERSION")
         .or_else(|_| std::env::var("LC_TERMINAL_VERSION"))
-        .unwrap_or_else(|_| UNKNOWN_VERSION.to_string());
+        .unwrap_or_else(|_| UNKNOWN_VERSION.to_owned());
 
     TerminalInfo {
         name: terminal,
@@ -220,7 +220,7 @@ fn get_starship_config() -> String {
             })
         })
         .and_then(|config_path| fs::read_to_string(config_path).ok())
-        .unwrap_or_else(|| UNKNOWN_CONFIG.to_string())
+        .unwrap_or_else(|| UNKNOWN_CONFIG.to_owned())
 }
 
 #[cfg(test)]
@@ -234,15 +234,15 @@ mod tests {
             os_type: os_info::Type::Linux,
             os_version: os_info::Version::Semantic(1, 2, 3),
             shell_info: ShellInfo {
-                name: "test_shell".to_string(),
-                version: "2.3.4".to_string(),
-                config: "No config".to_string(),
+                name: "test_shell".to_owned(),
+                version: "2.3.4".to_owned(),
+                config: "No config".to_owned(),
             },
             terminal_info: TerminalInfo {
-                name: "test_terminal".to_string(),
-                version: "5.6.7".to_string(),
+                name: "test_terminal".to_owned(),
+                version: "5.6.7".to_owned(),
             },
-            starship_config: "No Starship config".to_string(),
+            starship_config: "No Starship config".to_owned(),
         };
 
         let link = make_github_issue_link(environment);

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -25,7 +25,7 @@ pub fn update_configuration(name: &str, value: &str) {
 
     if let Some(table) = get_configuration().as_table_mut() {
         if !table.contains_key(keys[0]) {
-            table.insert(keys[0].to_string(), Value::Table(Map::new()));
+            table.insert(keys[0].to_owned(), Value::Table(Map::new()));
         }
 
         if let Some(values) = table.get(keys[0]).unwrap().as_table() {
@@ -33,19 +33,19 @@ pub fn update_configuration(name: &str, value: &str) {
 
             if value.parse::<bool>().is_ok() {
                 updated_values.insert(
-                    keys[1].to_string(),
+                    keys[1].to_owned(),
                     Value::Boolean(value.parse::<bool>().unwrap()),
                 );
             } else if value.parse::<i64>().is_ok() {
                 updated_values.insert(
-                    keys[1].to_string(),
+                    keys[1].to_owned(),
                     Value::Integer(value.parse::<i64>().unwrap()),
                 );
             } else {
-                updated_values.insert(keys[1].to_string(), Value::String(value.to_string()));
+                updated_values.insert(keys[1].to_owned(), Value::String(value.to_owned()));
             }
 
-            table.insert(keys[0].to_string(), Value::Table(updated_values));
+            table.insert(keys[0].to_owned(), Value::Table(updated_values));
         }
 
         write_configuration(table);
@@ -76,9 +76,9 @@ pub fn toggle_configuration(name: &str, key: &str) {
                         }
                     };
 
-                    updated_values.insert(key.to_string(), Value::Boolean(!current));
+                    updated_values.insert(key.to_owned(), Value::Boolean(!current));
 
-                    table.insert(name.to_string(), Value::Table(updated_values));
+                    table.insert(name.to_owned(), Value::Table(updated_values));
 
                     write_configuration(table);
                 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -103,7 +103,7 @@ impl<'a> Context<'a> {
     // Retrives a environment variable from the os or from a table if in testing mode
     pub fn get_env<K: AsRef<str>>(&self, key: K) -> Option<String> {
         if cfg!(test) {
-            self.env.get(key.as_ref()).map(|val| val.to_string())
+            self.env.get(key.as_ref()).map(|val| val.to_owned())
         } else {
             env::var(key.as_ref()).ok()
         }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -38,7 +38,7 @@ impl Default for StarshipLogger {
             log_file_content: fs::read_to_string(&session_log_file)
                 .unwrap_or_default()
                 .lines()
-                .map(|line| line.to_string())
+                .map(|line| line.to_owned())
                 .collect(),
             log_file: OnceCell::new(),
             log_file_path: session_log_file,

--- a/src/module.rs
+++ b/src/module.rs
@@ -88,8 +88,8 @@ impl<'a> Module<'a> {
     pub fn new(name: &str, desc: &str, config: Option<&'a toml::Value>) -> Module<'a> {
         Module {
             config,
-            name: name.to_string(),
-            description: desc.to_string(),
+            name: name.to_owned(),
+            description: desc.to_owned(),
             segments: Vec::new(),
             duration: Duration::default(),
         }
@@ -174,8 +174,8 @@ mod tests {
         let desc = "This is a unit test";
         let module = Module {
             config: None,
-            name: name.to_string(),
-            description: desc.to_string(),
+            name: name.to_owned(),
+            description: desc.to_owned(),
             segments: Vec::new(),
             duration: Duration::default(),
         };
@@ -189,8 +189,8 @@ mod tests {
         let desc = "This is a unit test";
         let module = Module {
             config: None,
-            name: name.to_string(),
-            description: desc.to_string(),
+            name: name.to_owned(),
+            description: desc.to_owned(),
             segments: vec![Segment::new(None, "")],
             duration: Duration::default(),
         };
@@ -204,8 +204,8 @@ mod tests {
         let desc = "This is a unit test";
         let module = Module {
             config: None,
-            name: name.to_string(),
-            description: desc.to_string(),
+            name: name.to_owned(),
+            description: desc.to_owned(),
             segments: vec![Segment::new(None, "\n")],
             duration: Duration::default(),
         };
@@ -219,8 +219,8 @@ mod tests {
         let desc = "This is a unit test";
         let module = Module {
             config: None,
-            name: name.to_string(),
-            description: desc.to_string(),
+            name: name.to_owned(),
+            description: desc.to_owned(),
             segments: vec![Segment::new(None, " ")],
             duration: Duration::default(),
         };

--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -43,7 +43,7 @@ fn get_aws_region_from_config(context: &Context, aws_profile: Option<&str>) -> O
     let region = region_line.split('=').nth(1)?;
     let region = region.trim();
 
-    Some(region.to_string())
+    Some(region.to_owned())
 }
 
 fn get_aws_profile_and_region(context: &Context) -> (Option<Profile>, Option<Region>) {
@@ -68,7 +68,7 @@ fn get_aws_profile_and_region(context: &Context) -> (Option<Profile>, Option<Reg
 fn alias_region(region: String, aliases: &HashMap<String, &str>) -> String {
     match aliases.get(&region) {
         None => region,
-        Some(alias) => (*alias).to_string(),
+        Some(alias) => (*alias).to_owned(),
     }
 }
 

--- a/src/modules/custom.rs
+++ b/src/modules/custom.rs
@@ -64,7 +64,7 @@ pub fn module<'a>(name: &str, context: &'a Context) -> Option<Module<'a>> {
                     if trimmed.is_empty() {
                         None
                     } else {
-                        Some(Ok(trimmed.to_string()))
+                        Some(Ok(trimmed.to_owned()))
                     }
                 }
                 _ => None,

--- a/src/modules/dart.rs
+++ b/src/modules/dart.rs
@@ -77,7 +77,7 @@ mod tests {
     #[test]
     fn test_parse_dart_version() {
         let input = "Dart VM version: 2.8.4 (stable)";
-        assert_eq!(parse_dart_version(input), Some("v2.8.4".to_string()));
+        assert_eq!(parse_dart_version(input), Some("v2.8.4".to_owned()));
     }
 
     #[test]

--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -130,7 +130,7 @@ fn get_current_dir(context: &Context, config: &DirectoryConfig) -> PathBuf {
                     if let Some(no_prefix) =
                         x.strip_prefix(r"Microsoft.PowerShell.Core\FileSystem::")
                     {
-                        x = no_prefix.to_string();
+                        x = no_prefix.to_owned();
                     }
                 }
                 Some(PathBuf::from(x))
@@ -176,7 +176,7 @@ fn contract_path(full_path: &Path, top_level_path: &Path, top_level_replacement:
     }
 
     if full_path == top_level_path {
-        return top_level_replacement.to_string();
+        return top_level_replacement.to_owned();
     }
 
     format!(
@@ -210,7 +210,7 @@ fn contract_repo_path(full_path: &Path, top_level_path: &Path) -> Option<String>
         let repo_name = components[components.len() - i - 1].as_os_str().to_str()?;
 
         if i == 0 {
-            return Some(repo_name.to_string());
+            return Some(repo_name.to_owned());
         }
 
         let path = PathBuf::from_iter(&components[components.len() - i..]);
@@ -279,8 +279,8 @@ fn to_fish_style(pwd_dir_length: usize, dir_string: String, truncated_dir_string
         .map(|word| -> String {
             let chars = UnicodeSegmentation::graphemes(word, true).collect::<Vec<&str>>();
             match word {
-                "" => "".to_string(),
-                _ if chars.len() <= pwd_dir_length => word.to_string(),
+                "" => "".to_owned(),
+                _ if chars.len() <= pwd_dir_length => word.to_owned(),
                 _ if word.starts_with('.') => chars[..=pwd_dir_length].join(""),
                 _ => chars[..pwd_dir_length].join(""),
             }
@@ -366,24 +366,24 @@ mod tests {
     fn substitute_prefix_and_middle() {
         let full_path = "/absolute/path/foo/bar/baz";
         let mut substitutions = IndexMap::new();
-        substitutions.insert("/absolute/path".to_string(), "");
-        substitutions.insert("/bar/".to_string(), "/");
+        substitutions.insert("/absolute/path".to_owned(), "");
+        substitutions.insert("/bar/".to_owned(), "/");
 
-        let output = substitute_path(full_path.to_string(), &substitutions);
+        let output = substitute_path(full_path.to_owned(), &substitutions);
         assert_eq!(output, "/foo/baz");
     }
 
     #[test]
     fn fish_style_with_user_home_contracted_path() {
         let path = "~/starship/engines/booster/rocket";
-        let output = to_fish_style(1, path.to_string(), "engines/booster/rocket");
+        let output = to_fish_style(1, path.to_owned(), "engines/booster/rocket");
         assert_eq!(output, "~/s/");
     }
 
     #[test]
     fn fish_style_with_user_home_contracted_path_and_dot_dir() {
         let path = "~/.starship/engines/booster/rocket";
-        let output = to_fish_style(1, path.to_string(), "engines/booster/rocket");
+        let output = to_fish_style(1, path.to_owned(), "engines/booster/rocket");
         assert_eq!(output, "~/.s/");
     }
 
@@ -391,7 +391,7 @@ mod tests {
     fn fish_style_with_no_contracted_path() {
         // `truncation_length = 2`
         let path = "/absolute/Path/not/in_a/repo/but_nested";
-        let output = to_fish_style(1, path.to_string(), "repo/but_nested");
+        let output = to_fish_style(1, path.to_owned(), "repo/but_nested");
         assert_eq!(output, "/a/P/n/i/");
     }
 
@@ -399,21 +399,21 @@ mod tests {
     fn fish_style_with_pwd_dir_len_no_contracted_path() {
         // `truncation_length = 2`
         let path = "/absolute/Path/not/in_a/repo/but_nested";
-        let output = to_fish_style(2, path.to_string(), "repo/but_nested");
+        let output = to_fish_style(2, path.to_owned(), "repo/but_nested");
         assert_eq!(output, "/ab/Pa/no/in/");
     }
 
     #[test]
     fn fish_style_with_duplicate_directories() {
         let path = "~/starship/tmp/C++/C++/C++";
-        let output = to_fish_style(1, path.to_string(), "C++");
+        let output = to_fish_style(1, path.to_owned(), "C++");
         assert_eq!(output, "~/s/t/C/C/");
     }
 
     #[test]
     fn fish_style_with_unicode() {
         let path = "~/starship/tmp/目录/a̐éö̲/目录";
-        let output = to_fish_style(1, path.to_string(), "目录");
+        let output = to_fish_style(1, path.to_owned(), "目录");
         assert_eq!(output, "~/s/t/目/a̐/");
     }
 

--- a/src/modules/docker_context.rs
+++ b/src/modules/docker_context.rs
@@ -244,7 +244,7 @@ mod tests {
         let config_content = "not valid json";
 
         let mut docker_config = File::create(&cfg_file)?;
-        docker_config.write_all(config_content.to_string().as_bytes())?;
+        docker_config.write_all(config_content.to_owned().as_bytes())?;
         docker_config.sync_all()?;
 
         let actual = ModuleRenderer::new("docker_context")

--- a/src/modules/erlang.rs
+++ b/src/modules/erlang.rs
@@ -62,7 +62,7 @@ fn get_erlang_version() -> Option<String> {
              io:format(\"~s\",[Content]),\
              halt(0)."
         ]
-    )?.stdout.trim().to_string())
+    )?.stdout.trim().to_owned())
 }
 
 #[cfg(test)]

--- a/src/modules/gcloud.rs
+++ b/src/modules/gcloud.rs
@@ -24,7 +24,7 @@ fn get_gcloud_account_from_config(current_config: &Path) -> Option<Account> {
         .take_while(|line| !line.starts_with('['))
         .find(|line| line.starts_with("account"))?;
     let account = account_line.split('=').nth(1)?.trim();
-    Some(account.to_string())
+    Some(account.to_owned())
 }
 
 fn get_gcloud_project_from_config(current_config: &Path) -> Option<Project> {
@@ -37,7 +37,7 @@ fn get_gcloud_project_from_config(current_config: &Path) -> Option<Project> {
         .take_while(|line| !line.starts_with('['))
         .find(|line| line.starts_with("project"))?;
     let project = project_line.split('=').nth(1)?.trim();
-    Some(project.to_string())
+    Some(project.to_owned())
 }
 
 fn get_gcloud_region_from_config(current_config: &Path) -> Option<Region> {
@@ -50,7 +50,7 @@ fn get_gcloud_region_from_config(current_config: &Path) -> Option<Region> {
         .take_while(|line| !line.starts_with('['))
         .find(|line| line.starts_with("region"))?;
     let region = region_line.split('=').nth(1)?.trim();
-    Some(region.to_string())
+    Some(region.to_owned())
 }
 
 fn get_active_config(context: &Context, config_root: &Path) -> Option<String> {
@@ -91,8 +91,8 @@ fn get_config_dir(context: &Context) -> Option<PathBuf> {
 
 fn alias_region(region: String, aliases: &HashMap<String, &str>) -> String {
     match aliases.get(&region) {
-        None => region.to_string(),
-        Some(alias) => (*alias).to_string(),
+        None => region.to_owned(),
+        Some(alias) => (*alias).to_owned(),
     }
 }
 

--- a/src/modules/git_branch.rs
+++ b/src/modules/git_branch.rs
@@ -243,8 +243,8 @@ mod tests {
             "",
             format!(
                 "branch: {} {} ",
-                Color::Blue.bold().paint("1337_hello_world").to_string(),
-                Color::Red.paint("THE COLORS").to_string()
+                Color::Blue.bold().paint("1337_hello_world").to_owned(),
+                Color::Red.paint("THE COLORS").to_owned()
             ),
         )
     }
@@ -258,10 +258,7 @@ mod tests {
             symbol = "git: "
             style = "green"
         "#,
-            format!(
-                "git: {}",
-                Color::Green.paint("1337_hello_world").to_string(),
-            ),
+            format!("git: {}", Color::Green.paint("1337_hello_world").to_owned(),),
         )
     }
 

--- a/src/modules/git_commit.rs
+++ b/src/modules/git_commit.rs
@@ -158,7 +158,7 @@ mod tests {
             Color::Green
                 .bold()
                 .paint(format!("({})", expected_hash))
-                .to_string()
+                .to_owned()
         ));
 
         assert_eq!(expected, actual);
@@ -191,7 +191,7 @@ mod tests {
             Color::Green
                 .bold()
                 .paint(format!("({})", expected_hash))
-                .to_string()
+                .to_owned()
         ));
 
         assert_eq!(expected, actual);
@@ -238,7 +238,7 @@ mod tests {
             Color::Green
                 .bold()
                 .paint(format!("({})", expected_hash))
-                .to_string()
+                .to_owned()
         ));
 
         assert_eq!(expected, actual);
@@ -281,7 +281,7 @@ mod tests {
             Color::Green
                 .bold()
                 .paint(format!("({})", expected_output.trim()))
-                .to_string()
+                .to_owned()
         ));
 
         assert_eq!(expected, actual);
@@ -333,7 +333,7 @@ mod tests {
             Color::Green
                 .bold()
                 .paint(format!("({})", expected_output.trim()))
-                .to_string()
+                .to_owned()
         ));
 
         assert_eq!(expected, actual);
@@ -405,7 +405,7 @@ mod tests {
             Color::Green
                 .bold()
                 .paint(format!("({})", expected_output.trim()))
-                .to_string()
+                .to_owned()
         ));
 
         assert_eq!(expected, actual);

--- a/src/modules/golang.rs
+++ b/src/modules/golang.rs
@@ -198,6 +198,6 @@ mod tests {
     #[test]
     fn test_format_go_version() {
         let input = "go version go1.12 darwin/amd64";
-        assert_eq!(format_go_version(input), Some("v1.12".to_string()));
+        assert_eq!(format_go_version(input), Some("v1.12".to_owned()));
     }
 }

--- a/src/modules/helm.rs
+++ b/src/modules/helm.rs
@@ -121,7 +121,7 @@ mod tests {
     fn test_format_helm_version() {
         let helm_2 = "Client: v2.16.9+g8ad7037";
         let helm_3 = "v3.1.1+ggit afe7058";
-        assert_eq!(format_helm_version(helm_2), Some("v2.16.9".to_string()));
-        assert_eq!(format_helm_version(helm_3), Some("v3.1.1".to_string()));
+        assert_eq!(format_helm_version(helm_2), Some("v2.16.9".to_owned()));
+        assert_eq!(format_helm_version(helm_3), Some("v3.1.1".to_owned()));
     }
 }

--- a/src/modules/hg_branch.rs
+++ b/src/modules/hg_branch.rs
@@ -77,7 +77,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 fn get_hg_branch_name(ctx: &Context) -> String {
     std::fs::read_to_string(ctx.current_dir.join(".hg").join("branch"))
         .map(|s| s.trim().into())
-        .unwrap_or_else(|_| "default".to_string())
+        .unwrap_or_else(|_| "default".to_owned())
 }
 
 fn get_hg_current_bookmark(ctx: &Context) -> Option<String> {

--- a/src/modules/java.rs
+++ b/src/modules/java.rs
@@ -102,58 +102,58 @@ mod tests {
     fn test_parse_java_version_openjdk() {
         let java_8 = "OpenJDK 64-Bit Server VM (25.222-b10) for linux-amd64 JRE (1.8.0_222-b10), built on Jul 11 2019 10:18:43 by \"openjdk\" with gcc 4.4.7 20120313 (Red Hat 4.4.7-23)";
         let java_11 = "OpenJDK 64-Bit Server VM (11.0.4+11-post-Ubuntu-1ubuntu219.04) for linux-amd64 JRE (11.0.4+11-post-Ubuntu-1ubuntu219.04), built on Jul 18 2019 18:21:46 by \"build\" with gcc 8.3.0";
-        assert_eq!(parse_java_version(java_11), Some("v11.0.4".to_string()));
-        assert_eq!(parse_java_version(java_8), Some("v1.8.0".to_string()));
+        assert_eq!(parse_java_version(java_11), Some("v11.0.4".to_owned()));
+        assert_eq!(parse_java_version(java_8), Some("v1.8.0".to_owned()));
     }
 
     #[test]
     fn test_parse_java_version_oracle() {
         let java_8 = "Java HotSpot(TM) Client VM (25.65-b01) for linux-arm-vfp-hflt JRE (1.8.0_65-b17), built on Oct  6 2015 16:19:04 by \"java_re\" with gcc 4.7.2 20120910 (prerelease)";
-        assert_eq!(parse_java_version(java_8), Some("v1.8.0".to_string()));
+        assert_eq!(parse_java_version(java_8), Some("v1.8.0".to_owned()));
     }
 
     #[test]
     fn test_parse_java_version_redhat() {
         let java_8 = "OpenJDK 64-Bit Server VM (25.222-b10) for linux-amd64 JRE (1.8.0_222-b10), built on Jul 11 2019 20:48:53 by \"root\" with gcc 7.3.1 20180303 (Red Hat 7.3.1-5)";
         let java_12 = "OpenJDK 64-Bit Server VM (12.0.2+10) for linux-amd64 JRE (12.0.2+10), built on Jul 18 2019 14:41:47 by \"jenkins\" with gcc 7.3.1 20180303 (Red Hat 7.3.1-5)";
-        assert_eq!(parse_java_version(java_8), Some("v1.8.0".to_string()));
-        assert_eq!(parse_java_version(java_12), Some("v12.0.2".to_string()));
+        assert_eq!(parse_java_version(java_8), Some("v1.8.0".to_owned()));
+        assert_eq!(parse_java_version(java_12), Some("v12.0.2".to_owned()));
     }
 
     #[test]
     fn test_parse_java_version_zulu() {
         let java_8 = "OpenJDK 64-Bit Server VM (25.222-b10) for linux-amd64 JRE (Zulu 8.40.0.25-CA-linux64) (1.8.0_222-b10), built on Jul 11 2019 11:36:39 by \"zulu_re\" with gcc 4.4.7 20120313 (Red Hat 4.4.7-3)";
         let java_11 = "OpenJDK 64-Bit Server VM (11.0.4+11-LTS) for linux-amd64 JRE (Zulu11.33+15-CA) (11.0.4+11-LTS), built on Jul 11 2019 21:37:17 by \"zulu_re\" with gcc 4.9.2 20150212 (Red Hat 4.9.2-6)";
-        assert_eq!(parse_java_version(java_8), Some("v1.8.0".to_string()));
-        assert_eq!(parse_java_version(java_11), Some("v11.0.4".to_string()));
+        assert_eq!(parse_java_version(java_8), Some("v1.8.0".to_owned()));
+        assert_eq!(parse_java_version(java_11), Some("v11.0.4".to_owned()));
     }
 
     #[test]
     fn test_parse_java_version_eclipse_openj9() {
         let java_8 = "Eclipse OpenJ9 OpenJDK 64-bit Server VM (1.8.0_222-b10) from linux-amd64 JRE with Extensions for OpenJDK for Eclipse OpenJ9 8.0.222.0, built on Jul 17 2019 21:29:18 by jenkins with g++ (GCC) 7.3.1 20180303 (Red Hat 7.3.1-5)";
         let java_11 = "Eclipse OpenJ9 OpenJDK 64-bit Server VM (11.0.4+11) from linux-amd64 JRE with Extensions for OpenJDK for Eclipse OpenJ9 11.0.4.0, built on Jul 17 2019 21:51:37 by jenkins with g++ (GCC) 7.3.1 20180303 (Red Hat 7.3.1-5)";
-        assert_eq!(parse_java_version(java_8), Some("v1.8.0".to_string()));
-        assert_eq!(parse_java_version(java_11), Some("v11.0.4".to_string()));
+        assert_eq!(parse_java_version(java_8), Some("v1.8.0".to_owned()));
+        assert_eq!(parse_java_version(java_11), Some("v11.0.4".to_owned()));
     }
 
     #[test]
     fn test_parse_java_version_graalvm() {
         let java_8 = "OpenJDK 64-Bit GraalVM CE 19.2.0.1 (25.222-b08-jvmci-19.2-b02) for linux-amd64 JRE (8u222), built on Jul 19 2019 17:37:13 by \"buildslave\" with gcc 7.3.0";
-        assert_eq!(parse_java_version(java_8), Some("v8".to_string()));
+        assert_eq!(parse_java_version(java_8), Some("v8".to_owned()));
     }
 
     #[test]
     fn test_parse_java_version_amazon_corretto() {
         let java_8 = "OpenJDK 64-Bit Server VM (25.222-b10) for linux-amd64 JRE (1.8.0_222-b10), built on Jul 11 2019 20:48:53 by \"root\" with gcc 7.3.1 20180303 (Red Hat 7.3.1-5)";
         let java_11 = "OpenJDK 64-Bit Server VM (11.0.4+11-LTS) for linux-amd64 JRE (11.0.4+11-LTS), built on Jul 11 2019 20:06:11 by \"\" with gcc 7.3.1 20180303 (Red Hat 7.3.1-5)";
-        assert_eq!(parse_java_version(java_8), Some("v1.8.0".to_string()));
-        assert_eq!(parse_java_version(java_11), Some("v11.0.4".to_string()));
+        assert_eq!(parse_java_version(java_8), Some("v1.8.0".to_owned()));
+        assert_eq!(parse_java_version(java_11), Some("v11.0.4".to_owned()));
     }
 
     #[test]
     fn test_parse_java_version_sapmachine() {
         let java_11 = "OpenJDK 64-Bit Server VM (11.0.4+11-LTS-sapmachine) for linux-amd64 JRE (11.0.4+11-LTS-sapmachine), built on Jul 17 2019 08:58:43 by \"\" with gcc 7.3.0";
-        assert_eq!(parse_java_version(java_11), Some("v11.0.4".to_string()));
+        assert_eq!(parse_java_version(java_11), Some("v11.0.4".to_owned()));
     }
 
     #[test]

--- a/src/modules/jobs.rs
+++ b/src/modules/jobs.rs
@@ -22,7 +22,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let module_number = if num_of_jobs > config.threshold {
         num_of_jobs.to_string()
     } else {
-        "".to_string()
+        "".to_owned()
     };
 
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {

--- a/src/modules/julia.rs
+++ b/src/modules/julia.rs
@@ -127,6 +127,6 @@ mod tests {
     #[test]
     fn test_format_julia_version() {
         let input = "julia version 1.4.0";
-        assert_eq!(format_julia_version(input), Some("v1.4.0".to_string()));
+        assert_eq!(format_julia_version(input), Some("v1.4.0".to_owned()));
     }
 }

--- a/src/modules/kotlin.rs
+++ b/src/modules/kotlin.rs
@@ -162,7 +162,7 @@ mod tests {
         let kotlin_input = "Kotlin version 1.4.21-release-411 (JRE 14.0.1+7)";
         assert_eq!(
             format_kotlin_version(kotlin_input),
-            Some("v1.4.21".to_string())
+            Some("v1.4.21".to_owned())
         );
     }
 
@@ -171,7 +171,7 @@ mod tests {
         let kotlin_input = "info: kotlinc-jvm 1.4.21 (JRE 14.0.1+7)";
         assert_eq!(
             format_kotlin_version(kotlin_input),
-            Some("v1.4.21".to_string())
+            Some("v1.4.21".to_owned())
         );
     }
 }

--- a/src/modules/kubernetes.rs
+++ b/src/modules/kubernetes.rs
@@ -23,7 +23,7 @@ fn get_kube_context(filename: path::PathBuf) -> Option<String> {
     if current_ctx.is_empty() {
         return None;
     }
-    Some(current_ctx.to_string())
+    Some(current_ctx.to_owned())
 }
 
 fn get_kube_ns(filename: path::PathBuf, current_ctx: String) -> Option<String> {
@@ -63,7 +63,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
     let kube_cfg = context
         .get_env("KUBECONFIG")
-        .unwrap_or(default_config_file.to_str()?.to_string());
+        .unwrap_or(default_config_file.to_str()?.to_owned());
 
     let kube_ctx = env::split_paths(&kube_cfg).find_map(get_kube_context)?;
 

--- a/src/modules/lua.rs
+++ b/src/modules/lua.rs
@@ -156,13 +156,13 @@ mod tests {
     #[test]
     fn test_format_lua_version() {
         let lua_input = "Lua 5.4.0  Copyright (C) 1994-2020 Lua.org, PUC-Rio";
-        assert_eq!(format_lua_version(lua_input), Some("v5.4.0".to_string()));
+        assert_eq!(format_lua_version(lua_input), Some("v5.4.0".to_owned()));
 
         let luajit_input =
             "LuaJIT 2.1.0-beta3 -- Copyright (C) 2005-2017 Mike Pall. http://luajit.org/";
         assert_eq!(
             format_lua_version(luajit_input),
-            Some("v2.1.0-beta3".to_string())
+            Some("v2.1.0-beta3".to_owned())
         );
     }
 }

--- a/src/modules/nodejs.rs
+++ b/src/modules/nodejs.rs
@@ -85,7 +85,7 @@ fn get_engines_version(base_dir: &Path) -> Option<String> {
     let json_str = utils::read_file(base_dir.join("package.json")).ok()?;
     let package_json: json::Value = json::from_str(&json_str).ok()?;
     let raw_version = package_json.get("engines")?.get("node")?.as_str()?;
-    Some(raw_version.to_string())
+    Some(raw_version.to_owned())
 }
 
 fn check_engines_version(nodejs_version: &str, engines_version: Option<String>) -> bool {

--- a/src/modules/package.rs
+++ b/src/modules/package.rs
@@ -199,7 +199,7 @@ fn get_package_version(base_dir: &Path, config: &PackageConfig) -> Option<String
 }
 
 fn format_version(version: &str) -> String {
-    let cleaned = version.replace('"', "").trim().to_string();
+    let cleaned = version.replace('"', "").trim().to_owned();
     if cleaned.starts_with('v') {
         cleaned
     } else {

--- a/src/modules/php.rs
+++ b/src/modules/php.rs
@@ -75,7 +75,7 @@ mod tests {
     #[test]
     fn test_format_php_version() {
         let input = "7.3.8";
-        assert_eq!(format_php_version(input), "v7.3.8".to_string());
+        assert_eq!(format_php_version(input), "v7.3.8".to_owned());
     }
 
     #[test]

--- a/src/modules/python.rs
+++ b/src/modules/python.rs
@@ -61,13 +61,13 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             .map(|variable| match variable {
                 "version" => {
                     let version = get_python_version(&config)?;
-                    Some(Ok(version.trim().to_string()))
+                    Some(Ok(version.trim().to_owned()))
                 }
                 "virtualenv" => {
                     let virtual_env = get_python_virtual_env(context);
-                    virtual_env.as_ref().map(|e| Ok(e.trim().to_string()))
+                    virtual_env.as_ref().map(|e| Ok(e.trim().to_owned()))
                 }
-                "pyenv_prefix" => Some(Ok(pyenv_prefix.to_string())),
+                "pyenv_prefix" => Some(Ok(pyenv_prefix.to_owned())),
                 _ => None,
             })
             .parse(None)

--- a/src/modules/ruby.rs
+++ b/src/modules/ruby.rs
@@ -128,17 +128,17 @@ mod tests {
     fn test_format_ruby_version() -> io::Result<()> {
         assert_eq!(
             format_ruby_version("ruby 2.1.10p492 (2016-04-01 revision 54464) [x86_64-darwin19.0]"),
-            Some("v2.1.10".to_string())
+            Some("v2.1.10".to_owned())
         );
         assert_eq!(
             format_ruby_version("ruby 2.5.1p57 (2018-03-29 revision 63029) [x86_64-linux-gnu]"),
-            Some("v2.5.1".to_string())
+            Some("v2.5.1".to_owned())
         );
         assert_eq!(
             format_ruby_version(
                 "ruby 2.7.0p0 (2019-12-25 revision 647ee6f091) [x86_64-linux-musl]"
             ),
-            Some("v2.7.0".to_string())
+            Some("v2.7.0".to_owned())
         );
 
         Ok(())

--- a/src/modules/status.rs
+++ b/src/modules/status.rs
@@ -222,7 +222,7 @@ mod tests {
         ];
 
         for (status, name) in exit_values.iter().zip(exit_values_name.iter()) {
-            let expected = name.map(|n| n.to_string());
+            let expected = name.map(|n| n.to_owned());
             let actual = ModuleRenderer::new("status")
                 .config(toml::toml! {
                     [status]
@@ -251,7 +251,7 @@ mod tests {
         ];
 
         for (status, name) in exit_values.iter().zip(exit_values_name.iter()) {
-            let expected = name.map(|n| n.to_string());
+            let expected = name.map(|n| n.to_owned());
             let actual = ModuleRenderer::new("status")
                 .config(toml::toml! {
                     [status]

--- a/src/modules/terraform.rs
+++ b/src/modules/terraform.rs
@@ -72,7 +72,7 @@ fn get_terraform_workspace(context: &Context) -> Option<String> {
         None => context.current_dir.join(".terraform"),
     };
     match utils::read_file(datadir.join("environment")) {
-        Err(ref e) if e.kind() == io::ErrorKind::NotFound => Some("default".to_string()),
+        Err(ref e) if e.kind() == io::ErrorKind::NotFound => Some("default".to_owned()),
         Ok(s) => Some(s),
         _ => None,
     }
@@ -106,7 +106,7 @@ mod tests {
         let input = "Terraform v0.12.14";
         assert_eq!(
             format_terraform_version(input),
-            Some("v0.12.14 ".to_string())
+            Some("v0.12.14 ".to_owned())
         );
     }
 
@@ -115,7 +115,7 @@ mod tests {
         let input = "Terraform v0.12.14-rc1";
         assert_eq!(
             format_terraform_version(input),
-            Some("v0.12.14-rc1 ".to_string())
+            Some("v0.12.14-rc1 ".to_owned())
         );
     }
 
@@ -124,7 +124,7 @@ mod tests {
         let input = "Terraform v0.12.14-dev (cca89f74)";
         assert_eq!(
             format_terraform_version(input),
-            Some("v0.12.14-dev (cca89f74) ".to_string())
+            Some("v0.12.14-dev (cca89f74) ".to_owned())
         );
     }
 
@@ -138,7 +138,7 @@ is 0.12.14. You can update by downloading from www.terraform.io/downloads.html
 ";
         assert_eq!(
             format_terraform_version(input),
-            Some("v0.12.13 ".to_string())
+            Some("v0.12.13 ".to_owned())
         );
     }
 

--- a/src/modules/utils/directory.rs
+++ b/src/modules/utils/directory.rs
@@ -29,42 +29,42 @@ mod tests {
     #[test]
     fn truncate_smaller_path_than_provided_length() {
         let path = "~/starship";
-        let output = truncate(path.to_string(), 3);
+        let output = truncate(path.to_owned(), 3);
         assert_eq!(output, "~/starship")
     }
 
     #[test]
     fn truncate_same_path_as_provided_length() {
         let path = "~/starship/engines";
-        let output = truncate(path.to_string(), 3);
+        let output = truncate(path.to_owned(), 3);
         assert_eq!(output, "~/starship/engines")
     }
 
     #[test]
     fn truncate_slightly_larger_path_than_provided_length() {
         let path = "~/starship/engines/booster";
-        let output = truncate(path.to_string(), 3);
+        let output = truncate(path.to_owned(), 3);
         assert_eq!(output, "starship/engines/booster")
     }
 
     #[test]
     fn truncate_larger_path_than_provided_length() {
         let path = "~/starship/engines/booster/rocket";
-        let output = truncate(path.to_string(), 3);
+        let output = truncate(path.to_owned(), 3);
         assert_eq!(output, "engines/booster/rocket")
     }
 
     #[test]
     fn truncate_same_path_as_provided_length_from_root() {
         let path = "/starship/engines/booster";
-        let output = truncate(path.to_string(), 3);
+        let output = truncate(path.to_owned(), 3);
         assert_eq!(output, "/starship/engines/booster");
     }
 
     #[test]
     fn truncate_larger_path_than_provided_length_from_root() {
         let path = "/starship/engines/booster/rocket";
-        let output = truncate(path.to_string(), 3);
+        let output = truncate(path.to_owned(), 3);
         assert_eq!(output, "engines/booster/rocket");
     }
 }

--- a/src/print.rs
+++ b/src/print.rs
@@ -349,7 +349,7 @@ fn better_width(s: &str) -> usize {
 pub fn format_duration(duration: &Duration) -> String {
     let milis = duration.as_millis();
     if milis == 0 {
-        "<1ms".to_string()
+        "<1ms".to_owned()
     } else {
         format!("{:?}ms", &milis)
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -408,12 +408,12 @@ mod tests {
         let test4 = "herpaderp";
         let test5 = "";
 
-        let zresult0 = wrap_seq_for_shell(test0.to_string(), Shell::Zsh, '\x1b', 'm');
-        let zresult1 = wrap_seq_for_shell(test1.to_string(), Shell::Zsh, '\x1b', 'm');
-        let zresult2 = wrap_seq_for_shell(test2.to_string(), Shell::Zsh, '\x1b', 'J');
-        let zresult3 = wrap_seq_for_shell(test3.to_string(), Shell::Zsh, 'O', 'O');
-        let zresult4 = wrap_seq_for_shell(test4.to_string(), Shell::Zsh, '\x1b', 'm');
-        let zresult5 = wrap_seq_for_shell(test5.to_string(), Shell::Zsh, '\x1b', 'm');
+        let zresult0 = wrap_seq_for_shell(test0.to_owned(), Shell::Zsh, '\x1b', 'm');
+        let zresult1 = wrap_seq_for_shell(test1.to_owned(), Shell::Zsh, '\x1b', 'm');
+        let zresult2 = wrap_seq_for_shell(test2.to_owned(), Shell::Zsh, '\x1b', 'J');
+        let zresult3 = wrap_seq_for_shell(test3.to_owned(), Shell::Zsh, 'O', 'O');
+        let zresult4 = wrap_seq_for_shell(test4.to_owned(), Shell::Zsh, '\x1b', 'm');
+        let zresult5 = wrap_seq_for_shell(test5.to_owned(), Shell::Zsh, '\x1b', 'm');
 
         assert_eq!(&zresult0, "%{\x1b2m%}hellomynamekeyes%{\x1b2m%}");
         assert_eq!(&zresult1, "%{\x1b]330;m%}lol%{\x1b]0m%}");
@@ -422,12 +422,12 @@ mod tests {
         assert_eq!(&zresult4, "herpaderp");
         assert_eq!(&zresult5, "");
 
-        let bresult0 = wrap_seq_for_shell(test0.to_string(), Shell::Bash, '\x1b', 'm');
-        let bresult1 = wrap_seq_for_shell(test1.to_string(), Shell::Bash, '\x1b', 'm');
-        let bresult2 = wrap_seq_for_shell(test2.to_string(), Shell::Bash, '\x1b', 'J');
-        let bresult3 = wrap_seq_for_shell(test3.to_string(), Shell::Bash, 'O', 'O');
-        let bresult4 = wrap_seq_for_shell(test4.to_string(), Shell::Bash, '\x1b', 'm');
-        let bresult5 = wrap_seq_for_shell(test5.to_string(), Shell::Bash, '\x1b', 'm');
+        let bresult0 = wrap_seq_for_shell(test0.to_owned(), Shell::Bash, '\x1b', 'm');
+        let bresult1 = wrap_seq_for_shell(test1.to_owned(), Shell::Bash, '\x1b', 'm');
+        let bresult2 = wrap_seq_for_shell(test2.to_owned(), Shell::Bash, '\x1b', 'J');
+        let bresult3 = wrap_seq_for_shell(test3.to_owned(), Shell::Bash, 'O', 'O');
+        let bresult4 = wrap_seq_for_shell(test4.to_owned(), Shell::Bash, '\x1b', 'm');
+        let bresult5 = wrap_seq_for_shell(test5.to_owned(), Shell::Bash, '\x1b', 'm');
 
         assert_eq!(&bresult0, "\\[\x1b2m\\]hellomynamekeyes\\[\x1b2m\\]");
         assert_eq!(&bresult1, "\\[\x1b]330;m\\]lol\\[\x1b]0m\\]");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
All instances of to_string() operating on &str were changed to .to_owned() which is highly optimized for that use case; The compiler may *choose* to optimize to_string() in some cases, but this removes that choice and ensures that optimization.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

to_owned() can in many cases become highly optimized compared to to_string(). It's an example of "compilers choice, vs always optimize". It used to *always* be better. I think this is no longer the case and made these changes under that assumption.

Below is some evidence of this being the case in the past, and I have also personally observed speed increases from using to_owned(), but it seems like that's not guaranteed to be the case anymore and is probably just a headache left over from yesteryear. I wouldn't worry too much about it. The changes still definitely improve compile time slightly, so just take that as you will as the consideration here.

https://medium.com/@ericdreichert/converting-str-to-string-vs-to-owned-with-two-benchmarks-a66fd5a081ce

TL;DR: Merge this if you like, but it seems like the newest update may render the changes moot, as the compiler seems to now prefer to generate the optimized assembly in many cases if not all of them.  You'll probably get about two seconds off your compile time at best with this change so that might still make it worth it if you value that sort of thing.

Results may vary.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

All changes are drop in equivalent. They change a reference into a String. All tests still pass, no new tests are needed. The only difference is the increased compile-time performance, and possible micro-optimizations being guaranteed rather than possibly gained. 

In other words, nothing of importance was changed. Small benefits were gained. 

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
