### PR TITLE
ci: fix changelog generation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,7 +63,7 @@ jobs:
           - target: x86_64-apple-darwin
             os: macOS-latest
             name: starship-x86_64-apple-darwin.tar.gz
-          
+
           # TODO: Enable once macos-11.0 pools are publicly available
           # https://github.com/actions/virtual-environments/issues/2486
           # - target: aarch64-apple-darwin
@@ -73,11 +73,11 @@ jobs:
           - target: x86_64-pc-windows-msvc
             os: windows-latest
             name: starship-x86_64-pc-windows-msvc.zip
-          
+
           - target: i686-pc-windows-msvc
             os: windows-latest
             name: starship-i686-pc-windows-msvc.zip
-          
+
           - target: aarch64-pc-windows-msvc
             os: windows-latest
             name: starship-aarch64-pc-windows-msvc.zip
@@ -153,7 +153,7 @@ jobs:
       - name: Setup | Go
         uses: actions/setup-go@v2
         with:
-          go-version: "^1.13.1"
+          go-version: "^1.15.7"
 
       - name: Setup | Artifacts
         uses: actions/download-artifact@v2
@@ -163,7 +163,7 @@ jobs:
 
       - name: Setup | Release notes
         run: |
-          go get -u github.com/git-chglog/git-chglog/cmd/git-chglog
+          GO111MODULE=on go get github.com/git-chglog/git-chglog/cmd/git-chglog@0.9.1
           git-chglog -c .github/chglog/release.yml $(git describe --tags) > RELEASE.md
 
       - name: Build | Publish


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR makes the changelog generator compile again.

Changes:

- Update to go to 1.15
- Pin git-chglog to 0.9.1 because 0.10.0 requires go 1.16 (unreleased) to build. To allow pinning git-chglog `GO111MODULE` needs to be set to `on`.
- Remove `-u` because apparently it can cause issues

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
