### PR TITLE
perf: skip wrapping ansi escape for ignored shells

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -246,6 +246,10 @@ pub fn wrap_seq_for_shell(
     escape_begin: char,
     escape_end: char,
 ) -> String {
+    if !matches!(shell, Shell::Bash | Shell::Zsh | Shell::Tcsh) {
+        return ansi;
+    }
+
     const BASH_BEG: &str = "\u{5c}\u{5b}"; // \[
     const BASH_END: &str = "\u{5c}\u{5d}"; // \]
     const ZSH_BEG: &str = "\u{25}\u{7b}"; // %{


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
There is no need to shells that don't have their ANSI escape codes wrapped to rebuild the ansi string.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
