### PR TITLE
feat(cmd_duration): Add notify display time

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -495,6 +495,7 @@ running `eval $(starship init $0)`, and then proceed as normal.
 | `disabled`          | `false`                       | Disables the `cmd_duration` module.                        |
 | `show_notifications`| `false`                       | Show desktop notifications when command completes.         |
 | `min_time_to_notify`| `45_000`                      | Shortest duration for notification (in milliseconds).      |
+| `notify_display_time` | `750`                       | Time to display a notification (in milliseconds). This value is not always respected by the notification server.      |
 
 ::: tip
 

--- a/src/configs/cmd_duration.rs
+++ b/src/configs/cmd_duration.rs
@@ -11,6 +11,7 @@ pub struct CmdDurationConfig<'a> {
     pub disabled: bool,
     pub show_notifications: bool,
     pub min_time_to_notify: i64,
+    pub notify_display_time: u64,
 }
 
 impl<'a> RootModuleConfig<'a> for CmdDurationConfig<'a> {
@@ -23,6 +24,7 @@ impl<'a> RootModuleConfig<'a> for CmdDurationConfig<'a> {
             disabled: false,
             show_notifications: false,
             min_time_to_notify: 45_000,
+            notify_display_time: 750,
         }
     }
 }

--- a/src/modules/cmd_duration.rs
+++ b/src/modules/cmd_duration.rs
@@ -101,6 +101,7 @@ fn undistract_me<'a, 'b>(
 ) -> Module<'a> {
     use ansi_term::{unstyle, ANSIStrings};
     use notify_rust::{Notification, Timeout};
+    use std::convert::TryFrom;
 
     if config.show_notifications && config.min_time_to_notify as u128 <= elapsed {
         let body = format!(
@@ -108,15 +109,19 @@ fn undistract_me<'a, 'b>(
             unstyle(&ANSIStrings(&module.ansi_strings()))
         );
 
-        let mut notification = Notification::new();
-        notification
-            .summary("Command finished")
-            .body(&body)
-            .icon("utilities-terminal")
-            .timeout(Timeout::Milliseconds(750));
+        if let Ok(display_time) = u32::try_from(config.notify_display_time) {
+            let mut notification = Notification::new();
+            notification
+                .summary("Command finished")
+                .body(&body)
+                .icon("utilities-terminal")
+                .timeout(Timeout::Milliseconds(display_time));
 
-        if let Err(err) = notification.show() {
-            log::trace!("Cannot show notification: {}", err);
+            if let Err(err) = notification.show() {
+                log::trace!("Cannot show notification: {}", err);
+            }
+        } else {
+            log::trace!("Notification display time size error");
         }
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
Adds a notify display duration configuration option to the cmd_duration module. 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #2194
Closes #3515

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
It turns out this is actually difficult to test, because, to quote the `notify-rust` docs, notification timeout is [often not respected by server, sorry.](https://docs.rs/notify-rust/4.2.2/notify_rust/struct.Notification.html#structfield.timeout) (which it turns out my system doesn't)
I think this is straightforward enough, but would appreciate others who can test.
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
