### PR TITLE
docs: Replace the section title "Gcloud" with "gcloud"

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1020,7 +1020,7 @@ By default the module will be shown if any of the following conditions are met:
 format = "via [e $version](bold red) "
 ```
 
-## gcloud
+## Google Cloud (`gcloud`)
 
 The `gcloud` module shows the current configuration for [`gcloud`](https://cloud.google.com/sdk/gcloud) CLI.
 This is based on the `~/.config/gcloud/active_config` file and the `~/.config/gcloud/configurations/config_{CONFIG NAME}` file and the `CLOUDSDK_CONFIG` env var.

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1020,7 +1020,7 @@ By default the module will be shown if any of the following conditions are met:
 format = "via [e $version](bold red) "
 ```
 
-## Gcloud
+## gcloud
 
 The `gcloud` module shows the current configuration for [`gcloud`](https://cloud.google.com/sdk/gcloud) CLI.
 This is based on the `~/.config/gcloud/active_config` file and the `~/.config/gcloud/configurations/config_{CONFIG NAME}` file and the `CLOUDSDK_CONFIG` env var.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This is a PR for the documentation just replacing the section title "Gcloud" with "gcloud" here: https://starship.rs/config/#gcloud.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The official representation of the `gcloud` command-line tool is `gcloud` not `Gcloud` and there is no chance the word is written as `Gcloud`.  (ref. https://cloud.google.com/sdk/gcloud) The starship module name is also `gcloud`. I understand all section names in the config page start with the capital case but I feel `Gcloud` weired a little and the `gcloud` is more natural.

#### Screenshots (if appropriate):
None

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
