### PR TITLE
test(directory): fix on windows without admin

### DIFF
--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -683,14 +683,14 @@ mod tests {
 
     #[test]
     fn root_directory() {
-        let actual = ModuleRenderer::new("directory").path("/").collect();
-        #[cfg(not(target_os = "windows"))]
-        let expected = Some(format!(
-            "{}{} ",
-            Color::Cyan.bold().paint("/"),
-            Color::Red.normal().paint("🔒")
-        ));
-        #[cfg(target_os = "windows")]
+        let actual = ModuleRenderer::new("directory")
+            .config(toml::toml! {
+                [directory]
+                read_only = ""
+                read_only_style = ""
+            })
+            .path("/")
+            .collect();
         let expected = Some(format!("{} ", Color::Cyan.bold().paint("/")));
 
         assert_eq!(expected, actual);
@@ -1466,6 +1466,8 @@ mod tests {
                 [directory]
                 use_logical_path = false
                 truncation_length = 0
+                read_only = ""
+                read_only_style = ""
             })
             .path(sys32_path)
             .collect();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Some of the tests in the directory module caused the read_only symbol to show up when not run as admin on windows. Handle this by disabling the module in the tests that triggered this for me.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
