### PR TITLE
fix: update git_commit default in READMEs

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1189,7 +1189,7 @@ The `git_commit` module shows the current commit hash and also the tag (if any) 
 | Option               | Default                                        | Description                                             |
 | -------------------- | ---------------------------------------------- | ------------------------------------------------------- |
 | `commit_hash_length` | `7`                                            | The length of the displayed git commit hash.            |
-| `format`             | `"[\\($hash\\)]($style) [\\($tag\\)]($style)"` | The format for the module.                              |
+| `format`             | `"[\\($hash$tag\\)]($style) "` | The format for the module.                              |
 | `style`              | `"bold green"`                                 | The style for the module.                               |
 | `only_detached`      | `true`                                         | Only show git commit hash when in detached `HEAD` state |
 | `tag_disabled`       | `true`                                         | Disables showing tag info in `git_commit` module.       |


### PR DESCRIPTION
#### Description

updates git_commit default in README files to the actual default

#### Motivation and Context

it was incorrect

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
