### PR TITLE
style: fix name of battery info provider implementation

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -126,7 +126,7 @@ impl<'a> Context<'a> {
             #[cfg(test)]
             cmd: HashMap::new(),
             #[cfg(feature = "battery")]
-            battery_info_provider: &crate::modules::BatteryStatusProviderImpl,
+            battery_info_provider: &crate::modules::BatteryInfoProviderImpl,
             cmd_timeout,
         }
     }

--- a/src/modules/battery.rs
+++ b/src/modules/battery.rs
@@ -130,9 +130,9 @@ pub trait BatteryInfoProvider {
     fn get_battery_info(&self) -> Option<BatteryInfo>;
 }
 
-pub struct BatteryStatusProviderImpl;
+pub struct BatteryInfoProviderImpl;
 
-impl BatteryInfoProvider for BatteryStatusProviderImpl {
+impl BatteryInfoProvider for BatteryInfoProviderImpl {
     fn get_battery_info(&self) -> Option<BatteryInfo> {
         let battery_manager = battery::Manager::new().ok()?;
         let batteries = battery_manager.batteries().ok()?;

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -65,7 +65,7 @@ mod zig;
 mod battery;
 
 #[cfg(feature = "battery")]
-pub use self::battery::{BatteryInfoProvider, BatteryStatusProviderImpl};
+pub use self::battery::{BatteryInfoProvider, BatteryInfoProviderImpl};
 
 use crate::config::RootModuleConfig;
 use crate::context::{Context, Shell};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
I noticed right after @matchai merged that the implementation of `BatteryInfoProvider` had an old name from when the interface was called `BatteryStatusProvider`, this fixes that mistake.

#### Motivation and Context
The name is confusing.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [X] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
