### PR TITLE
docs: Clarify wording on add_newline option

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -9,7 +9,7 @@ mkdir -p ~/.config && touch ~/.config/starship.toml
 All configuration for starship is done in this [TOML](https://github.com/toml-lang/toml) file:
 
 ```toml
-# Inserts a newline between shell prompts
+# Inserts a blank line between shell prompts
 add_newline = true
 
 # Replace the "❯" symbol in the prompt with "➜"
@@ -155,7 +155,7 @@ This is the list of prompt-wide configuration options.
 | -------------- | ------------------------------ | ----------------------------------------------------- |
 | `format`       | [link](#default-prompt-format) | Configure the format of the prompt.                   |
 | `scan_timeout` | `30`                           | Timeout for starship to scan files (in milliseconds). |
-| `add_newline`  | `true`                         | Inserts new line between shell prompts.               |
+| `add_newline`  | `true`                         | Inserts blank line between shell prompts.               |
 
 ### Example
 
@@ -171,7 +171,7 @@ format = """
 # Wait 10 milliseconds for starship to check files under the current directory.
 scan_timeout = 10
 
-# Disable the newline at the start of the prompt
+# Disable the blank line at the start of the prompt
 add_newline = false
 ```
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -9,8 +9,8 @@ mkdir -p ~/.config && touch ~/.config/starship.toml
 All configuration for starship is done in this [TOML](https://github.com/toml-lang/toml) file:
 
 ```toml
-# Don't print a new line at the start of the prompt
-add_newline = false
+# Inserts a newline between shell prompts
+add_newline = true
 
 # Replace the "❯" symbol in the prompt with "➜"
 [character]                            # The name of the module we are configuring is "character"
@@ -155,7 +155,7 @@ This is the list of prompt-wide configuration options.
 | -------------- | ------------------------------ | ----------------------------------------------------- |
 | `format`       | [link](#default-prompt-format) | Configure the format of the prompt.                   |
 | `scan_timeout` | `30`                           | Timeout for starship to scan files (in milliseconds). |
-| `add_newline`  | `true`                         | Add a new line before the start of the prompt.        |
+| `add_newline`  | `true`                         | Inserts new line between shell prompts.               |
 
 ### Example
 


### PR DESCRIPTION
#### Description
Change wording for the confusing `add_newline` sentence to something that hopefully makes more sense.

#### Motivation and Context
It aims to prevent users from being confused by the subtle difference between `add_newline` and `line_break` options

Closes #1987 

#### Screenshots (if appropriate):

#### How Has This Been Tested?
Tested by checking the docs local build.
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
