### PR TITLE
fix(java): use consistent separators for java path

### DIFF
--- a/src/modules/java.rs
+++ b/src/modules/java.rs
@@ -57,9 +57,9 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 fn get_java_version(context: &Context) -> Option<String> {
     let java_command = context
         .get_env("JAVA_HOME")
-        .and_then(|java_home| {
-            Path::new(&java_home)
-                .join("bin")
+        .map(PathBuf::from)
+        .and_then(|path| {
+            path.join("bin")
                 .join("java")
                 .into_os_string()
                 .into_string()

--- a/src/modules/java.rs
+++ b/src/modules/java.rs
@@ -88,6 +88,7 @@ mod tests {
     use ansi_term::Color;
     use std::fs::File;
     use std::io;
+    use std::path::PathBuf;
 
     #[test]
     fn test_parse_java_version_openjdk() {
@@ -264,6 +265,27 @@ mod tests {
         File::create(dir.path().join(".java-version"))?.sync_all()?;
         let actual = ModuleRenderer::new("java").path(dir.path()).collect();
         let expected = Some(format!("via {}", Color::Red.dimmed().paint("☕ v13.0.2 ")));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn test_java_home() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join("Main.java"))?.sync_all()?;
+        let java_home: PathBuf = ["a", "b", "c"].iter().collect();
+        let java_bin = java_home.join("bin").join("java");
+
+        let actual = ModuleRenderer::new("java")
+            .env("JAVA_HOME", java_home.to_str().unwrap())
+            .cmd(&format!("{} -Xinternalversion", java_bin.to_str().unwrap()),
+            Some(CommandOutput {
+                stdout: "OpenJDK 64-Bit Server VM (11.0.4+11-LTS-sapmachine) for linux-amd64 JRE (11.0.4+11-LTS-sapmachine), built on Jul 17 2019 08:58:43 by \"\" with gcc 7.3.0".to_owned(),
+                stderr: String::new(),
+            }))
+            .path(dir.path())
+            .collect();
+        let expected = Some(format!("via {}", Color::Red.dimmed().paint("☕ v11.0.4 ")));
         assert_eq!(expected, actual);
         dir.close()
     }

--- a/src/modules/java.rs
+++ b/src/modules/java.rs
@@ -1,6 +1,6 @@
 use crate::configs::java::JavaConfig;
 use crate::formatter::StringFormatter;
-use std::path::Path;
+use std::path::PathBuf;
 
 use super::{Context, Module, RootModuleConfig};
 

--- a/src/modules/java.rs
+++ b/src/modules/java.rs
@@ -61,8 +61,9 @@ fn get_java_version(context: &Context) -> Option<String> {
             Path::new(&java_home)
                 .join("bin")
                 .join("java")
-                .to_str()
-                .map(str::to_owned)
+                .into_os_string()
+                .into_string()
+                .ok()
         })
         .unwrap_or_else(|| String::from("java"));
 

--- a/src/modules/java.rs
+++ b/src/modules/java.rs
@@ -92,7 +92,6 @@ mod tests {
     use ansi_term::Color;
     use std::fs::File;
     use std::io;
-    use std::path::PathBuf;
 
     #[test]
     fn test_parse_java_version_openjdk() {

--- a/src/modules/java.rs
+++ b/src/modules/java.rs
@@ -55,15 +55,18 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 }
 
 fn get_java_version(context: &Context) -> Option<String> {
-    let java_command = match context.get_env("JAVA_HOME") {
-        Some(java_home) => {
-            let java_path = Path::new(&java_home).join("bin").join("java");
-            java_path.to_str().unwrap_or("java").to_owned()
-        }
-        None => String::from("java"),
-    };
+    let java_command = context
+        .get_env("JAVA_HOME")
+        .and_then(|java_home| {
+            Path::new(&java_home)
+                .join("bin")
+                .join("java")
+                .to_str()
+                .map(str::to_owned)
+        })
+        .unwrap_or_else(|| String::from("java"));
 
-    let output = context.exec_cmd(&java_command.as_str(), &["-Xinternalversion"])?;
+    let output = context.exec_cmd(&java_command, &["-Xinternalversion"])?;
     let java_version = if output.stdout.is_empty() {
         output.stderr
     } else {

--- a/src/modules/java.rs
+++ b/src/modules/java.rs
@@ -1,5 +1,6 @@
 use crate::configs::java::JavaConfig;
 use crate::formatter::StringFormatter;
+use std::path::Path;
 
 use super::{Context, Module, RootModuleConfig};
 
@@ -55,7 +56,10 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
 fn get_java_version(context: &Context) -> Option<String> {
     let java_command = match context.get_env("JAVA_HOME") {
-        Some(java_home) => format!("{}/bin/java", java_home),
+        Some(java_home) => {
+            let java_path = Path::new(&java_home).join("bin").join("java");
+            java_path.to_str().unwrap_or("java").to_owned()
+        }
         None => String::from("java"),
     };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This switches us from just appending `/bin/java` to `$JAVA_HOME` to
treating `$JAVA_HOME` as a path. This should fix any issues on Windows
where $JAVA_HOME might use `\` rather than `/`.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to #2427

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
