### PR TITLE
fix(git_commit): leading space in git commit tag

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1154,7 +1154,7 @@ The `git_commit` module shows the current commit hash and also the tag (if any) 
 | `style`              | `"bold green"`                                 | The style for the module.                               |
 | `only_detached`      | `true`                                         | Only show git commit hash when in detached `HEAD` state |
 | `tag_disabled`       | `true`                                         | Disables showing tag info in `git_commit` module.       |
-| `tag_symbol`         | `"🏷 "`                                        | Tag symbol prefixing the info shown                     |
+| `tag_symbol`         | `" 🏷 "`                                        | Tag symbol prefixing the info shown                     |
 | `disabled`           | `false`                                        | Disables the `git_commit` module.                       |
 
 ### Variables

--- a/src/configs/git_commit.rs
+++ b/src/configs/git_commit.rs
@@ -23,7 +23,7 @@ impl<'a> Default for GitCommitConfig<'a> {
             style: "green bold",
             only_detached: true,
             disabled: false,
-            tag_symbol: "🏷  ",
+            tag_symbol: " 🏷  ",
             tag_disabled: true,
         }
     }

--- a/src/modules/git_commit.rs
+++ b/src/modules/git_commit.rs
@@ -80,7 +80,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                         _ => None,
                     })
                     .map(|variable| match variable {
-                        "tag" => Some(Ok(format!(" {}{}", &config.tag_symbol, &tag_name))),
+                        "tag" => Some(Ok(format!("{}{}", &config.tag_symbol, &tag_name))),
                         _ => None,
                     })
                     .parse(None)
@@ -323,7 +323,7 @@ mod tests {
             .config(toml::toml! {
                 [git_commit]
                     tag_disabled = false
-                    tag_symbol = ""
+                    tag_symbol = " "
             })
             .path(&repo_dir.path())
             .collect();
@@ -395,7 +395,7 @@ mod tests {
                 [git_commit]
                     only_detached = false
                     tag_disabled = false
-                    tag_symbol = ""
+                    tag_symbol = " "
             })
             .path(&repo_dir.path())
             .collect();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This moves the hard-coded leading space on git commit tags into the config file.


#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #2692

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
