### PR TITLE
feat(elixir): Configure when module is shown

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -789,16 +789,16 @@ when there is a csproj file in the current directory.
 
 ### Options
 
-| Option              | Default                                                                                                  | Description                                              |
-| ------------------- | -------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
-| `format`            | `"[$symbol($version )(🎯 $tfm )]($style)"`                                                               | The format for the module.                               |
-| `symbol`            | `"•NET "`                                                                                                | The symbol used before displaying the version of dotnet. |
-| `heuristic`         | `true`                                                                                                   | Use faster version detection to keep starship snappy.    |
-| `detect_extensions` | `["sln", "csproj", "fsproj", "xproj"]`                                                                   | Which extensions should trigger this module.             |
-| `detect_files`      | `[ "global.json", "project.json", "Directory.Build.props", "Directory.Build.targets", "Packages.props"]` | Which filenames should trigger this module.              |
-| `detect_folders`    | `[]`                                                                                                     | Which folders should trigger this modules.               |
-| `style`             | `"bold blue"`                                                                                            | The style for the module.                                |
-| `disabled`          | `false`                                                                                                  | Disables the `dotnet` module.                            |
+| Option              | Default                                                                                                 | Description                                              |
+| ------------------- | ------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| `format`            | `"[$symbol($version )(🎯 $tfm )]($style)"`                                                              | The format for the module.                               |
+| `symbol`            | `"•NET "`                                                                                               | The symbol used before displaying the version of dotnet. |
+| `heuristic`         | `true`                                                                                                  | Use faster version detection to keep starship snappy.    |
+| `detect_extensions` | `["sln", "csproj", "fsproj", "xproj"]`                                                                  | Which extensions should trigger this module.             |
+| `detect_files`      | `["global.json", "project.json", "Directory.Build.props", "Directory.Build.targets", "Packages.props"]` | Which filenames should trigger this module.              |
+| `detect_folders`    | `[]`                                                                                                    | Which folders should trigger this modules.               |
+| `style`             | `"bold blue"`                                                                                           | The style for the module.                                |
+| `disabled`          | `false`                                                                                                 | Disables the `dotnet` module.                            |
 
 ### Variables
 
@@ -825,18 +825,21 @@ heuristic = false
 ## Elixir
 
 The `elixir` module shows the currently installed version of Elixir and Erlang/OTP.
-The module will be shown if any of the following conditions are met:
+By default the module will be shown if any of the following conditions are met:
 
 - The current directory contains a `mix.exs` file.
 
 ### Options
 
-| Option     | Default                                                   | Description                                                     |
-| ---------- | --------------------------------------------------------- | --------------------------------------------------------------- |
-| `symbol`   | `"💧 "`                                                   | The symbol used before displaying the version of Elixir/Erlang. |
-| `style`    | `"bold purple"`                                           | The style for the module.                                       |
-| `format`   | `'via [$symbol($version \(OTP $otp_version\) )]($style)'` | The format for the module elixir.                               |
-| `disabled` | `false`                                                   | Disables the `elixir` module.                                   |
+| Option              | Default                                                   | Description                                                     |
+| ------------------- | --------------------------------------------------------- | --------------------------------------------------------------- |
+| `symbol`            | `"💧 "`                                                   | The symbol used before displaying the version of Elixir/Erlang. |
+| `detect_extensions` | `[]`                                                      | Which extensions should trigger this module.                    |
+| `detect_files`      | `["mix.exs"]`                                             | Which filenames should trigger this module.                     |
+| `detect_folders`    | `[]`                                                      | Which folders should trigger this modules.                      |
+| `style`             | `"bold purple"`                                           | The style for the module.                                       |
+| `format`            | `'via [$symbol($version \(OTP $otp_version\) )]($style)'` | The format for the module elixir.                               |
+| `disabled`          | `false`                                                   | Disables the `elixir` module.                                   |
 
 ### Variables
 

--- a/src/configs/elixir.rs
+++ b/src/configs/elixir.rs
@@ -8,6 +8,9 @@ pub struct ElixirConfig<'a> {
     pub symbol: &'a str,
     pub style: &'a str,
     pub disabled: bool,
+    pub detect_extensions: Vec<&'a str>,
+    pub detect_files: Vec<&'a str>,
+    pub detect_folders: Vec<&'a str>,
 }
 
 impl<'a> RootModuleConfig<'a> for ElixirConfig<'a> {
@@ -17,6 +20,9 @@ impl<'a> RootModuleConfig<'a> for ElixirConfig<'a> {
             symbol: "💧 ",
             style: "bold purple",
             disabled: false,
+            detect_extensions: vec![],
+            detect_files: vec!["mix.exs"],
+            detect_folders: vec![],
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This makes it possible to configure when the elixir module is shown
based on the contents of a directory. This should make it possible to be
a lot more granular when configuring the module.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to #1977

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
