### PR TITLE
style: Improve modules consistency and small refactor

### DIFF
--- a/src/modules/cmake.rs
+++ b/src/modules/cmake.rs
@@ -33,7 +33,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             .map(|variable| match variable {
                 "version" => {
                     let cmake_version =
-                        get_cmake_version(&context.exec_cmd("cmake", &["--version"])?.stdout)?;
+                        parse_cmake_version(&context.exec_cmd("cmake", &["--version"])?.stdout)?;
                     VersionFormatter::format_module_version(
                         module.get_name(),
                         &cmake_version,
@@ -57,7 +57,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     Some(module)
 }
 
-fn get_cmake_version(cmake_version: &str) -> Option<String> {
+fn parse_cmake_version(cmake_version: &str) -> Option<String> {
     Some(
         cmake_version
             //split into ["cmake" "version" "3.10.2", ...]

--- a/src/modules/crystal.rs
+++ b/src/modules/crystal.rs
@@ -32,8 +32,9 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             })
             .map(|variable| match variable {
                 "version" => {
-                    let crystal_version =
-                        parse_crystal_version(&context.exec_cmd("crystal", &["--version"])?.stdout)?;
+                    let crystal_version = parse_crystal_version(
+                        &context.exec_cmd("crystal", &["--version"])?.stdout,
+                    )?;
                     VersionFormatter::format_module_version(
                         module.get_name(),
                         &crystal_version,

--- a/src/modules/crystal.rs
+++ b/src/modules/crystal.rs
@@ -33,7 +33,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             .map(|variable| match variable {
                 "version" => {
                     let crystal_version =
-                        get_crystal_version(&context.exec_cmd("crystal", &["--version"])?.stdout)?;
+                        parse_crystal_version(&context.exec_cmd("crystal", &["--version"])?.stdout)?;
                     VersionFormatter::format_module_version(
                         module.get_name(),
                         &crystal_version,
@@ -57,7 +57,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     Some(module)
 }
 
-fn get_crystal_version(crystal_version: &str) -> Option<String> {
+fn parse_crystal_version(crystal_version: &str) -> Option<String> {
     Some(
         crystal_version
             // split into ["Crystal", "0.35.1", ...]

--- a/src/modules/dart.rs
+++ b/src/modules/dart.rs
@@ -33,7 +33,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             .map(|variable| match variable {
                 "version" => {
                     let dart_version =
-                        get_dart_version(&context.exec_cmd("dart", &["--version"])?.stderr)?;
+                        parse_dart_version(&context.exec_cmd("dart", &["--version"])?.stderr)?;
                     VersionFormatter::format_module_version(
                         module.get_name(),
                         &dart_version,
@@ -57,7 +57,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     Some(module)
 }
 
-fn get_dart_version(dart_version: &str) -> Option<String> {
+fn parse_dart_version(dart_version: &str) -> Option<String> {
     Some(
         dart_version
             // split into ["Dart", "VM", "version:", "2.8.4", "(stable)", ...]

--- a/src/modules/deno.rs
+++ b/src/modules/deno.rs
@@ -32,7 +32,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             .map(|variable| match variable {
                 "version" => {
                     let deno_version =
-                        get_deno_version(&context.exec_cmd("deno", &["-V"])?.stdout)?;
+                        parse_deno_version(&context.exec_cmd("deno", &["-V"])?.stdout)?;
                     VersionFormatter::format_module_version(
                         module.get_name(),
                         &deno_version,
@@ -56,7 +56,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     Some(module)
 }
 
-fn get_deno_version(deno_version: &str) -> Option<String> {
+fn parse_deno_version(deno_version: &str) -> Option<String> {
     Some(
         deno_version
             // split into ["deno", "1.8.3"]

--- a/src/modules/golang.rs
+++ b/src/modules/golang.rs
@@ -32,7 +32,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             .map(|variable| match variable {
                 "version" => {
                     let golang_version =
-                        get_go_version(&context.exec_cmd("go", &["version"])?.stdout)?;
+                        parse_go_version(&context.exec_cmd("go", &["version"])?.stdout)?;
 
                     VersionFormatter::format_module_version(
                         module.get_name(),
@@ -57,7 +57,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     Some(module)
 }
 
-fn get_go_version(go_stdout: &str) -> Option<String> {
+fn parse_go_version(go_stdout: &str) -> Option<String> {
     // go version output looks like this:
     // go version go1.13.3 linux/amd64
 
@@ -189,6 +189,6 @@ mod tests {
     #[test]
     fn test_format_go_version() {
         let input = "go version go1.12 darwin/amd64";
-        assert_eq!(get_go_version(input), Some("1.12".to_string()));
+        assert_eq!(parse_go_version(input), Some("1.12".to_string()));
     }
 }

--- a/src/modules/helm.rs
+++ b/src/modules/helm.rs
@@ -32,7 +32,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             })
             .map(|variable| match variable {
                 "version" => {
-                    let helm_version = get_helm_version(
+                    let helm_version = parse_helm_version(
                         &context
                             .exec_cmd("helm", &["version", "--short", "--client"])?
                             .stdout,
@@ -60,7 +60,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     Some(module)
 }
 
-fn get_helm_version(helm_stdout: &str) -> Option<String> {
+fn parse_helm_version(helm_stdout: &str) -> Option<String> {
     // `helm version --short --client` output looks like this:
     // v3.1.1+gafe7058
     // `helm version --short --client` output looks like this for Helm 2:
@@ -123,10 +123,10 @@ mod tests {
     }
 
     #[test]
-    fn test_get_helm_version() {
+    fn test_parse_helm_version() {
         let helm_2 = "Client: v2.16.9+g8ad7037";
         let helm_3 = "v3.1.1+ggit afe7058";
-        assert_eq!(get_helm_version(helm_2), Some("2.16.9".to_string()));
-        assert_eq!(get_helm_version(helm_3), Some("3.1.1".to_string()));
+        assert_eq!(parse_helm_version(helm_2), Some("2.16.9".to_string()));
+        assert_eq!(parse_helm_version(helm_3), Some("3.1.1".to_string()));
     }
 }

--- a/src/modules/java.rs
+++ b/src/modules/java.rs
@@ -1,8 +1,8 @@
+use super::{Context, Module, RootModuleConfig};
 use crate::configs::java::JavaConfig;
 use crate::formatter::{StringFormatter, VersionFormatter};
+use crate::utils::get_command_string_output;
 use std::path::PathBuf;
-
-use super::{Context, Module, RootModuleConfig};
 
 use regex::Regex;
 const JAVA_VERSION_PATTERN: &str = "(?P<version>[\\d\\.]+)[^\\s]*\\s(?:built|from)";
@@ -34,7 +34,15 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 _ => None,
             })
             .map(|variable| match variable {
-                "version" => get_java_version(context, &config).map(Ok),
+                "version" => {
+                    let java_version = get_java_version(context)?;
+                    VersionFormatter::format_module_version(
+                        module.get_name(),
+                        &java_version,
+                        config.version_format,
+                    )
+                    .map(Ok)
+                }
                 _ => None,
             })
             .parse(None)
@@ -51,7 +59,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     Some(module)
 }
 
-fn get_java_version(context: &Context, config: &JavaConfig) -> Option<String> {
+fn get_java_version(context: &Context) -> Option<String> {
     let java_command = context
         .get_env("JAVA_HOME")
         .map(PathBuf::from)
@@ -65,27 +73,17 @@ fn get_java_version(context: &Context, config: &JavaConfig) -> Option<String> {
         .unwrap_or_else(|| String::from("java"));
 
     let output = context.exec_cmd(&java_command, &["-Xinternalversion"])?;
-    let java_version = if output.stdout.is_empty() {
-        output.stderr
-    } else {
-        output.stdout
-    };
+    let java_version_string = get_command_string_output(output);
 
-    format_java_version(&java_version, config.version_format)
+    parse_java_version(&java_version_string)
 }
 
-fn format_java_version(java_version: &str, version_format: &str) -> Option<String> {
+fn parse_java_version(java_version_string: &str) -> Option<String> {
     let re = Regex::new(JAVA_VERSION_PATTERN).ok()?;
-    let captures = re.captures(java_version)?;
+    let captures = re.captures(java_version_string)?;
     let version = &captures["version"];
 
-    match VersionFormatter::format_version(version, version_format) {
-        Ok(formatted) => Some(formatted),
-        Err(error) => {
-            log::warn!("Error formatting `java` version:\n{}", error);
-            Some(format!("v{}", version))
-        }
-    }
+    Some(version.to_string())
 }
 
 #[cfg(test)]
@@ -97,106 +95,67 @@ mod tests {
     use std::io;
 
     #[test]
-    fn test_format_java_version_openjdk() {
+    fn test_parse_java_version_openjdk() {
         let java_8 = "OpenJDK 64-Bit Server VM (25.222-b10) for linux-amd64 JRE (1.8.0_222-b10), built on Jul 11 2019 10:18:43 by \"openjdk\" with gcc 4.4.7 20120313 (Red Hat 4.4.7-23)";
         let java_11 = "OpenJDK 64-Bit Server VM (11.0.4+11-post-Ubuntu-1ubuntu219.04) for linux-amd64 JRE (11.0.4+11-post-Ubuntu-1ubuntu219.04), built on Jul 18 2019 18:21:46 by \"build\" with gcc 8.3.0";
-        assert_eq!(
-            format_java_version(java_11, "v${raw}"),
-            Some("v11.0.4".to_string())
-        );
-        assert_eq!(
-            format_java_version(java_8, "v${raw}"),
-            Some("v1.8.0".to_string())
-        );
+        assert_eq!(parse_java_version(java_8), Some("1.8.0".to_string()));
+        assert_eq!(parse_java_version(java_11), Some("11.0.4".to_string()));
     }
 
     #[test]
-    fn test_format_java_version_oracle() {
+    fn test_parse_java_version_oracle() {
         let java_8 = "Java HotSpot(TM) Client VM (25.65-b01) for linux-arm-vfp-hflt JRE (1.8.0_65-b17), built on Oct  6 2015 16:19:04 by \"java_re\" with gcc 4.7.2 20120910 (prerelease)";
-        assert_eq!(
-            format_java_version(java_8, "v${raw}"),
-            Some("v1.8.0".to_string())
-        );
+        assert_eq!(parse_java_version(java_8), Some("1.8.0".to_string()));
     }
 
     #[test]
-    fn test_format_java_version_redhat() {
+    fn test_parse_java_version_redhat() {
         let java_8 = "OpenJDK 64-Bit Server VM (25.222-b10) for linux-amd64 JRE (1.8.0_222-b10), built on Jul 11 2019 20:48:53 by \"root\" with gcc 7.3.1 20180303 (Red Hat 7.3.1-5)";
         let java_12 = "OpenJDK 64-Bit Server VM (12.0.2+10) for linux-amd64 JRE (12.0.2+10), built on Jul 18 2019 14:41:47 by \"jenkins\" with gcc 7.3.1 20180303 (Red Hat 7.3.1-5)";
-        assert_eq!(
-            format_java_version(java_8, "v${raw}"),
-            Some("v1.8.0".to_string())
-        );
-        assert_eq!(
-            format_java_version(java_12, "v${raw}"),
-            Some("v12.0.2".to_string())
-        );
+        assert_eq!(parse_java_version(java_8), Some("1.8.0".to_string()));
+        assert_eq!(parse_java_version(java_12), Some("12.0.2".to_string()));
     }
 
     #[test]
-    fn test_format_java_version_zulu() {
+    fn test_parse_java_version_zulu() {
         let java_8 = "OpenJDK 64-Bit Server VM (25.222-b10) for linux-amd64 JRE (Zulu 8.40.0.25-CA-linux64) (1.8.0_222-b10), built on Jul 11 2019 11:36:39 by \"zulu_re\" with gcc 4.4.7 20120313 (Red Hat 4.4.7-3)";
         let java_11 = "OpenJDK 64-Bit Server VM (11.0.4+11-LTS) for linux-amd64 JRE (Zulu11.33+15-CA) (11.0.4+11-LTS), built on Jul 11 2019 21:37:17 by \"zulu_re\" with gcc 4.9.2 20150212 (Red Hat 4.9.2-6)";
-        assert_eq!(
-            format_java_version(java_8, "v${raw}"),
-            Some("v1.8.0".to_string())
-        );
-        assert_eq!(
-            format_java_version(java_11, "v${raw}"),
-            Some("v11.0.4".to_string())
-        );
+        assert_eq!(parse_java_version(java_8), Some("1.8.0".to_string()));
+        assert_eq!(parse_java_version(java_11), Some("11.0.4".to_string()));
     }
 
     #[test]
-    fn test_format_java_version_eclipse_openj9() {
+    fn test_parse_java_version_eclipse_openj9() {
         let java_8 = "Eclipse OpenJ9 OpenJDK 64-bit Server VM (1.8.0_222-b10) from linux-amd64 JRE with Extensions for OpenJDK for Eclipse OpenJ9 8.0.222.0, built on Jul 17 2019 21:29:18 by jenkins with g++ (GCC) 7.3.1 20180303 (Red Hat 7.3.1-5)";
         let java_11 = "Eclipse OpenJ9 OpenJDK 64-bit Server VM (11.0.4+11) from linux-amd64 JRE with Extensions for OpenJDK for Eclipse OpenJ9 11.0.4.0, built on Jul 17 2019 21:51:37 by jenkins with g++ (GCC) 7.3.1 20180303 (Red Hat 7.3.1-5)";
-        assert_eq!(
-            format_java_version(java_8, "v${raw}"),
-            Some("v1.8.0".to_string())
-        );
-        assert_eq!(
-            format_java_version(java_11, "v${raw}"),
-            Some("v11.0.4".to_string())
-        );
+        assert_eq!(parse_java_version(java_8), Some("1.8.0".to_string()));
+        assert_eq!(parse_java_version(java_11), Some("11.0.4".to_string()));
     }
 
     #[test]
-    fn test_format_java_version_graalvm() {
+    fn test_parse_java_version_graalvm() {
         let java_8 = "OpenJDK 64-Bit GraalVM CE 19.2.0.1 (25.222-b08-jvmci-19.2-b02) for linux-amd64 JRE (8u222), built on Jul 19 2019 17:37:13 by \"buildslave\" with gcc 7.3.0";
-        assert_eq!(
-            format_java_version(java_8, "v${raw}"),
-            Some("v8".to_string())
-        );
+        assert_eq!(parse_java_version(java_8), Some("8".to_string()));
     }
 
     #[test]
-    fn test_format_java_version_amazon_corretto() {
+    fn test_parse_java_version_amazon_corretto() {
         let java_8 = "OpenJDK 64-Bit Server VM (25.222-b10) for linux-amd64 JRE (1.8.0_222-b10), built on Jul 11 2019 20:48:53 by \"root\" with gcc 7.3.1 20180303 (Red Hat 7.3.1-5)";
         let java_11 = "OpenJDK 64-Bit Server VM (11.0.4+11-LTS) for linux-amd64 JRE (11.0.4+11-LTS), built on Jul 11 2019 20:06:11 by \"\" with gcc 7.3.1 20180303 (Red Hat 7.3.1-5)";
-        assert_eq!(
-            format_java_version(java_8, "v${raw}"),
-            Some("v1.8.0".to_string())
-        );
-        assert_eq!(
-            format_java_version(java_11, "v${raw}"),
-            Some("v11.0.4".to_string())
-        );
+        assert_eq!(parse_java_version(java_8), Some("1.8.0".to_string()));
+        assert_eq!(parse_java_version(java_11), Some("11.0.4".to_string()));
     }
 
     #[test]
-    fn test_format_java_version_sapmachine() {
+    fn test_parse_java_version_sapmachine() {
         let java_11 = "OpenJDK 64-Bit Server VM (11.0.4+11-LTS-sapmachine) for linux-amd64 JRE (11.0.4+11-LTS-sapmachine), built on Jul 17 2019 08:58:43 by \"\" with gcc 7.3.0";
-        assert_eq!(
-            format_java_version(java_11, "v${raw}"),
-            Some("v11.0.4".to_string())
-        );
+        assert_eq!(parse_java_version(java_11), Some("11.0.4".to_string()));
     }
 
     #[test]
-    fn test_format_java_version_unknown() {
+    fn test_parse_java_version_unknown() {
         let unknown_jre = "Unknown JRE";
-        assert_eq!(format_java_version(unknown_jre, "v${raw}"), None);
+        assert_eq!(parse_java_version(unknown_jre), None);
     }
 
     #[test]

--- a/src/modules/julia.rs
+++ b/src/modules/julia.rs
@@ -33,7 +33,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             .map(|variable| match variable {
                 "version" => {
                     let julia_version =
-                        get_julia_version(&context.exec_cmd("julia", &["--version"])?.stdout)?;
+                        parse_julia_version(&context.exec_cmd("julia", &["--version"])?.stdout)?;
                     VersionFormatter::format_module_version(
                         module.get_name(),
                         &julia_version,
@@ -57,7 +57,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     Some(module)
 }
 
-fn get_julia_version(julia_stdout: &str) -> Option<String> {
+fn parse_julia_version(julia_stdout: &str) -> Option<String> {
     // julia version output looks like this:
     // julia version 1.4.0
 
@@ -128,8 +128,8 @@ mod tests {
     }
 
     #[test]
-    fn test_get_julia_version() {
+    fn test_parse_julia_version() {
         let input = "julia version 1.4.0";
-        assert_eq!(get_julia_version(input), Some("1.4.0".to_string()));
+        assert_eq!(parse_julia_version(input), Some("1.4.0".to_string()));
     }
 }

--- a/src/modules/kotlin.rs
+++ b/src/modules/kotlin.rs
@@ -3,6 +3,7 @@ use super::{Context, Module, RootModuleConfig};
 use crate::configs::kotlin::KotlinConfig;
 use crate::formatter::StringFormatter;
 use crate::formatter::VersionFormatter;
+use crate::utils::get_command_string_output;
 
 use regex::Regex;
 const KOTLIN_VERSION_PATTERN: &str = "(?P<version>[\\d\\.]+[\\d\\.]+[\\d\\.]+)";
@@ -35,7 +36,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             })
             .map(|variable| match variable {
                 "version" => {
-                    let kotlin_version = get_kotlin_version(context, &config.kotlin_binary)?;
+                    let kotlin_version = get_kotlin_version(context, config.kotlin_binary)?;
                     VersionFormatter::format_module_version(
                         module.get_name(),
                         &kotlin_version,
@@ -60,17 +61,10 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 }
 
 fn get_kotlin_version(context: &Context, kotlin_binary: &str) -> Option<String> {
-    match context.exec_cmd(kotlin_binary, &["-version"]) {
-        Some(output) => {
-            let kotlin_output = if output.stdout.is_empty() {
-                output.stderr
-            } else {
-                output.stdout
-            };
-            parse_kotlin_version(&kotlin_output)
-        }
-        None => None,
-    }
+    let command = context.exec_cmd(kotlin_binary, &["-version"])?;
+    let kotlin_version_string = get_command_string_output(command);
+
+    parse_kotlin_version(&kotlin_version_string)
 }
 
 fn parse_kotlin_version(kotlin_stdout: &str) -> Option<String> {

--- a/src/modules/lua.rs
+++ b/src/modules/lua.rs
@@ -3,6 +3,7 @@ use super::{Context, Module, RootModuleConfig};
 use crate::configs::lua::LuaConfig;
 use crate::formatter::StringFormatter;
 use crate::formatter::VersionFormatter;
+use crate::utils::get_command_string_output;
 
 /// Creates a module with the current Lua version
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
@@ -32,7 +33,9 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             })
             .map(|variable| match variable {
                 "version" => {
-                    let lua_version = get_lua_version(context, &config.lua_binary)?;
+                    let lua_version_string =
+                        get_command_string_output(context.exec_cmd(config.lua_binary, &["-v"])?);
+                    let lua_version = parse_lua_version(&lua_version_string)?;
                     VersionFormatter::format_module_version(
                         module.get_name(),
                         &lua_version,
@@ -54,17 +57,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     });
 
     Some(module)
-}
-
-fn get_lua_version(context: &Context, lua_binary: &str) -> Option<String> {
-    let output = context.exec_cmd(lua_binary, &["-v"])?;
-    let lua_version = if output.stdout.is_empty() {
-        output.stderr
-    } else {
-        output.stdout
-    };
-
-    parse_lua_version(&lua_version)
 }
 
 fn parse_lua_version(lua_version: &str) -> Option<String> {

--- a/src/modules/nodejs.rs
+++ b/src/modules/nodejs.rs
@@ -58,7 +58,11 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             })
             .map(|variable| match variable {
                 "version" => {
-                    let version = nodejs_version.deref().as_ref()?.trim_start_matches('v').trim();
+                    let version = nodejs_version
+                        .deref()
+                        .as_ref()?
+                        .trim_start_matches('v')
+                        .trim();
 
                     VersionFormatter::format_module_version(
                         module.get_name(),

--- a/src/modules/nodejs.rs
+++ b/src/modules/nodejs.rs
@@ -57,10 +57,16 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 _ => None,
             })
             .map(|variable| match variable {
-                "version" => Some(Ok(format_node_version(
-                    nodejs_version.deref().as_ref()?,
-                    config.version_format,
-                ))),
+                "version" => {
+                    let version = nodejs_version.deref().as_ref()?.trim_start_matches('v').trim();
+
+                    VersionFormatter::format_module_version(
+                        module.get_name(),
+                        version,
+                        config.version_format,
+                    )
+                    .map(Ok)
+                }
                 _ => None,
             })
             .parse(None)
@@ -104,18 +110,6 @@ fn check_engines_version(nodejs_version: &str, engines_version: Option<String>) 
         Err(_e) => return true,
     };
     r.matches(&v)
-}
-
-fn format_node_version(node_version: &str, version_format: &str) -> String {
-    let version = node_version.trim_start_matches('v').trim();
-
-    match VersionFormatter::format_version(version, version_format) {
-        Ok(formatted) => formatted,
-        Err(error) => {
-            log::warn!("Error formatting `node` version:\n{}", error);
-            format!("v{}", version)
-        }
-    }
 }
 
 #[cfg(test)]

--- a/src/modules/package.rs
+++ b/src/modules/package.rs
@@ -9,8 +9,6 @@ use regex::Regex;
 use serde_json as json;
 
 /// Creates a module with the current package version
-///
-/// Will display if a version is defined for your Node.js or Rust project (if one exists)
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let mut module = context.new_module("package");
     let config: PackageConfig = PackageConfig::try_load(module.config);

--- a/src/modules/python.rs
+++ b/src/modules/python.rs
@@ -5,6 +5,7 @@ use super::{Context, Module, RootModuleConfig};
 use crate::configs::python::PythonConfig;
 use crate::formatter::StringFormatter;
 use crate::formatter::VersionFormatter;
+use crate::utils::get_command_string_output;
 
 /// Creates a module with the current Python version and, if active, virtual environment.
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
@@ -73,13 +74,7 @@ fn get_python_version(context: &Context, config: &PythonConfig) -> Option<String
         .0
         .iter()
         .find_map(|binary| context.exec_cmd(binary, &["--version"]))
-        .map(|output| {
-            if output.stdout.is_empty() {
-                output.stderr
-            } else {
-                output.stdout
-            }
-        })?;
+        .map(|command| get_command_string_output(command))?;
 
     format_python_version(&version, config.version_format)
 }

--- a/src/modules/python.rs
+++ b/src/modules/python.rs
@@ -74,7 +74,7 @@ fn get_python_version(context: &Context, config: &PythonConfig) -> Option<String
         .0
         .iter()
         .find_map(|binary| context.exec_cmd(binary, &["--version"]))
-        .map(|command| get_command_string_output(command))?;
+        .map(get_command_string_output)?;
 
     format_python_version(&version, config.version_format)
 }

--- a/src/modules/rlang.rs
+++ b/src/modules/rlang.rs
@@ -30,7 +30,8 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             })
             .map(|variable| match variable {
                 "version" => {
-                    let r_version = get_r_version(context)?;
+                    let r_version_string = context.exec_cmd("R", &["--version"])?.stderr;
+                    let r_version = parse_r_version(&r_version_string)?;
                     VersionFormatter::format_module_version(
                         module.get_name(),
                         &r_version,
@@ -54,12 +55,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     Some(module)
 }
 
-fn get_r_version(context: &Context) -> Option<String> {
-    let r_version = context.exec_cmd("R", &["--version"])?.stderr;
-    parse_version(&r_version)
-}
-
-fn parse_version(r_version: &str) -> Option<String> {
+fn parse_r_version(r_version: &str) -> Option<String> {
     r_version
         .lines()
         // take first line
@@ -73,7 +69,7 @@ fn parse_version(r_version: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_version;
+    use super::parse_r_version;
     use crate::test::ModuleRenderer;
     use ansi_term::Color;
     use std::fs;
@@ -91,7 +87,7 @@ You are welcome to redistribute it under the terms of the
 GNU General Public License versions 2 or 3.
 For more information about these matters see
 https://www.gnu.org/licenses/."#;
-        assert_eq!(parse_version(r_v3), Some(String::from("4.1.0")));
+        assert_eq!(parse_r_version(r_v3), Some(String::from("4.1.0")));
     }
 
     #[test]

--- a/src/modules/scala.rs
+++ b/src/modules/scala.rs
@@ -3,6 +3,7 @@ use crate::formatter::StringFormatter;
 
 use super::{Context, Module, RootModuleConfig};
 use crate::formatter::VersionFormatter;
+use crate::utils::get_command_string_output;
 
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let mut module = context.new_module("scala");
@@ -56,18 +57,14 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 }
 
 fn get_scala_version(context: &Context) -> Option<String> {
-    let output = context.exec_cmd("scalac", &["-version"])?;
-    let scala_version = if output.stdout.is_empty() {
-        output.stderr
-    } else {
-        output.stdout
-    };
+    let command = context.exec_cmd("scalac", &["-version"])?;
+    let scala_version_string = get_command_string_output(command);
 
-    parse_scala_version(&scala_version)
+    parse_scala_version(&scala_version_string)
 }
 
-fn parse_scala_version(scala_version: &str) -> Option<String> {
-    let version = scala_version
+fn parse_scala_version(scala_version_string: &str) -> Option<String> {
+    let version = scala_version_string
         // split into ["Scala", "compiler", "version", "2.13.5", "--", ...]
         .split_whitespace()
         // take "2.13.5"

--- a/src/modules/terraform.rs
+++ b/src/modules/terraform.rs
@@ -36,7 +36,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             })
             .map(|variable| match variable {
                 "version" => {
-                    let terraform_version = get_terraform_version(
+                    let terraform_version = parse_terraform_version(
                         &context.exec_cmd("terraform", &["version"])?.stdout.as_str(),
                     )?;
                     VersionFormatter::format_module_version(
@@ -83,19 +83,18 @@ fn get_terraform_workspace(context: &Context) -> Option<String> {
     }
 }
 
-fn get_terraform_version(version: &str) -> Option<String> {
+fn parse_terraform_version(version: &str) -> Option<String> {
     // `terraform version` output looks like this
     // Terraform v0.12.14
     // With potential extra output if it detects you are not running the latest version
-    Some(
-        version
-            .lines()
-            .next()?
-            .trim_start_matches("Terraform ")
-            .trim()
-            .trim_start_matches('v')
-            .to_owned(),
-    )
+    let version = version
+        .lines()
+        .next()?
+        .trim_start_matches("Terraform ")
+        .trim()
+        .trim_start_matches('v');
+
+    Some(version.to_string())
 }
 
 #[cfg(test)]
@@ -107,38 +106,38 @@ mod tests {
     use std::io::{self, Write};
 
     #[test]
-    fn test_get_terraform_version_release() {
+    fn test_parse_terraform_version_release() {
         let input = "Terraform v0.12.14";
-        assert_eq!(get_terraform_version(input), Some("0.12.14".to_string()));
+        assert_eq!(parse_terraform_version(input), Some("0.12.14".to_string()));
     }
 
     #[test]
-    fn test_get_terraform_version_prerelease() {
+    fn test_parse_terraform_version_prerelease() {
         let input = "Terraform v0.12.14-rc1";
         assert_eq!(
-            get_terraform_version(input),
+            parse_terraform_version(input),
             Some("0.12.14-rc1".to_string())
         );
     }
 
     #[test]
-    fn test_get_terraform_version_development() {
+    fn test_parse_terraform_version_development() {
         let input = "Terraform v0.12.14-dev (cca89f74)";
         assert_eq!(
-            get_terraform_version(input),
+            parse_terraform_version(input),
             Some("0.12.14-dev (cca89f74)".to_string())
         );
     }
 
     #[test]
-    fn test_get_terraform_version_multiline() {
+    fn test_parse_terraform_version_multiline() {
         let input = "Terraform v0.12.13
 
 Your version of Terraform is out of date! The latest version
 is 0.12.14. You can update by downloading from www.terraform.io/downloads.html
 
 ";
-        assert_eq!(get_terraform_version(input), Some("0.12.13".to_string()));
+        assert_eq!(parse_terraform_version(input), Some("0.12.13".to_string()));
     }
 
     #[test]

--- a/src/modules/vagrant.rs
+++ b/src/modules/vagrant.rs
@@ -32,8 +32,9 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             })
             .map(|variable| match variable {
                 "version" => {
-                    let vagrant_version =
-                        parse_vagrant_version(&context.exec_cmd("vagrant", &["--version"])?.stdout)?;
+                    let vagrant_version = parse_vagrant_version(
+                        &context.exec_cmd("vagrant", &["--version"])?.stdout,
+                    )?;
                     VersionFormatter::format_module_version(
                         module.get_name(),
                         &vagrant_version,

--- a/src/modules/vagrant.rs
+++ b/src/modules/vagrant.rs
@@ -33,7 +33,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             .map(|variable| match variable {
                 "version" => {
                     let vagrant_version =
-                        get_vagrant_version(&context.exec_cmd("vagrant", &["--version"])?.stdout)?;
+                        parse_vagrant_version(&context.exec_cmd("vagrant", &["--version"])?.stdout)?;
                     VersionFormatter::format_module_version(
                         module.get_name(),
                         &vagrant_version,
@@ -57,11 +57,11 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     Some(module)
 }
 
-fn get_vagrant_version(vagrant_stdout: &str) -> Option<String> {
+fn parse_vagrant_version(vagrant_stdout: &str) -> Option<String> {
     // `vagrant --version` output looks like this:
     // Vagrant 2.2.10
     let version = vagrant_stdout
-        // split into ["Vagrant","2.2.10"]
+        // split into ["Vagrant", "2.2.10"]
         .split_whitespace()
         // return "2.2.10"
         .nth(1)?;
@@ -101,8 +101,8 @@ mod tests {
     }
 
     #[test]
-    fn test_get_vagrant_version() {
+    fn test_parse_vagrant_version() {
         let vagrant = "Vagrant 2.2.10\n";
-        assert_eq!(get_vagrant_version(vagrant), Some("2.2.10".to_string()));
+        assert_eq!(parse_vagrant_version(vagrant), Some("2.2.10".to_string()));
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -23,6 +23,14 @@ pub fn read_file<P: AsRef<Path> + Debug>(file_name: P) -> Result<String> {
     result
 }
 
+pub fn get_command_string_output(command: CommandOutput) -> String {
+    if command.stdout.is_empty() {
+        command.stderr
+    } else {
+        command.stdout
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct CommandOutput {
     pub stdout: String,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -17,7 +17,7 @@ pub fn read_file<P: AsRef<Path> + Debug>(file_name: P) -> Result<String> {
     if result.is_err() {
         log::debug!("Error reading file: {:?}", result);
     } else {
-        log::trace!("File read sucessfully");
+        log::trace!("File read successfully");
     };
 
     result
@@ -605,5 +605,19 @@ mod tests {
             wrap_colorseq_for_shell(test.to_owned(), Shell::PowerShell),
             test
         );
+    }
+
+    #[test]
+    fn test_get_command_string_output() {
+        let case1 = CommandOutput {
+            stdout: String::from("stdout"),
+            stderr: String::from("stderr"),
+        };
+        assert_eq!(get_command_string_output(case1), "stdout");
+        let case2 = CommandOutput {
+            stdout: String::from(""),
+            stderr: String::from("stderr"),
+        };
+        assert_eq!(get_command_string_output(case2), "stderr");
     }
 }


### PR DESCRIPTION
Updated some function names. Implemented utility method `get_command_string_output` because it's behavior was used in few modules. Updated java & python tests to test one thing (parsing version string to semantic version), not result of `VersionFormatter` which has it's own tests. 

#### Motivation and Context

This comment https://github.com/starship/starship/pull/2611#issuecomment-829797628

#### Screenshots (if appropriate):

#### How Has This Been Tested?
- [x] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
