### PR TITLE
feat(docker_context): Use DOCKER_HOST and DOCKER_CONTEXT enviroment variables 

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -791,7 +791,8 @@ truncation_symbol = "…/"
 
 The `docker_context` module shows the currently active
 [Docker context](https://docs.docker.com/engine/context/working-with-contexts/) if it's not set to
-`default`.
+`default` or if the `DOCKER_HOST` or `DOCKER_CONTEXT` environment variables are set (as they are meant
+to override the context in use).
 
 ### Options
 


### PR DESCRIPTION
#### Description
As described in #2022 and the Docker official documentation, the Docker Context can also be overriden by the `DOCKER_HOST` and `DOCKER_CONTEXT` environment variables. This PR detects the enviroment variables and updates the docker_context module accordingly.

#### Motivation and Context
The main motivation is to follow how the docker context works when those enviroments are set, accordingly to expected behavior.
Closes #2022 

#### Screenshots (if appropriate):

#### How Has This Been Tested?
We wrote some additional tests for the modules to ensure the correct behavior of the module.
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
