### PR TITLE
fix(cmake): Change cmake symbol to unicode triangle

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -454,7 +454,7 @@ the module will be activated if any of the following conditions are met:
 | Option              | Default                                | Description                                  |
 | ------------------- | -------------------------------------- | -------------------------------------------- |
 | `format`            | `"via [$symbol($version )]($style)"`   | The format for the module.                   |
-| `symbol`            | `"喝 "`                                | The symbol used before the version of cmake. |
+| `symbol`            | `"△ "`                                | The symbol used before the version of cmake. |
 | `detect_extensions` | `[]`                                   | Which extensions should trigger this moudle  |
 | `detect_files`      | `["CMakeLists.txt", "CMakeCache.txt"]` | Which filenames should trigger this module   |
 | `detect_folders`    | `[]`                                   | Which folders should trigger this module     |

--- a/src/configs/cmake.rs
+++ b/src/configs/cmake.rs
@@ -17,7 +17,7 @@ impl<'a> RootModuleConfig<'a> for CMakeConfig<'a> {
     fn new() -> Self {
         CMakeConfig {
             format: "via [$symbol($version )]($style)",
-            symbol: "喝 ",
+            symbol: "△ ",
             style: "bold blue",
             disabled: false,
             detect_extensions: vec![],

--- a/src/modules/cmake.rs
+++ b/src/modules/cmake.rs
@@ -77,7 +77,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("CMakeLists.txt"))?.sync_all()?;
         let actual = ModuleRenderer::new("cmake").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Blue.bold().paint("喝 v3.17.3 ")));
+        let expected = Some(format!("via {}", Color::Blue.bold().paint("△ v3.17.3 ")));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -87,7 +87,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("CMakeCache.txt"))?.sync_all()?;
         let actual = ModuleRenderer::new("cmake").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Blue.bold().paint("喝 v3.17.3 ")));
+        let expected = Some(format!("via {}", Color::Blue.bold().paint("△ v3.17.3 ")));
         assert_eq!(expected, actual);
         dir.close()
     }


### PR DESCRIPTION
Fixes #2446
Fixes #2009