### PR TITLE
feat(aws): add support for getting profile from awsu

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -249,6 +249,9 @@ The `aws` module shows the current AWS region and profile. This is based on
 When using [aws-vault](https://github.com/99designs/aws-vault) the profile
 is read from the `AWS_VAULT` env var.
 
+When using [awsu](https://github.com/kreuzwerker/awsu) the profile
+is read from the `AWSU_PROFILE` env var.
+
 ### Options
 
 | Option           | Default                                        | Description                                                     |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
Adds another override, like the `AWS_VAULT` one, that uses another environment variable to resolve the current AWS profile.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When using [awsu](https://github.com/kreuzwerker/awsu) the currently assumed role/profile is a helpful addition to the prompt.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
