### PR TITLE
fix: prevent cutting of the time

### DIFF
--- a/docs/presets/README.md
+++ b/docs/presets/README.md
@@ -113,7 +113,7 @@ format = '\[[$symbol($profile)(\($region\))(\[$duration\])]($style)\]'
 format = '\[[$symbol($version)]($style)\]'
 
 [cmd_duration]
-format = "[⏱ $duration]($style)"
+format = '\[⏱ $duration\]($style)'
 
 [conda]
 format = '\[[$symbol$environment]($style)\]'

--- a/docs/presets/README.md
+++ b/docs/presets/README.md
@@ -113,7 +113,7 @@ format = '\[[$symbol($profile)(\($region\))(\[$duration\])]($style)\]'
 format = '\[[$symbol($version)]($style)\]'
 
 [cmd_duration]
-format = '\[⏱ $duration\]($style)'
+format = '\[[⏱ $duration ]($style)\]'
 
 [conda]
 format = '\[[$symbol$environment]($style)\]'


### PR DESCRIPTION
#### Description
Changing the formatstring from double to single quotes with escapes ensures the time is shown correctly

#### Motivation and Context
Looked bad.

#### Screenshots (if appropriate):
Before:
![before](https://user-images.githubusercontent.com/27806916/124932409-588b9b00-e003-11eb-945e-ade49310c4f7.jpg)
After:
![after](https://user-images.githubusercontent.com/27806916/124932474-66412080-e003-11eb-8b84-5609102ecd35.jpg)

#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
