### PR TITLE
refactor(init): cleanup init stub

### DIFF
--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -147,23 +147,7 @@ pub fn init_stub(shell_name: &str) -> io::Result<()> {
             starship.sprint_posix()?
         ),
         "powershell" => print!(
-            /*
-             * Explanation of syntax:
-             *
-             *      iex: alias of Invoke-Expression
-             *
-             *      &: Explicitly tells PowerShell to execute path with Starship
-             *         executable.
-             *
-             *      @: multi-line stdout is returned as an array, but a single
-             *         line or no lines are returned as-is. @ ensures it's always
-             *         an array.
-             *
-             *      -join "`n": Joins the stdout array together as a string with
-             *                  newlines. PowerShell escapes with ` instead of \
-             *                  thus `n translates to a newline.
-             */
-            r#"iex (@(&"{}" init powershell --print-full-init) -join "`n")"#,
+            r#"Invoke-Expression (& "{}" init powershell --print-full-init | Out-String)"#,
             starship.sprint()?
         ),
         "ion" => print!("eval $({} init ion --print-full-init)", starship.sprint()?),

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -145,15 +145,21 @@ pub fn init_stub(shell_name: &str) -> io::Result<()> {
         "powershell" => print!(
             /*
              * Explanation of syntax:
-             * &: Explicitly tells powershell to execute path with starship executable.
              *
-             * @: multi-line stdout is returned as an array, but a single line or no lines
-             *    are returned as-is. @ ensures it's always an array.
+             *      iex: alias of Invoke-Expression
              *
-             * -join "`n": Joins the stdout array together as a string with newlines.
-             *             Powershell escapes with ` instead of \ thus `n translates to a newline.
+             *      &: Explicitly tells PowerShell to execute path with Starship
+             *         executable.
+             *
+             *      @: multi-line stdout is returned as an array, but a single
+             *         line or no lines are returned as-is. @ ensures it's always
+             *         an array.
+             *
+             *      -join "`n": Joins the stdout array together as a string with
+             *                  newlines. PowerShell escapes with ` instead of \
+             *                  thus `n translates to a newline.
              */
-            r#"Invoke-Expression (@(&"{}" init powershell --print-full-init) -join "`n")"#,
+            r#"iex (@(&"{}" init powershell --print-full-init) -join "`n")"#,
             starship.sprint()?
         ),
         "ion" => print!("eval $({} init ion --print-full-init)", starship.sprint()?),

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -88,8 +88,8 @@ pub fn init_stub(shell_name: &str) -> io::Result<()> {
 
     let starship = StarshipPath::init()?;
 
-    let setup_stub = match shell_basename {
-        "bash" => {
+    match shell_basename {
+        "bash" => print!(
             /*
              * The standard bash bootstrap is:
              *      `source <(starship init bash --print-full-init)`
@@ -121,68 +121,50 @@ pub fn init_stub(shell_name: &str) -> io::Result<()> {
              * https://github.com/starship/starship/pull/241
              * https://github.com/starship/starship/pull/278
              */
-            let script = {
-                format!(
-                    r#"if [ "${{BASH_VERSINFO[0]}}" -gt 4 ] || ([ "${{BASH_VERSINFO[0]}}" -eq 4 ] && [ "${{BASH_VERSINFO[1]}}" -ge 1 ])
-then
-source <("{0}" init bash --print-full-init)
-else
-source /dev/stdin <<<"$("{0}" init bash --print-full-init)"
-fi"#,
-                    starship.sprint_posix()?
-                )
-            };
+            r#"
+            major="${{BASH_VERSINFO[0]}}"
+            minor="${{BASH_VERSINFO[1]}}"
 
-            Some(script)
-        }
-        "zsh" => {
-            let script = format!(
-                "source <(\"{}\" init zsh --print-full-init)",
-                starship.sprint_posix()?
-            );
-            Some(script)
-        }
-        "fish" => {
+            if ((major > 4)) || {{ ((major == 4)) && ((minor >= 1)); }}; then
+                source <("{0}" init bash --print-full-init)
+            else
+                source /dev/stdin <<<"$("{0}" init bash --print-full-init)"
+            fi
+            "#,
+            starship.sprint_posix()?
+        ),
+        "zsh" => print!(
+            r#"source <("{}" init zsh --print-full-init)"#,
+            starship.sprint_posix()?
+        ),
+        "fish" => print!(
             // Fish does process substitution with pipes and psub instead of bash syntax
-            let script = format!(
-                "source (\"{}\" init fish --print-full-init | psub)",
-                starship.sprint_posix()?
-            );
-            Some(script)
-        }
-        "powershell" => {
-            // Explanation of syntax:
-            // &: Explicitly tells powershell to execute path with starship executable.
-            //
-            // @: multi-line stdout is returned as an array, but a single line or no lines
-            //    are returned as-is. @ ensures it's always an array.
-            //
-            // -join "`n": Joins the stdout array together as a string with newlines.
-            //             Powershell escapes with ` instead of \ thus `n translates to a newline.
-            let script = format!(
-                "Invoke-Expression (@(&\"{}\" init powershell --print-full-init) -join \"`n\")",
-                starship.sprint()?
-            );
-            Some(script)
-        }
-        "ion" => {
-            let script = format!("eval $({} init ion --print-full-init)", starship.sprint()?);
-            Some(script)
-        }
-        "elvish" => {
-            let script = format!(
-                "eval (\"{}\" init elvish --print-full-init | slurp)",
-                starship.sprint_posix()?
-            );
-            Some(script)
-        }
-        "tcsh" => {
-            let script = format!(
-                r#"eval "`("{}" init tcsh --print-full-init)`""#,
-                starship.sprint_posix()?
-            );
-            Some(script)
-        }
+            r#"source ("{}" init fish --print-full-init | psub)"#,
+            starship.sprint_posix()?
+        ),
+        "powershell" => print!(
+            /*
+             * Explanation of syntax:
+             * &: Explicitly tells powershell to execute path with starship executable.
+             *
+             * @: multi-line stdout is returned as an array, but a single line or no lines
+             *    are returned as-is. @ ensures it's always an array.
+             *
+             * -join "`n": Joins the stdout array together as a string with newlines.
+             *             Powershell escapes with ` instead of \ thus `n translates to a newline.
+             */
+            r#"Invoke-Expression (@(&"{}" init powershell --print-full-init) -join "`n")"#,
+            starship.sprint()?
+        ),
+        "ion" => print!("eval $({} init ion --print-full-init)", starship.sprint()?),
+        "elvish" => print!(
+            r#"eval ("{}" init elvish --print-full-init | slurp)"#,
+            starship.sprint_posix()?
+        ),
+        "tcsh" => print!(
+            r#"eval `("{}" init tcsh --print-full-init)`"#,
+            starship.sprint_posix()?
+        ),
         _ => {
             let quoted_arg = shell_words::quote(shell_basename);
             println!(
@@ -199,12 +181,8 @@ fi"#,
                  Please open an issue in the starship repo if you would like to \
                  see support for %s:\\nhttps://github.com/starship/starship/issues/new\\n\\n\" {0} {0}",
                 quoted_arg
-            );
-            None
+            )
         }
-    };
-    if let Some(script) = setup_stub {
-        print!("{}", script);
     };
     Ok(())
 }

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -122,14 +122,18 @@ pub fn init_stub(shell_name: &str) -> io::Result<()> {
              * https://github.com/starship/starship/pull/278
              */
             r#"
-            major="${{BASH_VERSINFO[0]}}"
-            minor="${{BASH_VERSINFO[1]}}"
+            __main() {{
+                local major="${{BASH_VERSINFO[0]}}"
+                local minor="${{BASH_VERSINFO[1]}}"
 
-            if ((major > 4)) || {{ ((major == 4)) && ((minor >= 1)); }}; then
-                source <("{0}" init bash --print-full-init)
-            else
-                source /dev/stdin <<<"$("{0}" init bash --print-full-init)"
-            fi
+                if ((major > 4)) || {{ ((major == 4)) && ((minor >= 1)); }}; then
+                    source <("{0}" init bash --print-full-init)
+                else
+                    source /dev/stdin <<<"$("{0}" init bash --print-full-init)"
+                fi
+            }}
+            __main
+            unset -f __main
             "#,
             starship.sprint_posix()?
         ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Reformat init stub generation code and alter `bash` version.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Improve readability of the `init_stub` procedure.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
