### PR TITLE
refactor(tcsh): set `prompt` once

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ shown below. Can't see yours? Have a look at the [extra platform instructions](h
    ```sh
    # ~/.tcshrc
 
-   eval `starship init tcsh`
+   eval "`starship init tcsh`"
    ```
 
 ## 🤝 Contributing

--- a/docs/README.md
+++ b/docs/README.md
@@ -127,5 +127,5 @@ description: Starship is the minimal, blazing fast, and extremely customizable p
    ```sh
    # ~/.tcshrc
 
-   eval `starship init tcsh`
+   eval "`starship init tcsh`"
    ```

--- a/install/install.sh
+++ b/install/install.sh
@@ -446,5 +446,5 @@ info "Please follow the steps for your shell to complete the installation:
   ${BOLD}${UNDERLINE}Tcsh${NO_COLOR}
   Add the following to the end of ${BOLD}~/.tcshrc${NO_COLOR}:
 
-      eval \`starship init tcsh\`
+      eval \"\`starship init tcsh\`\"
 "

--- a/src/init/starship.tcsh
+++ b/src/init/starship.tcsh
@@ -1,9 +1,22 @@
 setenv STARSHIP_SHELL tcsh;
 setenv STARSHIP_SESSION_KEY `::STARSHIP:: session`;
-set USER_PRECMD = "`alias precmd`";
-set USER_POSTCMD = "`alias postcmd`";
-set STARSHIP_PRECMD = 'set STARSHIP_CMD_STATUS = $status;set STARSHIP_PATH = ::STARSHIP::;set STARSHIP_END_TIME = `$STARSHIP_PATH time`;set STARSHIP_DURATION = 0;if ( $STARSHIP_START_TIME != -1 ) @ STARSHIP_DURATION = $STARSHIP_END_TIME - $STARSHIP_START_TIME;set prompt = "`$STARSHIP_PATH prompt --status $STARSHIP_CMD_STATUS --cmd-duration $STARSHIP_DURATION`";set STARSHIP_START_TIME = -1';
-set STARSHIP_POSTCMD = 'set STARSHIP_START_TIME = `::STARSHIP:: time`';
-alias precmd "$STARSHIP_PRECMD;$USER_PRECMD";
-alias postcmd "$STARSHIP_POSTCMD;$USER_POSTCMD";
-set STARSHIP_START_TIME = `::STARSHIP:: time`;
+
+set USER_PRECMD = `alias precmd`;
+set USER_POSTCMD = `alias postcmd`;
+
+set STARSHIP_PRECMD = '\
+    set STARSHIP_CMD_STATUS = $status; \
+    set STARSHIP_DURATION = 0; \
+    if ( $?STARSHIP_START_TIME ) then
+        set STARSHIP_END_TIME = `::STARSHIP:: time`; \
+        @ STARSHIP_DURATION = $STARSHIP_END_TIME - $STARSHIP_START_TIME; \
+        unset STARSHIP_START_TIME; \
+    endif'
+
+set STARSHIP_POSTCMD = '\
+    set STARSHIP_START_TIME = `::STARSHIP:: time`';
+
+alias precmd "$STARSHIP_PRECMD; $USER_PRECMD";
+alias postcmd "$STARSHIP_POSTCMD; $USER_POSTCMD";
+
+set prompt = '`::STARSHIP:: prompt --status "$STARSHIP_CMD_STATUS" --cmd-duration "$STARSHIP_DURATION"`'; 

--- a/src/init/starship.tcsh
+++ b/src/init/starship.tcsh
@@ -4,6 +4,7 @@ setenv STARSHIP_SESSION_KEY `::STARSHIP:: session`;
 set USER_PRECMD = `alias precmd`;
 set USER_POSTCMD = `alias postcmd`;
 
+# Runs just before each prompt is printed
 set STARSHIP_PRECMD = '\
     set STARSHIP_CMD_STATUS = $status; \
     set STARSHIP_DURATION = 0; \
@@ -13,6 +14,7 @@ set STARSHIP_PRECMD = '\
         unset STARSHIP_START_TIME; \
     endif'
 
+# Runs before each command gets executed
 set STARSHIP_POSTCMD = '\
     set STARSHIP_START_TIME = `::STARSHIP:: time`';
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Refactor `tcsh` init script to set `prompt` variable only once.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Make init script more readable by utilizing multi-line aliases that resemble functions and undo changes made by #2429 (I was wrong, quoting is in fact required)

/cc @vivekmalneedi

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
