### PR TITLE
feat(config): allow printing default and computed config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1628,7 +1628,7 @@ dependencies = [
 
 [[package]]
 name = "starship_module_config_derive"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "proc-macro2",
  "quote 1.0.9",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -694,6 +694,7 @@ checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
 dependencies = [
  "autocfg",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ term_size = "0.3.2"
 quick-xml = "0.22.0"
 rand = "0.8.3"
 serde = { version = "1.0.125", features = ["derive"] }
-indexmap = "1.6.2"
+indexmap = { version ="1.6.2", features = ["serde"] }
 notify-rust = { version = "4.3.0", optional = true }
 semver = "0.11.0"
 which = "4.0.2"

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -3,7 +3,7 @@
 To get started configuring starship, create the following file: `~/.config/starship.toml`.
 
 ```sh
-mkdir -p ~/.config && touch ~/.config/starship.toml
+mkdir -p ~/.config && starship print-config --default > ~/.config/starship.toml
 ```
 
 All configuration for starship is done in this [TOML](https://github.com/toml-lang/toml) file:

--- a/src/config.rs
+++ b/src/config.rs
@@ -480,7 +480,7 @@ mod tests {
 
     #[test]
     fn test_load_config() {
-        #[derive(Clone, ModuleConfig)]
+        #[derive(Clone, Default, ModuleConfig)]
         struct TestConfig<'a> {
             pub symbol: &'a str,
             pub disabled: bool,
@@ -506,13 +506,13 @@ mod tests {
 
     #[test]
     fn test_load_nested_config() {
-        #[derive(Clone, ModuleConfig)]
+        #[derive(Clone, Default, ModuleConfig)]
         struct TestConfig<'a> {
             pub untracked: SegmentDisplayConfig<'a>,
             pub modified: SegmentDisplayConfig<'a>,
         }
 
-        #[derive(PartialEq, Debug, Clone, ModuleConfig)]
+        #[derive(PartialEq, Debug, Clone, Default, ModuleConfig)]
         struct SegmentDisplayConfig<'a> {
             pub value: &'a str,
             pub style: Style,
@@ -553,7 +553,7 @@ mod tests {
 
     #[test]
     fn test_load_optional_config() {
-        #[derive(Clone, ModuleConfig)]
+        #[derive(Clone, Default, ModuleConfig)]
         struct TestConfig<'a> {
             pub optional: Option<&'a str>,
             pub hidden: Option<&'a str>,
@@ -574,7 +574,7 @@ mod tests {
 
     #[test]
     fn test_load_enum_config() {
-        #[derive(Clone, ModuleConfig)]
+        #[derive(Clone, Default, ModuleConfig)]
         struct TestConfig {
             pub switch_a: Switch,
             pub switch_b: Switch,
@@ -585,6 +585,12 @@ mod tests {
         enum Switch {
             On,
             Off,
+        }
+
+        impl Default for Switch {
+            fn default() -> Self {
+                Self::Off
+            }
         }
 
         impl<'a> ModuleConfig<'a> for Switch {

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,6 +2,7 @@ use crate::configs::StarshipRootConfig;
 use crate::utils;
 use ansi_term::{Color, Style};
 use indexmap::IndexMap;
+use serde::Serialize;
 
 use std::clone::Clone;
 use std::collections::HashMap;
@@ -174,7 +175,7 @@ where
 
 /// A wrapper around `Vec<T>` that implements `ModuleConfig`, and either
 /// accepts a value of type `T` or a list of values of type `T`.
-#[derive(Clone, Default)]
+#[derive(Clone, Default, Serialize)]
 pub struct VecOr<T>(pub Vec<T>);
 
 impl<'a, T> ModuleConfig<'a> for VecOr<T>

--- a/src/configs/aws.rs
+++ b/src/configs/aws.rs
@@ -1,8 +1,9 @@
 use crate::config::ModuleConfig;
+use serde::Serialize;
 use starship_module_config_derive::ModuleConfig;
 use std::collections::HashMap;
 
-#[derive(Clone, ModuleConfig)]
+#[derive(Clone, ModuleConfig, Serialize)]
 pub struct AwsConfig<'a> {
     pub format: &'a str,
     pub symbol: &'a str,

--- a/src/configs/battery.rs
+++ b/src/configs/battery.rs
@@ -1,8 +1,9 @@
 use crate::config::ModuleConfig;
 
+use serde::Serialize;
 use starship_module_config_derive::ModuleConfig;
 
-#[derive(Clone, ModuleConfig)]
+#[derive(Clone, ModuleConfig, Serialize)]
 pub struct BatteryConfig<'a> {
     pub full_symbol: &'a str,
     pub charging_symbol: &'a str,
@@ -32,7 +33,7 @@ impl<'a> Default for BatteryConfig<'a> {
     }
 }
 
-#[derive(Clone, ModuleConfig)]
+#[derive(Clone, ModuleConfig, Default, Serialize)]
 pub struct BatteryDisplayConfig<'a> {
     pub threshold: i64,
     pub style: &'a str,

--- a/src/configs/character.rs
+++ b/src/configs/character.rs
@@ -1,8 +1,9 @@
 use crate::config::ModuleConfig;
 
+use serde::Serialize;
 use starship_module_config_derive::ModuleConfig;
 
-#[derive(Clone, ModuleConfig)]
+#[derive(Clone, ModuleConfig, Serialize)]
 pub struct CharacterConfig<'a> {
     pub format: &'a str,
     pub success_symbol: &'a str,

--- a/src/configs/cmake.rs
+++ b/src/configs/cmake.rs
@@ -1,8 +1,9 @@
 use crate::config::ModuleConfig;
 
+use serde::Serialize;
 use starship_module_config_derive::ModuleConfig;
 
-#[derive(Clone, ModuleConfig)]
+#[derive(Clone, ModuleConfig, Serialize)]
 pub struct CMakeConfig<'a> {
     pub format: &'a str,
     pub symbol: &'a str,

--- a/src/configs/cmd_duration.rs
+++ b/src/configs/cmd_duration.rs
@@ -1,8 +1,9 @@
 use crate::config::ModuleConfig;
 
+use serde::Serialize;
 use starship_module_config_derive::ModuleConfig;
 
-#[derive(Clone, ModuleConfig)]
+#[derive(Clone, ModuleConfig, Serialize)]
 pub struct CmdDurationConfig<'a> {
     pub min_time: i64,
     pub format: &'a str,

--- a/src/configs/conda.rs
+++ b/src/configs/conda.rs
@@ -1,8 +1,9 @@
 use crate::config::ModuleConfig;
 
+use serde::Serialize;
 use starship_module_config_derive::ModuleConfig;
 
-#[derive(Clone, ModuleConfig)]
+#[derive(Clone, ModuleConfig, Serialize)]
 pub struct CondaConfig<'a> {
     pub truncation_length: usize,
     pub format: &'a str,

--- a/src/configs/crystal.rs
+++ b/src/configs/crystal.rs
@@ -1,8 +1,9 @@
 use crate::config::ModuleConfig;
 
+use serde::Serialize;
 use starship_module_config_derive::ModuleConfig;
 
-#[derive(Clone, ModuleConfig)]
+#[derive(Clone, ModuleConfig, Serialize)]
 pub struct CrystalConfig<'a> {
     pub format: &'a str,
     pub symbol: &'a str,

--- a/src/configs/custom.rs
+++ b/src/configs/custom.rs
@@ -1,29 +1,22 @@
 use crate::config::{ModuleConfig, VecOr};
 
+use serde::{self, Serialize};
 use starship_module_config_derive::ModuleConfig;
 
-#[derive(Clone, Default, PartialEq)]
-pub struct Files<'a>(pub Vec<&'a str>);
-
-#[derive(Clone, Default, PartialEq)]
-pub struct Extensions<'a>(pub Vec<&'a str>);
-
-#[derive(Clone, Default, PartialEq)]
-pub struct Directories<'a>(pub Vec<&'a str>);
-
-#[derive(Clone, ModuleConfig)]
+#[derive(Clone, ModuleConfig, Serialize)]
 pub struct CustomConfig<'a> {
     pub format: &'a str,
     pub symbol: &'a str,
     pub command: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub when: Option<&'a str>,
     pub shell: VecOr<&'a str>,
     pub description: &'a str,
     pub style: &'a str,
     pub disabled: bool,
-    pub files: Files<'a>,
-    pub extensions: Extensions<'a>,
-    pub directories: Directories<'a>,
+    pub files: Vec<&'a str>,
+    pub extensions: Vec<&'a str>,
+    pub directories: Vec<&'a str>,
 }
 
 impl<'a> Default for CustomConfig<'a> {
@@ -37,57 +30,9 @@ impl<'a> Default for CustomConfig<'a> {
             description: "<custom config>",
             style: "green bold",
             disabled: false,
-            files: Files::default(),
-            extensions: Extensions::default(),
-            directories: Directories::default(),
+            files: Vec::default(),
+            extensions: Vec::default(),
+            directories: Vec::default(),
         }
-    }
-}
-
-impl<'a> ModuleConfig<'a> for Files<'a> {
-    fn from_config(config: &'a toml::Value) -> Option<Self> {
-        let mut files = Vec::new();
-
-        for item in config.as_array()? {
-            if let Some(file) = item.as_str() {
-                files.push(file);
-            } else {
-                log::warn!("Unexpected file {:?}", item);
-            }
-        }
-
-        Some(Files(files))
-    }
-}
-
-impl<'a> ModuleConfig<'a> for Extensions<'a> {
-    fn from_config(config: &'a toml::Value) -> Option<Self> {
-        let mut extensions = Vec::new();
-
-        for item in config.as_array()? {
-            if let Some(file) = item.as_str() {
-                extensions.push(file);
-            } else {
-                log::warn!("Unexpected extension {:?}", item);
-            }
-        }
-
-        Some(Extensions(extensions))
-    }
-}
-
-impl<'a> ModuleConfig<'a> for Directories<'a> {
-    fn from_config(config: &'a toml::Value) -> Option<Self> {
-        let mut directories = Vec::new();
-
-        for item in config.as_array()? {
-            if let Some(file) = item.as_str() {
-                directories.push(file);
-            } else {
-                log::warn!("Unexpected directory {:?}", item);
-            }
-        }
-
-        Some(Directories(directories))
     }
 }

--- a/src/configs/dart.rs
+++ b/src/configs/dart.rs
@@ -1,8 +1,9 @@
 use crate::config::ModuleConfig;
 
+use serde::Serialize;
 use starship_module_config_derive::ModuleConfig;
 
-#[derive(Clone, ModuleConfig)]
+#[derive(Clone, ModuleConfig, Serialize)]
 pub struct DartConfig<'a> {
     pub format: &'a str,
     pub symbol: &'a str,

--- a/src/configs/directory.rs
+++ b/src/configs/directory.rs
@@ -1,9 +1,10 @@
 use crate::config::ModuleConfig;
 use indexmap::IndexMap;
 
+use serde::Serialize;
 use starship_module_config_derive::ModuleConfig;
 
-#[derive(Clone, ModuleConfig)]
+#[derive(Clone, ModuleConfig, Serialize)]
 pub struct DirectoryConfig<'a> {
     pub truncation_length: i64,
     pub truncate_to_repo: bool,

--- a/src/configs/docker_context.rs
+++ b/src/configs/docker_context.rs
@@ -1,8 +1,9 @@
 use crate::config::ModuleConfig;
 
+use serde::Serialize;
 use starship_module_config_derive::ModuleConfig;
 
-#[derive(Clone, ModuleConfig)]
+#[derive(Clone, ModuleConfig, Serialize)]
 pub struct DockerContextConfig<'a> {
     pub symbol: &'a str,
     pub style: &'a str,

--- a/src/configs/dotnet.rs
+++ b/src/configs/dotnet.rs
@@ -1,8 +1,9 @@
 use crate::config::ModuleConfig;
 
+use serde::Serialize;
 use starship_module_config_derive::ModuleConfig;
 
-#[derive(Clone, ModuleConfig)]
+#[derive(Clone, ModuleConfig, Serialize)]
 pub struct DotnetConfig<'a> {
     pub format: &'a str,
     pub symbol: &'a str,

--- a/src/configs/elixir.rs
+++ b/src/configs/elixir.rs
@@ -1,8 +1,9 @@
 use crate::config::ModuleConfig;
 
+use serde::Serialize;
 use starship_module_config_derive::ModuleConfig;
 
-#[derive(Clone, ModuleConfig)]
+#[derive(Clone, ModuleConfig, Serialize)]
 pub struct ElixirConfig<'a> {
     pub format: &'a str,
     pub symbol: &'a str,

--- a/src/configs/elm.rs
+++ b/src/configs/elm.rs
@@ -1,8 +1,9 @@
 use crate::config::ModuleConfig;
 
+use serde::Serialize;
 use starship_module_config_derive::ModuleConfig;
 
-#[derive(Clone, ModuleConfig)]
+#[derive(Clone, ModuleConfig, Serialize)]
 pub struct ElmConfig<'a> {
     pub format: &'a str,
     pub symbol: &'a str,

--- a/src/configs/env_var.rs
+++ b/src/configs/env_var.rs
@@ -1,12 +1,15 @@
 use crate::config::ModuleConfig;
 
+use serde::Serialize;
 use starship_module_config_derive::ModuleConfig;
 
-#[derive(Clone, ModuleConfig)]
+#[derive(Clone, ModuleConfig, Serialize)]
 pub struct EnvVarConfig<'a> {
     pub symbol: &'a str,
     pub style: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub variable: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub default: Option<&'a str>,
     pub format: &'a str,
     pub disabled: bool,

--- a/src/configs/erlang.rs
+++ b/src/configs/erlang.rs
@@ -1,8 +1,9 @@
 use crate::config::ModuleConfig;
 
+use serde::Serialize;
 use starship_module_config_derive::ModuleConfig;
 
-#[derive(Clone, ModuleConfig)]
+#[derive(Clone, ModuleConfig, Serialize)]
 pub struct ErlangConfig<'a> {
     pub format: &'a str,
     pub symbol: &'a str,

--- a/src/configs/gcloud.rs
+++ b/src/configs/gcloud.rs
@@ -1,8 +1,9 @@
 use crate::config::ModuleConfig;
+use serde::Serialize;
 use starship_module_config_derive::ModuleConfig;
 use std::collections::HashMap;
 
-#[derive(Clone, ModuleConfig)]
+#[derive(Clone, ModuleConfig, Serialize)]
 pub struct GcloudConfig<'a> {
     pub format: &'a str,
     pub symbol: &'a str,

--- a/src/configs/git_branch.rs
+++ b/src/configs/git_branch.rs
@@ -1,8 +1,9 @@
 use crate::config::ModuleConfig;
 
+use serde::Serialize;
 use starship_module_config_derive::ModuleConfig;
 
-#[derive(Clone, ModuleConfig)]
+#[derive(Clone, ModuleConfig, Serialize)]
 pub struct GitBranchConfig<'a> {
     pub format: &'a str,
     pub symbol: &'a str,

--- a/src/configs/git_commit.rs
+++ b/src/configs/git_commit.rs
@@ -1,8 +1,9 @@
 use crate::config::ModuleConfig;
 
+use serde::Serialize;
 use starship_module_config_derive::ModuleConfig;
 
-#[derive(Clone, ModuleConfig)]
+#[derive(Clone, ModuleConfig, Serialize)]
 pub struct GitCommitConfig<'a> {
     pub commit_hash_length: usize,
     pub format: &'a str,

--- a/src/configs/git_state.rs
+++ b/src/configs/git_state.rs
@@ -1,8 +1,9 @@
 use crate::config::ModuleConfig;
 
+use serde::Serialize;
 use starship_module_config_derive::ModuleConfig;
 
-#[derive(Clone, ModuleConfig)]
+#[derive(Clone, ModuleConfig, Serialize)]
 pub struct GitStateConfig<'a> {
     pub rebase: &'a str,
     pub merge: &'a str,

--- a/src/configs/git_status.rs
+++ b/src/configs/git_status.rs
@@ -1,8 +1,9 @@
 use crate::config::ModuleConfig;
 
+use serde::Serialize;
 use starship_module_config_derive::ModuleConfig;
 
-#[derive(Clone, ModuleConfig)]
+#[derive(Clone, ModuleConfig, Serialize)]
 pub struct GitStatusConfig<'a> {
     pub format: &'a str,
     pub style: &'a str,

--- a/src/configs/go.rs
+++ b/src/configs/go.rs
@@ -1,8 +1,9 @@
 use crate::config::ModuleConfig;
 
+use serde::Serialize;
 use starship_module_config_derive::ModuleConfig;
 
-#[derive(Clone, ModuleConfig)]
+#[derive(Clone, ModuleConfig, Serialize)]
 pub struct GoConfig<'a> {
     pub format: &'a str,
     pub symbol: &'a str,

--- a/src/configs/helm.rs
+++ b/src/configs/helm.rs
@@ -1,8 +1,9 @@
 use crate::config::ModuleConfig;
 
+use serde::Serialize;
 use starship_module_config_derive::ModuleConfig;
 
-#[derive(Clone, ModuleConfig)]
+#[derive(Clone, ModuleConfig, Serialize)]
 pub struct HelmConfig<'a> {
     pub format: &'a str,
     pub symbol: &'a str,

--- a/src/configs/hg_branch.rs
+++ b/src/configs/hg_branch.rs
@@ -1,8 +1,9 @@
 use crate::config::ModuleConfig;
 
+use serde::Serialize;
 use starship_module_config_derive::ModuleConfig;
 
-#[derive(Clone, ModuleConfig)]
+#[derive(Clone, ModuleConfig, Serialize)]
 pub struct HgBranchConfig<'a> {
     pub symbol: &'a str,
     pub style: &'a str,

--- a/src/configs/hostname.rs
+++ b/src/configs/hostname.rs
@@ -1,8 +1,9 @@
 use crate::config::ModuleConfig;
 
+use serde::Serialize;
 use starship_module_config_derive::ModuleConfig;
 
-#[derive(Clone, ModuleConfig)]
+#[derive(Clone, ModuleConfig, Serialize)]
 pub struct HostnameConfig<'a> {
     pub ssh_only: bool,
     pub trim_at: &'a str,

--- a/src/configs/java.rs
+++ b/src/configs/java.rs
@@ -1,8 +1,9 @@
 use crate::config::ModuleConfig;
 
+use serde::Serialize;
 use starship_module_config_derive::ModuleConfig;
 
-#[derive(Clone, ModuleConfig)]
+#[derive(Clone, ModuleConfig, Serialize)]
 pub struct JavaConfig<'a> {
     pub disabled: bool,
     pub format: &'a str,

--- a/src/configs/jobs.rs
+++ b/src/configs/jobs.rs
@@ -1,8 +1,9 @@
 use crate::config::ModuleConfig;
 
+use serde::Serialize;
 use starship_module_config_derive::ModuleConfig;
 
-#[derive(Clone, ModuleConfig)]
+#[derive(Clone, ModuleConfig, Serialize)]
 pub struct JobsConfig<'a> {
     pub threshold: i64,
     pub format: &'a str,

--- a/src/configs/julia.rs
+++ b/src/configs/julia.rs
@@ -1,8 +1,9 @@
 use crate::config::ModuleConfig;
 
+use serde::Serialize;
 use starship_module_config_derive::ModuleConfig;
 
-#[derive(Clone, ModuleConfig)]
+#[derive(Clone, ModuleConfig, Serialize)]
 pub struct JuliaConfig<'a> {
     pub format: &'a str,
     pub symbol: &'a str,

--- a/src/configs/kotlin.rs
+++ b/src/configs/kotlin.rs
@@ -1,8 +1,9 @@
 use crate::config::ModuleConfig;
 
+use serde::Serialize;
 use starship_module_config_derive::ModuleConfig;
 
-#[derive(Clone, ModuleConfig)]
+#[derive(Clone, ModuleConfig, Serialize)]
 pub struct KotlinConfig<'a> {
     pub format: &'a str,
     pub symbol: &'a str,

--- a/src/configs/kubernetes.rs
+++ b/src/configs/kubernetes.rs
@@ -1,9 +1,10 @@
 use crate::config::ModuleConfig;
 
+use serde::Serialize;
 use starship_module_config_derive::ModuleConfig;
 use std::collections::HashMap;
 
-#[derive(Clone, ModuleConfig)]
+#[derive(Clone, ModuleConfig, Serialize)]
 pub struct KubernetesConfig<'a> {
     pub symbol: &'a str,
     pub format: &'a str,

--- a/src/configs/lua.rs
+++ b/src/configs/lua.rs
@@ -1,8 +1,9 @@
 use crate::config::ModuleConfig;
 
+use serde::Serialize;
 use starship_module_config_derive::ModuleConfig;
 
-#[derive(Clone, ModuleConfig)]
+#[derive(Clone, ModuleConfig, Serialize)]
 pub struct LuaConfig<'a> {
     pub format: &'a str,
     pub symbol: &'a str,

--- a/src/configs/memory_usage.rs
+++ b/src/configs/memory_usage.rs
@@ -1,8 +1,9 @@
 use crate::config::ModuleConfig;
 
+use serde::Serialize;
 use starship_module_config_derive::ModuleConfig;
 
-#[derive(Clone, ModuleConfig)]
+#[derive(Clone, ModuleConfig, Serialize)]
 pub struct MemoryConfig<'a> {
     pub threshold: i64,
     pub format: &'a str,

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -1,3 +1,7 @@
+use crate::config::ModuleConfig;
+use serde::{self, Serialize};
+use starship_module_config_derive::ModuleConfig;
+
 pub mod aws;
 pub mod battery;
 pub mod character;
@@ -56,3 +60,65 @@ pub mod vagrant;
 pub mod zig;
 
 pub use starship_root::*;
+
+#[derive(Default, Serialize, ModuleConfig, Clone)]
+#[serde(default)]
+pub struct FullConfig<'a> {
+    #[serde(flatten)]
+    root: starship_root::StarshipRootConfig<'a>,
+    aws: aws::AwsConfig<'a>,
+    battery: battery::BatteryDisplayConfig<'a>,
+    character: character::CharacterConfig<'a>,
+    cmake: cmake::CMakeConfig<'a>,
+    cmd_duration: cmd_duration::CmdDurationConfig<'a>,
+    conda: conda::CondaConfig<'a>,
+    crystal: crystal::CrystalConfig<'a>,
+    custom: custom::CustomConfig<'a>,
+    dart: dart::DartConfig<'a>,
+    directory: directory::DirectoryConfig<'a>,
+    docker_context: docker_context::DockerContextConfig<'a>,
+    dotnet: dotnet::DotnetConfig<'a>,
+    elixir: elixir::ElixirConfig<'a>,
+    elm: elm::ElmConfig<'a>,
+    env_var: env_var::EnvVarConfig<'a>,
+    erlang: erlang::ErlangConfig<'a>,
+    gcloud: gcloud::GcloudConfig<'a>,
+    git_branch: git_branch::GitBranchConfig<'a>,
+    git_commit: git_commit::GitCommitConfig<'a>,
+    git_state: git_state::GitStateConfig<'a>,
+    git_status: git_status::GitStatusConfig<'a>,
+    go: go::GoConfig<'a>,
+    helm: helm::HelmConfig<'a>,
+    hg_branch: hg_branch::HgBranchConfig<'a>,
+    hostname: hostname::HostnameConfig<'a>,
+    java: java::JavaConfig<'a>,
+    jobs: jobs::JobsConfig<'a>,
+    julia: julia::JuliaConfig<'a>,
+    kotlin: kotlin::KotlinConfig<'a>,
+    kubernetes: kubernetes::KubernetesConfig<'a>,
+    lua: lua::LuaConfig<'a>,
+    memory_usage: memory_usage::MemoryConfig<'a>,
+    nim: nim::NimConfig<'a>,
+    nix_shell: nix_shell::NixShellConfig<'a>,
+    nodejs: nodejs::NodejsConfig<'a>,
+    ocaml: ocaml::OCamlConfig<'a>,
+    openstack: openstack::OspConfig<'a>,
+    package: package::PackageConfig<'a>,
+    perl: perl::PerlConfig<'a>,
+    php: php::PhpConfig<'a>,
+    purescript: purescript::PureScriptConfig<'a>,
+    python: python::PythonConfig<'a>,
+    ruby: ruby::RubyConfig<'a>,
+    rust: rust::RustConfig<'a>,
+    scala: scala::ScalaConfig<'a>,
+    shell: shell::ShellConfig<'a>,
+    shlvl: shlvl::ShLvlConfig<'a>,
+    singularity: singularity::SingularityConfig<'a>,
+    status: status::StatusConfig<'a>,
+    swift: swift::SwiftConfig<'a>,
+    terraform: terraform::TerraformConfig<'a>,
+    time: time::TimeConfig<'a>,
+    username: username::UsernameConfig<'a>,
+    vagrant: vagrant::VagrantConfig<'a>,
+    zig: zig::ZigConfig<'a>,
+}

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -1,4 +1,5 @@
 use crate::config::ModuleConfig;
+use indexmap::IndexMap;
 use serde::{self, Serialize};
 use starship_module_config_derive::ModuleConfig;
 
@@ -73,7 +74,6 @@ pub struct FullConfig<'a> {
     cmd_duration: cmd_duration::CmdDurationConfig<'a>,
     conda: conda::CondaConfig<'a>,
     crystal: crystal::CrystalConfig<'a>,
-    custom: custom::CustomConfig<'a>,
     dart: dart::DartConfig<'a>,
     directory: directory::DirectoryConfig<'a>,
     docker_context: docker_context::DockerContextConfig<'a>,
@@ -121,4 +121,5 @@ pub struct FullConfig<'a> {
     username: username::UsernameConfig<'a>,
     vagrant: vagrant::VagrantConfig<'a>,
     zig: zig::ZigConfig<'a>,
+    custom: IndexMap<String, custom::CustomConfig<'a>>,
 }

--- a/src/configs/nim.rs
+++ b/src/configs/nim.rs
@@ -1,8 +1,9 @@
 use crate::config::ModuleConfig;
 
+use serde::Serialize;
 use starship_module_config_derive::ModuleConfig;
 
-#[derive(Clone, ModuleConfig)]
+#[derive(Clone, ModuleConfig, Serialize)]
 pub struct NimConfig<'a> {
     pub format: &'a str,
     pub symbol: &'a str,

--- a/src/configs/nix_shell.rs
+++ b/src/configs/nix_shell.rs
@@ -1,8 +1,9 @@
 use crate::config::ModuleConfig;
 
+use serde::Serialize;
 use starship_module_config_derive::ModuleConfig;
 
-#[derive(Clone, ModuleConfig)]
+#[derive(Clone, ModuleConfig, Serialize)]
 pub struct NixShellConfig<'a> {
     pub format: &'a str,
     pub symbol: &'a str,

--- a/src/configs/nodejs.rs
+++ b/src/configs/nodejs.rs
@@ -1,8 +1,9 @@
 use crate::config::ModuleConfig;
 
+use serde::Serialize;
 use starship_module_config_derive::ModuleConfig;
 
-#[derive(Clone, ModuleConfig)]
+#[derive(Clone, ModuleConfig, Serialize)]
 pub struct NodejsConfig<'a> {
     pub format: &'a str,
     pub symbol: &'a str,

--- a/src/configs/ocaml.rs
+++ b/src/configs/ocaml.rs
@@ -1,8 +1,9 @@
 use crate::config::ModuleConfig;
 
+use serde::Serialize;
 use starship_module_config_derive::ModuleConfig;
 
-#[derive(Clone, ModuleConfig)]
+#[derive(Clone, ModuleConfig, Serialize)]
 pub struct OCamlConfig<'a> {
     pub format: &'a str,
     pub symbol: &'a str,

--- a/src/configs/openstack.rs
+++ b/src/configs/openstack.rs
@@ -1,7 +1,8 @@
 use crate::config::ModuleConfig;
+use serde::Serialize;
 use starship_module_config_derive::ModuleConfig;
 
-#[derive(Clone, ModuleConfig)]
+#[derive(Clone, ModuleConfig, Serialize)]
 pub struct OspConfig<'a> {
     pub format: &'a str,
     pub symbol: &'a str,

--- a/src/configs/package.rs
+++ b/src/configs/package.rs
@@ -1,8 +1,9 @@
 use crate::config::ModuleConfig;
 
+use serde::Serialize;
 use starship_module_config_derive::ModuleConfig;
 
-#[derive(Clone, ModuleConfig)]
+#[derive(Clone, ModuleConfig, Serialize)]
 pub struct PackageConfig<'a> {
     pub format: &'a str,
     pub symbol: &'a str,

--- a/src/configs/perl.rs
+++ b/src/configs/perl.rs
@@ -1,8 +1,9 @@
 use crate::config::ModuleConfig;
 
+use serde::Serialize;
 use starship_module_config_derive::ModuleConfig;
 
-#[derive(Clone, ModuleConfig)]
+#[derive(Clone, ModuleConfig, Serialize)]
 pub struct PerlConfig<'a> {
     pub symbol: &'a str,
     pub style: &'a str,

--- a/src/configs/php.rs
+++ b/src/configs/php.rs
@@ -1,8 +1,9 @@
 use crate::config::ModuleConfig;
 
+use serde::Serialize;
 use starship_module_config_derive::ModuleConfig;
 
-#[derive(Clone, ModuleConfig)]
+#[derive(Clone, ModuleConfig, Serialize)]
 pub struct PhpConfig<'a> {
     pub symbol: &'a str,
     pub style: &'a str,

--- a/src/configs/purescript.rs
+++ b/src/configs/purescript.rs
@@ -1,8 +1,9 @@
 use crate::config::ModuleConfig;
 
+use serde::Serialize;
 use starship_module_config_derive::ModuleConfig;
 
-#[derive(Clone, ModuleConfig)]
+#[derive(Clone, ModuleConfig, Serialize)]
 pub struct PureScriptConfig<'a> {
     pub format: &'a str,
     pub symbol: &'a str,

--- a/src/configs/python.rs
+++ b/src/configs/python.rs
@@ -1,8 +1,9 @@
 use crate::config::{ModuleConfig, VecOr};
 
+use serde::Serialize;
 use starship_module_config_derive::ModuleConfig;
 
-#[derive(Clone, ModuleConfig)]
+#[derive(Clone, ModuleConfig, Serialize)]
 pub struct PythonConfig<'a> {
     pub pyenv_version_name: bool,
     pub pyenv_prefix: &'a str,

--- a/src/configs/ruby.rs
+++ b/src/configs/ruby.rs
@@ -1,8 +1,9 @@
 use crate::config::ModuleConfig;
 
+use serde::Serialize;
 use starship_module_config_derive::ModuleConfig;
 
-#[derive(Clone, ModuleConfig)]
+#[derive(Clone, ModuleConfig, Serialize)]
 pub struct RubyConfig<'a> {
     pub format: &'a str,
     pub symbol: &'a str,

--- a/src/configs/rust.rs
+++ b/src/configs/rust.rs
@@ -1,8 +1,9 @@
 use crate::config::ModuleConfig;
 
+use serde::Serialize;
 use starship_module_config_derive::ModuleConfig;
 
-#[derive(Clone, ModuleConfig)]
+#[derive(Clone, ModuleConfig, Serialize)]
 pub struct RustConfig<'a> {
     pub format: &'a str,
     pub symbol: &'a str,

--- a/src/configs/scala.rs
+++ b/src/configs/scala.rs
@@ -1,8 +1,9 @@
 use crate::config::ModuleConfig;
 
+use serde::Serialize;
 use starship_module_config_derive::ModuleConfig;
 
-#[derive(Clone, ModuleConfig)]
+#[derive(Clone, ModuleConfig, Serialize)]
 pub struct ScalaConfig<'a> {
     pub disabled: bool,
     pub format: &'a str,

--- a/src/configs/shell.rs
+++ b/src/configs/shell.rs
@@ -1,8 +1,9 @@
 use crate::config::ModuleConfig;
 
+use serde::Serialize;
 use starship_module_config_derive::ModuleConfig;
 
-#[derive(Clone, ModuleConfig)]
+#[derive(Clone, ModuleConfig, Serialize)]
 pub struct ShellConfig<'a> {
     pub format: &'a str,
     pub bash_indicator: &'a str,

--- a/src/configs/shlvl.rs
+++ b/src/configs/shlvl.rs
@@ -1,8 +1,9 @@
 use crate::config::ModuleConfig;
 
+use serde::Serialize;
 use starship_module_config_derive::ModuleConfig;
 
-#[derive(Clone, ModuleConfig)]
+#[derive(Clone, ModuleConfig, Serialize)]
 pub struct ShLvlConfig<'a> {
     pub threshold: i64,
     pub format: &'a str,

--- a/src/configs/singularity.rs
+++ b/src/configs/singularity.rs
@@ -1,8 +1,9 @@
 use crate::config::ModuleConfig;
 
+use serde::Serialize;
 use starship_module_config_derive::ModuleConfig;
 
-#[derive(Clone, ModuleConfig)]
+#[derive(Clone, ModuleConfig, Serialize)]
 pub struct SingularityConfig<'a> {
     pub symbol: &'a str,
     pub format: &'a str,

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -1,8 +1,9 @@
 use crate::config::ModuleConfig;
 
+use serde::Serialize;
 use starship_module_config_derive::ModuleConfig;
 
-#[derive(Clone, ModuleConfig)]
+#[derive(Clone, ModuleConfig, Serialize)]
 pub struct StarshipRootConfig<'a> {
     pub format: &'a str,
     pub scan_timeout: u64,

--- a/src/configs/status.rs
+++ b/src/configs/status.rs
@@ -1,8 +1,9 @@
 use crate::config::ModuleConfig;
 
+use serde::Serialize;
 use starship_module_config_derive::ModuleConfig;
 
-#[derive(Clone, ModuleConfig)]
+#[derive(Clone, ModuleConfig, Serialize)]
 pub struct StatusConfig<'a> {
     pub format: &'a str,
     pub symbol: &'a str,

--- a/src/configs/swift.rs
+++ b/src/configs/swift.rs
@@ -1,8 +1,9 @@
 use crate::config::ModuleConfig;
 
+use serde::Serialize;
 use starship_module_config_derive::ModuleConfig;
 
-#[derive(Clone, ModuleConfig)]
+#[derive(Clone, ModuleConfig, Serialize)]
 pub struct SwiftConfig<'a> {
     pub format: &'a str,
     pub symbol: &'a str,

--- a/src/configs/terraform.rs
+++ b/src/configs/terraform.rs
@@ -1,8 +1,9 @@
 use crate::config::ModuleConfig;
 
+use serde::Serialize;
 use starship_module_config_derive::ModuleConfig;
 
-#[derive(Clone, ModuleConfig)]
+#[derive(Clone, ModuleConfig, Serialize)]
 pub struct TerraformConfig<'a> {
     pub format: &'a str,
     pub symbol: &'a str,

--- a/src/configs/time.rs
+++ b/src/configs/time.rs
@@ -1,12 +1,14 @@
 use crate::config::ModuleConfig;
 
+use serde::Serialize;
 use starship_module_config_derive::ModuleConfig;
 
-#[derive(Clone, ModuleConfig)]
+#[derive(Clone, ModuleConfig, Serialize)]
 pub struct TimeConfig<'a> {
     pub format: &'a str,
     pub style: &'a str,
     pub use_12hr: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub time_format: Option<&'a str>,
     pub disabled: bool,
     pub utc_time_offset: &'a str,

--- a/src/configs/username.rs
+++ b/src/configs/username.rs
@@ -1,8 +1,9 @@
 use crate::config::ModuleConfig;
 
+use serde::Serialize;
 use starship_module_config_derive::ModuleConfig;
 
-#[derive(Clone, ModuleConfig)]
+#[derive(Clone, ModuleConfig, Serialize)]
 pub struct UsernameConfig<'a> {
     pub format: &'a str,
     pub style_root: &'a str,

--- a/src/configs/vagrant.rs
+++ b/src/configs/vagrant.rs
@@ -1,8 +1,9 @@
 use crate::config::ModuleConfig;
 
+use serde::Serialize;
 use starship_module_config_derive::ModuleConfig;
 
-#[derive(Clone, ModuleConfig)]
+#[derive(Clone, ModuleConfig, Serialize)]
 pub struct VagrantConfig<'a> {
     pub format: &'a str,
     pub symbol: &'a str,

--- a/src/configs/zig.rs
+++ b/src/configs/zig.rs
@@ -1,8 +1,9 @@
 use crate::config::ModuleConfig;
 
+use serde::Serialize;
 use starship_module_config_derive::ModuleConfig;
 
-#[derive(Clone, ModuleConfig)]
+#[derive(Clone, ModuleConfig, Serialize)]
 pub struct ZigConfig<'a> {
     pub format: &'a str,
     pub symbol: &'a str,

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -4,6 +4,7 @@ use std::io::ErrorKind;
 use std::process;
 use std::process::Command;
 
+use crate::config::RootModuleConfig;
 use crate::config::StarshipConfig;
 use std::fs::File;
 use std::io::Write;
@@ -50,6 +51,27 @@ pub fn update_configuration(name: &str, value: &str) {
 
         write_configuration(table);
     }
+}
+
+pub fn print_configuration(use_default: bool) {
+    let config = if use_default {
+        // Get default config
+        let default_config = crate::configs::FullConfig::default();
+        // Convert back to Value because toml can't serialize FullConfig directly
+        toml::value::Value::try_from(default_config).unwrap()
+    } else {
+        // Get config as toml::Value
+        let user_config = get_configuration();
+        // Convert into FullConfig and fill in default values
+        let user_config = crate::configs::FullConfig::try_load(Some(&user_config));
+        // Convert back to Value because toml can't serialize FullConfig directly
+        toml::value::Value::try_from(user_config).unwrap()
+    };
+
+    let string_config = toml::to_string_pretty(&config).unwrap();
+
+    println!("# Warning: This config does not include keys that have an unset value");
+    println!("{}", string_config);
 }
 
 pub fn toggle_configuration(name: &str, key: &str) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -132,6 +132,17 @@ fn main() {
                 .arg(Arg::with_name("value").help("Value to place into that key")),
         )
         .subcommand(
+            SubCommand::with_name("print-config")
+                .about("Prints the computed starship configuration")
+                .arg(
+                    Arg::with_name("default")
+                        .short("d")
+                        .long("default")
+                        .help("Print the default instead of the computed config")
+                        .takes_value(false),
+                ),
+        )
+        .subcommand(
             SubCommand::with_name("toggle")
                 .about("Toggle a given starship module")
                 .arg(
@@ -207,6 +218,10 @@ fn main() {
             } else {
                 configure::edit_configuration()
             }
+        }
+        ("print-config", Some(sub_m)) => {
+            let print_default = sub_m.is_present("default");
+            configure::print_configuration(print_default)
         }
         ("toggle", Some(sub_m)) => {
             if let Some(name) = sub_m.value_of("name") {

--- a/src/modules/custom.rs
+++ b/src/modules/custom.rs
@@ -20,19 +20,12 @@ pub fn module<'a>(name: &str, context: &'a Context) -> Option<Module<'a>> {
     );
     let config = CustomConfig::load(toml_config);
 
-    let mut scan_dir = context.try_begin_scan()?;
-
-    if !config.files.0.is_empty() {
-        scan_dir = scan_dir.set_files(&config.files.0);
-    }
-    if !config.extensions.0.is_empty() {
-        scan_dir = scan_dir.set_extensions(&config.extensions.0);
-    }
-    if !config.directories.0.is_empty() {
-        scan_dir = scan_dir.set_folders(&config.directories.0);
-    }
-
-    let mut is_match = scan_dir.is_match();
+    let mut is_match = context
+        .try_begin_scan()?
+        .set_files(&config.files)
+        .set_extensions(&config.extensions)
+        .set_folders(&config.directories)
+        .is_match();
 
     if !is_match {
         if let Some(when) = config.when {

--- a/starship_module_config_derive/Cargo.toml
+++ b/starship_module_config_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starship_module_config_derive"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2018"
 authors = ["Matan Kushner <hello@matchai.me>"]
 homepage = "https://starship.rs"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR adds `starship print-config` to print the computed config and `starship print-config --default` to print the default config.

I made a new struct in `src/configs/mod.rs` that contains all the module configs and implements `serve::Serialize` and `ModuleConfig`.
Options that have a `None` value need to be skipped because toml doesn't support `None` values and a warning comment about this is added at the top of the generated config files.
Before formatting as toml the struct needs to be converted into a `toml::Value` because otherwise the toml crate won't be able to properly handle printing the top-level root options.
I also got rid of the wrapper struct in `custom.rs` because the other modules don't use this for `extensiosn`, `folders` and `extensions` either.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #2309
Related to #1921

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly. (not in-depth)
- [ ] I have updated the tests accordingly.
