### PR TITLE
fix(windows): fix windows terminal ANSI escape sequences

### DIFF
--- a/src/modules/username.rs
+++ b/src/modules/username.rs
@@ -21,10 +21,14 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let username = context.get_env(USERNAME_ENV_VAR)?;
     let logname = context.get_env("LOGNAME");
 
-    let user_uid = get_uid();
+    let is_root = if cfg!(not(target_os = "windows")) {
+        let user_uid = get_uid();
+        user_uid == ROOT_UID
+    } else {
+        false
+    };
 
     let is_not_login = logname.is_some() && username != logname.unwrap();
-    let is_root = user_uid == ROOT_UID;
 
     let mut module = context.new_module("username");
     let config: UsernameConfig = UsernameConfig::try_load(module.config);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -277,6 +277,7 @@ fn internal_exec_cmd(cmd: &str, args: &[&str]) -> Option<CommandOutput> {
         .args(args)
         .stderr(Stdio::piped())
         .stdout(Stdio::piped())
+        .stdin(Stdio::null())
         .spawn()
     {
         Ok(process) => process,


### PR DESCRIPTION
#### Description
Release 0.49.0 broke ANSI escape sequence processing for some Windows Terminal users by making some subtle changes how commands are now executed.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #2254
Closes #2246
Closes #2252

#### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/629536/106620640-0c2ec180-6572-11eb-8191-fc0cd2574487.png)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [X] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
