### PR TITLE
fix(install): fix install with busybox tar

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -120,8 +120,8 @@ unpack() {
 
   case "$archive" in
     *.tar.gz)
-      flags=$(test -n "${VERBOSE-}" && echo "-v" || echo "")
-      ${sudo} tar "${flags}" -xzf "${archive}" -C "${bin_dir}"
+      flags=$(test -n "${VERBOSE-}" && echo "-xzvf" || echo "-xzf")
+      ${sudo} tar "${flags}" "${archive}" -C "${bin_dir}"
       return 0
       ;;
     *.zip)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Busybox tar interpreted the empty string `"${flags}"` as a file input. I fixed this by also adding all the other flags to `${flags}`, thus ensuring it is never empty.

Another fix would have been to simply unquote `${flags}`, but that would have caused a shellcheck warning.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #2582

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
