### PR TITLE
style: enforce ALL_MODULES ordering in test

### DIFF
--- a/src/module.rs
+++ b/src/module.rs
@@ -178,7 +178,7 @@ mod tests {
 
     #[test]
     fn test_all_modules_is_in_alphabetical_order() {
-        let mut sorted_modules: Vec<&str> = ALL_MODULES.iter().map(|module| *module).collect();
+        let mut sorted_modules: Vec<&str> = ALL_MODULES.iter().copied().collect();
         sorted_modules.sort_unstable();
         assert_eq!(sorted_modules.as_slice(), ALL_MODULES);
     }

--- a/src/module.rs
+++ b/src/module.rs
@@ -179,7 +179,7 @@ mod tests {
     #[test]
     fn test_all_modules_is_in_alphabetical_order() {
         let mut sorted_modules: Vec<&str> = ALL_MODULES.iter().map(|module| *module).collect();
-        sorted_modules.sort();
+        sorted_modules.sort_unstable();
         assert_eq!(sorted_modules.as_slice(), ALL_MODULES);
     }
 

--- a/src/module.rs
+++ b/src/module.rs
@@ -6,7 +6,6 @@ use std::fmt;
 use std::time::Duration;
 
 // List of all modules
-// Keep these ordered alphabetically.
 // Default ordering is handled in configs/starship_root.rs
 pub const ALL_MODULES: &[&str] = &[
     "aws",
@@ -16,6 +15,7 @@ pub const ALL_MODULES: &[&str] = &[
     "cmake",
     "cmd_duration",
     "conda",
+    "crystal",
     "dart",
     "deno",
     "directory",
@@ -23,8 +23,8 @@ pub const ALL_MODULES: &[&str] = &[
     "dotnet",
     "elixir",
     "elm",
-    "erlang",
     "env_var",
+    "erlang",
     "gcloud",
     "git_branch",
     "git_commit",
@@ -35,7 +35,6 @@ pub const ALL_MODULES: &[&str] = &[
     "hg_branch",
     "hostname",
     "java",
-    "scala",
     "jobs",
     "julia",
     "kotlin",
@@ -50,24 +49,24 @@ pub const ALL_MODULES: &[&str] = &[
     "openstack",
     "package",
     "perl",
+    "php",
     "purescript",
     "python",
-    "rlang",
     "red",
+    "rlang",
     "ruby",
-    "crystal",
     "rust",
-    "php",
-    "swift",
-    "terraform",
+    "scala",
     "shell",
     "shlvl",
     "singularity",
     "status",
+    "swift",
+    "terraform",
     "time",
     "username",
-    "vcsh",
     "vagrant",
+    "vcsh",
     "vlang",
     "zig",
 ];
@@ -176,6 +175,13 @@ fn ansi_strings_modified(ansi_strings: Vec<ANSIString>, shell: Shell) -> Vec<ANS
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_all_modules_is_in_alphabetical_order() {
+        let mut sorted_modules: Vec<&str> = ALL_MODULES.iter().map(|module| *module).collect();
+        sorted_modules.sort();
+        assert_eq!(sorted_modules.as_slice(), ALL_MODULES);
+    }
 
     #[test]
     fn test_module_is_empty_with_no_segments() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
Comments are mere suggestions that can easily be ignored (proof: look at the PR). Instead we should enforce ALL_MODULES ordering in a test.

#### Motivation and Context
ALL_MODULES is supposed to be in alphabetical order but is not.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [X] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have updated the documentation accordingly.
- [X] I have updated the tests accordingly.
