### PR TITLE
fix(zsh) preserve zle-keymap-select

### DIFF
--- a/src/init/starship.zsh
+++ b/src/init/starship.zsh
@@ -66,15 +66,14 @@ starship_zle-keymap-select() {
 }
 
 ## Check for existing keymap-select widget.
-local existing_keymap_select_fn=$widgets[zle-keymap-select];
 # zle-keymap-select is a special widget so it'll be "user:fnName" or nothing. Let's get fnName only.
-existing_keymap_select_fn=${existing_keymap_select_fn//user:};
-if [[ -z $existing_keymap_select_fn ]]; then
+__starship_preserved_zle_keymap_select=${widgets[zle-keymap-select]#user:}
+if [[ -z $__starship_preserved_zle_keymap_select ]]; then
     zle -N zle-keymap-select starship_zle-keymap-select;
 else
     # Define a wrapper fn to call the original widget fn and then Starship's.
     starship_zle-keymap-select-wrapped() {
-        $existing_keymap_select_fn "$@";
+        $__starship_preserved_zle_keymap_select "$@";
         starship_zle-keymap-select "$@";
     }
     zle -N zle-keymap-select starship_zle-keymap-select-wrapped;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description

Fix incorrectly used `local` keyword in zsh init script. Declaring the variable as `local` caused it to be not set anymore inside `starship_zle-keymap-select-wrapped` function.

Also renamed `existing_keymap_select_fn` to `__starship_preserved_zle_keymap_select` for making it obvious that this variable was created by starship.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #2557 

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
