### PR TITLE
feat(cmake): Configure when the module is shown

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -442,19 +442,23 @@ vicmd_symbol = "[V](bold green) "
 
 ## CMake
 
-The `cmake` module shows the currently installed version of CMake if any of the following conditions are met:
+The `cmake` module shows the currently installed version of CMake. By default
+the module will be activated if any of the following conditions are met:
 
 - The current directory contains a `CMakeLists.txt` file
 - The current directory contains a `CMakeCache.txt` file
 
 ### Options
 
-| Option     | Default                              | Description                                  |
-| ---------- | ------------------------------------ | -------------------------------------------- |
-| `format`   | `"via [$symbol($version )]($style)"` | The format for the module.                   |
-| `symbol`   | `"喝 "`                              | The symbol used before the version of cmake. |
-| `style`    | `"bold blue"`                        | The style for the module.                    |
-| `disabled` | `false`                              | Disables the `cmake` module.                 |
+| Option              | Default                                | Description                                  |
+| ------------------- | -------------------------------------- | -------------------------------------------- |
+| `format`            | `"via [$symbol($version )]($style)"`   | The format for the module.                   |
+| `symbol`            | `"喝 "`                                | The symbol used before the version of cmake. |
+| `detect_extensions` | `[]`                                   | Which extensions should trigger this moudle  |
+| `detect_files`      | `["CMakeLists.txt", "CMakeCache.txt"]` | Which filenames should trigger this module   |
+| `detect_folders`    | `[]`                                   | Which folders should trigger this module     |
+| `style`             | `"bold blue"`                          | The style for the module.                    |
+| `disabled`          | `false`                                | Disables the `cmake` module.                 |
 
 ### Variables
 

--- a/src/configs/cmake.rs
+++ b/src/configs/cmake.rs
@@ -8,6 +8,9 @@ pub struct CMakeConfig<'a> {
     pub symbol: &'a str,
     pub style: &'a str,
     pub disabled: bool,
+    pub detect_extensions: Vec<&'a str>,
+    pub detect_files: Vec<&'a str>,
+    pub detect_folders: Vec<&'a str>,
 }
 
 impl<'a> RootModuleConfig<'a> for CMakeConfig<'a> {
@@ -17,6 +20,9 @@ impl<'a> RootModuleConfig<'a> for CMakeConfig<'a> {
             symbol: "喝 ",
             style: "bold blue",
             disabled: false,
+            detect_extensions: vec![],
+            detect_files: vec!["CMakeLists.txt", "CMakeCache.txt"],
+            detect_folders: vec![],
         }
     }
 }

--- a/src/modules/cmake.rs
+++ b/src/modules/cmake.rs
@@ -5,21 +5,21 @@ use crate::formatter::StringFormatter;
 use crate::utils;
 
 /// Creates a module with the current CMake version
-///
-/// Will display the CMake version if any of the following criteria are met:
-///     - The current directory contains a `CMakeLists.txt` or `CMakeCache.txt`
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let mut module = context.new_module("cmake");
+    let config = CMakeConfig::try_load(module.config);
+
     let is_cmake_project = context
         .try_begin_scan()?
-        .set_files(&["CMakeLists.txt", "CMakeCache.txt"])
+        .set_files(&config.detect_files)
+        .set_extensions(&config.detect_extensions)
+        .set_folders(&config.detect_folders)
         .is_match();
 
     if !is_cmake_project {
         return None;
     }
 
-    let mut module = context.new_module("cmake");
-    let config = CMakeConfig::try_load(module.config);
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter
             .map_meta(|variable, _| match variable {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This makes it possible to configure when the cmake module is shown
based on the contents of a directory. This should make it possible to
be a lot more granular when configuring the module.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to #1977 

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
