### PR TITLE
fix(jobs): Handle zero jobs with zero thresholds

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1453,7 +1453,8 @@ symbol = "🌟 "
 The `jobs` module shows the current number of jobs running.
 The module will be shown only if there are background jobs running.
 The module will show the number of jobs running if there is more than 1 job, or
-more than the `threshold` config value, if it exists.
+more than the `threshold` config value, if it exists. If `threshold` is set to 0,
+then the module will also show when there are 0 jobs running.
 
 ::: warning
 

--- a/src/modules/jobs.rs
+++ b/src/modules/jobs.rs
@@ -15,6 +15,15 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         .trim()
         .parse::<i64>()
         .ok()?;
+
+    if config.threshold < 0 {
+        log::warn!(
+            "threshold in [jobs] ({}) was less than zero",
+            config.threshold
+        );
+        return None;
+    }
+
     if num_of_jobs == 0 && config.threshold > 0 {
         return None;
     }

--- a/src/modules/jobs.rs
+++ b/src/modules/jobs.rs
@@ -28,11 +28,8 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         return None;
     }
 
-    let module_number = if num_of_jobs > config.threshold {
+    let module_number = if num_of_jobs > config.threshold || config.threshold == 0 {
         num_of_jobs.to_string()
-    } else if num_of_jobs == 0 && config.threshold == 0 {
-        // Explicitly show when there are 0 background jobs
-        "0".to_string()
     } else {
         "".to_string()
     };

--- a/src/modules/jobs.rs
+++ b/src/modules/jobs.rs
@@ -15,7 +15,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         .trim()
         .parse::<i64>()
         .ok()?;
-    if num_of_jobs == 0 {
+    if num_of_jobs == 0 && config.threshold > 0 {
         return None;
     }
 
@@ -107,6 +107,20 @@ mod test {
             .collect();
 
         let expected = Some(format!("{} ", Color::Blue.bold().paint("✦3")));
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn config_n1_job_0() {
+        let actual = ModuleRenderer::new("jobs")
+            .config(toml::toml! {
+                [jobs]
+                threshold = -1
+            })
+            .jobs(0)
+            .collect();
+
+        let expected = Some(format!("{} ", Color::Blue.bold().paint("✦0")));
         assert_eq!(expected, actual);
     }
 }

--- a/src/modules/jobs.rs
+++ b/src/modules/jobs.rs
@@ -21,6 +21,9 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
     let module_number = if num_of_jobs > config.threshold {
         num_of_jobs.to_string()
+    } else if num_of_jobs == 0 && config.threshold == 0 {
+        // Explicitly show when there are 0 background jobs
+        "0".to_string()
     } else {
         "".to_string()
     };
@@ -111,16 +114,30 @@ mod test {
     }
 
     #[test]
-    fn config_n1_job_0() {
+    fn config_0_job_0() {
         let actual = ModuleRenderer::new("jobs")
             .config(toml::toml! {
                 [jobs]
-                threshold = -1
+                threshold = 0
             })
             .jobs(0)
             .collect();
 
         let expected = Some(format!("{} ", Color::Blue.bold().paint("✦0")));
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn config_0_job_1() {
+        let actual = ModuleRenderer::new("jobs")
+            .config(toml::toml! {
+                [jobs]
+                threshold = 0
+            })
+            .jobs(1)
+            .collect();
+
+        let expected = Some(format!("{} ", Color::Blue.bold().paint("✦1")));
         assert_eq!(expected, actual);
     }
 }


### PR DESCRIPTION
First PR here, let me know if anything can be improved!

#### Description
Currently, if there are 0 jobs running then the jobs module doesn't show anything. However, if a negative threshold is specified (user wants to explicitly see that there are 0 jobs running), then it should show 0.

Closes #2610

#### How Has This Been Tested?

- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.

