### PR TITLE
perf(git_status): replace git2 in git status module with git cli

### DIFF
--- a/src/modules/git_status.rs
+++ b/src/modules/git_status.rs
@@ -203,26 +203,6 @@ fn get_repo_status(context: &Context, repo_root: &PathBuf) -> Result<RepoStatus>
     log::debug!("New repo status created");
 
     let mut repo_status = RepoStatus::default();
-    let config_output = context
-        .exec_cmd(
-            "git",
-            &[
-                "-C",
-                &repo_root.to_string_lossy(),
-                "config",
-                "--get",
-                "--local",
-                "status.showUntrackedFiles",
-            ],
-        )
-        .map_or("all".to_owned(), |output| output.stdout);
-
-    let untracked = "--untracked-files=".to_owned()
-        + if !config_output.trim().is_empty() {
-            config_output.trim()
-        } else {
-            "all"
-        };
     let status_output = context
         .exec_cmd(
             "git",
@@ -233,7 +213,6 @@ fn get_repo_status(context: &Context, repo_root: &PathBuf) -> Result<RepoStatus>
                 "--porcelain=2",
                 "--renames",
                 "--branch",
-                &untracked,
             ],
         )
         .ok_or_else(|| Error::new(ErrorKind::NotFound, "git status failed"))?;

--- a/src/modules/git_status.rs
+++ b/src/modules/git_status.rs
@@ -129,7 +129,15 @@ impl<'a> GitStatusInfo<'a> {
     pub fn check_repository(&self) -> Option<bool> {
         let repo_root = self.repo.root.as_ref()?;
         self.context
-            .exec_cmd("git", &["-C", &repo_root.to_string_lossy(), "--no-optional-locks", "status"])
+            .exec_cmd(
+                "git",
+                &[
+                    "-C",
+                    &repo_root.to_string_lossy(),
+                    "--no-optional-locks",
+                    "status",
+                ],
+            )
             .map(|output| output.stderr.trim().is_empty())
     }
 
@@ -234,7 +242,13 @@ fn get_stashed_count(context: &Context, repo_root: &PathBuf) -> std::io::Result<
     let stash_output = context
         .exec_cmd(
             "git",
-            &["-C", &repo_root.to_string_lossy(), "--no-optional-locks", "stash", "list"],
+            &[
+                "-C",
+                &repo_root.to_string_lossy(),
+                "--no-optional-locks",
+                "stash",
+                "list",
+            ],
         )
         .ok_or_else(|| Error::new(ErrorKind::NotFound, "git stash failed"))?;
 

--- a/src/modules/git_status.rs
+++ b/src/modules/git_status.rs
@@ -129,7 +129,7 @@ impl<'a> GitStatusInfo<'a> {
     pub fn check_repository(&self) -> Option<bool> {
         let repo_root = self.repo.root.as_ref()?;
         self.context
-            .exec_cmd("git", &["-C", &repo_root.to_string_lossy(), "status"])
+            .exec_cmd("git", &["-C", &repo_root.to_string_lossy(), "--no-optional-locks", "status"])
             .map(|output| output.stderr.trim().is_empty())
     }
 
@@ -209,6 +209,7 @@ fn get_repo_status(context: &Context, repo_root: &PathBuf) -> Result<RepoStatus>
             &[
                 "-C",
                 &repo_root.to_string_lossy(),
+                "--no-optional-locks",
                 "status",
                 "--porcelain=2",
                 "--renames",
@@ -233,7 +234,7 @@ fn get_stashed_count(context: &Context, repo_root: &PathBuf) -> std::io::Result<
     let stash_output = context
         .exec_cmd(
             "git",
-            &["-C", &repo_root.to_string_lossy(), "stash", "list"],
+            &["-C", &repo_root.to_string_lossy(), "--no-optional-locks", "stash", "list"],
         )
         .ok_or_else(|| Error::new(ErrorKind::NotFound, "git stash failed"))?;
 


### PR DESCRIPTION
#### Description
The git_status module has been rewritten to directly call the git cli using `git status -b --porcelain=2 -uall (etc.)` and `git stash list`.  Specifically, the Repository and Status structs from git2 are no longer used (and therefore git2 isn't used in this module).  They have been "replaced" by passing the repo directory directly to the git commands and the porcelain info is extracted directly to determine necessary information.  The `RepoStatus` struct has been modified with this new method and the `GitStatusInfo` struct has also been slightly tweaked.

**Important** in the contributing guidelines [testing section](https://github.com/starship/starship/blob/master/CONTRIBUTING.md#testing), it mentions placing code in `src/utils.rs` when an external command is being run.  Given the dynamic nature of `git` and the tests of this module, it seemed to me mocking this command when testing would nullify the behavior of the tests in this module.  _I am not 100% sure about this and I want to make sure this gets addressed._

#### Motivation and Context
After using starship on WSL, I noticed substantial performance issues when the `git_status` module was enabled.  I really liked this feature and after some digging I found the below issue that mentions potentially migrating this module from libgit2 - which is slow - to the git cli directly.

This allows one to symlink git.exe in linux and get much better performance in WSL and it sounds like there are also improvements in general.

Closes #1446 

#### Screenshots (if appropriate):
None

#### How Has This Been Tested?
I tested my changes by running `cargo check`, `cargo fmt`, and `cargo test` many times.

I ran the tests many times throughout making these changes on WSL and Windows.  Windows fails but as mentioned below, there were a couple issues that seemed limited to emoji and superuser permissions.  I don't have MacOS, so I cannot test it there :(

Only `src/modules/git_status.rs` has been modified but the issue linked above mentions some git structures already in place.  It may be useful to merge that code with this new code.

- [ ] I have tested using **MacOS**
- [X] I have tested using **Linux** (through WSL)
- [X] I have tested using **Windows** (caveat: some tests failed but these seemed to be related to emoji and superuser permissions)

#### Checklist:
I don't think there are any updates to documentation (that isn't auto-generated) and the tests seem to be working still.  However, please let me know if I am blatantly missing something.
- [X] I have updated the documentation accordingly. (none to update afaik)
- [X] I have updated the tests accordingly.  (none to update afaik but see above note about mocking external git commands)

I haven't submitted any issues, PRs, etc for this project before, I am also new to rust, and this is some of my first activity in an open source project.  Please let me know if there is anything I can improve on and if I have missed anything.