### PR TITLE
feat: treat empty string as none when formating

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -107,7 +107,7 @@ A conditional format string wrapped in `(` and `)` will not render if all variab
 
 For example:
 
-- `(@$region)` will show nothing if the variable `region` is `None`, otherwise `@` followed by the value of region.
+- `(@$region)` will show nothing if the variable `region` is `None` or empty string, otherwise `@` followed by the value of region.
 - `(some text)` will always show nothing since there are no variables wrapped in the braces.
 - When `$all` is a shortcut for `\[$a$b\] `, `($all)` will show nothing only if `$a` and `$b` are both `None`.
   This works the same as `(\[$a$b\] )`.

--- a/src/formatter/string_formatter.rs
+++ b/src/formatter/string_formatter.rs
@@ -310,9 +310,9 @@ impl<'a> StringFormatter<'a> {
                                                     VariableValue::Plain(plain_value) => {
                                                         !plain_value.is_empty()
                                                     }
-                                                    VariableValue::Styled(segments) => segments
-                                                        .into_iter()
-                                                        .any(|x| !x.value.is_empty()),
+                                                    VariableValue::Styled(segments) => {
+                                                        segments.iter().any(|x| !x.value.is_empty())
+                                                    }
                                                 })
                                                 // The variable is None or Err, or a meta variable
                                                 // that shouldn't show
@@ -610,7 +610,6 @@ mod tests {
         let result = formatter.parse(None).unwrap();
         assert_eq!(result.len(), 0);
     }
-
 
     #[test]
     fn test_nested_conditional() {

--- a/src/formatter/string_formatter.rs
+++ b/src/formatter/string_formatter.rs
@@ -284,7 +284,7 @@ impl<'a> StringFormatter<'a> {
                             .unwrap_or_else(|| Ok(Vec::new())),
                         FormatElement::Conditional(format) => {
                             // Show the conditional format string if all the variables inside are not
-                            // none.
+                            // none or empty string.
                             fn should_show_elements<'a>(
                                 format_elements: &[FormatElement],
                                 variables: &'a VariableMapType<'a>,
@@ -307,7 +307,12 @@ impl<'a> StringFormatter<'a> {
                                                             &meta_variables,
                                                         )
                                                     }
-                                                    _ => true,
+                                                    VariableValue::Plain(plain_value) => {
+                                                        !plain_value.is_empty()
+                                                    }
+                                                    VariableValue::Styled(segments) => segments
+                                                        .into_iter()
+                                                        .any(|x| !x.value.is_empty()),
                                                 })
                                                 // The variable is None or Err, or a meta variable
                                                 // that shouldn't show
@@ -577,6 +582,35 @@ mod tests {
         match_next!(result_iter, " should render but ", None);
         match_next!(result_iter, " shouldn't", None);
     }
+
+    #[test]
+    fn test_empty() {
+        const FORMAT_STR: &str = "(@$empty)";
+
+        let formatter = StringFormatter::new(FORMAT_STR)
+            .unwrap()
+            .map(|var| match var {
+                "empty" => Some(Ok("")),
+                _ => None,
+            });
+        let result = formatter.parse(None).unwrap();
+        assert_eq!(result.len(), 0);
+    }
+
+    #[test]
+    fn test_styled_empty() {
+        const FORMAT_STR: &str = "[(@$empty)](red bold)";
+
+        let formatter = StringFormatter::new(FORMAT_STR)
+            .unwrap()
+            .map(|variable| match variable {
+                "empty" => Some(Ok("")),
+                _ => None,
+            });
+        let result = formatter.parse(None).unwrap();
+        assert_eq!(result.len(), 0);
+    }
+
 
     #[test]
     fn test_nested_conditional() {


### PR DESCRIPTION
String formatter treats empty string as it was `None`

#### Motivation and Context
Closes #2700
Closes #1855

#### Screenshots (if appropriate):

#### How Has This Been Tested?
- [x] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:

- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
