### PR TITLE
refactor(log): change output colors to shades of blue for trace and debug

### DIFF
--- a/src/logger.rs
+++ b/src/logger.rs
@@ -109,8 +109,8 @@ impl log::Log for StarshipLogger {
             eprintln!(
                 "[{}] - ({}): {}",
                 match record.level() {
-                    Level::Trace => Color::Black.dimmed().paint(format!("{}", record.level())),
-                    Level::Debug => Color::Black.paint(format!("{}", record.level())),
+                    Level::Trace => Color::Blue.dimmed().paint(format!("{}", record.level())),
+                    Level::Debug => Color::Cyan.paint(format!("{}", record.level())),
                     Level::Info => Color::White.paint(format!("{}", record.level())),
                     Level::Warn => Color::Yellow.paint(format!("{}", record.level())),
                     Level::Error => Color::Red.paint(format!("{}", record.level())),


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
Make the colors for debug and trace log levels more visible.


#### Motivation and Context
Black and dark grey are illegible on terminals with dark backgrounds. Shades of blue work on light backgrounds as well.
Suggestions welcome for other colors that may be a better compromise.

#### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/24556329/107699039-24af8200-6cbe-11eb-8300-d1f89419669a.png)


#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
