### PR TITLE
feat(lua): Configure when the module is shown

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1566,7 +1566,7 @@ disabled = true
 ## Lua
 
 The `lua` module shows the currently installed version of Lua.
-The module will be shown if any of the following conditions are met:
+By default the module will be shown if any of the following conditions are met:
 
 - The current directory contains a `.lua-version` file
 - The current directory contains a `lua` directory
@@ -1574,13 +1574,16 @@ The module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Option       | Default                              | Description                                                                   |
-| ------------ | ------------------------------------ | ----------------------------------------------------------------------------- |
-| `format`     | `"via [$symbol($version )]($style)"` | The format for the module.                                                    |
-| `symbol`     | `"🌙 "`                              | A format string representing the symbol of Lua.                               |
-| `style`      | `"bold blue"`                        | The style for the module.                                                     |
-| `lua_binary` | `"lua"`                              | Configures the lua binary that Starship executes when getting the version.    |
-| `disabled`   | `false`                              | Disables the `lua` module.                                                    |
+| Option              | Default                              | Description                                                                   |
+| ------------------- | ------------------------------------ | ----------------------------------------------------------------------------- |
+| `format`            | `"via [$symbol($version )]($style)"` | The format for the module.                                                    |
+| `symbol`            | `"🌙 "`                              | A format string representing the symbol of Lua.                               |
+| `detect_extensions` | `["lua"]`                            | Which extensions should trigger this moudle.                                  |
+| `detect_files`      | `[".lua-version"]`                   | Which filenames should trigger this module.                                   |
+| `detect_folders`    | `["lua"]`                            | Which folders should trigger this module.                                     |
+| `style`             | `"bold blue"`                        | The style for the module.                                                     |
+| `lua_binary`        | `"lua"`                              | Configures the lua binary that Starship executes when getting the version.    |
+| `disabled`          | `false`                              | Disables the `lua` module.                                                    |
 
 ### Variables
 

--- a/src/configs/lua.rs
+++ b/src/configs/lua.rs
@@ -9,6 +9,9 @@ pub struct LuaConfig<'a> {
     pub style: &'a str,
     pub lua_binary: &'a str,
     pub disabled: bool,
+    pub detect_extensions: Vec<&'a str>,
+    pub detect_files: Vec<&'a str>,
+    pub detect_folders: Vec<&'a str>,
 }
 
 impl<'a> RootModuleConfig<'a> for LuaConfig<'a> {
@@ -19,6 +22,9 @@ impl<'a> RootModuleConfig<'a> for LuaConfig<'a> {
             style: "bold blue",
             lua_binary: "lua",
             disabled: false,
+            detect_extensions: vec!["lua"],
+            detect_files: vec![".lua-version"],
+            detect_folders: vec!["lua"],
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This makes it possible to configure when the lua module is shown
based on the contents of a directory. This should make it possible to
be a lot more granular when configuring the module.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to #1977 

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
