### PR TITLE
feat(helm): Configure when the module is shown

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1291,19 +1291,22 @@ format = "via [🏎💨 $version](bold cyan) "
 ## Helm
 
 The `helm` module shows the currently installed version of Helm.
-The module will be shown if any of the following conditions are met:
+By default the module will be shown if any of the following conditions are met:
 
 - The current directory contains a `helmfile.yaml` file
 - The current directory contains a `Chart.yaml` file
 
 ### Options
 
-| Option     | Default                            | Description                                      |
-| ---------- | ---------------------------------- | ------------------------------------------------ |
-| `format`   | `"via [$symbol($version )]($style)"` | The format for the module.                       |
-| `symbol`   | `"⎈ "`                             | A format string representing the symbol of Helm. |
-| `style`    | `"bold white"`                     | The style for the module.                        |
-| `disabled` | `false`                            | Disables the `helm` module.                      |
+| Option              | Default                              | Description                                      |
+| ------------------- | ------------------------------------ | ------------------------------------------------ |
+| `format`            | `"via [$symbol($version )]($style)"` | The format for the module.                       |
+| `detect_extensions` | `[]`                                 | Which extensions should trigger this module.     |
+| `detect_files`      | `["helmfile.yaml", "Chart.yaml"]`    | Which filenames should trigger this module.      |
+| `detect_folders`    | `[]`                                 | Which folders should trigger this modules.       |
+| `symbol`            | `"⎈ "`                               | A format string representing the symbol of Helm. |
+| `style`             | `"bold white"`                       | The style for the module.                        |
+| `disabled`          | `false`                              | Disables the `helm` module.                      |
 
 ### Variables
 

--- a/src/configs/helm.rs
+++ b/src/configs/helm.rs
@@ -8,6 +8,9 @@ pub struct HelmConfig<'a> {
     pub symbol: &'a str,
     pub style: &'a str,
     pub disabled: bool,
+    pub detect_extensions: Vec<&'a str>,
+    pub detect_files: Vec<&'a str>,
+    pub detect_folders: Vec<&'a str>,
 }
 
 impl<'a> RootModuleConfig<'a> for HelmConfig<'a> {
@@ -17,6 +20,9 @@ impl<'a> RootModuleConfig<'a> for HelmConfig<'a> {
             symbol: "⎈ ",
             style: "bold white",
             disabled: false,
+            detect_extensions: vec![],
+            detect_files: vec!["helmfile.yaml", "Chart.yaml"],
+            detect_folders: vec![],
         }
     }
 }

--- a/src/modules/helm.rs
+++ b/src/modules/helm.rs
@@ -4,22 +4,21 @@ use crate::configs::helm::HelmConfig;
 use crate::formatter::StringFormatter;
 
 /// Creates a module with the current Helm version
-///
-/// Will display the Helm version if any of the following criteria are met:
-///     - Current directory contains a `helmfile.yaml` file
-///     - Current directory contains a `Chart.yaml` file
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let mut module = context.new_module("helm");
+    let config = HelmConfig::try_load(module.config);
+
     let is_helm_project = context
         .try_begin_scan()?
-        .set_files(&["helmfile.yaml", "Chart.yaml"])
+        .set_files(&config.detect_files)
+        .set_extensions(&config.detect_extensions)
+        .set_folders(&config.detect_folders)
         .is_match();
 
     if !is_helm_project {
         return None;
     }
 
-    let mut module = context.new_module("helm");
-    let config = HelmConfig::try_load(module.config);
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter
             .map_meta(|var, _| match var {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This makes it possible to configure when the helm module is shown based
on the contents of a directory.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to #1977

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
