### PR TITLE
refactor(gcloud): lazily read active gcloud config

### DIFF
--- a/src/modules/gcloud.rs
+++ b/src/modules/gcloud.rs
@@ -1,125 +1,85 @@
-use std::fs::File;
-use std::io::{BufRead, BufReader, Error, ErrorKind};
+use once_cell::sync::Lazy;
+use std::ops::Deref;
+use std::path::Path;
 use std::path::PathBuf;
-use std::str::FromStr;
-use std::{collections::HashMap, path::Path};
 
 use super::{Context, Module, RootModuleConfig};
 
 use crate::configs::gcloud::GcloudConfig;
 use crate::formatter::StringFormatter;
+use crate::utils;
 
-type Account = String;
-type Project = String;
-type Region = String;
-type Active = String;
-
-fn get_gcloud_account_from_config(current_config: &Path) -> Option<Account> {
-    let file = File::open(&current_config).ok()?;
-    let reader = BufReader::new(file);
-    let lines = reader.lines().filter_map(Result::ok);
-    let account_line = lines
-        .skip_while(|line| line != "[core]")
+fn get_gcloud_account_from_config(cloud_config: &str) -> Option<String> {
+    let account_line = cloud_config
+        .lines()
+        .skip_while(|line| *line != "[core]")
         .skip(1)
         .take_while(|line| !line.starts_with('['))
         .find(|line| line.starts_with("account"))?;
-    let account = account_line.split('=').nth(1)?.trim();
+    let account = account_line.splitn(2, '=').nth(1)?.trim();
     Some(account.to_string())
 }
 
-fn get_gcloud_project_from_config(current_config: &Path) -> Option<Project> {
-    let file = File::open(&current_config).ok()?;
-    let reader = BufReader::new(file);
-    let lines = reader.lines().filter_map(Result::ok);
-    let project_line = lines
-        .skip_while(|line| line != "[core]")
+fn get_gcloud_project_from_config(cloud_config: &str) -> Option<String> {
+    let project_line = cloud_config
+        .lines()
+        .skip_while(|line| *line != "[core]")
         .skip(1)
         .take_while(|line| !line.starts_with('['))
         .find(|line| line.starts_with("project"))?;
-    let project = project_line.split('=').nth(1)?.trim();
+    let project = project_line.splitn(2, '=').nth(1)?.trim();
     Some(project.to_string())
 }
 
-fn get_gcloud_region_from_config(current_config: &Path) -> Option<Region> {
-    let file = File::open(&current_config).ok()?;
-    let reader = BufReader::new(file);
-    let lines = reader.lines().filter_map(Result::ok);
-    let region_line = lines
-        .skip_while(|line| line != "[compute]")
+fn get_gcloud_region_from_config(cloud_config: &str) -> Option<String> {
+    let region_line = cloud_config
+        .lines()
+        .skip_while(|line| *line != "[compute]")
         .skip(1)
         .take_while(|line| !line.starts_with('['))
         .find(|line| line.starts_with("region"))?;
-    let region = region_line.split('=').nth(1)?.trim();
+    let region = region_line.splitn(2, '=').nth(1)?.trim();
     Some(region.to_string())
 }
 
-fn get_active_config(context: &Context, config_root: &Path) -> Option<String> {
-    let config_name = context.get_env("CLOUDSDK_ACTIVE_CONFIG_NAME").or_else(|| {
-        let path = config_root.join("active_config");
-        let file = File::open(&path).ok()?;
-        let reader = BufReader::new(file);
-        let first_line = match reader.lines().next() {
-            Some(res) => res,
-            None => Err(Error::new(ErrorKind::NotFound, "empty")),
-        };
-        match first_line {
-            Ok(c) => Some(c),
-            Err(_) => None,
-        }
-    })?;
-    Some(config_name)
-}
-
-fn get_current_config_path(context: &Context) -> Option<PathBuf> {
+fn get_current_config(context: &Context) -> Option<(String, PathBuf)> {
     let config_dir = get_config_dir(context)?;
-    let active_config = get_active_config(context, &config_dir)?;
-    let current_config = config_dir.join(format!("configurations/config_{}", active_config));
-    Some(current_config)
+    let name = get_active_config(context, &config_dir)?;
+    let path = config_dir
+        .join("configurations")
+        .join(format!("config_{}", name));
+    Some((name, path))
 }
 
 fn get_config_dir(context: &Context) -> Option<PathBuf> {
-    let config_dir = context
+    context
         .get_env("CLOUDSDK_CONFIG")
-        .and_then(|path| PathBuf::from_str(&path).ok())
+        .map(PathBuf::from)
         .or_else(|| {
-            let mut home = context.get_home()?;
-            home.push(".config/gcloud");
-            Some(home)
-        })?;
-    Some(config_dir)
+            let home = context.get_home()?;
+            Some(home.join(".config").join("gcloud"))
+        })
 }
 
-fn alias_region(region: String, aliases: &HashMap<String, &str>) -> String {
-    match aliases.get(&region) {
-        None => region.to_string(),
-        Some(alias) => (*alias).to_string(),
-    }
+fn get_active_config(context: &Context, config_dir: &Path) -> Option<String> {
+    context.get_env("CLOUDSDK_ACTIVE_CONFIG_NAME").or_else(|| {
+        let path = config_dir.join("active_config");
+        match utils::read_file(path) {
+            Ok(data) => data.lines().next().map(String::from),
+            Err(_) => None,
+        }
+    })
 }
 
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let mut module = context.new_module("gcloud");
     let config: GcloudConfig = GcloudConfig::try_load(module.config);
 
-    let config_path = get_current_config_path(context)?;
-    let gcloud_account = get_gcloud_account_from_config(&config_path);
-    let gcloud_project = get_gcloud_project_from_config(&config_path);
-    let gcloud_region = get_gcloud_region_from_config(&config_path);
-    let config_dir = get_config_dir(context)?;
-    let gcloud_active: Option<Active> = get_active_config(context, &config_dir);
-
-    if gcloud_account.is_none()
-        && gcloud_project.is_none()
-        && gcloud_region.is_none()
-        && gcloud_active.is_none()
-    {
-        return None;
-    }
-
-    let mapped_region = if let Some(gcloud_region) = gcloud_region {
-        Some(alias_region(gcloud_region, &config.region_aliases))
-    } else {
-        None
-    };
+    let (active, config_path) = get_current_config(context)?;
+    let cloud_config = Lazy::new(|| match utils::read_file(config_path) {
+        Ok(data) => Some(data),
+        Err(_) => None,
+    });
 
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter
@@ -132,10 +92,29 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 _ => None,
             })
             .map(|variable| match variable {
-                "account" => gcloud_account.as_ref().map(Ok),
-                "project" => gcloud_project.as_ref().map(Ok),
-                "region" => mapped_region.as_ref().map(Ok),
-                "active" => gcloud_active.as_ref().map(Ok),
+                "account" => cloud_config
+                    .deref()
+                    .as_ref()
+                    .and_then(|cloud_config| get_gcloud_account_from_config(&cloud_config))
+                    .map(Ok),
+                "region" => cloud_config
+                    .deref()
+                    .as_ref()
+                    .and_then(|cloud_config| get_gcloud_region_from_config(&cloud_config))
+                    .and_then(|region| {
+                        config
+                            .region_aliases
+                            .get(&region)
+                            .map(|alias| String::from(*alias))
+                            .or(Some(region))
+                    })
+                    .map(Ok),
+                "project" => cloud_config
+                    .deref()
+                    .as_ref()
+                    .and_then(|cloud_config| get_gcloud_project_from_config(&cloud_config))
+                    .map(Ok),
+                "active" => Some(Ok(active.to_owned())),
                 _ => None,
             })
             .parse(None)
@@ -169,10 +148,11 @@ mod tests {
         active_config_file.write_all(b"default")?;
 
         create_dir(dir.path().join("configurations"))?;
-        let config_default_path = dir.path().join("configurations/config_default");
+        let config_default_path = dir.path().join("configurations").join("config_default");
         let mut config_default_file = File::create(&config_default_path)?;
         config_default_file.write_all(
-            b"[core]
+            b"\
+[core]
 account = foo@example.com
 ",
         )?;
@@ -197,10 +177,11 @@ account = foo@example.com
         active_config_file.write_all(b"default")?;
 
         create_dir(dir.path().join("configurations"))?;
-        let config_default_path = dir.path().join("configurations/config_default");
+        let config_default_path = dir.path().join("configurations").join("config_default");
         let mut config_default_file = File::create(&config_default_path)?;
         config_default_file.write_all(
-            b"[core]
+            b"\
+[core]
 account = foo@example.com
 
 [compute]
@@ -228,10 +209,11 @@ region = us-central1
         active_config_file.write_all(b"default")?;
 
         create_dir(dir.path().join("configurations"))?;
-        let config_default_path = dir.path().join("configurations/config_default");
+        let config_default_path = dir.path().join("configurations").join("config_default");
         let mut config_default_file = File::create(&config_default_path)?;
         config_default_file.write_all(
-            b"[core]
+            b"\
+[core]
 account = foo@example.com
 
 [compute]
@@ -283,10 +265,11 @@ region = us-central1
         active_config_file.write_all(b"default")?;
 
         create_dir(dir.path().join("configurations"))?;
-        let config_default_path = dir.path().join("configurations/config_default");
+        let config_default_path = dir.path().join("configurations").join("config_default");
         let mut config_default_file = File::create(&config_default_path)?;
         config_default_file.write_all(
-            b"[core]
+            b"\
+[core]
 project = abc
 ",
         )?;
@@ -328,18 +311,20 @@ project = abc
         active_config_file.write_all(b"default")?;
 
         create_dir(dir.path().join("configurations"))?;
-        let config_default_path = dir.path().join("configurations/config_default");
+        let config_default_path = dir.path().join("configurations").join("config_default");
         let mut config_default_file = File::create(&config_default_path)?;
         config_default_file.write_all(
-            b"[core]
+            b"\
+[core]
 project = default
 ",
         )?;
 
-        let config_overridden_path = dir.path().join("configurations/config_overridden");
+        let config_overridden_path = dir.path().join("configurations").join("config_overridden");
         let mut config_overridden_file = File::create(&config_overridden_path)?;
         config_overridden_file.write_all(
-            b"[core]
+            b"\
+[core]
 project = overridden
 ",
         )?;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Lazily read active gcloud config.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Avoid multiple gcloud config read operations.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
