### PR TITLE
fix(gcloud): Activate module only when logged in

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -986,8 +986,9 @@ format = "via [e $version](bold red) "
 
 ## Gcloud
 
-The `gcloud` module shows the current configuration for [`gcloud`](https://cloud.google.com/sdk/gcloud) CLI.
-This is based on the `~/.config/gcloud/active_config` file and the `~/.config/gcloud/configurations/config_{CONFIG NAME}` file and the `CLOUDSDK_CONFIG` env var.
+The `gcloud` module shows the current configuration for [`gcloud`](https://cloud.google.com/sdk/gcloud) CLI when logged in.
+This is based on the `~/.config/gcloud/active_config` file and the `~/.config/gcloud/configurations/config_{CONFIG NAME}`
+file and the `CLOUDSDK_CONFIG` env var.
 
 ### Options
 


### PR DESCRIPTION
#### Description
The way `gcloud` logs you in and out is by setting and revoking a credentials token in the `gcloud` config files. When doing so, `gcloud` already updates the account in the corresponding configuration file, which is what we use in this PR to activate the `starship` module.

#### Motivation and Context

When the GCP credentials are revoked, the default project is still active (the `active_config` is still present). You can't deactive the project through the `gcloud` CLI, `gcloud` assumes there must be always an active project, even when logged out. This can lead to confusing situations like the one described in #2132.

One could argue that you may want to change see the active project even with logged out, but how can we activate the`starship` module if `gcloud` assumes there is always an active project? In practice when dealing with `gcloud`, for most operations you need an active account.

#### How Has This Been Tested?
Aside of the automated tests, I manually checked the prompt shows correctly both when logged in and logged out (credentials revoked), with the default configuration active and an alternative one.

- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.