### PR TITLE
fix(memory_usage): prevent used swap underflow on windows

### DIFF
--- a/src/modules/memory_usage.rs
+++ b/src/modules/memory_usage.rs
@@ -51,7 +51,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         0 => system.free,
         _ => system.avail,
     };
-    let used_memory_kib = system.total - avail_memory_kib;
+    let used_memory_kib = system.total.saturating_sub(avail_memory_kib);
     let total_memory_kib = system.total;
     let ram_used = (used_memory_kib as f64 / total_memory_kib as f64) * 100.;
     let ram_pct = format_pct(ram_used, pct_sign);
@@ -63,7 +63,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
     let ram = format_usage_total(used_memory_kib, total_memory_kib);
     let total_swap_kib = system.swap_total;
-    let used_swap_kib = system.swap_total - system.swap_free;
+    let used_swap_kib = system.swap_total.saturating_sub(system.swap_free);
     let percent_swap_used = (used_swap_kib as f64 / total_swap_kib as f64) * 100.;
     let swap_pct = format_pct(percent_swap_used, pct_sign);
     let swap = format_usage_total(used_swap_kib, total_swap_kib);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
In some cases on windows (I think when swap utilization is around 0) `swap_free` can be larger than `swap_total`. Work around this by using saturating subtraction to handle the underflow properly.

`sys-info` will probably land the fix for this at some point, but it doesn't hurt making this safer here.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #2646

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
