### PR TITLE
style(battery): add space between icon and text for better visual

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -325,11 +325,11 @@ The module is only visible when the device's battery is below 10%.
 
 | Option               | Default                           | Description                                         |
 | -------------------- | --------------------------------- | --------------------------------------------------- |
-| `full_symbol`        | `""`                             | The symbol shown when the battery is full.          |
-| `charging_symbol`    | `""`                             | The symbol shown when the battery is charging.      |
-| `discharging_symbol` | `""`                             | The symbol shown when the battery is discharging.   |
-| `unknown_symbol`     | `""`                             | The symbol shown when the battery state is unknown. |
-| `empty_symbol`       | `""`                             | The symbol shown when the battery state is empty.   |
+| `full_symbol`        | `" "`                            | The symbol shown when the battery is full.          |
+| `charging_symbol`    | `" "`                            | The symbol shown when the battery is charging.      |
+| `discharging_symbol` | `" "`                            | The symbol shown when the battery is discharging.   |
+| `unknown_symbol`     | `" "`                            | The symbol shown when the battery state is unknown. |
+| `empty_symbol`       | `" "`                            | The symbol shown when the battery state is empty.   |
 | `format`             | `"[$symbol$percentage]($style) "` | The format for the module.                          |
 | `display`            | [link](#battery-display)          | Display threshold and style for the module.         |
 | `disabled`           | `false`                           | Disables the `battery` module.                      |
@@ -340,9 +340,9 @@ The module is only visible when the device's battery is below 10%.
 # ~/.config/starship.toml
 
 [battery]
-full_symbol = "🔋"
-charging_symbol = "⚡️"
-discharging_symbol = "💀"
+full_symbol = "🔋 "
+charging_symbol = "⚡️ "
+discharging_symbol = "💀 "
 ```
 
 ### Battery Display

--- a/src/configs/battery.rs
+++ b/src/configs/battery.rs
@@ -18,11 +18,11 @@ pub struct BatteryConfig<'a> {
 impl<'a> Default for BatteryConfig<'a> {
     fn default() -> Self {
         BatteryConfig {
-            full_symbol: "",
-            charging_symbol: "",
-            discharging_symbol: "",
-            unknown_symbol: "",
-            empty_symbol: "",
+            full_symbol: " ",
+            charging_symbol: " ",
+            discharging_symbol: " ",
+            unknown_symbol: " ",
+            empty_symbol: " ",
             format: "[$symbol$percentage]($style) ",
             display: vec![BatteryDisplayConfig {
                 threshold: 10,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
Add space between battery symbol and charge percentage.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Original motivation:
> We should unify the visual in Starship.

This is essentially repurposed @LitoMore's work with changes @davidkna suggested: https://github.com/starship/starship/pull/2333#discussion_r579138892
Closes #2333

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
