### PR TITLE
fix(git_branch): Make Git branch module support bare repositories

### DIFF
--- a/src/modules/git_branch.rs
+++ b/src/modules/git_branch.rs
@@ -27,12 +27,13 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
     let repo = context.get_repo().ok()?;
 
-    let repo_root = repo.root.as_ref()?;
-    let git_repo = Repository::open(repo_root).ok()?;
-    let is_detached = git_repo.head_detached().ok()?;
-    if config.only_attached && is_detached {
-        return None;
-    };
+    if let Some(repo_root) = repo.root.as_ref() {
+        let git_repo = Repository::open(repo_root).ok()?;
+        let is_detached = git_repo.head_detached().ok()?;
+        if config.only_attached && is_detached {
+            return None;
+        }
+    }
 
     let branch_name = repo.branch.as_ref()?;
     let mut graphemes: Vec<&str> = branch_name.graphemes(true).collect();
@@ -338,6 +339,33 @@ mod tests {
             .collect();
 
         let expected = None;
+
+        assert_eq!(expected, actual);
+        repo_dir.close()
+    }
+
+    #[test]
+    fn test_works_in_bare_repo() -> io::Result<()> {
+        let repo_dir = tempfile::tempdir()?;
+
+        Command::new("git")
+            .args(&["init", "--bare"])
+            .current_dir(&repo_dir)
+            .output()?;
+
+        Command::new("git")
+            .args(&["symbolic-ref", "HEAD", "refs/heads/main"])
+            .current_dir(&repo_dir)
+            .output()?;
+
+        let actual = ModuleRenderer::new("git_branch")
+            .path(&repo_dir.path())
+            .collect();
+
+        let expected = Some(format!(
+            "on {} ",
+            Color::Purple.bold().paint(format!("\u{e0a0} {}", "main")),
+        ));
 
         assert_eq!(expected, actual);
         repo_dir.close()


### PR DESCRIPTION
#### Description
Make the Git branch module support bare repositories.

#### Motivation and Context
Bare repositories don't have a working directory, causing the branch module to not show any information.
But bare repositories still have branches, tags, etc. that should still be shown in the prompt.

#### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/2461567/112728319-e9dc7300-8f26-11eb-950f-0522ff326386.png)

#### How Has This Been Tested?
Initialized a bare repository and tested that the prompt contains the branch name.
Tested on Powershell Core 7.1.3  running on Windows 10.

- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [X] I have tested using **Windows**

#### Checklist:
- [ ] I have updated the documentation accordingly.
- [X] I have updated the tests accordingly.
