### PR TITLE
fix(bash): escape interpretable characters

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -208,11 +208,12 @@ CMake suite maintained and supported by Kitware (kitware.com/cmake).\n",
 
 /// Wraps ANSI color escape sequences in the shell-appropriate wrappers.
 pub fn wrap_colorseq_for_shell(mut ansi: String, shell: Shell) -> String {
-    // Bash might interepret baskslashes and $
+    // Bash might interepret baskslashes, backticks and $
     // see #658 for more details
     if shell == Shell::Bash {
         ansi = ansi.replace('\\', r"\\");
         ansi = ansi.replace('$', r"\$");
+        ansi = ansi.replace('`', r"\`");
     }
 
     const ESCAPE_BEGIN: char = '\u{1b}';
@@ -489,6 +490,16 @@ mod tests {
         assert_eq!(
             wrap_colorseq_for_shell(test.to_owned(), Shell::Bash),
             r"\\\$(echo a)"
+        );
+        assert_eq!(
+            wrap_colorseq_for_shell(test.to_owned(), Shell::PowerShell),
+            test
+        );
+
+        let test = r"`echo a`";
+        assert_eq!(
+            wrap_colorseq_for_shell(test.to_owned(), Shell::Bash),
+            r"\`echo a\`"
         );
         assert_eq!(
             wrap_colorseq_for_shell(test.to_owned(), Shell::PowerShell),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -207,7 +207,14 @@ CMake suite maintained and supported by Kitware (kitware.com/cmake).\n",
 }
 
 /// Wraps ANSI color escape sequences in the shell-appropriate wrappers.
-pub fn wrap_colorseq_for_shell(ansi: String, shell: Shell) -> String {
+pub fn wrap_colorseq_for_shell(mut ansi: String, shell: Shell) -> String {
+    // Bash might interepret baskslashes and $
+    // see #658 for more details
+    if shell == Shell::Bash {
+        ansi = ansi.replace('\\', r"\\");
+        ansi = ansi.replace('$', r"\$");
+    }
+
     const ESCAPE_BEGIN: char = '\u{1b}';
     const ESCAPE_END: char = 'm';
     wrap_seq_for_shell(ansi, shell, ESCAPE_BEGIN, ESCAPE_END)
@@ -464,5 +471,28 @@ mod tests {
         assert_eq!(&bresult3, "\\[OH NO\\]");
         assert_eq!(&bresult4, "herpaderp");
         assert_eq!(&bresult5, "");
+    }
+
+    #[test]
+    fn test_bash_escape() {
+        let test = "$(echo a)";
+        assert_eq!(
+            wrap_colorseq_for_shell(test.to_owned(), Shell::Bash),
+            r"\$(echo a)"
+        );
+        assert_eq!(
+            wrap_colorseq_for_shell(test.to_owned(), Shell::PowerShell),
+            test
+        );
+
+        let test = r"\$(echo a)";
+        assert_eq!(
+            wrap_colorseq_for_shell(test.to_owned(), Shell::Bash),
+            r"\\\$(echo a)"
+        );
+        assert_eq!(
+            wrap_colorseq_for_shell(test.to_owned(), Shell::PowerShell),
+            test
+        );
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Bash will interpret some characters in the prompt which may lead it to inadvertently execute code. #884 previously fixed this, but it looks like the fix was removed at some point.

I added the fix to `wrap_colorseq_for_shell` which is roughly where the fix was previously located.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #2401

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
