### PR TITLE
fix(python): Handle PyPy python version correctly

### DIFF
--- a/src/modules/python.rs
+++ b/src/modules/python.rs
@@ -69,31 +69,30 @@ fn get_python_version(context: &Context, config: &PythonConfig) -> Option<String
     if config.pyenv_version_name {
         return Some(context.exec_cmd("pyenv", &["version-name"])?.stdout);
     };
-    let version = config.python_binary.0.iter().find_map(|binary| {
-        match context.exec_cmd(binary, &["--version"]) {
-            Some(output) => {
-                if output.stdout.is_empty() {
-                    Some(output.stderr)
-                } else {
-                    Some(output.stdout)
-                }
+    let version = config
+        .python_binary
+        .0
+        .iter()
+        .find_map(|binary| context.exec_cmd(binary, &["--version"]))
+        .map(|output| {
+            if output.stdout.is_empty() {
+                output.stderr
+            } else {
+                output.stdout
             }
-            None => None,
-        }
-    })?;
-    Some(format_python_version(&version))
+        })?;
+
+    format_python_version(&version)
 }
 
-fn format_python_version(python_stdout: &str) -> String {
-    format!(
-        "v{}",
-        python_stdout
-            .trim_start_matches("Python ")
-            .trim()
-            .split_whitespace()
-            .next()
-            .unwrap_or("?")
-    )
+fn format_python_version(python_version: &str) -> Option<String> {
+    let version = python_version
+        // split into ["Python", "3.8.6", ...]
+        .split_whitespace()
+        // return "3.8.6"
+        .nth(1)?;
+
+    Some(format!("v{}", version))
 }
 
 fn get_python_virtual_env(context: &Context) -> Option<String> {
@@ -125,19 +124,19 @@ mod tests {
     #[test]
     fn test_format_python_version() {
         let input = "Python 3.7.2";
-        assert_eq!(format_python_version(input), "v3.7.2");
+        assert_eq!(format_python_version(input), Some("v3.7.2".to_string()));
     }
 
     #[test]
     fn test_format_python_version_anaconda() {
         let input = "Python 3.6.10 :: Anaconda, Inc.";
-        assert_eq!(format_python_version(input), "v3.6.10");
+        assert_eq!(format_python_version(input), Some("v3.6.10".to_string()));
     }
 
     #[test]
     fn test_format_python_version_pypy() {
         let input = "Python 3.7.9 (7e6e2bb30ac5fbdbd443619cae28c51d5c162a02, Nov 24 2020, 10:03:59)\n[PyPy 7.3.3-beta0 with GCC 10.2.0]";
-        assert_eq!(format_python_version(input), "v3.7.9");
+        assert_eq!(format_python_version(input), Some("v3.7.9".to_string()));
     }
 
     #[test]

--- a/src/modules/python.rs
+++ b/src/modules/python.rs
@@ -89,8 +89,10 @@ fn format_python_version(python_stdout: &str) -> String {
         "v{}",
         python_stdout
             .trim_start_matches("Python ")
-            .trim_end_matches(":: Anaconda, Inc.")
             .trim()
+            .split_whitespace()
+            .next()
+            .unwrap_or("?")
     )
 }
 
@@ -130,6 +132,12 @@ mod tests {
     fn test_format_python_version_anaconda() {
         let input = "Python 3.6.10 :: Anaconda, Inc.";
         assert_eq!(format_python_version(input), "v3.6.10");
+    }
+
+    #[test]
+    fn test_format_python_version_pypy() {
+        let input = "Python 3.7.9 (7e6e2bb30ac5fbdbd443619cae28c51d5c162a02, Nov 24 2020, 10:03:59)\n[PyPy 7.3.3-beta0 with GCC 10.2.0]";
+        assert_eq!(format_python_version(input), "v3.7.9");
     }
 
     #[test]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Add support for parsing PyPy python version.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Before this fix, I get the following prompt:

```
... via 🐍 v3.7.9 (7e6e2bb30ac5fbdbd443619cae28c51d5c162a02, Nov 24 2020, 10:03:59)
[PyPy 7.3.3-beta0 with GCC 10.2.0]
```

With the fix:

```
... via 🐍 v3.7.9
```

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
