### PR TITLE
perf: Improve custom config OS check

### DIFF
--- a/src/modules/custom.rs
+++ b/src/modules/custom.rs
@@ -21,6 +21,12 @@ pub fn module<'a>(name: &str, context: &'a Context) -> Option<Module<'a>> {
     );
     let config = CustomConfig::load(toml_config);
 
+    if let Some(os) = config.os {
+        if os != env::consts::OS && !(os == "unix" && cfg!(unix)) {
+            return None;
+        }
+    }
+
     let mut is_match = context
         .try_begin_scan()?
         .set_files(&config.files)
@@ -34,12 +40,6 @@ pub fn module<'a>(name: &str, context: &'a Context) -> Option<Module<'a>> {
         }
 
         if !is_match {
-            return None;
-        }
-    }
-
-    if let Some(os) = config.os {
-        if os != env::consts::OS && !(os == "unix" && cfg!(unix)) {
             return None;
         }
     }


### PR DESCRIPTION
#### Description
Moving the OS check before other checks so that there is no performance hit for running the match in the incorrect OS.

#### Motivation and Context
I noticed that the `when` config condition always runs, even in an OS that did not match. This causes a performance hit on Windows, as the command might not exist there, and it will take a while to continue. I noticed 2 to 3 second pauses on Windows. These pauses do not happen on Linux.
Related to #2750 and #2751.

#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
