### PR TITLE
feat(nim): Configure when the module is shown

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1705,7 +1705,7 @@ truncation_symbol = ""
 ## Nim
 
 The `nim` module shows the currently installed version of Nim.
-The module will be shown if any of the following conditions are met:
+By default the module will be shown if any of the following conditions are met:
 
 - The current directory contains a `nim.cfg` file
 - The current directory contains a file with the `.nim` extension
@@ -1714,12 +1714,15 @@ The module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Option     | Default                            | Description                                           |
-| ---------- | ---------------------------------- | ----------------------------------------------------- |
-| `format`   | `"via [$symbol($version )]($style)"` | The format for the module                             |
-| `symbol`   | `"👑 "`                            | The symbol used before displaying the version of Nim. |
-| `style`    | `"bold yellow"`                    | The style for the module.                             |
-| `disabled` | `false`                            | Disables the `nim` module.                            |
+| Option               | Default                              | Description                                           |
+| -------------------- | ------------------------------------ | ----------------------------------------------------- |
+| `format`             | `"via [$symbol($version )]($style)"` | The format for the module                             |
+| `symbol`             | `"👑 "`                              | The symbol used before displaying the version of Nim. |
+| `detect_extensions`  | `["nim", "nims", "nimble"]`          | Which extensions should trigger this moudle.          |
+| `detect_files`       | `["nim.cfg"]`                        | Which filenames should trigger this module.           |
+| `detect_folders`     | `[]`                                 | Which folders should trigger this module.             |
+| `style`              | `"bold yellow"`                      | The style for the module.                             |
+| `disabled`           | `false`                              | Disables the `nim` module.                            |
 
 ### Variables
 

--- a/src/configs/nim.rs
+++ b/src/configs/nim.rs
@@ -8,6 +8,9 @@ pub struct NimConfig<'a> {
     pub symbol: &'a str,
     pub style: &'a str,
     pub disabled: bool,
+    pub detect_extensions: Vec<&'a str>,
+    pub detect_files: Vec<&'a str>,
+    pub detect_folders: Vec<&'a str>,
 }
 
 impl<'a> RootModuleConfig<'a> for NimConfig<'a> {
@@ -17,6 +20,9 @@ impl<'a> RootModuleConfig<'a> for NimConfig<'a> {
             symbol: "👑 ",
             style: "yellow bold",
             disabled: false,
+            detect_extensions: vec!["nim", "nims", "nimble"],
+            detect_files: vec!["nim.cfg"],
+            detect_folders: vec![],
         }
     }
 }

--- a/src/modules/nim.rs
+++ b/src/modules/nim.rs
@@ -4,23 +4,19 @@ use crate::configs::nim::NimConfig;
 use crate::formatter::StringFormatter;
 
 /// Creates a module with the current Nim version
-///
-/// Will display the Nim version if any of the following criteria are met:
-///     - The current directory contains a file with extension `.nim`, `.nims`, or `.nimble`
-///     - The current directory contains a `nim.cfg` file
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let mut module = context.new_module("nim");
+    let config = NimConfig::try_load(module.config);
     let is_nim_project = context
         .try_begin_scan()?
-        .set_files(&["nim.cfg"])
-        .set_extensions(&["nim", "nims", "nimble"])
+        .set_files(&config.detect_files)
+        .set_extensions(&config.detect_extensions)
+        .set_folders(&config.detect_files)
         .is_match();
 
     if !is_nim_project {
         return None;
     }
-
-    let mut module = context.new_module("nim");
-    let config = NimConfig::try_load(module.config);
 
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This makes it possible to configure when the nim module is shown
based on the contents of a directory. This should make it possible to
be a lot more granular when configuring the module.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to #1977

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
