### PR TITLE
fix(configure): fix print-config issues

### DIFF
--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -66,8 +66,12 @@ pub use starship_root::*;
 #[derive(Default, Serialize, ModuleConfig, Clone)]
 #[serde(default)]
 pub struct FullConfig<'a> {
-    #[serde(flatten)]
-    root: starship_root::StarshipRootConfig<'a>,
+    // Root config
+    pub format: &'a str,
+    pub scan_timeout: u64,
+    pub command_timeout: u64,
+    pub add_newline: bool,
+    // modules
     aws: aws::AwsConfig<'a>,
     battery: battery::BatteryDisplayConfig<'a>,
     character: character::CharacterConfig<'a>,
@@ -88,7 +92,7 @@ pub struct FullConfig<'a> {
     git_commit: git_commit::GitCommitConfig<'a>,
     git_state: git_state::GitStateConfig<'a>,
     git_status: git_status::GitStatusConfig<'a>,
-    go: go::GoConfig<'a>,
+    golang: go::GoConfig<'a>,
     helm: helm::HelmConfig<'a>,
     hg_branch: hg_branch::HgBranchConfig<'a>,
     hostname: hostname::HostnameConfig<'a>,

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -2,6 +2,7 @@ use crate::{config::ModuleConfig, module::ALL_MODULES};
 
 use serde::Serialize;
 
+// On changes please also update the `FullConfig` struct in `mod.rs`
 #[derive(Clone, Serialize)]
 pub struct StarshipRootConfig<'a> {
     pub format: &'a str,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR fixes issues for `print-config` related to the new `FullConfig` struct.

The `golang` module was incorrectly listed as `go`.

For `RootConfig` `#[serde(flatten)]` wasn't enough to make `print-config` (non `--default`) work. I inlined `RootConfig` instead and added a comment in `starship_root.rs` to ensure both are always changed together.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
