### PR TITLE
fix(package): fix meson version extraction if 'meson_version' is present

### DIFF
--- a/src/modules/package.rs
+++ b/src/modules/package.rs
@@ -165,7 +165,7 @@ fn extract_maven_version(file_contents: &str) -> Option<String> {
 fn extract_meson_version(file_contents: &str) -> Option<String> {
     let file_contents = file_contents.split_ascii_whitespace().collect::<String>();
 
-    let re = Regex::new(r#"project\([^())]*version:'(?P<version>[^']+)'[^())]*\)"#).unwrap();
+    let re = Regex::new(r#"project\([^())]*,version:'(?P<version>[^']+)'[^())]*\)"#).unwrap();
     let caps = re.captures(&file_contents)?;
 
     let formatted_version = format_version(&caps["version"]);
@@ -753,6 +753,18 @@ end";
         let project_dir = create_project_dir()?;
         fill_config(&project_dir, config_name, Some(&config_content))?;
         expect_output(&project_dir, None, None);
+        project_dir.close()
+    }
+
+    #[test]
+    fn test_extract_meson_version_with_meson_version() -> io::Result<()> {
+        let config_name = "meson.build";
+        let config_content =
+            "project('starship', 'rust', version: '0.1.0', meson_version: '>= 0.57.0')".to_string();
+
+        let project_dir = create_project_dir()?;
+        fill_config(&project_dir, config_name, Some(&config_content))?;
+        expect_output(&project_dir, Some("v0.1.0"), None);
         project_dir.close()
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Fix meson version extraction if 'meson_version' is present.

Previously, if `meson_version` is present after `version`, the meson project version will be extracted from `meson_version`.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**

- [x] I have tested using **Linux**

- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
