### PR TITLE
fix(init): make log messages on pwsh visible again

### DIFF
--- a/src/init/starship.ps1
+++ b/src/init/starship.ps1
@@ -27,6 +27,7 @@ function global:prompt {
         $startInfo = [System.Diagnostics.ProcessStartInfo]::new($Executable);
         $startInfo.StandardOutputEncoding = [System.Text.Encoding]::UTF8;
         $startInfo.RedirectStandardOutput = $true;
+        $startInfo.RedirectStandardError = $true;
         $startInfo.CreateNoWindow = $true;
         $startInfo.UseShellExecute = $false;
         if ($startInfo.ArgumentList.Add) {
@@ -48,7 +49,17 @@ function global:prompt {
             }
             $startInfo.Arguments = $escaped -Join ' ';
         }
-        [System.Diagnostics.Process]::Start($startInfo).StandardOutput.ReadToEnd();
+        $process = [System.Diagnostics.Process]::Start($startInfo)
+
+        # stderr isn't displayed with this style of invocation
+        # Manually write it to console
+        $stderr = $process.StandardError.ReadToEnd().Trim()
+        if ($stderr -ne '') {
+            # Write-Error doesn't work here
+            $host.ui.WriteErrorLine($stderr)
+        }
+
+        $process.StandardOutput.ReadToEnd();
     }
 
     $origDollarQuestion = $global:?


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

When starting `starship` with `System.Diagnostics.Process` in `prompt` `stderr` isn't printed to the console even if `$startInfo.RedirectStandardError` is `$false`.

Handle this by manually printing `starship` `stderr`.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
