### PR TITLE
test: allow running tests as root

### DIFF
--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -514,6 +514,7 @@ mod tests {
         }
 
         #[test]
+        #[ignore]
         fn directory_in_root() {
             let actual = ModuleRenderer::new("directory").path("/etc").collect();
             let expected = Some(format!(

--- a/src/modules/username.rs
+++ b/src/modules/username.rs
@@ -86,7 +86,6 @@ fn is_ssh_session(context: &Context) -> bool {
 #[cfg(test)]
 mod tests {
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
 
     // TODO: Add tests for if root user (UID == 0)
     // Requires mocking
@@ -100,6 +99,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn no_logname_env_variable() {
         let actual = ModuleRenderer::new("username")
             .env(super::USERNAME_ENV_VAR, "astronaut")
@@ -110,6 +110,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn logname_equals_user() {
         let actual = ModuleRenderer::new("username")
             .env("LOGNAME", "astronaut")
@@ -136,10 +137,16 @@ mod tests {
         let actual = ModuleRenderer::new("username")
             .env("LOGNAME", "astronaut")
             .env(super::USERNAME_ENV_VAR, "cosmonaut")
+            // Test output should not change when run by root/non-root user
+            .config(toml::toml! {
+                [username]
+                style_root = ""
+                style_user = ""
+            })
             .collect();
-        let expected = Some(format!("{} in ", Color::Yellow.bold().paint("cosmonaut")));
+        let expected = Some("cosmonaut in ");
 
-        assert_eq!(expected, actual);
+        assert_eq!(expected, actual.as_deref());
     }
 
     #[test]
@@ -147,10 +154,16 @@ mod tests {
         let actual = ModuleRenderer::new("username")
             .env(super::USERNAME_ENV_VAR, "astronaut")
             .env("SSH_CONNECTION", "192.168.223.17 36673 192.168.223.229 22")
+            // Test output should not change when run by root/non-root user
+            .config(toml::toml! {
+                [username]
+                style_root = ""
+                style_user = ""
+            })
             .collect();
-        let expected = Some(format!("{} in ", Color::Yellow.bold().paint("astronaut")));
+        let expected = Some("astronaut in ");
 
-        assert_eq!(expected, actual);
+        assert_eq!(expected, actual.as_deref());
     }
 
     #[test]
@@ -158,10 +171,16 @@ mod tests {
         let actual = ModuleRenderer::new("username")
             .env(super::USERNAME_ENV_VAR, "astronaut")
             .env("SSH_TTY", "/dev/pts/0")
+            // Test output should not change when run by root/non-root user
+            .config(toml::toml! {
+                [username]
+                style_root = ""
+                style_user = ""
+            })
             .collect();
-        let expected = Some(format!("{} in ", Color::Yellow.bold().paint("astronaut")));
+        let expected = Some("astronaut in ");
 
-        assert_eq!(expected, actual);
+        assert_eq!(expected, actual.as_deref());
     }
 
     #[test]
@@ -169,23 +188,33 @@ mod tests {
         let actual = ModuleRenderer::new("username")
             .env(super::USERNAME_ENV_VAR, "astronaut")
             .env("SSH_CLIENT", "192.168.0.101 39323 22")
+            // Test output should not change when run by root/non-root user
+            .config(toml::toml! {
+                [username]
+                style_root = ""
+                style_user = ""
+            })
             .collect();
-        let expected = Some(format!("{} in ", Color::Yellow.bold().paint("astronaut")));
+        let expected = Some("astronaut in ");
 
-        assert_eq!(expected, actual);
+        assert_eq!(expected, actual.as_deref());
     }
 
     #[test]
     fn show_always() {
         let actual = ModuleRenderer::new("username")
             .env(super::USERNAME_ENV_VAR, "astronaut")
+            // Test output should not change when run by root/non-root user
             .config(toml::toml! {
                 [username]
                 show_always = true
+
+                style_root = ""
+                style_user = ""
             })
             .collect();
-        let expected = Some(format!("{} in ", Color::Yellow.bold().paint("astronaut")));
+        let expected = Some("astronaut in ");
 
-        assert_eq!(expected, actual);
+        assert_eq!(expected, actual.as_deref());
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Some tests were failing when run as root, because the behaviour of the tested modules changed based on whether they were running as a root user. This caused the `style_root` to appear in `username` tests and in the directory module some paths that were assumed not to be writable, ended up writable.

This PR fixes this by either disabling the root-specific behaviour or by ignoring them by default, so they only run in the controlled CI environment.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #2568

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
