### PR TITLE
style(aws): Add spacing between profile and region

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -253,7 +253,7 @@ is read from the `AWS_VAULT` env var.
 
 | Option           | Default                                        | Description                                                     |
 | ---------------- | ---------------------------------------------- | --------------------------------------------------------------- |
-| `format`         | `'on [$symbol$profile(\($region\))]($style) '` | The format for the module.                                      |
+| `format`         | `'on [$symbol($profile )(\($region\) )]($style)'` | The format for the module.                                      |
 | `symbol`         | `"☁️ "`                                        | The symbol used before displaying the current AWS profile.      |
 | `region_aliases` |                                                | Table of region aliases to display in addition to the AWS name. |
 | `style`          | `"bold yellow"`                                | The style for the module.                                       |
@@ -278,7 +278,7 @@ is read from the `AWS_VAULT` env var.
 # ~/.config/starship.toml
 
 [aws]
-format = 'on [$symbol$profile(\($region\))]($style) '
+format = 'on [$symbol($profile )(\($region\) )]($style)'
 style = "bold blue"
 symbol = "🅰 "
 [aws.region_aliases]

--- a/docs/presets/README.md
+++ b/docs/presets/README.md
@@ -18,7 +18,7 @@ If emojis aren't your thing, this might catch your eye!
 
 ```toml
 [aws]
-symbol = " "
+symbol = "  "
 
 [conda]
 symbol = " "

--- a/src/configs/aws.rs
+++ b/src/configs/aws.rs
@@ -14,7 +14,7 @@ pub struct AwsConfig<'a> {
 impl<'a> RootModuleConfig<'a> for AwsConfig<'a> {
     fn new() -> Self {
         AwsConfig {
-            format: "on [$symbol$profile(\\($region\\))]($style) ",
+            format: "on [$symbol($profile )(\\($region\\) )]($style)",
             symbol: "☁️  ",
             style: "bold yellow",
             disabled: false,

--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -138,8 +138,8 @@ mod tests {
             .env("AWS_REGION", "ap-northeast-2")
             .collect();
         let expected = Some(format!(
-            "on {} ",
-            Color::Yellow.bold().paint("☁️  (ap-northeast-2)")
+            "on {}",
+            Color::Yellow.bold().paint("☁️  (ap-northeast-2) ")
         ));
 
         assert_eq!(expected, actual);
@@ -154,7 +154,7 @@ mod tests {
                 ap-southeast-2 = "au"
             })
             .collect();
-        let expected = Some(format!("on {} ", Color::Yellow.bold().paint("☁️  (au)")));
+        let expected = Some(format!("on {}", Color::Yellow.bold().paint("☁️  (au) ")));
 
         assert_eq!(expected, actual);
     }
@@ -166,8 +166,8 @@ mod tests {
             .env("AWS_DEFAULT_REGION", "ap-northeast-1")
             .collect();
         let expected = Some(format!(
-            "on {} ",
-            Color::Yellow.bold().paint("☁️  (ap-northeast-1)")
+            "on {}",
+            Color::Yellow.bold().paint("☁️  (ap-northeast-1) ")
         ));
 
         assert_eq!(expected, actual);
@@ -179,8 +179,8 @@ mod tests {
             .env("AWS_PROFILE", "astronauts")
             .collect();
         let expected = Some(format!(
-            "on {} ",
-            Color::Yellow.bold().paint("☁️  astronauts")
+            "on {}",
+            Color::Yellow.bold().paint("☁️  astronauts ")
         ));
 
         assert_eq!(expected, actual);
@@ -193,8 +193,8 @@ mod tests {
             .env("AWS_PROFILE", "astronauts-profile")
             .collect();
         let expected = Some(format!(
-            "on {} ",
-            Color::Yellow.bold().paint("☁️  astronauts-vault")
+            "on {}",
+            Color::Yellow.bold().paint("☁️  astronauts-vault ")
         ));
 
         assert_eq!(expected, actual);
@@ -207,8 +207,10 @@ mod tests {
             .env("AWS_REGION", "ap-northeast-2")
             .collect();
         let expected = Some(format!(
-            "on {} ",
-            Color::Yellow.bold().paint("☁️  astronauts(ap-northeast-2)")
+            "on {}",
+            Color::Yellow
+                .bold()
+                .paint("☁️  astronauts (ap-northeast-2) ")
         ));
 
         assert_eq!(expected, actual);
@@ -234,8 +236,8 @@ region = us-east-2
             .env("AWS_CONFIG_FILE", config_path.to_string_lossy().as_ref())
             .collect();
         let expected = Some(format!(
-            "on {} ",
-            Color::Yellow.bold().paint("☁️  (us-east-1)")
+            "on {}",
+            Color::Yellow.bold().paint("☁️  (us-east-1) ")
         ));
 
         assert_eq!(expected, actual);
@@ -266,8 +268,8 @@ region = us-east-2
             })
             .collect();
         let expected = Some(format!(
-            "on {} ",
-            Color::Yellow.bold().paint("☁️  astronauts(us-east-2)")
+            "on {}",
+            Color::Yellow.bold().paint("☁️  astronauts (us-east-2) ")
         ));
 
         assert_eq!(expected, actual);
@@ -281,8 +283,10 @@ region = us-east-2
             .env("AWS_REGION", "ap-northeast-1")
             .collect();
         let expected = Some(format!(
-            "on {} ",
-            Color::Yellow.bold().paint("☁️  astronauts(ap-northeast-1)")
+            "on {}",
+            Color::Yellow
+                .bold()
+                .paint("☁️  astronauts (ap-northeast-1) ")
         ));
 
         assert_eq!(expected, actual);
@@ -294,8 +298,8 @@ region = us-east-2
             .env("AWS_PROFILE", "astronauts")
             .collect();
         let expected = Some(format!(
-            "on {} ",
-            Color::Yellow.bold().paint("☁️  astronauts")
+            "on {}",
+            Color::Yellow.bold().paint("☁️  astronauts ")
         ));
 
         assert_eq!(expected, actual);
@@ -307,8 +311,8 @@ region = us-east-2
             .env("AWS_REGION", "ap-northeast-1")
             .collect();
         let expected = Some(format!(
-            "on {} ",
-            Color::Yellow.bold().paint("☁️  (ap-northeast-1)")
+            "on {}",
+            Color::Yellow.bold().paint("☁️  (ap-northeast-1) ")
         ));
 
         assert_eq!(expected, actual);


### PR DESCRIPTION
and also after the symbol when using the Nerd font glyph.

<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
Style of most modules is to have a space between distinguishable segments. The aws module was missing that between the profile and region segments. Also add a space after the Nerd font glyph. See screenshots below.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Style change to follow the look of the prompt modules.

#### Screenshots (if appropriate):
##### Before
<img src="https://user-images.githubusercontent.com/4120606/110191414-4819a880-7df6-11eb-920f-04a66e0f4928.png" alt="Before" width="275">

##### After
<img src="https://user-images.githubusercontent.com/4120606/110191418-4f40b680-7df6-11eb-8a96-387709d9b089.png" alt="After" width="275">

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [X] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have updated the documentation accordingly.
- [X] I have updated the tests accordingly.
