### PR TITLE
feat(swift): Configure when the module is shown

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2397,7 +2397,7 @@ disabled = false
 
 ## Swift
 
-The `swift` module shows the currently installed version of Swift.
+By default the `swift` module shows the currently installed version of Swift.
 The module will be shown if any of the following conditions are met:
 
 - The current directory contains a `Package.swift` file
@@ -2405,12 +2405,15 @@ The module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Option     | Default                              | Description                                      |
-| ---------- | ------------------------------------ | ------------------------------------------------ |
-| `format`   | `"via [$symbol($version )]($style)"` | The format for the module.                       |
-| `symbol`   | `"🐦 "`                              | A format string representing the symbol of Swift |
-| `style`    | `"bold 202"`                         | The style for the module.                        |
-| `disabled` | `false`                              | Disables the `swift` module.                     |
+| Option              | Default                              | Description                                      |
+| ------------------- | ------------------------------------ | ------------------------------------------------ |
+| `format`            | `"via [$symbol($version )]($style)"` | The format for the module.                       |
+| `symbol`            | `"🐦 "`                              | A format string representing the symbol of Swift |
+| `detect_extensions` | `["swift"]`                          | Which extensions should trigger this moudle.     |
+| `detect_files`      | `["Package.swift"]`                  | Which filenames should trigger this module.      |
+| `detect_folders`    | `[]`                                 | Which folders should trigger this module.        |
+| `style`             | `"bold 202"`                         | The style for the module.                        |
+| `disabled`          | `false`                              | Disables the `swift` module.                     |
 
 ### Variables
 

--- a/src/configs/swift.rs
+++ b/src/configs/swift.rs
@@ -8,6 +8,9 @@ pub struct SwiftConfig<'a> {
     pub symbol: &'a str,
     pub style: &'a str,
     pub disabled: bool,
+    pub detect_extensions: Vec<&'a str>,
+    pub detect_files: Vec<&'a str>,
+    pub detect_folders: Vec<&'a str>,
 }
 
 impl<'a> RootModuleConfig<'a> for SwiftConfig<'a> {
@@ -17,6 +20,9 @@ impl<'a> RootModuleConfig<'a> for SwiftConfig<'a> {
             symbol: "🐦 ",
             style: "bold 202",
             disabled: false,
+            detect_extensions: vec!["swift"],
+            detect_files: vec!["Package.swift"],
+            detect_folders: vec![],
         }
     }
 }

--- a/src/modules/swift.rs
+++ b/src/modules/swift.rs
@@ -4,22 +4,20 @@ use crate::configs::swift::SwiftConfig;
 use crate::formatter::StringFormatter;
 
 /// Creates a module with the current Swift version
-///
-/// Will display the Swift version if any of the following criteria are met:
-///     - The current directory contains a `Package.swift` file
-///     - The current directory contains a file with extension `.swift`
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let mut module = context.new_module("swift");
+    let config: SwiftConfig = SwiftConfig::try_load(module.config);
+
     let is_swift_project = context
         .try_begin_scan()?
-        .set_extensions(&["swift"])
+        .set_files(&config.detect_files)
+        .set_folders(&config.detect_folders)
+        .set_extensions(&config.detect_extensions)
         .is_match();
 
     if !is_swift_project {
         return None;
     }
-
-    let mut module = context.new_module("swift");
-    let config: SwiftConfig = SwiftConfig::try_load(module.config);
 
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This makes it possible to configure when the swift module is shown
based on the contents of a directory.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to #1977

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
