### PR TITLE
feat: Move 'v' version prefix to module config, allowing a user to remove it

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2037,8 +2037,9 @@ format = "via [$symbol$version](bold white)"
 The `python` module shows the currently installed version of Python and the
 current Python virtual environment if one is activated.
 
-If `pyenv_version_name` is set to `true`, it will display the pyenv version
-name. Otherwise, it will display the version number from `python --version`.
+If `pyenv_version` variable is used in the `format` option, it will display
+the version number from `version-name`. Otherwise, it will display
+the version number from `python --version`.
 
 By default the module will be shown if any of the following conditions are met:
 
@@ -2056,11 +2057,9 @@ By default the module will be shown if any of the following conditions are met:
 
 | Option               | Default                                                                                                       | Description                                                                            |
 | -------------------- | ------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
-| `format`             | `'via [${symbol}${pyenv_prefix}(${pyenv_version} )(v${version} )(\($virtualenv\))]($style)'`                  | The format for the module.                                                             |
+| `format`             | `'via [${symbol}(v${version} )(\($virtualenv\))]($style)'`                                                    | The format for the module.                                                             |
 | `symbol`             | `"🐍 "`                                                                                                       | A format string representing the symbol of Python                                      |
 | `style`              | `"yellow bold"`                                                                                               | The style for the module.                                                              |
-| `pyenv_version_name` | `false`                                                                                                       | Use pyenv to get Python version                                                        |
-| `pyenv_prefix`       | `pyenv `                                                                                                      | Prefix before pyenv version display, only used if pyenv is used                        |
 | `python_binary`      | `["python", "python3, "python2"]`                                                                             | Configures the python binaries that Starship should executes when getting the version. |
 | `detect_extensions`  | `[".py"]`                                                                                                     | Which extensions should trigger this moudle                                            |
 | `detect_files`       | `[".python-version", "Pipfile", "__init__.py", "pyproject.toml", "requirements.txt", "setup.py", "tox.ini"]`  | Which filenames should trigger this module                                             |
@@ -2092,7 +2091,6 @@ Python version 2, see example below.
 | version       | `"3.8.1"`       | The version of `python`                    |
 | symbol        | `"🐍 "`         | Mirrors the value of option `symbol`       |
 | style         | `"yellow bold"` | Mirrors the value of option `style`        |
-| pyenv_prefix  | `"pyenv "`      | Mirrors the value of option `pyenv_prefix` |
 | pyenv_version | `"system"`      | The version of `python` from `pyenv`       |
 | virtualenv    | `"venv"`        | The current `virtualenv` name              |
 
@@ -2104,7 +2102,6 @@ Python version 2, see example below.
 
 [python]
 symbol = "👾 "
-pyenv_version_name = true
 ```
 
 ```toml
@@ -2123,6 +2120,13 @@ python_binary = "python3"
 detect_extensions = []
 ```
 
+```toml
+# ~/.config/starship.toml
+
+[python]
+# Display the version from `pyenv version-name` instead of the version from `python --version`
+format = 'via [${symbol}(pyenv ${pyenv_version} )(\($virtualenv\))]($style)'
+```
 ## Ruby
 
 The `ruby` module shows the currently installed version of Ruby.

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -449,12 +449,12 @@ The `cmake` module shows the currently installed version of CMake if any of the 
 
 ### Options
 
-| Option     | Default                              | Description                                  |
-| ---------- | ------------------------------------ | -------------------------------------------- |
-| `format`   | `"via [$symbol($version )]($style)"` | The format for the module.                   |
-| `symbol`   | `"喝 "`                              | The symbol used before the version of cmake. |
-| `style`    | `"bold blue"`                        | The style for the module.                    |
-| `disabled` | `false`                              | Disables the `cmake` module.                 |
+| Option     | Default                               | Description                                  |
+| ---------- | ------------------------------------- | -------------------------------------------- |
+| `format`   | `"via [$symbol(v$version )]($style)"` | The format for the module.                   |
+| `symbol`   | `"喝 "`                               | The symbol used before the version of cmake. |
+| `style`    | `"bold blue"`                         | The style for the module.                    |
+| `disabled` | `false`                               | Disables the `cmake` module.                 |
 
 ### Variables
 
@@ -572,12 +572,12 @@ The module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Option     | Default                              | Description                                               |
-| ---------- | ------------------------------------ | --------------------------------------------------------- |
-| `symbol`   | `"🔮 "`                              | The symbol used before displaying the version of crystal. |
-| `style`    | `"bold red"`                         | The style for the module.                                 |
-| `format`   | `"via [$symbol($version )]($style)"` | The format for the module.                                |
-| `disabled` | `false`                              | Disables the `crystal` module.                            |
+| Option     | Default                               | Description                                               |
+| ---------- | ------------------------------------- | --------------------------------------------------------- |
+| `symbol`   | `"🔮 "`                               | The symbol used before displaying the version of crystal. |
+| `style`    | `"bold red"`                          | The style for the module.                                 |
+| `format`   | `"via [$symbol(v$version )]($style)"` | The format for the module.                                |
+| `disabled` | `false`                               | Disables the `crystal` module.                            |
 
 ### Variables
 
@@ -609,12 +609,12 @@ The module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Option     | Default                              | Description                                     |
-| ---------- | ------------------------------------ | ----------------------------------------------- |
-| `format`   | `"via [$symbol($version )]($style)"` | The format for the module.                      |
-| `symbol`   | `"🎯 "`                              | A format string representing the symbol of Dart |
-| `style`    | `"bold blue"`                        | The style for the module.                       |
-| `disabled` | `false`                              | Disables the `dart` module.                     |
+| Option     | Default                               | Description                                     |
+| ---------- | ------------------------------------- | ----------------------------------------------- |
+| `format`   | `"via [$symbol(v$version )]($style)"` | The format for the module.                      |
+| `symbol`   | `"🎯 "`                               | A format string representing the symbol of Dart |
+| `style`    | `"bold blue"`                         | The style for the module.                       |
+| `disabled` | `false`                               | Disables the `dart` module.                     |
 
 ### Variables
 
@@ -777,7 +777,7 @@ when there is a csproj file in the current directory.
 
 | Option      | Default                                   | Description                                              |
 | ----------- | ----------------------------------------- | -------------------------------------------------------- |
-| `format`    | `"[$symbol($version )(🎯 $tfm )]($style)"`  | The format for the module.                               |
+| `format`    | `"[$symbol(v$version )(🎯 $tfm )]($style)"` | The format for the module.                               |
 | `symbol`    | `"•NET "`                                 | The symbol used before displaying the version of dotnet. |
 | `heuristic` | `true`                                    | Use faster version detection to keep starship snappy.    |
 | `style`     | `"bold blue"`                             | The style for the module.                                |
@@ -854,12 +854,12 @@ The module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Option     | Default                              | Description                                     |
-| ---------- | ------------------------------------ | ----------------------------------------------- |
-| `format`   | `"via [$symbol($version )]($style)"` | The format for the module.                      |
-| `symbol`   | `"🌳 "`                              | A format string representing the symbol of Elm. |
-| `style`    | `"cyan bold"`                        | The style for the module.                       |
-| `disabled` | `false`                              | Disables the `elm` module.                      |
+| Option     | Default                               | Description                                     |
+| ---------- | ------------------------------------- | ----------------------------------------------- |
+| `format`   | `"via [$symbol(v$version )]($style)"` | The format for the module.                      |
+| `symbol`   | `"🌳 "`                               | A format string representing the symbol of Elm. |
+| `style`    | `"cyan bold"`                         | The style for the module.                       |
+| `disabled` | `false`                               | Disables the `elm` module.                      |
 
 ### Variables
 
@@ -1233,12 +1233,12 @@ The module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Option     | Default                            | Description                                    |
-| ---------- | ---------------------------------- | ---------------------------------------------- |
-| `format`   | `"via [$symbol($version )]($style)"` | The format for the module.                     |
-| `symbol`   | `"🐹 "`                            | A format string representing the symbol of Go. |
-| `style`    | `"bold cyan"`                      | The style for the module.                      |
-| `disabled` | `false`                            | Disables the `golang` module.                  |
+| Option     | Default                             | Description                                    |
+| ---------- | ----------------------------------- | ---------------------------------------------- |
+| `format`   | `"via [$symbol(v$version )]($style)"` | The format for the module.                     |
+| `symbol`   | `"🐹 "`                             | A format string representing the symbol of Go. |
+| `style`    | `"bold cyan"`                       | The style for the module.                      |
+| `disabled` | `false`                             | Disables the `golang` module.                  |
 
 ### Variables
 
@@ -1269,12 +1269,12 @@ The module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Option     | Default                            | Description                                      |
-| ---------- | ---------------------------------- | ------------------------------------------------ |
-| `format`   | `"via [$symbol($version )]($style)"` | The format for the module.                       |
-| `symbol`   | `"⎈ "`                             | A format string representing the symbol of Helm. |
-| `style`    | `"bold white"`                     | The style for the module.                        |
-| `disabled` | `false`                            | Disables the `helm` module.                      |
+| Option     | Default                             | Description                                      |
+| ---------- | ----------------------------------- | ------------------------------------------------ |
+| `format`   | `"via [$symbol(v$version )]($style)"` | The format for the module.                       |
+| `symbol`   | `"⎈ "`                              | A format string representing the symbol of Helm. |
+| `style`    | `"bold white"`                      | The style for the module.                        |
+| `disabled` | `false`                             | Disables the `helm` module.                      |
 
 ### Variables
 
@@ -1340,12 +1340,12 @@ The module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Option     | Default                                  | Description                                     |
-| ---------- | ---------------------------------------- | ----------------------------------------------- |
-| `format`   | `"via [${symbol}(${version} )]($style)"` | The format for the module.                      |
-| `symbol`   | `"☕ "`                                  | A format string representing the symbol of Java |
-| `style`    | `"red dimmed"`                           | The style for the module.                       |
-| `disabled` | `false`                                  | Disables the `java` module.                     |
+| Option     | Default                                   | Description                                     |
+| ---------- | ----------------------------------------- | ----------------------------------------------- |
+| `format`   | `"via [${symbol}(v${version} )]($style)"` | The format for the module.                      |
+| `symbol`   | `"☕ "`                                   | A format string representing the symbol of Java |
+| `style`    | `"red dimmed"`                            | The style for the module.                       |
+| `disabled` | `false`                                   | Disables the `java` module.                     |
 
 ### Variables
 
@@ -1414,12 +1414,12 @@ The module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Option     | Default                            | Description                                       |
-| ---------- | ---------------------------------- | ------------------------------------------------- |
-| `format`   | `"via [$symbol($version )]($style)"` | The format for the module.                        |
-| `symbol`   | `"ஃ "`                             | A format string representing the symbol of Julia. |
-| `style`    | `"bold purple"`                    | The style for the module.                         |
-| `disabled` | `false`                            | Disables the `julia` module.                      |
+| Option     | Default                             | Description                                       |
+| ---------- | ----------------------------------- | ------------------------------------------------- |
+| `format`   | `"via [$symbol(v$version )]($style)"` | The format for the module.                        |
+| `symbol`   | `"ஃ "`                              | A format string representing the symbol of Julia. |
+| `style`    | `"bold purple"`                     | The style for the module.                         |
+| `disabled` | `false`                             | Disables the `julia` module.                      |
 
 ### Variables
 
@@ -1449,13 +1449,13 @@ The module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Option          | Default                              | Description                                                                   |
-| --------------- | ------------------------------------ | ----------------------------------------------------------------------------- |
-| `format`        | `"via [$symbol($version )]($style)"` | The format for the module.                                                    |
-| `symbol`        | `"🅺 "`                              | A format string representing the symbol of Kotlin.                            |
-| `style`         | `"bold blue"`                        | The style for the module.                                                     |
-| `kotlin_binary` | `"kotlin"`                           | Configures the kotlin binary that Starship executes when getting the version. |
-| `disabled`      | `false`                              | Disables the `kotlin` module.                                                 |
+| Option          | Default                               | Description                                                                   |
+| --------------- | ------------------------------------- | ----------------------------------------------------------------------------- |
+| `format`        | `"via [$symbol(v$version )]($style)"` | The format for the module.                                                    |
+| `symbol`        | `"🅺 "`                               | A format string representing the symbol of Kotlin.                            |
+| `style`         | `"bold blue"`                         | The style for the module.                                                     |
+| `kotlin_binary` | `"kotlin"`                            | Configures the kotlin binary that Starship executes when getting the version. |
+| `disabled`      | `false`                               | Disables the `kotlin` module.                                                 |
 
 ### Variables
 
@@ -1561,13 +1561,13 @@ The module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Option       | Default                              | Description                                                                   |
-| ------------ | ------------------------------------ | ----------------------------------------------------------------------------- |
-| `format`     | `"via [$symbol($version )]($style)"` | The format for the module.                                                    |
-| `symbol`     | `"🌙 "`                              | A format string representing the symbol of Lua.                               |
-| `style`      | `"bold blue"`                        | The style for the module.                                                     |
-| `lua_binary` | `"lua"`                              | Configures the lua binary that Starship executes when getting the version.    |
-| `disabled`   | `false`                              | Disables the `lua` module.                                                    |
+| Option       | Default                               | Description                                                                   |
+| ------------ | ------------------------------------- | ----------------------------------------------------------------------------- |
+| `format`     | `"via [$symbol(v$version )]($style)"` | The format for the module.                                                    |
+| `symbol`     | `"🌙 "`                               | A format string representing the symbol of Lua.                               |
+| `style`      | `"bold blue"`                         | The style for the module.                                                     |
+| `lua_binary` | `"lua"`                               | Configures the lua binary that Starship executes when getting the version.    |
+| `disabled`   | `false`                               | Disables the `lua` module.                                                    |
 
 ### Variables
 
@@ -1685,12 +1685,12 @@ The module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Option     | Default                            | Description                                           |
-| ---------- | ---------------------------------- | ----------------------------------------------------- |
-| `format`   | `"via [$symbol($version )]($style)"` | The format for the module                             |
-| `symbol`   | `"👑 "`                            | The symbol used before displaying the version of Nim. |
-| `style`    | `"bold yellow"`                    | The style for the module.                             |
-| `disabled` | `false`                            | Disables the `nim` module.                            |
+| Option     | Default                             | Description                                           |
+| ---------- | ----------------------------------- | ----------------------------------------------------- |
+| `format`   | `"via [$symbol(v$version )]($style)"` | The format for the module                             |
+| `symbol`   | `"👑 "`                             | The symbol used before displaying the version of Nim. |
+| `style`    | `"bold yellow"`                     | The style for the module.                             |
+| `disabled` | `false`                             | Disables the `nim` module.                            |
 
 ### Variables
 
@@ -1764,12 +1764,12 @@ The module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Option     | Default                            | Description                                        |
-| ---------- | ---------------------------------- | -------------------------------------------------- |
-| `format`   | `"via [$symbol($version )]($style)"` | The format for the module.                         |
-| `symbol`   | `"⬢ "`                             | A format string representing the symbol of NodeJS. |
-| `style`    | `"bold green"`                     | The style for the module.                          |
-| `disabled` | `false`                            | Disables the `nodejs` module.                      |
+| Option     | Default                             | Description                                        |
+| ---------- | ----------------------------------- | -------------------------------------------------- |
+| `format`   | `"via [$symbol(v$version )]($style)"` | The format for the module.                         |
+| `symbol`   | `"⬢ "`                              | A format string representing the symbol of NodeJS. |
+| `style`    | `"bold green"`                      | The style for the module.                          |
+| `disabled` | `false`                             | Disables the `nodejs` module.                      |
 | `not_capable_style` | `bold red` | The style for the module when an engines property in Packages.json does not match the NodeJS version. |
 
 ### Variables
@@ -1805,12 +1805,12 @@ The module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Option     | Default                              | Description                                             |
-| ---------- | ------------------------------------ | ------------------------------------------------------- |
-| `format`   | `"via [$symbol($version )]($style)"` | The format string for the module.                       |
-| `symbol`   | `"🐫 "`                              | The symbol used before displaying the version of OCaml. |
-| `style`    | `"bold yellow"`                      | The style for the module.                               |
-| `disabled` | `false`                              | Disables the `ocaml` module.                            |
+| Option     | Default                               | Description                                             |
+| ---------- | ------------------------------------- | ------------------------------------------------------- |
+| `format`   | `"via [$symbol(v$version )]($style)"` | The format string for the module.                       |
+| `symbol`   | `"🐫 "`                               | The symbol used before displaying the version of OCaml. |
+| `style`    | `"bold yellow"`                       | The style for the module.                               |
+| `disabled` | `false`                               | Disables the `ocaml` module.                            |
 
 ### Variables
 
@@ -1895,13 +1895,13 @@ package, and shows its current version. The module currently supports `npm`, `ca
 
 ### Options
 
-| Option            | Default                            | Description                                                |
-| ----------------- | ---------------------------------- | ---------------------------------------------------------- |
-| `format`          | `"is [$symbol$version]($style) "`  | The format for the module.                                 |
-| `symbol`          | `"📦 "`                            | The symbol used before displaying the version the package. |
-| `style`           | `"bold 208"`                       | The style for the module.                                  |
-| `display_private` | `false`                            | Enable displaying version for packages marked as private.  |
-| `disabled`        | `false`                            | Disables the `package` module.                             |
+| Option            | Default                                   | Description                                                |
+| ----------------- | ----------------------------------------- | ---------------------------------------------------------- |
+| `format`          | `"is [${symbol}v${version}](${style}) "`  | The format for the module.                                 |
+| `symbol`          | `"📦 "`                                   | The symbol used before displaying the version the package. |
+| `style`           | `"bold 208"`                              | The style for the module.                                  |
+| `display_private` | `false`                                   | Enable displaying version for packages marked as private.  |
+| `disabled`        | `false`                                   | Disables the `package` module.                             |
 
 ### Variables
 
@@ -1935,12 +1935,12 @@ The module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Option     | Default                              | Description                                           |
-| ---------- | ------------------------------------ | ----------------------------------------------------- |
-| `format`   | `"via [$symbol($version )]($style)"` | The format string for the module.                     |
-| `symbol`   | `"🐪 "`                              | The symbol used before displaying the version of Perl |
-| `style`    | `"bold 149"`                         | The style for the module.                             |
-| `disabled` | `false`                              | Disables the `perl` module.                           |
+| Option     | Default                               | Description                                           |
+| ---------- | ------------------------------------- | ----------------------------------------------------- |
+| `format`   | `"via [$symbol(v$version )]($style)"` | The format string for the module.                     |
+| `symbol`   | `"🐪 "`                               | The symbol used before displaying the version of Perl |
+| `style`    | `"bold 149"`                          | The style for the module.                             |
+| `disabled` | `false`                               | Disables the `perl` module.                           |
 
 ### Variables
 
@@ -1970,12 +1970,12 @@ The module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Option     | Default                              | Description                                           |
-| ---------- | ------------------------------------ | ----------------------------------------------------- |
-| `format`   | `"via [$symbol($version )]($style)"` | The format for the module.                            |
-| `symbol`   | `"🐘 "`                              | The symbol used before displaying the version of PHP. |
-| `style`    | `"147 bold"`                         | The style for the module.                             |
-| `disabled` | `false`                              | Disables the `php` module.                            |
+| Option     | Default                               | Description                                           |
+| ---------- | ------------------------------------- | ----------------------------------------------------- |
+| `format`   | `"via [$symbol(v$version )]($style)"` | The format for the module.                            |
+| `symbol`   | `"🐘 "`                               | The symbol used before displaying the version of PHP. |
+| `style`    | `"147 bold"`                          | The style for the module.                             |
+| `disabled` | `false`                               | Disables the `php` module.                            |
 
 ### Variables
 
@@ -2006,12 +2006,12 @@ The module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Option     | Default                              | Description                                                  |
-| ---------- | ------------------------------------ | ------------------------------------------------------------ |
-| `format`   | `"via [$symbol($version )]($style)"` | The format for the module.                                   |
-| `symbol`   | `"<=> "`                             | The symbol used before displaying the version of PureScript. |
-| `style`    | `"bold white"`                       | The style for the module.                                    |
-| `disabled` | `false`                              | Disables the `purescript` module.                            |
+| Option     | Default                               | Description                                                  |
+| ---------- | ------------------------------------- | ------------------------------------------------------------ |
+| `format`   | `"via [$symbol(v$version )]($style)"` | The format for the module.                                   |
+| `symbol`   | `"<=> "`                              | The symbol used before displaying the version of PureScript. |
+| `style`    | `"bold white"`                        | The style for the module.                                    |
+| `disabled` | `false`                               | Disables the `purescript` module.                            |
 
 ### Variables
 
@@ -2054,18 +2054,18 @@ By default the module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Option               | Default                                                                                                      | Description                                                                            |
-| -------------------- | ------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- |
-| `format`             | `'via [${symbol}${pyenv_prefix}(${version} )(\($virtualenv\))]($style)'`                                     | The format for the module.                                                             |
-| `symbol`             | `"🐍 "`                                                                                                      | A format string representing the symbol of Python                                      |
-| `style`              | `"yellow bold"`                                                                                              | The style for the module.                                                              |
-| `pyenv_version_name` | `false`                                                                                                      | Use pyenv to get Python version                                                        |
-| `pyenv_prefix`       | `pyenv `                                                                                                     | Prefix before pyenv version display, only used if pyenv is used                        |
-| `python_binary`      | `["python", "python3, "python2"]`                                                                            | Configures the python binaries that Starship should executes when getting the version. |
-| `detect_extensions`  | `[".py"]`                                                                                                    | Which extensions should trigger this moudle                                            |
-| `detect_files`       | `[".python-version", "Pipfile", "__init__.py", "pyproject.toml", "requirements.txt", "setup.py", "tox.ini"]` | Which filenames should trigger this module                                             |
-| `detect_folders`     | `[]`                                                                                                         | Which folders should trigger this module                                               |
-| `disabled`           | `false`                                                                                                      | Disables the `python` module.                                                          |
+| Option               | Default                                                                                                       | Description                                                                            |
+| -------------------- | ------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| `format`             | `'via [${symbol}${pyenv_prefix}(${pyenv_version} )(v${version} )(\($virtualenv\))]($style)'`                  | The format for the module.                                                             |
+| `symbol`             | `"🐍 "`                                                                                                       | A format string representing the symbol of Python                                      |
+| `style`              | `"yellow bold"`                                                                                               | The style for the module.                                                              |
+| `pyenv_version_name` | `false`                                                                                                       | Use pyenv to get Python version                                                        |
+| `pyenv_prefix`       | `pyenv `                                                                                                      | Prefix before pyenv version display, only used if pyenv is used                        |
+| `python_binary`      | `["python", "python3, "python2"]`                                                                             | Configures the python binaries that Starship should executes when getting the version. |
+| `detect_extensions`  | `[".py"]`                                                                                                     | Which extensions should trigger this moudle                                            |
+| `detect_files`       | `[".python-version", "Pipfile", "__init__.py", "pyproject.toml", "requirements.txt", "setup.py", "tox.ini"]`  | Which filenames should trigger this module                                             |
+| `detect_folders`     | `[]`                                                                                                          | Which folders should trigger this module                                               |
+| `disabled`           | `false`                                                                                                       | Disables the `python` module.                                                          |
 
 ::: tip
 
@@ -2087,13 +2087,14 @@ Python version 2, see example below.
 
 ### Variables
 
-| Variable     | Example         | Description                                |
-| ------------ | --------------- | ------------------------------------------ |
-| version      | `"v3.8.1"`      | The version of `python`                    |
-| symbol       | `"🐍 "`         | Mirrors the value of option `symbol`       |
-| style        | `"yellow bold"` | Mirrors the value of option `style`        |
-| pyenv_prefix | `"pyenv "`      | Mirrors the value of option `pyenv_prefix` |
-| virtualenv   | `"venv"`        | The current `virtualenv` name              |
+| Variable      | Example         | Description                                |
+| ------------- | --------------- | ------------------------------------------ |
+| version       | `"3.8.1"`       | The version of `python`                    |
+| symbol        | `"🐍 "`         | Mirrors the value of option `symbol`       |
+| style         | `"yellow bold"` | Mirrors the value of option `style`        |
+| pyenv_prefix  | `"pyenv "`      | Mirrors the value of option `pyenv_prefix` |
+| pyenv_version | `"system"`      | The version of `python` from `pyenv`       |
+| virtualenv    | `"venv"`        | The current `virtualenv` name              |
 
 
 ### Example
@@ -2133,12 +2134,12 @@ The module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Option     | Default                            | Description                                      |
-| ---------- | ---------------------------------- | ------------------------------------------------ |
-| `format`   | `"via [$symbol($version )]($style)"` | The format for the module.                       |
-| `symbol`   | `"💎 "`                            | A format string representing the symbol of Ruby. |
-| `style`    | `"bold red"`                       | The style for the module.                        |
-| `disabled` | `false`                            | Disables the `ruby` module.                      |
+| Option     | Default                             | Description                                      |
+| ---------- | ----------------------------------- | ------------------------------------------------ |
+| `format`   | `"via [$symbol(v$version )]($style)"` | The format for the module.                       |
+| `symbol`   | `"💎 "`                             | A format string representing the symbol of Ruby. |
+| `style`    | `"bold red"`                        | The style for the module.                        |
+| `disabled` | `false`                             | Disables the `ruby` module.                      |
 
 ### Variables
 
@@ -2169,12 +2170,12 @@ The module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Option     | Default                            | Description                                     |
-| ---------- | ---------------------------------- | ----------------------------------------------- |
-| `format`   | `"via [$symbol($version )]($style)"` | The format for the module.                      |
-| `symbol`   | `"🦀 "`                            | A format string representing the symbol of Rust |
-| `style`    | `"bold red"`                       | The style for the module.                       |
-| `disabled` | `false`                            | Disables the `rust` module.                     |
+| Option     | Default                             | Description                                     |
+| ---------- | ----------------------------------- | ----------------------------------------------- |
+| `format`   | `"via [$symbol(v$version )]($style)"` | The format for the module.                      |
+| `symbol`   | `"🦀 "`                             | A format string representing the symbol of Rust |
+| `style`    | `"bold red"`                        | The style for the module.                       |
+| `disabled` | `false`                             | Disables the `rust` module.                     |
 
 ### Variables
 
@@ -2336,12 +2337,12 @@ The module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Option     | Default                              | Description                                      |
-| ---------- | ------------------------------------ | ------------------------------------------------ |
-| `format`   | `"via [$symbol($version )]($style)"` | The format for the module.                       |
-| `symbol`   | `"🐦 "`                              | A format string representing the symbol of Swift |
-| `style`    | `"bold 202"`                         | The style for the module.                        |
-| `disabled` | `false`                              | Disables the `swift` module.                     |
+| Option     | Default                               | Description                                      |
+| ---------- | ------------------------------------- | ------------------------------------------------ |
+| `format`   | `"via [$symbol(v$version )]($style)"` | The format for the module.                       |
+| `symbol`   | `"🐦 "`                               | A format string representing the symbol of Swift |
+| `style`    | `"bold 202"`                          | The style for the module.                        |
+| `disabled` | `false`                               | Disables the `swift` module.                     |
 
 ### Variables
 
@@ -2524,12 +2525,12 @@ The module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Option     | Default                            | Description                                         |
-| ---------- | ---------------------------------- | --------------------------------------------------- |
-| `format`   | `"via [$symbol($version )]($style)"` | The format for the module.                          |
-| `symbol`   | `"⍱ "`                             | A format string representing the symbol of Vagrant. |
-| `style`    | `"cyan bold"`                      | The style for the module.                           |
-| `disabled` | `false`                            | Disables the `Vagrant` module.                      |
+| Option     | Default                             | Description                                         |
+| ---------- | ----------------------------------- | --------------------------------------------------- |
+| `format`   | `"via [$symbol(v$version )]($style)"` | The format for the module.                          |
+| `symbol`   | `"⍱ "`                              | A format string representing the symbol of Vagrant. |
+| `style`    | `"cyan bold"`                       | The style for the module.                           |
+| `disabled` | `false`                             | Disables the `Vagrant` module.                      |
 
 ### Variables
 
@@ -2559,12 +2560,12 @@ The module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Option     | Default                              | Description                                           |
-| ---------- | ------------------------------------ | ----------------------------------------------------- |
-| `symbol`   | `"↯ "`                               | The symbol used before displaying the version of Zig. |
-| `style`    | `"bold yellow"`                      | The style for the module.                             |
-| `format`   | `"via [$symbol($version )]($style)"` | The format for the module.                            |
-| `disabled` | `false`                              | Disables the `zig` module.                            |
+| Option     | Default                               | Description                                           |
+| ---------- | ------------------------------------- | ----------------------------------------------------- |
+| `symbol`   | `"↯ "`                                | The symbol used before displaying the version of Zig. |
+| `style`    | `"bold yellow"`                       | The style for the module.                             |
+| `format`   | `"via [$symbol(v$version )]($style)"` | The format for the module.                            |
+| `disabled` | `false`                               | Disables the `zig` module.                            |
 
 ### Variables
 

--- a/src/configs/cmake.rs
+++ b/src/configs/cmake.rs
@@ -13,7 +13,7 @@ pub struct CMakeConfig<'a> {
 impl<'a> RootModuleConfig<'a> for CMakeConfig<'a> {
     fn new() -> Self {
         CMakeConfig {
-            format: "via [$symbol($version )]($style)",
+            format: "via [$symbol(v$version )]($style)",
             symbol: "喝 ",
             style: "bold blue",
             disabled: false,

--- a/src/configs/crystal.rs
+++ b/src/configs/crystal.rs
@@ -13,7 +13,7 @@ pub struct CrystalConfig<'a> {
 impl<'a> RootModuleConfig<'a> for CrystalConfig<'a> {
     fn new() -> Self {
         CrystalConfig {
-            format: "via [$symbol($version )]($style)",
+            format: "via [$symbol(v$version )]($style)",
             symbol: "🔮 ",
             style: "bold red",
             disabled: false,

--- a/src/configs/dart.rs
+++ b/src/configs/dart.rs
@@ -13,7 +13,7 @@ pub struct DartConfig<'a> {
 impl<'a> RootModuleConfig<'a> for DartConfig<'a> {
     fn new() -> Self {
         DartConfig {
-            format: "via [$symbol($version )]($style)",
+            format: "via [$symbol(v$version )]($style)",
             symbol: "🎯 ",
             style: "bold blue",
             disabled: false,

--- a/src/configs/dotnet.rs
+++ b/src/configs/dotnet.rs
@@ -14,7 +14,7 @@ pub struct DotnetConfig<'a> {
 impl<'a> RootModuleConfig<'a> for DotnetConfig<'a> {
     fn new() -> Self {
         DotnetConfig {
-            format: "[$symbol($version )(🎯 $tfm )]($style)",
+            format: "[$symbol(v$version )(🎯 $tfm )]($style)",
             symbol: "•NET ",
             style: "blue bold",
             heuristic: true,

--- a/src/configs/elm.rs
+++ b/src/configs/elm.rs
@@ -13,7 +13,7 @@ pub struct ElmConfig<'a> {
 impl<'a> RootModuleConfig<'a> for ElmConfig<'a> {
     fn new() -> Self {
         ElmConfig {
-            format: "via [$symbol($version )]($style)",
+            format: "via [$symbol(v$version )]($style)",
             symbol: "🌳 ",
             style: "cyan bold",
             disabled: false,

--- a/src/configs/go.rs
+++ b/src/configs/go.rs
@@ -13,7 +13,7 @@ pub struct GoConfig<'a> {
 impl<'a> RootModuleConfig<'a> for GoConfig<'a> {
     fn new() -> Self {
         GoConfig {
-            format: "via [$symbol($version )]($style)",
+            format: "via [$symbol(v$version )]($style)",
             symbol: "🐹 ",
             style: "bold cyan",
             disabled: false,

--- a/src/configs/helm.rs
+++ b/src/configs/helm.rs
@@ -13,7 +13,7 @@ pub struct HelmConfig<'a> {
 impl<'a> RootModuleConfig<'a> for HelmConfig<'a> {
     fn new() -> Self {
         HelmConfig {
-            format: "via [$symbol($version )]($style)",
+            format: "via [$symbol(v$version )]($style)",
             symbol: "⎈ ",
             style: "bold white",
             disabled: false,

--- a/src/configs/java.rs
+++ b/src/configs/java.rs
@@ -13,7 +13,7 @@ pub struct JavaConfig<'a> {
 impl<'a> RootModuleConfig<'a> for JavaConfig<'a> {
     fn new() -> Self {
         JavaConfig {
-            format: "via [$symbol($version )]($style)",
+            format: "via [$symbol(v$version )]($style)",
             disabled: false,
             style: "red dimmed",
             symbol: "☕ ",

--- a/src/configs/julia.rs
+++ b/src/configs/julia.rs
@@ -13,7 +13,7 @@ pub struct JuliaConfig<'a> {
 impl<'a> RootModuleConfig<'a> for JuliaConfig<'a> {
     fn new() -> Self {
         JuliaConfig {
-            format: "via [$symbol($version )]($style)",
+            format: "via [$symbol(v$version )]($style)",
             symbol: "ஃ ",
             style: "bold purple",
             disabled: false,

--- a/src/configs/kotlin.rs
+++ b/src/configs/kotlin.rs
@@ -14,7 +14,7 @@ pub struct KotlinConfig<'a> {
 impl<'a> RootModuleConfig<'a> for KotlinConfig<'a> {
     fn new() -> Self {
         KotlinConfig {
-            format: "via [$symbol($version )]($style)",
+            format: "via [$symbol(v$version )]($style)",
             symbol: "🅺 ",
             style: "bold blue",
             kotlin_binary: "kotlin",

--- a/src/configs/lua.rs
+++ b/src/configs/lua.rs
@@ -14,7 +14,7 @@ pub struct LuaConfig<'a> {
 impl<'a> RootModuleConfig<'a> for LuaConfig<'a> {
     fn new() -> Self {
         LuaConfig {
-            format: "via [$symbol($version )]($style)",
+            format: "via [$symbol(v$version )]($style)",
             symbol: "🌙 ",
             style: "bold blue",
             lua_binary: "lua",

--- a/src/configs/nim.rs
+++ b/src/configs/nim.rs
@@ -13,7 +13,7 @@ pub struct NimConfig<'a> {
 impl<'a> RootModuleConfig<'a> for NimConfig<'a> {
     fn new() -> Self {
         NimConfig {
-            format: "via [$symbol($version )]($style)",
+            format: "via [$symbol(v$version )]($style)",
             symbol: "👑 ",
             style: "yellow bold",
             disabled: false,

--- a/src/configs/nodejs.rs
+++ b/src/configs/nodejs.rs
@@ -14,7 +14,7 @@ pub struct NodejsConfig<'a> {
 impl<'a> RootModuleConfig<'a> for NodejsConfig<'a> {
     fn new() -> Self {
         NodejsConfig {
-            format: "via [$symbol($version )]($style)",
+            format: "via [$symbol(v$version )]($style)",
             symbol: "⬢ ",
             style: "bold green",
             disabled: false,

--- a/src/configs/ocaml.rs
+++ b/src/configs/ocaml.rs
@@ -13,7 +13,7 @@ pub struct OCamlConfig<'a> {
 impl<'a> RootModuleConfig<'a> for OCamlConfig<'a> {
     fn new() -> Self {
         OCamlConfig {
-            format: "via [$symbol($version )]($style)",
+            format: "via [$symbol(v$version )]($style)",
             symbol: "🐫 ",
             style: "bold yellow",
             disabled: false,

--- a/src/configs/package.rs
+++ b/src/configs/package.rs
@@ -14,7 +14,7 @@ pub struct PackageConfig<'a> {
 impl<'a> RootModuleConfig<'a> for PackageConfig<'a> {
     fn new() -> Self {
         PackageConfig {
-            format: "is [$symbol$version]($style) ",
+            format: "is [${symbol}v${version}](${style}) ",
             symbol: "📦 ",
             style: "208 bold",
             display_private: false,

--- a/src/configs/perl.rs
+++ b/src/configs/perl.rs
@@ -15,7 +15,7 @@ impl<'a> RootModuleConfig<'a> for PerlConfig<'a> {
         PerlConfig {
             symbol: "🐪 ",
             style: "149 bold",
-            format: "via [$symbol($version )]($style)",
+            format: "via [$symbol(v$version )]($style)",
             disabled: false,
         }
     }

--- a/src/configs/php.rs
+++ b/src/configs/php.rs
@@ -15,7 +15,7 @@ impl<'a> RootModuleConfig<'a> for PhpConfig<'a> {
         PhpConfig {
             symbol: "🐘 ",
             style: "147 bold",
-            format: "via [$symbol($version )]($style)",
+            format: "via [$symbol(v$version )]($style)",
             disabled: false,
         }
     }

--- a/src/configs/purescript.rs
+++ b/src/configs/purescript.rs
@@ -13,7 +13,7 @@ pub struct PureScriptConfig<'a> {
 impl<'a> RootModuleConfig<'a> for PureScriptConfig<'a> {
     fn new() -> Self {
         PureScriptConfig {
-            format: "via [$symbol($version )]($style)",
+            format: "via [$symbol(v$version )]($style)",
             symbol: "<=> ",
             style: "bold white",
             disabled: false,

--- a/src/configs/python.rs
+++ b/src/configs/python.rs
@@ -4,8 +4,6 @@ use starship_module_config_derive::ModuleConfig;
 
 #[derive(Clone, ModuleConfig)]
 pub struct PythonConfig<'a> {
-    pub pyenv_version_name: bool,
-    pub pyenv_prefix: &'a str,
     pub python_binary: VecOr<&'a str>,
     pub format: &'a str,
     pub style: &'a str,
@@ -19,10 +17,8 @@ pub struct PythonConfig<'a> {
 impl<'a> RootModuleConfig<'a> for PythonConfig<'a> {
     fn new() -> Self {
         PythonConfig {
-            pyenv_version_name: false,
-            pyenv_prefix: "pyenv ",
             python_binary: VecOr(vec!["python", "python3", "python2"]),
-            format: "via [${symbol}${pyenv_prefix}(${pyenv_version} )(v${version} )(\\($virtualenv\\))]($style)",
+            format: "via [${symbol}(v${version} )(\\($virtualenv\\))]($style)",
             style: "yellow bold",
             symbol: "🐍 ",
             disabled: false,

--- a/src/configs/python.rs
+++ b/src/configs/python.rs
@@ -22,7 +22,7 @@ impl<'a> RootModuleConfig<'a> for PythonConfig<'a> {
             pyenv_version_name: false,
             pyenv_prefix: "pyenv ",
             python_binary: VecOr(vec!["python", "python3", "python2"]),
-            format: "via [${symbol}${pyenv_prefix}(${version} )(\\($virtualenv\\))]($style)",
+            format: "via [${symbol}${pyenv_prefix}(${pyenv_version} )(v${version} )(\\($virtualenv\\))]($style)",
             style: "yellow bold",
             symbol: "🐍 ",
             disabled: false,

--- a/src/configs/ruby.rs
+++ b/src/configs/ruby.rs
@@ -13,7 +13,7 @@ pub struct RubyConfig<'a> {
 impl<'a> RootModuleConfig<'a> for RubyConfig<'a> {
     fn new() -> Self {
         RubyConfig {
-            format: "via [$symbol($version )]($style)",
+            format: "via [$symbol(v$version )]($style)",
             symbol: "💎 ",
             style: "bold red",
             disabled: false,

--- a/src/configs/rust.rs
+++ b/src/configs/rust.rs
@@ -13,7 +13,7 @@ pub struct RustConfig<'a> {
 impl<'a> RootModuleConfig<'a> for RustConfig<'a> {
     fn new() -> Self {
         RustConfig {
-            format: "via [$symbol($version )]($style)",
+            format: "via [$symbol(v$version )]($style)",
             symbol: "🦀 ",
             style: "bold red",
             disabled: false,

--- a/src/configs/swift.rs
+++ b/src/configs/swift.rs
@@ -13,7 +13,7 @@ pub struct SwiftConfig<'a> {
 impl<'a> RootModuleConfig<'a> for SwiftConfig<'a> {
     fn new() -> Self {
         SwiftConfig {
-            format: "via [$symbol($version )]($style)",
+            format: "via [$symbol(v$version )]($style)",
             symbol: "🐦 ",
             style: "bold 202",
             disabled: false,

--- a/src/configs/vagrant.rs
+++ b/src/configs/vagrant.rs
@@ -13,7 +13,7 @@ pub struct VagrantConfig<'a> {
 impl<'a> RootModuleConfig<'a> for VagrantConfig<'a> {
     fn new() -> Self {
         VagrantConfig {
-            format: "via [$symbol($version )]($style)",
+            format: "via [$symbol(v$version )]($style)",
             symbol: "⍱ ",
             style: "cyan bold",
             disabled: false,

--- a/src/configs/zig.rs
+++ b/src/configs/zig.rs
@@ -13,7 +13,7 @@ pub struct ZigConfig<'a> {
 impl<'a> RootModuleConfig<'a> for ZigConfig<'a> {
     fn new() -> Self {
         ZigConfig {
-            format: "via [$symbol($version )]($style)",
+            format: "via [$symbol(v$version )]($style)",
             symbol: "↯ ",
             style: "bold yellow",
             disabled: false,

--- a/src/modules/cmake.rs
+++ b/src/modules/cmake.rs
@@ -53,7 +53,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
 fn format_cmake_version(cmake_version: &str) -> Option<String> {
     let version = cmake_version.split_whitespace().nth(2)?;
-    Some(format!("v{}", version))
+    Some(version.to_string())
 }
 
 #[cfg(test)]

--- a/src/modules/crystal.rs
+++ b/src/modules/crystal.rs
@@ -61,10 +61,7 @@ fn format_crystal_version(crystal_version: &str) -> Option<String> {
         // return "0.35.1"
         .nth(1)?;
 
-    let mut formatted_version = String::with_capacity(version.len() + 1);
-    formatted_version.push('v');
-    formatted_version.push_str(version);
-    Some(formatted_version)
+    Some(version.to_string())
 }
 
 #[cfg(test)]

--- a/src/modules/dart.rs
+++ b/src/modules/dart.rs
@@ -63,7 +63,7 @@ fn parse_dart_version(dart_version: &str) -> Option<String> {
         // return "2.8.4"
         .nth(3)?;
 
-    Some(format!("v{}", version))
+    Some(version.to_string())
 }
 
 #[cfg(test)]
@@ -77,7 +77,7 @@ mod tests {
     #[test]
     fn test_parse_dart_version() {
         let input = "Dart VM version: 2.8.4 (stable)";
-        assert_eq!(parse_dart_version(input), Some("v2.8.4".to_string()));
+        assert_eq!(parse_dart_version(input), Some("2.8.4".to_string()));
     }
 
     #[test]

--- a/src/modules/dotnet.rs
+++ b/src/modules/dotnet.rs
@@ -235,10 +235,7 @@ fn get_pinned_sdk_version(json: &str) -> Option<Version> {
                     let version = sdk.get("version")?;
                     match version {
                         JValue::String(version_string) => {
-                            let mut buffer = String::with_capacity(version_string.len() + 1);
-                            buffer.push('v');
-                            buffer.push_str(version_string);
-                            Some(Version(buffer))
+                            Some(Version(version_string.to_string()))
                         }
                         _ => None,
                     }
@@ -290,7 +287,7 @@ fn map_str_to_lower(value: Option<&OsStr>) -> Option<String> {
 
 fn get_version_from_cli() -> Option<Version> {
     let version_output = utils::exec_cmd("dotnet", &["--version"])?;
-    Some(Version(format!("v{}", version_output.stdout.trim())))
+    Some(Version(version_output.stdout.trim().to_string()))
 }
 
 fn get_latest_sdk_from_cli() -> Option<Version> {
@@ -310,10 +307,7 @@ fn get_latest_sdk_from_cli() -> Option<Version> {
             let take_until = latest_sdk.find('[').or_else(parse_failed)? - 1;
             if take_until > 1 {
                 let version = &latest_sdk[..take_until];
-                let mut buffer = String::with_capacity(version.len() + 1);
-                buffer.push('v');
-                buffer.push_str(version);
-                Some(Version(buffer))
+                Some(Version(version.to_string()))
             } else {
                 parse_failed()
             }
@@ -621,7 +615,7 @@ mod tests {
     "#;
 
         let version = get_pinned_sdk_version(json_text).unwrap();
-        assert_eq!("v1.2.3", version.0);
+        assert_eq!("1.2.3", version.0);
     }
 
     #[test]

--- a/src/modules/elm.rs
+++ b/src/modules/elm.rs
@@ -40,7 +40,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             .map(|variable| match variable {
                 "version" => {
                     let elm_version = utils::exec_cmd("elm", &["--version"])?.stdout;
-                    let module_version = Some(format!("v{}", elm_version.trim()))?;
+                    let module_version = elm_version.trim().to_string();
                     Some(Ok(module_version))
                 }
                 _ => None,

--- a/src/modules/golang.rs
+++ b/src/modules/golang.rs
@@ -80,7 +80,7 @@ fn format_go_version(go_stdout: &str) -> Option<String> {
         // return "1.12.4"
         .next()?;
 
-    Some(format!("v{}", version))
+    Some(version.to_string())
 }
 
 #[cfg(test)]
@@ -198,6 +198,6 @@ mod tests {
     #[test]
     fn test_format_go_version() {
         let input = "go version go1.12 darwin/amd64";
-        assert_eq!(format_go_version(input), Some("v1.12".to_string()));
+        assert_eq!(format_go_version(input), Some("1.12".to_string()));
     }
 }

--- a/src/modules/helm.rs
+++ b/src/modules/helm.rs
@@ -69,6 +69,8 @@ fn format_helm_version(helm_stdout: &str) -> Option<String> {
             // return "v3.1.1" or " v3.1.1"
             .trim_start_matches("Client: ")
             // return "v3.1.1"
+            .trim_start_matches('v')
+            // return "3.1.1"
             .trim()
             .to_owned(),
     )
@@ -121,7 +123,7 @@ mod tests {
     fn test_format_helm_version() {
         let helm_2 = "Client: v2.16.9+g8ad7037";
         let helm_3 = "v3.1.1+ggit afe7058";
-        assert_eq!(format_helm_version(helm_2), Some("v2.16.9".to_string()));
-        assert_eq!(format_helm_version(helm_3), Some("v3.1.1".to_string()));
+        assert_eq!(format_helm_version(helm_2), Some("2.16.9".to_string()));
+        assert_eq!(format_helm_version(helm_3), Some("3.1.1".to_string()));
     }
 }

--- a/src/modules/java.rs
+++ b/src/modules/java.rs
@@ -87,7 +87,7 @@ fn parse_java_version(java_version: &str) -> Option<String> {
     let captures = re.captures(java_version)?;
     let version = &captures["version"];
 
-    Some(format!("v{}", &version))
+    Some(version.to_string())
 }
 
 #[cfg(test)]
@@ -102,58 +102,58 @@ mod tests {
     fn test_parse_java_version_openjdk() {
         let java_8 = "OpenJDK 64-Bit Server VM (25.222-b10) for linux-amd64 JRE (1.8.0_222-b10), built on Jul 11 2019 10:18:43 by \"openjdk\" with gcc 4.4.7 20120313 (Red Hat 4.4.7-23)";
         let java_11 = "OpenJDK 64-Bit Server VM (11.0.4+11-post-Ubuntu-1ubuntu219.04) for linux-amd64 JRE (11.0.4+11-post-Ubuntu-1ubuntu219.04), built on Jul 18 2019 18:21:46 by \"build\" with gcc 8.3.0";
-        assert_eq!(parse_java_version(java_11), Some("v11.0.4".to_string()));
-        assert_eq!(parse_java_version(java_8), Some("v1.8.0".to_string()));
+        assert_eq!(parse_java_version(java_11), Some("11.0.4".to_string()));
+        assert_eq!(parse_java_version(java_8), Some("1.8.0".to_string()));
     }
 
     #[test]
     fn test_parse_java_version_oracle() {
         let java_8 = "Java HotSpot(TM) Client VM (25.65-b01) for linux-arm-vfp-hflt JRE (1.8.0_65-b17), built on Oct  6 2015 16:19:04 by \"java_re\" with gcc 4.7.2 20120910 (prerelease)";
-        assert_eq!(parse_java_version(java_8), Some("v1.8.0".to_string()));
+        assert_eq!(parse_java_version(java_8), Some("1.8.0".to_string()));
     }
 
     #[test]
     fn test_parse_java_version_redhat() {
         let java_8 = "OpenJDK 64-Bit Server VM (25.222-b10) for linux-amd64 JRE (1.8.0_222-b10), built on Jul 11 2019 20:48:53 by \"root\" with gcc 7.3.1 20180303 (Red Hat 7.3.1-5)";
         let java_12 = "OpenJDK 64-Bit Server VM (12.0.2+10) for linux-amd64 JRE (12.0.2+10), built on Jul 18 2019 14:41:47 by \"jenkins\" with gcc 7.3.1 20180303 (Red Hat 7.3.1-5)";
-        assert_eq!(parse_java_version(java_8), Some("v1.8.0".to_string()));
-        assert_eq!(parse_java_version(java_12), Some("v12.0.2".to_string()));
+        assert_eq!(parse_java_version(java_8), Some("1.8.0".to_string()));
+        assert_eq!(parse_java_version(java_12), Some("12.0.2".to_string()));
     }
 
     #[test]
     fn test_parse_java_version_zulu() {
         let java_8 = "OpenJDK 64-Bit Server VM (25.222-b10) for linux-amd64 JRE (Zulu 8.40.0.25-CA-linux64) (1.8.0_222-b10), built on Jul 11 2019 11:36:39 by \"zulu_re\" with gcc 4.4.7 20120313 (Red Hat 4.4.7-3)";
         let java_11 = "OpenJDK 64-Bit Server VM (11.0.4+11-LTS) for linux-amd64 JRE (Zulu11.33+15-CA) (11.0.4+11-LTS), built on Jul 11 2019 21:37:17 by \"zulu_re\" with gcc 4.9.2 20150212 (Red Hat 4.9.2-6)";
-        assert_eq!(parse_java_version(java_8), Some("v1.8.0".to_string()));
-        assert_eq!(parse_java_version(java_11), Some("v11.0.4".to_string()));
+        assert_eq!(parse_java_version(java_8), Some("1.8.0".to_string()));
+        assert_eq!(parse_java_version(java_11), Some("11.0.4".to_string()));
     }
 
     #[test]
     fn test_parse_java_version_eclipse_openj9() {
         let java_8 = "Eclipse OpenJ9 OpenJDK 64-bit Server VM (1.8.0_222-b10) from linux-amd64 JRE with Extensions for OpenJDK for Eclipse OpenJ9 8.0.222.0, built on Jul 17 2019 21:29:18 by jenkins with g++ (GCC) 7.3.1 20180303 (Red Hat 7.3.1-5)";
         let java_11 = "Eclipse OpenJ9 OpenJDK 64-bit Server VM (11.0.4+11) from linux-amd64 JRE with Extensions for OpenJDK for Eclipse OpenJ9 11.0.4.0, built on Jul 17 2019 21:51:37 by jenkins with g++ (GCC) 7.3.1 20180303 (Red Hat 7.3.1-5)";
-        assert_eq!(parse_java_version(java_8), Some("v1.8.0".to_string()));
-        assert_eq!(parse_java_version(java_11), Some("v11.0.4".to_string()));
+        assert_eq!(parse_java_version(java_8), Some("1.8.0".to_string()));
+        assert_eq!(parse_java_version(java_11), Some("11.0.4".to_string()));
     }
 
     #[test]
     fn test_parse_java_version_graalvm() {
         let java_8 = "OpenJDK 64-Bit GraalVM CE 19.2.0.1 (25.222-b08-jvmci-19.2-b02) for linux-amd64 JRE (8u222), built on Jul 19 2019 17:37:13 by \"buildslave\" with gcc 7.3.0";
-        assert_eq!(parse_java_version(java_8), Some("v8".to_string()));
+        assert_eq!(parse_java_version(java_8), Some("8".to_string()));
     }
 
     #[test]
     fn test_parse_java_version_amazon_corretto() {
         let java_8 = "OpenJDK 64-Bit Server VM (25.222-b10) for linux-amd64 JRE (1.8.0_222-b10), built on Jul 11 2019 20:48:53 by \"root\" with gcc 7.3.1 20180303 (Red Hat 7.3.1-5)";
         let java_11 = "OpenJDK 64-Bit Server VM (11.0.4+11-LTS) for linux-amd64 JRE (11.0.4+11-LTS), built on Jul 11 2019 20:06:11 by \"\" with gcc 7.3.1 20180303 (Red Hat 7.3.1-5)";
-        assert_eq!(parse_java_version(java_8), Some("v1.8.0".to_string()));
-        assert_eq!(parse_java_version(java_11), Some("v11.0.4".to_string()));
+        assert_eq!(parse_java_version(java_8), Some("1.8.0".to_string()));
+        assert_eq!(parse_java_version(java_11), Some("11.0.4".to_string()));
     }
 
     #[test]
     fn test_parse_java_version_sapmachine() {
         let java_11 = "OpenJDK 64-Bit Server VM (11.0.4+11-LTS-sapmachine) for linux-amd64 JRE (11.0.4+11-LTS-sapmachine), built on Jul 17 2019 08:58:43 by \"\" with gcc 7.3.0";
-        assert_eq!(parse_java_version(java_11), Some("v11.0.4".to_string()));
+        assert_eq!(parse_java_version(java_11), Some("11.0.4".to_string()));
     }
 
     #[test]

--- a/src/modules/julia.rs
+++ b/src/modules/julia.rs
@@ -66,7 +66,7 @@ fn format_julia_version(julia_stdout: &str) -> Option<String> {
         .split_whitespace()
         .next()?;
 
-    Some(format!("v{}", version))
+    Some(version.to_string())
 }
 
 #[cfg(test)]
@@ -127,6 +127,6 @@ mod tests {
     #[test]
     fn test_format_julia_version() {
         let input = "julia version 1.4.0";
-        assert_eq!(format_julia_version(input), Some("v1.4.0".to_string()));
+        assert_eq!(format_julia_version(input), Some("1.4.0".to_string()));
     }
 }

--- a/src/modules/kotlin.rs
+++ b/src/modules/kotlin.rs
@@ -77,7 +77,7 @@ fn format_kotlin_version(kotlin_stdout: &str) -> Option<String> {
     let re = Regex::new(KOTLIN_VERSION_PATTERN).ok()?;
     let captures = re.captures(kotlin_stdout)?;
     let version = &captures["version"];
-    Some(format!("v{}", version))
+    Some(version.to_string())
 }
 
 #[cfg(test)]
@@ -162,7 +162,7 @@ mod tests {
         let kotlin_input = "Kotlin version 1.4.21-release-411 (JRE 14.0.1+7)";
         assert_eq!(
             format_kotlin_version(kotlin_input),
-            Some("v1.4.21".to_string())
+            Some("1.4.21".to_string())
         );
     }
 
@@ -171,7 +171,7 @@ mod tests {
         let kotlin_input = "info: kotlinc-jvm 1.4.21 (JRE 14.0.1+7)";
         assert_eq!(
             format_kotlin_version(kotlin_input),
-            Some("v1.4.21".to_string())
+            Some("1.4.21".to_string())
         );
     }
 }

--- a/src/modules/lua.rs
+++ b/src/modules/lua.rs
@@ -80,7 +80,7 @@ fn format_lua_version(lua_stdout: &str) -> Option<String> {
     let re = Regex::new(LUA_VERSION_PATERN).ok()?;
     let captures = re.captures(lua_stdout)?;
     let version = &captures["version"];
-    Some(format!("v{}", version))
+    Some(version.to_string())
 }
 
 #[cfg(test)]
@@ -156,13 +156,13 @@ mod tests {
     #[test]
     fn test_format_lua_version() {
         let lua_input = "Lua 5.4.0  Copyright (C) 1994-2020 Lua.org, PUC-Rio";
-        assert_eq!(format_lua_version(lua_input), Some("v5.4.0".to_string()));
+        assert_eq!(format_lua_version(lua_input), Some("5.4.0".to_string()));
 
         let luajit_input =
             "LuaJIT 2.1.0-beta3 -- Copyright (C) 2005-2017 Mike Pall. http://luajit.org/";
         assert_eq!(
             format_lua_version(luajit_input),
-            Some("v2.1.0-beta3".to_string())
+            Some("2.1.0-beta3".to_string())
         );
     }
 }

--- a/src/modules/nim.rs
+++ b/src/modules/nim.rs
@@ -37,7 +37,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 "version" => utils::exec_cmd("nim", &["--version"])
                     .map(|command_output| command_output.stdout)
                     .and_then(|nim_version_output| {
-                        Some(format!("v{}", parse_nim_version(&nim_version_output)?))
+                        Some(parse_nim_version(&nim_version_output)?.to_string())
                     })
                     .map(Ok),
                 _ => None,

--- a/src/modules/nodejs.rs
+++ b/src/modules/nodejs.rs
@@ -64,6 +64,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                     .deref()
                     .as_ref()
                     .map(|version| version.trim())
+                    .map(|version| version.trim_start_matches('v'))
                     .map(Ok),
                 _ => None,
             })

--- a/src/modules/ocaml.rs
+++ b/src/modules/ocaml.rs
@@ -50,7 +50,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                     } else {
                         utils::exec_cmd("ocaml", &["-vnum"])?.stdout
                     };
-                    Some(Ok(format!("v{}", &ocaml_version.trim())))
+                    Some(Ok(ocaml_version.trim().to_string()))
                 }
                 _ => None,
             })

--- a/src/modules/package.rs
+++ b/src/modules/package.rs
@@ -199,12 +199,7 @@ fn get_package_version(base_dir: &Path, config: &PackageConfig) -> Option<String
 }
 
 fn format_version(version: &str) -> String {
-    let cleaned = version.replace('"', "").trim().to_string();
-    if cleaned.starts_with('v') {
-        cleaned
-    } else {
-        format!("v{}", cleaned)
-    }
+    version.replace('"', "").trim().trim_start_matches('v').to_string()
 }
 
 #[cfg(test)]
@@ -219,17 +214,17 @@ mod tests {
 
     #[test]
     fn test_format_version() {
-        assert_eq!(format_version("0.1.0"), "v0.1.0");
-        assert_eq!(format_version(" 0.1.0 "), "v0.1.0");
-        assert_eq!(format_version("0.1.0 "), "v0.1.0");
-        assert_eq!(format_version(" 0.1.0"), "v0.1.0");
-        assert_eq!(format_version("\"0.1.0\""), "v0.1.0");
+        assert_eq!(format_version("0.1.0"), "0.1.0");
+        assert_eq!(format_version(" 0.1.0 "), "0.1.0");
+        assert_eq!(format_version("0.1.0 "), "0.1.0");
+        assert_eq!(format_version(" 0.1.0"), "0.1.0");
+        assert_eq!(format_version("\"0.1.0\""), "0.1.0");
 
-        assert_eq!(format_version("v0.1.0"), "v0.1.0");
-        assert_eq!(format_version(" v0.1.0 "), "v0.1.0");
-        assert_eq!(format_version(" v0.1.0"), "v0.1.0");
-        assert_eq!(format_version("v0.1.0 "), "v0.1.0");
-        assert_eq!(format_version("\"v0.1.0\""), "v0.1.0");
+        assert_eq!(format_version("v0.1.0"), "0.1.0");
+        assert_eq!(format_version(" v0.1.0 "), "0.1.0");
+        assert_eq!(format_version(" v0.1.0"), "0.1.0");
+        assert_eq!(format_version("v0.1.0 "), "0.1.0");
+        assert_eq!(format_version("\"v0.1.0\""), "0.1.0");
     }
 
     #[test]
@@ -668,7 +663,7 @@ end";
 
         let project_dir = create_project_dir()?;
         fill_config(&project_dir, "pom.xml", Some(&pom))?;
-        expect_output(&project_dir, Some("0.3.20-SNAPSHOT"), None)?;
+        expect_output(&project_dir, Some("v0.3.20-SNAPSHOT"), None)?;
         project_dir.close()
     }
 

--- a/src/modules/perl.rs
+++ b/src/modules/perl.rs
@@ -46,7 +46,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 "version" => {
                     let perl_version =
                         utils::exec_cmd("perl", &["-e", "printf q#%vd#,$^V;"])?.stdout;
-                    Some(Ok(format!("v{}", perl_version)))
+                    Some(Ok(perl_version.to_string()))
                 }
                 _ => None,
             })

--- a/src/modules/php.rs
+++ b/src/modules/php.rs
@@ -42,7 +42,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                             "echo PHP_MAJOR_VERSION.\".\".PHP_MINOR_VERSION.\".\".PHP_RELEASE_VERSION;",
                         ],
                     )?;
-                    Some(Ok(format_php_version(&php_cmd_output.stdout)))
+                    Some(Ok(php_cmd_output.stdout))
                 }
                 _ => None,
             })
@@ -60,23 +60,12 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     Some(module)
 }
 
-fn format_php_version(php_version: &str) -> String {
-    format!("v{}", php_version)
-}
-
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::test::ModuleRenderer;
     use ansi_term::Color;
     use std::fs::File;
     use std::io;
-
-    #[test]
-    fn test_format_php_version() {
-        let input = "7.3.8";
-        assert_eq!(format_php_version(input), "v7.3.8".to_string());
-    }
 
     #[test]
     fn folder_without_php_files() -> io::Result<()> {

--- a/src/modules/purescript.rs
+++ b/src/modules/purescript.rs
@@ -36,7 +36,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             .map(|variable| match variable {
                 "version" => {
                     let purs_version = utils::exec_cmd("purs", &["--version"])?.stdout;
-                    Some(Ok(format!("v{}", purs_version.trim())))
+                    Some(Ok(purs_version.trim().to_string()))
                 }
                 _ => None,
             })

--- a/src/modules/ruby.rs
+++ b/src/modules/ruby.rs
@@ -63,10 +63,7 @@ fn format_ruby_version(ruby_version: &str) -> Option<String> {
         // return "2.6.0"
         .next()?;
 
-    let mut formatted_version = String::with_capacity(version.len() + 1);
-    formatted_version.push('v');
-    formatted_version.push_str(version);
-    Some(formatted_version)
+    Some(version.to_string())
 }
 
 #[cfg(test)]
@@ -128,17 +125,17 @@ mod tests {
     fn test_format_ruby_version() -> io::Result<()> {
         assert_eq!(
             format_ruby_version("ruby 2.1.10p492 (2016-04-01 revision 54464) [x86_64-darwin19.0]"),
-            Some("v2.1.10".to_string())
+            Some("2.1.10".to_string())
         );
         assert_eq!(
             format_ruby_version("ruby 2.5.1p57 (2018-03-29 revision 63029) [x86_64-linux-gnu]"),
-            Some("v2.5.1".to_string())
+            Some("2.5.1".to_string())
         );
         assert_eq!(
             format_ruby_version(
                 "ruby 2.7.0p0 (2019-12-25 revision 647ee6f091) [x86_64-linux-musl]"
             ),
-            Some("v2.7.0".to_string())
+            Some("2.7.0".to_string())
         );
 
         Ok(())

--- a/src/modules/rust.rs
+++ b/src/modules/rust.rs
@@ -209,7 +209,7 @@ fn format_rustc_version(mut rustc_stdout: String) -> String {
     let offset = &rustc_stdout.find('(').unwrap_or_else(|| rustc_stdout.len());
     let formatted_version: String = rustc_stdout.drain(..offset).collect();
 
-    format!("v{}", formatted_version.replace("rustc", "").trim())
+    formatted_version.replace("rustc", "").trim().to_string()
 }
 
 #[derive(Debug, PartialEq)]
@@ -322,16 +322,16 @@ mod tests {
     #[test]
     fn test_format_rustc_version() {
         let nightly_input = String::from("rustc 1.34.0-nightly (b139669f3 2019-04-10)");
-        assert_eq!(format_rustc_version(nightly_input), "v1.34.0-nightly");
+        assert_eq!(format_rustc_version(nightly_input), "1.34.0-nightly");
 
         let beta_input = String::from("rustc 1.34.0-beta.1 (2bc1d406d 2019-04-10)");
-        assert_eq!(format_rustc_version(beta_input), "v1.34.0-beta.1");
+        assert_eq!(format_rustc_version(beta_input), "1.34.0-beta.1");
 
         let stable_input = String::from("rustc 1.34.0 (91856ed52 2019-04-10)");
-        assert_eq!(format_rustc_version(stable_input), "v1.34.0");
+        assert_eq!(format_rustc_version(stable_input), "1.34.0");
 
         let version_without_hash = String::from("rustc 1.34.0");
-        assert_eq!(format_rustc_version(version_without_hash), "v1.34.0");
+        assert_eq!(format_rustc_version(version_without_hash), "1.34.0");
     }
 
     #[test]

--- a/src/modules/swift.rs
+++ b/src/modules/swift.rs
@@ -61,7 +61,7 @@ fn parse_swift_version(swift_version: &str) -> Option<String> {
     // return "5.2.2" or "5.3-dev"
     let version = splited.next()?;
 
-    Some(format!("v{}", version))
+    Some(version.to_string())
 }
 
 #[cfg(test)]
@@ -75,13 +75,13 @@ mod tests {
     #[test]
     fn test_parse_swift_version() {
         let input = "Apple Swift version 5.2.2";
-        assert_eq!(parse_swift_version(input), Some(String::from("v5.2.2")));
+        assert_eq!(parse_swift_version(input), Some(String::from("5.2.2")));
     }
 
     #[test]
     fn test_parse_swift_version_without_org_name() {
         let input = "Swift version 5.3-dev (LLVM ..., Swift ...)";
-        assert_eq!(parse_swift_version(input), Some(String::from("v5.3-dev")));
+        assert_eq!(parse_swift_version(input), Some(String::from("5.3-dev")));
     }
 
     #[test]

--- a/src/modules/vagrant.rs
+++ b/src/modules/vagrant.rs
@@ -60,10 +60,7 @@ fn format_vagrant_version(vagrant_stdout: &str) -> Option<String> {
         // return "2.2.10"
         .nth(1)?;
 
-    let mut formatted_version = String::with_capacity(version.len() + 1);
-    formatted_version.push('v');
-    formatted_version.push_str(version);
-    Some(formatted_version)
+    Some(version.to_string())
 }
 
 #[cfg(test)]
@@ -100,6 +97,6 @@ mod tests {
     #[test]
     fn test_format_vagrant_version() {
         let vagrant = "Vagrant 2.2.10\n";
-        assert_eq!(format_vagrant_version(vagrant), Some("v2.2.10".to_string()));
+        assert_eq!(format_vagrant_version(vagrant), Some("2.2.10".to_string()));
     }
 }

--- a/src/modules/zig.rs
+++ b/src/modules/zig.rs
@@ -33,9 +33,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             })
             .map(|variable| match variable {
                 "version" => {
-                    let zig_version_output = utils::exec_cmd("zig", &["version"])?.stdout;
-                    let zig_version = format!("v{}", zig_version_output.trim());
-                    Some(Ok(zig_version))
+                    Some(Ok(utils::exec_cmd("zig", &["version"])?.stdout.trim().to_string()))
                 }
                 _ => None,
             })


### PR DESCRIPTION
#### Description
I removed the hardcoded `v` version prefix from a module's main file to its config file for most of the modules (see below details on which modules are affected), allowing any user to remove such prefix from their prompt
(though I'd also suggest removing it from the config file altogether as it doesn't add any informational value)

#### Motivation and Context
It allows a user to save valuable prompt space
Closes #2236

#### How Has This Been Tested?
After making a change to each module I ran `cargo test -- modules::<ModuleName>::tests` to make sure all module tests were passing and later ran this updated version of starship in a Windows Powershell session (though only testing the `rust`, `nodejs`, and `python` modules this way)

- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.

#### Modules affected:
2. Moved `v` from the module file to the config file:
  + cmake
  + crystal
  + dart
  + dotnet
  + elm
  + go
  + helm: original string has `v`, so added an extra `.trim_start_matches("v")`
  + java
  + julia
  + kotlin
  + lua
  + nim
  + nodejs: original string has `v`, so added an extra `.trim_start_matches('v')`
  + ocaml
  + package
  + perl
  + php
  + purescript
  + python: split python and pyenv versions to allow `v3.8.2` for the former while avoding `pyenv vsystem` for the latter (though that would also preclude `pyenv v3.8.2`)
  + ruby
  + rust
  + swift
  + vagrant
  + zig
2. Untouched, module already has no `v`
  + elixir
  + erlang
3. Untouched, module has no `$version`
  + aws
  + battery
  + character
  + cmd_duration
  + conda
  + custom
  + directory
  + docker_context
  + env_var
  + gcloud
  + git_branch, git_commit, git_state, git_status
  + hg_branch
  + hostname
  + jobs
  + kubernetes
  + memory_usage
  + mod
  + nix_shell
  + openstack
  + shlvl
  + singularity
  + starship_root
  + status
  + terraform
  + time
  + username
