### PR TITLE
feat(gcloud): Shorten google cloud iam service account addresses

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1001,14 +1001,15 @@ This is based on the `~/.config/gcloud/active_config` file and the `~/.config/gc
 
 ### Variables
 
-| Variable | Example           | Description                                                        |
-| -------- | ----------------- | ------------------------------------------------------------------ |
-| region   | `us-central1`     | The current GCP region                                             |
-| account  | `foo@example.com` | The current GCP profile                                            |
-| project  |                   | The current GCP project                                            |
-| active   | `default`         | The active config name written in `~/.config/gcloud/active_config` |
-| symbol   |                   | Mirrors the value of option `symbol`                               |
-| style\*  |                   | Mirrors the value of option `style`                                |
+| Variable   | Example           | Description                                                        |
+| --------   | ----------------- | ------------------------------------------------------------------ |
+|   region   |   `us-central1`   | The current GCP region                                             |
+|   account  |      `foo`        | The current GCP profile                                            |
+| account_at |   `@example.com`  | The current GCP profile at                                         |
+|   project  |                   | The current GCP project                                            |
+|   active   |     `default`     | The active config name written in `~/.config/gcloud/active_config` |
+|   symbol   |                   | Mirrors the value of option `symbol`                               |
+|   style\*  |                   | Mirrors the value of option `style`                                |
 
 \*: This variable can only be used as a part of a style string
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1005,7 +1005,7 @@ This is based on the `~/.config/gcloud/active_config` file and the `~/.config/gc
 | --------   | ----------------- | ------------------------------------------------------------------ |
 |   region   |   `us-central1`   | The current GCP region                                             |
 |   account  |      `foo`        | The current GCP profile                                            |
-| account_at |   `@example.com`  | The current GCP profile at                                         |
+|   domain   |   `example.com`   | The current GCP profile domain                                     |
 |   project  |                   | The current GCP project                                            |
 |   active   |     `default`     | The active config name written in `~/.config/gcloud/active_config` |
 |   symbol   |                   | Mirrors the value of option `symbol`                               |

--- a/src/configs/gcloud.rs
+++ b/src/configs/gcloud.rs
@@ -15,7 +15,7 @@ pub struct GcloudConfig<'a> {
 impl<'a> Default for GcloudConfig<'a> {
     fn default() -> Self {
         GcloudConfig {
-            format: "on [$symbol$account$account_at(\\($region\\))]($style) ",
+            format: "on [$symbol$account@$domain(\\($region\\))]($style) ",
             symbol: "☁️ ",
             style: "bold blue",
             disabled: false,

--- a/src/configs/gcloud.rs
+++ b/src/configs/gcloud.rs
@@ -15,7 +15,7 @@ pub struct GcloudConfig<'a> {
 impl<'a> Default for GcloudConfig<'a> {
     fn default() -> Self {
         GcloudConfig {
-            format: "on [$symbol$account(\\($region\\))]($style) ",
+            format: "on [$symbol$account$account_at(\\($region\\))]($style) ",
             symbol: "☁️ ",
             style: "bold blue",
             disabled: false,

--- a/src/modules/gcloud.rs
+++ b/src/modules/gcloud.rs
@@ -99,8 +99,9 @@ fn alias_region(region: String, aliases: &HashMap<String, &str>) -> String {
 fn map_account(account: String) -> (Option<String>, Option<String>) {
     match account.find('@') {
         Some(index) => {
-            let (account, at) = account.split_at(index);
-            (Some(account.to_owned()), Some(at.to_owned()))
+            let (account, mut domain) = account.split_at(index);
+            domain = domain.strip_prefix('@').unwrap();
+            (Some(account.to_owned()), Some(domain.to_owned()))
         }
         None => (Some(account), None),
     }
@@ -131,7 +132,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         None
     };
 
-    let (account, at) = match gcloud_account {
+    let (account, domain) = match gcloud_account {
         Some(account) => map_account(account),
         None => (None, None),
     };
@@ -148,7 +149,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             })
             .map(|variable| match variable {
                 "account" => account.as_ref().map(Ok),
-                "account_at" => at.as_ref().map(Ok),
+                "domain" => domain.as_ref().map(Ok),
                 "project" => gcloud_project.as_ref().map(Ok),
                 "region" => mapped_region.as_ref().map(Ok),
                 "active" => gcloud_active.as_ref().map(Ok),


### PR DESCRIPTION
Hello, thanks everyone for you hard work on this project. The experience of contributing was great! It was my first time doing anything in rust but I hope it will be somehow helpful. 

#### Description
Parses google account string into 2 variables so user can how he sees the information in prompt.

#### Motivation and Context
Closes #1737

#### Screenshots (if appropriate):

#### How Has This Been Tested?
I ran `cargo test` on MacOS and Linux.
- [x] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
