### PR TITLE
fix(init): remove quotes in bash init

### DIFF
--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -136,9 +136,9 @@ pub fn init_stub(shell_name: &str) -> io::Result<()> {
                 local minor="${{BASH_VERSINFO[1]}}"
 
                 if ((major > 4)) || {{ ((major == 4)) && ((minor >= 1)); }}; then
-                    source <("{0}" init bash --print-full-init)
+                    source <({0} init bash --print-full-init)
                 else
-                    source /dev/stdin <<<"$("{0}" init bash --print-full-init)"
+                    source /dev/stdin <<<"$({0} init bash --print-full-init)"
                 fi
             }}
             __main


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
In #2848 I forgot removing the quotes from the bash snippet, which means paths might be quoted twice.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
