### PR TITLE
feat(character): Add option for different symbol when root user [Draft]

### DIFF
--- a/src/configs/character.rs
+++ b/src/configs/character.rs
@@ -9,19 +9,22 @@ pub struct CharacterConfig<'a> {
     pub success_symbol: &'a str,
     pub error_symbol: &'a str,
     pub vicmd_symbol: &'a str,
-    pub root_symbol: &'a str,
+    pub root_success_symbol: &'a str,
+    pub root_error_symbol: &'a str,
+    pub root_symbol_enabled: bool,
     pub disabled: bool,
 }
 
 impl<'a> Default for CharacterConfig<'a> {
     fn default() -> Self {
-        const DEFAULT_SUCCESS_SYMBOL: &str = "[❯](bold green)";
         CharacterConfig {
             format: "$symbol ",
-            success_symbol: DEFAULT_SUCCESS_SYMBOL,
+            success_symbol: "[❯](bold green)",
             error_symbol: "[❯](bold red)",
             vicmd_symbol: "[❮](bold green)",
-            root_symbol: DEFAULT_SUCCESS_SYMBOL,
+            root_success_symbol: "[#](bold green)",
+            root_error_symbol: "[#](bold red)",
+            root_symbol_enabled: false,
             disabled: false,
         }
     }

--- a/src/configs/character.rs
+++ b/src/configs/character.rs
@@ -9,6 +9,7 @@ pub struct CharacterConfig<'a> {
     pub success_symbol: &'a str,
     pub error_symbol: &'a str,
     pub vicmd_symbol: &'a str,
+    pub root_symbol: &'a str,
     pub disabled: bool,
 }
 
@@ -19,6 +20,7 @@ impl<'a> Default for CharacterConfig<'a> {
             success_symbol: "[❯](bold green)",
             error_symbol: "[❯](bold red)",
             vicmd_symbol: "[❮](bold green)",
+            root_symbol: "[#](bold green)",
             disabled: false,
         }
     }

--- a/src/configs/character.rs
+++ b/src/configs/character.rs
@@ -15,12 +15,13 @@ pub struct CharacterConfig<'a> {
 
 impl<'a> Default for CharacterConfig<'a> {
     fn default() -> Self {
+        const DEFAULT_SUCCESS_SYMBOL:&str = "[❯](bold green)";
         CharacterConfig {
             format: "$symbol ",
-            success_symbol: "[❯](bold green)",
+            success_symbol: DEFAULT_SUCCESS_SYMBOL,
             error_symbol: "[❯](bold red)",
             vicmd_symbol: "[❮](bold green)",
-            root_symbol: "[#](bold green)",
+            root_symbol: DEFAULT_SUCCESS_SYMBOL,
             disabled: false,
         }
     }

--- a/src/configs/character.rs
+++ b/src/configs/character.rs
@@ -15,7 +15,7 @@ pub struct CharacterConfig<'a> {
 
 impl<'a> Default for CharacterConfig<'a> {
     fn default() -> Self {
-        const DEFAULT_SUCCESS_SYMBOL:&str = "[❯](bold green)";
+        const DEFAULT_SUCCESS_SYMBOL: &str = "[❯](bold green)";
         CharacterConfig {
             format: "$symbol ",
             success_symbol: DEFAULT_SUCCESS_SYMBOL,

--- a/src/modules/character.rs
+++ b/src/modules/character.rs
@@ -92,22 +92,12 @@ fn is_root_euid(context: &Context) -> bool {
                 None
             }
         },
-        None => {
-            log::warn!("Error running id -u");
-            None
-        }
+        None => None,
     };
 
     match euid {
-        Some(euid) => {
-            log::debug!("You are euid: {}", euid);
-            euid == root_uid
-        },
-        None => {
-            log::debug!("You are not root");
-            log::debug!("I dont know why this doesnt always pop up");
-            false
-        }
+        Some(euid) => euid == root_uid,
+        None => false,
     }
 }
 

--- a/src/modules/character.rs
+++ b/src/modules/character.rs
@@ -17,7 +17,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         Root,
     }
 
-    let assumed_mode: ShellEditMode = if !cfg!(windows) && is_root_euid(&context) {
+    let assumed_mode: ShellEditMode = if cfg!(linux) && is_root_euid(&context) {
         ShellEditMode::Root
     } else {
         ShellEditMode::Insert

--- a/src/modules/character.rs
+++ b/src/modules/character.rs
@@ -86,16 +86,22 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 fn is_root_euid(context: &Context) -> bool {
     let root_uid: usize = 0;
     let euid: Option<usize> = match context.exec_cmd("id", &["-u"]) {
-        Some(output) => match output.stdout.parse() {
+        Some(output) => match output.stdout.trim().parse() {
             Ok(euid) => Some(euid),
-            _ => None,
+            Err(e) => {
+                log::warn!("Error parsing {} with error {}", output.stdout, e);
+                None
+            }
         },
-        None => None,
+        None => {
+            log::warn!("Error running id -u");
+            None
+        }
     };
 
     match euid {
         Some(euid) => {
-            log::debug!("You are the root");
+            log::debug!("You are euid: {}", euid);
             euid == root_uid
         },
         None => {

--- a/src/modules/character.rs
+++ b/src/modules/character.rs
@@ -17,7 +17,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         Root,
     }
 
-    let assumed_mode: ShellEditMode = if cfg!(linux) && is_root_euid(&context) {
+    let assumed_mode: ShellEditMode = if cfg!(target_os = "linux") && is_root_euid(&context) {
         ShellEditMode::Root
     } else {
         ShellEditMode::Insert

--- a/src/modules/username.rs
+++ b/src/modules/username.rs
@@ -74,7 +74,7 @@ fn is_root_user() -> bool {
 }
 
 #[cfg(not(target_os = "windows"))]
-fn is_root_user() -> bool {
+pub fn is_root_user() -> bool {
     nix::unistd::geteuid() == nix::unistd::ROOT
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Adds ability to set different character module symbol for normal and root user as described in #2421 

I'm still very much learning Rust so I don't know if my approach follows Starship's design philosophy. Any and all feedback would be greatly appreciated.

- Added root_symbol option in character config
- Added fn is_root_euid which determines whether the user's euid is 0 (root)
- Edited existing tests such that their behavior does not change with my changes

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #2421 

#### Screenshots (if appropriate):
![starship_demo](https://user-images.githubusercontent.com/23267693/116141026-24f8d000-a6a6-11eb-87c1-5aa23e5c050b.png)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
