### PR TITLE
feat(python): Remove parentheses from pyvenv.cfg prompt parameter

### DIFF
--- a/src/modules/python.rs
+++ b/src/modules/python.rs
@@ -373,7 +373,7 @@ prompt = 'foo'
         venv_cfg.write_all(
             br#"
 home = something
-prompt = '(foo) '
+prompt = '(foo)'
         "#,
         )?;
         venv_cfg.sync_all()?;
@@ -390,7 +390,7 @@ prompt = '(foo) '
 
         assert_eq!(actual, expected);
         dir.close()
-    }    
+    }
 
     fn check_python2_renders(dir: &tempfile::TempDir, starship_config: Option<toml::Value>) {
         let config = starship_config.unwrap_or(toml::toml! {

--- a/src/modules/python.rs
+++ b/src/modules/python.rs
@@ -109,7 +109,7 @@ fn get_prompt_from_venv(venv_path: &Path) -> Option<String> {
         .ok()?
         .general_section()
         .get("prompt")
-        .map(String::from)
+        .map(|prompt| String::from(prompt.trim_matches(&['(', ')'] as &[_])))
 }
 
 #[cfg(test)]
@@ -364,6 +364,33 @@ prompt = 'foo'
         assert_eq!(actual, expected);
         dir.close()
     }
+
+    #[test]
+    fn with_active_venv_and_dirty_prompt() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        create_dir_all(dir.path().join("my_venv"))?;
+        let mut venv_cfg = File::create(dir.path().join("my_venv").join("pyvenv.cfg"))?;
+        venv_cfg.write_all(
+            br#"
+home = something
+prompt = '(foo) '
+        "#,
+        )?;
+        venv_cfg.sync_all()?;
+
+        let actual = ModuleRenderer::new("python")
+            .path(dir.path())
+            .env("VIRTUAL_ENV", dir.path().join("my_venv").to_str().unwrap())
+            .collect();
+
+        let expected = Some(format!(
+            "via {}",
+            Color::Yellow.bold().paint("🐍 v3.8.0 (foo) ")
+        ));
+
+        assert_eq!(actual, expected);
+        dir.close()
+    }    
 
     fn check_python2_renders(dir: &tempfile::TempDir, starship_config: Option<toml::Value>) {
         let config = starship_config.unwrap_or(toml::toml! {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Updated the retrieval of the the `prompt` parameter from `pyvenv.cfg` so that it removes extra parentheses. pipenv adds the `prompt` parameter with explicit parentheses when using a local `.venv` or setting the `PIPENV_VENV_IN_PROJECT` flag. This creates the 'double parentheses' in the issue below. Removing the additional parentheses when they are read from `pyvenv.cfg` does not affect the display of other python virtual environments. 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1844 

#### Screenshots (if appropriate):
Example `pyvenv.cfg` with `prompt` parameter as created by pipenv:
![image](https://user-images.githubusercontent.com/1111348/113484289-7cc06480-9475-11eb-8313-18c715d5ae8a.png)

Example `pyvenv.cfg` as created by the standard venv and `prompt` CLI option (`python3 -m venv venv --prompt venv-demo`):
![image](https://user-images.githubusercontent.com/1111348/113484390-0bcd7c80-9476-11eb-97cc-9992aeecfa21.png)

Example of double parentheses (before fix):
![image](https://user-images.githubusercontent.com/1111348/113484270-63b7b380-9475-11eb-9774-7fd84d8e1665.png)

After the fix:
![image](https://user-images.githubusercontent.com/1111348/113484597-2b18d980-9477-11eb-9323-05b3d87b5ea3.png)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
