### PR TITLE
feat(status): Add pipestatus display in status module

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2632,6 +2632,7 @@ This module is not supported on elvish shell.
 | ------------------------- | ----------------------------- | ------------------------------------------------------ |
 | `format`                  | `"[$symbol$status]($style) "` | The format of the module                               |
 | `symbol`                  | `"✖"`                         | The symbol displayed on program error                  |
+| `success_symbol`          | `"✔️"`                         | The symbol displayed on program success                |
 | `not_executable_symbol`   | `"🚫"`                        | The symbol displayed when file isn't executable        |
 | `not_found_symbol`        | `"🔍"`                        | The symbol displayed when the command can't be found   |
 | `sigint_symbol`           | `"🧱"`                        | The symbol displayed on SIGINT (Ctrl + c)              |
@@ -2639,6 +2640,9 @@ This module is not supported on elvish shell.
 | `style`                   | `"bold red"`                  | The style for the module.                              |
 | `recognize_signal_code`   | `true`                        | Enable signal mapping from exit code                   |
 | `map_symbol`              | `false`                       | Enable symbols mapping from exit code                  |
+| `pipestatus`              | `false`                       | Enable pipestatus reporting                            |
+| `pipestatus_separator`    | `|`                           | The symbol that separate in pipe program exit codes    |
+| `pipestatus_format`       | `\\[$pipestatus\\] => [$symbol$common_meaning$signal_name$maybe_int]($style)`  | The format of the module when the command is a pipeline |
 | `disabled`                | `true`                        | Disables the `status` module.                          |
 
 ### Variables
@@ -2651,6 +2655,7 @@ This module is not supported on elvish shell.
 | signal_number           | `9`     | Signal number corresponding to the exit code, only if signalled         |
 | signal_name             | `KILL`  | Name of the signal corresponding to the exit code, only if signalled    |
 | maybe_int               | `7`     | Contains the exit code number when no meaning has been found            |
+| pipestatus              |         | Rendering of in pipeline programs's exit codes, this is only available in pipestatus_format |
 | symbol                  |         | Mirrors the value of option `symbol`                                    |
 | style\*                 |         | Mirrors the value of option `style`                                     |
 

--- a/src/configs/status.rs
+++ b/src/configs/status.rs
@@ -7,6 +7,7 @@ use starship_module_config_derive::ModuleConfig;
 pub struct StatusConfig<'a> {
     pub format: &'a str,
     pub symbol: &'a str,
+    pub sucess_symbol: &'a str,
     pub not_executable_symbol: &'a str,
     pub not_found_symbol: &'a str,
     pub sigint_symbol: &'a str,
@@ -14,6 +15,9 @@ pub struct StatusConfig<'a> {
     pub style: &'a str,
     pub map_symbol: bool,
     pub recognize_signal_code: bool,
+    pub pipestatus: bool,
+    pub pipestatus_separator: &'a str,
+    pub pipestatus_format: &'a str,
     pub disabled: bool,
 }
 
@@ -22,6 +26,7 @@ impl<'a> Default for StatusConfig<'a> {
         StatusConfig {
             format: "[$symbol$status]($style) ",
             symbol: "✖",
+            sucess_symbol: "🟢",
             not_executable_symbol: "🚫",
             not_found_symbol: "🔍",
             sigint_symbol: "🧱",
@@ -29,6 +34,10 @@ impl<'a> Default for StatusConfig<'a> {
             style: "bold red",
             map_symbol: false,
             recognize_signal_code: true,
+            pipestatus: true,
+            pipestatus_separator: "|",
+            pipestatus_format:
+                "\\[$pipestatus\\] => [$symbol$common_meaning$signal_name$maybe_int]($style)",
             disabled: true,
         }
     }

--- a/src/configs/status.rs
+++ b/src/configs/status.rs
@@ -7,7 +7,7 @@ use starship_module_config_derive::ModuleConfig;
 pub struct StatusConfig<'a> {
     pub format: &'a str,
     pub symbol: &'a str,
-    pub sucess_symbol: &'a str,
+    pub success_symbol: &'a str,
     pub not_executable_symbol: &'a str,
     pub not_found_symbol: &'a str,
     pub sigint_symbol: &'a str,
@@ -26,7 +26,7 @@ impl<'a> Default for StatusConfig<'a> {
         StatusConfig {
             format: "[$symbol$status]($style) ",
             symbol: "✖",
-            sucess_symbol: "✔️",
+            success_symbol: "✔️",
             not_executable_symbol: "🚫",
             not_found_symbol: "🔍",
             sigint_symbol: "🧱",

--- a/src/configs/status.rs
+++ b/src/configs/status.rs
@@ -26,7 +26,7 @@ impl<'a> Default for StatusConfig<'a> {
         StatusConfig {
             format: "[$symbol$status]($style) ",
             symbol: "✖",
-            sucess_symbol: "🟢",
+            sucess_symbol: "✔️",
             not_executable_symbol: "🚫",
             not_found_symbol: "🔍",
             sigint_symbol: "🧱",
@@ -34,7 +34,7 @@ impl<'a> Default for StatusConfig<'a> {
             style: "bold red",
             map_symbol: false,
             recognize_signal_code: true,
-            pipestatus: true,
+            pipestatus: false,
             pipestatus_separator: "|",
             pipestatus_format:
                 "\\[$pipestatus\\] => [$symbol$common_meaning$signal_name$maybe_int]($style)",

--- a/src/init/starship.bash
+++ b/src/init/starship.bash
@@ -30,6 +30,9 @@ starship_preexec() {
 starship_precmd() {
     # Save the status, because commands in this pipeline will change $?
     STARSHIP_CMD_STATUS=$? STARSHIP_PIPE_STATUS=(${PIPESTATUS[@]})
+    if [[ "${#BP_PIPESTATUS[@]}" -gt "${#STARSHIP_PIPE_STATUS[@]}" ]]; then
+        STARSHIP_PIPE_STATUS=(${BP_PIPESTATUS[@]})
+    fi
 
     local NUM_JOBS=0
     # Evaluate the number of jobs before running the preseved prompt command, so that tools

--- a/src/init/starship.bash
+++ b/src/init/starship.bash
@@ -29,7 +29,7 @@ starship_preexec() {
 # Will be run before the prompt is drawn
 starship_precmd() {
     # Save the status, because commands in this pipeline will change $?
-    STARSHIP_CMD_STATUS=$?
+    STARSHIP_CMD_STATUS=$? STARSHIP_PIPE_STATUS=(${PIPESTATUS[@]})
 
     local NUM_JOBS=0
     # Evaluate the number of jobs before running the preseved prompt command, so that tools
@@ -46,10 +46,10 @@ starship_precmd() {
     if [[ $STARSHIP_START_TIME ]]; then
         STARSHIP_END_TIME=$(::STARSHIP:: time)
         STARSHIP_DURATION=$((STARSHIP_END_TIME - STARSHIP_START_TIME))
-        PS1="$(::STARSHIP:: prompt --status=$STARSHIP_CMD_STATUS --jobs="$NUM_JOBS" --cmd-duration=$STARSHIP_DURATION)"
+        PS1="$(::STARSHIP:: prompt --status=$STARSHIP_CMD_STATUS  --pipestatus ${STARSHIP_PIPE_STATUS[@]} --jobs="$NUM_JOBS" --cmd-duration=$STARSHIP_DURATION)"
         unset STARSHIP_START_TIME
     else
-        PS1="$(::STARSHIP:: prompt --status=$STARSHIP_CMD_STATUS --jobs="$NUM_JOBS")"
+        PS1="$(::STARSHIP:: prompt --status=$STARSHIP_CMD_STATUS --pipestatus ${STARSHIP_PIPE_STATUS[@]} --jobs="$NUM_JOBS")"
     fi
     STARSHIP_PREEXEC_READY=true  # Signal that we can safely restart the timer
 }

--- a/src/init/starship.fish
+++ b/src/init/starship.fish
@@ -8,7 +8,7 @@ function fish_prompt
     set STARSHIP_CMD_STATUS $status
     # Account for changes in variable name between v2.7 and v3.0
     set STARSHIP_DURATION "$CMD_DURATION$cmd_duration"
-    ::STARSHIP:: prompt --status=$STARSHIP_CMD_STATUS --keymap=$STARSHIP_KEYMAP --cmd-duration=$STARSHIP_DURATION --jobs=(count (jobs -p))
+    ::STARSHIP:: prompt --status=$STARSHIP_CMD_STATUS --pipestatus=$pipestatus --keymap=$STARSHIP_KEYMAP --cmd-duration=$STARSHIP_DURATION --jobs=(count (jobs -p))
 end
 
 # Disable virtualenv prompt, it breaks starship

--- a/src/init/starship.zsh
+++ b/src/init/starship.zsh
@@ -26,7 +26,7 @@ fi
 # Will be run before every prompt draw
 starship_precmd() {
     # Save the status, because commands in this pipeline will change $?
-    STARSHIP_CMD_STATUS=$?
+    STARSHIP_CMD_STATUS=$? STARSHIP_PIPE_STATUS=(${pipestatus[@]})
 
     # Compute cmd_duration, if we have a time to consume, otherwise clear the
     # previous duration
@@ -91,4 +91,4 @@ export STARSHIP_SESSION_KEY=${STARSHIP_SESSION_KEY:0:16}; # Trim to 16-digits if
 VIRTUAL_ENV_DISABLE_PROMPT=1
 
 setopt promptsubst
-PROMPT='$(::STARSHIP:: prompt --keymap="$KEYMAP" --status="$STARSHIP_CMD_STATUS" --cmd-duration="$STARSHIP_DURATION" --jobs="$STARSHIP_JOBS_COUNT")'
+PROMPT='$(::STARSHIP:: prompt --keymap="$KEYMAP" --status="$STARSHIP_CMD_STATUS" --pipestatus ${STARSHIP_PIPE_STATUS[@]} --cmd-duration="$STARSHIP_DURATION" --jobs="$STARSHIP_JOBS_COUNT")'

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,13 @@ fn main() {
         .help("The status code of the previously run command")
         .takes_value(true);
 
+    let pipestatus_arg = Arg::with_name("pipestatus")
+        .long("pipestatus")
+        .value_name("PIPESTATUS")
+        .help("Status codes from a command pipeline")
+        .long_help("Bash and Zsh supports returning codes for each process in a pipeline.")
+        .multiple(true);
+
     let path_arg = Arg::with_name("path")
         .short("p")
         .long("path")
@@ -91,6 +98,7 @@ fn main() {
             SubCommand::with_name("prompt")
                 .about("Prints the full starship prompt")
                 .arg(&status_code_arg)
+                .arg(&pipestatus_arg)
                 .arg(&path_arg)
                 .arg(&logical_path_arg)
                 .arg(&cmd_duration_arg)
@@ -113,6 +121,7 @@ fn main() {
                         .help("List out all supported modules"),
                 )
                 .arg(&status_code_arg)
+                .arg(&pipestatus_arg)
                 .arg(&path_arg)
                 .arg(&logical_path_arg)
                 .arg(&cmd_duration_arg)

--- a/src/modules/status.rs
+++ b/src/modules/status.rs
@@ -119,7 +119,7 @@ fn format_exit_code<'a>(
         formatter
             .map_meta(|var, _| match var {
                 "symbol" => match exit_code_int {
-                    0 => Some(config.sucess_symbol),
+                    0 => Some(config.success_symbol),
                     126 if config.map_symbol => Some(config.not_executable_symbol),
                     127 if config.map_symbol => Some(config.not_found_symbol),
                     130 if config.recognize_signal_code && config.map_symbol => {
@@ -431,7 +431,7 @@ mod tests {
                     [status]
                     format = "$symbol"
                     symbol = "🔴"
-                    sucess_symbol = "🟢"
+                    success_symbol = "🟢"
                     not_executable_symbol = "🚫"
                     not_found_symbol = "🔍"
                     sigint_symbol = "🧱"
@@ -475,7 +475,7 @@ mod tests {
                     [status]
                     format = "$symbol$int$signal_number"
                     symbol = "🔴"
-                    sucess_symbol = "🟢"
+                    success_symbol = "🟢"
                     not_executable_symbol = "🚫"
                     not_found_symbol = "🔍"
                     sigint_symbol = "🧱"
@@ -514,7 +514,7 @@ mod tests {
                     [status]
                     format = "F $symbol"
                     symbol = "🔴"
-                    sucess_symbol = "🟢"
+                    success_symbol = "🟢"
                     not_executable_symbol = "🚫"
                     not_found_symbol = "🔍"
                     sigint_symbol = "🧱"
@@ -554,7 +554,7 @@ mod tests {
                     [status]
                     format = "$symbol$maybe_int"
                     symbol = "🔴"
-                    sucess_symbol = "🟢"
+                    success_symbol = "🟢"
                     not_executable_symbol = "🚫"
                     not_found_symbol = "🔍"
                     sigint_symbol = "🧱"

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -130,6 +130,11 @@ impl<'a> ModuleRenderer<'a> {
         self
     }
 
+    pub fn pipestatus(mut self, status: &[i32]) -> Self {
+        self.context.pipestatus = Some(status.iter().map(|i| i.to_string()).collect());
+        self
+    }
+
     /// Renders the module returning its output
     pub fn collect(self) -> Option<String> {
         let ret = crate::print::get_module(self.name, self.context);


### PR DESCRIPTION

Take pipeline_status variable and format values in the prompt

#### Description
Bash and Zsh provide pipeline_status variable that contains exit code of processes in a pipe

#### Motivation and Context
It can be helpful to know the per-process exit code in a pipeline in order to know where a pipeline failed

This MR is based on this one https://github.com/starship/starship/pull/370
And closes this issue #1669 
It's also the continuation of this work https://github.com/starship/starship/pull/1948

#### Screenshots (if appropriate):
Sample outpout
![Screenshot_20210613_113247](https://user-images.githubusercontent.com/2104672/121802088-19a03a80-cc3b-11eb-9c63-5d806ba100db.png)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
- [x] Zsh support 
- [x] Fish support 
- [x] bash preexec https://github.com/rcaloras/bash-preexec/blob/master/bash-preexec.sh#L46
