### PR TITLE
fix(clippy): fix additional clippy lints in tests

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -503,7 +503,7 @@ mod tests {
         rust_config.load_config(&config);
 
         assert_eq!(rust_config.symbol, "T ");
-        assert_eq!(rust_config.disabled, true);
+        assert!(rust_config.disabled);
         assert_eq!(rust_config.some_array, vec!["A"]);
     }
 
@@ -631,7 +631,7 @@ mod tests {
     #[test]
     fn test_from_bool() {
         let config = Value::Boolean(true);
-        assert_eq!(<bool>::from_config(&config).unwrap(), true);
+        assert!(<bool>::from_config(&config).unwrap());
     }
 
     #[test]

--- a/src/context.rs
+++ b/src/context.rs
@@ -512,58 +512,46 @@ mod tests {
         let empty = testdir(&[])?;
         let empty_dc = DirContents::from_path(empty.path())?;
 
-        assert_eq!(
-            ScanDir {
-                dir_contents: &empty_dc,
-                files: &["package.json"],
-                extensions: &["js"],
-                folders: &["node_modules"],
-            }
-            .is_match(),
-            false
-        );
+        assert!(!ScanDir {
+            dir_contents: &empty_dc,
+            files: &["package.json"],
+            extensions: &["js"],
+            folders: &["node_modules"],
+        }
+        .is_match());
         empty.close()?;
 
         let rust = testdir(&["README.md", "Cargo.toml", "src/main.rs"])?;
         let rust_dc = DirContents::from_path(rust.path())?;
-        assert_eq!(
-            ScanDir {
-                dir_contents: &rust_dc,
-                files: &["package.json"],
-                extensions: &["js"],
-                folders: &["node_modules"],
-            }
-            .is_match(),
-            false
-        );
+        assert!(!ScanDir {
+            dir_contents: &rust_dc,
+            files: &["package.json"],
+            extensions: &["js"],
+            folders: &["node_modules"],
+        }
+        .is_match());
         rust.close()?;
 
         let java = testdir(&["README.md", "src/com/test/Main.java", "pom.xml"])?;
         let java_dc = DirContents::from_path(java.path())?;
-        assert_eq!(
-            ScanDir {
-                dir_contents: &java_dc,
-                files: &["package.json"],
-                extensions: &["js"],
-                folders: &["node_modules"],
-            }
-            .is_match(),
-            false
-        );
+        assert!(!ScanDir {
+            dir_contents: &java_dc,
+            files: &["package.json"],
+            extensions: &["js"],
+            folders: &["node_modules"],
+        }
+        .is_match());
         java.close()?;
 
         let node = testdir(&["README.md", "node_modules/lodash/main.js", "package.json"])?;
         let node_dc = DirContents::from_path(node.path())?;
-        assert_eq!(
-            ScanDir {
-                dir_contents: &node_dc,
-                files: &["package.json"],
-                extensions: &["js"],
-                folders: &["node_modules"],
-            }
-            .is_match(),
-            true
-        );
+        assert!(ScanDir {
+            dir_contents: &node_dc,
+            files: &["package.json"],
+            extensions: &["js"],
+            folders: &["node_modules"],
+        }
+        .is_match());
         node.close()?;
 
         Ok(())

--- a/src/modules/nim.rs
+++ b/src/modules/nim.rs
@@ -85,8 +85,8 @@ mod tests {
             .iter()
             .any(|&v| parse_nim_version(v).is_some());
 
-        assert_eq!(true, all_some);
-        assert_eq!(true, all_none);
+        assert!(all_some);
+        assert!(all_none);
 
         let sample_nimc_output = "Nim Compiler Version 1.2.0 [Linux: amd64]
             Compiled at 2020-04-03

--- a/src/modules/time.rs
+++ b/src/modules/time.rs
@@ -419,7 +419,7 @@ mod tests {
         let time_end = None;
         let time_now = NaiveTime::from_hms(10, 00, 00);
 
-        assert_eq!(is_inside_time_range(time_now, time_start, time_end), true);
+        assert!(is_inside_time_range(time_now, time_start, time_end));
     }
 
     #[test]
@@ -428,8 +428,8 @@ mod tests {
         let time_now = NaiveTime::from_hms(12, 00, 00);
         let time_now2 = NaiveTime::from_hms(8, 00, 00);
 
-        assert_eq!(is_inside_time_range(time_now, time_start, None), true);
-        assert_eq!(is_inside_time_range(time_now2, time_start, None), false);
+        assert!(is_inside_time_range(time_now, time_start, None));
+        assert!(!is_inside_time_range(time_now2, time_start, None));
     }
 
     #[test]
@@ -438,8 +438,8 @@ mod tests {
         let time_now = NaiveTime::from_hms(15, 00, 00);
         let time_now2 = NaiveTime::from_hms(19, 00, 00);
 
-        assert_eq!(is_inside_time_range(time_now, None, time_end), true);
-        assert_eq!(is_inside_time_range(time_now2, None, time_end), false);
+        assert!(is_inside_time_range(time_now, None, time_end));
+        assert!(!is_inside_time_range(time_now2, None, time_end));
     }
 
     #[test]
@@ -450,9 +450,9 @@ mod tests {
         let time_now2 = NaiveTime::from_hms(13, 00, 00);
         let time_now3 = NaiveTime::from_hms(20, 00, 00);
 
-        assert_eq!(is_inside_time_range(time_now, time_start, time_end), false);
-        assert_eq!(is_inside_time_range(time_now2, time_start, time_end), true);
-        assert_eq!(is_inside_time_range(time_now3, time_start, time_end), false);
+        assert!(!is_inside_time_range(time_now, time_start, time_end));
+        assert!(is_inside_time_range(time_now2, time_start, time_end));
+        assert!(!is_inside_time_range(time_now3, time_start, time_end));
     }
 
     #[test]
@@ -463,9 +463,9 @@ mod tests {
         let time_now2 = NaiveTime::from_hms(13, 00, 00);
         let time_now3 = NaiveTime::from_hms(20, 00, 00);
 
-        assert_eq!(is_inside_time_range(time_now, time_start, time_end), true);
-        assert_eq!(is_inside_time_range(time_now2, time_start, time_end), false);
-        assert_eq!(is_inside_time_range(time_now3, time_start, time_end), true);
+        assert!(is_inside_time_range(time_now, time_start, time_end));
+        assert!(!is_inside_time_range(time_now2, time_start, time_end));
+        assert!(is_inside_time_range(time_now3, time_start, time_end));
     }
 
     #[test]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Fixes new clippy lints introduced in rust 1.53.
This is a continuation of #2803 but this times I also fixed the clippy lint warnings for the test target (`--all-targets`).

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
