### PR TITLE
feat(gcloud): introduce separate `account` & `domain` format string variables

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1045,24 +1045,25 @@ This is based on the `~/.config/gcloud/active_config` file and the `~/.config/gc
 
 ### Options
 
-| Option           | Default                                        | Description                                                     |
-| ---------------- | ---------------------------------------------- | --------------------------------------------------------------- |
-| `format`         | `'on [$symbol$account(\($region\))]($style) '` | The format for the module.                                      |
-| `symbol`         | `"☁️  "`                                        | The symbol used before displaying the current GCP profile.      |
-| `region_aliases` |                                                | Table of region aliases to display in addition to the GCP name. |
-| `style`          | `"bold blue"`                                  | The style for the module.                                       |
-| `disabled`       | `false`                                        | Disables the `gcloud` module.                                   |
+| Option           | Default                                                  | Description                                                     |
+| ---------------- | -------------------------------------------------------- | --------------------------------------------------------------- |
+| `format`         | `'on [$symbol$account(@$domain)(\($region\))]($style) '` | The format for the module.                                      |
+| `symbol`         | `"☁️  "`                                                  | The symbol used before displaying the current GCP profile.      |
+| `region_aliases` |                                                          | Table of region aliases to display in addition to the GCP name. |
+| `style`          | `"bold blue"`                                            | The style for the module.                                       |
+| `disabled`       | `false`                                                  | Disables the `gcloud` module.                                   |
 
 ### Variables
 
-| Variable | Example           | Description                                                        |
-| -------- | ----------------- | ------------------------------------------------------------------ |
-| region   | `us-central1`     | The current GCP region                                             |
-| account  | `foo@example.com` | The current GCP profile                                            |
-| project  |                   | The current GCP project                                            |
-| active   | `default`         | The active config name written in `~/.config/gcloud/active_config` |
-| symbol   |                   | Mirrors the value of option `symbol`                               |
-| style\*  |                   | Mirrors the value of option `style`                                |
+| Variable | Example       | Description                                                        |
+| -------- | ------------- | ------------------------------------------------------------------ |
+| region   | `us-central1` | The current GCP region                                             |
+| account  | `foo`         | The current GCP profile                                            |
+| domain   | `example.com` | The current GCP profile domain                                     |
+| project  |               | The current GCP project                                            |
+| active   | `default`     | The active config name written in `~/.config/gcloud/active_config` |
+| symbol   |               | Mirrors the value of option `symbol`                               |
+| style\*  |               | Mirrors the value of option `style`                                |
 
 \*: This variable can only be used as a part of a style string
 
@@ -1074,7 +1075,7 @@ This is based on the `~/.config/gcloud/active_config` file and the `~/.config/gc
 # ~/.config/starship.toml
 
 [gcloud]
-format = 'on [$symbol$account(\($project\))]($style) '
+format = 'on [$symbol$account(@$domain)(\($project\))]($style) '
 ```
 
 #### Display active config name only

--- a/src/configs/gcloud.rs
+++ b/src/configs/gcloud.rs
@@ -15,7 +15,7 @@ pub struct GcloudConfig<'a> {
 impl<'a> Default for GcloudConfig<'a> {
     fn default() -> Self {
         GcloudConfig {
-            format: "on [$symbol$account(\\($region\\))]($style) ",
+            format: "on [$symbol$account(@$domain)(\\($region\\))]($style) ",
             symbol: "☁️  ",
             style: "bold blue",
             disabled: false,

--- a/src/modules/gcloud.rs
+++ b/src/modules/gcloud.rs
@@ -1,4 +1,5 @@
-use once_cell::sync::OnceCell;
+use once_cell::sync::{Lazy, OnceCell};
+use std::ops::Deref;
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -7,6 +8,8 @@ use super::{Context, Module, RootModuleConfig};
 use crate::configs::gcloud::GcloudConfig;
 use crate::formatter::StringFormatter;
 use crate::utils;
+
+type Account = (String, Option<String>);
 
 struct GcloudContext {
     config_name: String,
@@ -33,7 +36,7 @@ impl GcloudContext {
         }
     }
 
-    pub fn get_account(&self) -> Option<String> {
+    pub fn get_account(&self) -> Option<Account> {
         let config = self.get_config()?;
         let account_line = config
             .lines()
@@ -42,7 +45,11 @@ impl GcloudContext {
             .take_while(|line| !line.starts_with('['))
             .find(|line| line.starts_with("account"))?;
         let account = account_line.splitn(2, '=').nth(1)?.trim();
-        Some(account.to_string())
+        let mut segments = account.splitn(2, '@');
+        Some((
+            segments.next().map(String::from)?,
+            segments.next().map(String::from),
+        ))
     }
 
     pub fn get_project(&self) -> Option<String> {
@@ -105,6 +112,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
     let (config_name, config_path) = get_current_config(context)?;
     let gcloud_context = GcloudContext::new(&config_name, &config_path);
+    let account: Lazy<Option<Account>, _> = Lazy::new(|| gcloud_context.get_account());
 
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter
@@ -117,7 +125,16 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 _ => None,
             })
             .map(|variable| match variable {
-                "account" => gcloud_context.get_account().map(Ok),
+                "account" => account
+                    .deref()
+                    .as_ref()
+                    .map(|(account, _)| (*account).to_owned())
+                    .map(Ok),
+                "domain" => account
+                    .deref()
+                    .as_ref()
+                    .and_then(|(_, domain)| (*domain).to_owned())
+                    .map(Ok),
                 "region" => gcloud_context
                     .get_region()
                     .map(|region| {
@@ -179,6 +196,36 @@ account = foo@example.com
             "on {} ",
             Color::Blue.bold().paint("☁️  foo@example.com")
         ));
+
+        assert_eq!(actual, expected);
+        dir.close()
+    }
+
+    #[test]
+    fn account_with_custom_format_set() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let active_config_path = dir.path().join("active_config");
+        let mut active_config_file = File::create(&active_config_path)?;
+        active_config_file.write_all(b"default")?;
+
+        create_dir(dir.path().join("configurations"))?;
+        let config_default_path = dir.path().join("configurations").join("config_default");
+        let mut config_default_file = File::create(&config_default_path)?;
+        config_default_file.write_all(
+            b"\
+[core]
+account = foo@example.com
+",
+        )?;
+
+        let actual = ModuleRenderer::new("gcloud")
+            .env("CLOUDSDK_CONFIG", dir.path().to_string_lossy())
+            .config(toml::toml! {
+                [gcloud]
+                format = "on [$symbol$account(\\($region\\))]($style) "
+            })
+            .collect();
+        let expected = Some(format!("on {} ", Color::Blue.bold().paint("☁️  foo")));
 
         assert_eq!(actual, expected);
         dir.close()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Introduces separate `account` & `domain` format string variables.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is essentially #2587 rebased/stacked onto #2592
Closes #2587
Closes #1737

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.

---

/cc @cymruu