### PR TITLE
feat(elm): Configure when the module is shown

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -861,7 +861,7 @@ symbol = "🔮 "
 ## Elm
 
 The `elm` module shows the currently installed version of Elm.
-The module will be shown if any of the following conditions are met:
+By default the module will be shown if any of the following conditions are met:
 
 - The current directory contains a `elm.json` file
 - The current directory contains a `elm-package.json` file
@@ -871,12 +871,15 @@ The module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Option     | Default                              | Description                                     |
-| ---------- | ------------------------------------ | ----------------------------------------------- |
-| `format`   | `"via [$symbol($version )]($style)"` | The format for the module.                      |
-| `symbol`   | `"🌳 "`                              | A format string representing the symbol of Elm. |
-| `style`    | `"cyan bold"`                        | The style for the module.                       |
-| `disabled` | `false`                              | Disables the `elm` module.                      |
+| Option              | Default                                            | Description                                     |
+| ------------------- | -------------------------------------------------- | ----------------------------------------------- |
+| `format`            | `"via [$symbol($version )]($style)"`               | The format for the module.                      |
+| `symbol`            | `"🌳 "`                                            | A format string representing the symbol of Elm. |
+| `detect_extensions` | `["elm"]`                                          | Which extensions should trigger this module.    |
+| `detect_files`      | `["elm.json", "elm-package.json", ".elm-version"]` | Which filenames should trigger this module.     |
+| `detect_folders`    | `["elm-stuff"]`                                    | Which folders should trigger this modules.      |
+| `style`             | `"cyan bold"`                                      | The style for the module.                       |
+| `disabled`          | `false`                                            | Disables the `elm` module.                      |
 
 ### Variables
 

--- a/src/configs/elm.rs
+++ b/src/configs/elm.rs
@@ -8,6 +8,9 @@ pub struct ElmConfig<'a> {
     pub symbol: &'a str,
     pub style: &'a str,
     pub disabled: bool,
+    pub detect_extensions: Vec<&'a str>,
+    pub detect_files: Vec<&'a str>,
+    pub detect_folders: Vec<&'a str>,
 }
 
 impl<'a> RootModuleConfig<'a> for ElmConfig<'a> {
@@ -17,6 +20,9 @@ impl<'a> RootModuleConfig<'a> for ElmConfig<'a> {
             symbol: "🌳 ",
             style: "cyan bold",
             disabled: false,
+            detect_extensions: vec!["elm"],
+            detect_files: vec!["elm.json", "elm-package.json", ".elm-version"],
+            detect_folders: vec!["elm-stuff"],
         }
     }
 }

--- a/src/modules/elm.rs
+++ b/src/modules/elm.rs
@@ -4,27 +4,20 @@ use crate::configs::elm::ElmConfig;
 use crate::formatter::StringFormatter;
 
 /// Creates a module with the current Elm version
-///
-/// Will display the Elm version if any of the following criteria are met:
-///     - The current directory contains a `elm.json` file
-///     - The current directory contains a `elm-package.json` file
-///     - The current directory contains a `.elm-version` file
-///     - The current directory contains a `elm-stuff` folder
-///     - The current directory contains a `*.elm` files
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let mut module = context.new_module("elm");
+    let config: ElmConfig = ElmConfig::try_load(module.config);
+
     let is_elm_project = context
         .try_begin_scan()?
-        .set_files(&["elm.json", "elm-package.json", ".elm-version"])
-        .set_extensions(&["elm"])
-        .set_folders(&["elm-stuff"])
+        .set_files(&config.detect_files)
+        .set_extensions(&config.detect_extensions)
+        .set_folders(&config.detect_folders)
         .is_match();
 
     if !is_elm_project {
         return None;
     }
-
-    let mut module = context.new_module("elm");
-    let config: ElmConfig = ElmConfig::try_load(module.config);
 
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This makes it possible to configure when the elm module is shown
based on the contents of a directory. This should make it possible to
be a lot more granular when configuring the module.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to #1977

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
