### PR TITLE
feat: Right Prompt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1686,7 +1686,7 @@ dependencies = [
 
 [[package]]
 name = "starship"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "ansi_term 0.12.1",
  "attohttpc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starship"
-version = "0.55.0"
+version = "0.56.0"
 edition = "2018"
 authors = ["Matan Kushner <hello@matchai.me>"]
 homepage = "https://starship.rs"

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -151,29 +151,38 @@ This is the list of prompt-wide configuration options.
 
 ### Options
 
-| Option            | Default                        | Description                                                  |
-| ----------------- | ------------------------------ | ------------------------------------------------------------ |
-| `format`          | [link](#default-prompt-format) | Configure the format of the prompt.                          |
-| `scan_timeout`    | `30`                           | Timeout for starship to scan files (in milliseconds).        |
-| `command_timeout` | `500`                          | Timeout for commands executed by starship (in milliseconds). |
-| `add_newline`     | `true`                         | Inserts blank line between shell prompts.                    |
+| Option            | Default                        | Description                                                                                          |
+| ----------------- | ------------------------------ | ---------------------------------------------------------------------------------------------------- |
+| `format`          | [link](#default-prompt-format) | Configure the format of the prompt.                                                                  |
+| `format_right`    | `""`                           | Configure the format of the right prompt.                                                            |
+| `scan_timeout`    | `30`                           | Timeout for starship to scan files (in milliseconds).                                                |
+| `command_timeout` | `500`                          | Timeout for commands executed by starship (in milliseconds).                                         |
+| `add_newline`     | `true`                         | Inserts blank line between shell prompts.                                                            |
+| `split_padding`   | `3`                            | The minimum amount of space required between left and right prompt for the right prompt to be shown. |
 
 ### Example
 
 ```toml
 # ~/.config/starship.toml
 
-# Use custom format
+# Use custom format.
 format = """
 [┌───────────────────>](bold green)
 [│](bold green)$directory$rust$package
 [└─>](bold green) """
 
+# Display time on the right prompt.
+# This will only display if the terminal is wide enough.
+format_right = "$time"
+
 # Wait 10 milliseconds for starship to check files under the current directory.
 scan_timeout = 10
 
-# Disable the blank line at the start of the prompt
+# Disable the blank line at the start of the prompt.
 add_newline = false
+
+# Only display the right prompt if there's room for a 30 width margin between it and the left prompt.
+split_padding = 30
 ```
 
 ### Default Prompt Format

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -7,9 +7,11 @@ use std::cmp::Ordering;
 #[derive(Clone, Serialize)]
 pub struct StarshipRootConfig<'a> {
     pub format: &'a str,
+    pub format_right: &'a str,
     pub scan_timeout: u64,
     pub command_timeout: u64,
     pub add_newline: bool,
+    pub split_padding: usize,
 }
 
 // List of default prompt order
@@ -88,9 +90,11 @@ impl<'a> Default for StarshipRootConfig<'a> {
     fn default() -> Self {
         StarshipRootConfig {
             format: "$all",
+            format_right: "",
             scan_timeout: 30,
             command_timeout: 500,
             add_newline: true,
+            split_padding: 3,
         }
     }
 }
@@ -100,9 +104,11 @@ impl<'a> ModuleConfig<'a> for StarshipRootConfig<'a> {
         if let toml::Value::Table(config) = config {
             config.iter().for_each(|(k, v)| match k.as_str() {
                 "format" => self.format.load_config(v),
+                "format_right" => self.format_right.load_config(v),
                 "scan_timeout" => self.scan_timeout.load_config(v),
                 "command_timeout" => self.command_timeout.load_config(v),
                 "add_newline" => self.add_newline.load_config(v),
+                "split_padding" => self.split_padding.load_config(v),
                 unknown => {
                     if !ALL_MODULES.contains(&unknown) && unknown != "custom" {
                         log::warn!("Unknown config key '{}'", unknown);
@@ -110,9 +116,11 @@ impl<'a> ModuleConfig<'a> for StarshipRootConfig<'a> {
                         let did_you_mean = &[
                             // Root options
                             "format",
+                            "format_right",
                             "scan_timeout",
                             "command_timeout",
                             "add_newline",
+                            "split_padding",
                             // Modules
                             "custom",
                         ]

--- a/src/context.rs
+++ b/src/context.rs
@@ -42,6 +42,9 @@ pub struct Context<'a> {
     /// The shell the user is assumed to be running
     pub shell: Shell,
 
+    /// Width of terminal, or zero if width cannot be detected.
+    pub width: usize,
+
     /// A HashMap of environment variable mocks
     #[cfg(test)]
     pub env: HashMap<&'a str, String>,
@@ -121,6 +124,9 @@ impl<'a> Context<'a> {
             dir_contents: OnceCell::new(),
             repo: OnceCell::new(),
             shell,
+            width: term_size::dimensions()
+                .map(|(width, _)| width)
+                .unwrap_or_default(),
             #[cfg(test)]
             env: HashMap::new(),
             #[cfg(test)]

--- a/src/module.rs
+++ b/src/module.rs
@@ -1,4 +1,5 @@
 use crate::context::Shell;
+use crate::print::UnicodeWidthGraphemes;
 use crate::segment::Segment;
 use crate::utils::wrap_colorseq_for_shell;
 use ansi_term::{ANSIString, ANSIStrings};
@@ -123,6 +124,14 @@ impl<'a> Module<'a> {
             .iter()
             // no trim: if we add spaces/linebreaks it's not "empty" as we change the final output
             .all(|segment| segment.value.is_empty())
+    }
+
+    /// Get values of the module's segments
+    pub fn get_segments_width(&self) -> usize {
+        self.segments
+            .iter()
+            .map(|segment| segment.value.width_graphemes())
+            .sum()
     }
 
     /// Get values of the module's segments

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -77,6 +77,12 @@ impl<'a> ModuleRenderer<'a> {
         self
     }
 
+    /// Sets the terminal width of the underlying context
+    pub fn width(mut self, width: usize) -> Self {
+        self.context.width = width;
+        self
+    }
+
     /// Adds the variable to the env_mocks of the underlying context
     pub fn env<V: Into<String>>(mut self, key: &'a str, val: V) -> Self {
         self.context.env.insert(key, val.into());
@@ -128,6 +134,11 @@ impl<'a> ModuleRenderer<'a> {
     ) -> Self {
         self.context.battery_info_provider = battery_info_provider;
         self
+    }
+
+    /// Renders the prompt returning its output
+    pub fn prompt(self) -> String {
+        crate::print::get_prompt(self.context)
     }
 
     /// Renders the module returning its output


### PR DESCRIPTION
#### Description
Proof of concept for generic right prompt support.  The logic is as follows:
1. Divide left/right prompts up on a per line basis.
2. Calculate the column widths for left and right lines.
3. Output left line unconditionally.
4. If the terminal width is greater than the left line width, right line width, and minimum spacing between them, insert padding spaces to right align the right line, then output the right line.
5. If there are more left lines remaining, or there was a right line, emit a line break.  A right line necessitates a line break as it doesn't appear that we can reset the cursor position without the shell clearing all the text that appears after it.

If this feature and approach are something Starship is interested in, then I'll update documentation, add tests, etc.

#### Motivation and Context
This adds an approximation of the right prompt functionality that exists in Zsh.

Notable difference is Zsh actually has the concept of a right prompt, which allows it to exist on the same line as cursor, and the right prompt text is able to hide/show depending on whether the cursor's position overlaps with it.

#### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/13792812/110230597-f3922e00-7ec6-11eb-9292-d066d1e521a5.png)

#### How Has This Been Tested?
The golden path has been tested on:
 * Windows with Windows Terminal in Nushell (manually invoked, as the prompt doesn't seem to be via TTY and as such `term_size::dimensions()` returns None).
 * WSL with Windows Terminal/VSCode Terminal in Zsh.

- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [X] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
