### PR TITLE
refactor(scala): parse version w/o regex

### DIFF
--- a/src/modules/scala.rs
+++ b/src/modules/scala.rs
@@ -3,10 +3,6 @@ use crate::formatter::StringFormatter;
 
 use super::{Context, Module, RootModuleConfig};
 
-use regex::Regex;
-
-const SCALA_VERSION_PATTERN: &str = "version[\\s](?P<version>[^\\s]+)";
-
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let mut module = context.new_module("scala");
     let config: ScalaConfig = ScalaConfig::try_load(module.config);
@@ -65,9 +61,11 @@ fn get_scala_version(context: &Context) -> Option<String> {
 }
 
 fn parse_scala_version(scala_version: &str) -> Option<String> {
-    let re = Regex::new(SCALA_VERSION_PATTERN).ok()?;
-    let captures = re.captures(scala_version)?;
-    let version = &captures["version"];
+    let version = scala_version
+        // split into ["Scala", "compiler", "version", "2.13.5", "--", ...]
+        .split_whitespace()
+        // take "2.13.5"
+        .nth(3)?;
 
     Some(format!("v{}", &version))
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Parse Scala compiler version without regex.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Follow convention established by other modules.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
