### PR TITLE
feat(purescript): Configure when the module is shown

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2037,19 +2037,22 @@ format = "via [🔹 $version](147 bold) "
 ## PureScript
 
 The `purescript` module shows the currently installed version of PureScript version.
-The module will be shown if any of the following conditions are met:
+By default the module will be shown if any of the following conditions are met:
 
 - The current directory contains a `spago.dhall` file
-- The current directory contains a \*.purs files
+- The current directory contains a file with the `.purs` extension
 
 ### Options
 
-| Option     | Default                              | Description                                                  |
-| ---------- | ------------------------------------ | ------------------------------------------------------------ |
-| `format`   | `"via [$symbol($version )]($style)"` | The format for the module.                                   |
-| `symbol`   | `"<=> "`                             | The symbol used before displaying the version of PureScript. |
-| `style`    | `"bold white"`                       | The style for the module.                                    |
-| `disabled` | `false`                              | Disables the `purescript` module.                            |
+| Option               | Default                              | Description                                                  |
+| -------------------- | ------------------------------------ | ------------------------------------------------------------ |
+| `format`             | `"via [$symbol($version )]($style)"` | The format for the module.                                   |
+| `symbol`             | `"<=> "`                             | The symbol used before displaying the version of PureScript. |
+| `detect_extensions`  | `["purs"]`                           | Which extensions should trigger this moudle.                 |
+| `detect_files`       | `["spago.dhall"]`                    | Which filenames should trigger this module.                  |
+| `detect_folders`     | `[]`                                 | Which folders should trigger this module.                    |
+| `style`              | `"bold white"`                       | The style for the module.                                    |
+| `disabled`           | `false`                              | Disables the `purescript` module.                            |
 
 ### Variables
 

--- a/src/configs/purescript.rs
+++ b/src/configs/purescript.rs
@@ -8,6 +8,9 @@ pub struct PureScriptConfig<'a> {
     pub symbol: &'a str,
     pub style: &'a str,
     pub disabled: bool,
+    pub detect_extensions: Vec<&'a str>,
+    pub detect_files: Vec<&'a str>,
+    pub detect_folders: Vec<&'a str>,
 }
 
 impl<'a> RootModuleConfig<'a> for PureScriptConfig<'a> {
@@ -17,6 +20,9 @@ impl<'a> RootModuleConfig<'a> for PureScriptConfig<'a> {
             symbol: "<=> ",
             style: "bold white",
             disabled: false,
+            detect_extensions: vec!["purs"],
+            detect_files: vec!["spago.dhall"],
+            detect_folders: vec![],
         }
     }
 }

--- a/src/modules/purescript.rs
+++ b/src/modules/purescript.rs
@@ -4,23 +4,19 @@ use crate::configs::purescript::PureScriptConfig;
 use crate::formatter::StringFormatter;
 
 /// Creates a module with the current PureScript version
-///
-/// Will display the PureScript version if any of the following criteria are met:
-///     - Current directory contains a `spago.dhall` file
-///     - Current directory contains a `*.purs` files
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let mut module = context.new_module("purescript");
+    let config: PureScriptConfig = PureScriptConfig::try_load(module.config);
     let is_purs_project = context
         .try_begin_scan()?
-        .set_files(&["spago.dhall"])
-        .set_extensions(&["purs"])
+        .set_files(&config.detect_files)
+        .set_folders(&config.detect_folders)
+        .set_extensions(&config.detect_extensions)
         .is_match();
 
     if !is_purs_project {
         return None;
     }
-
-    let mut module = context.new_module("purescript");
-    let config: PureScriptConfig = PureScriptConfig::try_load(module.config);
 
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter


### PR DESCRIPTION
#### Description
<!--- Describe your changes in detail -->
This makes it possible to configure when the purescript module is shown
based on the contents of a directory. This should make it possible to
be a lot more granular when configuring the module.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to #1977 

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.