### PR TITLE
fix(shell): Support conditional format strings for `$indicator`

### DIFF
--- a/src/modules/shell.rs
+++ b/src/modules/shell.rs
@@ -28,6 +28,16 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 },
                 _ => None,
             })
+            .map(|var| match var {
+                "bash_indicator" => Some(Ok(config.bash_indicator)),
+                "fish_indicator" => Some(Ok(config.fish_indicator)),
+                "zsh_indicator" => Some(Ok(config.zsh_indicator)),
+                "powershell_indicator" => Some(Ok(config.powershell_indicator)),
+                "ion_indicator" => Some(Ok(config.ion_indicator)),
+                "elvish_indicator" => Some(Ok(config.elvish_indicator)),
+                "tcsh_indicator" => Some(Ok(config.tcsh_indicator)),
+                _ => None,
+            })
             .parse(None)
     });
 
@@ -231,6 +241,38 @@ mod tests {
             .config(toml::toml! {
                 [shell]
                 elvish_indicator = "[elvish](bold cyan)"
+                disabled = false
+            })
+            .collect();
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn test_custom_format_conditional_indicator_match() {
+        let expected = Some(format!("{} ", "B"));
+        let actual = ModuleRenderer::new("shell")
+            .shell(Shell::Bash)
+            .config(toml::toml! {
+                [shell]
+                bash_indicator = "B"
+                format = "($bash_indicator )"
+                disabled = false
+            })
+            .collect();
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn test_custom_format_conditional_indicator_no_match() {
+        let expected = None;
+        let actual = ModuleRenderer::new("shell")
+            .shell(Shell::Fish)
+            .config(toml::toml! {
+                [shell]
+                bash_indicator = "B"
+                format = "($indicator )"
                 disabled = false
             })
             .collect();


### PR DESCRIPTION
#### Description
<!--- Describe your changes in detail -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Previously attempting to use conditional format strings with `$indicator` would never display an indicator, e.g.:

```toml
[shell]
fish_indicator = ""
bash_indicator = "B "
format = "($indicator )"
disabled = false
```

This would always display an empty string. With this patch, this displays `B ` on bash and nothing on fish, as intended.

Closes #2474.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.