### PR TITLE
fix(utils): Safely unwrap the command output

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -289,8 +289,20 @@ fn internal_exec_cmd(cmd: &str, args: &[&str]) -> Option<CommandOutput> {
 
     match process.with_output_timeout(time_limit).terminating().wait() {
         Ok(Some(output)) => {
-            let stdout_string = String::from_utf8(output.stdout).unwrap();
-            let stderr_string = String::from_utf8(output.stderr).unwrap();
+            let stdout_string = match String::from_utf8(output.stdout) {
+                Ok(stdout) => stdout,
+                Err(error) => {
+                    log::warn!("Unable to decode stdout: {:?}", error);
+                    return None;
+                }
+            };
+            let stderr_string = match String::from_utf8(output.stderr) {
+                Ok(stderr) => stderr,
+                Err(error) => {
+                    log::warn!("Unable to decode stderr: {:?}", error);
+                    return None;
+                }
+            };
 
             log::trace!(
                 "stdout: {:?}, stderr: {:?}, exit code: \"{:?}\", took {:?}",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Safely unwrap the output of the commands executed by `utils::exec_cmd`,
this should avoid panics when the output of the command cannot be
decoded.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #2301

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
