### PR TITLE
feat(java): Configure when the module is shown

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1362,19 +1362,22 @@ disabled = false
 ## Java
 
 The `java` module shows the currently installed version of Java.
-The module will be shown if any of the following conditions are met:
+By default the module will be shown if any of the following conditions are met:
 
 - The current directory contains a `pom.xml`, `build.gradle.kts`, `build.sbt`, `.java-version`, `.deps.edn`, `project.clj`, or `build.boot` file
 - The current directory contains a file with the `.java`, `.class`, `.gradle`, `.jar`, `.clj`, or `.cljc` extension
 
 ### Options
 
-| Option     | Default                                  | Description                                     |
-| ---------- | ---------------------------------------- | ----------------------------------------------- |
-| `format`   | `"via [${symbol}(${version} )]($style)"` | The format for the module.                      |
-| `symbol`   | `"☕ "`                                  | A format string representing the symbol of Java |
-| `style`    | `"red dimmed"`                           | The style for the module.                       |
-| `disabled` | `false`                                  | Disables the `java` module.                     |
+| Option              | Default                                                                                                   | Description                                     |
+| ------------------- | --------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| `format`            | `"via [${symbol}(${version} )]($style)"`                                                                  | The format for the module.                      |
+| `detect_extensions` | `["java", "class", "gradle", "jar", "cljs", "cljc"]`                                                      | Which extensions should trigger this module.    |
+| `detect_files`      | `["pom.xml", "build.gradle.kts", "build.sbt", ".java-version", ".deps.edn", "project.clj", "build.boot"]` | Which filenames should trigger this module.     |
+| `detect_folders`    | `[]`                                                                                                      | Which folders should trigger this modules.      |
+| `symbol`            | `"☕ "`                                                                                                   | A format string representing the symbol of Java |
+| `style`             | `"red dimmed"`                                                                                            | The style for the module.                       |
+| `disabled`          | `false`                                                                                                   | Disables the `java` module.                     |
 
 ### Variables
 

--- a/src/configs/java.rs
+++ b/src/configs/java.rs
@@ -8,6 +8,9 @@ pub struct JavaConfig<'a> {
     pub format: &'a str,
     pub style: &'a str,
     pub symbol: &'a str,
+    pub detect_extensions: Vec<&'a str>,
+    pub detect_files: Vec<&'a str>,
+    pub detect_folders: Vec<&'a str>,
 }
 
 impl<'a> RootModuleConfig<'a> for JavaConfig<'a> {
@@ -17,6 +20,17 @@ impl<'a> RootModuleConfig<'a> for JavaConfig<'a> {
             disabled: false,
             style: "red dimmed",
             symbol: "☕ ",
+            detect_extensions: vec!["java", "class", "jar", "gradle", "clj", "cljc"],
+            detect_files: vec![
+                "pom.xml",
+                "build.gradle.kts",
+                "build.sbt",
+                ".java-version",
+                "deps.edn",
+                "project.clj",
+                "build.boot",
+            ],
+            detect_folders: vec![],
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This makes it possible to configure when the java module is shown
based on the contents of a directory.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to #1977

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
