### PR TITLE
fix(git_commit): Git commit show all tags

### DIFF
--- a/src/modules/git_commit.rs
+++ b/src/modules/git_commit.rs
@@ -48,11 +48,10 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         let tag_names = git_repo.tag_names(None).ok()?;
         let tag_and_refs = tag_names.iter().flat_map(|name| {
             let full_tag = format!("refs/tags/{}", name.unwrap());
-            let tag_obj = git_repo.find_reference(&full_tag)?.peel_to_tag()?;
-            let sig_obj = tag_obj.tagger().unwrap();
+            let ref_obj = git_repo.find_reference(&full_tag)?.peel_to_commit()?;
             git_repo
                 .find_reference(&full_tag)
-                .map(|reference| (String::from(name.unwrap()), sig_obj.when(), reference))
+                .map(|reference| (String::from(name.unwrap()), ref_obj.time(), reference))
         });
 
         let mut tag_name = String::new();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
Show all tags, lightweight and "heavyweight", on the current Git commit.

#### Motivation and Context
Previously lightweight commits was not shown, also only one tag was shown, even when the commit had multiple tags.
Closes #2282 

#### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/2461567/112902921-23f47300-90e7-11eb-9769-366c5893fdb6.png)

#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [X] I have tested using **Windows**

#### Checklist:
- [ ] I have updated the documentation accordingly.
- [X] I have updated the tests accordingly.
