### PR TITLE
feat(aws): Add support for profile from awsume

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -256,6 +256,9 @@ is read from the `AWS_VAULT` env var.
 When using [awsu](https://github.com/kreuzwerker/awsu) the profile
 is read from the `AWSU_PROFILE` env var.
 
+When using [AWSume](https://awsu.me) the profile
+is read from the `AWSUME_PROFILE` env var.
+
 ### Options
 
 | Option           | Default                                           | Description                                                     |

--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -47,7 +47,7 @@ fn get_aws_region_from_config(context: &Context, aws_profile: Option<&str>) -> O
 }
 
 fn get_aws_profile_and_region(context: &Context) -> (Option<Profile>, Option<Region>) {
-    let profile_env_vars = vec!["AWSU_PROFILE", "AWS_VAULT", "AWS_PROFILE"];
+    let profile_env_vars = vec!["AWSU_PROFILE", "AWS_VAULT", "AWSUME_PROFILE", "AWS_PROFILE"];
     let profile = profile_env_vars
         .iter()
         .find_map(|env_var| context.get_env(env_var));
@@ -209,6 +209,20 @@ mod tests {
         let expected = Some(format!(
             "on {}",
             Color::Yellow.bold().paint("☁️  astronauts-awsu ")
+        ));
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn profile_set_from_awsume() {
+        let actual = ModuleRenderer::new("aws")
+            .env("AWSUME_PROFILE", "astronauts-awsume")
+            .env("AWS_PROFILE", "astronauts-profile")
+            .collect();
+        let expected = Some(format!(
+            "on {}",
+            Color::Yellow.bold().paint("☁️  astronauts-awsume ")
         ));
 
         assert_eq!(expected, actual);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
We use AWESUME to assume into different accounts. It stores the profile in its own environment variable and sets the environment variables for the access key and secret key. 

#### Motivation and Context
Show same info as aws-vault

#### Screenshots (if appropriate):

#### How Has This Been Tested?
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
