### PR TITLE
feat(nodejs): Check for `.nvmrc`

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1863,6 +1863,7 @@ By default the module will be shown if any of the following conditions are met:
 
 - The current directory contains a `package.json` file
 - The current directory contains a `.node-version` file
+- The current directory contains a `.nvmrc` file
 - The current directory contains a `node_modules` directory
 - The current directory contains a file with the `.js`, `.mjs` or `.cjs` extension
 - The current directory contains a file with the `.ts` extension

--- a/src/configs/nodejs.rs
+++ b/src/configs/nodejs.rs
@@ -26,7 +26,7 @@ impl<'a> Default for NodejsConfig<'a> {
             disabled: false,
             not_capable_style: "bold red",
             detect_extensions: vec!["js", "mjs", "cjs", "ts"],
-            detect_files: vec!["package.json", ".node-version"],
+            detect_files: vec!["package.json", ".node-version", ".nvmrc"],
             detect_folders: vec!["node_modules"],
         }
     }

--- a/src/modules/nodejs.rs
+++ b/src/modules/nodejs.rs
@@ -171,7 +171,7 @@ mod tests {
     }
 
     #[test]
-    fn folder_with_node_version() -> io::Result<()> {
+    fn folder_with_nvmrc() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join(".nvmrc"))?.sync_all()?;
 

--- a/src/modules/nodejs.rs
+++ b/src/modules/nodejs.rs
@@ -171,6 +171,17 @@ mod tests {
     }
 
     #[test]
+    fn folder_with_node_version() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join(".nvmrc"))?.sync_all()?;
+
+        let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
+        let expected = Some(format!("via {}", Color::Green.bold().paint(" v12.0.0 ")));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
     fn folder_with_js_file() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("index.js"))?.sync_all()?;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

Check for `.nvmrc` file presence in `nodejs` module.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Starship already checks for `.node-version`, and [`.nvmrc`](https://github.com/nvm-sh/nvm#nvmrc) is another popular alternative that worth considering.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
