### PR TITLE
feat(php): Configure when the module is shown

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2000,20 +2000,23 @@ format = "via [🦪 $version]($style) "
 ## PHP
 
 The `php` module shows the currently installed version of PHP.
-The module will be shown if any of the following conditions are met:
+By default the module will be shown if any of the following conditions are met:
 
 - The current directory contains a `composer.json` file
 - The current directory contains a `.php-version` file
-- The current directory contains a `.php` file
+- The current directory contains a `.php` extension
 
 ### Options
 
-| Option     | Default                              | Description                                           |
-| ---------- | ------------------------------------ | ----------------------------------------------------- |
-| `format`   | `"via [$symbol($version )]($style)"` | The format for the module.                            |
-| `symbol`   | `"🐘 "`                              | The symbol used before displaying the version of PHP. |
-| `style`    | `"147 bold"`                         | The style for the module.                             |
-| `disabled` | `false`                              | Disables the `php` module.                            |
+| Option               | Default                              | Description                                           |
+| -------------------- | ------------------------------------ | ----------------------------------------------------- |
+| `format`             | `"via [$symbol($version )]($style)"` | The format for the module.                            |
+| `symbol`             | `"🐘 "`                              | The symbol used before displaying the version of PHP. |
+| `detect_extensions`  | `["php"]`                            | Which extensions should trigger this moudle.          |
+| `detect_files`       | `["composer.json", ".php-version"]`  | Which filenames should trigger this module.           |
+| `detect_folders`     | `[]`                                 | Which folders should trigger this module.             |
+| `style`              | `"147 bold"`                         | The style for the module.                             |
+| `disabled`           | `false`                              | Disables the `php` module.                            |
 
 ### Variables
 

--- a/src/configs/php.rs
+++ b/src/configs/php.rs
@@ -8,6 +8,9 @@ pub struct PhpConfig<'a> {
     pub style: &'a str,
     pub format: &'a str,
     pub disabled: bool,
+    pub detect_extensions: Vec<&'a str>,
+    pub detect_files: Vec<&'a str>,
+    pub detect_folders: Vec<&'a str>,
 }
 
 impl<'a> RootModuleConfig<'a> for PhpConfig<'a> {
@@ -17,6 +20,9 @@ impl<'a> RootModuleConfig<'a> for PhpConfig<'a> {
             style: "147 bold",
             format: "via [$symbol($version )]($style)",
             disabled: false,
+            detect_extensions: vec!["php"],
+            detect_files: vec!["composer.json", ".php-version"],
+            detect_folders: vec![],
         }
     }
 }

--- a/src/modules/php.rs
+++ b/src/modules/php.rs
@@ -4,23 +4,19 @@ use crate::configs::php::PhpConfig;
 use crate::formatter::StringFormatter;
 
 /// Creates a module with the current PHP version
-///
-/// Will display the PHP version if any of the following criteria are met:
-///     - Current directory contains a `.php` file
-///     - Current directory contains a `composer.json` or `.php-version` file
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let mut module = context.new_module("php");
+    let config: PhpConfig = PhpConfig::try_load(module.config);
     let is_php_project = context
         .try_begin_scan()?
-        .set_files(&["composer.json", ".php-version"])
-        .set_extensions(&["php"])
+        .set_files(&config.detect_files)
+        .set_folders(&config.detect_folders)
+        .set_extensions(&config.detect_extensions)
         .is_match();
 
     if !is_php_project {
         return None;
     }
-
-    let mut module = context.new_module("php");
-    let config: PhpConfig = PhpConfig::try_load(module.config);
 
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter


### PR DESCRIPTION
#### Description
<!--- Describe your changes in detail -->
This makes it possible to configure when the php module is shown
based on the contents of a directory. This should make it possible to
be a lot more granular when configuring the module.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to #1977 

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.