### PR TITLE
feat(config): Add support for `inverted` token in style strings

### DIFF
--- a/docs/advanced-config/README.md
+++ b/docs/advanced-config/README.md
@@ -98,9 +98,9 @@ Style strings are a list of words, separated by whitespace. The words are not ca
   - `<color>`
   - `none`
 
-where `<color>` is a color specifier (discussed below). `fg:<color>` and `<color>` currently do the same thing , though this may change in the future. The order of words in the string does not matter.
+where `<color>` is a color specifier (discussed below). `fg:<color>` and `<color>` currently do the same thing, though this may change in the future. `inverted` swaps the background and foreground colors. The order of words in the string does not matter.
 
-The `none` token overrides all other tokens in a string if it is not part of a `bg:` specifier, so that e.g. `fg:red none fg:blue` will still create a string with no styling. `bg:none`  sets the background to the default color so `fg:red bg:none` is equivalent to `red` or `fg:red` and `bg:green fg:red bg:none` is also equivalent to `fg:red` or `red`. It may become an error to use `none` in conjunction with other tokens in the future.
+The `none` token overrides all other tokens in a string if it is not part of a `bg:` specifier, so that e.g. `fg:red none fg:blue` will still create a string with no styling. `bg:none` sets the background to the default color so `fg:red bg:none` is equivalent to `red` or `fg:red` and `bg:green fg:red bg:none` is also equivalent to `fg:red` or `red`. It may become an error to use `none` in conjunction with other tokens in the future.
 
 A color specifier can be one of the following:
 

--- a/docs/advanced-config/README.md
+++ b/docs/advanced-config/README.md
@@ -28,7 +28,7 @@ function blastoff(){
 starship_precmd_user_func="blastoff"
 ```
 
-- To run a custom function right before a command runs, you can use the 
+- To run a custom function right before a command runs, you can use the
   [`DEBUG` trap mechanism](https://jichu4n.com/posts/debug-trap-and-prompt_command-in-bash/).
   However, you **must** trap the DEBUG signal *before* initializing Starship!
   Starship can preserve the value of the DEBUG trap, but if the trap is overwritten
@@ -44,7 +44,7 @@ eval $(starship init bash)
 
 ## Change Window Title
 
-Some shell prompts will automatically change the window title for you (e.g. to 
+Some shell prompts will automatically change the window title for you (e.g. to
 reflect your working directory). Fish even does it by default.
 Starship does not do this, but it's fairly straightforward to add this
 functionality to `bash` or `zsh`.
@@ -72,7 +72,7 @@ In `zsh`, add this to the `precmd_functions` array:
 precmd_functions+=(set_win_title)
 ```
 
-If you like the result, add these lines to your shell configuration file 
+If you like the result, add these lines to your shell configuration file
 (`~/.bashrc` or `~/.zshrc`) to make it permanent.
 
 For example, if you want to display your current directory in your terminal tab title,
@@ -92,6 +92,7 @@ Style strings are a list of words, separated by whitespace. The words are not ca
   - `bold`
   - `underline`
   - `dimmed`
+  - `reverse`
   - `bg:<color>`
   - `fg:<color>`
   - `<color>`

--- a/docs/advanced-config/README.md
+++ b/docs/advanced-config/README.md
@@ -92,7 +92,7 @@ Style strings are a list of words, separated by whitespace. The words are not ca
   - `bold`
   - `underline`
   - `dimmed`
-  - `reverse`
+  - `inverted`
   - `bg:<color>`
   - `fg:<color>`
   - `<color>`

--- a/src/config.rs
+++ b/src/config.rs
@@ -359,7 +359,8 @@ impl StarshipConfig {
  - 'underline'
  - 'bold'
  - 'italic'
- - '<color>'        (see the parse_color_string doc for valid color strings)
+ - 'reverse'
+ - '<color>'       (see the parse_color_string doc for valid color strings)
 */
 pub fn parse_style_string(style_string: &str) -> Option<ansi_term::Style> {
     style_string
@@ -383,6 +384,7 @@ pub fn parse_style_string(style_string: &str) -> Option<ansi_term::Style> {
                     "bold" => Some(style.bold()),
                     "italic" => Some(style.italic()),
                     "dimmed" => Some(style.dimmed()),
+                    "reverse" => Some(style.reverse()),
                     // When the string is supposed to be a color:
                     // Decide if we yield none, reset background or set color.
                     color_string => {
@@ -675,13 +677,14 @@ mod tests {
     }
 
     #[test]
-    fn table_get_styles_bold_italic_underline_green_dimmy_silly_caps() {
-        let config = Value::from("bOlD ItAlIc uNdErLiNe GrEeN diMMeD");
+    fn table_get_styles_bold_italic_underline_green_dimmed_reverse_silly_caps() {
+        let config = Value::from("bOlD ItAlIc uNdErLiNe GrEeN diMMeD ReVeRSe");
         let mystyle = <Style>::from_config(&config).unwrap();
         assert!(mystyle.is_bold);
         assert!(mystyle.is_italic);
         assert!(mystyle.is_underline);
         assert!(mystyle.is_dimmed);
+        assert!(mystyle.is_reverse);
         assert_eq!(
             mystyle,
             ansi_term::Style::new()
@@ -689,6 +692,7 @@ mod tests {
                 .italic()
                 .underline()
                 .dimmed()
+                .reverse()
                 .fg(Color::Green)
         );
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -677,6 +677,25 @@ mod tests {
     }
 
     #[test]
+    fn table_get_styles_bold_italic_underline_green_dimmed_silly_caps() {
+        let config = Value::from("bOlD ItAlIc uNdErLiNe GrEeN diMMeD");
+        let mystyle = <Style>::from_config(&config).unwrap();
+        assert!(mystyle.is_bold);
+        assert!(mystyle.is_italic);
+        assert!(mystyle.is_underline);
+        assert!(mystyle.is_dimmed);
+        assert_eq!(
+            mystyle,
+            ansi_term::Style::new()
+                .bold()
+                .italic()
+                .underline()
+                .dimmed()
+                .fg(Color::Green)
+        );
+    }
+
+    #[test]
     fn table_get_styles_bold_italic_underline_green_dimmed_reverse_silly_caps() {
         let config = Value::from("bOlD ItAlIc uNdErLiNe GrEeN diMMeD ReVeRSe");
         let mystyle = <Style>::from_config(&config).unwrap();

--- a/src/config.rs
+++ b/src/config.rs
@@ -359,7 +359,7 @@ impl StarshipConfig {
  - 'underline'
  - 'bold'
  - 'italic'
- - 'reverse'
+ - 'inverted'
  - '<color>'       (see the parse_color_string doc for valid color strings)
 */
 pub fn parse_style_string(style_string: &str) -> Option<ansi_term::Style> {
@@ -384,7 +384,7 @@ pub fn parse_style_string(style_string: &str) -> Option<ansi_term::Style> {
                     "bold" => Some(style.bold()),
                     "italic" => Some(style.italic()),
                     "dimmed" => Some(style.dimmed()),
-                    "reverse" => Some(style.reverse()),
+                    "inverted" => Some(style.reverse()),
                     // When the string is supposed to be a color:
                     // Decide if we yield none, reset background or set color.
                     color_string => {
@@ -696,8 +696,8 @@ mod tests {
     }
 
     #[test]
-    fn table_get_styles_bold_italic_underline_green_dimmed_reverse_silly_caps() {
-        let config = Value::from("bOlD ItAlIc uNdErLiNe GrEeN diMMeD ReVeRSe");
+    fn table_get_styles_bold_italic_underline_green_dimmed_inverted_silly_caps() {
+        let config = Value::from("bOlD ItAlIc uNdErLiNe GrEeN diMMeD InVeRTed");
         let mystyle = <Style>::from_config(&config).unwrap();
         assert!(mystyle.is_bold);
         assert!(mystyle.is_italic);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR adds support for the `inverted` keyword in style strings. This keyword swaps the foreground and background colors, similar to the `\e[7m` ANSI code.

~~(I chose `reverse` instead of `inverted` as I first proposed, because that's the terminology `ansi_term` uses).~~

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #2390 

#### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/46634000/115042426-be202d80-9ed3-11eb-9a76-0e2848011102.png)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.