### PR TITLE
feat(julia): Configure when the module is shown

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1435,7 +1435,7 @@ threshold = 4
 ## Julia
 
 The `julia` module shows the currently installed version of Julia.
-The module will be shown if any of the following conditions are met:
+By default the module will be shown if any of the following conditions are met:
 
 - The current directory contains a `Project.toml` file
 - The current directory contains a `Manifest.toml` file
@@ -1443,12 +1443,15 @@ The module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Option     | Default                            | Description                                       |
-| ---------- | ---------------------------------- | ------------------------------------------------- |
-| `format`   | `"via [$symbol($version )]($style)"` | The format for the module.                        |
-| `symbol`   | `"ஃ "`                             | A format string representing the symbol of Julia. |
-| `style`    | `"bold purple"`                    | The style for the module.                         |
-| `disabled` | `false`                            | Disables the `julia` module.                      |
+| Option              | Default                              | Description                                       |
+| ------------------- | ------------------------------------ | ------------------------------------------------- |
+| `format`            | `"via [$symbol($version )]($style)"` | The format for the module.                        |
+| `detect_extensions` | `["jl"]`                             | Which extensions should trigger this module.      |
+| `detect_files`      | `["Project.toml", "Manifest.toml"]`  | Which filenames should trigger this module.       |
+| `detect_folders`    | `[]`                                 | Which folders should trigger this modules.        |
+| `symbol`            | `"ஃ "`                               | A format string representing the symbol of Julia. |
+| `style`             | `"bold purple"`                      | The style for the module.                         |
+| `disabled`          | `false`                              | Disables the `julia` module.                      |
 
 ### Variables
 

--- a/src/configs/julia.rs
+++ b/src/configs/julia.rs
@@ -8,6 +8,9 @@ pub struct JuliaConfig<'a> {
     pub symbol: &'a str,
     pub style: &'a str,
     pub disabled: bool,
+    pub detect_extensions: Vec<&'a str>,
+    pub detect_files: Vec<&'a str>,
+    pub detect_folders: Vec<&'a str>,
 }
 
 impl<'a> RootModuleConfig<'a> for JuliaConfig<'a> {
@@ -17,6 +20,9 @@ impl<'a> RootModuleConfig<'a> for JuliaConfig<'a> {
             symbol: "ஃ ",
             style: "bold purple",
             disabled: false,
+            detect_extensions: vec!["jl"],
+            detect_files: vec!["Project.toml", "Manifest.toml"],
+            detect_folders: vec![],
         }
     }
 }

--- a/src/modules/julia.rs
+++ b/src/modules/julia.rs
@@ -4,24 +4,21 @@ use crate::configs::julia::JuliaConfig;
 use crate::formatter::StringFormatter;
 
 /// Creates a module with the current Julia version
-///
-/// Will display the Julia version if any of the following criteria are met:
-///     - Current directory contains a `Project.toml` file
-///     - Current directory contains a `Manifest.toml` file
-///     - Current directory contains a file with the `.jl` extension
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let mut module = context.new_module("julia");
+    let config = JuliaConfig::try_load(module.config);
+
     let is_julia_project = context
         .try_begin_scan()?
-        .set_files(&["Project.toml", "Manifest.toml"])
-        .set_extensions(&["jl"])
+        .set_files(&config.detect_files)
+        .set_extensions(&config.detect_extensions)
+        .set_folders(&config.detect_folders)
         .is_match();
 
     if !is_julia_project {
         return None;
     }
 
-    let mut module = context.new_module("julia");
-    let config = JuliaConfig::try_load(module.config);
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter
             .map_meta(|var, _| match var {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This makes it possible to configure when the julia module is shown
based on the contents of a directory.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to #1977

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
