### PR TITLE
fix: small typo in starship.fish

### DIFF
--- a/src/init/starship.fish
+++ b/src/init/starship.fish
@@ -15,7 +15,7 @@ end
 set VIRTUAL_ENV_DISABLE_PROMPT 1
 
 function fish_mode_prompt; end
-set -gx STARSHIP_SHELL="fish"
+set -gx STARSHIP_SHELL "fish"
 
 # Set up the session key that will be used to store logs
-set -gx STARSHIP_SESSION_KEY=(random 10000000000000 9999999999999999)
+set -gx STARSHIP_SESSION_KEY (random 10000000000000 9999999999999999)


### PR DESCRIPTION
#### Description
I usually builf starship from source and i've found this typo in the starship.fish file added in some recent commits.

#### Motivation and Context
The  problem is that  the `=` (equal sign) is not valid in the `set` semantic and broke the shell; so i simpli removed that.
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
