### PR TITLE
feat(dotnet): Configure when module is shown

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -762,8 +762,8 @@ The `dotnet` module shows the relevant version of the .NET Core SDK for the curr
 the SDK has been pinned in the current directory, the pinned version is shown. Otherwise the module
 shows the latest installed version of the SDK.
 
-This module will only be shown in your prompt when one or more of the following files are present in the
-current directory:
+By default this module will only be shown in your prompt when one or more of
+the following files are present in the current directory:
 
 - `global.json`
 - `project.json`
@@ -788,13 +788,16 @@ when there is a csproj file in the current directory.
 
 ### Options
 
-| Option      | Default                                   | Description                                              |
-| ----------- | ----------------------------------------- | -------------------------------------------------------- |
-| `format`    | `"[$symbol($version )(🎯 $tfm )]($style)"`  | The format for the module.                               |
-| `symbol`    | `"•NET "`                                 | The symbol used before displaying the version of dotnet. |
-| `heuristic` | `true`                                    | Use faster version detection to keep starship snappy.    |
-| `style`     | `"bold blue"`                             | The style for the module.                                |
-| `disabled`  | `false`                                   | Disables the `dotnet` module.                            |
+| Option              | Default                                                                                                  | Description                                              |
+| ------------------- | -------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| `format`            | `"[$symbol($version )(🎯 $tfm )]($style)"`                                                               | The format for the module.                               |
+| `symbol`            | `"•NET "`                                                                                                | The symbol used before displaying the version of dotnet. |
+| `heuristic`         | `true`                                                                                                   | Use faster version detection to keep starship snappy.    |
+| `detect_extensions` | `["sln", "csproj", "fsproj", "xproj"]`                                                                   | Which extensions should trigger this module.             |
+| `detect_files`      | `[ "global.json", "project.json", "Directory.Build.props", "Directory.Build.targets", "Packages.props"]` | Which filenames should trigger this module.              |
+| `detect_folders`    | `[]`                                                                                                     | Which folders should trigger this modules.               |
+| `style`             | `"bold blue"`                                                                                            | The style for the module.                                |
+| `disabled`          | `false`                                                                                                  | Disables the `dotnet` module.                            |
 
 ### Variables
 

--- a/src/configs/dotnet.rs
+++ b/src/configs/dotnet.rs
@@ -9,6 +9,9 @@ pub struct DotnetConfig<'a> {
     pub style: &'a str,
     pub heuristic: bool,
     pub disabled: bool,
+    pub detect_extensions: Vec<&'a str>,
+    pub detect_files: Vec<&'a str>,
+    pub detect_folders: Vec<&'a str>,
 }
 
 impl<'a> RootModuleConfig<'a> for DotnetConfig<'a> {
@@ -19,6 +22,15 @@ impl<'a> RootModuleConfig<'a> for DotnetConfig<'a> {
             style: "blue bold",
             heuristic: true,
             disabled: false,
+            detect_extensions: vec!["sln", "csproj", "fsproj", "xproj"],
+            detect_files: vec![
+                "global.json",
+                "project.json",
+                "Directory.Build.props",
+                "Directory.Build.targets",
+                "Packages.props",
+            ],
+            detect_folders: vec![],
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This makes it possible to configure when the dotnet module is shown
based on the contents of a directory. This should make it possible to be
a lot more granular when configuring the module.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to #1977 

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
