### PR TITLE
feat(zig): Configure when the module is shown

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2556,19 +2556,22 @@ format = "via [⍱ $version](bold white) "
 
 ## Zig
 
-The `zig` module shows the currently installed version of Zig.
+By default the the `zig` module shows the currently installed version of Zig.
 The module will be shown if any of the following conditions are met:
 
 - The current directory contains a `.zig` file
 
 ### Options
 
-| Option     | Default                              | Description                                           |
-| ---------- | ------------------------------------ | ----------------------------------------------------- |
-| `symbol`   | `"↯ "`                               | The symbol used before displaying the version of Zig. |
-| `style`    | `"bold yellow"`                      | The style for the module.                             |
-| `format`   | `"via [$symbol($version )]($style)"` | The format for the module.                            |
-| `disabled` | `false`                              | Disables the `zig` module.                            |
+| Option              | Default                              | Description                                           |
+| ------------------- | ------------------------------------ | ----------------------------------------------------- |
+| `symbol`            | `"↯ "`                               | The symbol used before displaying the version of Zig. |
+| `style`             | `"bold yellow"`                      | The style for the module.                             |
+| `format`            | `"via [$symbol($version )]($style)"` | The format for the module.                            |
+| `disabled`          | `false`                              | Disables the `zig` module.                            |
+| `detect_extensions` | `["zig"]`                            | Which extensions should trigger this module.          |
+| `detect_files`      | `[]`                                 | Which filenames should trigger this module.           |
+| `detect_folders`    | `[]`                                 | Which folders should trigger this module.             |
 
 ### Variables
 

--- a/src/configs/zig.rs
+++ b/src/configs/zig.rs
@@ -8,6 +8,9 @@ pub struct ZigConfig<'a> {
     pub symbol: &'a str,
     pub style: &'a str,
     pub disabled: bool,
+    pub detect_extensions: Vec<&'a str>,
+    pub detect_files: Vec<&'a str>,
+    pub detect_folders: Vec<&'a str>,
 }
 
 impl<'a> RootModuleConfig<'a> for ZigConfig<'a> {
@@ -17,6 +20,9 @@ impl<'a> RootModuleConfig<'a> for ZigConfig<'a> {
             symbol: "↯ ",
             style: "bold yellow",
             disabled: false,
+            detect_extensions: vec!["zig"],
+            detect_files: vec![],
+            detect_folders: vec![],
         }
     }
 }

--- a/src/modules/zig.rs
+++ b/src/modules/zig.rs
@@ -8,17 +8,19 @@ use crate::formatter::StringFormatter;
 /// Will display the Zig version if any of the following criteria are met:
 ///     - The current directory contains a file with extension `.zig`
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let mut module = context.new_module("zig");
+    let config = ZigConfig::try_load(module.config);
+
     let is_zig_project = context
         .try_begin_scan()?
-        .set_extensions(&["zig"])
+        .set_files(&config.detect_files)
+        .set_extensions(&config.detect_extensions)
+        .set_folders(&config.detect_folders)
         .is_match();
 
     if !is_zig_project {
         return None;
     }
-
-    let mut module = context.new_module("zig");
-    let config = ZigConfig::try_load(module.config);
 
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter

--- a/src/modules/zig.rs
+++ b/src/modules/zig.rs
@@ -4,9 +4,6 @@ use crate::configs::zig::ZigConfig;
 use crate::formatter::StringFormatter;
 
 /// Creates a module with the current Zig version
-///
-/// Will display the Zig version if any of the following criteria are met:
-///     - The current directory contains a file with extension `.zig`
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let mut module = context.new_module("zig");
     let config = ZigConfig::try_load(module.config);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This makes it possible to configure when the zig module is shown based on the contents of a directory.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to #1977 

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
