### PR TITLE
refactor: replace RootModuleConfig with Default

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -14,18 +14,15 @@ use toml::Value;
 /// Root config of a module.
 pub trait RootModuleConfig<'a>
 where
-    Self: ModuleConfig<'a>,
+    Self: ModuleConfig<'a> + Default,
 {
-    /// Create a new root module config with default values.
-    fn new() -> Self;
-
     /// Load root module config from given Value and fill unset variables with default
     /// values.
     fn load(config: &'a Value) -> Self {
         if config.get("prompt_order").is_some() {
             log::warn!("\"prompt_order\" has been removed in favor of \"format\". For more details, see: https://starship.rs/migrating-to-0.45.0/")
         }
-        Self::new().load_config(config)
+        Self::default().load_config(config)
     }
 
     /// Helper function that will call RootModuleConfig::load(config) if config is Some,
@@ -34,10 +31,12 @@ where
         if let Some(config) = config {
             Self::load(config)
         } else {
-            Self::new()
+            Self::default()
         }
     }
 }
+
+impl<'a, T: ModuleConfig<'a> + Default> RootModuleConfig<'a> for T {}
 
 /// Parsable config.
 pub trait ModuleConfig<'a>
@@ -346,7 +345,7 @@ impl StarshipConfig {
         if let Some(root_config) = &self.config {
             StarshipRootConfig::load(root_config)
         } else {
-            StarshipRootConfig::new()
+            StarshipRootConfig::default()
         }
     }
 }

--- a/src/configs/aws.rs
+++ b/src/configs/aws.rs
@@ -1,4 +1,4 @@
-use crate::config::{ModuleConfig, RootModuleConfig};
+use crate::config::ModuleConfig;
 use starship_module_config_derive::ModuleConfig;
 use std::collections::HashMap;
 
@@ -11,8 +11,8 @@ pub struct AwsConfig<'a> {
     pub region_aliases: HashMap<String, &'a str>,
 }
 
-impl<'a> RootModuleConfig<'a> for AwsConfig<'a> {
-    fn new() -> Self {
+impl<'a> Default for AwsConfig<'a> {
+    fn default() -> Self {
         AwsConfig {
             format: "on [$symbol($profile )(\\($region\\) )]($style)",
             symbol: "☁️  ",

--- a/src/configs/battery.rs
+++ b/src/configs/battery.rs
@@ -1,4 +1,4 @@
-use crate::config::{ModuleConfig, RootModuleConfig};
+use crate::config::ModuleConfig;
 
 use starship_module_config_derive::ModuleConfig;
 
@@ -14,8 +14,8 @@ pub struct BatteryConfig<'a> {
     pub format: &'a str,
 }
 
-impl<'a> RootModuleConfig<'a> for BatteryConfig<'a> {
-    fn new() -> Self {
+impl<'a> Default for BatteryConfig<'a> {
+    fn default() -> Self {
         BatteryConfig {
             full_symbol: "",
             charging_symbol: "",

--- a/src/configs/character.rs
+++ b/src/configs/character.rs
@@ -1,4 +1,4 @@
-use crate::config::{ModuleConfig, RootModuleConfig};
+use crate::config::ModuleConfig;
 
 use starship_module_config_derive::ModuleConfig;
 
@@ -11,8 +11,8 @@ pub struct CharacterConfig<'a> {
     pub disabled: bool,
 }
 
-impl<'a> RootModuleConfig<'a> for CharacterConfig<'a> {
-    fn new() -> Self {
+impl<'a> Default for CharacterConfig<'a> {
+    fn default() -> Self {
         CharacterConfig {
             format: "$symbol ",
             success_symbol: "[❯](bold green)",

--- a/src/configs/cmake.rs
+++ b/src/configs/cmake.rs
@@ -1,4 +1,4 @@
-use crate::config::{ModuleConfig, RootModuleConfig};
+use crate::config::ModuleConfig;
 
 use starship_module_config_derive::ModuleConfig;
 
@@ -13,8 +13,8 @@ pub struct CMakeConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> RootModuleConfig<'a> for CMakeConfig<'a> {
-    fn new() -> Self {
+impl<'a> Default for CMakeConfig<'a> {
+    fn default() -> Self {
         CMakeConfig {
             format: "via [$symbol($version )]($style)",
             symbol: "喝 ",

--- a/src/configs/cmd_duration.rs
+++ b/src/configs/cmd_duration.rs
@@ -1,4 +1,4 @@
-use crate::config::{ModuleConfig, RootModuleConfig};
+use crate::config::ModuleConfig;
 
 use starship_module_config_derive::ModuleConfig;
 
@@ -13,8 +13,8 @@ pub struct CmdDurationConfig<'a> {
     pub min_time_to_notify: i64,
 }
 
-impl<'a> RootModuleConfig<'a> for CmdDurationConfig<'a> {
-    fn new() -> Self {
+impl<'a> Default for CmdDurationConfig<'a> {
+    fn default() -> Self {
         CmdDurationConfig {
             min_time: 2_000,
             format: "took [$duration]($style) ",

--- a/src/configs/conda.rs
+++ b/src/configs/conda.rs
@@ -1,4 +1,4 @@
-use crate::config::{ModuleConfig, RootModuleConfig};
+use crate::config::ModuleConfig;
 
 use starship_module_config_derive::ModuleConfig;
 
@@ -12,8 +12,8 @@ pub struct CondaConfig<'a> {
     pub disabled: bool,
 }
 
-impl<'a> RootModuleConfig<'a> for CondaConfig<'a> {
-    fn new() -> Self {
+impl<'a> Default for CondaConfig<'a> {
+    fn default() -> Self {
         CondaConfig {
             truncation_length: 1,
             format: "via [$symbol$environment]($style) ",

--- a/src/configs/crystal.rs
+++ b/src/configs/crystal.rs
@@ -1,4 +1,4 @@
-use crate::config::{ModuleConfig, RootModuleConfig};
+use crate::config::ModuleConfig;
 
 use starship_module_config_derive::ModuleConfig;
 
@@ -13,8 +13,8 @@ pub struct CrystalConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> RootModuleConfig<'a> for CrystalConfig<'a> {
-    fn new() -> Self {
+impl<'a> Default for CrystalConfig<'a> {
+    fn default() -> Self {
         CrystalConfig {
             format: "via [$symbol($version )]($style)",
             symbol: "🔮 ",

--- a/src/configs/custom.rs
+++ b/src/configs/custom.rs
@@ -1,4 +1,4 @@
-use crate::config::{ModuleConfig, RootModuleConfig, VecOr};
+use crate::config::{ModuleConfig, VecOr};
 
 use starship_module_config_derive::ModuleConfig;
 
@@ -26,8 +26,8 @@ pub struct CustomConfig<'a> {
     pub directories: Directories<'a>,
 }
 
-impl<'a> RootModuleConfig<'a> for CustomConfig<'a> {
-    fn new() -> Self {
+impl<'a> Default for CustomConfig<'a> {
+    fn default() -> Self {
         CustomConfig {
             format: "[$symbol($output )]($style)",
             symbol: "",

--- a/src/configs/dart.rs
+++ b/src/configs/dart.rs
@@ -1,4 +1,4 @@
-use crate::config::{ModuleConfig, RootModuleConfig};
+use crate::config::ModuleConfig;
 
 use starship_module_config_derive::ModuleConfig;
 
@@ -13,8 +13,8 @@ pub struct DartConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> RootModuleConfig<'a> for DartConfig<'a> {
-    fn new() -> Self {
+impl<'a> Default for DartConfig<'a> {
+    fn default() -> Self {
         DartConfig {
             format: "via [$symbol($version )]($style)",
             symbol: "🎯 ",

--- a/src/configs/directory.rs
+++ b/src/configs/directory.rs
@@ -1,4 +1,4 @@
-use crate::config::{ModuleConfig, RootModuleConfig};
+use crate::config::ModuleConfig;
 use indexmap::IndexMap;
 
 use starship_module_config_derive::ModuleConfig;
@@ -19,8 +19,8 @@ pub struct DirectoryConfig<'a> {
     pub home_symbol: &'a str,
 }
 
-impl<'a> RootModuleConfig<'a> for DirectoryConfig<'a> {
-    fn new() -> Self {
+impl<'a> Default for DirectoryConfig<'a> {
+    fn default() -> Self {
         DirectoryConfig {
             truncation_length: 3,
             truncate_to_repo: true,

--- a/src/configs/docker_context.rs
+++ b/src/configs/docker_context.rs
@@ -1,4 +1,4 @@
-use crate::config::{ModuleConfig, RootModuleConfig};
+use crate::config::ModuleConfig;
 
 use starship_module_config_derive::ModuleConfig;
 
@@ -14,8 +14,8 @@ pub struct DockerContextConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> RootModuleConfig<'a> for DockerContextConfig<'a> {
-    fn new() -> Self {
+impl<'a> Default for DockerContextConfig<'a> {
+    fn default() -> Self {
         DockerContextConfig {
             symbol: "🐳 ",
             style: "blue bold",

--- a/src/configs/dotnet.rs
+++ b/src/configs/dotnet.rs
@@ -1,4 +1,4 @@
-use crate::config::{ModuleConfig, RootModuleConfig};
+use crate::config::ModuleConfig;
 
 use starship_module_config_derive::ModuleConfig;
 
@@ -14,8 +14,8 @@ pub struct DotnetConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> RootModuleConfig<'a> for DotnetConfig<'a> {
-    fn new() -> Self {
+impl<'a> Default for DotnetConfig<'a> {
+    fn default() -> Self {
         DotnetConfig {
             format: "[$symbol($version )(🎯 $tfm )]($style)",
             symbol: "•NET ",

--- a/src/configs/elixir.rs
+++ b/src/configs/elixir.rs
@@ -1,4 +1,4 @@
-use crate::config::{ModuleConfig, RootModuleConfig};
+use crate::config::ModuleConfig;
 
 use starship_module_config_derive::ModuleConfig;
 
@@ -13,8 +13,8 @@ pub struct ElixirConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> RootModuleConfig<'a> for ElixirConfig<'a> {
-    fn new() -> Self {
+impl<'a> Default for ElixirConfig<'a> {
+    fn default() -> Self {
         ElixirConfig {
             format: "via [$symbol($version \\(OTP $otp_version\\) )]($style)",
             symbol: "💧 ",

--- a/src/configs/elm.rs
+++ b/src/configs/elm.rs
@@ -1,4 +1,4 @@
-use crate::config::{ModuleConfig, RootModuleConfig};
+use crate::config::ModuleConfig;
 
 use starship_module_config_derive::ModuleConfig;
 
@@ -13,8 +13,8 @@ pub struct ElmConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> RootModuleConfig<'a> for ElmConfig<'a> {
-    fn new() -> Self {
+impl<'a> Default for ElmConfig<'a> {
+    fn default() -> Self {
         ElmConfig {
             format: "via [$symbol($version )]($style)",
             symbol: "🌳 ",

--- a/src/configs/env_var.rs
+++ b/src/configs/env_var.rs
@@ -1,4 +1,4 @@
-use crate::config::{ModuleConfig, RootModuleConfig};
+use crate::config::ModuleConfig;
 
 use starship_module_config_derive::ModuleConfig;
 
@@ -12,8 +12,8 @@ pub struct EnvVarConfig<'a> {
     pub disabled: bool,
 }
 
-impl<'a> RootModuleConfig<'a> for EnvVarConfig<'a> {
-    fn new() -> Self {
+impl<'a> Default for EnvVarConfig<'a> {
+    fn default() -> Self {
         EnvVarConfig {
             symbol: "",
             style: "black bold dimmed",

--- a/src/configs/erlang.rs
+++ b/src/configs/erlang.rs
@@ -1,4 +1,4 @@
-use crate::config::{ModuleConfig, RootModuleConfig};
+use crate::config::ModuleConfig;
 
 use starship_module_config_derive::ModuleConfig;
 
@@ -13,8 +13,8 @@ pub struct ErlangConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> RootModuleConfig<'a> for ErlangConfig<'a> {
-    fn new() -> Self {
+impl<'a> Default for ErlangConfig<'a> {
+    fn default() -> Self {
         ErlangConfig {
             format: "via [$symbol($version )]($style)",
             symbol: " ",

--- a/src/configs/gcloud.rs
+++ b/src/configs/gcloud.rs
@@ -1,4 +1,4 @@
-use crate::config::{ModuleConfig, RootModuleConfig};
+use crate::config::ModuleConfig;
 use starship_module_config_derive::ModuleConfig;
 use std::collections::HashMap;
 
@@ -11,8 +11,8 @@ pub struct GcloudConfig<'a> {
     pub region_aliases: HashMap<String, &'a str>,
 }
 
-impl<'a> RootModuleConfig<'a> for GcloudConfig<'a> {
-    fn new() -> Self {
+impl<'a> Default for GcloudConfig<'a> {
+    fn default() -> Self {
         GcloudConfig {
             format: "on [$symbol$account(\\($region\\))]($style) ",
             symbol: "☁️ ",

--- a/src/configs/git_branch.rs
+++ b/src/configs/git_branch.rs
@@ -1,4 +1,4 @@
-use crate::config::{ModuleConfig, RootModuleConfig};
+use crate::config::ModuleConfig;
 
 use starship_module_config_derive::ModuleConfig;
 
@@ -14,8 +14,8 @@ pub struct GitBranchConfig<'a> {
     pub disabled: bool,
 }
 
-impl<'a> RootModuleConfig<'a> for GitBranchConfig<'a> {
-    fn new() -> Self {
+impl<'a> Default for GitBranchConfig<'a> {
+    fn default() -> Self {
         GitBranchConfig {
             format: "on [$symbol$branch]($style)(:[$remote]($style)) ",
             symbol: " ",

--- a/src/configs/git_commit.rs
+++ b/src/configs/git_commit.rs
@@ -1,4 +1,4 @@
-use crate::config::{ModuleConfig, RootModuleConfig};
+use crate::config::ModuleConfig;
 
 use starship_module_config_derive::ModuleConfig;
 
@@ -13,8 +13,8 @@ pub struct GitCommitConfig<'a> {
     pub tag_disabled: bool,
 }
 
-impl<'a> RootModuleConfig<'a> for GitCommitConfig<'a> {
-    fn new() -> Self {
+impl<'a> Default for GitCommitConfig<'a> {
+    fn default() -> Self {
         GitCommitConfig {
             // be consistent with git by default, which has DEFAULT_ABBREV set to 7
             commit_hash_length: 7,

--- a/src/configs/git_state.rs
+++ b/src/configs/git_state.rs
@@ -1,4 +1,4 @@
-use crate::config::{ModuleConfig, RootModuleConfig};
+use crate::config::ModuleConfig;
 
 use starship_module_config_derive::ModuleConfig;
 
@@ -16,8 +16,8 @@ pub struct GitStateConfig<'a> {
     pub disabled: bool,
 }
 
-impl<'a> RootModuleConfig<'a> for GitStateConfig<'a> {
-    fn new() -> Self {
+impl<'a> Default for GitStateConfig<'a> {
+    fn default() -> Self {
         GitStateConfig {
             rebase: "REBASING",
             merge: "MERGING",

--- a/src/configs/git_status.rs
+++ b/src/configs/git_status.rs
@@ -1,4 +1,4 @@
-use crate::config::{ModuleConfig, RootModuleConfig};
+use crate::config::ModuleConfig;
 
 use starship_module_config_derive::ModuleConfig;
 
@@ -19,8 +19,8 @@ pub struct GitStatusConfig<'a> {
     pub disabled: bool,
 }
 
-impl<'a> RootModuleConfig<'a> for GitStatusConfig<'a> {
-    fn new() -> Self {
+impl<'a> Default for GitStatusConfig<'a> {
+    fn default() -> Self {
         GitStatusConfig {
             format: "([\\[$all_status$ahead_behind\\]]($style) )",
             style: "red bold",

--- a/src/configs/go.rs
+++ b/src/configs/go.rs
@@ -1,4 +1,4 @@
-use crate::config::{ModuleConfig, RootModuleConfig};
+use crate::config::ModuleConfig;
 
 use starship_module_config_derive::ModuleConfig;
 
@@ -13,8 +13,8 @@ pub struct GoConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> RootModuleConfig<'a> for GoConfig<'a> {
-    fn new() -> Self {
+impl<'a> Default for GoConfig<'a> {
+    fn default() -> Self {
         GoConfig {
             format: "via [$symbol($version )]($style)",
             symbol: "🐹 ",

--- a/src/configs/helm.rs
+++ b/src/configs/helm.rs
@@ -1,4 +1,4 @@
-use crate::config::{ModuleConfig, RootModuleConfig};
+use crate::config::ModuleConfig;
 
 use starship_module_config_derive::ModuleConfig;
 
@@ -13,8 +13,8 @@ pub struct HelmConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> RootModuleConfig<'a> for HelmConfig<'a> {
-    fn new() -> Self {
+impl<'a> Default for HelmConfig<'a> {
+    fn default() -> Self {
         HelmConfig {
             format: "via [$symbol($version )]($style)",
             symbol: "⎈ ",

--- a/src/configs/hg_branch.rs
+++ b/src/configs/hg_branch.rs
@@ -1,4 +1,4 @@
-use crate::config::{ModuleConfig, RootModuleConfig};
+use crate::config::ModuleConfig;
 
 use starship_module_config_derive::ModuleConfig;
 
@@ -12,8 +12,8 @@ pub struct HgBranchConfig<'a> {
     pub disabled: bool,
 }
 
-impl<'a> RootModuleConfig<'a> for HgBranchConfig<'a> {
-    fn new() -> Self {
+impl<'a> Default for HgBranchConfig<'a> {
+    fn default() -> Self {
         HgBranchConfig {
             symbol: " ",
             style: "bold purple",

--- a/src/configs/hostname.rs
+++ b/src/configs/hostname.rs
@@ -1,4 +1,4 @@
-use crate::config::{ModuleConfig, RootModuleConfig};
+use crate::config::ModuleConfig;
 
 use starship_module_config_derive::ModuleConfig;
 
@@ -11,8 +11,8 @@ pub struct HostnameConfig<'a> {
     pub disabled: bool,
 }
 
-impl<'a> RootModuleConfig<'a> for HostnameConfig<'a> {
-    fn new() -> Self {
+impl<'a> Default for HostnameConfig<'a> {
+    fn default() -> Self {
         HostnameConfig {
             ssh_only: true,
             trim_at: ".",

--- a/src/configs/java.rs
+++ b/src/configs/java.rs
@@ -1,4 +1,4 @@
-use crate::config::{ModuleConfig, RootModuleConfig};
+use crate::config::ModuleConfig;
 
 use starship_module_config_derive::ModuleConfig;
 
@@ -13,8 +13,8 @@ pub struct JavaConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> RootModuleConfig<'a> for JavaConfig<'a> {
-    fn new() -> Self {
+impl<'a> Default for JavaConfig<'a> {
+    fn default() -> Self {
         JavaConfig {
             format: "via [$symbol($version )]($style)",
             disabled: false,

--- a/src/configs/jobs.rs
+++ b/src/configs/jobs.rs
@@ -1,4 +1,4 @@
-use crate::config::{ModuleConfig, RootModuleConfig};
+use crate::config::ModuleConfig;
 
 use starship_module_config_derive::ModuleConfig;
 
@@ -11,8 +11,8 @@ pub struct JobsConfig<'a> {
     pub disabled: bool,
 }
 
-impl<'a> RootModuleConfig<'a> for JobsConfig<'a> {
-    fn new() -> Self {
+impl<'a> Default for JobsConfig<'a> {
+    fn default() -> Self {
         JobsConfig {
             threshold: 1,
             format: "[$symbol$number]($style) ",

--- a/src/configs/julia.rs
+++ b/src/configs/julia.rs
@@ -1,4 +1,4 @@
-use crate::config::{ModuleConfig, RootModuleConfig};
+use crate::config::ModuleConfig;
 
 use starship_module_config_derive::ModuleConfig;
 
@@ -13,8 +13,8 @@ pub struct JuliaConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> RootModuleConfig<'a> for JuliaConfig<'a> {
-    fn new() -> Self {
+impl<'a> Default for JuliaConfig<'a> {
+    fn default() -> Self {
         JuliaConfig {
             format: "via [$symbol($version )]($style)",
             symbol: "ஃ ",

--- a/src/configs/kotlin.rs
+++ b/src/configs/kotlin.rs
@@ -1,4 +1,4 @@
-use crate::config::{ModuleConfig, RootModuleConfig};
+use crate::config::ModuleConfig;
 
 use starship_module_config_derive::ModuleConfig;
 
@@ -14,8 +14,8 @@ pub struct KotlinConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> RootModuleConfig<'a> for KotlinConfig<'a> {
-    fn new() -> Self {
+impl<'a> Default for KotlinConfig<'a> {
+    fn default() -> Self {
         KotlinConfig {
             format: "via [$symbol($version )]($style)",
             symbol: "🅺 ",

--- a/src/configs/kubernetes.rs
+++ b/src/configs/kubernetes.rs
@@ -1,4 +1,4 @@
-use crate::config::{ModuleConfig, RootModuleConfig};
+use crate::config::ModuleConfig;
 
 use starship_module_config_derive::ModuleConfig;
 use std::collections::HashMap;
@@ -12,8 +12,8 @@ pub struct KubernetesConfig<'a> {
     pub context_aliases: HashMap<String, &'a str>,
 }
 
-impl<'a> RootModuleConfig<'a> for KubernetesConfig<'a> {
-    fn new() -> Self {
+impl<'a> Default for KubernetesConfig<'a> {
+    fn default() -> Self {
         KubernetesConfig {
             symbol: "☸ ",
             format: "[$symbol$context( \\($namespace\\))]($style) in ",

--- a/src/configs/lua.rs
+++ b/src/configs/lua.rs
@@ -1,4 +1,4 @@
-use crate::config::{ModuleConfig, RootModuleConfig};
+use crate::config::ModuleConfig;
 
 use starship_module_config_derive::ModuleConfig;
 
@@ -14,8 +14,8 @@ pub struct LuaConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> RootModuleConfig<'a> for LuaConfig<'a> {
-    fn new() -> Self {
+impl<'a> Default for LuaConfig<'a> {
+    fn default() -> Self {
         LuaConfig {
             format: "via [$symbol($version )]($style)",
             symbol: "🌙 ",

--- a/src/configs/memory_usage.rs
+++ b/src/configs/memory_usage.rs
@@ -1,4 +1,4 @@
-use crate::config::{ModuleConfig, RootModuleConfig};
+use crate::config::ModuleConfig;
 
 use starship_module_config_derive::ModuleConfig;
 
@@ -11,8 +11,8 @@ pub struct MemoryConfig<'a> {
     pub disabled: bool,
 }
 
-impl<'a> RootModuleConfig<'a> for MemoryConfig<'a> {
-    fn new() -> Self {
+impl<'a> Default for MemoryConfig<'a> {
+    fn default() -> Self {
         MemoryConfig {
             threshold: 75,
             format: "via $symbol[$ram( | $swap)]($style) ",

--- a/src/configs/nim.rs
+++ b/src/configs/nim.rs
@@ -1,4 +1,4 @@
-use crate::config::{ModuleConfig, RootModuleConfig};
+use crate::config::ModuleConfig;
 
 use starship_module_config_derive::ModuleConfig;
 
@@ -13,8 +13,8 @@ pub struct NimConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> RootModuleConfig<'a> for NimConfig<'a> {
-    fn new() -> Self {
+impl<'a> Default for NimConfig<'a> {
+    fn default() -> Self {
         NimConfig {
             format: "via [$symbol($version )]($style)",
             symbol: "👑 ",

--- a/src/configs/nix_shell.rs
+++ b/src/configs/nix_shell.rs
@@ -1,4 +1,4 @@
-use crate::config::{ModuleConfig, RootModuleConfig};
+use crate::config::ModuleConfig;
 
 use starship_module_config_derive::ModuleConfig;
 
@@ -15,8 +15,8 @@ pub struct NixShellConfig<'a> {
 /* The trailing double spaces in `symbol` are needed to work around issues with
 multiwidth emoji support in some shells. Please do not file a PR to change this
 unless you can show that your changes do not affect this workaround.  */
-impl<'a> RootModuleConfig<'a> for NixShellConfig<'a> {
-    fn new() -> Self {
+impl<'a> Default for NixShellConfig<'a> {
+    fn default() -> Self {
         NixShellConfig {
             format: "via [$symbol$state( \\($name\\))]($style) ",
             symbol: "❄️  ",

--- a/src/configs/nodejs.rs
+++ b/src/configs/nodejs.rs
@@ -1,4 +1,4 @@
-use crate::config::{ModuleConfig, RootModuleConfig};
+use crate::config::ModuleConfig;
 
 use starship_module_config_derive::ModuleConfig;
 
@@ -14,8 +14,8 @@ pub struct NodejsConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> RootModuleConfig<'a> for NodejsConfig<'a> {
-    fn new() -> Self {
+impl<'a> Default for NodejsConfig<'a> {
+    fn default() -> Self {
         NodejsConfig {
             format: "via [$symbol($version )]($style)",
             symbol: " ",

--- a/src/configs/ocaml.rs
+++ b/src/configs/ocaml.rs
@@ -1,4 +1,4 @@
-use crate::config::{ModuleConfig, RootModuleConfig};
+use crate::config::ModuleConfig;
 
 use starship_module_config_derive::ModuleConfig;
 
@@ -13,8 +13,8 @@ pub struct OCamlConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> RootModuleConfig<'a> for OCamlConfig<'a> {
-    fn new() -> Self {
+impl<'a> Default for OCamlConfig<'a> {
+    fn default() -> Self {
         OCamlConfig {
             format: "via [$symbol($version )]($style)",
             symbol: "🐫 ",

--- a/src/configs/openstack.rs
+++ b/src/configs/openstack.rs
@@ -1,4 +1,4 @@
-use crate::config::{ModuleConfig, RootModuleConfig};
+use crate::config::ModuleConfig;
 use starship_module_config_derive::ModuleConfig;
 
 #[derive(Clone, ModuleConfig)]
@@ -9,8 +9,8 @@ pub struct OspConfig<'a> {
     pub disabled: bool,
 }
 
-impl<'a> RootModuleConfig<'a> for OspConfig<'a> {
-    fn new() -> Self {
+impl<'a> Default for OspConfig<'a> {
+    fn default() -> Self {
         OspConfig {
             format: "on [$symbol$cloud(\\($project\\))]($style) ",
             symbol: "☁️  ",

--- a/src/configs/package.rs
+++ b/src/configs/package.rs
@@ -1,4 +1,4 @@
-use crate::config::{ModuleConfig, RootModuleConfig};
+use crate::config::ModuleConfig;
 
 use starship_module_config_derive::ModuleConfig;
 
@@ -11,8 +11,8 @@ pub struct PackageConfig<'a> {
     pub disabled: bool,
 }
 
-impl<'a> RootModuleConfig<'a> for PackageConfig<'a> {
-    fn new() -> Self {
+impl<'a> Default for PackageConfig<'a> {
+    fn default() -> Self {
         PackageConfig {
             format: "is [$symbol$version]($style) ",
             symbol: "📦 ",

--- a/src/configs/perl.rs
+++ b/src/configs/perl.rs
@@ -1,4 +1,4 @@
-use crate::config::{ModuleConfig, RootModuleConfig};
+use crate::config::ModuleConfig;
 
 use starship_module_config_derive::ModuleConfig;
 
@@ -13,8 +13,8 @@ pub struct PerlConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> RootModuleConfig<'a> for PerlConfig<'a> {
-    fn new() -> Self {
+impl<'a> Default for PerlConfig<'a> {
+    fn default() -> Self {
         PerlConfig {
             symbol: "🐪 ",
             style: "149 bold",

--- a/src/configs/php.rs
+++ b/src/configs/php.rs
@@ -1,4 +1,4 @@
-use crate::config::{ModuleConfig, RootModuleConfig};
+use crate::config::ModuleConfig;
 
 use starship_module_config_derive::ModuleConfig;
 
@@ -13,8 +13,8 @@ pub struct PhpConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> RootModuleConfig<'a> for PhpConfig<'a> {
-    fn new() -> Self {
+impl<'a> Default for PhpConfig<'a> {
+    fn default() -> Self {
         PhpConfig {
             symbol: "🐘 ",
             style: "147 bold",

--- a/src/configs/purescript.rs
+++ b/src/configs/purescript.rs
@@ -1,4 +1,4 @@
-use crate::config::{ModuleConfig, RootModuleConfig};
+use crate::config::ModuleConfig;
 
 use starship_module_config_derive::ModuleConfig;
 
@@ -13,8 +13,8 @@ pub struct PureScriptConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> RootModuleConfig<'a> for PureScriptConfig<'a> {
-    fn new() -> Self {
+impl<'a> Default for PureScriptConfig<'a> {
+    fn default() -> Self {
         PureScriptConfig {
             format: "via [$symbol($version )]($style)",
             symbol: "<=> ",

--- a/src/configs/python.rs
+++ b/src/configs/python.rs
@@ -1,4 +1,4 @@
-use crate::config::{ModuleConfig, RootModuleConfig, VecOr};
+use crate::config::{ModuleConfig, VecOr};
 
 use starship_module_config_derive::ModuleConfig;
 
@@ -16,8 +16,8 @@ pub struct PythonConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> RootModuleConfig<'a> for PythonConfig<'a> {
-    fn new() -> Self {
+impl<'a> Default for PythonConfig<'a> {
+    fn default() -> Self {
         PythonConfig {
             pyenv_version_name: false,
             pyenv_prefix: "pyenv ",

--- a/src/configs/ruby.rs
+++ b/src/configs/ruby.rs
@@ -1,4 +1,4 @@
-use crate::config::{ModuleConfig, RootModuleConfig};
+use crate::config::ModuleConfig;
 
 use starship_module_config_derive::ModuleConfig;
 
@@ -13,8 +13,8 @@ pub struct RubyConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> RootModuleConfig<'a> for RubyConfig<'a> {
-    fn new() -> Self {
+impl<'a> Default for RubyConfig<'a> {
+    fn default() -> Self {
         RubyConfig {
             format: "via [$symbol($version )]($style)",
             symbol: "💎 ",

--- a/src/configs/rust.rs
+++ b/src/configs/rust.rs
@@ -1,4 +1,4 @@
-use crate::config::{ModuleConfig, RootModuleConfig};
+use crate::config::ModuleConfig;
 
 use starship_module_config_derive::ModuleConfig;
 
@@ -13,8 +13,8 @@ pub struct RustConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> RootModuleConfig<'a> for RustConfig<'a> {
-    fn new() -> Self {
+impl<'a> Default for RustConfig<'a> {
+    fn default() -> Self {
         RustConfig {
             format: "via [$symbol($version )]($style)",
             symbol: "🦀 ",

--- a/src/configs/scala.rs
+++ b/src/configs/scala.rs
@@ -1,4 +1,4 @@
-use crate::config::{ModuleConfig, RootModuleConfig};
+use crate::config::ModuleConfig;
 
 use starship_module_config_derive::ModuleConfig;
 
@@ -13,8 +13,8 @@ pub struct ScalaConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> RootModuleConfig<'a> for ScalaConfig<'a> {
-    fn new() -> Self {
+impl<'a> Default for ScalaConfig<'a> {
+    fn default() -> Self {
         ScalaConfig {
             format: "via [$symbol($version )]($style)",
             disabled: false,

--- a/src/configs/shell.rs
+++ b/src/configs/shell.rs
@@ -1,4 +1,4 @@
-use crate::config::{ModuleConfig, RootModuleConfig};
+use crate::config::ModuleConfig;
 
 use starship_module_config_derive::ModuleConfig;
 
@@ -15,8 +15,8 @@ pub struct ShellConfig<'a> {
     pub disabled: bool,
 }
 
-impl<'a> RootModuleConfig<'a> for ShellConfig<'a> {
-    fn new() -> Self {
+impl<'a> Default for ShellConfig<'a> {
+    fn default() -> Self {
         ShellConfig {
             format: "$indicator ",
             bash_indicator: "bsh",

--- a/src/configs/shlvl.rs
+++ b/src/configs/shlvl.rs
@@ -1,4 +1,4 @@
-use crate::config::{ModuleConfig, RootModuleConfig};
+use crate::config::ModuleConfig;
 
 use starship_module_config_derive::ModuleConfig;
 
@@ -12,8 +12,8 @@ pub struct ShLvlConfig<'a> {
     pub disabled: bool,
 }
 
-impl<'a> RootModuleConfig<'a> for ShLvlConfig<'a> {
-    fn new() -> Self {
+impl<'a> Default for ShLvlConfig<'a> {
+    fn default() -> Self {
         ShLvlConfig {
             threshold: 2,
             format: "[$symbol$shlvl]($style) ",

--- a/src/configs/singularity.rs
+++ b/src/configs/singularity.rs
@@ -1,4 +1,4 @@
-use crate::config::{ModuleConfig, RootModuleConfig};
+use crate::config::ModuleConfig;
 
 use starship_module_config_derive::ModuleConfig;
 
@@ -10,8 +10,8 @@ pub struct SingularityConfig<'a> {
     pub disabled: bool,
 }
 
-impl<'a> RootModuleConfig<'a> for SingularityConfig<'a> {
-    fn new() -> Self {
+impl<'a> Default for SingularityConfig<'a> {
+    fn default() -> Self {
         SingularityConfig {
             format: "[$symbol\\[$env\\]]($style) ",
             symbol: "",

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -1,4 +1,4 @@
-use crate::config::{ModuleConfig, RootModuleConfig};
+use crate::config::ModuleConfig;
 
 use starship_module_config_derive::ModuleConfig;
 
@@ -76,8 +76,8 @@ pub const PROMPT_ORDER: &[&str] = &[
     "character",
 ];
 
-impl<'a> RootModuleConfig<'a> for StarshipRootConfig<'a> {
-    fn new() -> Self {
+impl<'a> Default for StarshipRootConfig<'a> {
+    fn default() -> Self {
         StarshipRootConfig {
             format: "$all",
             scan_timeout: 30,

--- a/src/configs/status.rs
+++ b/src/configs/status.rs
@@ -1,4 +1,4 @@
-use crate::config::{ModuleConfig, RootModuleConfig};
+use crate::config::ModuleConfig;
 
 use starship_module_config_derive::ModuleConfig;
 
@@ -16,8 +16,8 @@ pub struct StatusConfig<'a> {
     pub disabled: bool,
 }
 
-impl<'a> RootModuleConfig<'a> for StatusConfig<'a> {
-    fn new() -> Self {
+impl<'a> Default for StatusConfig<'a> {
+    fn default() -> Self {
         StatusConfig {
             format: "[$symbol$status]($style) ",
             symbol: "✖",

--- a/src/configs/swift.rs
+++ b/src/configs/swift.rs
@@ -1,4 +1,4 @@
-use crate::config::{ModuleConfig, RootModuleConfig};
+use crate::config::ModuleConfig;
 
 use starship_module_config_derive::ModuleConfig;
 
@@ -13,8 +13,8 @@ pub struct SwiftConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> RootModuleConfig<'a> for SwiftConfig<'a> {
-    fn new() -> Self {
+impl<'a> Default for SwiftConfig<'a> {
+    fn default() -> Self {
         SwiftConfig {
             format: "via [$symbol($version )]($style)",
             symbol: "🐦 ",

--- a/src/configs/terraform.rs
+++ b/src/configs/terraform.rs
@@ -1,4 +1,4 @@
-use crate::config::{ModuleConfig, RootModuleConfig};
+use crate::config::ModuleConfig;
 
 use starship_module_config_derive::ModuleConfig;
 
@@ -13,8 +13,8 @@ pub struct TerraformConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> RootModuleConfig<'a> for TerraformConfig<'a> {
-    fn new() -> Self {
+impl<'a> Default for TerraformConfig<'a> {
+    fn default() -> Self {
         TerraformConfig {
             format: "via [$symbol$workspace]($style) ",
             symbol: "💠 ",

--- a/src/configs/time.rs
+++ b/src/configs/time.rs
@@ -1,4 +1,4 @@
-use crate::config::{ModuleConfig, RootModuleConfig};
+use crate::config::ModuleConfig;
 
 use starship_module_config_derive::ModuleConfig;
 
@@ -13,8 +13,8 @@ pub struct TimeConfig<'a> {
     pub time_range: &'a str,
 }
 
-impl<'a> RootModuleConfig<'a> for TimeConfig<'a> {
-    fn new() -> Self {
+impl<'a> Default for TimeConfig<'a> {
+    fn default() -> Self {
         TimeConfig {
             format: "at [$time]($style) ",
             style: "bold yellow",

--- a/src/configs/username.rs
+++ b/src/configs/username.rs
@@ -1,4 +1,4 @@
-use crate::config::{ModuleConfig, RootModuleConfig};
+use crate::config::ModuleConfig;
 
 use starship_module_config_derive::ModuleConfig;
 
@@ -11,8 +11,8 @@ pub struct UsernameConfig<'a> {
     pub disabled: bool,
 }
 
-impl<'a> RootModuleConfig<'a> for UsernameConfig<'a> {
-    fn new() -> Self {
+impl<'a> Default for UsernameConfig<'a> {
+    fn default() -> Self {
         UsernameConfig {
             format: "[$user]($style) in ",
             style_root: "red bold",

--- a/src/configs/vagrant.rs
+++ b/src/configs/vagrant.rs
@@ -1,4 +1,4 @@
-use crate::config::{ModuleConfig, RootModuleConfig};
+use crate::config::ModuleConfig;
 
 use starship_module_config_derive::ModuleConfig;
 
@@ -13,8 +13,8 @@ pub struct VagrantConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> RootModuleConfig<'a> for VagrantConfig<'a> {
-    fn new() -> Self {
+impl<'a> Default for VagrantConfig<'a> {
+    fn default() -> Self {
         VagrantConfig {
             format: "via [$symbol($version )]($style)",
             symbol: "⍱ ",

--- a/src/configs/zig.rs
+++ b/src/configs/zig.rs
@@ -1,4 +1,4 @@
-use crate::config::{ModuleConfig, RootModuleConfig};
+use crate::config::ModuleConfig;
 
 use starship_module_config_derive::ModuleConfig;
 
@@ -13,8 +13,8 @@ pub struct ZigConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> RootModuleConfig<'a> for ZigConfig<'a> {
-    fn new() -> Self {
+impl<'a> Default for ZigConfig<'a> {
+    fn default() -> Self {
         ZigConfig {
             format: "via [$symbol($version )]($style)",
             symbol: "↯ ",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR replaces `impl RootModuleConfig` with `impl Default` in `config/*.rs` and implements `RootModuleConfig` for `ModuleConfig + Default`.

This should simplify printing the default config in the future (#2309) and it's a step towards using serde (#553).

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
