### PR TITLE
docs(faq): make uninstall instructions shell-independent

### DIFF
--- a/docs/faq/README.md
+++ b/docs/faq/README.md
@@ -101,5 +101,5 @@ If Starship was installed using the `curl | bash` script, the following command 
 
 ```sh
 # Locate and delete the starship binary
-rm "$(which starship)"
+bash -c 'rm "$(which starship)"'
 ```


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description

The uninstall instructions assume that the user is running Bash, which is a safe bet, but isn't always the case.

#### Motivation and Context

This change wraps the uninstall command in `bash -c`, making it shell-independent in most cases. It will close issue #2484.

Closes #2484

#### Screenshots (if appropriate):

N/A

#### How Has This Been Tested?

I ran `bash -c 'rm "$(which starship)"'` to uninstall Starship, and it worked, even though I'm using Fish as my shell (this is good).

- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**


#### Checklist:

- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
