### PR TITLE
feat(config): print a suggestion for unknown fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,7 +247,7 @@ dependencies = [
  "ansi_term 0.11.0",
  "atty",
  "bitflags 1.2.1",
- "strsim",
+ "strsim 0.8.0",
  "textwrap",
  "unicode-width",
  "vec_map",
@@ -1614,6 +1614,7 @@ dependencies = [
  "shadow-rs",
  "shell-words",
  "starship_module_config_derive",
+ "strsim 0.10.0",
  "sys-info",
  "tempfile",
  "term_size",
@@ -1628,7 +1629,7 @@ dependencies = [
 
 [[package]]
 name = "starship_module_config_derive"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "proc-macro2",
  "quote 1.0.9",
@@ -1640,6 +1641,12 @@ name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ once_cell = "1.7.2"
 chrono = "0.4.19"
 sys-info = "0.8.0"
 byte-unit = "4.0.10"
-starship_module_config_derive = { version = "0.2.0", path = "starship_module_config_derive" }
+starship_module_config_derive = { version = "0.2.1", path = "starship_module_config_derive" }
 yaml-rust = "0.4.5"
 pest = "2.1.3"
 pest_derive = "2.1.0"
@@ -67,6 +67,7 @@ notify-rust = { version = "4.3.0", optional = true }
 semver = "0.11.0"
 which = "4.1.0"
 shadow-rs = "0.5.25"
+strsim = "0.10.0"
 
 process_control = { version = "3.0.1", features = ["crossbeam-channel"] }
 

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -118,7 +118,7 @@ impl<'a> ModuleConfig<'a> for StarshipRootConfig<'a> {
                             (score > 0.8).then(|| (score, field))
                         })
                         .max_by(
-                            |(score_a, _field_a), (score_b, _field_d)| {
+                            |(score_a, _field_a), (score_b, _field_b)| {
                                 score_a.partial_cmp(score_b).unwrap_or(Ordering::Equal)
                             },
                         );

--- a/starship_module_config_derive/Cargo.toml
+++ b/starship_module_config_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starship_module_config_derive"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2018"
 authors = ["Matan Kushner <hello@matchai.me>"]
 homepage = "https://starship.rs"

--- a/starship_module_config_derive/src/lib.rs
+++ b/starship_module_config_derive/src/lib.rs
@@ -57,7 +57,7 @@ fn impl_module_config(dinput: DeriveInput) -> proc_macro::TokenStream {
                                         (score > 0.8).then(|| (score, field))
                                     })
                                     .max_by(
-                                        |(score_a, _field_a), (score_b, _field_d)| {
+                                        |(score_a, _field_a), (score_b, _field_b)| {
                                             score_a.partial_cmp(score_b).unwrap_or(::std::cmp::Ordering::Equal)
                                         },
                                     );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR changes the unknown config key message to also include a suggestion which key name should be used instead.

The candidate scoring algorithm/library are the same as what `clap` uses.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

For this config:
```toml
[go]
symbol = " "

[nodejs]
disable = true
```
Output:
```
[WARN] - (starship::configs::starship_root): Unknown config key 'go'
[WARN] - (starship::configs::starship_root): Did you mean 'golang'?
[WARN] - (starship::configs::nodejs): Unknown config key 'disable'
[WARN] - (starship::configs::nodejs): Did you mean 'disabled'?

```

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
