### PR TITLE
build: Update snapcraft.yaml

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -81,6 +81,4 @@ architectures:
   - build-on: armhf
   - build-on: i386
   - build-on: ppc64el
-    build-error: ignore
   - build-on: s390x
-    build-error: ignore


### PR DESCRIPTION
build-error is not a valid syntax in snapcraft.yaml
The build-error lines are causing _all_ architecture builds to fail.

![Screenshot_20210331_115239](https://user-images.githubusercontent.com/1841272/113133600-c27ff180-9217-11eb-9b15-22468669d1cb.png)

```
Running pull phase...
Issues while validating snapcraft.yaml: The 'architectures[4]' property does not match the required schema: additional properties are not allowed ('build-error' was unexpected) or orderedDict([('build-on', 'ppc64el'), ('build-error', 'ignore')]) is not of type 'string'
Build failed
```

Sounds like an interesting option, but not one that exists right now, as far as I can tell! :D