### PR TITLE
feat: Add Operating System condition to custom commands

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -3012,7 +3012,7 @@ If you have an interesting example not covered there, feel free to share it ther
 | `style`       | `"bold green"`                  | The style for the module.                                                                                                  |
 | `format`      | `"[$symbol($output )]($style)"` | The format for the module.                                                                                                 |
 | `disabled`    | `false`                         | Disables this `custom` module.                      |
-| `os`          |                                 | Operating System name on which the module will be shown. |
+| `os`          |                                 | Operating System name on which the module will be shown (linux, macos, windows, ... ) [See possible values](https://doc.rust-lang.org/std/env/consts/constant.OS.html). |
 
 ### Variables
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -3012,7 +3012,7 @@ If you have an interesting example not covered there, feel free to share it ther
 | `style`       | `"bold green"`                  | The style for the module.                                                                                                  |
 | `format`      | `"[$symbol($output )]($style)"` | The format for the module.                                                                                                 |
 | `disabled`    | `false`                         | Disables this `custom` module.                      |
-| `os`          |                                 | Operating System name on which the module will be shown (linux, macos, windows, ... ) [See possible values](https://doc.rust-lang.org/std/env/consts/constant.OS.html). |
+| `os`          |                                 | Operating System name on which the module will be shown (unix, linux, macos, windows, ... ) [See possible values](https://doc.rust-lang.org/std/env/consts/constant.OS.html). |
 
 ### Variables
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2974,6 +2974,7 @@ These modules will be shown if any of the following conditions are met:
 - The current directory contains a directory whose name is in `directories`
 - The current directory contains a file whose extension is in `extensions`
 - The `when` command returns 0
+- The current Operating System (std::env::consts::OS) matchs with `so` field if defined.
 
 ::: tip
 
@@ -3010,7 +3011,8 @@ If you have an interesting example not covered there, feel free to share it ther
 | `symbol`      | `""`                            | The symbol used before displaying the command output.                                                                      |
 | `style`       | `"bold green"`                  | The style for the module.                                                                                                  |
 | `format`      | `"[$symbol($output )]($style)"` | The format for the module.                                                                                                 |
-| `disabled`    | `false`                         | Disables this `custom` module.                                                                                             |
+| `disabled`    | `false`                         | Disables this `custom` module.                      |
+| `so`          |                                 | Operating System name on which the module will be shown. |
 
 ### Variables
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2974,7 +2974,7 @@ These modules will be shown if any of the following conditions are met:
 - The current directory contains a directory whose name is in `directories`
 - The current directory contains a file whose extension is in `extensions`
 - The `when` command returns 0
-- The current Operating System (std::env::consts::OS) matchs with `so` field if defined.
+- The current Operating System (std::env::consts::OS) matchs with `os` field if defined.
 
 ::: tip
 
@@ -3012,7 +3012,7 @@ If you have an interesting example not covered there, feel free to share it ther
 | `style`       | `"bold green"`                  | The style for the module.                                                                                                  |
 | `format`      | `"[$symbol($output )]($style)"` | The format for the module.                                                                                                 |
 | `disabled`    | `false`                         | Disables this `custom` module.                      |
-| `so`          |                                 | Operating System name on which the module will be shown. |
+| `os`          |                                 | Operating System name on which the module will be shown. |
 
 ### Variables
 

--- a/src/configs/custom.rs
+++ b/src/configs/custom.rs
@@ -17,6 +17,8 @@ pub struct CustomConfig<'a> {
     pub files: Vec<&'a str>,
     pub extensions: Vec<&'a str>,
     pub directories: Vec<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub so: Option<&'a str>,
 }
 
 impl<'a> Default for CustomConfig<'a> {
@@ -33,6 +35,7 @@ impl<'a> Default for CustomConfig<'a> {
             files: Vec::default(),
             extensions: Vec::default(),
             directories: Vec::default(),
+            so: None,
         }
     }
 }

--- a/src/configs/custom.rs
+++ b/src/configs/custom.rs
@@ -18,7 +18,7 @@ pub struct CustomConfig<'a> {
     pub extensions: Vec<&'a str>,
     pub directories: Vec<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub so: Option<&'a str>,
+    pub os: Option<&'a str>,
 }
 
 impl<'a> Default for CustomConfig<'a> {
@@ -35,7 +35,7 @@ impl<'a> Default for CustomConfig<'a> {
             files: Vec::default(),
             extensions: Vec::default(),
             directories: Vec::default(),
-            so: None,
+            os: None,
         }
     }
 }

--- a/src/modules/custom.rs
+++ b/src/modules/custom.rs
@@ -33,8 +33,8 @@ pub fn module<'a>(name: &str, context: &'a Context) -> Option<Module<'a>> {
             is_match = exec_when(when, &config.shell.0);
         }
 
-        if let Some(so) = config.so {
-            is_match = so == env::consts::OS;
+        if let Some(os) = config.os {
+            is_match = os == env::consts::OS;
         }
 
         if !is_match {

--- a/src/modules/custom.rs
+++ b/src/modules/custom.rs
@@ -1,3 +1,4 @@
+use std::env;
 use std::io::Write;
 use std::process::{Command, Output, Stdio};
 use std::time::Instant;
@@ -30,6 +31,10 @@ pub fn module<'a>(name: &str, context: &'a Context) -> Option<Module<'a>> {
     if !is_match {
         if let Some(when) = config.when {
             is_match = exec_when(when, &config.shell.0);
+        }
+
+        if let Some(so) = config.so {
+            is_match = so == env::consts::OS;
         }
 
         if !is_match {

--- a/src/modules/custom.rs
+++ b/src/modules/custom.rs
@@ -39,7 +39,7 @@ pub fn module<'a>(name: &str, context: &'a Context) -> Option<Module<'a>> {
     }
 
     if let Some(os) = config.os {
-        if os != env::consts::OS {
+        if os != env::consts::OS && !(os == "unix" && env::consts::OS != "windows") {
             return None;
         }
     }

--- a/src/modules/custom.rs
+++ b/src/modules/custom.rs
@@ -33,11 +33,13 @@ pub fn module<'a>(name: &str, context: &'a Context) -> Option<Module<'a>> {
             is_match = exec_when(when, &config.shell.0);
         }
 
-        if let Some(os) = config.os {
-            is_match = os == env::consts::OS;
-        }
-
         if !is_match {
+            return None;
+        }
+    }
+
+    if let Some(os) = config.os {
+        if os != env::consts::OS {
             return None;
         }
     }

--- a/src/modules/custom.rs
+++ b/src/modules/custom.rs
@@ -39,7 +39,7 @@ pub fn module<'a>(name: &str, context: &'a Context) -> Option<Module<'a>> {
     }
 
     if let Some(os) = config.os {
-        if os != env::consts::OS && !(os == "unix" && env::consts::OS != "windows") {
+        if os != env::consts::OS && !(os == "unix" && cfg!(unix)) {
             return None;
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Tries to implement #2750.
Add optional so to custom configs to allow filter them by Operating System.
Internally, it uses [env::consts::OS](https://doc.rust-lang.org/std/env/consts/constant.OS.html) to match against different Operating Systems.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #2750.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
