### PR TITLE
feat(python): Configure when the module is shown

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -388,7 +388,7 @@ can do this in two ways:
 
 By default it only changes color. If you also want to change it's shape take a
 look at [this example](#with-custom-error-shape).
- 
+
 ::: warning
 `error_symbol` is not supported on elvish shell.
 :::
@@ -2040,30 +2040,32 @@ current Python virtual environment if one is activated.
 If `pyenv_version_name` is set to `true`, it will display the pyenv version
 name. Otherwise, it will display the version number from `python --version`.
 
-The module will be shown if any of the following conditions are met:
+By default the module will be shown if any of the following conditions are met:
 
 - The current directory contains a `.python-version` file
-- The current directory contains a `requirements.txt` file
-- The current directory contains a `pyproject.toml` file
-- The current directory contains a file with the `.py` extension (and `scan_for_pyfiles` is true)
 - The current directory contains a `Pipfile` file
-- The current directory contains a `tox.ini` file
-- The current directory contains a `setup.py` file
 - The current directory contains a `__init__.py` file
+- The current directory contains a `pyproject.toml` file
+- The current directory contains a `requirements.txt` file
+- The current directory contains a `setup.py` file
+- The current directory contains a `tox.ini` file
+- The current directory contains a file with the `.py` extension.
 - A virtual environment is currently activated
 
 ### Options
 
-| Option               | Default                                                                 | Description                                                                            |
-| -------------------- | ----------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
-| `format`             | `'via [${symbol}${pyenv_prefix}(${version} )(\($virtualenv\))]($style)'` | The format for the module.                                                             |
-| `symbol`             | `"🐍 "`                                                                 | A format string representing the symbol of Python                                      |
-| `style`              | `"yellow bold"`                                                         | The style for the module.                                                              |
-| `pyenv_version_name` | `false`                                                                 | Use pyenv to get Python version                                                        |
-| `pyenv_prefix`       | `pyenv `                                                                | Prefix before pyenv version display, only used if pyenv is used                        |
-| `scan_for_pyfiles`   | `true`                                                                  | If false, Python files in the current directory will not show this module.             |
-| `python_binary`      | `["python", "python3, "python2"]`                                       | Configures the python binaries that Starship should executes when getting the version. |
-| `disabled`           | `false`                                                                 | Disables the `python` module.                                                          |
+| Option               | Default                                                                                                      | Description                                                                            |
+| -------------------- | ------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- |
+| `format`             | `'via [${symbol}${pyenv_prefix}(${version} )(\($virtualenv\))]($style)'`                                     | The format for the module.                                                             |
+| `symbol`             | `"🐍 "`                                                                                                      | A format string representing the symbol of Python                                      |
+| `style`              | `"yellow bold"`                                                                                              | The style for the module.                                                              |
+| `pyenv_version_name` | `false`                                                                                                      | Use pyenv to get Python version                                                        |
+| `pyenv_prefix`       | `pyenv `                                                                                                     | Prefix before pyenv version display, only used if pyenv is used                        |
+| `python_binary`      | `["python", "python3, "python2"]`                                                                            | Configures the python binaries that Starship should executes when getting the version. |
+| `detect_extensions`  | `[".py"]`                                                                                                    | Which extensions should trigger this moudle                                            |
+| `detect_files`       | `[".python-version", "Pipfile", "__init__.py", "pyproject.toml", "requirements.txt", "setup.py", "tox.ini"]` | Which filenames should trigger this module                                             |
+| `detect_folders`     | `[]`                                                                                                         | Which folders should trigger this module                                               |
+| `disabled`           | `false`                                                                                                      | Disables the `python` module.                                                          |
 
 ::: tip
 
@@ -2110,6 +2112,14 @@ pyenv_version_name = true
 [python]
 # Only use the `python3` binary to get the version.
 python_binary = "python3"
+```
+
+```toml
+# ~/.config/starship.toml
+
+[python]
+# Don't trigger for files with the py extension
+detect_extensions = []
 ```
 
 ## Ruby

--- a/src/configs/python.rs
+++ b/src/configs/python.rs
@@ -7,11 +7,13 @@ pub struct PythonConfig<'a> {
     pub pyenv_version_name: bool,
     pub pyenv_prefix: &'a str,
     pub python_binary: VecOr<&'a str>,
-    pub scan_for_pyfiles: bool,
     pub format: &'a str,
     pub style: &'a str,
     pub symbol: &'a str,
     pub disabled: bool,
+    pub detect_extensions: Vec<&'a str>,
+    pub detect_files: Vec<&'a str>,
+    pub detect_folders: Vec<&'a str>,
 }
 
 impl<'a> RootModuleConfig<'a> for PythonConfig<'a> {
@@ -20,11 +22,21 @@ impl<'a> RootModuleConfig<'a> for PythonConfig<'a> {
             pyenv_version_name: false,
             pyenv_prefix: "pyenv ",
             python_binary: VecOr(vec!["python", "python3", "python2"]),
-            scan_for_pyfiles: true,
             format: "via [${symbol}${pyenv_prefix}(${version} )(\\($virtualenv\\))]($style)",
             style: "yellow bold",
             symbol: "🐍 ",
             disabled: false,
+            detect_extensions: vec!["py"],
+            detect_files: vec![
+                "requirements.txt",
+                ".python-version",
+                "pyproject.toml",
+                "Pipfile",
+                "tox.ini",
+                "setup.py",
+                "__init__.py",
+            ],
+            detect_folders: vec![],
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This makes it possible to configure when the python module is shown
based on the contents of a directory. This should make it possible to
be a lot more granular when configuring the module.
    
This includes a breaking change since we are removing the
`scan_for_pyfiles` configuration option in favour of setting the
`detect_extensions` to an empty array.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to #1977 

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
