### PR TITLE
fix(init): improve starship path escaping

### DIFF
--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -33,8 +33,17 @@ impl StarshipPath {
             .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "can't convert to str"))?;
         Ok(current_exe)
     }
+
+    /// Returns POSIX quoted path to starship binary
     fn sprint(&self) -> io::Result<String> {
-        self.str_path().map(|s| s.replace("\"", "\"'\"'\""))
+        self.str_path().map(|p| shell_words::quote(p).into_owned())
+    }
+
+    /// PowerShell specific path escaping
+    fn sprint_pwsh(&self) -> io::Result<String> {
+        self.str_path()
+            .map(|s| s.replace("'", "''"))
+            .map(|s| format!("'{}'", s))
     }
     fn sprint_posix(&self) -> io::Result<String> {
         // On non-Windows platform, return directly.
@@ -71,7 +80,7 @@ impl StarshipPath {
                 str_path
             }
         };
-        Ok(posix_path.replace("\"", "\"'\"'\""))
+        Ok(shell_words::quote(posix_path).into_owned())
     }
 }
 
@@ -138,25 +147,25 @@ pub fn init_stub(shell_name: &str) -> io::Result<()> {
             starship.sprint_posix()?
         ),
         "zsh" => print!(
-            r#"source <("{}" init zsh --print-full-init)"#,
+            r#"source <({} init zsh --print-full-init)"#,
             starship.sprint_posix()?
         ),
         "fish" => print!(
             // Fish does process substitution with pipes and psub instead of bash syntax
-            r#"source ("{}" init fish --print-full-init | psub)"#,
+            r#"source ({} init fish --print-full-init | psub)"#,
             starship.sprint_posix()?
         ),
         "powershell" => print!(
-            r#"Invoke-Expression (& "{}" init powershell --print-full-init | Out-String)"#,
-            starship.sprint()?
+            r#"Invoke-Expression (& {} init powershell --print-full-init | Out-String)"#,
+            starship.sprint_pwsh()?
         ),
         "ion" => print!("eval $({} init ion --print-full-init)", starship.sprint()?),
         "elvish" => print!(
-            r#"eval ("{}" init elvish --print-full-init | slurp)"#,
+            r#"eval ({} init elvish --print-full-init | slurp)"#,
             starship.sprint_posix()?
         ),
         "tcsh" => print!(
-            r#"eval `("{}" init tcsh --print-full-init)`"#,
+            r#"eval `({} init tcsh --print-full-init)`"#,
             starship.sprint_posix()?
         ),
         _ => {
@@ -190,7 +199,7 @@ pub fn init_main(shell_name: &str) -> io::Result<()> {
         "bash" => print_script(BASH_INIT, &starship_path.sprint_posix()?),
         "zsh" => print_script(ZSH_INIT, &starship_path.sprint_posix()?),
         "fish" => print_script(FISH_INIT, &starship_path.sprint_posix()?),
-        "powershell" => print_script(PWSH_INIT, &starship_path.sprint()?),
+        "powershell" => print_script(PWSH_INIT, &starship_path.sprint_pwsh()?),
         "ion" => print_script(ION_INIT, &starship_path.sprint()?),
         "elvish" => print_script(ELVISH_INIT, &starship_path.sprint_posix()?),
         "tcsh" => print_script(TCSH_INIT, &starship_path.sprint_posix()?),
@@ -206,8 +215,7 @@ pub fn init_main(shell_name: &str) -> io::Result<()> {
 }
 
 fn print_script(script: &str, path: &str) {
-    let starship_path_string = format!("\"{}\"", path);
-    let script = script.replace("::STARSHIP::", &starship_path_string);
+    let script = script.replace("::STARSHIP::", path);
     print!("{}", script);
 }
 
@@ -239,3 +247,25 @@ const ION_INIT: &str = include_str!("starship.ion");
 const ELVISH_INIT: &str = include_str!("starship.elv");
 
 const TCSH_INIT: &str = include_str!("starship.tcsh");
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn escape_pwsh() -> io::Result<()> {
+        let starship_path = StarshipPath {
+            native_path: PathBuf::from(r"C:\starship.exe"),
+        };
+        assert_eq!(starship_path.sprint_pwsh()?, r"'C:\starship.exe'");
+        Ok(())
+    }
+
+    #[test]
+    fn escape_tick_pwsh() -> io::Result<()> {
+        let starship_path = StarshipPath {
+            native_path: PathBuf::from(r"C:\'starship.exe"),
+        };
+        assert_eq!(starship_path.sprint_pwsh()?, r"'C:\''starship.exe'");
+        Ok(())
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR replaces the quoting code for `starship init` with quoting via `shell_words::quote`. It also adds `sprint_pwsh()` in addition to `sprint()` to better account for string escaping in PowerShell.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
~~@exactly-one-kas I think this might fix #2767, but I'm not sure what kind of path was failing for you. Can you please confirm whether this fixes your issue?~~
Edit: it seems to fix it

Closes #2767

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
