### PR TITLE
fix(context): remove unwrap when pwd is unavailable

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -66,7 +66,10 @@ impl<'a> Context<'a> {
         let path = arguments
             .value_of("path")
             .map(PathBuf::from)
-            .unwrap_or_else(|| env::current_dir().expect("Unable to identify current directory"));
+            .or_else(|| env::current_dir().ok())
+            .or_else(|| env::var("PWD").map(PathBuf::from).ok())
+            .or_else(|| arguments.value_of("logical_path").map(PathBuf::from))
+            .unwrap_or_default();
 
         // Retrive the "logical directory".
         // If the path argument is not set fall back to the PWD env variable set by many shells
@@ -74,12 +77,8 @@ impl<'a> Context<'a> {
         let logical_path = arguments
             .value_of("logical_path")
             .map(PathBuf::from)
-            .unwrap_or_else(|| {
-                env::var("PWD").map(PathBuf::from).unwrap_or_else(|err| {
-                    log::debug!("Unable to get path from $PWD: {}", err);
-                    path.clone()
-                })
-            });
+            .or_else(|| env::var("PWD").map(PathBuf::from).ok())
+            .unwrap_or_else(|| path.clone());
 
         Context::new_with_shell_and_path(arguments, shell, path, logical_path)
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR removes the `unwrap`/`expect` in `context` when `env::current_dir()` fails and adds a fallback to `--logtical-path` and `$PWD` and finally an empty string.


#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #2485

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
