### PR TITLE
fix(init): fix error message when trying to 'starship init' with an unsupported shell

### DIFF
--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -185,7 +185,7 @@ fi"#,
         }
         Some(shell_basename) => {
             println!(
-                "\"{0}\" is not yet supported by starship.\n\
+                "{0} is not yet supported by starship.\n\
                 For the time being, we support bash, zsh, fish, and ion.\n\
                 Please open an issue in the starship repo if you would like to\
                 see support for {0}:\nhttps://github.com/starship/starship/issues/new\n",

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -175,20 +175,20 @@ fi"#,
         }
         None => {
             println!(
-                "Invalid shell name provided: {}\\n\
+                "Invalid shell name provided: {}\n\
                  If this issue persists, please open an \
-                 issue in the starship repo: \\n\
-                 https://github.com/starship/starship/issues/new\\n\"",
+                 issue in the starship repo: \n\
+                 https://github.com/starship/starship/issues/new\n",
                 shell_name
             );
             None
         }
         Some(shell_basename) => {
             println!(
-                "printf \"\\n{0} is not yet supported by starship.\\n\
-                 For the time being, we support bash, zsh, fish, and ion.\\n\
-                 Please open an issue in the starship repo if you would like to \
-                 see support for {0}:\\nhttps://github.com/starship/starship/issues/new\"\\n\\n",
+                "\"{0}\" is not yet supported by starship.\n\
+                For the time being, we support bash, zsh, fish, and ion.\n\
+                Please open an issue in the starship repo if you would like to\
+                see support for {0}:\nhttps://github.com/starship/starship/issues/new\n",
                 shell_basename
             );
             None


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

#### Motivation and Context

#### Screenshots (if appropriate):
```shell
-> starship init unknown_shell
printf "\nunknown_shell is not yet supported by starship.\nFor the time being, we support bash, zsh, fish, and ion.\nPlease open an issue in the starship repo if you would like to see support for unknown_shell:\nhttps://github.com/starship/starship/issues/new"\n\n
```
#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.