### PR TITLE
fix(directory): Handle non-UTF-8 folder names

### DIFF
--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -187,7 +187,7 @@ fn contract_path(full_path: &Path, top_level_path: &Path, top_level_replacement:
     let sub_path = full_path
         .without_prefix()
         .strip_prefix(top_level_path.without_prefix())
-        .expect("strip path prefix");
+        .unwrap_or(full_path);
 
     format!(
         "{replacement}{separator}{path}",

--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -174,7 +174,7 @@ fn is_readonly_dir(path: &Path) -> bool {
 /// `top_level_replacement`.
 fn contract_path(full_path: &Path, top_level_path: &Path, top_level_replacement: &str) -> String {
     if !full_path.normalised_starts_with(top_level_path) {
-        return full_path.to_slash().unwrap();
+        return full_path.to_slash_lossy();
     }
 
     if full_path.normalised_equals(top_level_path) {
@@ -193,7 +193,7 @@ fn contract_path(full_path: &Path, top_level_path: &Path, top_level_replacement:
         "{replacement}{separator}{path}",
         replacement = top_level_replacement,
         separator = "/",
-        path = sub_path.to_slash().expect("slash path")
+        path = sub_path.to_slash_lossy()
     )
 }
 
@@ -213,7 +213,9 @@ fn contract_repo_path(full_path: &Path, top_level_path: &Path) -> Option<String>
         }
 
         let components: Vec<_> = full_path.components().collect();
-        let repo_name = components[components.len() - i - 1].as_os_str().to_str()?;
+        let repo_name = components[components.len() - i - 1]
+            .as_os_str()
+            .to_string_lossy();
 
         if i == 0 {
             return Some(repo_name.to_string());
@@ -224,7 +226,7 @@ fn contract_repo_path(full_path: &Path, top_level_path: &Path) -> Option<String>
             "{repo_name}{separator}{path}",
             repo_name = repo_name,
             separator = "/",
-            path = path.to_slash()?
+            path = path.to_slash_lossy()
         ));
     }
     None
@@ -1498,5 +1500,50 @@ mod tests {
             .collect();
 
         assert_eq!(expected, actual);
+    }
+
+    // sample for invalid unicode from https://doc.rust-lang.org/std/ffi/struct.OsStr.html#method.to_string_lossy
+    #[cfg(any(unix, target_os = "redox"))]
+    fn invalid_path() -> PathBuf {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+
+        // Here, the values 0x66 and 0x6f correspond to 'f' and 'o'
+        // respectively. The value 0x80 is a lone continuation byte, invalid
+        // in a UTF-8 sequence.
+        let source = [0x66, 0x6f, 0x80, 0x6f];
+        let os_str = OsStr::from_bytes(&source[..]);
+
+        PathBuf::from(os_str)
+    }
+
+    #[cfg(windows)]
+    fn invalid_path() -> PathBuf {
+        use std::ffi::OsString;
+        use std::os::windows::prelude::*;
+    
+        // Here the values 0x0066 and 0x006f correspond to 'f' and 'o'
+        // respectively. The value 0xD800 is a lone surrogate half, invalid
+        // in a UTF-16 sequence.
+        let source = [0x0066, 0x006f, 0xD800, 0x006f];
+        let os_string = OsString::from_wide(&source[..]);
+    
+        PathBuf::from(os_string)
+    }
+
+    #[test]
+    #[cfg(any(unix, windows, target_os = "redox"))]
+    fn invalid_unicode() {
+        let path = invalid_path();
+        let expected = Some(format!(
+            "{} ",
+            Color::Cyan.bold().paint(path.to_string_lossy())
+        ));
+
+        let actual = ModuleRenderer::new("directory")
+            .path(path)
+            .collect();
+
+        assert_eq!(expected, actual);        
     }
 }

--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -1521,13 +1521,13 @@ mod tests {
     fn invalid_path() -> PathBuf {
         use std::ffi::OsString;
         use std::os::windows::prelude::*;
-    
+
         // Here the values 0x0066 and 0x006f correspond to 'f' and 'o'
         // respectively. The value 0xD800 is a lone surrogate half, invalid
         // in a UTF-16 sequence.
         let source = [0x0066, 0x006f, 0xD800, 0x006f];
         let os_string = OsString::from_wide(&source[..]);
-    
+
         PathBuf::from(os_string)
     }
 
@@ -1540,10 +1540,8 @@ mod tests {
             Color::Cyan.bold().paint(path.to_string_lossy())
         ));
 
-        let actual = ModuleRenderer::new("directory")
-            .path(path)
-            .collect();
+        let actual = ModuleRenderer::new("directory").path(path).collect();
 
-        assert_eq!(expected, actual);        
+        assert_eq!(expected, actual);
     }
 }


### PR DESCRIPTION
Co-Authored-By: Thomas Hurst <tom@hur.st>

<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Replaces conversions from `Path`/`PathBuf` to strings in `directory.rs`to use lossy versions that don't panic.

Based on the changes by @Freaky (#1426). I only added to test case and fixed another panic for this PR.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1426

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
