### PR TITLE
refactor: use `unwrap_or_default`

### DIFF
--- a/src/configure.rs
+++ b/src/configure.rs
@@ -140,11 +140,11 @@ fn get_editor() -> String {
 }
 
 fn get_editor_internal(visual: Option<String>, editor: Option<String>) -> String {
-    let editor_name = visual.unwrap_or_else(|| "".into());
+    let editor_name = visual.unwrap_or_default();
     if !editor_name.is_empty() {
         return editor_name;
     }
-    let editor_name = editor.unwrap_or_else(|| "".into());
+    let editor_name = editor.unwrap_or_default();
     if !editor_name.is_empty() {
         return editor_name;
     }

--- a/src/modules/conda.rs
+++ b/src/modules/conda.rs
@@ -9,9 +9,7 @@ use crate::formatter::StringFormatter;
 /// Will display the Conda environment iff `$CONDA_DEFAULT_ENV` is set.
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     // Reference implementation: https://github.com/denysdovhan/spaceship-prompt/blob/master/sections/conda.zsh
-    let conda_env = context
-        .get_env("CONDA_DEFAULT_ENV")
-        .unwrap_or_else(|| "".into());
+    let conda_env = context.get_env("CONDA_DEFAULT_ENV").unwrap_or_default();
     if conda_env.trim().is_empty() {
         return None;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Swap `.unwrap_or_else(|| "".into())` pattern with simpler and more idiomatic `.unwrap_or_default()`.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Simplify unwrapping options that default to empty strings.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
