### PR TITLE
feat(config): warn about unknown config key names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1628,7 +1628,7 @@ dependencies = [
 
 [[package]]
 name = "starship_module_config_derive"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "proc-macro2",
  "quote 1.0.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ once_cell = "1.7.2"
 chrono = "0.4.19"
 sys-info = "0.8.0"
 byte-unit = "4.0.10"
-starship_module_config_derive = { version = "0.1.2", path = "starship_module_config_derive" }
+starship_module_config_derive = { version = "0.2.0", path = "starship_module_config_derive" }
 yaml-rust = "0.4.5"
 pest = "2.1.3"
 pest_derive = "2.1.0"

--- a/starship_module_config_derive/Cargo.toml
+++ b/starship_module_config_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starship_module_config_derive"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2018"
 authors = ["Matan Kushner <hello@matchai.me>"]
 homepage = "https://starship.rs"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

This PR prints a warning when an unknown config key is encountered:
`[WARN] - (starship::configs::starship_root): Unknown config key 'docker' `

This PR builds on the changes to `starship_module_config_derive` in #2521 to use `default` (https://github.com/starship/starship/pull/2521#issuecomment-808752340).

`load_config(&self, config: &'a Value) -> Self` is replaced by `load_config(&mut self, config: &'a Value)` and it loops over the config table now instead of checking every key individually.

`RootModuleConfig` implements `ModuleConfig` manually now to avoid issues with other modules not being known by the module.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #1213

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
