### PR TITLE
fix(init): Quote path for elvish init

### DIFF
--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -168,7 +168,7 @@ fi"#,
         }
         Some("elvish") => {
             let script = format!(
-                "eval ({} init elvish --print-full-init | slurp)",
+                "eval (\"{}\" init elvish --print-full-init | slurp)",
                 starship.sprint_posix()?
             );
             Some(script)


### PR DESCRIPTION
#### Description
Added quotes to the init function string of elvish shell.

#### Motivation and Context
Closes #2293

#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.

#### Notes:
This has been a simple edit I did directly in GitHub, I currently don’t have an environment to test this. I added excacty four characters, two escaped quotes, to the init string of elvish, this should not affect any code.