### PR TITLE
fix(dotnet): Don't treat folder with .sln file as a .NET project

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -839,7 +839,6 @@ the following files are present in the current directory:
 - `Directory.Build.props`
 - `Directory.Build.targets`
 - `Packages.props`
-- `*.sln`
 - `*.csproj`
 - `*.fsproj`
 - `*.xproj`
@@ -863,7 +862,7 @@ when there is a csproj file in the current directory.
 | `version_format`    | `"v${raw}"`                                                                                             | The version format. Available vars are `raw`, `major`, `minor`, & `patch` |
 | `symbol`            | `".NET "`                                                                                               | The symbol used before displaying the version of dotnet.                  |
 | `heuristic`         | `true`                                                                                                  | Use faster version detection to keep starship snappy.                     |
-| `detect_extensions` | `["sln", "csproj", "fsproj", "xproj"]`                                                                  | Which extensions should trigger this module.                              |
+| `detect_extensions` | `["csproj", "fsproj", "xproj"]`                                                                  | Which extensions should trigger this module.                              |
 | `detect_files`      | `["global.json", "project.json", "Directory.Build.props", "Directory.Build.targets", "Packages.props"]` | Which filenames should trigger this module.                               |
 | `detect_folders`    | `[]`                                                                                                    | Which folders should trigger this modules.                                |
 | `style`             | `"bold blue"`                                                                                           | The style for the module.                                                 |

--- a/src/configs/dotnet.rs
+++ b/src/configs/dotnet.rs
@@ -25,7 +25,7 @@ impl<'a> Default for DotnetConfig<'a> {
             style: "blue bold",
             heuristic: true,
             disabled: false,
-            detect_extensions: vec!["sln", "csproj", "fsproj", "xproj"],
+            detect_extensions: vec!["csproj", "fsproj", "xproj"],
             detect_files: vec![
                 "global.json",
                 "project.json",

--- a/src/modules/dotnet.rs
+++ b/src/modules/dotnet.rs
@@ -395,10 +395,7 @@ mod tests {
     fn shows_latest_in_directory_with_solution() -> io::Result<()> {
         let workspace = create_workspace(false)?;
         touch_path(&workspace, "solution.sln", None)?;
-        expect_output(
-            &workspace.path(),
-            Some(format!("{}", Color::Blue.bold().paint(".NET v3.1.103 "))),
-        );
+        expect_output(&workspace.path(), None);
         workspace.close()
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
Change the detect_extensions of the .NET module, so that the `.sln` file will not trigger the .NET prompt.
According to the [VS documentation](https://docs.microsoft.com/en-us/visualstudio/ide/solutions-and-projects-in-visual-studio?view=vs-2019),the `.sln` file is 

> simply **a container for one or more related projects**, along with build information, Visual Studio window settings, and any miscellaneous files that **aren't associated with a particular project**.

The project might be C++ project or something else. **Currently, the .NET module will treat all folders with `.sln` file as .NET project, which is confusing.**

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #2567

I found that **the .NET module will be triggered in my C++ project**. 
Here is the screen shot:

![图片](https://user-images.githubusercontent.com/51704722/120885912-f4e60a80-c61d-11eb-94ec-e6b22f797861.png)


#### Screenshots (if appropriate):
After fix, the `.sln` file won't trigger the .NET module
![图片](https://user-images.githubusercontent.com/51704722/120886095-c0bf1980-c61e-11eb-981c-1454d9ab6ea9.png)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
