### PR TITLE
fix: correct fish syntax error when setting variables

### DIFF
--- a/src/init/starship.fish
+++ b/src/init/starship.fish
@@ -15,7 +15,7 @@ end
 set VIRTUAL_ENV_DISABLE_PROMPT 1
 
 function fish_mode_prompt; end
-set -gx STARSHIP_SHELL="fish"
+set -gx STARSHIP_SHELL "fish"
 
 # Set up the session key that will be used to store logs
-set -gx STARSHIP_SESSION_KEY=(random 10000000000000 9999999999999999)
+set -gx STARSHIP_SESSION_KEY (random 10000000000000 9999999999999999)


### PR DESCRIPTION
#### Description
Fix syntax error.

#### Motivation and Context
Closes #2316
Closes #2319

#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.