### PR TITLE
feat(vagrant): Configure when the module is shown

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2532,7 +2532,7 @@ By default the module will be shown if any of the following conditions are met:
 | ------------------- | ------------------------------------ | --------------------------------------------------- |
 | `format`            | `"via [$symbol($version )]($style)"` | The format for the module.                          |
 | `symbol`            | `"⍱ "`                               | A format string representing the symbol of Vagrant. |
-| `detect_extensions` | `[""]`                               | Which extensions should trigger this module.        |
+| `detect_extensions` | `[]`                                 | Which extensions should trigger this module.        |
 | `detect_files`      | `["Vagrantfile"]`                    | Which filenames should trigger this module.         |
 | `detect_folders`    | `[]`                                 | Which folders should trigger this module.           |
 | `style`             | `"cyan bold"`                        | The style for the module.                           |

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2522,18 +2522,21 @@ show_always = true
 ## Vagrant
 
 The `vagrant` module shows the currently installed version of Vagrant.
-The module will be shown if any of the following conditions are met:
+By default the module will be shown if any of the following conditions are met:
 
 - The current directory contains a `Vagrantfile` file
 
 ### Options
 
-| Option     | Default                            | Description                                         |
-| ---------- | ---------------------------------- | --------------------------------------------------- |
-| `format`   | `"via [$symbol($version )]($style)"` | The format for the module.                          |
-| `symbol`   | `"⍱ "`                             | A format string representing the symbol of Vagrant. |
-| `style`    | `"cyan bold"`                      | The style for the module.                           |
-| `disabled` | `false`                            | Disables the `Vagrant` module.                      |
+| Option              | Default                              | Description                                         |
+| ------------------- | ------------------------------------ | --------------------------------------------------- |
+| `format`            | `"via [$symbol($version )]($style)"` | The format for the module.                          |
+| `symbol`            | `"⍱ "`                               | A format string representing the symbol of Vagrant. |
+| `detect_extensions` | `[""]`                               | Which extensions should trigger this module.        |
+| `detect_files`      | `["Vagrantfile"]`                    | Which filenames should trigger this module.         |
+| `detect_folders`    | `[]`                                 | Which folders should trigger this module.           |
+| `style`             | `"cyan bold"`                        | The style for the module.                           |
+| `disabled`          | `false`                              | Disables the `Vagrant` module.                      |
 
 ### Variables
 

--- a/src/configs/vagrant.rs
+++ b/src/configs/vagrant.rs
@@ -8,6 +8,9 @@ pub struct VagrantConfig<'a> {
     pub symbol: &'a str,
     pub style: &'a str,
     pub disabled: bool,
+    pub detect_extensions: Vec<&'a str>,
+    pub detect_files: Vec<&'a str>,
+    pub detect_folders: Vec<&'a str>,
 }
 
 impl<'a> RootModuleConfig<'a> for VagrantConfig<'a> {
@@ -17,6 +20,9 @@ impl<'a> RootModuleConfig<'a> for VagrantConfig<'a> {
             symbol: "⍱ ",
             style: "cyan bold",
             disabled: false,
+            detect_extensions: vec![],
+            detect_files: vec!["Vagrantfile"],
+            detect_folders: vec![],
         }
     }
 }

--- a/src/modules/vagrant.rs
+++ b/src/modules/vagrant.rs
@@ -4,21 +4,21 @@ use crate::configs::vagrant::VagrantConfig;
 use crate::formatter::StringFormatter;
 
 /// Creates a module with the current Vagrant version
-///
-/// Will display the Vagrant version if any of the following criteria are met:
-///     - Current directory contains a `Vagrantfile` file
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let mut module = context.new_module("vagrant");
+    let config = VagrantConfig::try_load(module.config);
+
     let is_vagrant_project = context
         .try_begin_scan()?
-        .set_files(&["Vagrantfile"])
+        .set_files(&config.detect_files)
+        .set_extensions(&config.detect_extensions)
+        .set_folders(&config.detect_folders)
         .is_match();
 
     if !is_vagrant_project {
         return None;
     }
 
-    let mut module = context.new_module("vagrant");
-    let config = VagrantConfig::try_load(module.config);
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter
             .map_meta(|var, _| match var {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This makes it possible to configure when the vagrant module is shown based on the contents of a directory.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to #1977

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
