### PR TITLE
feat(golang): Configure when the module is shown

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1233,7 +1233,7 @@ behind = "⇣${count}"
 ## Golang
 
 The `golang` module shows the currently installed version of Golang.
-The module will be shown if any of the following conditions are met:
+By default the module will be shown if any of the following conditions are met:
 
 - The current directory contains a `go.mod` file
 - The current directory contains a `go.sum` file
@@ -1246,12 +1246,15 @@ The module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Option     | Default                            | Description                                    |
-| ---------- | ---------------------------------- | ---------------------------------------------- |
-| `format`   | `"via [$symbol($version )]($style)"` | The format for the module.                     |
-| `symbol`   | `"🐹 "`                            | A format string representing the symbol of Go. |
-| `style`    | `"bold cyan"`                      | The style for the module.                      |
-| `disabled` | `false`                            | Disables the `golang` module.                  |
+| Option               | Default                                                                        | Description                                    |
+| -------------------- | ------------------------------------------------------------------------------ | ---------------------------------------------- |
+| `format`             | `"via [$symbol($version )]($style)"`                                           | The format for the module.                     |
+| `symbol`             | `"🐹 "`                                                                        | A format string representing the symbol of Go. |
+| `detect_extensions`  | `["go"]`                                                                       | Which extensions should trigger this moudle.   |
+| `detect_files`       | `["go.mod", "go.sum", "glide.yaml", "Gopkg.yml", "Gopkg.lock", ".go-version"]` | Which filenames should trigger this module.    |
+| `detect_folders`     | `["Godeps"]`                                                                   | Which folders should trigger this module.      |
+| `style`              | `"bold cyan"`                                                                  | The style for the module.                      |
+| `disabled`           | `false`                                                                        | Disables the `golang` module.                  |
 
 ### Variables
 

--- a/src/configs/go.rs
+++ b/src/configs/go.rs
@@ -8,6 +8,9 @@ pub struct GoConfig<'a> {
     pub symbol: &'a str,
     pub style: &'a str,
     pub disabled: bool,
+    pub detect_extensions: Vec<&'a str>,
+    pub detect_files: Vec<&'a str>,
+    pub detect_folders: Vec<&'a str>,
 }
 
 impl<'a> RootModuleConfig<'a> for GoConfig<'a> {
@@ -17,6 +20,16 @@ impl<'a> RootModuleConfig<'a> for GoConfig<'a> {
             symbol: "🐹 ",
             style: "bold cyan",
             disabled: false,
+            detect_extensions: vec!["go"],
+            detect_files: vec![
+                "go.mod",
+                "go.sum",
+                "glide.yaml",
+                "Gopkg.yml",
+                "Gopkg.lock",
+                ".go-version",
+            ],
+            detect_folders: vec!["Godeps"],
         }
     }
 }


### PR DESCRIPTION
#### Description
<!--- Describe your changes in detail -->
This makes it possible to configure when the golang module is shown
based on the contents of a directory. This should make it possible to
be a lot more granular when configuring the module.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to #1977 

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.