### PR TITLE
feat(nodejs): Configure when the module is shown

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1783,7 +1783,7 @@ format = 'via [☃️ $state( \($name\))](bold blue) '
 ## NodeJS
 
 The `nodejs` module shows the currently installed version of NodeJS.
-The module will be shown if any of the following conditions are met:
+By default the module will be shown if any of the following conditions are met:
 
 - The current directory contains a `package.json` file
 - The current directory contains a `.node-version` file
@@ -1793,13 +1793,16 @@ The module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Option     | Default                            | Description                                        |
-| ---------- | ---------------------------------- | -------------------------------------------------- |
-| `format`   | `"via [$symbol($version )]($style)"` | The format for the module.                         |
-| `symbol`   | `"⬢ "`                             | A format string representing the symbol of NodeJS. |
-| `style`    | `"bold green"`                     | The style for the module.                          |
-| `disabled` | `false`                            | Disables the `nodejs` module.                      |
-| `not_capable_style` | `bold red` | The style for the module when an engines property in Packages.json does not match the NodeJS version. |
+| Option              | Default                              | Description                                        |
+| ------------------- | ------------------------------------ | -------------------------------------------------- |
+| `format`            | `"via [$symbol($version )]($style)"` | The format for the module.                         |
+| `symbol`            | `"⬢ "`                               | A format string representing the symbol of NodeJS. |
+| `detect_extensions` | `["js", "mjs", "cjs", "ts"]`         | Which extensions should trigger this moudle.       |
+| `detect_files`      | `["package.json", ".node-version"]`  | Which filenames should trigger this module.        |
+| `detect_folders`    | `["node_modules"]`                   | Which folders should trigger this module.          |
+| `style`             | `"bold green"`                       | The style for the module.                          |
+| `disabled`          | `false`                              | Disables the `nodejs` module.                      |
+| `not_capable_style` | `bold red`                           | The style for the module when an engines property in Packages.json does not match the NodeJS version. |
 
 ### Variables
 

--- a/src/configs/nodejs.rs
+++ b/src/configs/nodejs.rs
@@ -9,6 +9,9 @@ pub struct NodejsConfig<'a> {
     pub style: &'a str,
     pub disabled: bool,
     pub not_capable_style: &'a str,
+    pub detect_extensions: Vec<&'a str>,
+    pub detect_files: Vec<&'a str>,
+    pub detect_folders: Vec<&'a str>,
 }
 
 impl<'a> RootModuleConfig<'a> for NodejsConfig<'a> {
@@ -19,6 +22,9 @@ impl<'a> RootModuleConfig<'a> for NodejsConfig<'a> {
             style: "bold green",
             disabled: false,
             not_capable_style: "bold red",
+            detect_extensions: vec!["js", "mjs", "cjs", "ts"],
+            detect_files: vec!["package.json", ".node-version"],
+            detect_folders: vec!["node_modules"],
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This makes it possible to configure when the nodejs module is shown
based on the contents of a directory. This should make it possible to
be a lot more granular when configuring the module.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to #1977

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
