### PR TITLE
fix(nu): use correct session key variable name

### DIFF
--- a/src/init/starship.nu
+++ b/src/init/starship.nu
@@ -1,5 +1,5 @@
 let-env STARSHIP_SHELL = "nu"
-let-env STARSHIP_SESSION = (random chars -l 16)
+let-env STARSHIP_SESSION_KEY = (random chars -l 16)
 
 def starship_prompt [] {
     # jobs are not supported


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
The nu init script was setting `STARSHIP_SESSION` instead of the correct `STARSHIP_SESSION_KEY` variable. 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
