### PR TITLE
fix(configure): fix launching .cmd editors

### DIFF
--- a/src/configure.rs
+++ b/src/configure.rs
@@ -135,8 +135,9 @@ pub fn write_configuration(table: &mut Table) {
 pub fn edit_configuration() {
     let config_path = get_config_path();
     let editor_cmd = shell_words::split(&get_editor()).expect("Unmatched quotes found in $EDITOR.");
+    let editor_path = which::which(&editor_cmd[0]).expect("Unable to locate editor in $PATH.");
 
-    let command = Command::new(&editor_cmd[0])
+    let command = Command::new(editor_path)
         .args(&editor_cmd[1..])
         .arg(config_path)
         .status();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
When running `starship config` the editor was being started with plain `Command::new` instead of `utils::exec_cmd` which meant that it wasn't using `which` to find the editor binary. This PR makes the command use `which` to find the appropriate binary. `utils::exec_cmd` can't be used here because it needs a timeout.  Not using `which` prevented `starship config` from launching some editor like Visual Studio Code via `code.cmd`. 


#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
