### PR TITLE
feat(perl): Configure when the module is shown

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1963,7 +1963,7 @@ format = "via [🎁 $version](208 bold) "
 ## Perl
 
 The `perl` module shows the currently installed version of Perl.
-The module will be shown if any of the following conditions are met:
+By default the module will be shown if any of the following conditions are met:
 
 - The current directory contains a `Makefile.PL` or `Build.PL` file
 - The current directory contains a `cpanfile` or `cpanfile.snapshot` file
@@ -1973,12 +1973,15 @@ The module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Option     | Default                              | Description                                           |
-| ---------- | ------------------------------------ | ----------------------------------------------------- |
-| `format`   | `"via [$symbol($version )]($style)"` | The format string for the module.                     |
-| `symbol`   | `"🐪 "`                              | The symbol used before displaying the version of Perl |
-| `style`    | `"bold 149"`                         | The style for the module.                             |
-| `disabled` | `false`                              | Disables the `perl` module.                           |
+| Option               | Default                              | Description                                           |
+| -------------------- | ------------------------------------ | ----------------------------------------------------- |
+| `format`             | `"via [$symbol($version )]($style)"` | The format string for the module.                     |
+| `symbol`             | `"🐪 "`                              | The symbol used before displaying the version of Perl |
+| `detect_extensions`  | `["pl", "pm", "pod"]`                | Which extensions should trigger this moudle.          |
+| `detect_files`       | `["Makefile.PL", "Build.PL", "cpanfile", "cpanfile.snapshot", "META.json", "META.yml", ".perl-version"]` | Which filenames should trigger this module. |
+| `detect_folders`     | `[]`                                 | Which folders should trigger this module.             |
+| `style`              | `"bold 149"`                         | The style for the module.                             |
+| `disabled`           | `false`                              | Disables the `perl` module.                           |
 
 ### Variables
 

--- a/src/configs/perl.rs
+++ b/src/configs/perl.rs
@@ -8,6 +8,9 @@ pub struct PerlConfig<'a> {
     pub style: &'a str,
     pub format: &'a str,
     pub disabled: bool,
+    pub detect_extensions: Vec<&'a str>,
+    pub detect_files: Vec<&'a str>,
+    pub detect_folders: Vec<&'a str>,
 }
 
 impl<'a> RootModuleConfig<'a> for PerlConfig<'a> {
@@ -17,6 +20,17 @@ impl<'a> RootModuleConfig<'a> for PerlConfig<'a> {
             style: "149 bold",
             format: "via [$symbol($version )]($style)",
             disabled: false,
+            detect_extensions: vec!["pl", "pm", "pod"],
+            detect_files: vec![
+                "Makefile.PL",
+                "Build.PL",
+                "cpanfile",
+                "cpanfile.snapshot",
+                "META.json",
+                "META.yml",
+                ".perl-version",
+            ],
+            detect_folders: vec![],
         }
     }
 }


### PR DESCRIPTION
#### Description
<!--- Describe your changes in detail -->
This makes it possible to configure when the perl module is shown
based on the contents of a directory. This should make it possible to
be a lot more granular when configuring the module.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to #1977 

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.