### PR TITLE
fix: standardize nix_shell symbol string format

### DIFF
--- a/src/configs/nix_shell.rs
+++ b/src/configs/nix_shell.rs
@@ -20,7 +20,7 @@ impl<'a> Default for NixShellConfig<'a> {
     fn default() -> Self {
         NixShellConfig {
             format: "via [$symbol$state( \\($name\\))]($style) ",
-            symbol: "❄️  ",
+            symbol: "❄️ ",
             style: "bold blue",
             impure_msg: "impure",
             pure_msg: "pure",

--- a/src/modules/nix_shell.rs
+++ b/src/modules/nix_shell.rs
@@ -88,7 +88,7 @@ mod tests {
         let actual = ModuleRenderer::new("nix_shell")
             .env("IN_NIX_SHELL", "pure")
             .collect();
-        let expected = Some(format!("via {} ", Color::Blue.bold().paint("❄️  pure")));
+        let expected = Some(format!("via {} ", Color::Blue.bold().paint("❄️ pure")));
 
         assert_eq!(expected, actual);
     }
@@ -98,7 +98,7 @@ mod tests {
         let actual = ModuleRenderer::new("nix_shell")
             .env("IN_NIX_SHELL", "impure")
             .collect();
-        let expected = Some(format!("via {} ", Color::Blue.bold().paint("❄️  impure")));
+        let expected = Some(format!("via {} ", Color::Blue.bold().paint("❄️ impure")));
 
         assert_eq!(expected, actual);
     }
@@ -111,7 +111,7 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "via {} ",
-            Color::Blue.bold().paint("❄️  pure (starship)")
+            Color::Blue.bold().paint("❄️ pure (starship)")
         ));
 
         assert_eq!(expected, actual);
@@ -125,7 +125,7 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "via {} ",
-            Color::Blue.bold().paint("❄️  impure (starship)")
+            Color::Blue.bold().paint("❄️ impure (starship)")
         ));
 
         assert_eq!(expected, actual);


### PR DESCRIPTION
#### Description
Change the current default `nix_shell` module symbol string to the same format used in other modules, removing the double spaces.
I changed the default configuration string and the matching module tests.

#### Motivation and Context
Closes #2776 
Closes #2907

#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
