### PR TITLE
fix(print-config): use proper defaults for top-level values

### DIFF
--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -64,7 +64,7 @@ pub mod zig;
 
 pub use starship_root::*;
 
-#[derive(Default, Serialize, ModuleConfig, Clone)]
+#[derive(Serialize, ModuleConfig, Clone)]
 #[serde(default)]
 pub struct FullConfig<'a> {
     // Root config
@@ -129,4 +129,72 @@ pub struct FullConfig<'a> {
     vagrant: vagrant::VagrantConfig<'a>,
     zig: zig::ZigConfig<'a>,
     custom: IndexMap<String, custom::CustomConfig<'a>>,
+}
+
+impl<'a> Default for FullConfig<'a> {
+    fn default() -> Self {
+        Self {
+            format: "$all",
+            scan_timeout: 30,
+            command_timeout: 500,
+            add_newline: true,
+
+            aws: Default::default(),
+            battery: Default::default(),
+            character: Default::default(),
+            cmake: Default::default(),
+            cmd_duration: Default::default(),
+            conda: Default::default(),
+            crystal: Default::default(),
+            dart: Default::default(),
+            deno: Default::default(),
+            directory: Default::default(),
+            docker_context: Default::default(),
+            dotnet: Default::default(),
+            elixir: Default::default(),
+            elm: Default::default(),
+            env_var: Default::default(),
+            erlang: Default::default(),
+            gcloud: Default::default(),
+            git_branch: Default::default(),
+            git_commit: Default::default(),
+            git_state: Default::default(),
+            git_status: Default::default(),
+            golang: Default::default(),
+            helm: Default::default(),
+            hg_branch: Default::default(),
+            hostname: Default::default(),
+            java: Default::default(),
+            jobs: Default::default(),
+            julia: Default::default(),
+            kotlin: Default::default(),
+            kubernetes: Default::default(),
+            lua: Default::default(),
+            memory_usage: Default::default(),
+            nim: Default::default(),
+            nix_shell: Default::default(),
+            nodejs: Default::default(),
+            ocaml: Default::default(),
+            openstack: Default::default(),
+            package: Default::default(),
+            perl: Default::default(),
+            php: Default::default(),
+            purescript: Default::default(),
+            python: Default::default(),
+            ruby: Default::default(),
+            rust: Default::default(),
+            scala: Default::default(),
+            shell: Default::default(),
+            shlvl: Default::default(),
+            singularity: Default::default(),
+            status: Default::default(),
+            swift: Default::default(),
+            terraform: Default::default(),
+            time: Default::default(),
+            username: Default::default(),
+            vagrant: Default::default(),
+            zig: Default::default(),
+            custom: Default::default(),
+        }
+    }
 }

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -80,6 +80,7 @@ pub const PROMPT_ORDER: &[&str] = &[
     "character",
 ];
 
+// On changes please also update `Default` for the `FullConfig` struct in `mod.rs`
 impl<'a> Default for StarshipRootConfig<'a> {
     fn default() -> Self {
         StarshipRootConfig {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Instead of the proper default values for starship the root level values in `FullConfig` were just using the derived defaults. I fixed this by implementing `Default` manually.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #2603
Closes #2650

#### Screenshots (if appropriate):
config file:
```
format = "test"
```


old:
```
❯ starship print-config
# Warning: This config does not include keys that have an unset value
format = 'test'
scan_timeout = 0
command_timeout = 0
add_newline = false
...

❯ starship print-config -d
# Warning: This config does not include keys that have an unset value
format = ''
scan_timeout = 0
command_timeout = 0
add_newline = false
...
```

new:
```
❯ cargo run -- print-config
# Warning: This config does not include keys that have an unset value
format = 'test'
scan_timeout = 30
command_timeout = 500
add_newline = true
...

❯ cargo run -- print-config -d
# Warning: This config does not include keys that have an unset value
format = '$all'
scan_timeout = 30
command_timeout = 500
add_newline = true
...
```

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
