### PR TITLE
fix(rust): support for `rust-toolchain.toml`

### DIFF
--- a/src/modules/rust.rs
+++ b/src/modules/rust.rs
@@ -63,7 +63,7 @@ fn get_module_version(context: &Context, config: &RustConfig) -> Option<String> 
     // check
     // 1. `$RUSTUP_TOOLCHAIN`
     // 2. `rustup override list`
-    // 3. `rust-toolchain` in `.` or parent directories
+    // 3. `rust-toolchain` or `rust-toolchain.toml` in `.` or parent directories
     // as `rustup` does.
     // https://github.com/rust-lang/rustup.rs/tree/eb694fcada7becc5d9d160bf7c623abe84f8971d#override-precedence
     //
@@ -163,9 +163,21 @@ fn find_rust_toolchain_file(context: &Context) -> Option<String> {
         }
     }
 
+    if let Ok(true) = context
+        .dir_contents()
+        .map(|dir| dir.has_file("rust-toolchain.toml"))
+    {
+        if let Some(toolchain) = read_channel(Path::new("rust-toolchain.toml")) {
+            return Some(toolchain);
+        }
+    }
+
     let mut dir = &*context.current_dir;
     loop {
         if let Some(toolchain) = read_channel(&dir.join("rust-toolchain")) {
+            return Some(toolchain);
+        }
+        if let Some(toolchain) = read_channel(&dir.join("rust-toolchain.toml")) {
             return Some(toolchain);
         }
         dir = dir.parent()?;

--- a/src/modules/rust.rs
+++ b/src/modules/rust.rs
@@ -157,6 +157,24 @@ fn find_rust_toolchain_file(context: &Context) -> Option<String> {
         .map(|c| c.trim().to_owned())
     }
 
+    if context
+        .dir_contents()
+        .map_or(false, |dir| dir.has_file("rust-toolchain"))
+    {
+        if let Some(toolchain) = read_channel(Path::new("rust-toolchain"), false) {
+            return Some(toolchain);
+        }
+    }
+
+    if context
+        .dir_contents()
+        .map_or(false, |dir| dir.has_file("rust-toolchain.toml"))
+    {
+        if let Some(toolchain) = read_channel(Path::new("rust-toolchain.toml"), true) {
+            return Some(toolchain);
+        }
+    }
+
     let mut dir = &*context.current_dir;
     loop {
         if let Some(toolchain) = read_channel(&dir.join("rust-toolchain"), false) {

--- a/src/modules/rust.rs
+++ b/src/modules/rust.rs
@@ -143,9 +143,9 @@ fn find_rust_toolchain_file(context: &Context) -> Option<String> {
     fn read_channel(path: &Path, only_toml: bool) -> Option<String> {
         let contents = fs::read_to_string(path).ok()?;
 
-        match (contents.lines().count(), only_toml) {
-            (0, _) => None,
-            (1, false) => Some(contents),
+        match contents.lines().count() {
+            0 => None,
+            1 if !only_toml => Some(contents),
             _ => {
                 toml::from_str::<OverrideFile>(&contents)
                     .ok()?


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR adds support for `rust-toolchain.toml` in the rust module.
A related Issue is #417, and this just adds some lines to PR #426.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I haven't opened a issue for this, but when I enter a directory with `rust-toolchain.toml` rustup started to install the toolchain. This is the same issue as #417 but with `.toml` file.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
