### PR TITLE
feat(directory): Directory substitution styling

### DIFF
--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -1856,7 +1856,7 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "{} ",
-            ANSIStrings(&vec![
+            ANSIStrings(&[
                 Color::Cyan.bold().paint("meters"),
                 Color::Green.bold().paint("/"),
                 Color::Cyan.bold().paint("fuel-gauge"),
@@ -1909,7 +1909,7 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "{} ",
-            ANSIStrings(&vec![
+            ANSIStrings(&[
                 Color::Cyan.bold().paint("[meters](red bold)"),
                 Color::Green.bold().paint("/"),
                 Color::Cyan.bold().paint("fuel-gauge"),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This allows directory substitutions to include style specifiers.

##### Compatibility
This will cause issues with any users that already have a style string in their substitutions table - they will have to escape those style strings if they want the e.g. literal string `[foo](bold)` to appear in their prompt.

##### Implementation
This results in some extensive changes to the implementation of the `directory` module. Once substitutions are applied, we're no longer working with a string, but something that stores style information as well. I defined a `StyleString` type that is a wrapper for a vec of `{ char, Style }` structs in order to simplify things a bit. This styled directory string still needs to be truncated, so I just inlined the implementation of that into `module`.



#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This is beneficial for a couple of reasons:
1. This allows the user to change the color of the path separation character, which can help readability.
2. This allows the user to specify special colors for special directories, which can help warn when they are about to do something dangerous.

This was requested in #1837.

#### Screenshots (if appropriate):
Here's a simple example and the result
```toml
[directory.substitutions]
"/" = "[╱](red bold)"
"rust" = "[rust](fg:161)"
```

![With Substitution Styling](https://user-images.githubusercontent.com/40727264/117373798-d0610c00-ae80-11eb-8dbc-86037e2aa429.png)



#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

I ran the Linux test suite. This should only affect the directory module.


#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.

I have not updated the documentation because I'm not sure if it is necessary for this change.