### PR TITLE
fix: Remove trailing whitespace from Terraform version

### DIFF
--- a/src/modules/terraform.rs
+++ b/src/modules/terraform.rs
@@ -94,8 +94,7 @@ fn get_terraform_version(version: &str) -> Option<String> {
             .trim_start_matches("Terraform ")
             .trim()
             .trim_start_matches('v')
-            .to_owned()
-            + " ",
+            .to_owned(),
     )
 }
 
@@ -110,7 +109,7 @@ mod tests {
     #[test]
     fn test_get_terraform_version_release() {
         let input = "Terraform v0.12.14";
-        assert_eq!(get_terraform_version(input), Some("0.12.14 ".to_string()));
+        assert_eq!(get_terraform_version(input), Some("0.12.14".to_string()));
     }
 
     #[test]
@@ -118,7 +117,7 @@ mod tests {
         let input = "Terraform v0.12.14-rc1";
         assert_eq!(
             get_terraform_version(input),
-            Some("0.12.14-rc1 ".to_string())
+            Some("0.12.14-rc1".to_string())
         );
     }
 
@@ -127,7 +126,7 @@ mod tests {
         let input = "Terraform v0.12.14-dev (cca89f74)";
         assert_eq!(
             get_terraform_version(input),
-            Some("0.12.14-dev (cca89f74) ".to_string())
+            Some("0.12.14-dev (cca89f74)".to_string())
         );
     }
 
@@ -139,7 +138,7 @@ Your version of Terraform is out of date! The latest version
 is 0.12.14. You can update by downloading from www.terraform.io/downloads.html
 
 ";
-        assert_eq!(get_terraform_version(input), Some("0.12.13 ".to_string()));
+        assert_eq!(get_terraform_version(input), Some("0.12.13".to_string()));
     }
 
     #[test]
@@ -152,7 +151,7 @@ is 0.12.14. You can update by downloading from www.terraform.io/downloads.html
             .path(dir.path())
             .config(toml::toml! {
                 [terraform]
-                format = "via [$symbol$version$workspace]($style) "
+                format = "via [$symbol$version $workspace]($style) "
             })
             .collect();
 
@@ -177,7 +176,7 @@ is 0.12.14. You can update by downloading from www.terraform.io/downloads.html
             .path(dir.path())
             .config(toml::toml! {
                 [terraform]
-                format = "via [$symbol$version$workspace]($style) "
+                format = "via [$symbol$version $workspace]($style) "
             })
             .collect();
 


### PR DESCRIPTION
Terraform's `$version` includes a single trailing whitespace that restricts the formatting options available to the user.

#### Description
This PR removes the trailing whitespace that's appended to Terraform's version.

#### Motivation and Context
I've styled Starship's modules as 'pills' with a background colour that's different from the terminal. In its current form it's not possible to have Terraform's version flush with the edge.

<img width="274" alt="Screenshot - Code - 2021-05-15 16 04 13" src="https://user-images.githubusercontent.com/7218120/118367035-a43c3e00-b598-11eb-85c1-050015dba66c.png">

Example configuration (Nerd Font won't render on GitHub, but you get the idea).
```
[terraform]
format = "[](black)[$symbol$version]($style)[](black) "
version_format = "$raw"

style = "purple bg:black"
symbol = "ﯟ "
```

If the space is desired, it can be added explicitly by the user. This is consistent with how other module's versions are formatted.
```
format = "[$symbol$version $workspace]($style) "
```

#### Screenshots (if appropriate):
_See above._

#### How Has This Been Tested?
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
