### PR TITLE
feat: abbreviate package.json semantic versions

### DIFF
--- a/src/modules/package.rs
+++ b/src/modules/package.rs
@@ -68,7 +68,8 @@ fn extract_package_version(file_contents: &str, display_private: bool) -> Option
     };
 
     let formatted_version = format_version(raw_version);
-    if formatted_version == "v0.0.0-development" || formatted_version.find("semantic").is_some() {
+    if formatted_version == "v0.0.0-development" || formatted_version.find("semantic").is_some()
+    {
         return Some("semantic".to_string());
     };
 

--- a/src/modules/package.rs
+++ b/src/modules/package.rs
@@ -68,7 +68,7 @@ fn extract_package_version(file_contents: &str, display_private: bool) -> Option
     };
 
     let formatted_version = format_version(raw_version);
-    if formatted_version.ends_with("-semantically-released") {
+    if formatted_version == "v0.0.0-development" || formatted_version.find("semantic").is_some() {
         return Some("semantic".to_string());
     };
 
@@ -348,17 +348,47 @@ mod tests {
     }
 
     #[test]
-    fn test_package_version_with_semantic_version() -> io::Result<()> {
+    fn test_package_version_semantic_development_version() -> io::Result<()> {
         let config_name = "package.json";
         let config_content = json::json!({
             "name": "starship",
-            "version": "0.0.0-semantically-released"
+            "version": "0.0.0-development"
         })
         .to_string();
 
         let project_dir = create_project_dir()?;
         fill_config(&project_dir, config_name, Some(&config_content))?;
         expect_output(&project_dir, Some("semantic"), None)?;
+        project_dir.close()
+    }
+
+    #[test]
+    fn test_package_version_with_semantic_other_version() -> io::Result<()> {
+        let config_name = "package.json";
+        let config_content = json::json!({
+            "name": "starship",
+            "version": "v0.0.0-semantically-released"
+        })
+        .to_string();
+
+        let project_dir = create_project_dir()?;
+        fill_config(&project_dir, config_name, Some(&config_content))?;
+        expect_output(&project_dir, Some("semantic"), None)?;
+        project_dir.close()
+    }
+
+    #[test]
+    fn test_package_version_with_non_semantic_tag() -> io::Result<()> {
+        let config_name = "package.json";
+        let config_content = json::json!({
+            "name": "starship",
+            "version": "v0.0.0-alpha"
+        })
+        .to_string();
+
+        let project_dir = create_project_dir()?;
+        fill_config(&project_dir, config_name, Some(&config_content))?;
+        expect_output(&project_dir, Some("v0.0.0-alpha"), None)?;
         project_dir.close()
     }
 

--- a/src/modules/package.rs
+++ b/src/modules/package.rs
@@ -68,6 +68,10 @@ fn extract_package_version(file_contents: &str, display_private: bool) -> Option
     };
 
     let formatted_version = format_version(raw_version);
+    if formatted_version.ends_with("-semantically-released") {
+        return Some("semantic".to_string());
+    };
+
     Some(formatted_version)
 }
 
@@ -340,6 +344,21 @@ mod tests {
         let project_dir = create_project_dir()?;
         fill_config(&project_dir, config_name, Some(&config_content))?;
         expect_output(&project_dir, Some("v0.1.0"), Some(starship_config))?;
+        project_dir.close()
+    }
+
+    #[test]
+    fn test_package_version_with_semantic_version() -> io::Result<()> {
+        let config_name = "package.json";
+        let config_content = json::json!({
+            "name": "starship",
+            "version": "0.0.0-semantically-released"
+        })
+        .to_string();
+
+        let project_dir = create_project_dir()?;
+        fill_config(&project_dir, config_name, Some(&config_content))?;
+        expect_output(&project_dir, Some("semantic"), None)?;
         project_dir.close()
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description

npm packages often use semantic release as a tool to automate versioning, by having a program look at conventional commit messages, like those on this repo.

This PR abbreviates long versions like `v0.0.0-semantically-released` to `semantic`

#### Motivation and Context

For npm packages, a somewhat common pattern is using semantic release, which allows a ci tool (e.g. github actions) to automatically determine versions based on (a conventional) commit history. This means that the correct version isn't actually in the package.json file.
Normally, you'll see a version like 0.0.0-semantically-released in the package.json, to indicate that the package version is derived elsewhere. In it's current implementation, this is awkward because it conveys little meaning, uses quite a bit of space, and doesn't actually let you know the version

#### Screenshots:

![Screenshot_20210205_155513](https://user-images.githubusercontent.com/8162045/107093694-4941c080-67cb-11eb-83c9-7ed6ababf55e.png)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
