### PR TITLE
feat(ocaml): add `switch_indicator` and `switch_name` variable

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1876,11 +1876,12 @@ By default the module will be shown if any of the following conditions are met:
 
 ### Variables
 
-| Variable | Example   | Description                          |
-| -------- | --------- | ------------------------------------ |
-| version  | `v4.10.0` | The version of `ocaml`               |
-| symbol   |           | Mirrors the value of option `symbol` |
-| style\*  |           | Mirrors the value of option `style`  |
+| Variable | Example      | Description                          |
+| -------- | ------------ | ------------------------------------ |
+| version  | `v4.10.0`    | The version of `ocaml`               |
+| switch   | `my-project` | The active `opam` switch             |
+| symbol   |              | Mirrors the value of option `symbol` |
+| style\*  |              | Mirrors the value of option `style`  |
 
 \*: This variable can only be used as a part of a style string
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1864,24 +1864,27 @@ By default the module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Option              | Default                              | Description                                             |
-| ------------------- | ------------------------------------ | ------------------------------------------------------- |
-| `format`            | `"via [$symbol($version )]($style)"` | The format string for the module.                       |
-| `symbol`            | `"🐫 "`                              | The symbol used before displaying the version of OCaml. |
-| `detect_extensions` | `["opam", "ml", "mli", "re", "rei"]` | Which extensions should trigger this module.            |
-| `detect_files`      | `["dune", "dune-project", "jbuild", "jbuild-ignore", ".merlin"]` | Which filenames should trigger this module. |
-| `detect_folders`    | `["_opam", "esy.lock"]`              | Which folders should trigger this module.               |
-| `style`             | `"bold yellow"`                      | The style for the module.                               |
-| `disabled`          | `false`                              | Disables the `ocaml` module.                            |
+| Option                    | Default                                                                  | Description                                             |
+| ------------------------- | ------------------------------------------------------------------------ | ------------------------------------------------------- |
+| `format`                  | `"via [$symbol($version )(\($switch_indicator$switch_name\) )]($style)"` | The format string for the module.                       |
+| `symbol`                  | `"🐫 "`                                                                  | The symbol used before displaying the version of OCaml. |
+| `global_switch_indicator` | `""`                                                                     | The format string used to represent global OPAM switch. |
+| `local_switch_indicator`  | `"*"`                                                                    | The format string used to represent local OPAM switch.  |
+| `detect_extensions`       | `["opam", "ml", "mli", "re", "rei"]`                                     | Which extensions should trigger this module.            |
+| `detect_files`            | `["dune", "dune-project", "jbuild", "jbuild-ignore", ".merlin"]`         | Which filenames should trigger this module.             |
+| `detect_folders`          | `["_opam", "esy.lock"]`                                                  | Which folders should trigger this module.               |
+| `style`                   | `"bold yellow"`                                                          | The style for the module.                               |
+| `disabled`                | `false`                                                                  | Disables the `ocaml` module.                            |
 
 ### Variables
 
-| Variable | Example      | Description                          |
-| -------- | ------------ | ------------------------------------ |
-| version  | `v4.10.0`    | The version of `ocaml`               |
-| switch   | `my-project` | The active `opam` switch             |
-| symbol   |              | Mirrors the value of option `symbol` |
-| style\*  |              | Mirrors the value of option `style`  |
+| Variable         | Example      | Description                                                       |
+| ---------------- | ------------ | ----------------------------------------------------------------- |
+| version          | `v4.10.0`    | The version of `ocaml`                                            |
+| switch_name      | `my-project` | The active OPAM switch                                            |
+| switch_indicator |              | Mirrors the value of `indicator` for currently active OPAM switch |
+| symbol           |              | Mirrors the value of option `symbol`                              |
+| style\*          |              | Mirrors the value of option `style`                               |
 
 \*: This variable can only be used as a part of a style string
 

--- a/src/configs/ocaml.rs
+++ b/src/configs/ocaml.rs
@@ -4,6 +4,8 @@ use starship_module_config_derive::ModuleConfig;
 
 #[derive(Clone, ModuleConfig)]
 pub struct OCamlConfig<'a> {
+    pub global_switch_indicator: &'a str,
+    pub local_switch_indicator: &'a str,
     pub format: &'a str,
     pub symbol: &'a str,
     pub style: &'a str,
@@ -16,7 +18,9 @@ pub struct OCamlConfig<'a> {
 impl<'a> Default for OCamlConfig<'a> {
     fn default() -> Self {
         OCamlConfig {
-            format: "via [$symbol($version )]($style)",
+            global_switch_indicator: "",
+            local_switch_indicator: "*",
+            format: "via [$symbol($version )(\\($switch_indicator$switch_name\\) )]($style)",
             symbol: "🐫 ",
             style: "bold yellow",
             disabled: false,

--- a/src/modules/ocaml.rs
+++ b/src/modules/ocaml.rs
@@ -11,6 +11,7 @@ enum SwitchType {
     Global,
     Local,
 }
+type OpamSwitch = (SwitchType, String);
 
 /// Creates a module with the current OCaml version
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
@@ -27,7 +28,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         return None;
     }
 
-    let opam_switch: Lazy<Option<(SwitchType, String)>, _> = Lazy::new(|| get_opam_switch(context));
+    let opam_switch: Lazy<Option<OpamSwitch>, _> = Lazy::new(|| get_opam_switch(context));
 
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter
@@ -80,7 +81,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     Some(module)
 }
 
-fn get_opam_switch(context: &Context) -> Option<(SwitchType, String)> {
+fn get_opam_switch(context: &Context) -> Option<OpamSwitch> {
     let opam_switch = context
         .exec_cmd("opam", &["switch", "show", "--safe"])?
         .stdout;
@@ -88,7 +89,7 @@ fn get_opam_switch(context: &Context) -> Option<(SwitchType, String)> {
     parse_opam_switch(&opam_switch.trim())
 }
 
-fn parse_opam_switch(opam_switch: &str) -> Option<(SwitchType, String)> {
+fn parse_opam_switch(opam_switch: &str) -> Option<OpamSwitch> {
     let path = Path::new(opam_switch);
     if !path.has_root() {
         Some((SwitchType::Global, opam_switch.to_string()))

--- a/src/modules/ocaml.rs
+++ b/src/modules/ocaml.rs
@@ -90,6 +90,10 @@ fn get_opam_switch(context: &Context) -> Option<OpamSwitch> {
 }
 
 fn parse_opam_switch(opam_switch: &str) -> Option<OpamSwitch> {
+    if opam_switch.is_empty() {
+        return None;
+    }
+
     let path = Path::new(opam_switch);
     if !path.has_root() {
         Some((SwitchType::Global, opam_switch.to_string()))
@@ -297,6 +301,26 @@ mod tests {
             "via {}",
             Color::Yellow.bold().paint("🐫 v4.10.0 (default) ")
         ));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn without_opam_switch() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join("any.ml"))?.sync_all()?;
+
+        let actual = ModuleRenderer::new("ocaml")
+            .cmd(
+                "opam switch show --safe",
+                Some(CommandOutput {
+                    stdout: String::default(),
+                    stderr: String::default(),
+                }),
+            )
+            .path(dir.path())
+            .collect();
+        let expected = Some(format!("via {}", Color::Yellow.bold().paint("🐫 v4.10.0 ")));
         assert_eq!(expected, actual);
         dir.close()
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -129,6 +129,10 @@ active boot switches: -d:release\n",
             stdout: String::from("4.10.0\n"),
             stderr: String::default(),
         }),
+        "opam switch show --safe" => Some(CommandOutput {
+            stdout: String::from("default\n"),
+            stderr: String::default(),
+        }),
         "esy ocaml -vnum" => Some(CommandOutput {
             stdout: String::from("4.08.1\n"),
             stderr: String::default(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Support displaying OPAM switch with configurable global/local indicator. As suggested by OPAM authors: https://opam.ocaml.org/doc/Tricks.html#Display-the-current-quot-opam-switch-quot-in-the-prompt

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #2479
Detailed explanation: https://github.com/starship/starship/pull/2479#issuecomment-805504311

#### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1170440/112431926-6d883b00-8d40-11eb-8b77-05a353c9c1ac.png)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.

---

@cdaringe I reused your initial commit. Please feel free to improve it with your suggestions! :wink: 
