### PR TITLE
refactor: ModuleRenderer -> TestRenderer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,7 +106,7 @@ Testing is critical to making sure starship works as intended on systems big and
 
 Unit tests are written using the built-in Rust testing library in the same file as the implementation, as is traditionally done in Rust codebases. These tests can be run with `cargo test` and are run on GitHub as part of our GitHub Actions continuous integration to ensure consistent behavior.
 
-All tests that test the rendered output of a module should use `ModuleRenderer`. For Example:
+All tests that test the rendered output of a prompt or module should use `TestRenderer`. For Example:
 
 ```rust
 use super::{Context, Module, RootModuleConfig};
@@ -123,7 +123,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 #[cfg(test)]
 mod tests {
    use super::*;
-   use crate::test::ModuleRenderer;
+   use crate::test::TestRenderer;
    use ansi_term::Color;
    use std::fs::File;
    use std::io;
@@ -137,7 +137,7 @@ mod tests {
       File::create(dir.path().join("YOUR_FILE"))?.sync_all()?;
 
       // The output of the module
-      let actual = ModuleRenderer::new("YOUR_MODULE_NAME")
+      let actual = TestRenderer::new()
          // For a custom path
          .path(&tempdir.path())
          // For a custom config
@@ -148,7 +148,7 @@ mod tests {
          // For env mocking
          .env("KEY","VALUE")
          // Run the module and collect the output
-         .collect();
+         .module("YOUR_MODULE_NAME");
 
       // The value that should be rendered by the module.
       let expected = Some(format!("{} ",Color::Black.paint("THIS SHOULD BE RENDERED")));

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1686,7 +1686,7 @@ dependencies = [
 
 [[package]]
 name = "starship"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "ansi_term 0.12.1",
  "attohttpc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1686,7 +1686,7 @@ dependencies = [
 
 [[package]]
 name = "starship"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "ansi_term 0.12.1",
  "attohttpc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starship"
-version = "0.55.0"
+version = "0.56.0"
 edition = "2018"
 authors = ["Matan Kushner <hello@matchai.me>"]
 homepage = "https://starship.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starship"
-version = "0.56.0"
+version = "0.57.0"
 edition = "2018"
 authors = ["Matan Kushner <hello@matchai.me>"]
 homepage = "https://starship.rs"

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -151,14 +151,15 @@ This is the list of prompt-wide configuration options.
 
 ### Options
 
-| Option            | Default                        | Description                                                                                          |
-| ----------------- | ------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| `format`          | [link](#default-prompt-format) | Configure the format of the prompt.                                                                  |
-| `format_right`    | `""`                           | Configure the format of the right prompt.                                                            |
-| `scan_timeout`    | `30`                           | Timeout for starship to scan files (in milliseconds).                                                |
-| `command_timeout` | `500`                          | Timeout for commands executed by starship (in milliseconds).                                         |
-| `add_newline`     | `true`                         | Inserts blank line between shell prompts.                                                            |
-| `split_padding`   | `3`                            | The minimum amount of space required between left and right prompt for the right prompt to be shown. |
+| Option             | Default                        | Description                                                                                          |
+| ------------------ | ------------------------------ | ---------------------------------------------------------------------------------------------------- |
+| `format`           | [link](#default-prompt-format) | Configure the format of the prompt.                                                                  |
+| `format_right`     | `""`                           | Configure the format of the right prompt.                                                            |
+| `format_secondary` | `""`                           | Configure the format of the secondary prompt, which is return by `--prompt-mode=secondary`.          |
+| `scan_timeout`     | `30`                           | Timeout for starship to scan files (in milliseconds).                                                |
+| `command_timeout`  | `500`                          | Timeout for commands executed by starship (in milliseconds).                                         |
+| `add_newline`      | `true`                         | Inserts blank line between shell prompts.                                                            |
+| `split_padding`    | `3`                            | The minimum amount of space required between left and right prompt for the right prompt to be shown. |
 
 ### Example
 
@@ -174,6 +175,10 @@ format = """
 # Display time on the right prompt.
 # This will only display if the terminal is wide enough.
 format_right = "$time"
+
+# Display status on the secondary prompt.
+# This will only display if the shell makes use of the secondary prompt, for example  Zsh's `RPROMPT`.
+format_secondary = "$status"
 
 # Wait 10 milliseconds for starship to check files under the current directory.
 scan_timeout = 10

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -151,29 +151,38 @@ This is the list of prompt-wide configuration options.
 
 ### Options
 
-| Option            | Default                        | Description                                                  |
-| ----------------- | ------------------------------ | ------------------------------------------------------------ |
-| `format`          | [link](#default-prompt-format) | Configure the format of the prompt.                          |
-| `scan_timeout`    | `30`                           | Timeout for starship to scan files (in milliseconds).        |
-| `command_timeout` | `500`                          | Timeout for commands executed by starship (in milliseconds). |
-| `add_newline`     | `true`                         | Inserts blank line between shell prompts.                    |
+| Option            | Default                        | Description                                                                                          |
+| ----------------- | ------------------------------ | ---------------------------------------------------------------------------------------------------- |
+| `format`          | [link](#default-prompt-format) | Configure the format of the prompt.                                                                  |
+| `format_right`    | `""`                           | Configure the format of the right prompt.                                                            |
+| `scan_timeout`    | `30`                           | Timeout for starship to scan files (in milliseconds).                                                |
+| `command_timeout` | `500`                          | Timeout for commands executed by starship (in milliseconds).                                         |
+| `add_newline`     | `true`                         | Inserts blank line between shell prompts.                                                            |
+| `split_padding`   | `3`                            | The minimum amount of space required between left and right prompt for the right prompt to be shown. |
 
 ### Example
 
 ```toml
 # ~/.config/starship.toml
 
-# Use custom format
+# Use custom format.
 format = """
 [┌───────────────────>](bold green)
 [│](bold green)$directory$rust$package
 [└─>](bold green) """
 
+# Display time on the right prompt.
+# This will only display if the terminal is wide enough.
+format_right = "$time"
+
 # Wait 10 milliseconds for starship to check files under the current directory.
 scan_timeout = 10
 
-# Disable the blank line at the start of the prompt
+# Disable the blank line at the start of the prompt.
 add_newline = false
+
+# Only display the right prompt if there's room for a 30 width margin between it and the left prompt.
+split_padding = 30
 ```
 
 ### Default Prompt Format

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -8,6 +8,7 @@ use std::cmp::Ordering;
 pub struct StarshipRootConfig<'a> {
     pub format: &'a str,
     pub format_right: &'a str,
+    pub format_secondary: &'a str,
     pub scan_timeout: u64,
     pub command_timeout: u64,
     pub add_newline: bool,
@@ -91,6 +92,7 @@ impl<'a> Default for StarshipRootConfig<'a> {
         StarshipRootConfig {
             format: "$all",
             format_right: "",
+            format_secondary: "",
             scan_timeout: 30,
             command_timeout: 500,
             add_newline: true,
@@ -105,6 +107,7 @@ impl<'a> ModuleConfig<'a> for StarshipRootConfig<'a> {
             config.iter().for_each(|(k, v)| match k.as_str() {
                 "format" => self.format.load_config(v),
                 "format_right" => self.format_right.load_config(v),
+                "format_secondary" => self.format_secondary.load_config(v),
                 "scan_timeout" => self.scan_timeout.load_config(v),
                 "command_timeout" => self.command_timeout.load_config(v),
                 "add_newline" => self.add_newline.load_config(v),
@@ -117,6 +120,7 @@ impl<'a> ModuleConfig<'a> for StarshipRootConfig<'a> {
                             // Root options
                             "format",
                             "format_right",
+                            "format_secondary",
                             "scan_timeout",
                             "command_timeout",
                             "add_newline",

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -7,9 +7,11 @@ use std::cmp::Ordering;
 #[derive(Clone, Serialize)]
 pub struct StarshipRootConfig<'a> {
     pub format: &'a str,
+    pub format_right: &'a str,
     pub scan_timeout: u64,
     pub command_timeout: u64,
     pub add_newline: bool,
+    pub split_padding: usize,
 }
 
 // List of default prompt order
@@ -88,9 +90,11 @@ impl<'a> Default for StarshipRootConfig<'a> {
     fn default() -> Self {
         StarshipRootConfig {
             format: "$all",
+            format_right: "",
             scan_timeout: 30,
             command_timeout: 500,
             add_newline: true,
+            split_padding: 3,
         }
     }
 }
@@ -100,9 +104,11 @@ impl<'a> ModuleConfig<'a> for StarshipRootConfig<'a> {
         if let toml::Value::Table(config) = config {
             config.iter().for_each(|(k, v)| match k.as_str() {
                 "format" => self.format.load_config(v),
+                "format_right" => self.format_right.load_config(v),
                 "scan_timeout" => self.scan_timeout.load_config(v),
                 "command_timeout" => self.command_timeout.load_config(v),
                 "add_newline" => self.add_newline.load_config(v),
+                "split_padding" => self.split_padding.load_config(v),
                 unknown => {
                     if !ALL_MODULES.contains(&unknown) && unknown != "custom" {
                         log::warn!("Unknown config key '{}'", unknown);
@@ -110,9 +116,11 @@ impl<'a> ModuleConfig<'a> for StarshipRootConfig<'a> {
                         let did_you_mean = &[
                             // Root options
                             "format",
+                            "format_right",
                             "scan_timeout",
                             "command_timeout",
                             "add_newline",
+                            "split_padding",
                             // Modules
                             "custom",
                         ]

--- a/src/context.rs
+++ b/src/context.rs
@@ -22,6 +22,9 @@ pub struct Context<'a> {
     /// The deserialized configuration map from the user's `starship.toml` file.
     pub config: StarshipConfig,
 
+    /// Which prompt to render.  By default, the main prompt is rendered.
+    pub prompt_mode: PromptMode,
+
     /// The current working directory that starship is being called in.
     pub current_dir: PathBuf,
 
@@ -58,6 +61,11 @@ pub struct Context<'a> {
 
     /// Timeout for the execution of commands
     cmd_timeout: Duration,
+}
+
+pub enum PromptMode {
+    Main,
+    Secondary,
 }
 
 impl<'a> Context<'a> {
@@ -98,6 +106,12 @@ impl<'a> Context<'a> {
     ) -> Context {
         let config = StarshipConfig::initialize();
 
+        let prompt_mode = match arguments.value_of("prompt_mode") {
+            Some("main") => PromptMode::Main,
+            Some("secondary") => PromptMode::Secondary,
+            _ => PromptMode::Main,
+        };
+
         // Unwrap the clap arguments into a simple hashtable
         // we only care about single arguments at this point, there isn't a
         // use-case for a list of arguments yet.
@@ -118,6 +132,7 @@ impl<'a> Context<'a> {
 
         Context {
             config,
+            prompt_mode,
             properties,
             current_dir,
             logical_dir,

--- a/src/context.rs
+++ b/src/context.rs
@@ -42,6 +42,9 @@ pub struct Context<'a> {
     /// The shell the user is assumed to be running
     pub shell: Shell,
 
+    /// Width of terminal, or zero if width cannot be detected.
+    pub width: usize,
+
     /// A HashMap of environment variable mocks
     #[cfg(test)]
     pub env: HashMap<&'a str, String>,
@@ -121,6 +124,9 @@ impl<'a> Context<'a> {
             dir_contents: OnceCell::new(),
             repo: OnceCell::new(),
             shell,
+            width: term_size::dimensions()
+                .map(|(width, _)| width)
+                .unwrap_or_default(),
             #[cfg(test)]
             env: HashMap::new(),
             #[cfg(test)]

--- a/src/init/starship.zsh
+++ b/src/init/starship.zsh
@@ -92,3 +92,4 @@ VIRTUAL_ENV_DISABLE_PROMPT=1
 
 setopt promptsubst
 PROMPT='$(::STARSHIP:: prompt --keymap="$KEYMAP" --status="$STARSHIP_CMD_STATUS" --cmd-duration="$STARSHIP_DURATION" --jobs="$STARSHIP_JOBS_COUNT")'
+RPROMPT='$(::STARSHIP:: prompt --prompt-mode=secondary --keymap="$KEYMAP" --status="$STARSHIP_CMD_STATUS" --cmd-duration="$STARSHIP_DURATION" --jobs="$STARSHIP_JOBS_COUNT")'

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,6 +90,15 @@ fn main() {
         .subcommand(
             SubCommand::with_name("prompt")
                 .about("Prints the full starship prompt")
+                .arg(
+                    Arg::with_name("prompt_mode")
+                        .long("prompt-mode")
+                        .value_name("PROMPT_MODE")
+                        .help("Which prompt mode to render.")
+                        .takes_value(true)
+                        .possible_values(&["main", "secondary"])
+                        .default_value("main"),
+                )
                 .arg(&status_code_arg)
                 .arg(&path_arg)
                 .arg(&logical_path_arg)

--- a/src/module.rs
+++ b/src/module.rs
@@ -1,4 +1,5 @@
 use crate::context::Shell;
+use crate::print::UnicodeWidthGraphemes;
 use crate::segment::Segment;
 use crate::utils::wrap_colorseq_for_shell;
 use ansi_term::{ANSIString, ANSIStrings};
@@ -123,6 +124,14 @@ impl<'a> Module<'a> {
             .iter()
             // no trim: if we add spaces/linebreaks it's not "empty" as we change the final output
             .all(|segment| segment.value.is_empty())
+    }
+
+    /// Get values of the module's segments
+    pub fn get_segments_width(&self) -> usize {
+        self.segments
+            .iter()
+            .map(|segment| segment.value.width_graphemes())
+            .sum()
     }
 
     /// Get values of the module's segments

--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -180,7 +180,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
 #[cfg(test)]
 mod tests {
-    use crate::test::ModuleRenderer;
+    use crate::test::TestRenderer;
     use ansi_term::Color;
     use std::fs::File;
     use std::io::{self, Write};
@@ -188,7 +188,7 @@ mod tests {
     #[test]
     #[ignore]
     fn no_region_set() {
-        let actual = ModuleRenderer::new("aws").collect();
+        let actual = TestRenderer::new().module("aws");
         let expected = None;
 
         assert_eq!(expected, actual);
@@ -196,9 +196,9 @@ mod tests {
 
     #[test]
     fn region_set() {
-        let actual = ModuleRenderer::new("aws")
+        let actual = TestRenderer::new()
             .env("AWS_REGION", "ap-northeast-2")
-            .collect();
+            .module("aws");
         let expected = Some(format!(
             "on {}",
             Color::Yellow.bold().paint("☁️  (ap-northeast-2) ")
@@ -209,13 +209,13 @@ mod tests {
 
     #[test]
     fn region_set_with_alias() {
-        let actual = ModuleRenderer::new("aws")
+        let actual = TestRenderer::new()
             .env("AWS_REGION", "ap-southeast-2")
             .config(toml::toml! {
                 [aws.region_aliases]
                 ap-southeast-2 = "au"
             })
-            .collect();
+            .module("aws");
         let expected = Some(format!("on {}", Color::Yellow.bold().paint("☁️  (au) ")));
 
         assert_eq!(expected, actual);
@@ -223,10 +223,10 @@ mod tests {
 
     #[test]
     fn default_region_set() {
-        let actual = ModuleRenderer::new("aws")
+        let actual = TestRenderer::new()
             .env("AWS_REGION", "ap-northeast-2")
             .env("AWS_DEFAULT_REGION", "ap-northeast-1")
-            .collect();
+            .module("aws");
         let expected = Some(format!(
             "on {}",
             Color::Yellow.bold().paint("☁️  (ap-northeast-1) ")
@@ -237,9 +237,9 @@ mod tests {
 
     #[test]
     fn profile_set() {
-        let actual = ModuleRenderer::new("aws")
+        let actual = TestRenderer::new()
             .env("AWS_PROFILE", "astronauts")
-            .collect();
+            .module("aws");
         let expected = Some(format!(
             "on {}",
             Color::Yellow.bold().paint("☁️  astronauts ")
@@ -250,10 +250,10 @@ mod tests {
 
     #[test]
     fn profile_set_from_aws_vault() {
-        let actual = ModuleRenderer::new("aws")
+        let actual = TestRenderer::new()
             .env("AWS_VAULT", "astronauts-vault")
             .env("AWS_PROFILE", "astronauts-profile")
-            .collect();
+            .module("aws");
         let expected = Some(format!(
             "on {}",
             Color::Yellow.bold().paint("☁️  astronauts-vault ")
@@ -264,10 +264,10 @@ mod tests {
 
     #[test]
     fn profile_set_from_awsu() {
-        let actual = ModuleRenderer::new("aws")
+        let actual = TestRenderer::new()
             .env("AWSU_PROFILE", "astronauts-awsu")
             .env("AWS_PROFILE", "astronauts-profile")
-            .collect();
+            .module("aws");
         let expected = Some(format!(
             "on {}",
             Color::Yellow.bold().paint("☁️  astronauts-awsu ")
@@ -278,10 +278,10 @@ mod tests {
 
     #[test]
     fn profile_set_from_awsume() {
-        let actual = ModuleRenderer::new("aws")
+        let actual = TestRenderer::new()
             .env("AWSUME_PROFILE", "astronauts-awsume")
             .env("AWS_PROFILE", "astronauts-profile")
-            .collect();
+            .module("aws");
         let expected = Some(format!(
             "on {}",
             Color::Yellow.bold().paint("☁️  astronauts-awsume ")
@@ -292,10 +292,10 @@ mod tests {
 
     #[test]
     fn profile_and_region_set() {
-        let actual = ModuleRenderer::new("aws")
+        let actual = TestRenderer::new()
             .env("AWS_PROFILE", "astronauts")
             .env("AWS_REGION", "ap-northeast-2")
-            .collect();
+            .module("aws");
         let expected = Some(format!(
             "on {}",
             Color::Yellow
@@ -322,9 +322,9 @@ region = us-east-2
             .as_bytes(),
         )?;
 
-        let actual = ModuleRenderer::new("aws")
+        let actual = TestRenderer::new()
             .env("AWS_CONFIG_FILE", config_path.to_string_lossy().as_ref())
-            .collect();
+            .module("aws");
         let expected = Some(format!(
             "on {}",
             Color::Yellow.bold().paint("☁️  (us-east-1) ")
@@ -350,13 +350,13 @@ region = us-east-2
             .as_bytes(),
         )?;
 
-        let actual = ModuleRenderer::new("aws")
+        let actual = TestRenderer::new()
             .env("AWS_CONFIG_FILE", config_path.to_string_lossy().as_ref())
             .env("AWS_PROFILE", "astronauts")
             .config(toml::toml! {
                 [aws]
             })
-            .collect();
+            .module("aws");
         let expected = Some(format!(
             "on {}",
             Color::Yellow.bold().paint("☁️  astronauts (us-east-2) ")
@@ -368,10 +368,10 @@ region = us-east-2
 
     #[test]
     fn profile_and_region_set_with_display_all() {
-        let actual = ModuleRenderer::new("aws")
+        let actual = TestRenderer::new()
             .env("AWS_PROFILE", "astronauts")
             .env("AWS_REGION", "ap-northeast-1")
-            .collect();
+            .module("aws");
         let expected = Some(format!(
             "on {}",
             Color::Yellow
@@ -384,9 +384,9 @@ region = us-east-2
 
     #[test]
     fn profile_set_with_display_all() {
-        let actual = ModuleRenderer::new("aws")
+        let actual = TestRenderer::new()
             .env("AWS_PROFILE", "astronauts")
-            .collect();
+            .module("aws");
         let expected = Some(format!(
             "on {}",
             Color::Yellow.bold().paint("☁️  astronauts ")
@@ -397,9 +397,9 @@ region = us-east-2
 
     #[test]
     fn region_set_with_display_all() {
-        let actual = ModuleRenderer::new("aws")
+        let actual = TestRenderer::new()
             .env("AWS_REGION", "ap-northeast-1")
-            .collect();
+            .module("aws");
         let expected = Some(format!(
             "on {}",
             Color::Yellow.bold().paint("☁️  (ap-northeast-1) ")
@@ -410,14 +410,14 @@ region = us-east-2
 
     #[test]
     fn profile_and_region_set_with_display_region() {
-        let actual = ModuleRenderer::new("aws")
+        let actual = TestRenderer::new()
             .env("AWS_PROFILE", "astronauts")
             .env("AWS_DEFAULT_REGION", "ap-northeast-1")
             .config(toml::toml! {
                 [aws]
                 format = "on [$symbol$region]($style) "
             })
-            .collect();
+            .module("aws");
         let expected = Some(format!(
             "on {} ",
             Color::Yellow.bold().paint("☁️  ap-northeast-1")
@@ -428,14 +428,14 @@ region = us-east-2
 
     #[test]
     fn profile_and_region_set_with_display_profile() {
-        let actual = ModuleRenderer::new("aws")
+        let actual = TestRenderer::new()
             .env("AWS_PROFILE", "astronauts")
             .env("AWS_REGION", "ap-northeast-1")
             .config(toml::toml! {
                 [aws]
                 format = "on [$symbol$profile]($style) "
             })
-            .collect();
+            .module("aws");
         let expected = Some(format!(
             "on {} ",
             Color::Yellow.bold().paint("☁️  astronauts")
@@ -446,13 +446,13 @@ region = us-east-2
 
     #[test]
     fn region_set_with_display_profile() {
-        let actual = ModuleRenderer::new("aws")
+        let actual = TestRenderer::new()
             .env("AWS_REGION", "ap-northeast-1")
             .config(toml::toml! {
                 [aws]
                 format = "on [$symbol$profile]($style) "
             })
-            .collect();
+            .module("aws");
         let expected = Some(format!("on {} ", Color::Yellow.bold().paint("☁️  ")));
 
         assert_eq!(expected, actual);
@@ -467,7 +467,7 @@ region = us-east-2
             Utc,
         );
 
-        let actual = ModuleRenderer::new("aws")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [aws]
                 show_duration = true
@@ -478,7 +478,7 @@ region = us-east-2
                 "AWS_SESSION_EXPIRATION",
                 now_plus_half_hour.to_rfc3339_opts(SecondsFormat::Secs, true),
             )
-            .collect();
+            .module("aws");
         let expected = Some(format!(
             "on {}",
             Color::Yellow
@@ -516,7 +516,7 @@ expiration={}
             .as_bytes(),
         )?;
 
-        let actual = ModuleRenderer::new("aws")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [aws]
                 show_duration = true
@@ -527,7 +527,7 @@ expiration={}
                 "AWS_CREDENTIALS_FILE",
                 credentials_path.to_string_lossy().as_ref(),
             )
-            .collect();
+            .module("aws");
         let expected = Some(format!(
             "on {}",
             Color::Yellow
@@ -542,14 +542,14 @@ expiration={}
 
     #[test]
     fn profile_and_region_set_show_duration() {
-        let actual = ModuleRenderer::new("aws")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [aws]
                 show_duration = true
             })
             .env("AWS_PROFILE", "astronauts")
             .env("AWS_REGION", "ap-northeast-2")
-            .collect();
+            .module("aws");
         let expected = Some(format!(
             "on {}",
             Color::Yellow
@@ -571,7 +571,7 @@ expiration={}
 
         let symbol = "!!!";
 
-        let actual = ModuleRenderer::new("aws")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [aws]
                 show_duration = true
@@ -583,7 +583,7 @@ expiration={}
                 "AWS_SESSION_EXPIRATION",
                 now.to_rfc3339_opts(SecondsFormat::Secs, true),
             )
-            .collect();
+            .module("aws");
         let expected = Some(format!(
             "on {}",
             Color::Yellow
@@ -597,12 +597,12 @@ expiration={}
     #[test]
     #[ignore]
     fn region_not_set_with_display_region() {
-        let actual = ModuleRenderer::new("aws")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [aws]
                 format = "on [$symbol$region]($style) "
             })
-            .collect();
+            .module("aws");
         let expected = None;
 
         assert_eq!(expected, actual);

--- a/src/modules/battery.rs
+++ b/src/modules/battery.rs
@@ -177,7 +177,7 @@ impl BatteryInfoProvider for BatteryInfoProviderImpl {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test::ModuleRenderer;
+    use crate::test::TestRenderer;
     use ansi_term::Color;
 
     #[test]
@@ -186,14 +186,14 @@ mod tests {
 
         mock.expect_get_battery_info().times(1).returning(|| None);
 
-        let actual = ModuleRenderer::new("battery")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [[battery.display]]
                 threshold = 100
                 style = ""
             })
             .battery_info_provider(&mock)
-            .collect();
+            .module("battery");
         let expected = None;
 
         assert_eq!(expected, actual);
@@ -211,14 +211,14 @@ mod tests {
             })
         });
 
-        let actual = ModuleRenderer::new("battery")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [[battery.display]]
                 threshold = 100
                 style = ""
             })
             .battery_info_provider(&mock)
-            .collect();
+            .module("battery");
         let expected = None;
 
         assert_eq!(expected, actual);
@@ -236,14 +236,14 @@ mod tests {
             })
         });
 
-        let actual = ModuleRenderer::new("battery")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [[battery.display]]
                 threshold = 100
                 style = ""
             })
             .battery_info_provider(&mock)
-            .collect();
+            .module("battery");
         let expected = Some(String::from(" 100% "));
 
         assert_eq!(expected, actual);
@@ -261,14 +261,14 @@ mod tests {
             })
         });
 
-        let actual = ModuleRenderer::new("battery")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [[battery.display]]
                 threshold = 90
                 style = ""
             })
             .battery_info_provider(&mock)
-            .collect();
+            .module("battery");
         let expected = Some(String::from(" 80% "));
 
         assert_eq!(expected, actual);
@@ -286,14 +286,14 @@ mod tests {
             })
         });
 
-        let actual = ModuleRenderer::new("battery")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [[battery.display]]
                 threshold = 100
                 style = ""
             })
             .battery_info_provider(&mock)
-            .collect();
+            .module("battery");
         let expected = Some(String::from(" 80% "));
 
         assert_eq!(expected, actual);
@@ -311,14 +311,14 @@ mod tests {
             })
         });
 
-        let actual = ModuleRenderer::new("battery")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [[battery.display]]
                 threshold = 100
                 style = ""
             })
             .battery_info_provider(&mock)
-            .collect();
+            .module("battery");
         let expected = Some(String::from(" 0% "));
 
         assert_eq!(expected, actual);
@@ -336,14 +336,14 @@ mod tests {
             })
         });
 
-        let actual = ModuleRenderer::new("battery")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [[battery.display]]
                 threshold = 100
                 style = ""
             })
             .battery_info_provider(&mock)
-            .collect();
+            .module("battery");
         let expected = Some(String::from(" 0% "));
 
         assert_eq!(expected, actual);
@@ -361,14 +361,14 @@ mod tests {
             })
         });
 
-        let actual = ModuleRenderer::new("battery")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [[battery.display]]
                 threshold = 50
                 style = ""
             })
             .battery_info_provider(&mock)
-            .collect();
+            .module("battery");
         let expected = None;
 
         assert_eq!(expected, actual);
@@ -386,14 +386,14 @@ mod tests {
             })
         });
 
-        let actual = ModuleRenderer::new("battery")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [[battery.display]]
                 threshold = 50
                 style = "bold red"
             })
             .battery_info_provider(&mock)
-            .collect();
+            .module("battery");
         let expected = Some(format!("{} ", Color::Red.bold().paint(" 40%")));
 
         assert_eq!(expected, actual);
@@ -411,14 +411,14 @@ mod tests {
             })
         });
 
-        let actual = ModuleRenderer::new("battery")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [[battery.display]]
                 threshold = 100
                 style = ""
             })
             .battery_info_provider(&mock)
-            .collect();
+            .module("battery");
         let expected = Some(String::from(" 13% "));
 
         assert_eq!(expected, actual);

--- a/src/modules/character.rs
+++ b/src/modules/character.rs
@@ -70,7 +70,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 #[cfg(test)]
 mod test {
     use crate::context::Shell;
-    use crate::test::ModuleRenderer;
+    use crate::test::TestRenderer;
     use ansi_term::Color;
 
     #[test]
@@ -78,11 +78,11 @@ mod test {
         let expected = Some(format!("{} ", Color::Green.bold().paint("❯")));
 
         // Status code 0
-        let actual = ModuleRenderer::new("character").status(0).collect();
+        let actual = TestRenderer::new().status(0).module("character");
         assert_eq!(expected, actual);
 
         // No status code
-        let actual = ModuleRenderer::new("character").collect();
+        let actual = TestRenderer::new().module("character");
         assert_eq!(expected, actual);
     }
 
@@ -93,7 +93,7 @@ mod test {
         let exit_values = [1, 54321, -5000];
 
         for status in &exit_values {
-            let actual = ModuleRenderer::new("character").status(*status).collect();
+            let actual = TestRenderer::new().status(*status).module("character");
             assert_eq!(expected, actual);
         }
     }
@@ -107,26 +107,26 @@ mod test {
 
         // Test failure values
         for status in &exit_values {
-            let actual = ModuleRenderer::new("character")
+            let actual = TestRenderer::new()
                 .config(toml::toml! {
                     [character]
                     success_symbol = "[➜](bold green)"
                     error_symbol = "[✖](bold red)"
                 })
                 .status(*status)
-                .collect();
+                .module("character");
             assert_eq!(expected_fail, actual);
         }
 
         // Test success
-        let actual = ModuleRenderer::new("character")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [character]
                 success_symbol = "[➜](bold green)"
                 error_symbol = "[✖](bold red)"
             })
             .status(0)
-            .collect();
+            .module("character");
         assert_eq!(expected_success, actual);
     }
 
@@ -137,28 +137,28 @@ mod test {
         let expected_other = Some(format!("{} ", Color::Green.bold().paint("❯")));
 
         // zle keymap is vicmd
-        let actual = ModuleRenderer::new("character")
+        let actual = TestRenderer::new()
             .shell(Shell::Zsh)
             .keymap("vicmd")
-            .collect();
+            .module("character");
         assert_eq!(expected_vicmd, actual);
 
         // specified vicmd character
-        let actual = ModuleRenderer::new("character")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [character]
                 vicmd_symbol = "[V](bold green)"
             })
             .shell(Shell::Zsh)
             .keymap("vicmd")
-            .collect();
+            .module("character");
         assert_eq!(expected_specified, actual);
 
         // zle keymap is other
-        let actual = ModuleRenderer::new("character")
+        let actual = TestRenderer::new()
             .shell(Shell::Zsh)
             .keymap("visual")
-            .collect();
+            .module("character");
         assert_eq!(expected_other, actual);
     }
 
@@ -169,28 +169,28 @@ mod test {
         let expected_other = Some(format!("{} ", Color::Green.bold().paint("❯")));
 
         // fish keymap is default
-        let actual = ModuleRenderer::new("character")
+        let actual = TestRenderer::new()
             .shell(Shell::Fish)
             .keymap("default")
-            .collect();
+            .module("character");
         assert_eq!(expected_vicmd, actual);
 
         // specified vicmd character
-        let actual = ModuleRenderer::new("character")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [character]
                 vicmd_symbol = "[V](bold green)"
             })
             .shell(Shell::Fish)
             .keymap("default")
-            .collect();
+            .module("character");
         assert_eq!(expected_specified, actual);
 
         // fish keymap is other
-        let actual = ModuleRenderer::new("character")
+        let actual = TestRenderer::new()
             .shell(Shell::Fish)
             .keymap("visual")
-            .collect();
+            .module("character");
         assert_eq!(expected_other, actual);
     }
 }

--- a/src/modules/cmake.rs
+++ b/src/modules/cmake.rs
@@ -70,7 +70,7 @@ fn get_cmake_version(cmake_version: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use crate::test::ModuleRenderer;
+    use crate::test::TestRenderer;
     use ansi_term::Color;
     use std::fs::File;
     use std::io;
@@ -78,7 +78,7 @@ mod tests {
     #[test]
     fn folder_without_cmake_lists() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
-        let actual = ModuleRenderer::new("cmake").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("cmake");
         let expected = None;
         assert_eq!(expected, actual);
         dir.close()
@@ -88,7 +88,7 @@ mod tests {
     fn folder_with_cmake_lists() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("CMakeLists.txt"))?.sync_all()?;
-        let actual = ModuleRenderer::new("cmake").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("cmake");
         let expected = Some(format!("via {}", Color::Blue.bold().paint("△ v3.17.3 ")));
         assert_eq!(expected, actual);
         dir.close()
@@ -98,7 +98,7 @@ mod tests {
     fn buildfolder_with_cmake_cache() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("CMakeCache.txt"))?.sync_all()?;
-        let actual = ModuleRenderer::new("cmake").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("cmake");
         let expected = Some(format!("via {}", Color::Blue.bold().paint("△ v3.17.3 ")));
         assert_eq!(expected, actual);
         dir.close()

--- a/src/modules/cmd_duration.rs
+++ b/src/modules/cmd_duration.rs
@@ -96,14 +96,14 @@ fn undistract_me<'a, 'b>(
 
 #[cfg(test)]
 mod tests {
-    use crate::test::ModuleRenderer;
+    use crate::test::TestRenderer;
     use ansi_term::Color;
 
     #[test]
     fn config_blank_duration_1s() {
-        let actual = ModuleRenderer::new("cmd_duration")
+        let actual = TestRenderer::new()
             .cmd_duration(1000)
-            .collect();
+            .module("cmd_duration");
 
         let expected = None;
         assert_eq!(expected, actual);
@@ -111,9 +111,9 @@ mod tests {
 
     #[test]
     fn config_blank_duration_5s() {
-        let actual = ModuleRenderer::new("cmd_duration")
+        let actual = TestRenderer::new()
             .cmd_duration(5000)
-            .collect();
+            .module("cmd_duration");
 
         let expected = Some(format!("took {} ", Color::Yellow.bold().paint("5s")));
         assert_eq!(expected, actual);
@@ -121,13 +121,13 @@ mod tests {
 
     #[test]
     fn config_5s_duration_3s() {
-        let actual = ModuleRenderer::new("cmd_duration")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [cmd_duration]
                 min_time = 5000
             })
             .cmd_duration(3000)
-            .collect();
+            .module("cmd_duration");
 
         let expected = None;
         assert_eq!(expected, actual);
@@ -135,13 +135,13 @@ mod tests {
 
     #[test]
     fn config_5s_duration_10s() {
-        let actual = ModuleRenderer::new("cmd_duration")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [cmd_duration]
                 min_time = 5000
             })
             .cmd_duration(10000)
-            .collect();
+            .module("cmd_duration");
 
         let expected = Some(format!("took {} ", Color::Yellow.bold().paint("10s")));
         assert_eq!(expected, actual);
@@ -149,13 +149,13 @@ mod tests {
 
     #[test]
     fn config_1s_duration_prefix_underwent() {
-        let actual = ModuleRenderer::new("cmd_duration")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [cmd_duration]
                 format = "underwent [$duration]($style) "
             })
             .cmd_duration(1000)
-            .collect();
+            .module("cmd_duration");
 
         let expected = None;
         assert_eq!(expected, actual);
@@ -163,13 +163,13 @@ mod tests {
 
     #[test]
     fn config_5s_duration_prefix_underwent() {
-        let actual = ModuleRenderer::new("cmd_duration")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [cmd_duration]
                 format = "underwent [$duration]($style) "
             })
             .cmd_duration(5000)
-            .collect();
+            .module("cmd_duration");
 
         let expected = Some(format!("underwent {} ", Color::Yellow.bold().paint("5s")));
         assert_eq!(expected, actual);

--- a/src/modules/conda.rs
+++ b/src/modules/conda.rs
@@ -53,12 +53,12 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
 #[cfg(test)]
 mod tests {
-    use crate::test::ModuleRenderer;
+    use crate::test::TestRenderer;
     use ansi_term::Color;
 
     #[test]
     fn not_in_env() {
-        let actual = ModuleRenderer::new("conda").collect();
+        let actual = TestRenderer::new().module("conda");
 
         let expected = None;
 
@@ -67,13 +67,13 @@ mod tests {
 
     #[test]
     fn ignore_base() {
-        let actual = ModuleRenderer::new("conda")
+        let actual = TestRenderer::new()
             .env("CONDA_DEFAULT_ENV", "base")
             .config(toml::toml! {
                 [conda]
                 ignore_base = true
             })
-            .collect();
+            .module("conda");
 
         let expected = None;
 
@@ -82,9 +82,9 @@ mod tests {
 
     #[test]
     fn env_set() {
-        let actual = ModuleRenderer::new("conda")
+        let actual = TestRenderer::new()
             .env("CONDA_DEFAULT_ENV", "astronauts")
-            .collect();
+            .module("conda");
 
         let expected = Some(format!(
             "via {} ",
@@ -96,9 +96,9 @@ mod tests {
 
     #[test]
     fn truncate() {
-        let actual = ModuleRenderer::new("conda")
+        let actual = TestRenderer::new()
             .env("CONDA_DEFAULT_ENV", "/some/really/long/and/really/annoying/path/that/shouldnt/be/displayed/fully/conda/my_env")
-            .collect();
+            .module("conda");
 
         let expected = Some(format!("via {} ", Color::Green.bold().paint("🅒 my_env")));
 

--- a/src/modules/crystal.rs
+++ b/src/modules/crystal.rs
@@ -70,7 +70,7 @@ fn get_crystal_version(crystal_version: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use crate::test::ModuleRenderer;
+    use crate::test::TestRenderer;
     use ansi_term::Color;
     use std::fs::File;
     use std::io;
@@ -78,7 +78,7 @@ mod tests {
     #[test]
     fn folder_without_crystal_files() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
-        let actual = ModuleRenderer::new("crystal").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("crystal");
         let expected = None;
         assert_eq!(expected, actual);
 
@@ -90,7 +90,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("shard.yml"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("crystal").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("crystal");
         let expected = Some(format!("via {}", Color::Red.bold().paint("🔮 v0.35.1 ")));
         assert_eq!(expected, actual);
 
@@ -102,7 +102,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("main.cr"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("crystal").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("crystal");
         let expected = Some(format!("via {}", Color::Red.bold().paint("🔮 v0.35.1 ")));
         assert_eq!(expected, actual);
 

--- a/src/modules/dart.rs
+++ b/src/modules/dart.rs
@@ -70,7 +70,7 @@ fn get_dart_version(dart_version: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use crate::test::ModuleRenderer;
+    use crate::test::TestRenderer;
     use ansi_term::Color;
     use std::fs::{self, File};
     use std::io;
@@ -78,7 +78,7 @@ mod tests {
     #[test]
     fn folder_without_dart_file() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
-        let actual = ModuleRenderer::new("dart").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("dart");
         let expected = None;
         assert_eq!(expected, actual);
         dir.close()
@@ -89,7 +89,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("any.dart"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("dart").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("dart");
         let expected = Some(format!("via {}", Color::Blue.bold().paint("🎯 v2.8.4 ")));
         assert_eq!(expected, actual);
         dir.close()
@@ -100,7 +100,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         fs::create_dir_all(dir.path().join(".dart_tool"))?;
 
-        let actual = ModuleRenderer::new("dart").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("dart");
         let expected = Some(format!("via {}", Color::Blue.bold().paint("🎯 v2.8.4 ")));
         assert_eq!(expected, actual);
         dir.close()
@@ -111,7 +111,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("pubspec.yaml"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("dart").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("dart");
         let expected = Some(format!("via {}", Color::Blue.bold().paint("🎯 v2.8.4 ")));
         assert_eq!(expected, actual);
         dir.close()
@@ -122,7 +122,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("pubspec.yml"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("dart").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("dart");
         let expected = Some(format!("via {}", Color::Blue.bold().paint("🎯 v2.8.4 ")));
         assert_eq!(expected, actual);
         dir.close()
@@ -133,7 +133,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("pubspec.lock"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("dart").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("dart");
         let expected = Some(format!("via {}", Color::Blue.bold().paint("🎯 v2.8.4 ")));
         assert_eq!(expected, actual);
         dir.close()

--- a/src/modules/deno.rs
+++ b/src/modules/deno.rs
@@ -69,7 +69,7 @@ fn get_deno_version(deno_version: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use crate::test::ModuleRenderer;
+    use crate::test::TestRenderer;
     use ansi_term::Color;
     use std::fs::File;
     use std::io;
@@ -77,7 +77,7 @@ mod tests {
     #[test]
     fn folder_without_deno_files() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
-        let actual = ModuleRenderer::new("deno").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("deno");
         let expected = None;
         assert_eq!(expected, actual);
         dir.close()
@@ -87,7 +87,7 @@ mod tests {
     fn folder_with_mod_ts() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("mod.ts"))?.sync_all()?;
-        let actual = ModuleRenderer::new("deno").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("deno");
         let expected = Some(format!("via {}", Color::Green.bold().paint("🦕 v1.8.3 ")));
         assert_eq!(expected, actual);
         dir.close()
@@ -97,7 +97,7 @@ mod tests {
     fn folder_with_mod_js() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("mod.js"))?.sync_all()?;
-        let actual = ModuleRenderer::new("deno").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("deno");
         let expected = Some(format!("via {}", Color::Green.bold().paint("🦕 v1.8.3 ")));
         assert_eq!(expected, actual);
         dir.close()
@@ -107,7 +107,7 @@ mod tests {
     fn folder_with_deps_ts() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("deps.ts"))?.sync_all()?;
-        let actual = ModuleRenderer::new("deno").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("deno");
         let expected = Some(format!("via {}", Color::Green.bold().paint("🦕 v1.8.3 ")));
         assert_eq!(expected, actual);
         dir.close()
@@ -117,7 +117,7 @@ mod tests {
     fn folder_with_deps_js() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("deps.js"))?.sync_all()?;
-        let actual = ModuleRenderer::new("deno").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("deno");
         let expected = Some(format!("via {}", Color::Green.bold().paint("🦕 v1.8.3 ")));
         assert_eq!(expected, actual);
         dir.close()

--- a/src/modules/docker_context.rs
+++ b/src/modules/docker_context.rs
@@ -85,7 +85,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
 #[cfg(test)]
 mod tests {
-    use crate::test::ModuleRenderer;
+    use crate::test::TestRenderer;
     use ansi_term::Color;
     use std::fs::File;
     use std::io::{self, Write};
@@ -93,9 +93,9 @@ mod tests {
     #[test]
     fn only_trigger_when_docker_config_exists() -> io::Result<()> {
         let cfg_dir = tempfile::tempdir()?;
-        let actual = ModuleRenderer::new("docker_context")
+        let actual = TestRenderer::new()
             .env("DOCKER_CONFIG", cfg_dir.path().to_string_lossy())
-            .collect();
+            .module("docker_context");
         let expected = None;
 
         assert_eq!(expected, actual);
@@ -118,10 +118,10 @@ mod tests {
         docker_config.write_all(config_content.to_string().as_bytes())?;
         docker_config.sync_all()?;
 
-        let actual = ModuleRenderer::new("docker_context")
+        let actual = TestRenderer::new()
             .env("DOCKER_CONFIG", cfg_dir.path().to_string_lossy())
             .path(pwd.path())
-            .collect();
+            .module("docker_context");
 
         let expected = Some(format!("via {} ", Color::Blue.bold().paint("🐳 starship")));
 
@@ -147,10 +147,10 @@ mod tests {
         docker_config.write_all(config_content.to_string().as_bytes())?;
         docker_config.sync_all()?;
 
-        let actual = ModuleRenderer::new("docker_context")
+        let actual = TestRenderer::new()
             .env("DOCKER_CONFIG", cfg_dir.path().to_string_lossy())
             .path(pwd.path())
-            .collect();
+            .module("docker_context");
 
         let expected = Some(format!("via {} ", Color::Blue.bold().paint("🐳 starship")));
 
@@ -176,10 +176,10 @@ mod tests {
         docker_config.write_all(config_content.to_string().as_bytes())?;
         docker_config.sync_all()?;
 
-        let actual = ModuleRenderer::new("docker_context")
+        let actual = TestRenderer::new()
             .env("DOCKER_CONFIG", cfg_dir.path().to_string_lossy())
             .path(pwd.path())
-            .collect();
+            .module("docker_context");
 
         let expected = Some(format!("via {} ", Color::Blue.bold().paint("🐳 starship")));
 
@@ -202,9 +202,9 @@ mod tests {
         docker_config.write_all(config_content.to_string().as_bytes())?;
         docker_config.sync_all()?;
 
-        let actual = ModuleRenderer::new("docker_context")
+        let actual = TestRenderer::new()
             .env("DOCKER_CONFIG", cfg_dir.path().to_string_lossy())
-            .collect();
+            .module("docker_context");
 
         let expected = None;
 
@@ -226,13 +226,13 @@ mod tests {
         docker_config.write_all(config_content.to_string().as_bytes())?;
         docker_config.sync_all()?;
 
-        let actual = ModuleRenderer::new("docker_context")
+        let actual = TestRenderer::new()
             .env("DOCKER_CONFIG", cfg_dir.path().to_string_lossy())
             .config(toml::toml! {
                 [docker_context]
                 only_with_files = false
             })
-            .collect();
+            .module("docker_context");
 
         let expected = Some(format!("via {} ", Color::Blue.bold().paint("🐳 starship")));
 
@@ -252,13 +252,13 @@ mod tests {
         docker_config.write_all(config_content.to_string().as_bytes())?;
         docker_config.sync_all()?;
 
-        let actual = ModuleRenderer::new("docker_context")
+        let actual = TestRenderer::new()
             .env("DOCKER_CONFIG", cfg_dir.path().to_string_lossy())
             .config(toml::toml! {
                 [docker_context]
                 only_with_files = false
             })
-            .collect();
+            .module("docker_context");
 
         let expected = None;
 
@@ -271,13 +271,13 @@ mod tests {
     fn test_docker_host_env() -> io::Result<()> {
         let cfg_dir = tempfile::tempdir()?;
 
-        let actual = ModuleRenderer::new("docker_context")
+        let actual = TestRenderer::new()
             .env("DOCKER_HOST", "udp://starship@127.0.0.1:53")
             .config(toml::toml! {
                 [docker_context]
                 only_with_files = false
             })
-            .collect();
+            .module("docker_context");
         let expected = Some(format!(
             "via {} ",
             Color::Blue.bold().paint("🐳 udp://starship@127.0.0.1:53")
@@ -292,13 +292,13 @@ mod tests {
     fn test_docker_context_env() -> io::Result<()> {
         let cfg_dir = tempfile::tempdir()?;
 
-        let actual = ModuleRenderer::new("docker_context")
+        let actual = TestRenderer::new()
             .env("DOCKER_CONTEXT", "starship")
             .config(toml::toml! {
                 [docker_context]
                 only_with_files = false
             })
-            .collect();
+            .module("docker_context");
         let expected = Some(format!("via {} ", Color::Blue.bold().paint("🐳 starship")));
 
         assert_eq!(expected, actual);
@@ -320,14 +320,14 @@ mod tests {
         docker_config.write_all(config_content.to_string().as_bytes())?;
         docker_config.sync_all()?;
 
-        let actual = ModuleRenderer::new("docker_context")
+        let actual = TestRenderer::new()
             .env("DOCKER_CONTEXT", "starship")
             .env("DOCKER_CONFIG", cfg_dir.path().to_string_lossy())
             .config(toml::toml! {
                 [docker_context]
                 only_with_files = false
             })
-            .collect();
+            .module("docker_context");
         let expected = Some(format!("via {} ", Color::Blue.bold().paint("🐳 starship")));
 
         assert_eq!(expected, actual);
@@ -349,7 +349,7 @@ mod tests {
         docker_config.write_all(config_content.to_string().as_bytes())?;
         docker_config.sync_all()?;
 
-        let actual = ModuleRenderer::new("docker_context")
+        let actual = TestRenderer::new()
             .env("DOCKER_HOST", "udp://starship@127.0.0.1:53")
             .env("DOCKER_CONTEXT", "starship")
             .env("DOCKER_CONFIG", cfg_dir.path().to_string_lossy())
@@ -357,7 +357,7 @@ mod tests {
                 [docker_context]
                 only_with_files = false
             })
-            .collect();
+            .module("docker_context");
         let expected = Some(format!(
             "via {} ",
             Color::Blue.bold().paint("🐳 udp://starship@127.0.0.1:53")

--- a/src/modules/dotnet.rs
+++ b/src/modules/dotnet.rs
@@ -344,7 +344,7 @@ enum FileType {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test::ModuleRenderer;
+    use crate::test::TestRenderer;
     use ansi_term::Color;
     use std::fs::{self, OpenOptions};
     use std::io::{self, Write};
@@ -606,7 +606,7 @@ mod tests {
     }
 
     fn expect_output(dir: &Path, expected: Option<String>) {
-        let actual = ModuleRenderer::new("dotnet").path(dir).collect();
+        let actual = TestRenderer::new().path(dir).module("dotnet");
 
         assert_eq!(actual, expected);
     }

--- a/src/modules/elixir.rs
+++ b/src/modules/elixir.rs
@@ -90,7 +90,7 @@ fn parse_elixir_version(version: &str) -> Option<(String, String)> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test::ModuleRenderer;
+    use crate::test::TestRenderer;
     use ansi_term::Color;
     use std::fs::File;
     use std::io;
@@ -131,7 +131,7 @@ Elixir 1.13.0-dev (compiled with Erlang/OTP 23)
         let dir = tempfile::tempdir()?;
 
         let expected = None;
-        let output = ModuleRenderer::new("elixir").path(dir.path()).collect();
+        let output = TestRenderer::new().path(dir.path()).module("elixir");
 
         assert_eq!(output, expected);
 
@@ -147,7 +147,7 @@ Elixir 1.13.0-dev (compiled with Erlang/OTP 23)
             "via {}",
             Color::Purple.bold().paint("💧 v1.10 (OTP 22) ")
         ));
-        let output = ModuleRenderer::new("elixir").path(dir.path()).collect();
+        let output = TestRenderer::new().path(dir.path()).module("elixir");
 
         assert_eq!(output, expected);
 

--- a/src/modules/elm.rs
+++ b/src/modules/elm.rs
@@ -58,7 +58,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
 #[cfg(test)]
 mod tests {
-    use crate::test::ModuleRenderer;
+    use crate::test::TestRenderer;
     use ansi_term::Color;
     use std::fs::{self, File};
     use std::io;
@@ -66,7 +66,7 @@ mod tests {
     #[test]
     fn folder_without_elm() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
-        let actual = ModuleRenderer::new("elm").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("elm");
         let expected = None;
         assert_eq!(expected, actual);
         dir.close()
@@ -76,7 +76,7 @@ mod tests {
     fn folder_with_elm_json() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("elm.json"))?.sync_all()?;
-        let actual = ModuleRenderer::new("elm").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("elm");
         let expected = Some(format!("via {}", Color::Cyan.bold().paint("🌳 v0.19.1 ")));
         assert_eq!(expected, actual);
         dir.close()
@@ -86,7 +86,7 @@ mod tests {
     fn folder_with_elm_package_json() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("elm-package.json"))?.sync_all()?;
-        let actual = ModuleRenderer::new("elm").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("elm");
         let expected = Some(format!("via {}", Color::Cyan.bold().paint("🌳 v0.19.1 ")));
         assert_eq!(expected, actual);
         dir.close()
@@ -96,7 +96,7 @@ mod tests {
     fn folder_with_elm_version() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join(".elm-version"))?.sync_all()?;
-        let actual = ModuleRenderer::new("elm").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("elm");
         let expected = Some(format!("via {}", Color::Cyan.bold().paint("🌳 v0.19.1 ")));
         assert_eq!(expected, actual);
         dir.close()
@@ -107,7 +107,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         let elmstuff = dir.path().join("elm-stuff");
         fs::create_dir_all(&elmstuff)?;
-        let actual = ModuleRenderer::new("elm").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("elm");
         let expected = Some(format!("via {}", Color::Cyan.bold().paint("🌳 v0.19.1 ")));
         assert_eq!(expected, actual);
         dir.close()
@@ -117,7 +117,7 @@ mod tests {
     fn folder_with_elm_file() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("main.elm"))?.sync_all()?;
-        let actual = ModuleRenderer::new("elm").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("elm");
         let expected = Some(format!("via {}", Color::Cyan.bold().paint("🌳 v0.19.1 ")));
         assert_eq!(expected, actual);
         dir.close()

--- a/src/modules/env_var.rs
+++ b/src/modules/env_var.rs
@@ -52,18 +52,18 @@ fn get_env_value(context: &Context, name: &str, default: Option<&str>) -> Option
 
 #[cfg(test)]
 mod test {
-    use crate::test::ModuleRenderer;
+    use crate::test::TestRenderer;
     use ansi_term::{Color, Style};
 
     const TEST_VAR_VALUE: &str = "astronauts";
 
     #[test]
     fn empty_config() {
-        let actual = ModuleRenderer::new("env_var")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [env_var]
             })
-            .collect();
+            .module("env_var");
         let expected = None;
 
         assert_eq!(expected, actual);
@@ -71,13 +71,13 @@ mod test {
 
     #[test]
     fn defined_variable() {
-        let actual = ModuleRenderer::new("env_var")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [env_var]
                 variable = "TEST_VAR"
             })
             .env("TEST_VAR", TEST_VAR_VALUE)
-            .collect();
+            .module("env_var");
         let expected = Some(format!("with {} ", style().paint(TEST_VAR_VALUE)));
 
         assert_eq!(expected, actual);
@@ -85,12 +85,12 @@ mod test {
 
     #[test]
     fn undefined_variable() {
-        let actual = ModuleRenderer::new("env_var")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [env_var]
                 variable = "TEST_VAR"
             })
-            .collect();
+            .module("env_var");
         let expected = None;
 
         assert_eq!(expected, actual);
@@ -98,14 +98,14 @@ mod test {
 
     #[test]
     fn default_has_no_effect() {
-        let actual = ModuleRenderer::new("env_var")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [env_var]
                 variable = "TEST_VAR"
                 default = "N/A"
             })
             .env("TEST_VAR", TEST_VAR_VALUE)
-            .collect();
+            .module("env_var");
         let expected = Some(format!("with {} ", style().paint(TEST_VAR_VALUE)));
 
         assert_eq!(expected, actual);
@@ -113,13 +113,13 @@ mod test {
 
     #[test]
     fn default_takes_effect() {
-        let actual = ModuleRenderer::new("env_var")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [env_var]
                 variable = "UNDEFINED_TEST_VAR"
                 default = "N/A"
             })
-            .collect();
+            .module("env_var");
         let expected = Some(format!("with {} ", style().paint("N/A")));
 
         assert_eq!(expected, actual);
@@ -127,14 +127,14 @@ mod test {
 
     #[test]
     fn symbol() {
-        let actual = ModuleRenderer::new("env_var")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [env_var]
                 variable = "TEST_VAR"
                 format = "with [■ $env_value](black bold dimmed) "
             })
             .env("TEST_VAR", TEST_VAR_VALUE)
-            .collect();
+            .module("env_var");
         let expected = Some(format!(
             "with {} ",
             style().paint(format!("■ {}", TEST_VAR_VALUE))
@@ -145,14 +145,14 @@ mod test {
 
     #[test]
     fn prefix() {
-        let actual = ModuleRenderer::new("env_var")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [env_var]
                 variable = "TEST_VAR"
                 format = "with [_$env_value](black bold dimmed) "
             })
             .env("TEST_VAR", TEST_VAR_VALUE)
-            .collect();
+            .module("env_var");
         let expected = Some(format!(
             "with {} ",
             style().paint(format!("_{}", TEST_VAR_VALUE))
@@ -163,14 +163,14 @@ mod test {
 
     #[test]
     fn suffix() {
-        let actual = ModuleRenderer::new("env_var")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [env_var]
                 variable = "TEST_VAR"
                 format = "with [${env_value}_](black bold dimmed) "
             })
             .env("TEST_VAR", TEST_VAR_VALUE)
-            .collect();
+            .module("env_var");
         let expected = Some(format!(
             "with {} ",
             style().paint(format!("{}_", TEST_VAR_VALUE))

--- a/src/modules/erlang.rs
+++ b/src/modules/erlang.rs
@@ -72,7 +72,7 @@ fn get_erlang_version(context: &Context) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use crate::test::ModuleRenderer;
+    use crate::test::TestRenderer;
     use ansi_term::Color;
     use std::fs::File;
     use std::io;
@@ -82,7 +82,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
 
         let expected = None;
-        let output = ModuleRenderer::new("erlang").path(dir.path()).collect();
+        let output = TestRenderer::new().path(dir.path()).module("erlang");
 
         assert_eq!(output, expected);
 
@@ -95,7 +95,7 @@ mod tests {
         File::create(dir.path().join("rebar.config"))?.sync_all()?;
 
         let expected = Some(format!("via {}", Color::Red.bold().paint(" v22.1.3 ")));
-        let output = ModuleRenderer::new("erlang").path(dir.path()).collect();
+        let output = TestRenderer::new().path(dir.path()).module("erlang");
 
         assert_eq!(output, expected);
 

--- a/src/modules/gcloud.rs
+++ b/src/modules/gcloud.rs
@@ -173,7 +173,7 @@ mod tests {
 
     use ansi_term::Color;
 
-    use crate::test::ModuleRenderer;
+    use crate::test::TestRenderer;
 
     #[test]
     fn account_set() -> io::Result<()> {
@@ -192,9 +192,9 @@ account = foo@example.com
 ",
         )?;
 
-        let actual = ModuleRenderer::new("gcloud")
+        let actual = TestRenderer::new()
             .env("CLOUDSDK_CONFIG", dir.path().to_string_lossy())
-            .collect();
+            .module("gcloud");
         let expected = Some(format!(
             "on {} ",
             Color::Blue.bold().paint("☁️  foo@example.com")
@@ -221,13 +221,13 @@ account = foo@example.com
 ",
         )?;
 
-        let actual = ModuleRenderer::new("gcloud")
+        let actual = TestRenderer::new()
             .env("CLOUDSDK_CONFIG", dir.path().to_string_lossy())
             .config(toml::toml! {
                 [gcloud]
                 format = "on [$symbol$account(\\($region\\))]($style) "
             })
-            .collect();
+            .module("gcloud");
         let expected = Some(format!("on {} ", Color::Blue.bold().paint("☁️  foo")));
 
         assert_eq!(actual, expected);
@@ -254,9 +254,9 @@ region = us-central1
 ",
         )?;
 
-        let actual = ModuleRenderer::new("gcloud")
+        let actual = TestRenderer::new()
             .env("CLOUDSDK_CONFIG", dir.path().to_string_lossy())
-            .collect();
+            .module("gcloud");
         let expected = Some(format!(
             "on {} ",
             Color::Blue.bold().paint("☁️  foo@example.com(us-central1)")
@@ -286,13 +286,13 @@ region = us-central1
 ",
         )?;
 
-        let actual = ModuleRenderer::new("gcloud")
+        let actual = TestRenderer::new()
             .env("CLOUDSDK_CONFIG", dir.path().to_string_lossy())
             .config(toml::toml! {
                 [gcloud.region_aliases]
                 us-central1 = "uc1"
             })
-            .collect();
+            .module("gcloud");
         let expected = Some(format!(
             "on {} ",
             Color::Blue.bold().paint("☁️  foo@example.com(uc1)")
@@ -309,13 +309,13 @@ region = us-central1
         let mut active_config_file = File::create(&active_config_path)?;
         active_config_file.write_all(b"default1")?;
 
-        let actual = ModuleRenderer::new("gcloud")
+        let actual = TestRenderer::new()
             .env("CLOUDSDK_CONFIG", dir.path().to_string_lossy())
             .config(toml::toml! {
                 [gcloud]
                 format = "on [$symbol$active]($style) "
             })
-            .collect();
+            .module("gcloud");
         let expected = Some(format!("on {} ", Color::Blue.bold().paint("☁️  default1")));
 
         assert_eq!(actual, expected);
@@ -339,13 +339,13 @@ project = abc
 ",
         )?;
 
-        let actual = ModuleRenderer::new("gcloud")
+        let actual = TestRenderer::new()
             .env("CLOUDSDK_CONFIG", dir.path().to_string_lossy())
             .config(toml::toml! {
                 [gcloud]
                 format = "on [$symbol$project]($style) "
             })
-            .collect();
+            .module("gcloud");
         let expected = Some(format!("on {} ", Color::Blue.bold().paint("☁️  abc")));
 
         assert_eq!(actual, expected);
@@ -369,14 +369,14 @@ project = abc
 ",
         )?;
 
-        let actual = ModuleRenderer::new("gcloud")
+        let actual = TestRenderer::new()
             .env("CLOUDSDK_CORE_PROJECT", "env_project")
             .env("CLOUDSDK_CONFIG", dir.path().to_string_lossy())
             .config(toml::toml! {
                 [gcloud]
                 format = "on [$symbol$project]($style) "
             })
-            .collect();
+            .module("gcloud");
         let expected = Some(format!(
             "on {} ",
             Color::Blue.bold().paint("☁️  env_project")
@@ -389,13 +389,13 @@ project = abc
     #[test]
     fn region_not_set_with_display_region() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
-        let actual = ModuleRenderer::new("gcloud")
+        let actual = TestRenderer::new()
             .env("CLOUDSDK_CONFIG", dir.path().to_string_lossy())
             .config(toml::toml! {
                 [gcloud]
                 format = "on [$symbol$region]($style) "
             })
-            .collect();
+            .module("gcloud");
         let expected = None;
 
         assert_eq!(expected, actual);
@@ -428,14 +428,14 @@ project = overridden
 ",
         )?;
 
-        let actual = ModuleRenderer::new("gcloud")
+        let actual = TestRenderer::new()
             .env("CLOUDSDK_CONFIG", dir.path().to_string_lossy())
             .env("CLOUDSDK_ACTIVE_CONFIG_NAME", "overridden")
             .config(toml::toml! {
                 [gcloud]
                 format = "on [$symbol$project]($style) "
             })
-            .collect();
+            .module("gcloud");
         let expected = Some(format!("on {} ", Color::Blue.bold().paint("☁️  overridden")));
 
         assert_eq!(actual, expected);

--- a/src/modules/git_branch.rs
+++ b/src/modules/git_branch.rs
@@ -123,15 +123,15 @@ mod tests {
     use std::io;
     use std::process::Command;
 
-    use crate::test::{fixture_repo, FixtureProvider, ModuleRenderer};
+    use crate::test::{fixture_repo, FixtureProvider, TestRenderer};
 
     #[test]
     fn show_nothing_on_empty_dir() -> io::Result<()> {
         let repo_dir = tempfile::tempdir()?;
 
-        let actual = ModuleRenderer::new("git_branch")
+        let actual = TestRenderer::new()
             .path(repo_dir.path())
-            .collect();
+            .module("git_branch");
         let expected = None;
 
         assert_eq!(expected, actual);
@@ -280,9 +280,9 @@ mod tests {
             .current_dir(&repo_dir)
             .output()?;
 
-        let actual = ModuleRenderer::new("git_branch")
+        let actual = TestRenderer::new()
             .path(&repo_dir.path())
-            .collect();
+            .module("git_branch");
 
         let expected = Some(format!(
             "on {} ",
@@ -302,13 +302,13 @@ mod tests {
             .current_dir(repo_dir.path())
             .output()?;
 
-        let actual = ModuleRenderer::new("git_branch")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [git_branch]
                     only_attached = true
             })
             .path(&repo_dir.path())
-            .collect();
+            .module("git_branch");
 
         let expected = Some(format!(
             "on {} ",
@@ -330,13 +330,13 @@ mod tests {
             .current_dir(&repo_dir.path())
             .output()?;
 
-        let actual = ModuleRenderer::new("git_branch")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [git_branch]
                     only_attached = true
             })
             .path(&repo_dir.path())
-            .collect();
+            .module("git_branch");
 
         let expected = None;
 
@@ -358,9 +358,9 @@ mod tests {
             .current_dir(&repo_dir)
             .output()?;
 
-        let actual = ModuleRenderer::new("git_branch")
+        let actual = TestRenderer::new()
             .path(&repo_dir.path())
-            .collect();
+            .module("git_branch");
 
         let expected = Some(format!(
             "on {} ",
@@ -387,7 +387,7 @@ mod tests {
     //     // git2 does not care about our mocking
     //     std::env::set_var("GIT_DIR", repo_dir.path().join(".git"));
 
-    //     let actual = ModuleRenderer::new("git_branch").collect();
+    //     let actual = TestRenderer::new("git_branch").module("git_branch");
 
     //     std::env::remove_var("GIT_DIR");
 
@@ -429,7 +429,7 @@ mod tests {
             .current_dir(repo_dir.path())
             .output()?;
 
-        let actual = ModuleRenderer::new("git_branch")
+        let actual = TestRenderer::new()
             .config(
                 toml::from_str(&format!(
                     "
@@ -442,7 +442,7 @@ mod tests {
                 .unwrap(),
             )
             .path(repo_dir.path())
-            .collect();
+            .module("git_branch");
 
         let expected = Some(format!(
             "on {} ",
@@ -468,7 +468,7 @@ mod tests {
             .current_dir(repo_dir.path())
             .output()?;
 
-        let actual = ModuleRenderer::new("git_branch")
+        let actual = TestRenderer::new()
             .config(
                 toml::from_str(&format!(
                     r#"
@@ -481,7 +481,7 @@ mod tests {
                 .unwrap(),
             )
             .path(repo_dir.path())
-            .collect();
+            .module("git_branch");
 
         assert_eq!(Some(expected.into()), actual);
         repo_dir.close()

--- a/src/modules/git_commit.rs
+++ b/src/modules/git_commit.rs
@@ -108,15 +108,15 @@ mod tests {
     use std::process::Command;
     use std::{io, str};
 
-    use crate::test::{fixture_repo, FixtureProvider, ModuleRenderer};
+    use crate::test::{fixture_repo, FixtureProvider, TestRenderer};
 
     #[test]
     fn show_nothing_on_empty_dir() -> io::Result<()> {
         let repo_dir = tempfile::tempdir()?;
 
-        let actual = ModuleRenderer::new("git_commit")
+        let actual = TestRenderer::new()
             .path(&repo_dir.path())
-            .collect();
+            .module("git_commit");
 
         let expected = None;
 
@@ -136,13 +136,13 @@ mod tests {
         git_output.truncate(7);
         let expected_hash = str::from_utf8(&git_output).unwrap();
 
-        let actual = ModuleRenderer::new("git_commit")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [git_commit]
                     only_detached = false
             })
             .path(&repo_dir.path())
-            .collect();
+            .module("git_commit");
 
         let expected = Some(format!(
             "{} ",
@@ -168,14 +168,14 @@ mod tests {
         git_output.truncate(14);
         let expected_hash = str::from_utf8(&git_output).unwrap();
 
-        let actual = ModuleRenderer::new("git_commit")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [git_commit]
                     only_detached = false
                     commit_hash_length = 14
             })
             .path(&repo_dir.path())
-            .collect();
+            .module("git_commit");
 
         let expected = Some(format!(
             "{} ",
@@ -193,9 +193,9 @@ mod tests {
     fn test_render_commit_hash_only_detached_on_branch() -> io::Result<()> {
         let repo_dir = fixture_repo(FixtureProvider::Git)?;
 
-        let actual = ModuleRenderer::new("git_commit")
+        let actual = TestRenderer::new()
             .path(&repo_dir.path())
-            .collect();
+            .module("git_commit");
 
         let expected = None;
 
@@ -220,9 +220,9 @@ mod tests {
         git_output.truncate(7);
         let expected_hash = str::from_utf8(&git_output).unwrap();
 
-        let actual = ModuleRenderer::new("git_commit")
+        let actual = TestRenderer::new()
             .path(&repo_dir.path())
-            .collect();
+            .module("git_commit");
 
         let expected = Some(format!(
             "{} ",
@@ -257,7 +257,7 @@ mod tests {
 
         let expected_output = format!("{} {}", commit_output, tag_output);
 
-        let actual = ModuleRenderer::new("git_commit")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [git_commit]
                     only_detached = false
@@ -265,7 +265,7 @@ mod tests {
                     tag_symbol = ""
             })
             .path(&repo_dir.path())
-            .collect();
+            .module("git_commit");
 
         let expected = Some(format!(
             "{} ",
@@ -310,14 +310,14 @@ mod tests {
 
         let expected_output = format!("{} {}", commit_output, tag_output);
 
-        let actual = ModuleRenderer::new("git_commit")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [git_commit]
                     tag_disabled = false
                     tag_symbol = " "
             })
             .path(&repo_dir.path())
-            .collect();
+            .module("git_commit");
 
         let expected = Some(format!(
             "{} ",
@@ -381,7 +381,7 @@ mod tests {
 
         let expected_output = format!("{} {}", commit_output, tag_output);
 
-        let actual = ModuleRenderer::new("git_commit")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [git_commit]
                     only_detached = false
@@ -389,7 +389,7 @@ mod tests {
                     tag_symbol = " "
             })
             .path(&repo_dir.path())
-            .collect();
+            .module("git_commit");
 
         let expected = Some(format!(
             "{} ",

--- a/src/modules/git_state.rs
+++ b/src/modules/git_state.rs
@@ -179,15 +179,15 @@ mod tests {
     use std::path::Path;
     use std::process::{Command, Stdio};
 
-    use crate::test::ModuleRenderer;
+    use crate::test::TestRenderer;
 
     #[test]
     fn show_nothing_on_empty_dir() -> io::Result<()> {
         let repo_dir = tempfile::tempdir()?;
 
-        let actual = ModuleRenderer::new("git_state")
+        let actual = TestRenderer::new()
             .path(repo_dir.path())
-            .collect();
+            .module("git_state");
 
         let expected = None;
 
@@ -202,7 +202,7 @@ mod tests {
 
         run_git_cmd(&["rebase", "other-branch"], Some(path), false)?;
 
-        let actual = ModuleRenderer::new("git_state").path(path).collect();
+        let actual = TestRenderer::new().path(path).module("git_state");
 
         let expected = Some(format!("({}) ", Color::Yellow.bold().paint("REBASING 1/1")));
 
@@ -217,7 +217,7 @@ mod tests {
 
         run_git_cmd(&["merge", "other-branch"], Some(path), false)?;
 
-        let actual = ModuleRenderer::new("git_state").path(path).collect();
+        let actual = TestRenderer::new().path(path).module("git_state");
 
         let expected = Some(format!("({}) ", Color::Yellow.bold().paint("MERGING")));
 
@@ -232,7 +232,7 @@ mod tests {
 
         run_git_cmd(&["cherry-pick", "other-branch"], Some(path), false)?;
 
-        let actual = ModuleRenderer::new("git_state").path(path).collect();
+        let actual = TestRenderer::new().path(path).module("git_state");
 
         let expected = Some(format!(
             "({}) ",
@@ -250,7 +250,7 @@ mod tests {
 
         run_git_cmd(&["bisect", "start"], Some(path), false)?;
 
-        let actual = ModuleRenderer::new("git_state").path(path).collect();
+        let actual = TestRenderer::new().path(path).module("git_state");
 
         let expected = Some(format!("({}) ", Color::Yellow.bold().paint("BISECTING")));
 
@@ -265,7 +265,7 @@ mod tests {
 
         run_git_cmd(&["revert", "--no-commit", "HEAD~1"], Some(path), false)?;
 
-        let actual = ModuleRenderer::new("git_state").path(path).collect();
+        let actual = TestRenderer::new().path(path).module("git_state");
 
         let expected = Some(format!("({}) ", Color::Yellow.bold().paint("REVERTING")));
 

--- a/src/modules/git_status.rs
+++ b/src/modules/git_status.rs
@@ -322,7 +322,7 @@ mod tests {
     use std::path::Path;
     use std::process::Command;
 
-    use crate::test::{fixture_repo, FixtureProvider, ModuleRenderer};
+    use crate::test::{fixture_repo, FixtureProvider, TestRenderer};
 
     /// Right after the calls to git the filesystem state may not have finished
     /// updating yet causing some of the tests to fail. These barriers are placed
@@ -348,9 +348,9 @@ mod tests {
     fn show_nothing_on_empty_dir() -> io::Result<()> {
         let repo_dir = tempfile::tempdir()?;
 
-        let actual = ModuleRenderer::new("git_status")
+        let actual = TestRenderer::new()
             .path(repo_dir.path())
-            .collect();
+            .module("git_status");
         let expected = None;
 
         assert_eq!(expected, actual);
@@ -363,9 +363,9 @@ mod tests {
 
         behind(&repo_dir.path())?;
 
-        let actual = ModuleRenderer::new("git_status")
+        let actual = TestRenderer::new()
             .path(repo_dir.path())
-            .collect();
+            .module("git_status");
         let expected = format_output("⇣");
 
         assert_eq!(expected, actual);
@@ -378,13 +378,13 @@ mod tests {
 
         behind(&repo_dir.path())?;
 
-        let actual = ModuleRenderer::new("git_status")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [git_status]
                 behind = "⇣$count"
             })
             .path(repo_dir.path())
-            .collect();
+            .module("git_status");
         let expected = format_output("⇣1");
 
         assert_eq!(expected, actual);
@@ -398,9 +398,9 @@ mod tests {
         File::create(repo_dir.path().join("readme.md"))?.sync_all()?;
         ahead(&repo_dir.path())?;
 
-        let actual = ModuleRenderer::new("git_status")
+        let actual = TestRenderer::new()
             .path(&repo_dir.path())
-            .collect();
+            .module("git_status");
         let expected = format_output("⇡");
 
         assert_eq!(expected, actual);
@@ -414,13 +414,13 @@ mod tests {
         File::create(repo_dir.path().join("readme.md"))?.sync_all()?;
         ahead(&repo_dir.path())?;
 
-        let actual = ModuleRenderer::new("git_status")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [git_status]
                 ahead="⇡$count"
             })
             .path(&repo_dir.path())
-            .collect();
+            .module("git_status");
         let expected = format_output("⇡1");
 
         assert_eq!(expected, actual);
@@ -433,9 +433,9 @@ mod tests {
 
         diverge(&repo_dir.path())?;
 
-        let actual = ModuleRenderer::new("git_status")
+        let actual = TestRenderer::new()
             .path(&repo_dir.path())
-            .collect();
+            .module("git_status");
         let expected = format_output("⇕");
 
         assert_eq!(expected, actual);
@@ -448,13 +448,13 @@ mod tests {
 
         diverge(&repo_dir.path())?;
 
-        let actual = ModuleRenderer::new("git_status")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [git_status]
                 diverged=r"⇕⇡$ahead_count⇣$behind_count"
             })
             .path(&repo_dir.path())
-            .collect();
+            .module("git_status");
         let expected = format_output("⇕⇡1⇣1");
 
         assert_eq!(expected, actual);
@@ -467,9 +467,9 @@ mod tests {
 
         create_conflict(&repo_dir.path())?;
 
-        let actual = ModuleRenderer::new("git_status")
+        let actual = TestRenderer::new()
             .path(&repo_dir.path())
-            .collect();
+            .module("git_status");
         let expected = format_output("=");
 
         assert_eq!(expected, actual);
@@ -482,13 +482,13 @@ mod tests {
 
         create_conflict(&repo_dir.path())?;
 
-        let actual = ModuleRenderer::new("git_status")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [git_status]
                 conflicted = "=$count"
             })
             .path(&repo_dir.path())
-            .collect();
+            .module("git_status");
         let expected = format_output("=1");
 
         assert_eq!(expected, actual);
@@ -501,9 +501,9 @@ mod tests {
 
         create_untracked(&repo_dir.path())?;
 
-        let actual = ModuleRenderer::new("git_status")
+        let actual = TestRenderer::new()
             .path(&repo_dir.path())
-            .collect();
+            .module("git_status");
         let expected = format_output("?");
 
         assert_eq!(expected, actual);
@@ -516,13 +516,13 @@ mod tests {
 
         create_untracked(&repo_dir.path())?;
 
-        let actual = ModuleRenderer::new("git_status")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [git_status]
                 untracked = "?$count"
             })
             .path(&repo_dir.path())
-            .collect();
+            .module("git_status");
         let expected = format_output("?1");
 
         assert_eq!(expected, actual);
@@ -541,9 +541,9 @@ mod tests {
             .output()?;
         barrier();
 
-        let actual = ModuleRenderer::new("git_status")
+        let actual = TestRenderer::new()
             .path(&repo_dir.path())
-            .collect();
+            .module("git_status");
         let expected = None;
 
         assert_eq!(expected, actual);
@@ -563,9 +563,9 @@ mod tests {
             .output()?;
         barrier();
 
-        let actual = ModuleRenderer::new("git_status")
+        let actual = TestRenderer::new()
             .path(&repo_dir.path())
-            .collect();
+            .module("git_status");
         let expected = format_output("$");
 
         assert_eq!(expected, actual);
@@ -586,13 +586,13 @@ mod tests {
             .output()?;
         barrier();
 
-        let actual = ModuleRenderer::new("git_status")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [git_status]
                 stashed = r"\$$count"
             })
             .path(&repo_dir.path())
-            .collect();
+            .module("git_status");
         let expected = format_output("$1");
 
         assert_eq!(expected, actual);
@@ -605,9 +605,9 @@ mod tests {
 
         create_modified(&repo_dir.path())?;
 
-        let actual = ModuleRenderer::new("git_status")
+        let actual = TestRenderer::new()
             .path(&repo_dir.path())
-            .collect();
+            .module("git_status");
         let expected = format_output("!");
 
         assert_eq!(expected, actual);
@@ -620,13 +620,13 @@ mod tests {
 
         create_modified(&repo_dir.path())?;
 
-        let actual = ModuleRenderer::new("git_status")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [git_status]
                 modified = "!$count"
             })
             .path(&repo_dir.path())
-            .collect();
+            .module("git_status");
         let expected = format_output("!1");
 
         assert_eq!(expected, actual);
@@ -639,9 +639,9 @@ mod tests {
 
         create_added(&repo_dir.path())?;
 
-        let actual = ModuleRenderer::new("git_status")
+        let actual = TestRenderer::new()
             .path(&repo_dir.path())
-            .collect();
+            .module("git_status");
         let expected = format_output("!");
 
         assert_eq!(expected, actual);
@@ -654,9 +654,9 @@ mod tests {
 
         create_staged(&repo_dir.path())?;
 
-        let actual = ModuleRenderer::new("git_status")
+        let actual = TestRenderer::new()
             .path(&repo_dir.path())
-            .collect();
+            .module("git_status");
         let expected = format_output("+");
 
         assert_eq!(expected, actual);
@@ -669,13 +669,13 @@ mod tests {
 
         create_staged(&repo_dir.path())?;
 
-        let actual = ModuleRenderer::new("git_status")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [git_status]
                 staged = "+[$count](green)"
             })
             .path(&repo_dir.path())
-            .collect();
+            .module("git_status");
         let expected = Some(format!(
             "{} ",
             ANSIStrings(&[
@@ -695,9 +695,9 @@ mod tests {
 
         create_renamed(&repo_dir.path())?;
 
-        let actual = ModuleRenderer::new("git_status")
+        let actual = TestRenderer::new()
             .path(&repo_dir.path())
-            .collect();
+            .module("git_status");
         let expected = format_output("»");
 
         assert_eq!(expected, actual);
@@ -710,13 +710,13 @@ mod tests {
 
         create_renamed(&repo_dir.path())?;
 
-        let actual = ModuleRenderer::new("git_status")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [git_status]
                 renamed = "»$count"
             })
             .path(&repo_dir.path())
-            .collect();
+            .module("git_status");
         let expected = format_output("»1");
 
         assert_eq!(expected, actual);
@@ -729,9 +729,9 @@ mod tests {
 
         create_deleted(&repo_dir.path())?;
 
-        let actual = ModuleRenderer::new("git_status")
+        let actual = TestRenderer::new()
             .path(&repo_dir.path())
-            .collect();
+            .module("git_status");
         let expected = format_output("✘");
 
         assert_eq!(expected, actual);
@@ -744,13 +744,13 @@ mod tests {
 
         create_deleted(&repo_dir.path())?;
 
-        let actual = ModuleRenderer::new("git_status")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [git_status]
                 deleted = "✘$count"
             })
             .path(&repo_dir.path())
-            .collect();
+            .module("git_status");
         let expected = format_output("✘1");
 
         assert_eq!(expected, actual);
@@ -779,7 +779,7 @@ mod tests {
         fs::rename(repo_dir.path().join("b"), repo_dir.path().join("c"))?;
         barrier();
 
-        let actual = ModuleRenderer::new("git_status")
+        let actual = TestRenderer::new()
             .path(&repo_dir.path())
             .config(toml::toml! {
                 [git_status]
@@ -788,7 +788,7 @@ mod tests {
                 untracked = "U"
                 renamed = "R"
             })
-            .collect();
+            .module("git_status");
         let expected = format_output("DUA");
 
         assert_eq!(actual, expected);

--- a/src/modules/golang.rs
+++ b/src/modules/golang.rs
@@ -77,7 +77,7 @@ fn get_go_version(go_stdout: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test::ModuleRenderer;
+    use crate::test::TestRenderer;
     use ansi_term::Color;
     use std::fs::{self, File};
     use std::io;
@@ -86,7 +86,7 @@ mod tests {
     fn folder_without_go_files() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
 
-        let actual = ModuleRenderer::new("golang").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("golang");
 
         let expected = None;
         assert_eq!(expected, actual);
@@ -98,7 +98,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("main.go"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("golang").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("golang");
 
         let expected = Some(format!("via {}", Color::Cyan.bold().paint("🐹 v1.12.1 ")));
         assert_eq!(expected, actual);
@@ -110,7 +110,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("go.mod"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("golang").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("golang");
 
         let expected = Some(format!("via {}", Color::Cyan.bold().paint("🐹 v1.12.1 ")));
         assert_eq!(expected, actual);
@@ -122,7 +122,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("go.sum"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("golang").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("golang");
 
         let expected = Some(format!("via {}", Color::Cyan.bold().paint("🐹 v1.12.1 ")));
         assert_eq!(expected, actual);
@@ -135,7 +135,7 @@ mod tests {
         let godeps = dir.path().join("Godeps");
         fs::create_dir_all(&godeps)?;
 
-        let actual = ModuleRenderer::new("golang").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("golang");
 
         let expected = Some(format!("via {}", Color::Cyan.bold().paint("🐹 v1.12.1 ")));
         assert_eq!(expected, actual);
@@ -147,7 +147,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("glide.yaml"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("golang").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("golang");
 
         let expected = Some(format!("via {}", Color::Cyan.bold().paint("🐹 v1.12.1 ")));
         assert_eq!(expected, actual);
@@ -159,7 +159,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("Gopkg.yml"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("golang").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("golang");
 
         let expected = Some(format!("via {}", Color::Cyan.bold().paint("🐹 v1.12.1 ")));
         assert_eq!(expected, actual);
@@ -170,7 +170,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("Gopkg.lock"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("golang").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("golang");
         let expected = Some(format!("via {}", Color::Cyan.bold().paint("🐹 v1.12.1 ")));
         assert_eq!(expected, actual);
         dir.close()
@@ -180,7 +180,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join(".go-version"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("golang").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("golang");
         let expected = Some(format!("via {}", Color::Cyan.bold().paint("🐹 v1.12.1 ")));
         assert_eq!(expected, actual);
         dir.close()

--- a/src/modules/helm.rs
+++ b/src/modules/helm.rs
@@ -82,7 +82,7 @@ fn get_helm_version(helm_stdout: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test::ModuleRenderer;
+    use crate::test::TestRenderer;
     use ansi_term::Color;
     use std::fs::File;
     use std::io;
@@ -91,7 +91,7 @@ mod tests {
     fn folder_without_helm_files() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
 
-        let actual = ModuleRenderer::new("helm").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("helm");
 
         let expected = None;
         assert_eq!(expected, actual);
@@ -103,7 +103,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("helmfile.yaml"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("helm").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("helm");
 
         let expected = Some(format!("via {}", Color::White.bold().paint("⎈ v3.1.1 ")));
         assert_eq!(expected, actual);
@@ -115,7 +115,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("Chart.yaml"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("helm").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("helm");
 
         let expected = Some(format!("via {}", Color::White.bold().paint("⎈ v3.1.1 ")));
         assert_eq!(expected, actual);

--- a/src/modules/hg_branch.rs
+++ b/src/modules/hg_branch.rs
@@ -105,7 +105,7 @@ mod tests {
     use std::path::Path;
     use std::process::Command;
 
-    use crate::test::{fixture_repo, FixtureProvider, ModuleRenderer};
+    use crate::test::{fixture_repo, FixtureProvider, TestRenderer};
 
     enum Expect<'a> {
         BranchName(&'a str),
@@ -120,9 +120,9 @@ mod tests {
     fn show_nothing_on_empty_dir() -> io::Result<()> {
         let repo_dir = tempfile::tempdir()?;
 
-        let actual = ModuleRenderer::new("hg_branch")
+        let actual = TestRenderer::new()
             .path(repo_dir.path())
-            .collect();
+            .module("hg_branch");
 
         let expected = None;
         assert_eq!(expected, actual);
@@ -287,7 +287,7 @@ mod tests {
         config: Option<toml::Value>,
         expectations: &[Expect],
     ) {
-        let actual = ModuleRenderer::new("hg_branch")
+        let actual = TestRenderer::new()
             .path(repo_dir.to_str().unwrap())
             .config(config.unwrap_or_else(|| {
                 toml::toml! {
@@ -295,7 +295,7 @@ mod tests {
                     disabled = false
                 }
             }))
-            .collect();
+            .module("hg_branch");
 
         let mut expect_branch_name = "default";
         let mut expect_style = Color::Purple.bold();

--- a/src/modules/hostname.rs
+++ b/src/modules/hostname.rs
@@ -67,7 +67,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
 #[cfg(test)]
 mod tests {
-    use crate::test::ModuleRenderer;
+    use crate::test::TestRenderer;
     use ansi_term::{Color, Style};
 
     macro_rules! get_hostname {
@@ -87,13 +87,13 @@ mod tests {
     #[test]
     fn ssh_only_false() {
         let hostname = get_hostname!();
-        let actual = ModuleRenderer::new("hostname")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [hostname]
                 ssh_only = false
                 trim_at = ""
             })
-            .collect();
+            .module("hostname");
         let expected = Some(format!("{} in ", style().paint(hostname)));
 
         assert_eq!(expected, actual);
@@ -101,12 +101,12 @@ mod tests {
 
     #[test]
     fn no_ssh() {
-        let actual = ModuleRenderer::new("hostname")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [hostname]
                 ssh_only = true
             })
-            .collect();
+            .module("hostname");
         let expected = None;
 
         assert_eq!(expected, actual);
@@ -115,14 +115,14 @@ mod tests {
     #[test]
     fn ssh() {
         let hostname = get_hostname!();
-        let actual = ModuleRenderer::new("hostname")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [hostname]
                 ssh_only = true
                 trim_at = ""
             })
             .env("SSH_CONNECTION", "something")
-            .collect();
+            .module("hostname");
         let expected = Some(format!("{} in ", style().paint(hostname)));
 
         assert_eq!(expected, actual);
@@ -131,13 +131,13 @@ mod tests {
     #[test]
     fn no_trim_at() {
         let hostname = get_hostname!();
-        let actual = ModuleRenderer::new("hostname")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [hostname]
                 ssh_only = false
                 trim_at = ""
             })
-            .collect();
+            .module("hostname");
         let expected = Some(format!("{} in ", style().paint(hostname)));
 
         assert_eq!(expected, actual);
@@ -147,13 +147,13 @@ mod tests {
     fn trim_at() {
         let hostname = get_hostname!();
         let (remainder, trim_at) = hostname.split_at(1);
-        let actual = ModuleRenderer::new("hostname")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [hostname]
                 ssh_only = false
                 trim_at = trim_at
             })
-            .collect();
+            .module("hostname");
         let expected = Some(format!("{} in ", style().paint(remainder)));
 
         assert_eq!(expected, actual);

--- a/src/modules/java.rs
+++ b/src/modules/java.rs
@@ -91,7 +91,7 @@ fn format_java_version(java_version: &str, version_format: &str) -> Option<Strin
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{test::ModuleRenderer, utils::CommandOutput};
+    use crate::{test::TestRenderer, utils::CommandOutput};
     use ansi_term::Color;
     use std::fs::File;
     use std::io;
@@ -202,7 +202,7 @@ mod tests {
     #[test]
     fn folder_without_java_file() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
-        let actual = ModuleRenderer::new("java").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("java");
         let expected = None;
         assert_eq!(expected, actual);
         dir.close()
@@ -212,7 +212,7 @@ mod tests {
     fn folder_with_java_file() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("Main.java"))?.sync_all()?;
-        let actual = ModuleRenderer::new("java").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("java");
         let expected = Some(format!("via {}", Color::Red.dimmed().paint("☕ v13.0.2 ")));
         assert_eq!(expected, actual);
         dir.close()
@@ -222,10 +222,10 @@ mod tests {
     fn folder_with_java_file_preview() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("Main.java"))?.sync_all()?;
-        let actual = ModuleRenderer::new("java").cmd("java -Xinternalversion", Some(CommandOutput {
+        let actual = TestRenderer::new().cmd("java -Xinternalversion", Some(CommandOutput {
             stdout: "OpenJDK 64-Bit Server VM (16+14) for bsd-aarch64 JRE (16+14), built on Jan 17 2021 07:19:47 by \"brew\" with clang Apple LLVM 12.0.0 (clang-1200.0.32.28)\n".to_owned(),
             stderr: "".to_owned()
-        })).path(dir.path()).collect();
+        })).path(dir.path()).module("java");
         let expected = Some(format!("via {}", Color::Red.dimmed().paint("☕ v16 ")));
         assert_eq!(expected, actual);
         dir.close()
@@ -235,10 +235,10 @@ mod tests {
     fn folder_with_java_file_no_java_installed() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("Main.java"))?.sync_all()?;
-        let actual = ModuleRenderer::new("java")
+        let actual = TestRenderer::new()
             .cmd("java -Xinternalversion", None)
             .path(dir.path())
-            .collect();
+            .module("java");
         let expected = Some(format!("via {}", Color::Red.dimmed().paint("☕ ")));
         assert_eq!(expected, actual);
         dir.close()
@@ -248,7 +248,7 @@ mod tests {
     fn folder_with_class_file() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("Main.class"))?.sync_all()?;
-        let actual = ModuleRenderer::new("java").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("java");
         let expected = Some(format!("via {}", Color::Red.dimmed().paint("☕ v13.0.2 ")));
         assert_eq!(expected, actual);
         dir.close()
@@ -258,7 +258,7 @@ mod tests {
     fn folder_with_gradle_file() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("build.gradle"))?.sync_all()?;
-        let actual = ModuleRenderer::new("java").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("java");
         let expected = Some(format!("via {}", Color::Red.dimmed().paint("☕ v13.0.2 ")));
         assert_eq!(expected, actual);
         dir.close()
@@ -268,7 +268,7 @@ mod tests {
     fn folder_with_jar_archive() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("test.jar"))?.sync_all()?;
-        let actual = ModuleRenderer::new("java").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("java");
         let expected = Some(format!("via {}", Color::Red.dimmed().paint("☕ v13.0.2 ")));
         assert_eq!(expected, actual);
         dir.close()
@@ -278,7 +278,7 @@ mod tests {
     fn folder_with_pom_file() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("pom.xml"))?.sync_all()?;
-        let actual = ModuleRenderer::new("java").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("java");
         let expected = Some(format!("via {}", Color::Red.dimmed().paint("☕ v13.0.2 ")));
         assert_eq!(expected, actual);
         dir.close()
@@ -288,7 +288,7 @@ mod tests {
     fn folder_with_gradle_kotlin_build_file() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("build.gradle.kts"))?.sync_all()?;
-        let actual = ModuleRenderer::new("java").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("java");
         let expected = Some(format!("via {}", Color::Red.dimmed().paint("☕ v13.0.2 ")));
         assert_eq!(expected, actual);
         dir.close()
@@ -298,7 +298,7 @@ mod tests {
     fn folder_with_sbt_build_file() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("build.gradle.kts"))?.sync_all()?;
-        let actual = ModuleRenderer::new("java").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("java");
         let expected = Some(format!("via {}", Color::Red.dimmed().paint("☕ v13.0.2 ")));
         assert_eq!(expected, actual);
         dir.close()
@@ -308,7 +308,7 @@ mod tests {
     fn folder_with_java_version_file() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join(".java-version"))?.sync_all()?;
-        let actual = ModuleRenderer::new("java").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("java");
         let expected = Some(format!("via {}", Color::Red.dimmed().paint("☕ v13.0.2 ")));
         assert_eq!(expected, actual);
         dir.close()
@@ -321,7 +321,7 @@ mod tests {
         let java_home: PathBuf = ["a", "b", "c"].iter().collect();
         let java_bin = java_home.join("bin").join("java");
 
-        let actual = ModuleRenderer::new("java")
+        let actual = TestRenderer::new()
             .env("JAVA_HOME", java_home.to_str().unwrap())
             .cmd(&format!("{} -Xinternalversion", java_bin.to_str().unwrap()),
             Some(CommandOutput {
@@ -329,7 +329,7 @@ mod tests {
                 stderr: String::new(),
             }))
             .path(dir.path())
-            .collect();
+            .module("java");
         let expected = Some(format!("via {}", Color::Red.dimmed().paint("☕ v11.0.4 ")));
         assert_eq!(expected, actual);
         dir.close()

--- a/src/modules/jobs.rs
+++ b/src/modules/jobs.rs
@@ -65,12 +65,12 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
 #[cfg(test)]
 mod test {
-    use crate::test::ModuleRenderer;
+    use crate::test::TestRenderer;
     use ansi_term::Color;
 
     #[test]
     fn config_blank_job_0() {
-        let actual = ModuleRenderer::new("jobs").jobs(0).collect();
+        let actual = TestRenderer::new().jobs(0).module("jobs");
 
         let expected = None;
         assert_eq!(expected, actual);
@@ -78,7 +78,7 @@ mod test {
 
     #[test]
     fn config_blank_job_1() {
-        let actual = ModuleRenderer::new("jobs").jobs(1).collect();
+        let actual = TestRenderer::new().jobs(1).module("jobs");
 
         let expected = Some(format!("{} ", Color::Blue.bold().paint("✦")));
         assert_eq!(expected, actual);
@@ -86,7 +86,7 @@ mod test {
 
     #[test]
     fn config_blank_job_2() {
-        let actual = ModuleRenderer::new("jobs").jobs(2).collect();
+        let actual = TestRenderer::new().jobs(2).module("jobs");
 
         let expected = Some(format!("{} ", Color::Blue.bold().paint("✦2")));
         assert_eq!(expected, actual);
@@ -94,13 +94,13 @@ mod test {
 
     #[test]
     fn config_2_job_2() {
-        let actual = ModuleRenderer::new("jobs")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [jobs]
                 threshold = 2
             })
             .jobs(2)
-            .collect();
+            .module("jobs");
 
         let expected = Some(format!("{} ", Color::Blue.bold().paint("✦")));
         assert_eq!(expected, actual);
@@ -108,13 +108,13 @@ mod test {
 
     #[test]
     fn config_2_job_3() {
-        let actual = ModuleRenderer::new("jobs")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [jobs]
                 threshold = 2
             })
             .jobs(3)
-            .collect();
+            .module("jobs");
 
         let expected = Some(format!("{} ", Color::Blue.bold().paint("✦3")));
         assert_eq!(expected, actual);
@@ -122,13 +122,13 @@ mod test {
 
     #[test]
     fn config_0_job_0() {
-        let actual = ModuleRenderer::new("jobs")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [jobs]
                 threshold = 0
             })
             .jobs(0)
-            .collect();
+            .module("jobs");
 
         let expected = Some(format!("{} ", Color::Blue.bold().paint("✦0")));
         assert_eq!(expected, actual);
@@ -136,13 +136,13 @@ mod test {
 
     #[test]
     fn config_0_job_1() {
-        let actual = ModuleRenderer::new("jobs")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [jobs]
                 threshold = 0
             })
             .jobs(1)
-            .collect();
+            .module("jobs");
 
         let expected = Some(format!("{} ", Color::Blue.bold().paint("✦1")));
         assert_eq!(expected, actual);

--- a/src/modules/julia.rs
+++ b/src/modules/julia.rs
@@ -75,7 +75,7 @@ fn get_julia_version(julia_stdout: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test::ModuleRenderer;
+    use crate::test::TestRenderer;
     use ansi_term::Color;
     use std::fs::File;
     use std::io;
@@ -84,7 +84,7 @@ mod tests {
     fn folder_without_julia_file() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
 
-        let actual = ModuleRenderer::new("julia").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("julia");
 
         let expected = None;
         assert_eq!(expected, actual);
@@ -96,7 +96,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("hello.jl"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("julia").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("julia");
 
         let expected = Some(format!("via {}", Color::Purple.bold().paint("ஃ v1.4.0 ")));
         assert_eq!(expected, actual);
@@ -108,7 +108,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("Project.toml"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("julia").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("julia");
 
         let expected = Some(format!("via {}", Color::Purple.bold().paint("ஃ v1.4.0 ")));
         assert_eq!(expected, actual);
@@ -120,7 +120,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("Manifest.toml"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("julia").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("julia");
 
         let expected = Some(format!("via {}", Color::Purple.bold().paint("ஃ v1.4.0 ")));
         assert_eq!(expected, actual);

--- a/src/modules/kotlin.rs
+++ b/src/modules/kotlin.rs
@@ -87,7 +87,7 @@ fn parse_kotlin_version(kotlin_stdout: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test::ModuleRenderer;
+    use crate::test::TestRenderer;
     use ansi_term::Color;
     use std::fs::File;
     use std::io;
@@ -95,7 +95,7 @@ mod tests {
     #[test]
     fn folder_without_kotlin_files() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
-        let actual = ModuleRenderer::new("kotlin").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("kotlin");
         let expected = None;
         assert_eq!(expected, actual);
         dir.close()
@@ -105,7 +105,7 @@ mod tests {
     fn folder_with_kotlin_file() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("main.kt"))?.sync_all()?;
-        let actual = ModuleRenderer::new("kotlin").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("kotlin");
         let expected = Some(format!("via {}", Color::Blue.bold().paint("🅺 v1.4.21 ")));
         assert_eq!(expected, actual);
         dir.close()
@@ -115,7 +115,7 @@ mod tests {
     fn folder_with_kotlin_script_file() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("main.kts"))?.sync_all()?;
-        let actual = ModuleRenderer::new("kotlin").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("kotlin");
         let expected = Some(format!("via {}", Color::Blue.bold().paint("🅺 v1.4.21 ")));
         assert_eq!(expected, actual);
         dir.close()
@@ -131,10 +131,10 @@ mod tests {
              kotlin_binary = "kotlin"
         };
 
-        let actual = ModuleRenderer::new("kotlin")
+        let actual = TestRenderer::new()
             .path(dir.path())
             .config(config)
-            .collect();
+            .module("kotlin");
 
         let expected = Some(format!("via {}", Color::Blue.bold().paint("🅺 v1.4.21 ")));
         assert_eq!(expected, actual);
@@ -151,10 +151,10 @@ mod tests {
              kotlin_binary = "kotlinc"
         };
 
-        let actual = ModuleRenderer::new("kotlin")
+        let actual = TestRenderer::new()
             .path(dir.path())
             .config(config)
-            .collect();
+            .module("kotlin");
 
         let expected = Some(format!("via {}", Color::Blue.bold().paint("🅺 v1.4.21 ")));
         assert_eq!(expected, actual);

--- a/src/modules/kubernetes.rs
+++ b/src/modules/kubernetes.rs
@@ -104,7 +104,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
 #[cfg(test)]
 mod tests {
-    use crate::test::ModuleRenderer;
+    use crate::test::TestRenderer;
     use ansi_term::Color;
     use std::env;
     use std::fs::File;
@@ -134,10 +134,10 @@ users: []
         )?;
         file.sync_all()?;
 
-        let actual = ModuleRenderer::new("kubernetes")
+        let actual = TestRenderer::new()
             .path(dir.path())
             .env("KUBECONFIG", filename.to_string_lossy().as_ref())
-            .collect();
+            .module("kubernetes");
 
         assert_eq!(None, actual);
 
@@ -164,7 +164,7 @@ users: []
         )?;
         file.sync_all()?;
 
-        let actual = ModuleRenderer::new("kubernetes")
+        let actual = TestRenderer::new()
             .path(dir.path())
             .env("KUBECONFIG", filename.to_string_lossy().as_ref())
             .config(toml::toml! {
@@ -173,7 +173,7 @@ users: []
                 [kubernetes.context_aliases]
                 "test_context" = "test_alias"
             })
-            .collect();
+            .module("kubernetes");
 
         let expected = Some(format!("{} in ", Color::Cyan.bold().paint("☸ test_alias")));
         assert_eq!(expected, actual);
@@ -205,14 +205,14 @@ users: []
         )?;
         file.sync_all()?;
 
-        let actual = ModuleRenderer::new("kubernetes")
+        let actual = TestRenderer::new()
             .path(dir.path())
             .env("KUBECONFIG", filename.to_string_lossy().as_ref())
             .config(toml::toml! {
                 [kubernetes]
                 disabled = false
             })
-            .collect();
+            .module("kubernetes");
 
         let expected = Some(format!(
             "{} in ",
@@ -248,14 +248,14 @@ users: []
         )?;
         file.sync_all()?;
 
-        let actual = ModuleRenderer::new("kubernetes")
+        let actual = TestRenderer::new()
             .path(dir.path())
             .env("KUBECONFIG", filename.to_string_lossy().as_ref())
             .config(toml::toml! {
                 [kubernetes]
                 disabled = false
             })
-            .collect();
+            .module("kubernetes");
 
         let expected = Some(format!(
             "{} in ",
@@ -296,14 +296,14 @@ users: []
         )?;
         file.sync_all()?;
 
-        let actual = ModuleRenderer::new("kubernetes")
+        let actual = TestRenderer::new()
             .path(dir.path())
             .env("KUBECONFIG", filename.to_string_lossy().as_ref())
             .config(toml::toml! {
                 [kubernetes]
                 disabled = false
             })
-            .collect();
+            .module("kubernetes");
 
         let expected = Some(format!(
             "{} in ",
@@ -354,7 +354,7 @@ users: []
         file_ctx.sync_all()?;
 
         // Test current_context first
-        let actual_cc_first = ModuleRenderer::new("kubernetes")
+        let actual_cc_first = TestRenderer::new()
             .path(dir.path())
             .env(
                 "KUBECONFIG",
@@ -366,10 +366,10 @@ users: []
                 [kubernetes]
                 disabled = false
             })
-            .collect();
+            .module("kubernetes");
 
         // And tes with context and namespace first
-        let actual_ctx_first = ModuleRenderer::new("kubernetes")
+        let actual_ctx_first = TestRenderer::new()
             .path(dir.path())
             .env(
                 "KUBECONFIG",
@@ -381,7 +381,7 @@ users: []
                 [kubernetes]
                 disabled = false
             })
-            .collect();
+            .module("kubernetes");
 
         let expected = Some(format!(
             "{} in ",

--- a/src/modules/line_break.rs
+++ b/src/modules/line_break.rs
@@ -14,12 +14,12 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
 #[cfg(test)]
 mod test {
-    use crate::test::ModuleRenderer;
+    use crate::test::TestRenderer;
 
     #[test]
     fn produces_result() {
         let expected = Some(String::from("\n"));
-        let actual = ModuleRenderer::new("line_break").collect();
+        let actual = TestRenderer::new().module("line_break");
         assert_eq!(expected, actual);
     }
 }

--- a/src/modules/lua.rs
+++ b/src/modules/lua.rs
@@ -87,7 +87,7 @@ fn parse_lua_version(lua_version: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test::ModuleRenderer;
+    use crate::test::TestRenderer;
     use ansi_term::Color;
     use std::fs::{self, File};
     use std::io;
@@ -95,7 +95,7 @@ mod tests {
     #[test]
     fn folder_without_lua_files() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
-        let actual = ModuleRenderer::new("lua").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("lua");
         let expected = None;
         assert_eq!(expected, actual);
         dir.close()
@@ -105,7 +105,7 @@ mod tests {
     fn folder_with_lua_file() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("main.lua"))?.sync_all()?;
-        let actual = ModuleRenderer::new("lua").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("lua");
         let expected = Some(format!("via {}", Color::Blue.bold().paint("🌙 v5.4.0 ")));
         assert_eq!(expected, actual);
         dir.close()
@@ -116,7 +116,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join(".lua-version"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("lua").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("lua");
         let expected = Some(format!("via {}", Color::Blue.bold().paint("🌙 v5.4.0 ")));
         assert_eq!(expected, actual);
         dir.close()
@@ -128,7 +128,7 @@ mod tests {
         let lua_dir = dir.path().join("lua");
         fs::create_dir_all(&lua_dir)?;
 
-        let actual = ModuleRenderer::new("lua").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("lua");
         let expected = Some(format!("via {}", Color::Blue.bold().paint("🌙 v5.4.0 ")));
         assert_eq!(expected, actual);
         dir.close()
@@ -144,10 +144,10 @@ mod tests {
              lua_binary = "luajit"
         };
 
-        let actual = ModuleRenderer::new("lua")
+        let actual = TestRenderer::new()
             .path(dir.path())
             .config(config)
-            .collect();
+            .module("lua");
 
         let expected = Some(format!("via {}", Color::Blue.bold().paint("🌙 v2.0.5 ")));
         assert_eq!(expected, actual);

--- a/src/modules/nim.rs
+++ b/src/modules/nim.rs
@@ -70,7 +70,7 @@ fn parse_nim_version(version_cmd_output: &str) -> Option<&str> {
 #[cfg(test)]
 mod tests {
     use super::parse_nim_version;
-    use crate::test::ModuleRenderer;
+    use crate::test::TestRenderer;
     use ansi_term::Color;
     use std::fs::File;
     use std::io;
@@ -102,7 +102,7 @@ mod tests {
     fn folder_without_nim() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("nim.txt"))?.sync_all()?;
-        let actual = ModuleRenderer::new("nim").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("nim");
         let expected = None;
         assert_eq!(expected, actual);
         dir.close()
@@ -112,7 +112,7 @@ mod tests {
     fn folder_with_nimble_file() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("main.nimble"))?.sync_all()?;
-        let actual = ModuleRenderer::new("nim").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("nim");
         let expected = Some(format!("via {}", Color::Yellow.bold().paint("👑 v1.2.0 ")));
         assert_eq!(expected, actual);
         dir.close()
@@ -122,7 +122,7 @@ mod tests {
     fn folder_with_nim_file() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("main.nim"))?.sync_all()?;
-        let actual = ModuleRenderer::new("nim").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("nim");
         let expected = Some(format!("via {}", Color::Yellow.bold().paint("👑 v1.2.0 ")));
         assert_eq!(expected, actual);
         dir.close()
@@ -132,7 +132,7 @@ mod tests {
     fn folder_with_nims_file() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("main.nims"))?.sync_all()?;
-        let actual = ModuleRenderer::new("nim").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("nim");
         let expected = Some(format!("via {}", Color::Yellow.bold().paint("👑 v1.2.0 ")));
         assert_eq!(expected, actual);
         dir.close()
@@ -142,7 +142,7 @@ mod tests {
     fn folder_with_cfg_file() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("cfg.nim"))?.sync_all()?;
-        let actual = ModuleRenderer::new("nim").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("nim");
         let expected = Some(format!("via {}", Color::Yellow.bold().paint("👑 v1.2.0 ")));
         assert_eq!(expected, actual);
         dir.close()

--- a/src/modules/nix_shell.rs
+++ b/src/modules/nix_shell.rs
@@ -62,12 +62,12 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
 #[cfg(test)]
 mod tests {
-    use crate::test::ModuleRenderer;
+    use crate::test::TestRenderer;
     use ansi_term::Color;
 
     #[test]
     fn no_env_variables() {
-        let actual = ModuleRenderer::new("nix_shell").collect();
+        let actual = TestRenderer::new().module("nix_shell");
         let expected = None;
 
         assert_eq!(expected, actual);
@@ -75,9 +75,9 @@ mod tests {
 
     #[test]
     fn invalid_env_variables() {
-        let actual = ModuleRenderer::new("nix_shell")
+        let actual = TestRenderer::new()
             .env("IN_NIX_SHELL", "something_wrong")
-            .collect();
+            .module("nix_shell");
         let expected = None;
 
         assert_eq!(expected, actual);
@@ -85,9 +85,9 @@ mod tests {
 
     #[test]
     fn pure_shell() {
-        let actual = ModuleRenderer::new("nix_shell")
+        let actual = TestRenderer::new()
             .env("IN_NIX_SHELL", "pure")
-            .collect();
+            .module("nix_shell");
         let expected = Some(format!("via {} ", Color::Blue.bold().paint("❄️  pure")));
 
         assert_eq!(expected, actual);
@@ -95,9 +95,9 @@ mod tests {
 
     #[test]
     fn impure_shell() {
-        let actual = ModuleRenderer::new("nix_shell")
+        let actual = TestRenderer::new()
             .env("IN_NIX_SHELL", "impure")
-            .collect();
+            .module("nix_shell");
         let expected = Some(format!("via {} ", Color::Blue.bold().paint("❄️  impure")));
 
         assert_eq!(expected, actual);
@@ -105,10 +105,10 @@ mod tests {
 
     #[test]
     fn pure_shell_name() {
-        let actual = ModuleRenderer::new("nix_shell")
+        let actual = TestRenderer::new()
             .env("IN_NIX_SHELL", "pure")
             .env("name", "starship")
-            .collect();
+            .module("nix_shell");
         let expected = Some(format!(
             "via {} ",
             Color::Blue.bold().paint("❄️  pure (starship)")
@@ -119,10 +119,10 @@ mod tests {
 
     #[test]
     fn impure_shell_name() {
-        let actual = ModuleRenderer::new("nix_shell")
+        let actual = TestRenderer::new()
             .env("IN_NIX_SHELL", "impure")
             .env("name", "starship")
-            .collect();
+            .module("nix_shell");
         let expected = Some(format!(
             "via {} ",
             Color::Blue.bold().paint("❄️  impure (starship)")

--- a/src/modules/nodejs.rs
+++ b/src/modules/nodejs.rs
@@ -120,7 +120,7 @@ fn format_node_version(node_version: &str, version_format: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use crate::test::ModuleRenderer;
+    use crate::test::TestRenderer;
     use ansi_term::Color;
     use std::fs::{self, File};
     use std::io;
@@ -129,7 +129,7 @@ mod tests {
     #[test]
     fn folder_without_node_files() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
-        let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("nodejs");
         let expected = None;
         assert_eq!(expected, actual);
         dir.close()
@@ -140,7 +140,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("package.json"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("nodejs");
         let expected = Some(format!("via {}", Color::Green.bold().paint(" v12.0.0 ")));
         assert_eq!(expected, actual);
         dir.close()
@@ -153,7 +153,7 @@ mod tests {
         let esy_lock = dir.path().join("esy.lock");
         fs::create_dir_all(&esy_lock)?;
 
-        let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("nodejs");
         let expected = None;
         assert_eq!(expected, actual);
         dir.close()
@@ -164,7 +164,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join(".node-version"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("nodejs");
         let expected = Some(format!("via {}", Color::Green.bold().paint(" v12.0.0 ")));
         assert_eq!(expected, actual);
         dir.close()
@@ -175,7 +175,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join(".nvmrc"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("nodejs");
         let expected = Some(format!("via {}", Color::Green.bold().paint(" v12.0.0 ")));
         assert_eq!(expected, actual);
         dir.close()
@@ -186,7 +186,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("index.js"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("nodejs");
         let expected = Some(format!("via {}", Color::Green.bold().paint(" v12.0.0 ")));
         assert_eq!(expected, actual);
         dir.close()
@@ -197,7 +197,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("index.mjs"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("nodejs");
         let expected = Some(format!("via {}", Color::Green.bold().paint(" v12.0.0 ")));
         assert_eq!(expected, actual);
         dir.close()
@@ -208,7 +208,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("index.cjs"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("nodejs");
         let expected = Some(format!("via {}", Color::Green.bold().paint(" v12.0.0 ")));
         assert_eq!(expected, actual);
         dir.close()
@@ -219,7 +219,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("index.ts"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("nodejs");
         let expected = Some(format!("via {}", Color::Green.bold().paint(" v12.0.0 ")));
         assert_eq!(expected, actual);
         dir.close()
@@ -231,7 +231,7 @@ mod tests {
         let node_modules = dir.path().join("node_modules");
         fs::create_dir_all(&node_modules)?;
 
-        let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("nodejs");
         let expected = Some(format!("via {}", Color::Green.bold().paint(" v12.0.0 ")));
         assert_eq!(expected, actual);
         dir.close()
@@ -250,7 +250,7 @@ mod tests {
         )?;
         file.sync_all()?;
 
-        let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("nodejs");
         let expected = Some(format!("via {}", Color::Green.bold().paint(" v12.0.0 ")));
         assert_eq!(expected, actual);
         dir.close()
@@ -269,7 +269,7 @@ mod tests {
         )?;
         file.sync_all()?;
 
-        let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("nodejs");
         let expected = Some(format!("via {}", Color::Red.bold().paint(" v12.0.0 ")));
         assert_eq!(expected, actual);
         dir.close()

--- a/src/modules/ocaml.rs
+++ b/src/modules/ocaml.rs
@@ -111,7 +111,7 @@ fn parse_opam_switch(opam_switch: &str) -> Option<OpamSwitch> {
 #[cfg(test)]
 mod tests {
     use super::{parse_opam_switch, SwitchType};
-    use crate::{test::ModuleRenderer, utils::CommandOutput};
+    use crate::{test::TestRenderer, utils::CommandOutput};
     use ansi_term::Color;
     use std::fs::{self, File};
     use std::io;
@@ -133,7 +133,7 @@ mod tests {
     #[test]
     fn folder_without_ocaml_file() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
-        let actual = ModuleRenderer::new("ocaml").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("ocaml");
         let expected = None;
         assert_eq!(expected, actual);
         dir.close()
@@ -144,7 +144,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("any.opam"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("ocaml").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("ocaml");
         let expected = Some(format!(
             "via {}",
             Color::Yellow.bold().paint("🐫 v4.10.0 (default) ")
@@ -158,7 +158,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         fs::create_dir_all(dir.path().join("_opam"))?;
 
-        let actual = ModuleRenderer::new("ocaml").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("ocaml");
         let expected = Some(format!(
             "via {}",
             Color::Yellow.bold().paint("🐫 v4.10.0 (default) ")
@@ -176,7 +176,7 @@ mod tests {
             dir.path().join("package.lock"),
             r#"{"dependencies": {"ocaml": "4.8.1000"}}"#,
         )?;
-        let actual = ModuleRenderer::new("ocaml").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("ocaml");
         let expected = Some(format!(
             "via {}",
             Color::Yellow.bold().paint("🐫 v4.08.1 (default) ")
@@ -190,7 +190,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("dune"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("ocaml").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("ocaml");
         let expected = Some(format!(
             "via {}",
             Color::Yellow.bold().paint("🐫 v4.10.0 (default) ")
@@ -204,7 +204,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("dune-project"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("ocaml").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("ocaml");
         let expected = Some(format!(
             "via {}",
             Color::Yellow.bold().paint("🐫 v4.10.0 (default) ")
@@ -218,7 +218,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("jbuild"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("ocaml").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("ocaml");
         let expected = Some(format!(
             "via {}",
             Color::Yellow.bold().paint("🐫 v4.10.0 (default) ")
@@ -232,7 +232,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("jbuild-ignore"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("ocaml").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("ocaml");
         let expected = Some(format!(
             "via {}",
             Color::Yellow.bold().paint("🐫 v4.10.0 (default) ")
@@ -246,7 +246,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join(".merlin"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("ocaml").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("ocaml");
         let expected = Some(format!(
             "via {}",
             Color::Yellow.bold().paint("🐫 v4.10.0 (default) ")
@@ -260,7 +260,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("any.ml"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("ocaml").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("ocaml");
         let expected = Some(format!(
             "via {}",
             Color::Yellow.bold().paint("🐫 v4.10.0 (default) ")
@@ -274,7 +274,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("any.mli"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("ocaml").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("ocaml");
         let expected = Some(format!(
             "via {}",
             Color::Yellow.bold().paint("🐫 v4.10.0 (default) ")
@@ -288,7 +288,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("any.re"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("ocaml").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("ocaml");
         let expected = Some(format!(
             "via {}",
             Color::Yellow.bold().paint("🐫 v4.10.0 (default) ")
@@ -302,7 +302,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("any.rei"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("ocaml").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("ocaml");
         let expected = Some(format!(
             "via {}",
             Color::Yellow.bold().paint("🐫 v4.10.0 (default) ")
@@ -316,7 +316,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("any.ml"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("ocaml")
+        let actual = TestRenderer::new()
             .cmd(
                 "opam switch show --safe",
                 Some(CommandOutput {
@@ -325,7 +325,7 @@ mod tests {
                 }),
             )
             .path(dir.path())
-            .collect();
+            .module("ocaml");
         let expected = Some(format!("via {}", Color::Yellow.bold().paint("🐫 v4.10.0 ")));
         assert_eq!(expected, actual);
         dir.close()
@@ -336,7 +336,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("any.ml"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("ocaml")
+        let actual = TestRenderer::new()
             .cmd(
                 "opam switch show --safe",
                 Some(CommandOutput {
@@ -345,7 +345,7 @@ mod tests {
                 }),
             )
             .path(dir.path())
-            .collect();
+            .module("ocaml");
         let expected = Some(format!(
             "via {}",
             Color::Yellow
@@ -361,7 +361,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("any.ml"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("ocaml")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [ocaml]
                 global_switch_indicator = "g/"
@@ -374,7 +374,7 @@ mod tests {
                 }),
             )
             .path(dir.path())
-            .collect();
+            .module("ocaml");
         let expected = Some(format!(
             "via {}",
             Color::Yellow
@@ -390,7 +390,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("any.ml"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("ocaml")
+        let actual = TestRenderer::new()
             .cmd(
                 "opam switch show --safe",
                 Some(CommandOutput {
@@ -399,7 +399,7 @@ mod tests {
                 }),
             )
             .path(dir.path())
-            .collect();
+            .module("ocaml");
         let expected = Some(format!(
             "via {}",
             Color::Yellow.bold().paint("🐫 v4.10.0 (*my-project) ")
@@ -413,7 +413,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("any.ml"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("ocaml")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [ocaml]
                 local_switch_indicator = "^"
@@ -426,7 +426,7 @@ mod tests {
                 }),
             )
             .path(dir.path())
-            .collect();
+            .module("ocaml");
         let expected = Some(format!(
             "via {}",
             Color::Yellow.bold().paint("🐫 v4.10.0 (^my-project) ")

--- a/src/modules/openstack.rs
+++ b/src/modules/openstack.rs
@@ -85,7 +85,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
 #[cfg(test)]
 mod tests {
-    use crate::test::ModuleRenderer;
+    use crate::test::TestRenderer;
     use ansi_term::Color;
     use std::fs::File;
     use std::io::{self, Write};
@@ -106,13 +106,13 @@ clouds:
     interface: public
 ",
         )?;
-        let actual = ModuleRenderer::new("openstack")
+        let actual = TestRenderer::new()
             .env("PWD", dir.path().to_str().unwrap())
             .env("OS_CLOUD", "corp")
             .config(toml::toml! {
                 [openstack]
             })
-            .collect();
+            .module("openstack");
         let expected = Some(format!(
             "on {} ",
             Color::Yellow.bold().paint("☁️  corp(testproject)")
@@ -132,13 +132,13 @@ clouds:
 dummy_yaml
 ",
         )?;
-        let actual = ModuleRenderer::new("openstack")
+        let actual = TestRenderer::new()
             .env("PWD", dir.path().to_str().unwrap())
             .env("OS_CLOUD", "test")
             .config(toml::toml! {
                 [openstack]
             })
-            .collect();
+            .module("openstack");
         let expected = Some(format!("on {} ", Color::Yellow.bold().paint("☁️  test")));
 
         assert_eq!(actual, expected);
@@ -152,13 +152,13 @@ dummy_yaml
         let mut file = File::create(&config_path)?;
         file.write_all(b"")?;
         drop(file);
-        let actual = ModuleRenderer::new("openstack")
+        let actual = TestRenderer::new()
             .env("PWD", dir.path().to_str().unwrap())
             .env("OS_CLOUD", "test")
             .config(toml::toml! {
                 [openstack]
             })
-            .collect();
+            .module("openstack");
         let expected = Some(format!("on {} ", Color::Yellow.bold().paint("☁️  test")));
 
         assert_eq!(actual, expected);

--- a/src/modules/package.rs
+++ b/src/modules/package.rs
@@ -252,7 +252,7 @@ fn format_version(version: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{test::ModuleRenderer, utils::CommandOutput};
+    use crate::{test::TestRenderer, utils::CommandOutput};
     use ansi_term::Color;
     use std::fs::File;
     use std::io;
@@ -308,7 +308,7 @@ license = "MIT"
             [package]
             disabled = false
         };
-        let actual = ModuleRenderer::new("package")
+        let actual = TestRenderer::new()
             .cmd(
                 "nimble dump --json",
                 Some(CommandOutput {
@@ -338,7 +338,7 @@ license = "MIT"
             )
             .path(project_dir.path())
             .config(starship_config)
-            .collect();
+            .module("package");
 
         let expected = Some(format!(
             "is {} ",
@@ -368,11 +368,11 @@ license = "MIT"
             [package]
             disabled = false
         };
-        let actual = ModuleRenderer::new("package")
+        let actual = TestRenderer::new()
             .cmd("nimble dump --json", None)
             .path(project_dir.path())
             .config(starship_config)
-            .collect();
+            .module("package");
 
         let expected = None;
 
@@ -389,11 +389,11 @@ license = "MIT"
             [package]
             disabled = false
         };
-        let actual = ModuleRenderer::new("package")
+        let actual = TestRenderer::new()
             .cmd("nimble dump --json", None)
             .path(project_dir.path())
             .config(starship_config)
-            .collect();
+            .module("package");
 
         let expected = None;
 
@@ -1015,10 +1015,10 @@ Module {
             disabled = false
         });
 
-        let actual = ModuleRenderer::new("package")
+        let actual = TestRenderer::new()
             .path(project_dir.path())
             .config(starship_config)
-            .collect();
+            .module("package");
         let text = String::from(contains.unwrap_or(""));
         let expected = Some(format!(
             "is {} ",

--- a/src/modules/perl.rs
+++ b/src/modules/perl.rs
@@ -59,7 +59,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
 #[cfg(test)]
 mod tests {
-    use crate::test::ModuleRenderer;
+    use crate::test::TestRenderer;
     use ansi_term::Color;
     use std::fs::File;
     use std::io;
@@ -68,7 +68,7 @@ mod tests {
     fn folder_without_perl_files() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
 
-        let actual = ModuleRenderer::new("perl").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("perl");
 
         let expected = None;
         assert_eq!(expected, actual);
@@ -80,7 +80,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("Makefile.PL"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("perl").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("perl");
 
         let expected = Some(format!(
             "via {}",
@@ -95,7 +95,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("Build.PL"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("perl").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("perl");
 
         let expected = Some(format!(
             "via {}",
@@ -110,7 +110,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("cpanfile"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("perl").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("perl");
 
         let expected = Some(format!(
             "via {}",
@@ -125,7 +125,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("cpanfile.snapshot"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("perl").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("perl");
 
         let expected = Some(format!(
             "via {}",
@@ -140,7 +140,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("META.json"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("perl").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("perl");
 
         let expected = Some(format!(
             "via {}",
@@ -155,7 +155,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("META.yml"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("perl").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("perl");
 
         let expected = Some(format!(
             "via {}",
@@ -170,7 +170,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join(".perl-version"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("perl").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("perl");
 
         let expected = Some(format!(
             "via {}",
@@ -185,7 +185,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("any.pl"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("perl").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("perl");
 
         let expected = Some(format!(
             "via {}",
@@ -200,7 +200,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("any.pm"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("perl").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("perl");
 
         let expected = Some(format!(
             "via {}",
@@ -215,7 +215,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("any.pod"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("perl").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("perl");
 
         let expected = Some(format!(
             "via {}",

--- a/src/modules/php.rs
+++ b/src/modules/php.rs
@@ -58,7 +58,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
 #[cfg(test)]
 mod tests {
-    use crate::test::ModuleRenderer;
+    use crate::test::TestRenderer;
     use ansi_term::Color;
     use std::fs::File;
     use std::io;
@@ -67,7 +67,7 @@ mod tests {
     fn folder_without_php_files() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
 
-        let actual = ModuleRenderer::new("php").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("php");
 
         let expected = None;
         assert_eq!(expected, actual);
@@ -79,7 +79,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("composer.json"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("php").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("php");
 
         let expected = Some(format!(
             "via {}",
@@ -94,7 +94,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join(".php-version"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("php").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("php");
 
         let expected = Some(format!(
             "via {}",
@@ -109,7 +109,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("any.php"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("php").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("php");
 
         let expected = Some(format!(
             "via {}",

--- a/src/modules/purescript.rs
+++ b/src/modules/purescript.rs
@@ -57,7 +57,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
 #[cfg(test)]
 mod tests {
-    use crate::test::ModuleRenderer;
+    use crate::test::TestRenderer;
     use ansi_term::Color;
     use std::fs::File;
     use std::io;
@@ -65,7 +65,7 @@ mod tests {
     #[test]
     fn folder_without_purescript_files() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
-        let actual = ModuleRenderer::new("purescript").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("purescript");
         let expected = None;
         assert_eq!(expected, actual);
         dir.close()
@@ -76,7 +76,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("Main.purs"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("purescript").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("purescript");
         let expected = Some(format!("via {}", Color::White.bold().paint("<=> v0.13.5 ")));
         assert_eq!(expected, actual);
         dir.close()
@@ -87,7 +87,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("spago.dhall"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("purescript").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("purescript");
         let expected = Some(format!("via {}", Color::White.bold().paint("<=> v0.13.5 ")));
         assert_eq!(expected, actual);
         dir.close()

--- a/src/modules/python.rs
+++ b/src/modules/python.rs
@@ -120,7 +120,7 @@ fn get_prompt_from_venv(venv_path: &Path) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test::ModuleRenderer;
+    use crate::test::TestRenderer;
     use ansi_term::Color;
     use std::fs::{create_dir_all, File};
     use std::io;
@@ -177,7 +177,7 @@ Python 3.7.9 (7e6e2bb30ac5fbdbd443619cae28c51d5c162a02, Nov 24 2020, 10:03:59)
     #[test]
     fn folder_without_python_files() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
-        let actual = ModuleRenderer::new("python").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("python");
         let expected = None;
         assert_eq!(expected, actual);
 
@@ -290,10 +290,10 @@ Python 3.7.9 (7e6e2bb30ac5fbdbd443619cae28c51d5c162a02, Nov 24 2020, 10:03:59)
             [python]
             detect_extensions = []
         };
-        let actual = ModuleRenderer::new("python")
+        let actual = TestRenderer::new()
             .path(dir.path())
             .config(config)
-            .collect();
+            .module("python");
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -341,10 +341,10 @@ Python 3.7.9 (7e6e2bb30ac5fbdbd443619cae28c51d5c162a02, Nov 24 2020, 10:03:59)
     fn with_virtual_env() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("main.py"))?.sync_all()?;
-        let actual = ModuleRenderer::new("python")
+        let actual = TestRenderer::new()
             .path(dir.path())
             .env("VIRTUAL_ENV", "/foo/bar/my_venv")
-            .collect();
+            .module("python");
 
         let expected = Some(format!(
             "via {}",
@@ -359,10 +359,10 @@ Python 3.7.9 (7e6e2bb30ac5fbdbd443619cae28c51d5c162a02, Nov 24 2020, 10:03:59)
     fn with_active_venv() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
 
-        let actual = ModuleRenderer::new("python")
+        let actual = TestRenderer::new()
             .path(dir.path())
             .env("VIRTUAL_ENV", "/foo/bar/my_venv")
-            .collect();
+            .module("python");
 
         let expected = Some(format!(
             "via {}",
@@ -386,10 +386,10 @@ prompt = 'foo'
         )?;
         venv_cfg.sync_all()?;
 
-        let actual = ModuleRenderer::new("python")
+        let actual = TestRenderer::new()
             .path(dir.path())
             .env("VIRTUAL_ENV", dir.path().join("my_venv").to_str().unwrap())
-            .collect();
+            .module("python");
 
         let expected = Some(format!(
             "via {}",
@@ -413,10 +413,10 @@ prompt = '(foo)'
         )?;
         venv_cfg.sync_all()?;
 
-        let actual = ModuleRenderer::new("python")
+        let actual = TestRenderer::new()
             .path(dir.path())
             .env("VIRTUAL_ENV", dir.path().join("my_venv").to_str().unwrap())
-            .collect();
+            .module("python");
 
         let expected = Some(format!(
             "via {}",
@@ -433,10 +433,10 @@ prompt = '(foo)'
             python_binary = "python2"
         });
 
-        let actual = ModuleRenderer::new("python")
+        let actual = TestRenderer::new()
             .path(dir.path())
             .config(config)
-            .collect();
+            .module("python");
 
         let expected = Some(format!("via {}", Color::Yellow.bold().paint("🐍 v2.7.17 ")));
         assert_eq!(expected, actual);
@@ -448,10 +448,10 @@ prompt = '(foo)'
              python_binary = "python3"
         });
 
-        let actual = ModuleRenderer::new("python")
+        let actual = TestRenderer::new()
             .path(dir.path())
             .config(config)
-            .collect();
+            .module("python");
 
         let expected = Some(format!("via {}", Color::Yellow.bold().paint("🐍 v3.8.0 ")));
         assert_eq!(expected, actual);
@@ -466,10 +466,10 @@ prompt = '(foo)'
              python_binary = ["python", "python3"]
         });
 
-        let actual = ModuleRenderer::new("python")
+        let actual = TestRenderer::new()
             .path(dir.path())
             .config(config)
-            .collect();
+            .module("python");
 
         let expected = Some(format!("via {}", Color::Yellow.bold().paint("🐍 v3.8.0 ")));
         assert_eq!(expected, actual);
@@ -482,10 +482,10 @@ prompt = '(foo)'
              pyenv_prefix = "test_pyenv "
         });
 
-        let actual = ModuleRenderer::new("python")
+        let actual = TestRenderer::new()
             .path(dir.path())
             .config(config)
-            .collect();
+            .module("python");
 
         let expected = Some(format!(
             "via {}",

--- a/src/modules/red.rs
+++ b/src/modules/red.rs
@@ -56,7 +56,7 @@ fn parse_red_version(red_version: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::parse_red_version;
-    use crate::test::ModuleRenderer;
+    use crate::test::TestRenderer;
     use ansi_term::Color;
     use std::fs::File;
     use std::io;
@@ -70,7 +70,7 @@ mod tests {
     #[test]
     fn folder_without_red_files() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
-        let actual = ModuleRenderer::new("red").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("red");
         let expected = None;
         assert_eq!(expected, actual);
         dir.close()
@@ -80,7 +80,7 @@ mod tests {
     fn folder_with_red_files() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("hello.red"))?.sync_all()?;
-        let actual = ModuleRenderer::new("red").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("red");
         let expected = Some(format!("via {}", Color::Red.bold().paint("🔺 v0.6.4 ")));
         assert_eq!(expected, actual);
         dir.close()
@@ -90,7 +90,7 @@ mod tests {
     fn folder_with_reds_files() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("hello.reds"))?.sync_all()?;
-        let actual = ModuleRenderer::new("red").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("red");
         let expected = Some(format!("via {}", Color::Red.bold().paint("🔺 v0.6.4 ")));
         assert_eq!(expected, actual);
         dir.close()

--- a/src/modules/rlang.rs
+++ b/src/modules/rlang.rs
@@ -74,7 +74,7 @@ fn parse_version(r_version: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::parse_version;
-    use crate::test::ModuleRenderer;
+    use crate::test::TestRenderer;
     use ansi_term::Color;
     use std::fs;
     use std::fs::File;
@@ -152,7 +152,7 @@ https://www.gnu.org/licenses/."#;
     }
 
     fn check_r_render(dir: &tempfile::TempDir) {
-        let actual = ModuleRenderer::new("rlang").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("rlang");
         let expected = Some(format!("via {}", Color::Blue.bold().paint("📐 v4.1.0 ")));
         assert_eq!(expected, actual);
     }

--- a/src/modules/ruby.rs
+++ b/src/modules/ruby.rs
@@ -78,7 +78,7 @@ fn format_ruby_version(ruby_version: &str, version_format: &str) -> Option<Strin
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test::ModuleRenderer;
+    use crate::test::TestRenderer;
     use ansi_term::Color;
     use std::fs::File;
     use std::io;
@@ -87,7 +87,7 @@ mod tests {
     fn folder_without_ruby_files() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
 
-        let actual = ModuleRenderer::new("ruby").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("ruby");
 
         let expected = None;
         assert_eq!(expected, actual);
@@ -99,7 +99,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("Gemfile"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("ruby").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("ruby");
 
         let expected = Some(format!("via {}", Color::Red.bold().paint("💎 v2.5.1 ")));
         assert_eq!(expected, actual);
@@ -111,7 +111,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join(".ruby-version"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("ruby").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("ruby");
 
         let expected = Some(format!("via {}", Color::Red.bold().paint("💎 v2.5.1 ")));
         assert_eq!(expected, actual);
@@ -123,7 +123,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("any.rb"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("ruby").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("ruby");
 
         let expected = Some(format!("via {}", Color::Red.bold().paint("💎 v2.5.1 ")));
         assert_eq!(expected, actual);

--- a/src/modules/scala.rs
+++ b/src/modules/scala.rs
@@ -79,7 +79,7 @@ fn parse_scala_version(scala_version: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test::ModuleRenderer;
+    use crate::test::TestRenderer;
     use ansi_term::Color;
     use std::fs::{self, File};
     use std::io;
@@ -103,7 +103,7 @@ mod tests {
     #[test]
     fn folder_without_scala_file() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
-        let actual = ModuleRenderer::new("scala").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("scala");
         let expected = None;
         assert_eq!(expected, actual);
         dir.close()
@@ -113,7 +113,7 @@ mod tests {
     fn folder_with_scala_file() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("Test.scala"))?.sync_all()?;
-        let actual = ModuleRenderer::new("scala").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("scala");
         let expected = Some(format!("via {}", Color::Red.bold().paint("🆂 v2.13.5 ")));
         assert_eq!(expected, actual);
         dir.close()
@@ -123,10 +123,10 @@ mod tests {
     fn folder_with_scala_file_no_scala_installed() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("Test.scala"))?.sync_all()?;
-        let actual = ModuleRenderer::new("scala")
+        let actual = TestRenderer::new()
             .cmd("scalac -version", None)
             .path(dir.path())
-            .collect();
+            .module("scala");
         let expected = Some(format!("via {}", Color::Red.bold().paint("🆂 ")));
         assert_eq!(expected, actual);
         dir.close()
@@ -136,7 +136,7 @@ mod tests {
     fn folder_with_sbt_file() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("build.sbt"))?.sync_all()?;
-        let actual = ModuleRenderer::new("scala").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("scala");
         let expected = Some(format!("via {}", Color::Red.bold().paint("🆂 v2.13.5 ")));
         assert_eq!(expected, actual);
         dir.close()
@@ -146,7 +146,7 @@ mod tests {
     fn folder_with_scala_env_file() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join(".scalaenv"))?.sync_all()?;
-        let actual = ModuleRenderer::new("scala").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("scala");
         let expected = Some(format!("via {}", Color::Red.bold().paint("🆂 v2.13.5 ")));
         assert_eq!(expected, actual);
         dir.close()
@@ -156,7 +156,7 @@ mod tests {
     fn folder_with_sbt_env_file() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join(".sbtenv"))?.sync_all()?;
-        let actual = ModuleRenderer::new("scala").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("scala");
         let expected = Some(format!("via {}", Color::Red.bold().paint("🆂 v2.13.5 ")));
         assert_eq!(expected, actual);
         dir.close()
@@ -166,7 +166,7 @@ mod tests {
     fn folder_with_metals_dir() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         fs::create_dir_all(dir.path().join(".metals"))?;
-        let actual = ModuleRenderer::new("scala").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("scala");
         let expected = Some(format!("via {}", Color::Red.bold().paint("🆂 v2.13.5 ")));
         assert_eq!(expected, actual);
         dir.close()

--- a/src/modules/shell.rs
+++ b/src/modules/shell.rs
@@ -57,13 +57,13 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 #[cfg(test)]
 mod tests {
     use crate::context::Shell;
-    use crate::test::ModuleRenderer;
+    use crate::test::TestRenderer;
     use ansi_term::Color;
 
     #[test]
     fn test_none_if_disabled() {
         let expected = None;
-        let actual = ModuleRenderer::new("shell").shell(Shell::Bash).collect();
+        let actual = TestRenderer::new().shell(Shell::Bash).module("shell");
 
         assert_eq!(expected, actual);
     }
@@ -71,7 +71,7 @@ mod tests {
     #[test]
     fn test_none_if_unknown_shell() {
         let expected = None;
-        let actual = ModuleRenderer::new("shell").shell(Shell::Unknown).collect();
+        let actual = TestRenderer::new().shell(Shell::Unknown).module("shell");
 
         assert_eq!(expected, actual);
     }
@@ -79,13 +79,13 @@ mod tests {
     #[test]
     fn test_bash_default_format() {
         let expected = Some(format!("{} ", "bsh"));
-        let actual = ModuleRenderer::new("shell")
+        let actual = TestRenderer::new()
             .shell(Shell::Bash)
             .config(toml::toml! {
                 [shell]
                 disabled = false
             })
-            .collect();
+            .module("shell");
 
         assert_eq!(expected, actual);
     }
@@ -93,14 +93,14 @@ mod tests {
     #[test]
     fn test_bash_custom_format() {
         let expected = Some(format!("{} ", Color::Cyan.bold().paint("bash")));
-        let actual = ModuleRenderer::new("shell")
+        let actual = TestRenderer::new()
             .shell(Shell::Bash)
             .config(toml::toml! {
                 [shell]
                 bash_indicator = "[bash](bold cyan)"
                 disabled = false
             })
-            .collect();
+            .module("shell");
 
         assert_eq!(expected, actual);
     }
@@ -108,13 +108,13 @@ mod tests {
     #[test]
     fn test_fish_default_format() {
         let expected = Some(format!("{} ", "fsh"));
-        let actual = ModuleRenderer::new("shell")
+        let actual = TestRenderer::new()
             .shell(Shell::Fish)
             .config(toml::toml! {
                 [shell]
                 disabled = false
             })
-            .collect();
+            .module("shell");
 
         assert_eq!(expected, actual);
     }
@@ -122,14 +122,14 @@ mod tests {
     #[test]
     fn test_fish_custom_format() {
         let expected = Some(format!("{} ", Color::Cyan.bold().paint("fish")));
-        let actual = ModuleRenderer::new("shell")
+        let actual = TestRenderer::new()
             .shell(Shell::Fish)
             .config(toml::toml! {
                 [shell]
                 fish_indicator = "[fish](cyan bold)"
                 disabled = false
             })
-            .collect();
+            .module("shell");
 
         assert_eq!(expected, actual);
     }
@@ -137,13 +137,13 @@ mod tests {
     #[test]
     fn test_zsh_default_format() {
         let expected = Some(format!("{} ", "zsh"));
-        let actual = ModuleRenderer::new("shell")
+        let actual = TestRenderer::new()
             .shell(Shell::Zsh)
             .config(toml::toml! {
                 [shell]
                 disabled = false
             })
-            .collect();
+            .module("shell");
 
         assert_eq!(expected, actual);
     }
@@ -151,14 +151,14 @@ mod tests {
     #[test]
     fn test_zsh_custom_format() {
         let expected = Some(format!("{} ", Color::Cyan.bold().paint("zsh")));
-        let actual = ModuleRenderer::new("shell")
+        let actual = TestRenderer::new()
             .shell(Shell::Bash)
             .config(toml::toml! {
                 [shell]
                 bash_indicator = "[zsh](bold cyan)"
                 disabled = false
             })
-            .collect();
+            .module("shell");
 
         assert_eq!(expected, actual);
     }
@@ -166,13 +166,13 @@ mod tests {
     #[test]
     fn test_powershell_default_format() {
         let expected = Some(format!("{} ", "psh"));
-        let actual = ModuleRenderer::new("shell")
+        let actual = TestRenderer::new()
             .shell(Shell::PowerShell)
             .config(toml::toml! {
                 [shell]
                 disabled = false
             })
-            .collect();
+            .module("shell");
 
         assert_eq!(expected, actual);
     }
@@ -180,14 +180,14 @@ mod tests {
     #[test]
     fn test_powershell_custom_format() {
         let expected = Some(format!("{} ", Color::Cyan.bold().paint("powershell")));
-        let actual = ModuleRenderer::new("shell")
+        let actual = TestRenderer::new()
             .shell(Shell::PowerShell)
             .config(toml::toml! {
                 [shell]
                 powershell_indicator = "[powershell](bold cyan)"
                 disabled = false
             })
-            .collect();
+            .module("shell");
 
         assert_eq!(expected, actual);
     }
@@ -195,13 +195,13 @@ mod tests {
     #[test]
     fn test_ion_default_format() {
         let expected = Some(format!("{} ", "ion"));
-        let actual = ModuleRenderer::new("shell")
+        let actual = TestRenderer::new()
             .shell(Shell::Ion)
             .config(toml::toml! {
                 [shell]
                 disabled = false
             })
-            .collect();
+            .module("shell");
 
         assert_eq!(expected, actual);
     }
@@ -209,14 +209,14 @@ mod tests {
     #[test]
     fn test_ion_custom_format() {
         let expected = Some(format!("{} ", Color::Cyan.bold().paint("ion")));
-        let actual = ModuleRenderer::new("shell")
+        let actual = TestRenderer::new()
             .shell(Shell::Ion)
             .config(toml::toml! {
                 [shell]
                 ion_indicator = "[ion](bold cyan)"
                 disabled = false
             })
-            .collect();
+            .module("shell");
 
         assert_eq!(expected, actual);
     }
@@ -224,13 +224,13 @@ mod tests {
     #[test]
     fn test_elvish_default_format() {
         let expected = Some(format!("{} ", "esh"));
-        let actual = ModuleRenderer::new("shell")
+        let actual = TestRenderer::new()
             .shell(Shell::Elvish)
             .config(toml::toml! {
                 [shell]
                 disabled = false
             })
-            .collect();
+            .module("shell");
 
         assert_eq!(expected, actual);
     }
@@ -238,14 +238,14 @@ mod tests {
     #[test]
     fn test_elvish_custom_format() {
         let expected = Some(format!("{} ", Color::Cyan.bold().paint("elvish")));
-        let actual = ModuleRenderer::new("shell")
+        let actual = TestRenderer::new()
             .shell(Shell::Elvish)
             .config(toml::toml! {
                 [shell]
                 elvish_indicator = "[elvish](bold cyan)"
                 disabled = false
             })
-            .collect();
+            .module("shell");
 
         assert_eq!(expected, actual);
     }
@@ -253,13 +253,13 @@ mod tests {
     #[test]
     fn test_nu_default_format() {
         let expected = Some(format!("{} ", "nu"));
-        let actual = ModuleRenderer::new("shell")
+        let actual = TestRenderer::new()
             .shell(Shell::Nu)
             .config(toml::toml! {
                 [shell]
                 disabled = false
             })
-            .collect();
+            .module("shell");
 
         assert_eq!(expected, actual);
     }
@@ -267,14 +267,14 @@ mod tests {
     #[test]
     fn test_nu_custom_format() {
         let expected = Some(format!("{} ", Color::Cyan.bold().paint("nu")));
-        let actual = ModuleRenderer::new("shell")
+        let actual = TestRenderer::new()
             .shell(Shell::Nu)
             .config(toml::toml! {
                 [shell]
                 nu_indicator = "[nu](bold cyan)"
                 disabled = false
             })
-            .collect();
+            .module("shell");
 
         assert_eq!(expected, actual);
     }
@@ -282,7 +282,7 @@ mod tests {
     #[test]
     fn test_custom_format_conditional_indicator_match() {
         let expected = Some(format!("{} ", "B"));
-        let actual = ModuleRenderer::new("shell")
+        let actual = TestRenderer::new()
             .shell(Shell::Bash)
             .config(toml::toml! {
                 [shell]
@@ -290,7 +290,7 @@ mod tests {
                 format = "($bash_indicator )"
                 disabled = false
             })
-            .collect();
+            .module("shell");
 
         assert_eq!(expected, actual);
     }
@@ -298,7 +298,7 @@ mod tests {
     #[test]
     fn test_custom_format_conditional_indicator_no_match() {
         let expected = None;
-        let actual = ModuleRenderer::new("shell")
+        let actual = TestRenderer::new()
             .shell(Shell::Fish)
             .config(toml::toml! {
                 [shell]
@@ -306,7 +306,7 @@ mod tests {
                 format = "($indicator )"
                 disabled = false
             })
-            .collect();
+            .module("shell");
 
         assert_eq!(expected, actual);
     }

--- a/src/modules/shlvl.rs
+++ b/src/modules/shlvl.rs
@@ -65,7 +65,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 mod tests {
     use ansi_term::{Color, Style};
 
-    use crate::test::ModuleRenderer;
+    use crate::test::TestRenderer;
 
     use super::SHLVL_ENV_VAR;
 
@@ -76,12 +76,12 @@ mod tests {
 
     #[test]
     fn empty_config() {
-        let actual = ModuleRenderer::new("shlvl")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [shlvl]
             })
             .env(SHLVL_ENV_VAR, "2")
-            .collect();
+            .module("shlvl");
         let expected = None;
 
         assert_eq!(expected, actual);
@@ -89,13 +89,13 @@ mod tests {
 
     #[test]
     fn enabled() {
-        let actual = ModuleRenderer::new("shlvl")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [shlvl]
                 disabled = false
             })
             .env(SHLVL_ENV_VAR, "2")
-            .collect();
+            .module("shlvl");
         let expected = Some(format!("{} ", style().paint("↕️  2")));
 
         assert_eq!(expected, actual);
@@ -103,12 +103,12 @@ mod tests {
 
     #[test]
     fn no_level() {
-        let actual = ModuleRenderer::new("shlvl")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [shlvl]
                 disabled = false
             })
-            .collect();
+            .module("shlvl");
         let expected = None;
 
         assert_eq!(expected, actual);
@@ -116,13 +116,13 @@ mod tests {
 
     #[test]
     fn enabled_config_level_1() {
-        let actual = ModuleRenderer::new("shlvl")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [shlvl]
                 disabled = false
             })
             .env(SHLVL_ENV_VAR, "1")
-            .collect();
+            .module("shlvl");
         let expected = None;
 
         assert_eq!(expected, actual);
@@ -130,14 +130,14 @@ mod tests {
 
     #[test]
     fn lower_threshold() {
-        let actual = ModuleRenderer::new("shlvl")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [shlvl]
                 threshold = 1
                 disabled = false
             })
             .env(SHLVL_ENV_VAR, "1")
-            .collect();
+            .module("shlvl");
         let expected = Some(format!("{} ", style().paint("↕️  1")));
 
         assert_eq!(expected, actual);
@@ -145,14 +145,14 @@ mod tests {
 
     #[test]
     fn higher_threshold() {
-        let actual = ModuleRenderer::new("shlvl")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [shlvl]
                 threshold = 3
                 disabled = false
             })
             .env(SHLVL_ENV_VAR, "1")
-            .collect();
+            .module("shlvl");
         let expected = None;
 
         assert_eq!(expected, actual);
@@ -160,14 +160,14 @@ mod tests {
 
     #[test]
     fn custom_style() {
-        let actual = ModuleRenderer::new("shlvl")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [shlvl]
                 style = "Red Underline"
                 disabled = false
             })
             .env(SHLVL_ENV_VAR, "2")
-            .collect();
+            .module("shlvl");
         let expected = Some(format!("{} ", Color::Red.underline().paint("↕️  2")));
 
         assert_eq!(expected, actual);
@@ -175,14 +175,14 @@ mod tests {
 
     #[test]
     fn custom_symbol() {
-        let actual = ModuleRenderer::new("shlvl")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [shlvl]
                 symbol = "shlvl is "
                 disabled = false
             })
             .env(SHLVL_ENV_VAR, "2")
-            .collect();
+            .module("shlvl");
         let expected = Some(format!("{} ", style().paint("shlvl is 2")));
 
         assert_eq!(expected, actual);
@@ -190,14 +190,14 @@ mod tests {
 
     #[test]
     fn formatting() {
-        let actual = ModuleRenderer::new("shlvl")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [shlvl]
                 format = "$symbol going down [$shlvl]($style) GOING UP "
                 disabled = false
             })
             .env(SHLVL_ENV_VAR, "2")
-            .collect();
+            .module("shlvl");
         let expected = Some(format!("↕️   going down {} GOING UP ", style().paint("2")));
 
         assert_eq!(expected, actual);
@@ -205,7 +205,7 @@ mod tests {
 
     #[test]
     fn repeat() {
-        let actual = ModuleRenderer::new("shlvl")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [shlvl]
                 format = "[$symbol>]($style) "
@@ -214,7 +214,7 @@ mod tests {
                 disabled = false
             })
             .env(SHLVL_ENV_VAR, "3")
-            .collect();
+            .module("shlvl");
         let expected = Some(format!("{} ", style().paint("~~~>")));
 
         assert_eq!(expected, actual);

--- a/src/modules/singularity.rs
+++ b/src/modules/singularity.rs
@@ -42,21 +42,21 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
 #[cfg(test)]
 mod tests {
-    use crate::test::ModuleRenderer;
+    use crate::test::TestRenderer;
     use ansi_term::Color;
 
     #[test]
     fn no_env_set() {
-        let actual = ModuleRenderer::new("singularity").collect();
+        let actual = TestRenderer::new().module("singularity");
 
         let expected = None;
         assert_eq!(expected, actual);
     }
     #[test]
     fn env_set() {
-        let actual = ModuleRenderer::new("singularity")
+        let actual = TestRenderer::new()
             .env("SINGULARITY_NAME", "centos.img")
-            .collect();
+            .module("singularity");
 
         let expected = Some(format!(
             "{} ",

--- a/src/modules/status.rs
+++ b/src/modules/status.rs
@@ -148,29 +148,29 @@ fn status_signal_name(signal: SignalNumber) -> Option<&'static str> {
 mod tests {
     use ansi_term::Color;
 
-    use crate::test::ModuleRenderer;
+    use crate::test::TestRenderer;
 
     #[test]
     fn success_status() {
         let expected = None;
 
         // Status code 0
-        let actual = ModuleRenderer::new("status")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [status]
                 disabled = false
             })
             .status(0)
-            .collect();
+            .module("status");
         assert_eq!(expected, actual);
 
         // No status code
-        let actual = ModuleRenderer::new("status")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [status]
                 disabled = false
             })
-            .collect();
+            .module("status");
         assert_eq!(expected, actual);
     }
 
@@ -178,7 +178,7 @@ mod tests {
     fn not_enabled() {
         let expected = None;
 
-        let actual = ModuleRenderer::new("status").status(1).collect();
+        let actual = TestRenderer::new().status(1).module("status");
         assert_eq!(expected, actual);
     }
 
@@ -191,14 +191,14 @@ mod tests {
                 "{} ",
                 Color::Red.bold().paint(format!("✖{}", status))
             ));
-            let actual = ModuleRenderer::new("status")
+            let actual = TestRenderer::new()
                 .config(toml::toml! {
                     [status]
                     symbol = "✖"
                     disabled = false
                 })
                 .status(*status)
-                .collect();
+                .module("status");
             assert_eq!(expected, actual);
         }
     }
@@ -217,14 +217,14 @@ mod tests {
 
         for (status, name) in exit_values.iter().zip(exit_values_name.iter()) {
             let expected = name.map(|n| n.to_string());
-            let actual = ModuleRenderer::new("status")
+            let actual = TestRenderer::new()
                 .config(toml::toml! {
                     [status]
                     format = "$common_meaning$signal_name"
                     disabled = false
                 })
                 .status(*status)
-                .collect();
+                .module("status");
             assert_eq!(expected, actual);
         }
     }
@@ -244,7 +244,7 @@ mod tests {
 
         for (status, name) in exit_values.iter().zip(exit_values_name.iter()) {
             let expected = name.map(|n| n.to_string());
-            let actual = ModuleRenderer::new("status")
+            let actual = TestRenderer::new()
                 .config(toml::toml! {
                     [status]
                     format = "$common_meaning$signal_name"
@@ -252,7 +252,7 @@ mod tests {
                     disabled = false
                 })
                 .status(*status)
-                .collect();
+                .module("status");
             assert_eq!(expected, actual);
         }
     }
@@ -273,14 +273,14 @@ mod tests {
 
         for (status, name) in exit_values.iter().zip(exit_values_name.iter()) {
             let expected = name.map(|n| n.to_string());
-            let actual = ModuleRenderer::new("status")
+            let actual = TestRenderer::new()
                 .config(toml::toml! {
                     [status]
                     format = "$maybe_int"
                     disabled = false
                 })
                 .status(*status)
-                .collect();
+                .module("status");
             assert_eq!(expected, actual);
         }
     }
@@ -292,7 +292,7 @@ mod tests {
 
         for (status, name) in exit_values.iter().zip(exit_values_name.iter()) {
             let expected = Some(name.to_string());
-            let actual = ModuleRenderer::new("status")
+            let actual = TestRenderer::new()
                 .config(toml::toml! {
                     [status]
                     format = "$symbol"
@@ -306,7 +306,7 @@ mod tests {
                     disabled = false
                 })
                 .status(*status)
-                .collect();
+                .module("status");
             assert_eq!(expected, actual);
         }
     }
@@ -318,7 +318,7 @@ mod tests {
 
         for (status, name) in exit_values.iter().zip(exit_values_name.iter()) {
             let expected = Some(name.to_string());
-            let actual = ModuleRenderer::new("status")
+            let actual = TestRenderer::new()
                 .config(toml::toml! {
                     [status]
                     format = "$symbol"
@@ -332,7 +332,7 @@ mod tests {
                     disabled = false
                 })
                 .status(*status)
-                .collect();
+                .module("status");
             assert_eq!(expected, actual);
         }
     }

--- a/src/modules/swift.rs
+++ b/src/modules/swift.rs
@@ -71,7 +71,7 @@ fn parse_swift_version(swift_version: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::parse_swift_version;
-    use crate::test::ModuleRenderer;
+    use crate::test::TestRenderer;
     use ansi_term::Color;
     use std::fs::File;
     use std::io;
@@ -92,7 +92,7 @@ mod tests {
     fn folder_without_swift_files() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("swift.txt"))?.sync_all()?;
-        let actual = ModuleRenderer::new("swift").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("swift");
         let expected = None;
         assert_eq!(expected, actual);
         dir.close()
@@ -102,7 +102,7 @@ mod tests {
     fn folder_with_package_file() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("Package.swift"))?.sync_all()?;
-        let actual = ModuleRenderer::new("swift").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("swift");
         let expected = Some(format!(
             "via {}",
             Color::Fixed(202).bold().paint("🐦 v5.2.2 ")
@@ -115,7 +115,7 @@ mod tests {
     fn folder_with_swift_file() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("main.swift"))?.sync_all()?;
-        let actual = ModuleRenderer::new("swift").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("swift");
         let expected = Some(format!(
             "via {}",
             Color::Fixed(202).bold().paint("🐦 v5.2.2 ")

--- a/src/modules/terraform.rs
+++ b/src/modules/terraform.rs
@@ -101,7 +101,7 @@ fn get_terraform_version(version: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test::ModuleRenderer;
+    use crate::test::TestRenderer;
     use ansi_term::Color;
     use std::fs::{self, File};
     use std::io::{self, Write};
@@ -147,13 +147,13 @@ is 0.12.14. You can update by downloading from www.terraform.io/downloads.html
         let tf_dir = dir.path().join(".terraform");
         fs::create_dir(&tf_dir)?;
 
-        let actual = ModuleRenderer::new("terraform")
+        let actual = TestRenderer::new()
             .path(dir.path())
             .config(toml::toml! {
                 [terraform]
                 format = "via [$symbol$version $workspace]($style) "
             })
-            .collect();
+            .module("terraform");
 
         let expected = Some(format!(
             "via {} ",
@@ -172,13 +172,13 @@ is 0.12.14. You can update by downloading from www.terraform.io/downloads.html
         file.write_all(b"development")?;
         file.sync_all()?;
 
-        let actual = ModuleRenderer::new("terraform")
+        let actual = TestRenderer::new()
             .path(dir.path())
             .config(toml::toml! {
                 [terraform]
                 format = "via [$symbol$version $workspace]($style) "
             })
-            .collect();
+            .module("terraform");
 
         let expected = Some(format!(
             "via {} ",
@@ -192,7 +192,7 @@ is 0.12.14. You can update by downloading from www.terraform.io/downloads.html
     fn folder_without_dotterraform() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
 
-        let actual = ModuleRenderer::new("terraform").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("terraform");
         let expected = None;
 
         assert_eq!(expected, actual);
@@ -204,7 +204,7 @@ is 0.12.14. You can update by downloading from www.terraform.io/downloads.html
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("main.tf"))?;
 
-        let actual = ModuleRenderer::new("terraform").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("terraform");
         let expected = Some(format!(
             "via {} ",
             Color::Fixed(105).bold().paint("💠 default")
@@ -219,10 +219,10 @@ is 0.12.14. You can update by downloading from www.terraform.io/downloads.html
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("main.tf"))?;
 
-        let actual = ModuleRenderer::new("terraform")
+        let actual = TestRenderer::new()
             .path(dir.path())
             .env("TF_WORKSPACE", "development")
-            .collect();
+            .module("terraform");
         let expected = Some(format!(
             "via {} ",
             Color::Fixed(105).bold().paint("💠 development")
@@ -242,10 +242,10 @@ is 0.12.14. You can update by downloading from www.terraform.io/downloads.html
         file.write_all(b"development")?;
         file.sync_all()?;
 
-        let actual = ModuleRenderer::new("terraform")
+        let actual = TestRenderer::new()
             .path(dir.path())
             .env("TF_DATA_DIR", datadir.path().to_str().unwrap())
-            .collect();
+            .module("terraform");
         let expected = Some(format!(
             "via {} ",
             Color::Fixed(105).bold().paint("💠 development")
@@ -262,7 +262,7 @@ is 0.12.14. You can update by downloading from www.terraform.io/downloads.html
         let tf_dir = dir.path().join(".terraform");
         fs::create_dir(&tf_dir)?;
 
-        let actual = ModuleRenderer::new("terraform").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("terraform");
         let expected = Some(format!(
             "via {} ",
             Color::Fixed(105).bold().paint("💠 default")
@@ -281,7 +281,7 @@ is 0.12.14. You can update by downloading from www.terraform.io/downloads.html
         file.write_all(b"development")?;
         file.sync_all()?;
 
-        let actual = ModuleRenderer::new("terraform").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("terraform");
         let expected = Some(format!(
             "via {} ",
             Color::Fixed(105).bold().paint("💠 development")

--- a/src/modules/time.rs
+++ b/src/modules/time.rs
@@ -153,7 +153,7 @@ tests become extra important */
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test::ModuleRenderer;
+    use crate::test::TestRenderer;
     use chrono::offset::TimeZone;
 
     const FMT_12: &str = "%r";
@@ -470,12 +470,12 @@ mod tests {
 
     #[test]
     fn config_enabled() {
-        let actual = ModuleRenderer::new("time")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [time]
                 disabled = false
             })
-            .collect();
+            .module("time");
 
         // We can't test what it actually is...but we can assert that it is something
         assert!(actual.is_some());
@@ -483,7 +483,7 @@ mod tests {
 
     #[test]
     fn config_blank() {
-        let actual = ModuleRenderer::new("time").collect();
+        let actual = TestRenderer::new().module("time");
 
         let expected = None;
         assert_eq!(expected, actual);
@@ -491,14 +491,14 @@ mod tests {
 
     #[test]
     fn config_check_prefix_and_suffix() {
-        let actual = ModuleRenderer::new("time")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 [time]
                 disabled = false
                 format = "at [\\[$time\\]]($style) "
                 time_format = "%T"
             })
-            .collect()
+            .module("time")
             .unwrap();
 
         // This is the prefix with "at ", the color code, then the prefix char [

--- a/src/modules/username.rs
+++ b/src/modules/username.rs
@@ -85,14 +85,14 @@ fn is_ssh_session(context: &Context) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use crate::test::ModuleRenderer;
+    use crate::test::TestRenderer;
 
     // TODO: Add tests for if root user (UID == 0)
     // Requires mocking
 
     #[test]
     fn no_env_variables() {
-        let actual = ModuleRenderer::new("username").collect();
+        let actual = TestRenderer::new().module("username");
         let expected = None;
 
         assert_eq!(expected, actual);
@@ -101,9 +101,9 @@ mod tests {
     #[test]
     #[ignore]
     fn no_logname_env_variable() {
-        let actual = ModuleRenderer::new("username")
+        let actual = TestRenderer::new()
             .env(super::USERNAME_ENV_VAR, "astronaut")
-            .collect();
+            .module("username");
         let expected = None;
 
         assert_eq!(expected, actual);
@@ -112,10 +112,10 @@ mod tests {
     #[test]
     #[ignore]
     fn logname_equals_user() {
-        let actual = ModuleRenderer::new("username")
+        let actual = TestRenderer::new()
             .env("LOGNAME", "astronaut")
             .env(super::USERNAME_ENV_VAR, "astronaut")
-            .collect();
+            .module("username");
         let expected = None;
 
         assert_eq!(expected, actual);
@@ -124,9 +124,9 @@ mod tests {
     #[test]
     fn ssh_wo_username() {
         // SSH connection w/o username
-        let actual = ModuleRenderer::new("username")
+        let actual = TestRenderer::new()
             .env("SSH_CONNECTION", "192.168.223.17 36673 192.168.223.229 22")
-            .collect();
+            .module("username");
         let expected = None;
 
         assert_eq!(expected, actual);
@@ -134,7 +134,7 @@ mod tests {
 
     #[test]
     fn current_user_not_logname() {
-        let actual = ModuleRenderer::new("username")
+        let actual = TestRenderer::new()
             .env("LOGNAME", "astronaut")
             .env(super::USERNAME_ENV_VAR, "cosmonaut")
             // Test output should not change when run by root/non-root user
@@ -143,7 +143,7 @@ mod tests {
                 style_root = ""
                 style_user = ""
             })
-            .collect();
+            .module("username");
         let expected = Some("cosmonaut in ");
 
         assert_eq!(expected, actual.as_deref());
@@ -151,7 +151,7 @@ mod tests {
 
     #[test]
     fn ssh_connection() {
-        let actual = ModuleRenderer::new("username")
+        let actual = TestRenderer::new()
             .env(super::USERNAME_ENV_VAR, "astronaut")
             .env("SSH_CONNECTION", "192.168.223.17 36673 192.168.223.229 22")
             // Test output should not change when run by root/non-root user
@@ -160,7 +160,7 @@ mod tests {
                 style_root = ""
                 style_user = ""
             })
-            .collect();
+            .module("username");
         let expected = Some("astronaut in ");
 
         assert_eq!(expected, actual.as_deref());
@@ -168,7 +168,7 @@ mod tests {
 
     #[test]
     fn ssh_connection_tty() {
-        let actual = ModuleRenderer::new("username")
+        let actual = TestRenderer::new()
             .env(super::USERNAME_ENV_VAR, "astronaut")
             .env("SSH_TTY", "/dev/pts/0")
             // Test output should not change when run by root/non-root user
@@ -177,7 +177,7 @@ mod tests {
                 style_root = ""
                 style_user = ""
             })
-            .collect();
+            .module("username");
         let expected = Some("astronaut in ");
 
         assert_eq!(expected, actual.as_deref());
@@ -185,7 +185,7 @@ mod tests {
 
     #[test]
     fn ssh_connection_client() {
-        let actual = ModuleRenderer::new("username")
+        let actual = TestRenderer::new()
             .env(super::USERNAME_ENV_VAR, "astronaut")
             .env("SSH_CLIENT", "192.168.0.101 39323 22")
             // Test output should not change when run by root/non-root user
@@ -194,7 +194,7 @@ mod tests {
                 style_root = ""
                 style_user = ""
             })
-            .collect();
+            .module("username");
         let expected = Some("astronaut in ");
 
         assert_eq!(expected, actual.as_deref());
@@ -202,7 +202,7 @@ mod tests {
 
     #[test]
     fn show_always() {
-        let actual = ModuleRenderer::new("username")
+        let actual = TestRenderer::new()
             .env(super::USERNAME_ENV_VAR, "astronaut")
             // Test output should not change when run by root/non-root user
             .config(toml::toml! {
@@ -212,7 +212,7 @@ mod tests {
                 style_root = ""
                 style_user = ""
             })
-            .collect();
+            .module("username");
         let expected = Some("astronaut in ");
 
         assert_eq!(expected, actual.as_deref());

--- a/src/modules/vagrant.rs
+++ b/src/modules/vagrant.rs
@@ -72,7 +72,7 @@ fn get_vagrant_version(vagrant_stdout: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test::ModuleRenderer;
+    use crate::test::TestRenderer;
     use ansi_term::Color;
     use std::fs::File;
     use std::io;
@@ -81,7 +81,7 @@ mod tests {
     fn folder_without_vagrant_files() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
 
-        let actual = ModuleRenderer::new("vagrant").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("vagrant");
 
         let expected = None;
         assert_eq!(expected, actual);
@@ -93,7 +93,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("Vagrantfile"))?.sync_all()?;
 
-        let actual = ModuleRenderer::new("vagrant").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("vagrant");
 
         let expected = Some(format!("via {}", Color::Cyan.bold().paint("⍱ v2.2.10 ")));
         assert_eq!(expected, actual);

--- a/src/modules/vcsh.rs
+++ b/src/modules/vcsh.rs
@@ -46,12 +46,12 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
 #[cfg(test)]
 mod tests {
-    use crate::test::ModuleRenderer;
+    use crate::test::TestRenderer;
     use ansi_term::Color;
 
     #[test]
     fn not_in_env() {
-        let actual = ModuleRenderer::new("vcsh").collect();
+        let actual = TestRenderer::new().module("vcsh");
 
         let expected = None;
 
@@ -60,9 +60,9 @@ mod tests {
 
     #[test]
     fn env_set() {
-        let actual = ModuleRenderer::new("vcsh")
+        let actual = TestRenderer::new()
             .env("VCSH_REPO_NAME", "astronauts")
-            .collect();
+            .module("vcsh");
 
         let expected = Some(format!(
             "vcsh {} ",

--- a/src/modules/vlang.rs
+++ b/src/modules/vlang.rs
@@ -62,7 +62,7 @@ fn parse_v_version(v_version: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::parse_v_version;
-    use crate::test::ModuleRenderer;
+    use crate::test::TestRenderer;
     use ansi_term::Color;
     use std::fs::File;
     use std::io;
@@ -76,7 +76,7 @@ mod tests {
     #[test]
     fn folder_without_v_files() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
-        let actual = ModuleRenderer::new("vlang").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("vlang");
         let expected = None;
         assert_eq!(expected, actual);
         dir.close()
@@ -86,7 +86,7 @@ mod tests {
     fn folder_with_v_files() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("hello.v"))?.sync_all()?;
-        let actual = ModuleRenderer::new("vlang").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("vlang");
         let expected = Some(format!("via {}", Color::Blue.bold().paint("V v0.2 ")));
         assert_eq!(expected, actual);
         dir.close()
@@ -96,7 +96,7 @@ mod tests {
     fn folder_with_vmod_file() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("v.mod"))?.sync_all()?;
-        let actual = ModuleRenderer::new("vlang").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("vlang");
         let expected = Some(format!("via {}", Color::Blue.bold().paint("V v0.2 ")));
         assert_eq!(expected, actual);
         dir.close()
@@ -106,7 +106,7 @@ mod tests {
     fn folder_with_vpkg_file() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("vpkg.json"))?.sync_all()?;
-        let actual = ModuleRenderer::new("vlang").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("vlang");
         let expected = Some(format!("via {}", Color::Blue.bold().paint("V v0.2 ")));
         assert_eq!(expected, actual);
         dir.close()
@@ -116,7 +116,7 @@ mod tests {
     fn folder_with_vpkg_lockfile() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join(".vpkg-lock.json"))?.sync_all()?;
-        let actual = ModuleRenderer::new("vlang").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("vlang");
         let expected = Some(format!("via {}", Color::Blue.bold().paint("V v0.2 ")));
         assert_eq!(expected, actual);
         dir.close()

--- a/src/modules/zig.rs
+++ b/src/modules/zig.rs
@@ -58,7 +58,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
 #[cfg(test)]
 mod tests {
-    use crate::test::ModuleRenderer;
+    use crate::test::TestRenderer;
     use ansi_term::Color;
     use std::fs::File;
     use std::io;
@@ -67,7 +67,7 @@ mod tests {
     fn folder_without_zig() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("zig.txt"))?.sync_all()?;
-        let actual = ModuleRenderer::new("zig").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("zig");
         let expected = None;
         assert_eq!(expected, actual);
         dir.close()
@@ -77,7 +77,7 @@ mod tests {
     fn folder_with_zig_file() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("main.zig"))?.sync_all()?;
-        let actual = ModuleRenderer::new("zig").path(dir.path()).collect();
+        let actual = TestRenderer::new().path(dir.path()).module("zig");
         let expected = Some(format!("via {}", Color::Yellow.bold().paint("↯ v0.6.0 ")));
         assert_eq!(expected, actual);
         dir.close()

--- a/src/print.rs
+++ b/src/print.rs
@@ -562,11 +562,11 @@ pub fn format_duration(duration: &Duration) -> String {
 #[cfg(test)]
 mod tests {
     use crate::context::PromptMode;
-    use crate::test::ModuleRenderer;
+    use crate::test::TestRenderer;
 
     #[test]
     fn test_prompt_left() {
-        let actual = ModuleRenderer::new("")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 format = "HOST:user  ~\n> "
                 add_newline = false
@@ -582,7 +582,7 @@ mod tests {
     fn test_prompt_right() {
         // Prompt can't end on a right line, so it must always end of a trailing
         // line break if right prompt has more lines than left prompt.
-        let actual = ModuleRenderer::new("")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 format = ""
                 format_right = "5:17 PM\nSaturday, May 5"
@@ -599,7 +599,7 @@ mod tests {
 
     #[test]
     fn test_prompt_both() {
-        let actual = ModuleRenderer::new("")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 format = "HOST:user  ~\n> "
                 format_right = "5:17 PM"
@@ -615,7 +615,7 @@ mod tests {
 
     #[test]
     fn test_prompt_both_too_narrow() {
-        let actual = ModuleRenderer::new("")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 format = "HOST:user  ~\n> "
                 format_right = "5:17 PM"
@@ -631,7 +631,7 @@ mod tests {
 
     #[test]
     fn test_prompt_secondary() {
-        let actual = ModuleRenderer::new("")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 format_secondary = "<<"
             })
@@ -644,7 +644,7 @@ mod tests {
 
     #[test]
     fn test_prompt_secondary_multiline() {
-        let actual = ModuleRenderer::new("")
+        let actual = TestRenderer::new()
             .config(toml::toml! {
                 format_secondary = "<<\n<<"
             })

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -1,4 +1,4 @@
-use crate::context::{Context, Shell};
+use crate::context::{Context, PromptMode, Shell};
 use crate::logger::StarshipLogger;
 use crate::{config::StarshipConfig, utils::CommandOutput};
 use log::{Level, LevelFilter};
@@ -50,6 +50,12 @@ impl<'a> ModuleRenderer<'a> {
         context.config = StarshipConfig { config: None };
 
         Self { name, context }
+    }
+
+    /// Sets the terminal width of the underlying context
+    pub fn prompt_mode(mut self, prompt_mode: PromptMode) -> Self {
+        self.context.prompt_mode = prompt_mode;
+        self
     }
 
     pub fn path<T>(mut self, path: T) -> Self

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -30,14 +30,13 @@ static LOGGER: Lazy<()> = Lazy::new(|| {
 });
 
 /// Render a specific starship module by name
-pub struct ModuleRenderer<'a> {
-    name: &'a str,
+pub struct TestRenderer<'a> {
     context: Context<'a>,
 }
 
-impl<'a> ModuleRenderer<'a> {
-    /// Creates a new ModuleRenderer
-    pub fn new(name: &'a str) -> Self {
+impl<'a> TestRenderer<'a> {
+    /// Creates a new TestRenderer
+    pub fn new() -> Self {
         // Start logger
         Lazy::force(&LOGGER);
 
@@ -49,7 +48,7 @@ impl<'a> ModuleRenderer<'a> {
         );
         context.config = StarshipConfig { config: None };
 
-        Self { name, context }
+        Self { context }
     }
 
     /// Sets the terminal width of the underlying context
@@ -148,8 +147,8 @@ impl<'a> ModuleRenderer<'a> {
     }
 
     /// Renders the module returning its output
-    pub fn collect(self) -> Option<String> {
-        let ret = crate::print::get_module(self.name, self.context);
+    pub fn module(self, name: &str) -> Option<String> {
+        let ret = crate::print::get_module(name, self.context);
         // all tests rely on the fact that an empty module produces None as output as the
         // convention was that there would be no module but None. This is nowadays not anymore
         // the case (to get durations for all modules). So here we make it so, that an empty

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -77,6 +77,12 @@ impl<'a> ModuleRenderer<'a> {
         self
     }
 
+    /// Sets the terminal width of the underlying context
+    pub fn width(mut self, width: usize) -> Self {
+        self.context.width = width;
+        self
+    }
+
     /// Adds the variable to the env_mocks of the underlying context
     pub fn env<V: Into<String>>(mut self, key: &'a str, val: V) -> Self {
         self.context.env.insert(key, val.into());
@@ -128,6 +134,11 @@ impl<'a> ModuleRenderer<'a> {
     ) -> Self {
         self.context.battery_info_provider = battery_info_provider;
         self
+    }
+
+    /// Renders the prompt returning its output
+    pub fn prompt(self) -> String {
+        crate::print::get_prompt(self.context)
     }
 
     /// Renders the module returning its output


### PR DESCRIPTION
#### Description
Refactors ModuleRenderer to TestRenderer to cover it's expanded usage of also being used to test overall prompt output.  Instead of ModuleRenderer taking in the name of a module during construction, TestRenderer does not take that input, is configured otherwise the same, and then is consumed by calling either `prompt()` or `module(name: &str)` to generate the appropriate output for the test.

This is dependent on https://github.com/starship/starship/pull/2786.

#### Motivation and Context
This seemed like the cleanest way to add support for testing overall prompt generation, not just specific modules.

#### Screenshots (if appropriate):
N/A

#### How Has This Been Tested?
Ensured code compiles and ran `cargo test` on Windows and WSL Linux.  The tests that are failing are the same as on master.

- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
