### PR TITLE
fix(dotnet): make default format consistent with other modules

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -419,7 +419,7 @@ look at [this example](#with-custom-error-shape).
 
 ::: warning
 
-`vicmd_symbol` is only supported in fish and zsh. 
+`vicmd_symbol` is only supported in fish and zsh.
 
 :::
 
@@ -859,7 +859,7 @@ when there is a csproj file in the current directory.
 
 | Option              | Default                                                                                                 | Description                                                               |
 | ------------------- | ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| `format`            | `"[$symbol($version )(🎯 $tfm )]($style)"`                                                              | The format for the module.                                                |
+| `format`            | `"via [$symbol($version )(🎯 $tfm )]($style)"`                                                          | The format for the module.                                                |
 | `version_format`    | `"v${raw}"`                                                                                             | The version format. Available vars are `raw`, `major`, `minor`, & `patch` |
 | `symbol`            | `".NET "`                                                                                               | The symbol used before displaying the version of dotnet.                  |
 | `heuristic`         | `true`                                                                                                  | Use faster version detection to keep starship snappy.                     |
@@ -2295,7 +2295,7 @@ python_binary = ["./venv/bin/python", "python", "python3", "python2"]
 
 ## R
 
-The `rlang` module shows the currently installed version of R. The module will be shown if 
+The `rlang` module shows the currently installed version of R. The module will be shown if
 any of the following conditions are met:
 
 - The current directory contains a file with the `.R` extension.

--- a/src/configs/dotnet.rs
+++ b/src/configs/dotnet.rs
@@ -19,7 +19,7 @@ pub struct DotnetConfig<'a> {
 impl<'a> Default for DotnetConfig<'a> {
     fn default() -> Self {
         DotnetConfig {
-            format: "[$symbol($version )(🎯 $tfm )]($style)",
+            format: "via [$symbol($version )(🎯 $tfm )]($style)",
             version_format: "v${raw}",
             symbol: ".NET ",
             style: "blue bold",

--- a/src/modules/dotnet.rs
+++ b/src/modules/dotnet.rs
@@ -364,7 +364,10 @@ mod tests {
         touch_path(&workspace, "Directory.Build.props", None)?;
         expect_output(
             &workspace.path(),
-            Some(format!("{}", Color::Blue.bold().paint(".NET v3.1.103 "))),
+            Some(format!(
+                "via {}",
+                Color::Blue.bold().paint(".NET v3.1.103 ")
+            )),
         );
         workspace.close()
     }
@@ -376,8 +379,8 @@ mod tests {
         expect_output(
             &workspace.path(),
             Some(format!(
-                "{}",
-                Color::Blue.bold().paint("via .NET v3.1.103 ")
+                "via {}",
+                Color::Blue.bold().paint(".NET v3.1.103 ")
             )),
         );
         workspace.close()
@@ -389,7 +392,10 @@ mod tests {
         touch_path(&workspace, "Packages.props", None)?;
         expect_output(
             &workspace.path(),
-            Some(format!("{}", Color::Blue.bold().paint(".NET v3.1.103 "))),
+            Some(format!(
+                "via {}",
+                Color::Blue.bold().paint(".NET v3.1.103 ")
+            )),
         );
         workspace.close()
     }
@@ -410,7 +416,7 @@ mod tests {
         expect_output(
             &workspace.path(),
             Some(format!(
-                "{}",
+                "via {}",
                 Color::Blue.bold().paint(".NET v3.1.103 🎯 netstandard2.0 ")
             )),
         );
@@ -423,7 +429,10 @@ mod tests {
         touch_path(&workspace, "project.fsproj", None)?;
         expect_output(
             &workspace.path(),
-            Some(format!("{}", Color::Blue.bold().paint(".NET v3.1.103 "))),
+            Some(format!(
+                "via {}",
+                Color::Blue.bold().paint(".NET v3.1.103 ")
+            )),
         );
         workspace.close()
     }
@@ -434,7 +443,10 @@ mod tests {
         touch_path(&workspace, "project.xproj", None)?;
         expect_output(
             &workspace.path(),
-            Some(format!("{}", Color::Blue.bold().paint(".NET v3.1.103 "))),
+            Some(format!(
+                "via {}",
+                Color::Blue.bold().paint(".NET v3.1.103 ")
+            )),
         );
         workspace.close()
     }
@@ -445,7 +457,10 @@ mod tests {
         touch_path(&workspace, "project.json", None)?;
         expect_output(
             &workspace.path(),
-            Some(format!("{}", Color::Blue.bold().paint(".NET v3.1.103 "))),
+            Some(format!(
+                "via {}",
+                Color::Blue.bold().paint(".NET v3.1.103 ")
+            )),
         );
         workspace.close()
     }
@@ -457,7 +472,7 @@ mod tests {
         touch_path(&workspace, "global.json", Some(&global_json))?;
         expect_output(
             &workspace.path(),
-            Some(format!("{}", Color::Blue.bold().paint(".NET v1.2.3 "))),
+            Some(format!("via {}", Color::Blue.bold().paint(".NET v1.2.3 "))),
         );
         workspace.close()
     }
@@ -472,7 +487,7 @@ mod tests {
         expect_output(
             &workspace.path().join("project"),
             Some(format!(
-                "{}",
+                "via {}",
                 Color::Blue.bold().paint(".NET v1.2.3 🎯 netstandard2.0 ")
             )),
         );
@@ -493,10 +508,8 @@ mod tests {
         expect_output(
             &workspace.path().join("deep/path/to/project"),
             Some(format!(
-                "{}",
-                Color::Blue
-                    .bold()
-                    .paint("via .NET v1.2.3 🎯 netstandard2.0 ")
+                "via {}",
+                Color::Blue.bold().paint(".NET v1.2.3 🎯 netstandard2.0 ")
             )),
         );
         workspace.close()
@@ -510,7 +523,7 @@ mod tests {
         expect_output(
             workspace.path(),
             Some(format!(
-                "{}",
+                "via {}",
                 Color::Blue.bold().paint(".NET v3.1.103 🎯 netstandard2.0 ")
             )),
         );
@@ -525,7 +538,7 @@ mod tests {
         expect_output(
             workspace.path(),
             Some(format!(
-                "{}",
+                "via {}",
                 Color::Blue
                     .bold()
                     .paint(".NET v3.1.103 🎯 netstandard2.0;net461 ")

--- a/src/modules/dotnet.rs
+++ b/src/modules/dotnet.rs
@@ -364,7 +364,10 @@ mod tests {
         touch_path(&workspace, "Directory.Build.props", None)?;
         expect_output(
             &workspace.path(),
-            Some(format!("{}", Color::Blue.bold().paint("via .NET v3.1.103 "))),
+            Some(format!(
+                "{}",
+                Color::Blue.bold().paint("via .NET v3.1.103 ")
+            )),
         );
         workspace.close()
     }
@@ -375,7 +378,10 @@ mod tests {
         touch_path(&workspace, "Directory.Build.targets", None)?;
         expect_output(
             &workspace.path(),
-            Some(format!("{}", Color::Blue.bold().paint("via .NET v3.1.103 "))),
+            Some(format!(
+                "{}",
+                Color::Blue.bold().paint("via .NET v3.1.103 ")
+            )),
         );
         workspace.close()
     }
@@ -386,7 +392,10 @@ mod tests {
         touch_path(&workspace, "Packages.props", None)?;
         expect_output(
             &workspace.path(),
-            Some(format!("{}", Color::Blue.bold().paint("via .NET v3.1.103 "))),
+            Some(format!(
+                "{}",
+                Color::Blue.bold().paint("via .NET v3.1.103 ")
+            )),
         );
         workspace.close()
     }
@@ -408,7 +417,9 @@ mod tests {
             &workspace.path(),
             Some(format!(
                 "{}",
-                Color::Blue.bold().paint("via .NET v3.1.103 🎯 netstandard2.0 ")
+                Color::Blue
+                    .bold()
+                    .paint("via .NET v3.1.103 🎯 netstandard2.0 ")
             )),
         );
         workspace.close()
@@ -420,7 +431,10 @@ mod tests {
         touch_path(&workspace, "project.fsproj", None)?;
         expect_output(
             &workspace.path(),
-            Some(format!("{}", Color::Blue.bold().paint("via .NET v3.1.103 "))),
+            Some(format!(
+                "{}",
+                Color::Blue.bold().paint("via .NET v3.1.103 ")
+            )),
         );
         workspace.close()
     }
@@ -431,7 +445,10 @@ mod tests {
         touch_path(&workspace, "project.xproj", None)?;
         expect_output(
             &workspace.path(),
-            Some(format!("{}", Color::Blue.bold().paint("via .NET v3.1.103 "))),
+            Some(format!(
+                "{}",
+                Color::Blue.bold().paint("via .NET v3.1.103 ")
+            )),
         );
         workspace.close()
     }
@@ -442,7 +459,10 @@ mod tests {
         touch_path(&workspace, "project.json", None)?;
         expect_output(
             &workspace.path(),
-            Some(format!("{}", Color::Blue.bold().paint("via .NET v3.1.103 "))),
+            Some(format!(
+                "{}",
+                Color::Blue.bold().paint("via .NET v3.1.103 ")
+            )),
         );
         workspace.close()
     }
@@ -470,7 +490,9 @@ mod tests {
             &workspace.path().join("project"),
             Some(format!(
                 "{}",
-                Color::Blue.bold().paint("via .NET v1.2.3 🎯 netstandard2.0 ")
+                Color::Blue
+                    .bold()
+                    .paint("via .NET v1.2.3 🎯 netstandard2.0 ")
             )),
         );
         workspace.close()
@@ -491,7 +513,9 @@ mod tests {
             &workspace.path().join("deep/path/to/project"),
             Some(format!(
                 "{}",
-                Color::Blue.bold().paint("via .NET v1.2.3 🎯 netstandard2.0 ")
+                Color::Blue
+                    .bold()
+                    .paint("via .NET v1.2.3 🎯 netstandard2.0 ")
             )),
         );
         workspace.close()
@@ -506,7 +530,9 @@ mod tests {
             workspace.path(),
             Some(format!(
                 "{}",
-                Color::Blue.bold().paint("via .NET v3.1.103 🎯 netstandard2.0 ")
+                Color::Blue
+                    .bold()
+                    .paint("via .NET v3.1.103 🎯 netstandard2.0 ")
             )),
         );
         workspace.close()

--- a/src/modules/dotnet.rs
+++ b/src/modules/dotnet.rs
@@ -364,10 +364,7 @@ mod tests {
         touch_path(&workspace, "Directory.Build.props", None)?;
         expect_output(
             &workspace.path(),
-            Some(format!(
-                "{}",
-                Color::Blue.bold().paint(".NET v3.1.103 ")
-            )),
+            Some(format!("{}", Color::Blue.bold().paint(".NET v3.1.103 "))),
         );
         workspace.close()
     }
@@ -392,10 +389,7 @@ mod tests {
         touch_path(&workspace, "Packages.props", None)?;
         expect_output(
             &workspace.path(),
-            Some(format!(
-                "{}",
-                Color::Blue.bold().paint(".NET v3.1.103 ")
-            )),
+            Some(format!("{}", Color::Blue.bold().paint(".NET v3.1.103 "))),
         );
         workspace.close()
     }
@@ -417,9 +411,7 @@ mod tests {
             &workspace.path(),
             Some(format!(
                 "{}",
-                Color::Blue
-                    .bold()
-                    .paint(".NET v3.1.103 🎯 netstandard2.0 ")
+                Color::Blue.bold().paint(".NET v3.1.103 🎯 netstandard2.0 ")
             )),
         );
         workspace.close()
@@ -431,10 +423,7 @@ mod tests {
         touch_path(&workspace, "project.fsproj", None)?;
         expect_output(
             &workspace.path(),
-            Some(format!(
-                "{}",
-                Color::Blue.bold().paint(".NET v3.1.103 ")
-            )),
+            Some(format!("{}", Color::Blue.bold().paint(".NET v3.1.103 "))),
         );
         workspace.close()
     }
@@ -445,10 +434,7 @@ mod tests {
         touch_path(&workspace, "project.xproj", None)?;
         expect_output(
             &workspace.path(),
-            Some(format!(
-                "{}",
-                Color::Blue.bold().paint(".NET v3.1.103 ")
-            )),
+            Some(format!("{}", Color::Blue.bold().paint(".NET v3.1.103 "))),
         );
         workspace.close()
     }
@@ -459,10 +445,7 @@ mod tests {
         touch_path(&workspace, "project.json", None)?;
         expect_output(
             &workspace.path(),
-            Some(format!(
-                "{}",
-                Color::Blue.bold().paint(".NET v3.1.103 ")
-            )),
+            Some(format!("{}", Color::Blue.bold().paint(".NET v3.1.103 "))),
         );
         workspace.close()
     }
@@ -490,9 +473,7 @@ mod tests {
             &workspace.path().join("project"),
             Some(format!(
                 "{}",
-                Color::Blue
-                    .bold()
-                    .paint(".NET v1.2.3 🎯 netstandard2.0 ")
+                Color::Blue.bold().paint(".NET v1.2.3 🎯 netstandard2.0 ")
             )),
         );
         workspace.close()
@@ -513,9 +494,7 @@ mod tests {
             &workspace.path().join("deep/path/to/project"),
             Some(format!(
                 "{}",
-                Color::Blue
-                    .bold()
-                    .paint(".NET v1.2.3 🎯 netstandard2.0 ")
+                Color::Blue.bold().paint(".NET v1.2.3 🎯 netstandard2.0 ")
             )),
         );
         workspace.close()
@@ -530,9 +509,7 @@ mod tests {
             workspace.path(),
             Some(format!(
                 "{}",
-                Color::Blue
-                    .bold()
-                    .paint(".NET v3.1.103 🎯 netstandard2.0 ")
+                Color::Blue.bold().paint(".NET v3.1.103 🎯 netstandard2.0 ")
             )),
         );
         workspace.close()

--- a/src/modules/dotnet.rs
+++ b/src/modules/dotnet.rs
@@ -494,7 +494,9 @@ mod tests {
             &workspace.path().join("deep/path/to/project"),
             Some(format!(
                 "{}",
-                Color::Blue.bold().paint(".NET v1.2.3 🎯 netstandard2.0 ")
+                Color::Blue
+                    .bold()
+                    .paint("via .NET v1.2.3 🎯 netstandard2.0 ")
             )),
         );
         workspace.close()

--- a/src/modules/dotnet.rs
+++ b/src/modules/dotnet.rs
@@ -366,7 +366,7 @@ mod tests {
             &workspace.path(),
             Some(format!(
                 "{}",
-                Color::Blue.bold().paint("via .NET v3.1.103 ")
+                Color::Blue.bold().paint(".NET v3.1.103 ")
             )),
         );
         workspace.close()
@@ -394,7 +394,7 @@ mod tests {
             &workspace.path(),
             Some(format!(
                 "{}",
-                Color::Blue.bold().paint("via .NET v3.1.103 ")
+                Color::Blue.bold().paint(".NET v3.1.103 ")
             )),
         );
         workspace.close()
@@ -419,7 +419,7 @@ mod tests {
                 "{}",
                 Color::Blue
                     .bold()
-                    .paint("via .NET v3.1.103 🎯 netstandard2.0 ")
+                    .paint(".NET v3.1.103 🎯 netstandard2.0 ")
             )),
         );
         workspace.close()
@@ -433,7 +433,7 @@ mod tests {
             &workspace.path(),
             Some(format!(
                 "{}",
-                Color::Blue.bold().paint("via .NET v3.1.103 ")
+                Color::Blue.bold().paint(".NET v3.1.103 ")
             )),
         );
         workspace.close()
@@ -447,7 +447,7 @@ mod tests {
             &workspace.path(),
             Some(format!(
                 "{}",
-                Color::Blue.bold().paint("via .NET v3.1.103 ")
+                Color::Blue.bold().paint(".NET v3.1.103 ")
             )),
         );
         workspace.close()
@@ -461,7 +461,7 @@ mod tests {
             &workspace.path(),
             Some(format!(
                 "{}",
-                Color::Blue.bold().paint("via .NET v3.1.103 ")
+                Color::Blue.bold().paint(".NET v3.1.103 ")
             )),
         );
         workspace.close()
@@ -474,7 +474,7 @@ mod tests {
         touch_path(&workspace, "global.json", Some(&global_json))?;
         expect_output(
             &workspace.path(),
-            Some(format!("{}", Color::Blue.bold().paint("via .NET v1.2.3 "))),
+            Some(format!("{}", Color::Blue.bold().paint(".NET v1.2.3 "))),
         );
         workspace.close()
     }
@@ -492,7 +492,7 @@ mod tests {
                 "{}",
                 Color::Blue
                     .bold()
-                    .paint("via .NET v1.2.3 🎯 netstandard2.0 ")
+                    .paint(".NET v1.2.3 🎯 netstandard2.0 ")
             )),
         );
         workspace.close()
@@ -515,7 +515,7 @@ mod tests {
                 "{}",
                 Color::Blue
                     .bold()
-                    .paint("via .NET v1.2.3 🎯 netstandard2.0 ")
+                    .paint(".NET v1.2.3 🎯 netstandard2.0 ")
             )),
         );
         workspace.close()
@@ -532,7 +532,7 @@ mod tests {
                 "{}",
                 Color::Blue
                     .bold()
-                    .paint("via .NET v3.1.103 🎯 netstandard2.0 ")
+                    .paint(".NET v3.1.103 🎯 netstandard2.0 ")
             )),
         );
         workspace.close()
@@ -549,7 +549,7 @@ mod tests {
                 "{}",
                 Color::Blue
                     .bold()
-                    .paint("via .NET v3.1.103 🎯 netstandard2.0;net461 ")
+                    .paint(".NET v3.1.103 🎯 netstandard2.0;net461 ")
             )),
         );
         workspace.close()

--- a/src/modules/dotnet.rs
+++ b/src/modules/dotnet.rs
@@ -364,7 +364,7 @@ mod tests {
         touch_path(&workspace, "Directory.Build.props", None)?;
         expect_output(
             &workspace.path(),
-            Some(format!("{}", Color::Blue.bold().paint(".NET v3.1.103 "))),
+            Some(format!("{}", Color::Blue.bold().paint("via .NET v3.1.103 "))),
         );
         workspace.close()
     }
@@ -375,7 +375,7 @@ mod tests {
         touch_path(&workspace, "Directory.Build.targets", None)?;
         expect_output(
             &workspace.path(),
-            Some(format!("{}", Color::Blue.bold().paint(".NET v3.1.103 "))),
+            Some(format!("{}", Color::Blue.bold().paint("via .NET v3.1.103 "))),
         );
         workspace.close()
     }
@@ -386,7 +386,7 @@ mod tests {
         touch_path(&workspace, "Packages.props", None)?;
         expect_output(
             &workspace.path(),
-            Some(format!("{}", Color::Blue.bold().paint(".NET v3.1.103 "))),
+            Some(format!("{}", Color::Blue.bold().paint("via .NET v3.1.103 "))),
         );
         workspace.close()
     }
@@ -408,7 +408,7 @@ mod tests {
             &workspace.path(),
             Some(format!(
                 "{}",
-                Color::Blue.bold().paint(".NET v3.1.103 🎯 netstandard2.0 ")
+                Color::Blue.bold().paint("via .NET v3.1.103 🎯 netstandard2.0 ")
             )),
         );
         workspace.close()
@@ -420,7 +420,7 @@ mod tests {
         touch_path(&workspace, "project.fsproj", None)?;
         expect_output(
             &workspace.path(),
-            Some(format!("{}", Color::Blue.bold().paint(".NET v3.1.103 "))),
+            Some(format!("{}", Color::Blue.bold().paint("via .NET v3.1.103 "))),
         );
         workspace.close()
     }
@@ -431,7 +431,7 @@ mod tests {
         touch_path(&workspace, "project.xproj", None)?;
         expect_output(
             &workspace.path(),
-            Some(format!("{}", Color::Blue.bold().paint(".NET v3.1.103 "))),
+            Some(format!("{}", Color::Blue.bold().paint("via .NET v3.1.103 "))),
         );
         workspace.close()
     }
@@ -442,7 +442,7 @@ mod tests {
         touch_path(&workspace, "project.json", None)?;
         expect_output(
             &workspace.path(),
-            Some(format!("{}", Color::Blue.bold().paint(".NET v3.1.103 "))),
+            Some(format!("{}", Color::Blue.bold().paint("via .NET v3.1.103 "))),
         );
         workspace.close()
     }
@@ -454,7 +454,7 @@ mod tests {
         touch_path(&workspace, "global.json", Some(&global_json))?;
         expect_output(
             &workspace.path(),
-            Some(format!("{}", Color::Blue.bold().paint(".NET v1.2.3 "))),
+            Some(format!("{}", Color::Blue.bold().paint("via .NET v1.2.3 "))),
         );
         workspace.close()
     }
@@ -470,7 +470,7 @@ mod tests {
             &workspace.path().join("project"),
             Some(format!(
                 "{}",
-                Color::Blue.bold().paint(".NET v1.2.3 🎯 netstandard2.0 ")
+                Color::Blue.bold().paint("via .NET v1.2.3 🎯 netstandard2.0 ")
             )),
         );
         workspace.close()
@@ -491,7 +491,7 @@ mod tests {
             &workspace.path().join("deep/path/to/project"),
             Some(format!(
                 "{}",
-                Color::Blue.bold().paint(".NET v1.2.3 🎯 netstandard2.0 ")
+                Color::Blue.bold().paint("via .NET v1.2.3 🎯 netstandard2.0 ")
             )),
         );
         workspace.close()
@@ -506,7 +506,7 @@ mod tests {
             workspace.path(),
             Some(format!(
                 "{}",
-                Color::Blue.bold().paint(".NET v3.1.103 🎯 netstandard2.0 ")
+                Color::Blue.bold().paint("via .NET v3.1.103 🎯 netstandard2.0 ")
             )),
         );
         workspace.close()
@@ -523,7 +523,7 @@ mod tests {
                 "{}",
                 Color::Blue
                     .bold()
-                    .paint(".NET v3.1.103 🎯 netstandard2.0;net461 ")
+                    .paint("via .NET v3.1.103 🎯 netstandard2.0;net461 ")
             )),
         );
         workspace.close()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

Add `via ` prefix to `dotnet` modules's default format config.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Make it consistent with other modules.

#### Screenshots (if appropriate):

Before:

![image](https://user-images.githubusercontent.com/44045911/124379897-4ac8d380-dcec-11eb-9c22-de9159352251.png)

After: 
![image](https://user-images.githubusercontent.com/44045911/124379861-11906380-dcec-11eb-9b99-bb07220b571b.png)


#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
