### PR TITLE
feat(erlang): Configure when the module is shown

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -957,7 +957,7 @@ By default the module will be shown if any of the following conditions are met:
 | `style`             | `"bold red"`                         | The style for the module.                                |
 | `detect_extensions` | `[]`                                 | Which extensions should trigger this module.             |
 | `detect_files`      | `["rebar.config", "elang.mk"]`       | Which filenames should trigger this module.              |
-| `detect_folders`    | `["elm-stuff"]`                      | Which folders should trigger this modules.               |
+| `detect_folders`    | `[]`                                 | Which folders should trigger this modules.               |
 | `format`            | `"via [$symbol($version )]($style)"` | The format for the module.                               |
 | `disabled`          | `false`                              | Disables the `erlang` module.                            |
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -944,19 +944,22 @@ default = "unknown shell"
 ## Erlang
 
 The `erlang` module shows the currently installed version of Erlang/OTP.
-The module will be shown if any of the following conditions are met:
+By default the module will be shown if any of the following conditions are met:
 
 - The current directory contains a `rebar.config` file.
 - The current directory contains a `erlang.mk` file.
 
 ### Options
 
-| Option     | Default                            | Description                                              |
-| ---------- | ---------------------------------- | -------------------------------------------------------- |
-| `symbol`   | `" "`                             | The symbol used before displaying the version of erlang. |
-| `style`    | `"bold red"`                       | The style for the module.                                |
-| `format`   | `"via [$symbol($version )]($style)"` | The format for the module.                               |
-| `disabled` | `false`                            | Disables the `erlang` module.                            |
+| Option              | Default                              | Description                                              |
+| ------------------- | ------------------------------------ | -------------------------------------------------------- |
+| `symbol`            | `" "`                               | The symbol used before displaying the version of erlang. |
+| `style`             | `"bold red"`                         | The style for the module.                                |
+| `detect_extensions` | `[]`                                 | Which extensions should trigger this module.             |
+| `detect_files`      | `["rebar.config", "elang.mk"]`       | Which filenames should trigger this module.              |
+| `detect_folders`    | `["elm-stuff"]`                      | Which folders should trigger this modules.               |
+| `format`            | `"via [$symbol($version )]($style)"` | The format for the module.                               |
+| `disabled`          | `false`                              | Disables the `erlang` module.                            |
 
 ### Variables
 

--- a/src/configs/erlang.rs
+++ b/src/configs/erlang.rs
@@ -8,6 +8,9 @@ pub struct ErlangConfig<'a> {
     pub symbol: &'a str,
     pub style: &'a str,
     pub disabled: bool,
+    pub detect_extensions: Vec<&'a str>,
+    pub detect_files: Vec<&'a str>,
+    pub detect_folders: Vec<&'a str>,
 }
 
 impl<'a> RootModuleConfig<'a> for ErlangConfig<'a> {
@@ -17,6 +20,9 @@ impl<'a> RootModuleConfig<'a> for ErlangConfig<'a> {
             symbol: " ",
             style: "bold red",
             disabled: false,
+            detect_extensions: vec![],
+            detect_files: vec!["rebar.config", "erlang.mk"],
+            detect_folders: vec![],
         }
     }
 }

--- a/src/modules/erlang.rs
+++ b/src/modules/erlang.rs
@@ -4,22 +4,20 @@ use crate::configs::erlang::ErlangConfig;
 use crate::formatter::StringFormatter;
 
 /// Create a module with the current Erlang version
-///
-/// Will display the Erlang version if any of the following criteria are met:
-///     - Current directory contains a rebar.config file
-///     - Current directory contains a erlang.mk file
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let mut module = context.new_module("erlang");
+    let config = ErlangConfig::try_load(module.config);
+
     let is_erlang_project = context
         .try_begin_scan()?
-        .set_files(&["rebar.config", "erlang.mk"])
+        .set_files(&config.detect_files)
+        .set_extensions(&config.detect_extensions)
+        .set_folders(&config.detect_folders)
         .is_match();
 
     if !is_erlang_project {
         return None;
     }
-
-    let mut module = context.new_module("erlang");
-    let config = ErlangConfig::try_load(module.config);
 
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This makes it possible to configure when the erlang module is shown
based on the contents of a directory. This should make it possible to
be a lot more granular when configuring the module.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to #1977

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
