### PR TITLE
docs: Remove status_ prefix from status module variables

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2310,7 +2310,7 @@ This module is not supported on elvish shell.
 [status]
 style = "bg:blue"
 symbol = "🔴"
-format = '[\[$symbol $status_common_meaning$status_signal_name$status_maybe_int\]]($style) '
+format = '[\[$symbol $common_meaning$signal_name$maybe_int\]]($style) '
 map_symbol = true
 disabled = false
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2310,7 +2310,7 @@ This module is not supported on elvish shell.
 [status]
 style = "bg:blue"
 symbol = "🔴"
-format = '[\[$symbol $common_meaning$signal_name$maybe_int\]]($style) '
+format = '[\[$symbol $status_common_meaning$status_signal_name$status_maybe_int\]]($style) '
 map_symbol = true
 disabled = false
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

When using the `status` module, the [example configuration](https://starship.rs/config/#example-45) references using variables with the `$status_` prefix. This does not work. This PR simply updates the documentation to reference a valid configuration example.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

With the config as currently described in the documentation:
![image](https://user-images.githubusercontent.com/28414793/106690221-701baf00-659f-11eb-9e04-d272f14b7f47.png)

Removing the `$status_` prefix:
![image](https://user-images.githubusercontent.com/28414793/106690258-7c077100-659f-11eb-8597-02100d61c2ad.png)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [X] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
