### PR TITLE
fix: count jobs with for loop to fix MacOS count issue

### DIFF
--- a/src/init/starship.bash
+++ b/src/init/starship.bash
@@ -31,11 +31,11 @@ starship_precmd() {
     # Save the status, because commands in this pipeline will change $?
     STARSHIP_CMD_STATUS=$?
 
-    local NUM_JOBS
+    local NUM_JOBS=0
     # Evaluate the number of jobs before running the preseved prompt command, so that tools
     # like z/autojump, which background certain jobs, do not cause spurious background jobs
-    # to be displayed by starship. Also avoids forking to run `wc`, slightly improving perf
-    NUM_JOBS=$(n=0; while read line; do [[ $line ]] && n=$((n+1));done <<< $(jobs -p) ; echo $n)
+    # to be displayed by starship. Also avoids forking to run `wc`, slightly improving perf.
+    for job in $(jobs -p); do [[ $job ]] && ((NUM_JOBS++)); done
 
     # Run the bash precmd function, if it's set. If not set, evaluates to no-op
     "${starship_precmd_user_func-:}"


### PR DESCRIPTION

#### Description
In #1897 we replaced a `wc -l` with a bash-native job counter, but subsequently discovered that bash on MacOS folds `<<<` output into a single line, preventing line counting.

A for loop works around that problem, is still bash-native, and works the same on MacOS and Linux.

While we're at it, also removed the need for command substitution and an `echo` by doing the work directly on `NUM_JOBS`.

Fixes #2241.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [X] I have tested using **MacOS**
- [X] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
