### PR TITLE
fix: PowerShell init - replace Get-Error with $error[0]

### DIFF
--- a/src/init/starship.ps1
+++ b/src/init/starship.ps1
@@ -82,7 +82,7 @@ function global:prompt {
         # In case we have a False on the Dollar hook, we know there's an error.
         if (-not $origDollarQuestion) {
             # We retrieve the InvocationInfo from the most recent error.
-            $lastCmdletError = try { Get-Error |  Where-Object { $_ -ne $null } | Select-Object -expand InvocationInfo } catch { $null }
+            $lastCmdletError = try { $error[0] |  Where-Object { $_ -ne $null } | Select-Object -ExpandProperty InvocationInfo } catch { $null }
             # We check if the last command executed matches the line that caused the last error, in which case we know
             # it was an internal Powershell command, otherwise, there MUST be an error code.
             $lastExitCodeForPrompt = if ($null -ne $lastCmdletError -and $lastCmd.CommandLine -eq $lastCmdletError.Line) { 1 } else { $origLastExitCode }

--- a/src/init/starship.ps1
+++ b/src/init/starship.ps1
@@ -81,7 +81,7 @@ function global:prompt {
     if ($lastCmd = Get-History -Count 1) {
         # In case we have a False on the Dollar hook, we know there's an error.
         if (-not $origDollarQuestion) {
-            # We retrieve the InvocationInfo from the most recent error.
+            # We retrieve the InvocationInfo from the most recent error using $error[0]
             $lastCmdletError = try { $error[0] |  Where-Object { $_ -ne $null } | Select-Object -ExpandProperty InvocationInfo } catch { $null }
             # We check if the last command executed matches the line that caused the last error, in which case we know
             # it was an internal Powershell command, otherwise, there MUST be an error code.


### PR DESCRIPTION
#### Description
`Get-Error` does not exist in all versions of PowerShell, and attempting to use it on machines where it does not exist pollutes `$error`. Someone may be tempted to use `-ErrorAction Ignore` but since the command does not exist, it still ends up in `$error`

This is a dual bug fix because it actually gets errors on all machines now and it does not pollute `$error`.
#### Motivation and Context
In looking for unrelated errors, I kept seeing an error about `Get-Error` not existing, and narrowed it down to starship.

I also changed `-expand` to `-ExpandProperty` while I was at it because it is best practice.

#### Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/8278033/125060004-369a2300-e0ac-11eb-8efc-124a43e5ebba.png)

`$error[0]` exists in all versions of PowerShell and will not cause issues even if there are no errors

![image](https://user-images.githubusercontent.com/8278033/125060181-60534a00-e0ac-11eb-9a7a-1384dcd95a02.png)

#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

I didn't test within starship, but I did at the console. First, I opened a fresh console with no errors and you can see that attempting to get `$lastCmdletError` did not cause errors. Next, I forced an error, then I ran the line again and you can see that it did get `$lastCmdletError`

![image](https://user-images.githubusercontent.com/8278033/125061027-39494800-e0ad-11eb-8fa5-c0000d24cbda.png)

#### Checklist:
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.

There are no other instances of `Get-Error`, including tests, so this was likely the only place it was being used