### PR TITLE
refactor: read CLI options as `str`

### DIFF
--- a/src/modules/character.rs
+++ b/src/modules/character.rs
@@ -22,10 +22,8 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let config: CharacterConfig = CharacterConfig::try_load(module.config);
 
     let props = &context.properties;
-    let exit_code_default = String::from("0");
-    let exit_code = props.get("status_code").unwrap_or(&exit_code_default);
-    let keymap_default = String::from("viins");
-    let keymap = props.get("keymap").unwrap_or(&keymap_default);
+    let exit_code = props.get("status_code").map(String::as_str).unwrap_or("0");
+    let keymap = props.get("keymap").map(String::as_str).unwrap_or("viins");
     let exit_success = exit_code == "0";
 
     // Match shell "keymap" names to normalized vi modes
@@ -33,7 +31,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     // Unfortunately, this is also the name of the non-vi default mode.
     // We do some environment detection in src/init.rs to translate.
     // The result: in non-vi fish, keymap is always reported as "insert"
-    let mode = match (&context.shell, keymap.as_str()) {
+    let mode = match (&context.shell, keymap) {
         (Shell::Fish, "default") | (Shell::Zsh, "vicmd") => ShellEditMode::Normal,
         _ => ASSUMED_MODE,
     };

--- a/src/modules/jobs.rs
+++ b/src/modules/jobs.rs
@@ -11,7 +11,8 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let props = &context.properties;
     let num_of_jobs = props
         .get("jobs")
-        .unwrap_or(&"0".into())
+        .map(String::as_str)
+        .unwrap_or("0")
         .trim()
         .parse::<i64>()
         .ok()?;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Read `keymap`, `status`, and `jobs` option values as `str`-s.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It makes unwrapping to defaults less clunky.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
