### PR TITLE
fix(git_status): Show git add -N files as unstaged

### DIFF
--- a/src/modules/git_status.rs
+++ b/src/modules/git_status.rs
@@ -256,7 +256,7 @@ impl RepoStatus {
 
     fn is_modified(status: &str) -> bool {
         // is_wt_modified
-        status.starts_with("1 .M")
+        status.starts_with("1 .M") || status.starts_with("1 .A")
     }
 
     fn is_staged(status: &str) -> bool {
@@ -634,6 +634,21 @@ mod tests {
     }
 
     #[test]
+    fn shows_added() -> io::Result<()> {
+        let repo_dir = fixture_repo(FixtureProvider::Git)?;
+
+        create_added(&repo_dir.path())?;
+
+        let actual = ModuleRenderer::new("git_status")
+            .path(&repo_dir.path())
+            .collect();
+        let expected = format_output("!");
+
+        assert_eq!(expected, actual);
+        repo_dir.close()
+    }
+
+    #[test]
     fn shows_staged_file() -> io::Result<()> {
         let repo_dir = fixture_repo(FixtureProvider::Git)?;
 
@@ -866,6 +881,18 @@ mod tests {
 
     fn create_untracked(repo_dir: &Path) -> io::Result<()> {
         File::create(repo_dir.join("license"))?.sync_all()?;
+
+        Ok(())
+    }
+
+    fn create_added(repo_dir: &Path) -> io::Result<()> {
+        File::create(repo_dir.join("license"))?.sync_all()?;
+
+        Command::new("git")
+            .args(&["add", "-A", "-N"])
+            .current_dir(repo_dir)
+            .output()?;
+        barrier();
 
         Ok(())
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
Adding a new file with `git add -N` adds it but does not stage it. Currently Starship shows this as staged. I added the `1 .A` text to `is_modified` to catch this case, and I added a test case and fixture for it.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1155. The fix is exactly what @andytom suggested [here](https://github.com/starship/starship/issues/1155#issuecomment-826387786)

#### Screenshots (if appropriate):

Before:
![image](https://user-images.githubusercontent.com/5133558/117504549-a0813980-af50-11eb-8474-dd57aa124484.png)

After:
![image](https://user-images.githubusercontent.com/5133558/117504577-abd46500-af50-11eb-8812-ca135c92b5ea.png)

#### How Has This Been Tested?
I tested using `cargo test` by adding a test case matching what the author of the issue was seeing. I'm on Windows Subsystem for Linux. The change is isolated to the `git_status` module
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**


#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
