### PR TITLE
feat(shell): add unknown_indicator parameter

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2421,17 +2421,18 @@ To enable it, set `disabled` to `false` in your configuration file.
 
 ### Options
 
-| Option                 | Default       | Description                                   |
-| ---------------------- | ------------- | --------------------------------------------- |
-| `bash_indicator`       | `bsh`         | A format string used to represent bash.       |
-| `fish_indicator`       | `fsh`         | A format string used to represent fish.       |
-| `zsh_indicator`        | `zsh`         | A format string used to represent zsh.        |
-| `powershell_indicator` | `psh`         | A format string used to represent powershell. |
-| `ion_indicator`        | `ion`         | A format string used to represent ion.        |
-| `elvish_indicator`     | `esh`         | A format string used to represent elvish.     |
-| `tcsh_indicator`       | `tsh`         | A format string used to represent tcsh.       |
-| `format`               | `$indicator ` | The format for the module.                    |
-| `disabled`             | `true`        | Disables the `shell` module.                  |
+| Option                 | Default       | Description                                                  |
+| ---------------------- | ------------- | ------------------------------------------------------------ |
+| `bash_indicator`       | `bsh`         | A format string used to represent bash.                      |
+| `fish_indicator`       | `fsh`         | A format string used to represent fish.                      |
+| `zsh_indicator`        | `zsh`         | A format string used to represent zsh.                       |
+| `powershell_indicator` | `psh`         | A format string used to represent powershell.                |
+| `ion_indicator`        | `ion`         | A format string used to represent ion.                       |
+| `elvish_indicator`     | `esh`         | A format string used to represent elvish.                    |
+| `tcsh_indicator`       | `tsh`         | A format string used to represent tcsh.                      |
+| `default`              |               | The default value to be displayed when the shell is unknown. |
+| `format`               | `$indicator ` | The format for the module.                                   |
+| `disabled`             | `true`        | Disables the `shell` module.                                 |
 
 ### Variables
 
@@ -2447,6 +2448,7 @@ To enable it, set `disabled` to `false` in your configuration file.
 [shell]
 fish_indicator = ""
 powershell_indicator = "_"
+default = "mystery shell"
 disabled = false
 ```
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2430,7 +2430,7 @@ To enable it, set `disabled` to `false` in your configuration file.
 | `ion_indicator`        | `ion`         | A format string used to represent ion.                       |
 | `elvish_indicator`     | `esh`         | A format string used to represent elvish.                    |
 | `tcsh_indicator`       | `tsh`         | A format string used to represent tcsh.                      |
-| `default`              |               | The default value to be displayed when the shell is unknown. |
+| `unknown_indicator`    |               | The default value to be displayed when the shell is unknown. |
 | `format`               | `$indicator ` | The format for the module.                                   |
 | `disabled`             | `true`        | Disables the `shell` module.                                 |
 
@@ -2448,7 +2448,7 @@ To enable it, set `disabled` to `false` in your configuration file.
 [shell]
 fish_indicator = ""
 powershell_indicator = "_"
-default = "mystery shell"
+unknown_indicator = "mystery shell"
 disabled = false
 ```
 

--- a/src/configs/shell.rs
+++ b/src/configs/shell.rs
@@ -13,6 +13,7 @@ pub struct ShellConfig<'a> {
     pub ion_indicator: &'a str,
     pub elvish_indicator: &'a str,
     pub tcsh_indicator: &'a str,
+    pub default: &'a str,
     pub disabled: bool,
 }
 
@@ -27,6 +28,7 @@ impl<'a> Default for ShellConfig<'a> {
             ion_indicator: "ion",
             elvish_indicator: "esh",
             tcsh_indicator: "tsh",
+            default: "",
             disabled: true,
         }
     }

--- a/src/configs/shell.rs
+++ b/src/configs/shell.rs
@@ -13,7 +13,7 @@ pub struct ShellConfig<'a> {
     pub ion_indicator: &'a str,
     pub elvish_indicator: &'a str,
     pub tcsh_indicator: &'a str,
-    pub default: &'a str,
+    pub unknown_indicator: &'a str,
     pub disabled: bool,
 }
 
@@ -28,7 +28,7 @@ impl<'a> Default for ShellConfig<'a> {
             ion_indicator: "ion",
             elvish_indicator: "esh",
             tcsh_indicator: "tsh",
-            default: "",
+            unknown_indicator: "",
             disabled: true,
         }
     }

--- a/src/modules/shell.rs
+++ b/src/modules/shell.rs
@@ -24,7 +24,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                     Shell::Ion => Some(config.ion_indicator),
                     Shell::Elvish => Some(config.elvish_indicator),
                     Shell::Tcsh => Some(config.tcsh_indicator),
-                    Shell::Unknown => Some(config.default),
+                    Shell::Unknown => Some(config.unknown_indicator),
                 },
                 _ => None,
             })
@@ -36,6 +36,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 "ion_indicator" => Some(Ok(config.ion_indicator)),
                 "elvish_indicator" => Some(Ok(config.elvish_indicator)),
                 "tcsh_indicator" => Some(Ok(config.tcsh_indicator)),
+                "unknown_indicator" => Some(Ok(config.unknown_indicator)),
                 _ => None,
             })
             .parse(None)

--- a/src/modules/shell.rs
+++ b/src/modules/shell.rs
@@ -24,7 +24,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                     Shell::Ion => Some(config.ion_indicator),
                     Shell::Elvish => Some(config.elvish_indicator),
                     Shell::Tcsh => Some(config.tcsh_indicator),
-                    Shell::Unknown => None,
+                    Shell::Unknown => Some(config.default),
                 },
                 _ => None,
             })


### PR DESCRIPTION
This adds a default parameter for the shell module, which is displayed in case Starship is not able to identify the shell.

#### Description
Fairly simple addition of a 'unknown-indicator' element in the ShellConfig struct. 
Please note that I'm a complete beginner in Rust, so if there's any mistakes, I'll be glad to rectify them 😅

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #2541 

#### How Has This Been Tested?
Running `cargo test` passes all existing tests. Let me know if I should add one more test case (like `test_default_if_unknown_shell`).
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
