### PR TITLE
docs(config): issue #1973, minimal prompt example

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -246,6 +246,16 @@ $shell\
 $character"""
 ```
 
+An alternative way to disable modules is to remove them from the prompt. Users prefering a more minimal prompt could for example use
+```toml
+format = """
+$username\
+$hostname\
+$directory\
+$shell\
+$character"""
+```
+
 ## AWS
 
 The `aws` module shows the current AWS region and profile. This is based on

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -178,7 +178,7 @@ add_newline = false
 
 ### Default Prompt Format
 
-The default `format` is used to define the format of the prompt, if empty or no `format` is provided. The default is as shown:
+If `format` is empty or no `format` is provided, a default value is used. The default is as shown:
 
 ```toml
 format = "$all"


### PR DESCRIPTION
#### Description
I slightly changed the wording under heading "Default Prompt Format" and added an example minimal prompt. It was not clear that removing modules from the prompt disables them.

#### Motivation and Context
Closes #1973

#### Checklist:
- [x ] I have updated the documentation accordingly.
- [? ] I have updated the tests accordingly.
