### PR TITLE
feat(docker_context): Configure when module is shown

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -730,7 +730,7 @@ The `docker_context` module shows the currently active
 | `only_with_files`   | `true`                                                        | Only show when there's a match                                                    |
 | `detect_extensions` | `[]`                                                          | Which extensions should trigger this module (needs `only_with_files` to be true). |
 | `detect_files`      | `["docker-compose.yml", "docker-compose.yaml", "Dockerfile"]` | Which filenames should trigger this module (needs `only_with_files` to be true).  |
-| `detect_folders`    | `[]`                                                          | Which folders should trigger this module (needs `only_with_files` to be ture).    |
+| `detect_folders`    | `[]`                                                          | Which folders should trigger this module (needs `only_with_files` to be true).    |
 | `style`             | `"blue bold"`                                                 | The style for the module.                                                         |
 | `disabled`          | `false`                                                       | Disables the `docker_context` module.                                             |
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -723,13 +723,16 @@ The `docker_context` module shows the currently active
 
 ### Options
 
-| Option            | Default                            | Description                                                                                                     |
-| ----------------- | ---------------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| `format`          | `"via [$symbol$context]($style) "` | The format for the module.                                                                                      |
-| `symbol`          | `"🐳 "`                            | The symbol used before displaying the Docker context.                                                           |
-| `style`           | `"blue bold"`                      | The style for the module.                                                                                       |
-| `only_with_files` | `true`                             | Only show when there's a `docker-compose.yml`, `docker-compose.yaml`, or `Dockerfile` in the current directory. |
-| `disabled`        | `false`                            | Disables the `docker_context` module.                                                                           |
+| Option              | Default                                                       | Description                                                                       |
+| ------------------- | ------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| `format`            | `"via [$symbol$context]($style) "`                            | The format for the module.                                                        |
+| `symbol`            | `"🐳 "`                                                       | The symbol used before displaying the Docker context.                             |
+| `only_with_files`   | `true`                                                        | Only show when there's a match                                                    |
+| `detect_extensions` | `[]`                                                          | Which extensions should trigger this module (needs `only_with_files` to be true). |
+| `detect_files`      | `["docker-compose.yml", "docker-compose.yaml", "Dockerfile"]` | Which filenames should trigger this module (needs `only_with_files` to be true).  |
+| `detect_folders`    | `[]`                                                          | Which folders should trigger this module (needs `only_with_files` to be ture).    |
+| `style`             | `"blue bold"`                                                 | The style for the module.                                                         |
+| `disabled`          | `false`                                                       | Disables the `docker_context` module.                                             |
 
 ### Variables
 

--- a/src/configs/docker_context.rs
+++ b/src/configs/docker_context.rs
@@ -9,6 +9,9 @@ pub struct DockerContextConfig<'a> {
     pub format: &'a str,
     pub only_with_files: bool,
     pub disabled: bool,
+    pub detect_extensions: Vec<&'a str>,
+    pub detect_files: Vec<&'a str>,
+    pub detect_folders: Vec<&'a str>,
 }
 
 impl<'a> RootModuleConfig<'a> for DockerContextConfig<'a> {
@@ -19,6 +22,9 @@ impl<'a> RootModuleConfig<'a> for DockerContextConfig<'a> {
             format: "via [$symbol$context]($style) ",
             only_with_files: true,
             disabled: false,
+            detect_extensions: vec![],
+            detect_files: vec!["docker-compose.yml", "docker-compose.yaml", "Dockerfile"],
+            detect_folders: vec![],
         }
     }
 }

--- a/src/modules/docker_context.rs
+++ b/src/modules/docker_context.rs
@@ -20,11 +20,14 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     if config.only_with_files
         && !context
             .try_begin_scan()?
-            .set_files(&["docker-compose.yml", "docker-compose.yaml", "Dockerfile"])
+            .set_files(&config.detect_files)
+            .set_extensions(&config.detect_extensions)
+            .set_folders(&config.detect_folders)
             .is_match()
     {
         return None;
     }
+
     let docker_config = PathBuf::from(
         &context
             .get_env_os("DOCKER_CONFIG")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This makes it possible to configure when the docker_context module is
shown based on the contents of a directory. This should make it possible
to be a lot more granular when configuring the module.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to #1977 

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
