### PR TITLE
feat: Secondary Prompt (PromptMode)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1686,7 +1686,7 @@ dependencies = [
 
 [[package]]
 name = "starship"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "ansi_term 0.12.1",
  "attohttpc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1686,7 +1686,7 @@ dependencies = [
 
 [[package]]
 name = "starship"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "ansi_term 0.12.1",
  "attohttpc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starship"
-version = "0.55.0"
+version = "0.56.0"
 edition = "2018"
 authors = ["Matan Kushner <hello@matchai.me>"]
 homepage = "https://starship.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starship"
-version = "0.56.0"
+version = "0.57.0"
 edition = "2018"
 authors = ["Matan Kushner <hello@matchai.me>"]
 homepage = "https://starship.rs"

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -151,14 +151,15 @@ This is the list of prompt-wide configuration options.
 
 ### Options
 
-| Option            | Default                        | Description                                                                                          |
-| ----------------- | ------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| `format`          | [link](#default-prompt-format) | Configure the format of the prompt.                                                                  |
-| `format_right`    | `""`                           | Configure the format of the right prompt.                                                            |
-| `scan_timeout`    | `30`                           | Timeout for starship to scan files (in milliseconds).                                                |
-| `command_timeout` | `500`                          | Timeout for commands executed by starship (in milliseconds).                                         |
-| `add_newline`     | `true`                         | Inserts blank line between shell prompts.                                                            |
-| `split_padding`   | `3`                            | The minimum amount of space required between left and right prompt for the right prompt to be shown. |
+| Option             | Default                        | Description                                                                                          |
+| ------------------ | ------------------------------ | ---------------------------------------------------------------------------------------------------- |
+| `format`           | [link](#default-prompt-format) | Configure the format of the prompt.                                                                  |
+| `format_right`     | `""`                           | Configure the format of the right prompt.                                                            |
+| `format_secondary` | `""`                           | Configure the format of the secondary prompt, which is return by `--prompt-mode=secondary`.          |
+| `scan_timeout`     | `30`                           | Timeout for starship to scan files (in milliseconds).                                                |
+| `command_timeout`  | `500`                          | Timeout for commands executed by starship (in milliseconds).                                         |
+| `add_newline`      | `true`                         | Inserts blank line between shell prompts.                                                            |
+| `split_padding`    | `3`                            | The minimum amount of space required between left and right prompt for the right prompt to be shown. |
 
 ### Example
 
@@ -174,6 +175,10 @@ format = """
 # Display time on the right prompt.
 # This will only display if the terminal is wide enough.
 format_right = "$time"
+
+# Display status on the secondary prompt.
+# This will only display if the shell makes use of the secondary prompt, for example  Zsh's `RPROMPT`.
+format_secondary = "$status"
 
 # Wait 10 milliseconds for starship to check files under the current directory.
 scan_timeout = 10

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -151,29 +151,38 @@ This is the list of prompt-wide configuration options.
 
 ### Options
 
-| Option            | Default                        | Description                                                  |
-| ----------------- | ------------------------------ | ------------------------------------------------------------ |
-| `format`          | [link](#default-prompt-format) | Configure the format of the prompt.                          |
-| `scan_timeout`    | `30`                           | Timeout for starship to scan files (in milliseconds).        |
-| `command_timeout` | `500`                          | Timeout for commands executed by starship (in milliseconds). |
-| `add_newline`     | `true`                         | Inserts blank line between shell prompts.                    |
+| Option            | Default                        | Description                                                                                          |
+| ----------------- | ------------------------------ | ---------------------------------------------------------------------------------------------------- |
+| `format`          | [link](#default-prompt-format) | Configure the format of the prompt.                                                                  |
+| `format_right`    | `""`                           | Configure the format of the right prompt.                                                            |
+| `scan_timeout`    | `30`                           | Timeout for starship to scan files (in milliseconds).                                                |
+| `command_timeout` | `500`                          | Timeout for commands executed by starship (in milliseconds).                                         |
+| `add_newline`     | `true`                         | Inserts blank line between shell prompts.                                                            |
+| `split_padding`   | `3`                            | The minimum amount of space required between left and right prompt for the right prompt to be shown. |
 
 ### Example
 
 ```toml
 # ~/.config/starship.toml
 
-# Use custom format
+# Use custom format.
 format = """
 [┌───────────────────>](bold green)
 [│](bold green)$directory$rust$package
 [└─>](bold green) """
 
+# Display time on the right prompt.
+# This will only display if the terminal is wide enough.
+format_right = "$time"
+
 # Wait 10 milliseconds for starship to check files under the current directory.
 scan_timeout = 10
 
-# Disable the blank line at the start of the prompt
+# Disable the blank line at the start of the prompt.
 add_newline = false
+
+# Only display the right prompt if there's room for a 30 width margin between it and the left prompt.
+split_padding = 30
 ```
 
 ### Default Prompt Format

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -8,6 +8,7 @@ use std::cmp::Ordering;
 pub struct StarshipRootConfig<'a> {
     pub format: &'a str,
     pub format_right: &'a str,
+    pub format_secondary: &'a str,
     pub scan_timeout: u64,
     pub command_timeout: u64,
     pub add_newline: bool,
@@ -91,6 +92,7 @@ impl<'a> Default for StarshipRootConfig<'a> {
         StarshipRootConfig {
             format: "$all",
             format_right: "",
+            format_secondary: "",
             scan_timeout: 30,
             command_timeout: 500,
             add_newline: true,
@@ -105,6 +107,7 @@ impl<'a> ModuleConfig<'a> for StarshipRootConfig<'a> {
             config.iter().for_each(|(k, v)| match k.as_str() {
                 "format" => self.format.load_config(v),
                 "format_right" => self.format_right.load_config(v),
+                "format_secondary" => self.format_secondary.load_config(v),
                 "scan_timeout" => self.scan_timeout.load_config(v),
                 "command_timeout" => self.command_timeout.load_config(v),
                 "add_newline" => self.add_newline.load_config(v),
@@ -117,6 +120,7 @@ impl<'a> ModuleConfig<'a> for StarshipRootConfig<'a> {
                             // Root options
                             "format",
                             "format_right",
+                            "format_secondary",
                             "scan_timeout",
                             "command_timeout",
                             "add_newline",

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -7,9 +7,11 @@ use std::cmp::Ordering;
 #[derive(Clone, Serialize)]
 pub struct StarshipRootConfig<'a> {
     pub format: &'a str,
+    pub format_right: &'a str,
     pub scan_timeout: u64,
     pub command_timeout: u64,
     pub add_newline: bool,
+    pub split_padding: usize,
 }
 
 // List of default prompt order
@@ -88,9 +90,11 @@ impl<'a> Default for StarshipRootConfig<'a> {
     fn default() -> Self {
         StarshipRootConfig {
             format: "$all",
+            format_right: "",
             scan_timeout: 30,
             command_timeout: 500,
             add_newline: true,
+            split_padding: 3,
         }
     }
 }
@@ -100,9 +104,11 @@ impl<'a> ModuleConfig<'a> for StarshipRootConfig<'a> {
         if let toml::Value::Table(config) = config {
             config.iter().for_each(|(k, v)| match k.as_str() {
                 "format" => self.format.load_config(v),
+                "format_right" => self.format_right.load_config(v),
                 "scan_timeout" => self.scan_timeout.load_config(v),
                 "command_timeout" => self.command_timeout.load_config(v),
                 "add_newline" => self.add_newline.load_config(v),
+                "split_padding" => self.split_padding.load_config(v),
                 unknown => {
                     if !ALL_MODULES.contains(&unknown) && unknown != "custom" {
                         log::warn!("Unknown config key '{}'", unknown);
@@ -110,9 +116,11 @@ impl<'a> ModuleConfig<'a> for StarshipRootConfig<'a> {
                         let did_you_mean = &[
                             // Root options
                             "format",
+                            "format_right",
                             "scan_timeout",
                             "command_timeout",
                             "add_newline",
+                            "split_padding",
                             // Modules
                             "custom",
                         ]

--- a/src/context.rs
+++ b/src/context.rs
@@ -22,6 +22,9 @@ pub struct Context<'a> {
     /// The deserialized configuration map from the user's `starship.toml` file.
     pub config: StarshipConfig,
 
+    /// Which prompt to render.  By default, the main prompt is rendered.
+    pub prompt_mode: PromptMode,
+
     /// The current working directory that starship is being called in.
     pub current_dir: PathBuf,
 
@@ -58,6 +61,11 @@ pub struct Context<'a> {
 
     /// Timeout for the execution of commands
     cmd_timeout: Duration,
+}
+
+pub enum PromptMode {
+    Main,
+    Secondary,
 }
 
 impl<'a> Context<'a> {
@@ -98,6 +106,12 @@ impl<'a> Context<'a> {
     ) -> Context {
         let config = StarshipConfig::initialize();
 
+        let prompt_mode = match arguments.value_of("prompt_mode") {
+            Some("main") => PromptMode::Main,
+            Some("secondary") => PromptMode::Secondary,
+            _ => PromptMode::Main,
+        };
+
         // Unwrap the clap arguments into a simple hashtable
         // we only care about single arguments at this point, there isn't a
         // use-case for a list of arguments yet.
@@ -118,6 +132,7 @@ impl<'a> Context<'a> {
 
         Context {
             config,
+            prompt_mode,
             properties,
             current_dir,
             logical_dir,

--- a/src/context.rs
+++ b/src/context.rs
@@ -42,6 +42,9 @@ pub struct Context<'a> {
     /// The shell the user is assumed to be running
     pub shell: Shell,
 
+    /// Width of terminal, or zero if width cannot be detected.
+    pub width: usize,
+
     /// A HashMap of environment variable mocks
     #[cfg(test)]
     pub env: HashMap<&'a str, String>,
@@ -121,6 +124,9 @@ impl<'a> Context<'a> {
             dir_contents: OnceCell::new(),
             repo: OnceCell::new(),
             shell,
+            width: term_size::dimensions()
+                .map(|(width, _)| width)
+                .unwrap_or_default(),
             #[cfg(test)]
             env: HashMap::new(),
             #[cfg(test)]

--- a/src/init/starship.zsh
+++ b/src/init/starship.zsh
@@ -92,3 +92,4 @@ VIRTUAL_ENV_DISABLE_PROMPT=1
 
 setopt promptsubst
 PROMPT='$(::STARSHIP:: prompt --keymap="$KEYMAP" --status="$STARSHIP_CMD_STATUS" --cmd-duration="$STARSHIP_DURATION" --jobs="$STARSHIP_JOBS_COUNT")'
+RPROMPT='$(::STARSHIP:: prompt --prompt-mode=secondary --keymap="$KEYMAP" --status="$STARSHIP_CMD_STATUS" --cmd-duration="$STARSHIP_DURATION" --jobs="$STARSHIP_JOBS_COUNT")'

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,6 +90,15 @@ fn main() {
         .subcommand(
             SubCommand::with_name("prompt")
                 .about("Prints the full starship prompt")
+                .arg(
+                    Arg::with_name("prompt_mode")
+                        .long("prompt-mode")
+                        .value_name("PROMPT_MODE")
+                        .help("Which prompt mode to render.")
+                        .takes_value(true)
+                        .possible_values(&["main", "secondary"])
+                        .default_value("main"),
+                )
                 .arg(&status_code_arg)
                 .arg(&path_arg)
                 .arg(&logical_path_arg)

--- a/src/module.rs
+++ b/src/module.rs
@@ -1,4 +1,5 @@
 use crate::context::Shell;
+use crate::print::UnicodeWidthGraphemes;
 use crate::segment::Segment;
 use crate::utils::wrap_colorseq_for_shell;
 use ansi_term::{ANSIString, ANSIStrings};
@@ -123,6 +124,14 @@ impl<'a> Module<'a> {
             .iter()
             // no trim: if we add spaces/linebreaks it's not "empty" as we change the final output
             .all(|segment| segment.value.is_empty())
+    }
+
+    /// Get values of the module's segments
+    pub fn get_segments_width(&self) -> usize {
+        self.segments
+            .iter()
+            .map(|segment| segment.value.width_graphemes())
+            .sum()
     }
 
     /// Get values of the module's segments

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -1,4 +1,4 @@
-use crate::context::{Context, Shell};
+use crate::context::{Context, PromptMode, Shell};
 use crate::logger::StarshipLogger;
 use crate::{config::StarshipConfig, utils::CommandOutput};
 use log::{Level, LevelFilter};
@@ -50,6 +50,12 @@ impl<'a> ModuleRenderer<'a> {
         context.config = StarshipConfig { config: None };
 
         Self { name, context }
+    }
+
+    /// Sets the terminal width of the underlying context
+    pub fn prompt_mode(mut self, prompt_mode: PromptMode) -> Self {
+        self.context.prompt_mode = prompt_mode;
+        self
     }
 
     pub fn path<T>(mut self, path: T) -> Self

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -77,6 +77,12 @@ impl<'a> ModuleRenderer<'a> {
         self
     }
 
+    /// Sets the terminal width of the underlying context
+    pub fn width(mut self, width: usize) -> Self {
+        self.context.width = width;
+        self
+    }
+
     /// Adds the variable to the env_mocks of the underlying context
     pub fn env<V: Into<String>>(mut self, key: &'a str, val: V) -> Self {
         self.context.env.insert(key, val.into());
@@ -128,6 +134,11 @@ impl<'a> ModuleRenderer<'a> {
     ) -> Self {
         self.context.battery_info_provider = battery_info_provider;
         self
+    }
+
+    /// Renders the prompt returning its output
+    pub fn prompt(self) -> String {
+        crate::print::get_prompt(self.context)
     }
 
     /// Renders the module returning its output


### PR DESCRIPTION
#### Description
Adds support for inline right prompts in shells that support it (such as `zsh` with `RPROMPT`).  This is distinct from the `format_right` support added in https://github.com/starship/starship/pull/2425, as that adds support for multiline right prompt and does not support having the right prompt on the same line as input.  This adds support for having prompt text on the same line as input, but does not support multiline.  Both features can be used together.

Please bikeshed on what to call this.  PromptMode + Main/Secondary doesn't feel great.

#### Motivation and Context
This finishes adding all the right prompt functionality available in Zsh via something like POWERLEVEL9K, based on my understanding of the functionality.

#### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/13792812/120909616-9162d980-c62b-11eb-84c9-ccdcd133e7cd.png)

#### How Has This Been Tested?
Tested via prompt unit tests and in WSL Zsh.

- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
