### PR TITLE
fix(fish): explicitly set scope in fish init script

### DIFF
--- a/src/init/starship.fish
+++ b/src/init/starship.fish
@@ -1,14 +1,14 @@
 function fish_prompt
     switch "$fish_key_bindings"
         case fish_hybrid_key_bindings fish_vi_key_bindings
-            set keymap "$fish_bind_mode"
+            set STARSHIP_KEYMAP "$fish_bind_mode"
         case '*'
-            set keymap insert
+            set STARSHIP_KEYMAP insert
     end
-    set exit_code $status
+    set STARSHIP_CMD_STATUS $status
     # Account for changes in variable name between v2.7 and v3.0
-    set starship_duration "$CMD_DURATION$cmd_duration"
-    ::STARSHIP:: prompt --status=$exit_code --keymap=$keymap --cmd-duration=$starship_duration --jobs=(count (jobs -p))
+    set STARSHIP_DURATION "$CMD_DURATION$cmd_duration"
+    ::STARSHIP:: prompt --status=$STARSHIP_CMD_STATUS --keymap=$STARSHIP_KEYMAP --cmd-duration=$STARSHIP_DURATION --jobs=(count (jobs -p))
 end
 
 # disable virtualenv prompt, it breaks starship

--- a/src/init/starship.fish
+++ b/src/init/starship.fish
@@ -14,7 +14,9 @@ end
 # disable virtualenv prompt, it breaks starship
 set -g VIRTUAL_ENV_DISABLE_PROMPT 1
 
-function fish_mode_prompt; end
+# Remove default mode prompt
+builtin functions -e fish_mode_prompt
+
 set -gx STARSHIP_SHELL "fish"
 
 # Set up the session key that will be used to store logs

--- a/src/init/starship.fish
+++ b/src/init/starship.fish
@@ -11,7 +11,7 @@ function fish_prompt
     ::STARSHIP:: prompt --status=$STARSHIP_CMD_STATUS --keymap=$STARSHIP_KEYMAP --cmd-duration=$STARSHIP_DURATION --jobs=(count (jobs -p))
 end
 
-# disable virtualenv prompt, it breaks starship
+# Disable virtualenv prompt, it breaks starship
 set -g VIRTUAL_ENV_DISABLE_PROMPT 1
 
 # Remove default mode prompt

--- a/src/init/starship.fish
+++ b/src/init/starship.fish
@@ -5,14 +5,14 @@ function fish_prompt
         case '*'
             set keymap insert
     end
-    set -l exit_code $status
+    set exit_code $status
     # Account for changes in variable name between v2.7 and v3.0
-    set -l starship_duration "$CMD_DURATION$cmd_duration"
+    set starship_duration "$CMD_DURATION$cmd_duration"
     ::STARSHIP:: prompt --status=$exit_code --keymap=$keymap --cmd-duration=$starship_duration --jobs=(count (jobs -p))
 end
 
 # disable virtualenv prompt, it breaks starship
-set VIRTUAL_ENV_DISABLE_PROMPT 1
+set -g VIRTUAL_ENV_DISABLE_PROMPT 1
 
 function fish_mode_prompt; end
 set -gx STARSHIP_SHELL "fish"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

This PR consists of ~~two~~ three changes:

- Remove unnecessary `-l` argument to be consistent with the `set keymap` above, and prefix variable names with Starship to avoid conflicts.

  In fish, variables are automatically scoped to parent function if no scope is specified, so `-l` makes no difference for the two changed lines.
  (However, this is not the same for `set keymap` case, as `-l/--local` will scope it to `switch`.)

  This change is purely for styling.

- Explicitly set `$VIRTUAL_ENV_DISABLE_PROMPT`'s scope to global

  In fish, variables have a default scope of global while sourcing scripts. But user may try different things like putting Starship load scripts into a function.

  ![image](https://user-images.githubusercontent.com/44045911/115902954-9877c300-a495-11eb-907d-a800ffdea7d6.png)

  Notice how `$VIRTUAL_ENV_DISABLE_PROMPT` is actually not set if Starship is loaded via a function.

- Erase `fish_mode_prompt` function instead of overwriting it with an empty function.

  This should be theoretically faster (though don't actually matter at all), and less confusing than an empty function.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
