### PR TITLE
docs: Update Nix installation documentation

### DIFF
--- a/docs/installing/README.md
+++ b/docs/installing/README.md
@@ -32,19 +32,16 @@ Enable the `programs.starship` module in your `home.nix` file, and add your sett
   programs.starship = {
     enable = true;
     enableZshIntegration = true;
+    # Configuration written to ~/.config/starship.toml
     settings = {
-      add_newline = false;
-      format = lib.concatStrings [
-        "$line_break"
-        "$package"
-        "$line_break"
-        "$character"
-      ];
-      scan_timeout = 10;
-      character = {
-        success_symbol = "➜";
-        error_symbol = "➜";
-      };
+      # add_newline = false;
+
+      # character = {
+      #   success_symbol = "[➜](bold green)";
+      #   error_symbol = "[➜](bold red)";
+      # };
+
+      # package.disabled = true;
     };
   };
 }

--- a/docs/installing/README.md
+++ b/docs/installing/README.md
@@ -25,7 +25,32 @@ nix-env -iA nixos.starship
 
 #### Declarative, single user, via [home-manager](home-manager)
 
-Add `pkgs.starship` to your `home.packages` in your `home.nix` file, then run
+Enable the `programs.starship` module in your `home.nix` file, and add your settings
+
+```nix
+{
+  programs.starship = {
+    enable = true;
+    enableZshIntegration = true;
+    settings = {
+      add_newline = false;
+      format = lib.concatStrings [
+        "$line_break"
+        "$package"
+        "$line_break"
+        "$character"
+      ];
+      scan_timeout = 10;
+      character = {
+        success_symbol = "➜";
+        error_symbol = "➜";
+      };
+    };
+  };
+}
+```
+
+then run
 
 ```sh
 home-manager switch
@@ -33,20 +58,9 @@ home-manager switch
 
 #### Declarative, system-wide, with NixOS
 
-Add `pkgs.starship` to `environment.packages` in your `configuration.nix`,
+Add `pkgs.starship` to `environment.systemPackages` in your `configuration.nix`,
 then run
 
 ```sh
 sudo nixos-rebuild switch
-```
-
-### Modifying Init Scripts
-
-#### With Nix and home-manager, using zsh:
-
-Add the following to `programs.zsh.initExtra` in your `home.nix` file, then
-run
-
-```sh
-home-manager switch
 ```


### PR DESCRIPTION
This changes the documentation to show the provided Home Manager module instead of manual Home Manager installation instructions. Also fixes a typo in the NixOS instructions and removes the unfinished and now unnecessary section on zsh integration via Home manager (since that is included in the provided module).

#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
