### PR TITLE
feat(crystal): Configure when the module is shown

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -580,9 +580,9 @@ By default the module will be shown if any of the following conditions are met:
 | ------------------- | ------------------------------------ | --------------------------------------------------------- |
 | `symbol`            | `"🔮 "`                              | The symbol used before displaying the version of crystal. |
 | `style`             | `"bold red"`                         | The style for the module.                                 |
-| `detect_extensions` | `["cr"]`                             | Which extensions should trigger this moudle               |
-| `detect_files`      | `["shard.yml"]`                      | Which filenames should trigger this module                |
-| `detect_folders`    | `[]`                                 | Which folders should trigger this module                  |
+| `detect_extensions` | `["cr"]`                             | Which extensions should trigger this module.              |
+| `detect_files`      | `["shard.yml"]`                      | Which filenames should trigger this module.               |
+| `detect_folders`    | `[]`                                 | Which folders should trigger this module.                 |
 | `format`            | `"via [$symbol($version )]($style)"` | The format for the module.                                |
 | `disabled`          | `false`                              | Disables the `crystal` module.                            |
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -569,19 +569,22 @@ format = "[$symbol$environment](dimmed green) "
 ## Crystal
 
 The `crystal` module shows the currently installed version of Crystal.
-The module will be shown if any of the following conditions are met:
+By default the module will be shown if any of the following conditions are met:
 
 - The current directory contains a `shard.yml` file
 - The current directory contains a `.cr` file
 
 ### Options
 
-| Option     | Default                              | Description                                               |
-| ---------- | ------------------------------------ | --------------------------------------------------------- |
-| `symbol`   | `"🔮 "`                              | The symbol used before displaying the version of crystal. |
-| `style`    | `"bold red"`                         | The style for the module.                                 |
-| `format`   | `"via [$symbol($version )]($style)"` | The format for the module.                                |
-| `disabled` | `false`                              | Disables the `crystal` module.                            |
+| Option              | Default                              | Description                                               |
+| ------------------- | ------------------------------------ | --------------------------------------------------------- |
+| `symbol`            | `"🔮 "`                              | The symbol used before displaying the version of crystal. |
+| `style`             | `"bold red"`                         | The style for the module.                                 |
+| `detect_extensions` | `["cr"]`                             | Which extensions should trigger this moudle               |
+| `detect_files`      | `["shard.yml"]`                      | Which filenames should trigger this module                |
+| `detect_folders`    | `[]`                                 | Which folders should trigger this module                  |
+| `format`            | `"via [$symbol($version )]($style)"` | The format for the module.                                |
+| `disabled`          | `false`                              | Disables the `crystal` module.                            |
 
 ### Variables
 

--- a/src/configs/crystal.rs
+++ b/src/configs/crystal.rs
@@ -8,6 +8,9 @@ pub struct CrystalConfig<'a> {
     pub symbol: &'a str,
     pub style: &'a str,
     pub disabled: bool,
+    pub detect_extensions: Vec<&'a str>,
+    pub detect_files: Vec<&'a str>,
+    pub detect_folders: Vec<&'a str>,
 }
 
 impl<'a> RootModuleConfig<'a> for CrystalConfig<'a> {
@@ -17,6 +20,9 @@ impl<'a> RootModuleConfig<'a> for CrystalConfig<'a> {
             symbol: "🔮 ",
             style: "bold red",
             disabled: false,
+            detect_extensions: vec!["cr"],
+            detect_files: vec!["shard.yml"],
+            detect_folders: vec![],
         }
     }
 }

--- a/src/modules/crystal.rs
+++ b/src/modules/crystal.rs
@@ -4,23 +4,20 @@ use crate::configs::crystal::CrystalConfig;
 use crate::formatter::StringFormatter;
 
 /// Creates a module with the current Crystal version
-///
-/// Will display the Crystal version if any of the following criteria are met:
-///     - Current directory contains a `.cr` file
-///     - Current directory contains a `shard.yml` file
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let mut module = context.new_module("crystal");
+    let config: CrystalConfig = CrystalConfig::try_load(module.config);
+
     let is_crystal_project = context
         .try_begin_scan()?
-        .set_files(&["shard.yml"])
-        .set_extensions(&["cr"])
+        .set_files(&config.detect_files)
+        .set_extensions(&config.detect_extensions)
+        .set_folders(&config.detect_folders)
         .is_match();
 
     if !is_crystal_project {
         return None;
     }
-
-    let mut module = context.new_module("crystal");
-    let config: CrystalConfig = CrystalConfig::try_load(module.config);
 
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This makes it possible to configure when the crystal module is shown
based on the contents of a directory. This should make it possible to
be a lot more granular when configuring the module.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to #1977 

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
