### PR TITLE
feat(kubernetes): implements regex matching for context aliases

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1722,6 +1722,33 @@ format = 'on [⛵ $context \($namespace\)](dimmed green) '
 disabled = false
 [kubernetes.context_aliases]
 "dev.local.cluster.k8s" = "dev"
+".*/openshift-cluster/.*" = "openshift"
+"gke_.*_(?P<cluster>[\\w-]+)" = "gke-$cluster"
+```
+
+#### Regex Matching
+
+Additional to simple aliasing, `context_aliases` also supports
+extended matching and renaming using regular expressions.
+
+The regular expression must match on the entire kube context,
+capture groups can be referenced using `$name` and `$N` in the replacement.
+This is more explained in the [regex crate](https://docs.rs/regex/1.5.4/regex/struct.Regex.html#method.replace) documentation.
+
+Long and automatically generated cluster names can be identified
+and shortened using regular expressions:
+
+```toml
+[kubernetes.context_aliases]
+# OpenShift contexts carry the namespace and user in the kube context: `namespace/name/user`:
+".*/openshift-cluster/.*" = "openshift"
+# Or better, to rename every OpenShift cluster at once:
+".*/(?P<cluster>[\\w-]+)/.*" = "$cluster"
+
+# Contexts from GKE, AWS and other cloud providers usually carry additional information, like the region/zone.
+# The following entry matches on the GKE format (`gke_projectname_zone_cluster-name`)
+# and renames every matching kube context into a more readable format (`gke-cluster-name`):
+"gke_.*_(?P<cluster>[\\w-]+)" = "gke-$cluster"
 ```
 
 ## Line Break


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

Extends the existing feature of kubernetes context aliases with regular expressions, context aliases now can match on the context via regex, match groups can then be used in the alias for dynamic naming. E.g.:

```toml
[kubernetes.context_aliases]
"gke_.*_(?P<cluster>[\\w-]+)" = "gke-$cluster"
```

This matches on `gke_infra-cluster-28cccff6_europe-west4_cluster-1` and produces the alias `gke-cluster-1`. This is very useful for cloud providers (GKE, Azure), as well as OpenShift clusters (`namespace/openshift-cluster/user` -> `.*/openshift-cluster/.*`).

#### Motivation and Context

Closes #800
Closes #839
Closes #851

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [X] I have tested using **Linux**
- [ ] I have tested using **Windows**

I tested manually (my own kube context) and added tests to the kubernetes module which are supposed to show that existing functionality is not broken and the added functionality works as expected.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have updated the documentation accordingly.
- [X] I have updated the tests accordingly.
