### PR TITLE
docs(preset): add a new SHLVL icon to Nerd Font Symbols preset

### DIFF
--- a/docs/presets/README.md
+++ b/docs/presets/README.md
@@ -83,6 +83,9 @@ symbol = " "
 [scala]
 symbol = " "
 
+[shlvl]
+symbol = " "
+
 [swift]
 symbol = "ﯣ "
 ```


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

I feel the default icon `↕️` is a little confusing. It may not be very clear what it represents until one read the docs.

This PR adds a new icon `` (nf-fa-terminal, f120) to Nerd Font Symbols preset in order to solve the issue. Or, if it fits, make it the default icon.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
