### PR TITLE
style(init): Cleanup the unknown shell message

### DIFF
--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -193,9 +193,17 @@ fi"#,
         Some(shell_basename) => {
             println!(
                 "printf \"\\n{0} is not yet supported by starship.\\n\
-                 For the time being, we support bash, zsh, fish, and ion.\\n\
+                 For the time being, we support the following shells:\\n\
+                 * bash\\n\
+                 * elvish\\n\
+                 * fish\\n\
+                 * ion\\n\
+                 * powershell\\n\
+                 * tcsh\\n\
+                 * zsh\\n\
+                 \\n\
                  Please open an issue in the starship repo if you would like to \
-                 see support for {0}:\\nhttps://github.com/starship/starship/issues/new\"\\n\\n",
+                 see support for {0}:\\nhttps://github.com/starship/starship/issues/new\\n\\n\"",
                 shell_basename
             );
             None

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -180,17 +180,7 @@ fi"#,
             );
             Some(script)
         }
-        None => {
-            println!(
-                "Invalid shell name provided: {}\\n\
-                 If this issue persists, please open an \
-                 issue in the starship repo: \\n\
-                 https://github.com/starship/starship/issues/new\\n\"",
-                shell_name
-            );
-            None
-        }
-        Some(shell_basename) => {
+        _ => {
             println!(
                 "printf \"\\n{0} is not yet supported by starship.\\n\
                  For the time being, we support the following shells:\\n\
@@ -204,7 +194,7 @@ fi"#,
                  \\n\
                  Please open an issue in the starship repo if you would like to \
                  see support for {0}:\\nhttps://github.com/starship/starship/issues/new\\n\\n\"",
-                shell_basename
+                shell_name
             );
             None
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Have make a small change to the message that is printed when an unknown
shell is used. This correct the placement of the trailing `"` so that
the two training new lines are correctly printed and updates the list of
supported shells.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Before:
```
❯ eval $(starship init fakesh)

fakesh is not yet supported by starship.
For the time being, we support bash, zsh, fish, and ion.
Please open an issue in the starship repo if you would like to see support for fakesh:
https://github.com/starship/starship/issues/newnn
```

After:
```
❯ eval $(target/debug/starship init fakesh)

fakesh is not yet supported by starship.
For the time being, we support the following shells:
* bash
* elvish
* fish
* ion
* powershell
* tcsh
* zsh

Please open an issue in the starship repo if you would like to see support for fakesh:
https://github.com/starship/starship/issues/new

```

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
