### PR TITLE
feat(rust): Configure when the module is shown

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2190,7 +2190,7 @@ symbol = "🔺 "
 
 ## Rust
 
-The `rust` module shows the currently installed version of Rust.
+By default the `rust` module shows the currently installed version of Rust.
 The module will be shown if any of the following conditions are met:
 
 - The current directory contains a `Cargo.toml` file
@@ -2198,12 +2198,15 @@ The module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Option     | Default                            | Description                                     |
-| ---------- | ---------------------------------- | ----------------------------------------------- |
-| `format`   | `"via [$symbol($version )]($style)"` | The format for the module.                      |
-| `symbol`   | `"🦀 "`                            | A format string representing the symbol of Rust |
-| `style`    | `"bold red"`                       | The style for the module.                       |
-| `disabled` | `false`                            | Disables the `rust` module.                     |
+| Option              | Default                              | Description                                     |
+| ------------------- | ------------------------------------ | ----------------------------------------------- |
+| `format`            | `"via [$symbol($version )]($style)"` | The format for the module.                      |
+| `symbol`            | `"🦀 "`                              | A format string representing the symbol of Rust |
+| `detect_extensions` | `["rs"]`                             | Which extensions should trigger this module.    |
+| `detect_files`      | `["Cargo.toml"]`                     | Which filenames should trigger this module.     |
+| `detect_folders`    | `[]`                                 | Which folders should trigger this module.       |
+| `style`             | `"bold red"`                         | The style for the module.                       |
+| `disabled`          | `false`                              | Disables the `rust` module.                     |
 
 ### Variables
 

--- a/src/configs/rust.rs
+++ b/src/configs/rust.rs
@@ -8,6 +8,9 @@ pub struct RustConfig<'a> {
     pub symbol: &'a str,
     pub style: &'a str,
     pub disabled: bool,
+    pub detect_extensions: Vec<&'a str>,
+    pub detect_files: Vec<&'a str>,
+    pub detect_folders: Vec<&'a str>,
 }
 
 impl<'a> RootModuleConfig<'a> for RustConfig<'a> {
@@ -17,6 +20,9 @@ impl<'a> RootModuleConfig<'a> for RustConfig<'a> {
             symbol: "🦀 ",
             style: "bold red",
             disabled: false,
+            detect_extensions: vec!["rs"],
+            detect_files: vec!["Cargo.toml"],
+            detect_folders: vec![],
         }
     }
 }

--- a/src/modules/rust.rs
+++ b/src/modules/rust.rs
@@ -10,23 +10,21 @@ use crate::configs::rust::RustConfig;
 use crate::formatter::StringFormatter;
 
 /// Creates a module with the current Rust version
-///
-/// Will display the Rust version if any of the following criteria are met:
-///     - Current directory contains a file with a `.rs` extension
-///     - Current directory contains a `Cargo.toml` file
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let mut module = context.new_module("rust");
+    let config = RustConfig::try_load(module.config);
+
     let is_rs_project = context
         .try_begin_scan()?
-        .set_files(&["Cargo.toml"])
-        .set_extensions(&["rs"])
+        .set_files(&config.detect_files)
+        .set_extensions(&config.detect_extensions)
+        .set_folders(&config.detect_folders)
         .is_match();
 
     if !is_rs_project {
         return None;
     }
 
-    let mut module = context.new_module("rust");
-    let config = RustConfig::try_load(module.config);
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter
             .map_meta(|var, _| match var {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This makes it possible to configure when the rust module is shown
based on the contents of a directory.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to #1977

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
