### PR TITLE
fix(init): Use shorter name for STARSHIP_SHELL PowerShell variable

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -247,7 +247,7 @@ impl<'a> Context<'a> {
             "bash" => Shell::Bash,
             "fish" => Shell::Fish,
             "ion" => Shell::Ion,
-            "powershell" => Shell::PowerShell,
+            "pwsh" => Shell::PowerShell,
             "zsh" => Shell::Zsh,
             "elvish" => Shell::Elvish,
             "tcsh" => Shell::Tcsh,

--- a/src/init/starship.ps1
+++ b/src/init/starship.ps1
@@ -1,7 +1,7 @@
 #!/usr/bin/env pwsh
 
 function global:prompt {
-        
+
     function Get-Cwd {
         $cwd = Get-Location
         $provider_prefix = "$($cwd.Provider.ModuleName)\$($cwd.Provider.Name)::"
@@ -10,7 +10,7 @@ function global:prompt {
             # NOTE: ProviderPath is only a physical filesystem path for the "FileSystem" provider
             # E.g. `Dev:\` -> `C:\Users\Joe Bloggs\Dev\`
             Path = $cwd.ProviderPath;
-            # Resolve the provider-logical path 
+            # Resolve the provider-logical path
             # NOTE: Attempt to trim any "provider prefix" from the path string.
             # E.g. `Microsoft.PowerShell.Core\FileSystem::Dev:\` -> `Dev:\`
             LogicalPath =
@@ -67,7 +67,7 @@ function global:prompt {
 
     # @ makes sure the result is an array even if single or no values are returned
     $jobs = @(Get-Job | Where-Object { $_.State -eq 'Running' }).Count
-    
+
     $cwd = Get-Cwd
     $arguments = @(
         "prompt"
@@ -75,7 +75,7 @@ function global:prompt {
         "--logical-path=$($cwd.LogicalPath)",
         "--jobs=$($jobs)"
     )
-    
+
     # Whe start from the premise that the command executed correctly, which covers also the fresh console.
     $lastExitCodeForPrompt = 0
     if ($lastCmd = Get-History -Count 1) {
@@ -88,7 +88,7 @@ function global:prompt {
             $lastExitCodeForPrompt = if ($null -ne $lastCmdletError -and $lastCmd.CommandLine -eq $lastCmdletError.Line) { 1 } else { $origLastExitCode }
         }
         $duration = [math]::Round(($lastCmd.EndExecutionTime - $lastCmd.StartExecutionTime).TotalMilliseconds)
-        
+
         $arguments += "--cmd-duration=$($duration)"
     }
 
@@ -124,7 +124,7 @@ function global:prompt {
 # Disable virtualenv prompt, it breaks starship
 $ENV:VIRTUAL_ENV_DISABLE_PROMPT=1
 
-$ENV:STARSHIP_SHELL = "powershell"
+$ENV:STARSHIP_SHELL = "pwsh"
 
 # Set up the session key that will be used to store logs
 $ENV:STARSHIP_SESSION_KEY = -join ((48..57) + (65..90) + (97..122) | Get-Random -Count 16 | ForEach-Object { [char]$_ })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
This renames the environment variable `$Env:STARSHIP_SHELL` from 'powershell' to 'pwsh'.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The string 'powershell' is just too long and does not provide any extra information. 
Also, Starship doesn't have the ability to right align segments, so left prompt space is a premium. 

This also makes it uniform with respect to the `shell` module - both the `shell` module and STARSHIP_SHELL variable will now say 'pwsh'

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
