### PR TITLE
feat(dart): Configure when the module is shown

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -605,7 +605,7 @@ format = "via [✨ $version](bold blue) "
 ## Dart
 
 The `dart` module shows the currently installed version of Dart.
-The module will be shown if any of the following conditions are met:
+By default the module will be shown if any of the following conditions are met:
 
 - The current directory contains a file with `.dart` extension
 - The current directory contains a `.dart_tool` directory
@@ -613,12 +613,15 @@ The module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Option     | Default                              | Description                                     |
-| ---------- | ------------------------------------ | ----------------------------------------------- |
-| `format`   | `"via [$symbol($version )]($style)"` | The format for the module.                      |
-| `symbol`   | `"🎯 "`                              | A format string representing the symbol of Dart |
-| `style`    | `"bold blue"`                        | The style for the module.                       |
-| `disabled` | `false`                              | Disables the `dart` module.                     |
+| Option              | Default                              | Description                                     |
+| ------------------- | ------------------------------------ | ----------------------------------------------- |
+| `format`            | `"via [$symbol($version )]($style)"` | The format for the module.                      |
+| `symbol`            | `"🎯 "`                              | A format string representing the symbol of Dart |
+| `detect_extensions` | `['dart']`                           | Which extensions should trigger this moudle.    |
+| `detect_files`      | `["pubspec.yaml", "pubsepc.lock"]`   | Which filenames should trigger this module.     |
+| `detect_folders`    | `[".dart_tool"]`                     | Which folders should trigger this module.       |
+| `style`             | `"bold blue"`                        | The style for the module.                       |
+| `disabled`          | `false`                              | Disables the `dart` module.                     |
 
 ### Variables
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -609,19 +609,19 @@ By default the module will be shown if any of the following conditions are met:
 
 - The current directory contains a file with `.dart` extension
 - The current directory contains a `.dart_tool` directory
-- The current directory contains a `pubspec.yaml` or `pubspec.lock` file
+- The current directory contains a `pubspec.yaml`, `pubspec.yml` or `pubspec.lock` file
 
 ### Options
 
-| Option              | Default                              | Description                                     |
-| ------------------- | ------------------------------------ | ----------------------------------------------- |
-| `format`            | `"via [$symbol($version )]($style)"` | The format for the module.                      |
-| `symbol`            | `"🎯 "`                              | A format string representing the symbol of Dart |
-| `detect_extensions` | `['dart']`                           | Which extensions should trigger this moudle.    |
-| `detect_files`      | `["pubspec.yaml", "pubsepc.lock"]`   | Which filenames should trigger this module.     |
-| `detect_folders`    | `[".dart_tool"]`                     | Which folders should trigger this module.       |
-| `style`             | `"bold blue"`                        | The style for the module.                       |
-| `disabled`          | `false`                              | Disables the `dart` module.                     |
+| Option              | Default                                           | Description                                     |
+| ------------------- | ------------------------------------------------- | ----------------------------------------------- |
+| `format`            | `"via [$symbol($version )]($style)"`              | The format for the module.                      |
+| `symbol`            | `"🎯 "`                                           | A format string representing the symbol of Dart |
+| `detect_extensions` | `['dart']`                                        | Which extensions should trigger this moudle.    |
+| `detect_files`      | `["pubspec.yaml", "pubspec.yml", "pubspec.lock"]` | Which filenames should trigger this module.     |
+| `detect_folders`    | `[".dart_tool"]`                                  | Which folders should trigger this module.       |
+| `style`             | `"bold blue"`                                     | The style for the module.                       |
+| `disabled`          | `false`                                           | Disables the `dart` module.                     |
 
 ### Variables
 

--- a/src/configs/dart.rs
+++ b/src/configs/dart.rs
@@ -8,6 +8,9 @@ pub struct DartConfig<'a> {
     pub symbol: &'a str,
     pub style: &'a str,
     pub disabled: bool,
+    pub detect_extensions: Vec<&'a str>,
+    pub detect_files: Vec<&'a str>,
+    pub detect_folders: Vec<&'a str>,
 }
 
 impl<'a> RootModuleConfig<'a> for DartConfig<'a> {
@@ -17,6 +20,9 @@ impl<'a> RootModuleConfig<'a> for DartConfig<'a> {
             symbol: "🎯 ",
             style: "bold blue",
             disabled: false,
+            detect_extensions: vec!["dart"],
+            detect_files: vec!["pubspec.yaml", "pubspec.yml", "pubspec.lock"],
+            detect_folders: vec![".dart_tool"],
         }
     }
 }

--- a/src/modules/crystal.rs
+++ b/src/modules/crystal.rs
@@ -4,10 +4,6 @@ use crate::configs::crystal::CrystalConfig;
 use crate::formatter::StringFormatter;
 
 /// Creates a module with the current Crystal version
-///
-/// Will display the Crystal version if any of the following criteria are met:
-///     - Current directory contains a `.cr` file
-///     - Current directory contains a `shard.yml` file
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let is_crystal_project = context
         .try_begin_scan()?

--- a/src/modules/dart.rs
+++ b/src/modules/dart.rs
@@ -4,11 +4,6 @@ use crate::configs::dart::DartConfig;
 use crate::formatter::StringFormatter;
 
 /// Creates a module with the current Dart version
-///
-/// Will display the Dart version if any of the following criteria are met:
-///     - Current directory contains a file with `.dart` extension
-///     - Current directory contains a `.dart_tool` directory
-///     - Current directory contains a `pubspec.yaml`/`pubspec.yml` or `pubspec.lock` file
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let mut module = context.new_module("dart");
     let config: DartConfig = DartConfig::try_load(module.config);

--- a/src/modules/dart.rs
+++ b/src/modules/dart.rs
@@ -10,19 +10,19 @@ use crate::formatter::StringFormatter;
 ///     - Current directory contains a `.dart_tool` directory
 ///     - Current directory contains a `pubspec.yaml`/`pubspec.yml` or `pubspec.lock` file
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let mut module = context.new_module("dart");
+    let config: DartConfig = DartConfig::try_load(module.config);
+
     let is_dart_project = context
         .try_begin_scan()?
-        .set_extensions(&["dart"])
-        .set_folders(&[".dart_tool"])
-        .set_files(&["pubspec.yaml", "pubspec.yml", "pubspec.lock"])
+        .set_files(&config.detect_files)
+        .set_extensions(&config.detect_extensions)
+        .set_folders(&config.detect_folders)
         .is_match();
 
     if !is_dart_project {
         return None;
     }
-
-    let mut module = context.new_module("dart");
-    let config: DartConfig = DartConfig::try_load(module.config);
 
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This makes it possible to configure when the dart module is shown based
on the contents of a directory. This should make it possible to be a lot
more granular when configuring the module.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to #1977 

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
