### PR TITLE
feat(aws): hide AWS prompt if no profile section is associated to current profile

### DIFF
--- a/src/configs/aws.rs
+++ b/src/configs/aws.rs
@@ -9,6 +9,7 @@ pub struct AwsConfig<'a> {
     pub style: &'a str,
     pub disabled: bool,
     pub region_aliases: HashMap<String, &'a str>,
+    pub hide_profiles_without_section: bool,
 }
 
 impl<'a> Default for AwsConfig<'a> {
@@ -19,6 +20,7 @@ impl<'a> Default for AwsConfig<'a> {
             style: "bold yellow",
             disabled: false,
             region_aliases: HashMap::new(),
+            hide_profiles_without_section: false,
         }
     }
 }


### PR DESCRIPTION
#### Description
The goal of this PR is to add some conditions to disable the AWS prompt by checking the existence of a profile section in either the  credentials or the configuration file (if any profile environment variable is set).

I added a new configuration option (`hide_profiles_without_section`) to the module that toggles this new functionality (it should probably be removed in the future but it impacted too many tests for them to be changed before receiving some feedback).

I am looking for feedback regarding the implementation and potential oversights/issues.

#### Motivation and Context

Hides the AWS prompt when it is usually not needed (e.g. when no profiles have been set). Goes a bit further than the linked issue since it also disables the prompt for profiles other than `default` if the set profile has no matching sections in either the credentials or config file (**Note**: this might be an undesirable behavior but it was intentionally implemented this way).

Closes #3457
Closes #2184
Closes #2871
Closes #3504

#### How Has This Been Tested?
I added some tests to the AWS module to reflect the new functionality and I ran `cargo test modules::aws` to ensure no breaking changes were introduced.
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [ ] I have updated the documentation accordingly. (Not done since I am unsure about the future of the new option)
- [x] I have updated the tests accordingly.
