### PR TITLE
feat(ocaml): Configure when the module is shown

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1832,7 +1832,7 @@ format = "via [🤖 $version](bold green) "
 ## OCaml
 
 The `ocaml` module shows the currently installed version of OCaml.
-The module will be shown if any of the following conditions are met:
+By default the module will be shown if any of the following conditions are met:
 
 - The current directory contains a file with `.opam` extension or `_opam` directory
 - The current directory contains a `esy.lock` directory
@@ -1843,12 +1843,15 @@ The module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Option     | Default                              | Description                                             |
-| ---------- | ------------------------------------ | ------------------------------------------------------- |
-| `format`   | `"via [$symbol($version )]($style)"` | The format string for the module.                       |
-| `symbol`   | `"🐫 "`                              | The symbol used before displaying the version of OCaml. |
-| `style`    | `"bold yellow"`                      | The style for the module.                               |
-| `disabled` | `false`                              | Disables the `ocaml` module.                            |
+| Option              | Default                              | Description                                             |
+| ------------------- | ------------------------------------ | ------------------------------------------------------- |
+| `format`            | `"via [$symbol($version )]($style)"` | The format string for the module.                       |
+| `symbol`            | `"🐫 "`                              | The symbol used before displaying the version of OCaml. |
+| `detect_extensions` | `["opam", "ml", "mli", "re", "rei"]` | Which extensions should trigger this moudle.            |
+| `detect_files`      | `["dune", "dune-project", "jbuild", "jbuild-ignore", ".merlin"]` | Which filenames should trigger this module. |
+| `detect_folders`    | `["_opam", "esy.lock"]`              | Which folders should trigger this module.               |
+| `style`             | `"bold yellow"`                      | The style for the module.                               |
+| `disabled`          | `false`                              | Disables the `ocaml` module.                            |
 
 ### Variables
 

--- a/src/configs/ocaml.rs
+++ b/src/configs/ocaml.rs
@@ -8,6 +8,9 @@ pub struct OCamlConfig<'a> {
     pub symbol: &'a str,
     pub style: &'a str,
     pub disabled: bool,
+    pub detect_extensions: Vec<&'a str>,
+    pub detect_files: Vec<&'a str>,
+    pub detect_folders: Vec<&'a str>,
 }
 
 impl<'a> RootModuleConfig<'a> for OCamlConfig<'a> {
@@ -17,6 +20,9 @@ impl<'a> RootModuleConfig<'a> for OCamlConfig<'a> {
             symbol: "🐫 ",
             style: "bold yellow",
             disabled: false,
+            detect_extensions: vec!["opam", "ml", "mli", "re", "rei"],
+            detect_files: vec!["dune", "dune-project", "jbuild", "jbuild-ignore", ".merlin"],
+            detect_folders: vec!["_opam", "esy.lock"],
         }
     }
 }


### PR DESCRIPTION
#### Description
<!--- Describe your changes in detail -->
This makes it possible to configure when the ocaml module is shown
based on the contents of a directory. This should make it possible to
be a lot more granular when configuring the module.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to #1977 

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.