### PR TITLE
fix(gcloud): add double space after cloud emoji symbol

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1040,7 +1040,7 @@ This is based on the `~/.config/gcloud/active_config` file and the `~/.config/gc
 | Option           | Default                                        | Description                                                     |
 | ---------------- | ---------------------------------------------- | --------------------------------------------------------------- |
 | `format`         | `'on [$symbol$account(\($region\))]($style) '` | The format for the module.                                      |
-| `symbol`         | `"☁️ "`                                         | The symbol used before displaying the current GCP profile.      |
+| `symbol`         | `"☁️  "`                                        | The symbol used before displaying the current GCP profile.      |
 | `region_aliases` |                                                | Table of region aliases to display in addition to the GCP name. |
 | `style`          | `"bold blue"`                                  | The style for the module.                                       |
 | `disabled`       | `false`                                        | Disables the `gcloud` module.                                   |

--- a/src/configs/gcloud.rs
+++ b/src/configs/gcloud.rs
@@ -16,7 +16,7 @@ impl<'a> Default for GcloudConfig<'a> {
     fn default() -> Self {
         GcloudConfig {
             format: "on [$symbol$account(\\($region\\))]($style) ",
-            symbol: "☁️ ",
+            symbol: "☁️  ",
             style: "bold blue",
             disabled: false,
             region_aliases: HashMap::new(),

--- a/src/modules/gcloud.rs
+++ b/src/modules/gcloud.rs
@@ -177,7 +177,7 @@ account = foo@example.com
             .collect();
         let expected = Some(format!(
             "on {} ",
-            Color::Blue.bold().paint("☁️ foo@example.com")
+            Color::Blue.bold().paint("☁️  foo@example.com")
         ));
 
         assert_eq!(actual, expected);
@@ -209,7 +209,7 @@ region = us-central1
             .collect();
         let expected = Some(format!(
             "on {} ",
-            Color::Blue.bold().paint("☁️ foo@example.com(us-central1)")
+            Color::Blue.bold().paint("☁️  foo@example.com(us-central1)")
         ));
 
         assert_eq!(actual, expected);
@@ -245,7 +245,7 @@ region = us-central1
             .collect();
         let expected = Some(format!(
             "on {} ",
-            Color::Blue.bold().paint("☁️ foo@example.com(uc1)")
+            Color::Blue.bold().paint("☁️  foo@example.com(uc1)")
         ));
 
         assert_eq!(actual, expected);
@@ -266,7 +266,7 @@ region = us-central1
                 format = "on [$symbol$active]($style) "
             })
             .collect();
-        let expected = Some(format!("on {} ", Color::Blue.bold().paint("☁️ default1")));
+        let expected = Some(format!("on {} ", Color::Blue.bold().paint("☁️  default1")));
 
         assert_eq!(actual, expected);
         dir.close()
@@ -296,7 +296,7 @@ project = abc
                 format = "on [$symbol$project]($style) "
             })
             .collect();
-        let expected = Some(format!("on {} ", Color::Blue.bold().paint("☁️ abc")));
+        let expected = Some(format!("on {} ", Color::Blue.bold().paint("☁️  abc")));
 
         assert_eq!(actual, expected);
         dir.close()
@@ -352,7 +352,7 @@ project = overridden
                 format = "on [$symbol$project]($style) "
             })
             .collect();
-        let expected = Some(format!("on {} ", Color::Blue.bold().paint("☁️ overridden")));
+        let expected = Some(format!("on {} ", Color::Blue.bold().paint("☁️  overridden")));
 
         assert_eq!(actual, expected);
         dir.close()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Symbols using double-width emojis typically use double trailing space as listed here: https://github.com/starship/starship/issues/2616#issuecomment-829338508

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Ensure GCloud follows established conventions.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
