### PR TITLE
feat(ocaml): add switch variable to ocaml format

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1880,6 +1880,7 @@ By default the module will be shown if any of the following conditions are met:
 | Variable | Example   | Description                          |
 | -------- | --------- | ------------------------------------ |
 | version  | `v4.10.0` | The version of `ocaml`               |
+| switch   | `my-project` | The active `opam` switch             |
 | symbol   |           | Mirrors the value of option `symbol` |
 | style\*  |           | Mirrors the value of option `style`  |
 

--- a/src/modules/ocaml.rs
+++ b/src/modules/ocaml.rs
@@ -235,7 +235,7 @@ mod tests {
                format = "$switch"
             })
             .collect();
-        let expected = Some("test-switch-name".to_string());
+        let expected = Some("my-test.switch".to_string());
         assert_eq!(expected, actual);
         dir.close()
     }

--- a/src/modules/ocaml.rs
+++ b/src/modules/ocaml.rs
@@ -31,16 +31,11 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             })
             .map(|variable| match variable {
                 "switch" => {
-                    let stdout = context.exec_cmd("opam", &["switch", "-s", "show"])?.stdout;
+                    let stdout = context
+                        .exec_cmd("opam", &["switch", "-s", "--safe", "show"])?
+                        .stdout;
                     let switch_raw = stdout.trim();
-                    let path = Path::new(switch_raw);
-                    let normalized = if path.has_root() {
-                        // use named local switch, often prefixed with full path by opam
-                        path.file_name()?.to_str()?
-                    } else {
-                        switch_raw
-                    };
-                    Some(Ok(normalized.to_owned()))
+                    Some(Ok(Path::new(switch_raw).file_name()?.to_str()?.to_owned()))
                 }
                 "version" => {
                     let is_esy_project = context

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -129,7 +129,7 @@ active boot switches: -d:release\n",
             stdout: String::from("4.10.0\n"),
             stderr: String::default(),
         }),
-        "opam switch -s show" => Some(CommandOutput {
+        "opam switch -s --safe show" => Some(CommandOutput {
           stdout: String::from("/path/to/my-test.switch\n"),
           stderr: String::default(),
       }),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -130,7 +130,7 @@ active boot switches: -d:release\n",
             stderr: String::default(),
         }),
         "opam switch -s show" => Some(CommandOutput {
-          stdout: String::from("test-switch-name\n"),
+          stdout: String::from("/path/to/my-test.switch\n"),
           stderr: String::default(),
       }),
         "esy ocaml -vnum" => Some(CommandOutput {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -129,6 +129,10 @@ active boot switches: -d:release\n",
             stdout: String::from("4.10.0\n"),
             stderr: String::default(),
         }),
+        "opam switch -s show" => Some(CommandOutput {
+          stdout: String::from("test-switch-name\n"),
+          stderr: String::default(),
+      }),
         "esy ocaml -vnum" => Some(CommandOutput {
             stdout: String::from("4.08.1\n"),
             stderr: String::default(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description

- support rendering the opam `switch`

#### Motivation and Context

- `switch` to me is more useful than ocaml `version`. i suspect users of local switches also would desire to see their switch vs ocaml version

#### Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/1003261/111840917-61245e00-88ba-11eb-99f6-3c111577c6da.png)

#### How Has This Been Tested?

1. installed my binary locally, ran it
2. unit test

- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
