### PR TITLE
feat(aws): temporary credentials countdown prompt

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -277,12 +277,13 @@ date is read from the `AWSUME_EXPIRATION` env var.
 
 ### Variables
 
-| Variable | Example          | Description                          |
-| -------- | ---------------- | ------------------------------------ |
-| region   | `ap-northeast-1` | The current AWS region               |
-| profile  | `astronauts`     | The current AWS profile              |
-| symbol   |                  | Mirrors the value of option `symbol` |
-| style\*  |                  | Mirrors the value of option `style`  |
+| Variable | Example          | Description                                 |
+| -------- | ---------------- | ------------------------------------------- |
+| region   | `ap-northeast-1` | The current AWS region                      |
+| profile  | `astronauts`     | The current AWS profile                     |
+| duration | `2h27m20s`       | The temporary credentials validity duration |
+| symbol   |                  | Mirrors the value of option `symbol`        |
+| style\*  |                  | Mirrors the value of option `style`         |
 
 \*: This variable can only be used as a part of a style string
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -251,7 +251,7 @@ $character"""
 The `aws` module shows the current AWS region and profile. This is based on
 `AWS_REGION`, `AWS_DEFAULT_REGION`, and `AWS_PROFILE` env var with
 `~/.aws/config` file. This module also shows an expiration timer when using temporary
-credentials. w
+credentials.
 
 When using [aws-vault](https://github.com/99designs/aws-vault) the profile
 is read from the `AWS_VAULT` env var and the credentials expiration date

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -250,26 +250,30 @@ $character"""
 
 The `aws` module shows the current AWS region and profile. This is based on
 `AWS_REGION`, `AWS_DEFAULT_REGION`, and `AWS_PROFILE` env var with
-`~/.aws/config` file.
+`~/.aws/config` file. This module also shows an expiration timer when using temporary
+credentials. w
 
 When using [aws-vault](https://github.com/99designs/aws-vault) the profile
-is read from the `AWS_VAULT` env var.
+is read from the `AWS_VAULT` env var and the credentials expiration date
+is read from the `AWS_SESSION_EXPIRATION` env var.
 
 When using [awsu](https://github.com/kreuzwerker/awsu) the profile
 is read from the `AWSU_PROFILE` env var.
 
 When using [AWSume](https://awsu.me) the profile
-is read from the `AWSUME_PROFILE` env var.
+is read from the `AWSUME_PROFILE` env var and the credentials expiration
+date is read from the `AWSUME_EXPIRATION` env var.
 
 ### Options
 
-| Option           | Default                                           | Description                                                     |
-| ---------------- | ------------------------------------------------- | --------------------------------------------------------------- |
-| `format`         | `'on [$symbol($profile )(\($region\) )]($style)'` | The format for the module.                                      |
-| `symbol`         | `"☁️ "`                                            | The symbol used before displaying the current AWS profile.      |
-| `region_aliases` |                                                   | Table of region aliases to display in addition to the AWS name. |
-| `style`          | `"bold yellow"`                                   | The style for the module.                                       |
-| `disabled`       | `false`                                           | Disables the `aws` module.                                      |
+| Option              | Default                                                          | Description                                                       |
+| ------------------- | ---------------------------------------------------------------- | ----------------------------------------------------------------- |
+| `format`            | `'on [$symbol($profile )(\($region\) )(\[$duration\])]($style)'` | The format for the module.                                        |
+| `symbol`            | `"☁️ "`                                                           | The symbol used before displaying the current AWS profile.        |
+| `region_aliases`    |                                                                  | Table of region aliases to display in addition to the AWS name.   |
+| `style`             | `"bold yellow"`                                                  | The style for the module.                                         |
+| `expiration_symbol` | `X`                                                              | The symbol displayed when the temporary credentials have expired. |
+| `disabled`          | `false`                                                          | Disables the `AWS` module.                                        |
 
 ### Variables
 

--- a/src/configs/aws.rs
+++ b/src/configs/aws.rs
@@ -9,7 +9,6 @@ pub struct AwsConfig<'a> {
     pub style: &'a str,
     pub disabled: bool,
     pub region_aliases: HashMap<String, &'a str>,
-    pub show_duration: bool,
     pub expiration_symbol: &'a str,
 }
 
@@ -21,7 +20,6 @@ impl<'a> Default for AwsConfig<'a> {
             style: "bold yellow",
             disabled: false,
             region_aliases: HashMap::new(),
-            show_duration: false,
             expiration_symbol: "X",
         }
     }

--- a/src/configs/aws.rs
+++ b/src/configs/aws.rs
@@ -9,16 +9,20 @@ pub struct AwsConfig<'a> {
     pub style: &'a str,
     pub disabled: bool,
     pub region_aliases: HashMap<String, &'a str>,
+    pub show_duration: bool,
+    pub expiration_symbol: &'a str,
 }
 
 impl<'a> Default for AwsConfig<'a> {
     fn default() -> Self {
         AwsConfig {
-            format: "on [$symbol($profile )(\\($region\\) )]($style)",
+            format: "on [$symbol($profile )(\\($region\\) )(\\[$duration\\])]($style)",
             symbol: "☁️  ",
             style: "bold yellow",
             disabled: false,
             region_aliases: HashMap::new(),
+            show_duration: false,
+            expiration_symbol: "X",
         }
     }
 }

--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -4,6 +4,8 @@ use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
 use std::str::FromStr;
 
+use chrono::DateTime;
+
 use super::{Context, Module, RootModuleConfig};
 
 use crate::configs::aws::AwsConfig;
@@ -12,15 +14,30 @@ use crate::formatter::StringFormatter;
 type Profile = String;
 type Region = String;
 
-fn get_aws_region_from_config(context: &Context, aws_profile: Option<&str>) -> Option<Region> {
-    let config_location = context
+fn get_credentials_file_path(context: &Context) -> Option<PathBuf> {
+    context
+        .get_env("AWS_CREDENTIALS_FILE")
+        .and_then(|path| PathBuf::from_str(&path).ok())
+        .or_else(|| {
+            let mut home = context.get_home()?;
+            home.push(".aws/credentials");
+            Some(home)
+        })
+}
+
+fn get_config_file_path(context: &Context) -> Option<PathBuf> {
+    context
         .get_env("AWS_CONFIG_FILE")
         .and_then(|path| PathBuf::from_str(&path).ok())
         .or_else(|| {
             let mut home = context.get_home()?;
             home.push(".aws/config");
             Some(home)
-        })?;
+        })
+}
+
+fn get_aws_region_from_config(context: &Context, aws_profile: Option<&str>) -> Option<Region> {
+    let config_location = get_config_file_path(context)?;
 
     let file = File::open(&config_location).ok()?;
     let reader = BufReader::new(file);
@@ -65,6 +82,35 @@ fn get_aws_profile_and_region(context: &Context) -> (Option<Profile>, Option<Reg
     }
 }
 
+fn get_credentials_duration(context: &Context, aws_profile: Option<&Profile>) -> Option<i64> {
+    let expiration_date = if let Some(expiration_date) = context.get_env("AWS_SESSION_EXPIRATION") {
+        chrono::DateTime::parse_from_rfc3339(&expiration_date).ok()
+    } else {
+        let credentials_location = get_credentials_file_path(context)?;
+
+        let file = File::open(&credentials_location).ok()?;
+        let reader = BufReader::new(file);
+        let lines = reader.lines().filter_map(Result::ok);
+
+        let profile_line = if let Some(aws_profile) = aws_profile {
+            format!("[{}]", aws_profile)
+        } else {
+            "[default]".to_string()
+        };
+
+        let expiration_date_line = lines
+            .skip_while(|line| line != &profile_line)
+            .skip(1)
+            .take_while(|line| !line.starts_with('['))
+            .find(|line| line.starts_with("expiration"))?;
+
+        let expiration_date = expiration_date_line.split('=').nth(1)?;
+        DateTime::parse_from_rfc3339(expiration_date).ok()
+    }?;
+
+    Some(expiration_date.timestamp() - chrono::Local::now().timestamp())
+}
+
 fn alias_region(region: String, aliases: &HashMap<String, &str>) -> String {
     match aliases.get(&region) {
         None => region,
@@ -87,6 +133,18 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         None
     };
 
+    let duration = if config.show_duration {
+        get_credentials_duration(context, aws_profile.as_ref()).map(|duration| {
+            if duration > 0 {
+                format!("{}s", duration.to_string())
+            } else {
+                config.expiration_symbol.to_string()
+            }
+        })
+    } else {
+        None
+    };
+
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter
             .map_meta(|variable, _| match variable {
@@ -100,6 +158,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             .map(|variable| match variable {
                 "profile" => aws_profile.as_ref().map(Ok),
                 "region" => mapped_region.as_ref().map(Ok),
+                "duration" => duration.as_ref().map(Ok),
                 _ => None,
             })
             .parse(None)
@@ -378,6 +437,142 @@ region = us-east-2
             })
             .collect();
         let expected = Some(format!("on {} ", Color::Yellow.bold().paint("☁️  ")));
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn expiration_date_set() {
+        use chrono::{DateTime, NaiveDateTime, SecondsFormat, Utc};
+
+        let now_plus_half_hour: DateTime<Utc> = chrono::DateTime::from_utc(
+            NaiveDateTime::from_timestamp(chrono::Local::now().timestamp() + 1800, 0),
+            Utc,
+        );
+
+        let actual = ModuleRenderer::new("aws")
+            .config(toml::toml! {
+                [aws]
+                show_duration = true
+            })
+            .env("AWS_PROFILE", "astronauts")
+            .env("AWS_REGION", "ap-northeast-2")
+            .env(
+                "AWS_SESSION_EXPIRATION",
+                now_plus_half_hour.to_rfc3339_opts(SecondsFormat::Secs, true),
+            )
+            .collect();
+        let expected = Some(format!(
+            "on {}",
+            Color::Yellow
+                .bold()
+                .paint("☁️  astronauts (ap-northeast-2) [1800s]")
+        ));
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn expiration_date_set_from_file() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let credentials_path = dir.path().join("credentials");
+        let mut file = File::create(&credentials_path)?;
+
+        use chrono::{DateTime, NaiveDateTime, Utc};
+
+        let now_plus_half_hour: DateTime<Utc> = chrono::DateTime::from_utc(
+            NaiveDateTime::from_timestamp(chrono::Local::now().timestamp() + 1800, 0),
+            Utc,
+        );
+
+        let expiration_date = now_plus_half_hour.to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+
+        file.write_all(
+            format!(
+                "[astronauts]
+aws_access_key_id=dummy
+aws_secret_access_key=dummy
+expiration={}
+",
+                expiration_date
+            )
+            .as_bytes(),
+        )?;
+
+        let actual = ModuleRenderer::new("aws")
+            .config(toml::toml! {
+                [aws]
+                show_duration = true
+            })
+            .env("AWS_PROFILE", "astronauts")
+            .env("AWS_REGION", "ap-northeast-2")
+            .env(
+                "AWS_CREDENTIALS_FILE",
+                credentials_path.to_string_lossy().as_ref(),
+            )
+            .collect();
+        let expected = Some(format!(
+            "on {}",
+            Color::Yellow
+                .bold()
+                .paint("☁️  astronauts (ap-northeast-2) [1800s]")
+        ));
+
+        assert_eq!(expected, actual);
+
+        dir.close()
+    }
+
+    #[test]
+    fn profile_and_region_set_show_duration() {
+        let actual = ModuleRenderer::new("aws")
+            .config(toml::toml! {
+                [aws]
+                show_duration = true
+            })
+            .env("AWS_PROFILE", "astronauts")
+            .env("AWS_REGION", "ap-northeast-2")
+            .collect();
+        let expected = Some(format!(
+            "on {}",
+            Color::Yellow
+                .bold()
+                .paint("☁️  astronauts (ap-northeast-2) ")
+        ));
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn expiration_date_set_expired() {
+        use chrono::{DateTime, NaiveDateTime, SecondsFormat, Utc};
+
+        let now: DateTime<Utc> = chrono::DateTime::from_utc(
+            NaiveDateTime::from_timestamp(chrono::Local::now().timestamp() - 1800, 0),
+            Utc,
+        );
+
+        let symbol = "!!!";
+
+        let actual = ModuleRenderer::new("aws")
+            .config(toml::toml! {
+                [aws]
+                show_duration = true
+                expiration_symbol = symbol
+            })
+            .env("AWS_PROFILE", "astronauts")
+            .env("AWS_REGION", "ap-northeast-2")
+            .env(
+                "AWS_SESSION_EXPIRATION",
+                now.to_rfc3339_opts(SecondsFormat::Secs, true),
+            )
+            .collect();
+        let expected = Some(format!(
+            "on {}",
+            Color::Yellow
+                .bold()
+                .paint(format!("☁️  astronauts (ap-northeast-2) [{}]", symbol))
+        ));
 
         assert_eq!(expected, actual);
     }

--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -10,7 +10,7 @@ use super::{Context, Module, RootModuleConfig};
 
 use crate::configs::aws::AwsConfig;
 use crate::formatter::StringFormatter;
-use crate::modules::cmd_duration::render_time;
+use crate::utils::render_time;
 
 type Profile = String;
 type Region = String;

--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -10,6 +10,7 @@ use super::{Context, Module, RootModuleConfig};
 
 use crate::configs::aws::AwsConfig;
 use crate::formatter::StringFormatter;
+use crate::modules::cmd_duration::render_time;
 
 type Profile = String;
 type Region = String;
@@ -140,7 +141,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let duration = if config.show_duration {
         get_credentials_duration(context, aws_profile.as_ref()).map(|duration| {
             if duration > 0 {
-                format!("{}s", duration.to_string())
+                render_time((duration * 1000) as u128,  false)
             } else {
                 config.expiration_symbol.to_string()
             }
@@ -470,7 +471,7 @@ region = us-east-2
             "on {}",
             Color::Yellow
                 .bold()
-                .paint("☁️  astronauts (ap-northeast-2) [1800s]")
+                .paint("☁️  astronauts (ap-northeast-2) [30m]")
         ));
 
         assert_eq!(expected, actual);
@@ -519,7 +520,7 @@ expiration={}
             "on {}",
             Color::Yellow
                 .bold()
-                .paint("☁️  astronauts (ap-northeast-2) [1800s]")
+                .paint("☁️  astronauts (ap-northeast-2) [30m]")
         ));
 
         assert_eq!(expected, actual);

--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -83,7 +83,11 @@ fn get_aws_profile_and_region(context: &Context) -> (Option<Profile>, Option<Reg
 }
 
 fn get_credentials_duration(context: &Context, aws_profile: Option<&Profile>) -> Option<i64> {
-    let expiration_date = if let Some(expiration_date) = context.get_env("AWS_SESSION_EXPIRATION") {
+    let expiration_env_vars = vec!["AWS_SESSION_EXPIRATION", "AWSUME_EXPIRATION"];
+    let expiration_date = if let Some(expiration_date) = expiration_env_vars
+        .iter()
+        .find_map(|env_var| context.get_env(env_var))
+    {
         chrono::DateTime::parse_from_rfc3339(&expiration_date).ok()
     } else {
         let credentials_location = get_credentials_file_path(context)?;

--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -108,7 +108,7 @@ fn get_credentials_duration(context: &Context, aws_profile: Option<&Profile>) ->
             .take_while(|line| !line.starts_with('['))
             .find(|line| line.starts_with("expiration"))?;
 
-        let expiration_date = expiration_date_line.split('=').nth(1)?;
+        let expiration_date = expiration_date_line.split('=').nth(1)?.trim();
         DateTime::parse_from_rfc3339(expiration_date).ok()
     }?;
 

--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -141,7 +141,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let duration = {
         get_credentials_duration(context, aws_profile.as_ref()).map(|duration| {
             if duration > 0 {
-                render_time((duration * 1000) as u128,  false)
+                render_time((duration * 1000) as u128, false)
             } else {
                 config.expiration_symbol.to_string()
             }

--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -138,7 +138,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         None
     };
 
-    let duration = if config.show_duration {
+    let duration = {
         get_credentials_duration(context, aws_profile.as_ref()).map(|duration| {
             if duration > 0 {
                 render_time((duration * 1000) as u128,  false)
@@ -146,8 +146,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 config.expiration_symbol.to_string()
             }
         })
-    } else {
-        None
     };
 
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {

--- a/src/modules/cmd_duration.rs
+++ b/src/modules/cmd_duration.rs
@@ -2,6 +2,7 @@ use super::{Context, Module, RootModuleConfig};
 
 use crate::configs::cmd_duration::CmdDurationConfig;
 use crate::formatter::StringFormatter;
+use crate::utils::render_time;
 
 /// Outputs the time it took the last command to execute
 ///
@@ -48,36 +49,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     });
 
     Some(undistract_me(module, &config, elapsed))
-}
-
-// Render the time into a nice human-readable string
-pub fn render_time(raw_millis: u128, show_millis: bool) -> String {
-    // Calculate a simple breakdown into days/hours/minutes/seconds/milliseconds
-    let (millis, raw_seconds) = (raw_millis % 1000, raw_millis / 1000);
-    let (seconds, raw_minutes) = (raw_seconds % 60, raw_seconds / 60);
-    let (minutes, raw_hours) = (raw_minutes % 60, raw_minutes / 60);
-    let (hours, days) = (raw_hours % 24, raw_hours / 24);
-
-    let components = [days, hours, minutes, seconds];
-    let suffixes = ["d", "h", "m", "s"];
-
-    let mut rendered_components: Vec<String> = components
-        .iter()
-        .zip(&suffixes)
-        .map(render_time_component)
-        .collect();
-    if show_millis || raw_millis < 1000 {
-        rendered_components.push(render_time_component((&millis, &"ms")));
-    }
-    rendered_components.join("")
-}
-
-/// Render a single component of the time string, giving an empty string if component is zero
-fn render_time_component((component, suffix): (&u128, &&str)) -> String {
-    match component {
-        0 => String::new(),
-        n => format!("{}{}", n, suffix),
-    }
 }
 
 #[cfg(not(feature = "notify-rust"))]

--- a/src/modules/cmd_duration.rs
+++ b/src/modules/cmd_duration.rs
@@ -51,7 +51,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 }
 
 // Render the time into a nice human-readable string
-fn render_time(raw_millis: u128, show_millis: bool) -> String {
+pub fn render_time(raw_millis: u128, show_millis: bool) -> String {
     // Calculate a simple breakdown into days/hours/minutes/seconds/milliseconds
     let (millis, raw_seconds) = (raw_millis % 1000, raw_millis / 1000);
     let (seconds, raw_minutes) = (raw_seconds % 60, raw_seconds / 60);

--- a/src/modules/cmd_duration.rs
+++ b/src/modules/cmd_duration.rs
@@ -96,30 +96,8 @@ fn undistract_me<'a, 'b>(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::test::ModuleRenderer;
     use ansi_term::Color;
-
-    #[test]
-    fn test_500ms() {
-        assert_eq!(render_time(500_u128, true), "500ms")
-    }
-    #[test]
-    fn test_10s() {
-        assert_eq!(render_time(10_000_u128, true), "10s")
-    }
-    #[test]
-    fn test_90s() {
-        assert_eq!(render_time(90_000_u128, true), "1m30s")
-    }
-    #[test]
-    fn test_10110s() {
-        assert_eq!(render_time(10_110_000_u128, true), "2h48m30s")
-    }
-    #[test]
-    fn test_1d() {
-        assert_eq!(render_time(86_400_000_u128, true), "1d")
-    }
 
     #[test]
     fn config_blank_duration_1s() {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -382,6 +382,27 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_500ms() {
+        assert_eq!(render_time(500_u128, true), "500ms")
+    }
+    #[test]
+    fn test_10s() {
+        assert_eq!(render_time(10_000_u128, true), "10s")
+    }
+    #[test]
+    fn test_90s() {
+        assert_eq!(render_time(90_000_u128, true), "1m30s")
+    }
+    #[test]
+    fn test_10110s() {
+        assert_eq!(render_time(10_110_000_u128, true), "2h48m30s")
+    }
+    #[test]
+    fn test_1d() {
+        assert_eq!(render_time(86_400_000_u128, true), "1d")
+    }
+
+    #[test]
     fn exec_mocked_command() {
         let result = exec_cmd("dummy_command", &[], Duration::from_millis(500));
         let expected = Some(CommandOutput {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -347,6 +347,36 @@ fn internal_exec_cmd(cmd: &str, args: &[&str], time_limit: Duration) -> Option<C
     }
 }
 
+// Render the time into a nice human-readable string
+pub fn render_time(raw_millis: u128, show_millis: bool) -> String {
+    // Calculate a simple breakdown into days/hours/minutes/seconds/milliseconds
+    let (millis, raw_seconds) = (raw_millis % 1000, raw_millis / 1000);
+    let (seconds, raw_minutes) = (raw_seconds % 60, raw_seconds / 60);
+    let (minutes, raw_hours) = (raw_minutes % 60, raw_minutes / 60);
+    let (hours, days) = (raw_hours % 24, raw_hours / 24);
+
+    let components = [days, hours, minutes, seconds];
+    let suffixes = ["d", "h", "m", "s"];
+
+    let mut rendered_components: Vec<String> = components
+        .iter()
+        .zip(&suffixes)
+        .map(render_time_component)
+        .collect();
+    if show_millis || raw_millis < 1000 {
+        rendered_components.push(render_time_component((&millis, &"ms")));
+    }
+    rendered_components.join("")
+}
+
+/// Render a single component of the time string, giving an empty string if component is zero
+fn render_time_component((component, suffix): (&u128, &&str)) -> String {
+    match component {
+        0 => String::new(),
+        n => format!("{}{}", n, suffix),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
#### Description
This PR adds the possibility to display the remaining duration of temporary AWS credentials in the prompt. The remaining duration is put between brackets after the region in seconds if the credentials are still valid or a customizable symbol if they are expired. 

The duration is retrieved in two different ways :
- by looking at the `AWS_SESSION_EXPIRATION` env variable which is set by `aws-vault` or the `AWSUME_EXPIRATION` which is set by AWsume.
- by looking for a `expiration` line in the profile section in the AWS credentials file (#1978).

#### Motivation and Context
Display remaining duration of the temporary credentials associated to the current profile.
Closes #1978 

#### Screenshots
Valid credentials
![image](https://user-images.githubusercontent.com/55436785/111360197-c0049000-868c-11eb-92d2-33bd7c0f487a.png)

Expired credentials (obviously the symbol could be better)
![image](https://user-images.githubusercontent.com/55436785/111366535-e679f980-8693-11eb-8449-51bb284f30a4.png)

#### How Has This Been Tested?
Added some tests to test the new functionality. I ran `cargo test modules::aws` succesfully.
- [ ] I have tested using **MacOS**
- [X] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [X] I have updated the documentation accordingly.
- [X] I have updated the tests accordingly.
