### PR TITLE
docs: fix typo `moudle` -> `module`

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -458,7 +458,7 @@ the module will be activated if any of the following conditions are met:
 | ------------------- | -------------------------------------- | -------------------------------------------- |
 | `format`            | `"via [$symbol($version )]($style)"`   | The format for the module.                   |
 | `symbol`            | `"△ "`                                | The symbol used before the version of cmake. |
-| `detect_extensions` | `[]`                                   | Which extensions should trigger this moudle  |
+| `detect_extensions` | `[]`                                   | Which extensions should trigger this module  |
 | `detect_files`      | `["CMakeLists.txt", "CMakeCache.txt"]` | Which filenames should trigger this module   |
 | `detect_folders`    | `[]`                                   | Which folders should trigger this module     |
 | `style`             | `"bold blue"`                          | The style for the module.                    |
@@ -624,7 +624,7 @@ By default the module will be shown if any of the following conditions are met:
 | ------------------- | ------------------------------------------------- | ----------------------------------------------- |
 | `format`            | `"via [$symbol($version )]($style)"`              | The format for the module.                      |
 | `symbol`            | `"🎯 "`                                           | A format string representing the symbol of Dart |
-| `detect_extensions` | `['dart']`                                        | Which extensions should trigger this moudle.    |
+| `detect_extensions` | `['dart']`                                        | Which extensions should trigger this module.    |
 | `detect_files`      | `["pubspec.yaml", "pubspec.yml", "pubspec.lock"]` | Which filenames should trigger this module.     |
 | `detect_folders`    | `[".dart_tool"]`                                  | Which folders should trigger this module.       |
 | `style`             | `"bold blue"`                                     | The style for the module.                       |
@@ -1266,7 +1266,7 @@ By default the module will be shown if any of the following conditions are met:
 | -------------------- | ------------------------------------------------------------------------------ | ---------------------------------------------- |
 | `format`             | `"via [$symbol($version )]($style)"`                                           | The format for the module.                     |
 | `symbol`             | `"🐹 "`                                                                        | A format string representing the symbol of Go. |
-| `detect_extensions`  | `["go"]`                                                                       | Which extensions should trigger this moudle.   |
+| `detect_extensions`  | `["go"]`                                                                       | Which extensions should trigger this module.   |
 | `detect_files`       | `["go.mod", "go.sum", "glide.yaml", "Gopkg.yml", "Gopkg.lock", ".go-version"]` | Which filenames should trigger this module.    |
 | `detect_folders`     | `["Godeps"]`                                                                   | Which folders should trigger this module.      |
 | `style`              | `"bold cyan"`                                                                  | The style for the module.                      |
@@ -1615,7 +1615,7 @@ By default the module will be shown if any of the following conditions are met:
 | ------------------- | ------------------------------------ | ----------------------------------------------------------------------------- |
 | `format`            | `"via [$symbol($version )]($style)"` | The format for the module.                                                    |
 | `symbol`            | `"🌙 "`                              | A format string representing the symbol of Lua.                               |
-| `detect_extensions` | `["lua"]`                            | Which extensions should trigger this moudle.                                  |
+| `detect_extensions` | `["lua"]`                            | Which extensions should trigger this module.                                  |
 | `detect_files`      | `[".lua-version"]`                   | Which filenames should trigger this module.                                   |
 | `detect_folders`    | `["lua"]`                            | Which folders should trigger this module.                                     |
 | `style`             | `"bold blue"`                        | The style for the module.                                                     |
@@ -1742,7 +1742,7 @@ By default the module will be shown if any of the following conditions are met:
 | -------------------- | ------------------------------------ | ----------------------------------------------------- |
 | `format`             | `"via [$symbol($version )]($style)"` | The format for the module                             |
 | `symbol`             | `"👑 "`                              | The symbol used before displaying the version of Nim. |
-| `detect_extensions`  | `["nim", "nims", "nimble"]`          | Which extensions should trigger this moudle.          |
+| `detect_extensions`  | `["nim", "nims", "nimble"]`          | Which extensions should trigger this module.          |
 | `detect_files`       | `["nim.cfg"]`                        | Which filenames should trigger this module.           |
 | `detect_folders`     | `[]`                                 | Which folders should trigger this module.             |
 | `style`              | `"bold yellow"`                      | The style for the module.                             |
@@ -1824,7 +1824,7 @@ By default the module will be shown if any of the following conditions are met:
 | ------------------- | ------------------------------------ | -------------------------------------------------- |
 | `format`            | `"via [$symbol($version )]($style)"` | The format for the module.                         |
 | `symbol`            | `" "`                               | A format string representing the symbol of NodeJS. |
-| `detect_extensions` | `["js", "mjs", "cjs", "ts"]`         | Which extensions should trigger this moudle.       |
+| `detect_extensions` | `["js", "mjs", "cjs", "ts"]`         | Which extensions should trigger this module.       |
 | `detect_files`      | `["package.json", ".node-version"]`  | Which filenames should trigger this module.        |
 | `detect_folders`    | `["node_modules"]`                   | Which folders should trigger this module.          |
 | `style`             | `"bold green"`                       | The style for the module.                          |
@@ -1868,7 +1868,7 @@ By default the module will be shown if any of the following conditions are met:
 | ------------------- | ------------------------------------ | ------------------------------------------------------- |
 | `format`            | `"via [$symbol($version )]($style)"` | The format string for the module.                       |
 | `symbol`            | `"🐫 "`                              | The symbol used before displaying the version of OCaml. |
-| `detect_extensions` | `["opam", "ml", "mli", "re", "rei"]` | Which extensions should trigger this moudle.            |
+| `detect_extensions` | `["opam", "ml", "mli", "re", "rei"]` | Which extensions should trigger this module.            |
 | `detect_files`      | `["dune", "dune-project", "jbuild", "jbuild-ignore", ".merlin"]` | Which filenames should trigger this module. |
 | `detect_folders`    | `["_opam", "esy.lock"]`              | Which folders should trigger this module.               |
 | `style`             | `"bold yellow"`                      | The style for the module.                               |
@@ -2001,7 +2001,7 @@ By default the module will be shown if any of the following conditions are met:
 | -------------------- | ------------------------------------ | ----------------------------------------------------- |
 | `format`             | `"via [$symbol($version )]($style)"` | The format string for the module.                     |
 | `symbol`             | `"🐪 "`                              | The symbol used before displaying the version of Perl |
-| `detect_extensions`  | `["pl", "pm", "pod"]`                | Which extensions should trigger this moudle.          |
+| `detect_extensions`  | `["pl", "pm", "pod"]`                | Which extensions should trigger this module.          |
 | `detect_files`       | `["Makefile.PL", "Build.PL", "cpanfile", "cpanfile.snapshot", "META.json", "META.yml", ".perl-version"]` | Which filenames should trigger this module. |
 | `detect_folders`     | `[]`                                 | Which folders should trigger this module.             |
 | `style`              | `"bold 149"`                         | The style for the module.                             |
@@ -2039,7 +2039,7 @@ By default the module will be shown if any of the following conditions are met:
 | -------------------- | ------------------------------------ | ----------------------------------------------------- |
 | `format`             | `"via [$symbol($version )]($style)"` | The format for the module.                            |
 | `symbol`             | `"🐘 "`                              | The symbol used before displaying the version of PHP. |
-| `detect_extensions`  | `["php"]`                            | Which extensions should trigger this moudle.          |
+| `detect_extensions`  | `["php"]`                            | Which extensions should trigger this module.          |
 | `detect_files`       | `["composer.json", ".php-version"]`  | Which filenames should trigger this module.           |
 | `detect_folders`     | `[]`                                 | Which folders should trigger this module.             |
 | `style`              | `"147 bold"`                         | The style for the module.                             |
@@ -2078,7 +2078,7 @@ By default the module will be shown if any of the following conditions are met:
 | -------------------- | ------------------------------------ | ------------------------------------------------------------ |
 | `format`             | `"via [$symbol($version )]($style)"` | The format for the module.                                   |
 | `symbol`             | `"<=> "`                             | The symbol used before displaying the version of PureScript. |
-| `detect_extensions`  | `["purs"]`                           | Which extensions should trigger this moudle.                 |
+| `detect_extensions`  | `["purs"]`                           | Which extensions should trigger this module.                 |
 | `detect_files`       | `["spago.dhall"]`                    | Which filenames should trigger this module.                  |
 | `detect_folders`     | `[]`                                 | Which folders should trigger this module.                    |
 | `style`              | `"bold white"`                       | The style for the module.                                    |
@@ -2133,7 +2133,7 @@ By default the module will be shown if any of the following conditions are met:
 | `pyenv_version_name` | `false`                                                                                                      | Use pyenv to get Python version                                                        |
 | `pyenv_prefix`       | `pyenv `                                                                                                     | Prefix before pyenv version display, only used if pyenv is used                        |
 | `python_binary`      | `["python", "python3, "python2"]`                                                                            | Configures the python binaries that Starship should executes when getting the version. |
-| `detect_extensions`  | `[".py"]`                                                                                                    | Which extensions should trigger this moudle                                            |
+| `detect_extensions`  | `[".py"]`                                                                                                    | Which extensions should trigger this module                                            |
 | `detect_files`       | `[".python-version", "Pipfile", "__init__.py", "pyproject.toml", "requirements.txt", "setup.py", "tox.ini"]` | Which filenames should trigger this module                                             |
 | `detect_folders`     | `[]`                                                                                                         | Which folders should trigger this module                                               |
 | `disabled`           | `false`                                                                                                      | Disables the `python` module.                                                          |
@@ -2498,7 +2498,7 @@ The module will be shown if any of the following conditions are met:
 | ------------------- | ------------------------------------ | ------------------------------------------------ |
 | `format`            | `"via [$symbol($version )]($style)"` | The format for the module.                       |
 | `symbol`            | `"🐦 "`                              | A format string representing the symbol of Swift |
-| `detect_extensions` | `["swift"]`                          | Which extensions should trigger this moudle.     |
+| `detect_extensions` | `["swift"]`                          | Which extensions should trigger this module.     |
 | `detect_files`      | `["Package.swift"]`                  | Which filenames should trigger this module.      |
 | `detect_folders`    | `[]`                                 | Which folders should trigger this module.        |
 | `style`             | `"bold 202"`                         | The style for the module.                        |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Fix typo in README.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Prior art: https://github.com/starship/starship/pull/2501#issuecomment-806214169

@erikphansen I've reused your original commit :+1: 

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
