### PR TITLE
build: add more architectures to Snap package

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -81,5 +81,6 @@ architectures:
   - build-on: armhf
   - build-on: i386
   - build-on: ppc64el
+    build-error: ignore
   - build-on: s390x
     build-error: ignore

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -76,5 +76,10 @@ apps:
       - removable-media
 
 architectures:
-  - build-on: i386
   - build-on: amd64
+  - build-on: arm64
+  - build-on: armhf
+  - build-on: i386
+  - build-on: ppc64el
+  - build-on: s390x
+    build-error: ignore


### PR DESCRIPTION
#### Description

I added `arm64` as a build platform to the snapcraft yaml. I also tried building this with `snapcraft build` on my arm64 Ubuntu installation, and it seemed to work 🎉 

#### Motivation and Context
Closes #2381 

#### Screenshots (if appropriate):

#### How Has This Been Tested?

I tested by running `snapcraft build`.

- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.


#### edit:

This now brings in all supported snap platforms, with an allowed failure for `s390x` which currently fails to build:

```text
	arch=arm64	state=Successfully built
	arch=armhf	state=Successfully built
	arch=i386	state=Successfully built
	arch=amd64	state=Successfully built
	arch=ppc64el	state=Successfully built
	arch=s390x	state=Failed to build
```