### PR TITLE
perf(init): Prefer set -x over export for fish users

### DIFF
--- a/src/init/starship.fish
+++ b/src/init/starship.fish
@@ -15,7 +15,7 @@ end
 set VIRTUAL_ENV_DISABLE_PROMPT 1
 
 function fish_mode_prompt; end
-export STARSHIP_SHELL="fish"
+set -gx STARSHIP_SHELL="fish"
 
 # Set up the session key that will be used to store logs
-export STARSHIP_SESSION_KEY=(random 10000000000000 9999999999999999)
+set -gx STARSHIP_SESSION_KEY=(random 10000000000000 9999999999999999)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

#### Motivation and Context

In Fish, `export` is a function that wraps the built-in `set` command for compatibility with POSIX shells. It’s more idiomatic and has slightly less overhead to use the built-in `set -x` instead. See https://github.com/fish-shell/fish-shell/issues/2704#issuecomment-178749261.

With `export`:

```
$ hyperfine "fish -ic exit"
Benchmark #1: fish -ic exit
  Time (mean ± σ):      41.8 ms ±   1.1 ms    [User: 29.1 ms, System: 12.7 ms]
  Range (min … max):    40.2 ms …  45.5 ms    57 runs
```

With `set -x`:

```
$ hyperfine "fish -ic exit"
Benchmark #1: fish -ic exit
  Time (mean ± σ):      38.7 ms ±   1.5 ms    [User: 26.6 ms, System: 11.7 ms]
  Range (min … max):    35.4 ms …  43.2 ms    60 runs
```

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
