### PR TITLE
feat(test): allow dynamic mocking of commands

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -43,7 +43,12 @@ pub struct Context<'a> {
     pub shell: Shell,
 
     /// A HashMap of environment variable mocks
+    #[cfg(test)]
     pub env: HashMap<&'a str, String>,
+
+    /// A HashMap of command mocks
+    #[cfg(test)]
+    pub cmd: HashMap<&'a str, Option<CommandOutput>>,
 
     /// Timeout for the execution of commands
     cmd_timeout: Duration,
@@ -114,7 +119,10 @@ impl<'a> Context<'a> {
             dir_contents: OnceCell::new(),
             repo: OnceCell::new(),
             shell,
+            #[cfg(test)]
             env: HashMap::new(),
+            #[cfg(test)]
+            cmd: HashMap::new(),
             cmd_timeout,
         }
     }
@@ -129,21 +137,27 @@ impl<'a> Context<'a> {
     }
 
     // Retrives a environment variable from the os or from a table if in testing mode
+    #[cfg(test)]
     pub fn get_env<K: AsRef<str>>(&self, key: K) -> Option<String> {
-        if cfg!(test) {
-            self.env.get(key.as_ref()).map(|val| val.to_string())
-        } else {
-            env::var(key.as_ref()).ok()
-        }
+        self.env.get(key.as_ref()).map(|val| val.to_string())
+    }
+
+    #[cfg(not(test))]
+    #[inline]
+    pub fn get_env<K: AsRef<str>>(&self, key: K) -> Option<String> {
+        env::var(key.as_ref()).ok()
     }
 
     // Retrives a environment variable from the os or from a table if in testing mode (os version)
+    #[cfg(test)]
     pub fn get_env_os<K: AsRef<str>>(&self, key: K) -> Option<OsString> {
-        if cfg!(test) {
-            self.env.get(key.as_ref()).map(OsString::from)
-        } else {
-            env::var_os(key.as_ref())
-        }
+        self.env.get(key.as_ref()).map(OsString::from)
+    }
+
+    #[cfg(not(test))]
+    #[inline]
+    pub fn get_env_os<K: AsRef<str>>(&self, key: K) -> Option<OsString> {
+        env::var_os(key.as_ref())
     }
 
     /// Convert a `~` in a path to the home directory
@@ -246,7 +260,18 @@ impl<'a> Context<'a> {
     }
 
     /// Execute a command and return the output on stdout and stderr if successful
+    #[inline]
     pub fn exec_cmd(&self, cmd: &str, args: &[&str]) -> Option<CommandOutput> {
+        #[cfg(test)]
+        {
+            let command = match args.len() {
+                0 => cmd.to_owned(),
+                _ => format!("{} {}", cmd, args.join(" ")),
+            };
+            if let Some(output) = self.cmd.get(command.as_str()) {
+                return output.clone();
+            }
+        }
         exec_cmd(cmd, args, self.cmd_timeout)
     }
 }

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -1,6 +1,6 @@
-use crate::config::StarshipConfig;
 use crate::context::{Context, Shell};
 use crate::logger::StarshipLogger;
+use crate::{config::StarshipConfig, utils::CommandOutput};
 use log::{Level, LevelFilter};
 use once_cell::sync::Lazy;
 use std::io;
@@ -80,6 +80,12 @@ impl<'a> ModuleRenderer<'a> {
     /// Adds the variable to the env_mocks of the underlying context
     pub fn env<V: Into<String>>(mut self, key: &'a str, val: V) -> Self {
         self.context.env.insert(key, val.into());
+        self
+    }
+
+    /// Adds the command to the commandv_mocks of the underlying context
+    pub fn cmd(mut self, key: &'a str, val: Option<CommandOutput>) -> Self {
+        self.context.cmd.insert(key, val);
         self
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -16,7 +16,7 @@ pub fn read_file<P: AsRef<Path>>(file_name: P) -> Result<String> {
     Ok(data)
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CommandOutput {
     pub stdout: String,
     pub stderr: String,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

I added a new method `cmd` to `ModuleRenderer` to allow dynamic mocking of commands and implemented it in `Context`.
I added two additional tests for the java module that make use of this new feature.
In addition, for a small perf boost I gated the `Context.env` `HashMap` with `#[cfg(test)]`.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #942

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
