### PR TITLE
feat(terraform): Configure when the module is shown

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2386,19 +2386,22 @@ If you still want to enable it, [follow the example shown below](#with-version).
 
 :::
 
-The module will be shown if any of the following conditions are met:
+By default the module will be shown if any of the following conditions are met:
 
 - The current directory contains a `.terraform` folder
 - Current directory contains a file with the `.tf` or `.hcl` extensions
 
 ### Options
 
-| Option     | Default                              | Description                                           |
-| ---------- | ------------------------------------ | ----------------------------------------------------- |
-| `format`   | `"via [$symbol$workspace]($style) "` | The format string for the module.                     |
-| `symbol`   | `"💠 "`                              | A format string shown before the terraform workspace. |
-| `style`    | `"bold 105"`                         | The style for the module.                             |
-| `disabled` | `false`                              | Disables the `terraform` module.                      |
+| Option              | Default                              | Description                                           |
+| ------------------- | ------------------------------------ | ----------------------------------------------------- |
+| `format`            | `"via [$symbol$workspace]($style) "` | The format string for the module.                     |
+| `symbol`            | `"💠"`                               | A format string shown before the terraform workspace. |
+| `detect_extensions` | `["tf", "hcl"]`                      | Which extensions should trigger this module.          |
+| `detect_files`      | `[]`                                 | Which filenames should trigger this module.           |
+| `detect_folders`    | `[".terraform"]`                     | Which folders should trigger this module.             |
+| `style`             | `"bold 105"`                         | The style for the module.                             |
+| `disabled`          | `false`                              | Disables the `terraform` module.                      |
 
 ### Variables
 

--- a/src/configs/terraform.rs
+++ b/src/configs/terraform.rs
@@ -8,6 +8,9 @@ pub struct TerraformConfig<'a> {
     pub symbol: &'a str,
     pub style: &'a str,
     pub disabled: bool,
+    pub detect_extensions: Vec<&'a str>,
+    pub detect_files: Vec<&'a str>,
+    pub detect_folders: Vec<&'a str>,
 }
 
 impl<'a> RootModuleConfig<'a> for TerraformConfig<'a> {
@@ -17,6 +20,9 @@ impl<'a> RootModuleConfig<'a> for TerraformConfig<'a> {
             symbol: "💠 ",
             style: "bold 105",
             disabled: false,
+            detect_extensions: vec!["tf", "hcl"],
+            detect_files: vec![],
+            detect_folders: vec![".terraform"],
         }
     }
 }

--- a/src/modules/terraform.rs
+++ b/src/modules/terraform.rs
@@ -8,23 +8,20 @@ use std::io;
 use std::path::PathBuf;
 
 /// Creates a module with the current Terraform version and workspace
-///
-/// Will display the Terraform version and workspace if any of the following criteria are met:
-///     - Current directory contains a `.terraform` directory
-///     - Current directory contains a file with the `.tf` extension
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let mut module = context.new_module("terraform");
+    let config: TerraformConfig = TerraformConfig::try_load(module.config);
+
     let is_terraform_project = context
         .try_begin_scan()?
-        .set_folders(&[".terraform"])
-        .set_extensions(&["tf", "hcl"])
+        .set_files(&config.detect_files)
+        .set_folders(&config.detect_folders)
+        .set_extensions(&config.detect_extensions)
         .is_match();
 
     if !is_terraform_project {
         return None;
     }
-
-    let mut module = context.new_module("terraform");
-    let config: TerraformConfig = TerraformConfig::try_load(module.config);
 
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter


### PR DESCRIPTION
#### Description
<!--- Describe your changes in detail -->
This makes it possible to configure when the terraform module is shown
based on the contents of a directory. This should make it possible to
be a lot more granular when configuring the module.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to #1977 

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
