### PR TITLE
fix(jobs): Add the symbol and number thresholds respecting the `threshold` option

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1549,9 +1549,18 @@ symbol = "🌟 "
 
 The `jobs` module shows the current number of jobs running.
 The module will be shown only if there are background jobs running.
-The module will show the number of jobs running if there is more than 1 job, or
-more than the `threshold` config value, if it exists. If `threshold` is set to 0,
-then the module will also show when there are 0 jobs running.
+The module will show the number of jobs running if there are at least
+2 jobs, or more than the `number_threshold` config value, if it exists.
+The module will show a symbol if there is at least 1 job, or more than the
+`symbol_threshold` config value, if it exists. You can set both values
+to 0 in order to *always* show the symbol and number of jobs, even if there are
+0 jobs running.
+
+The default functionality is:
+
+- 0 jobs -> Nothing is shown.
+- 1 job -> `symbol` is shown.
+- 2 jobs or more -> `symbol` + `number` are shown.
 
 ::: warning
 
@@ -1559,15 +1568,27 @@ This module is not supported on tcsh and nu.
 
 :::
 
+::: warning
+
+The `threshold` option is deprecated, but if you want to use it,
+the module will show the number of jobs running if there is more than 1 job, or
+more than the `threshold` config value, if it exists. If `threshold` is set to 0,
+then the module will also show when there are 0 jobs running.
+
+:::
+
 ### Options
 
-| Option      | Default                       | Description                                      |
-| ----------- | ----------------------------- | ------------------------------------------------ |
-| `threshold` | `1`                           | Show number of jobs if exceeded.                 |
-| `format`    | `"[$symbol$number]($style) "` | The format for the module.                       |
-| `symbol`    | `"✦"`                         | A format string representing the number of jobs. |
-| `style`     | `"bold blue"`                 | The style for the module.                        |
-| `disabled`  | `false`                       | Disables the `jobs` module.                      |
+| Option             | Default                       | Description                                                                                 |
+| -----------        | ----------------------------- | ------------------------------------------------                                            |
+| `threshold`\*      | `1`                           | Show number of jobs if exceeded.                                                            |
+| `symbol_threshold` | `1`                           | Show `symbol` if the job count is at least `symbol_threshold`.                              |
+| `number_threshold` | `2`                           | Show the number of jobs if the job count is at least `number_threshold`.                    |
+| `format`           | `"[$symbol$number]($style) "` | The format for the module.                                                                  |
+| `symbol`           | `"✦"`                         | The string used to represent the `symbol` variable.                                         |
+| `style`            | `"bold blue"`                 | The style for the module.                                                                   |
+| `disabled`         | `false`                       | Disables the `jobs` module.                                                                 |
+\*: This option is deprecated, please use the `number_threshold` and `symbol_threshold` options instead.
 
 ### Variables
 
@@ -1586,7 +1607,8 @@ This module is not supported on tcsh and nu.
 
 [jobs]
 symbol = "+ "
-threshold = 4
+number_threshold = 4
+symbol_threshold = 0
 ```
 
 ## Julia

--- a/src/configs/jobs.rs
+++ b/src/configs/jobs.rs
@@ -6,6 +6,8 @@ use starship_module_config_derive::ModuleConfig;
 #[derive(Clone, ModuleConfig, Serialize)]
 pub struct JobsConfig<'a> {
     pub threshold: i64,
+    pub symbol_threshold: i64,
+    pub number_threshold: i64,
     pub format: &'a str,
     pub symbol: &'a str,
     pub style: &'a str,
@@ -16,6 +18,8 @@ impl<'a> Default for JobsConfig<'a> {
     fn default() -> Self {
         JobsConfig {
             threshold: 1,
+            symbol_threshold: 1,
+            number_threshold: 2,
             format: "[$symbol$number]($style) ",
             symbol: "✦",
             style: "bold blue",

--- a/src/modules/jobs.rs
+++ b/src/modules/jobs.rs
@@ -41,7 +41,11 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         .parse::<i64>()
         .ok()?;
 
-    if num_of_jobs == 0 && config.threshold > 0 {
+    if num_of_jobs == 0
+        && config.threshold > 0
+        && config.number_threshold > 0
+        && config.symbol_threshold > 0
+    {
         return None;
     }
 
@@ -129,6 +133,96 @@ mod test {
     }
 
     #[test]
+    fn config_default_is_present_jobs_1() {
+        let actual = ModuleRenderer::new("jobs")
+            .config(toml::toml! {
+                [jobs]
+                threshold = 1
+            })
+            .jobs(1)
+            .collect();
+
+        let expected = Some(format!("{} ", Color::Blue.bold().paint("✦")));
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn config_default_is_present_jobs_2() {
+        let actual = ModuleRenderer::new("jobs")
+            .config(toml::toml! {
+                [jobs]
+                threshold = 1
+            })
+            .jobs(2)
+            .collect();
+
+        let expected = Some(format!("{} ", Color::Blue.bold().paint("✦2")));
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn config_conflicting_thresholds_default_jobs_1() {
+        let actual = ModuleRenderer::new("jobs")
+            .config(toml::toml! {
+                [jobs]
+                threshold = 1
+                number_threshold = 2
+            })
+            .jobs(1)
+            .collect();
+
+        let expected = Some(format!("{} ", Color::Blue.bold().paint("✦")));
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn config_conflicting_thresholds_default_no_symbol_jobs_1() {
+        let actual = ModuleRenderer::new("jobs")
+            .config(toml::toml! {
+                [jobs]
+                threshold = 1
+                symbol_threshold = 0
+                number_threshold = 2
+            })
+            .jobs(1)
+            .collect();
+
+        let expected = Some(format!("{} ", Color::Blue.bold().paint("✦")));
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn config_conflicting_thresholds_no_symbol_jobs_1() {
+        let actual = ModuleRenderer::new("jobs")
+            .config(toml::toml! {
+                [jobs]
+                threshold = 0
+                symbol_threshold = 0
+                number_threshold = 2
+            })
+            .jobs(1)
+            .collect();
+
+        let expected = Some(format!("{} ", Color::Blue.bold().paint("✦1")));
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn config_conflicting_thresholds_jobs_2() {
+        let actual = ModuleRenderer::new("jobs")
+            .config(toml::toml! {
+                [jobs]
+                threshold = 1
+                number_threshold = 2
+            })
+            .jobs(2)
+            .collect();
+
+        let expected = Some(format!("{} ", Color::Blue.bold().paint("✦2")));
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
     fn config_2_job_2() {
         let actual = ModuleRenderer::new("jobs")
             .config(toml::toml! {
@@ -143,6 +237,35 @@ mod test {
     }
 
     #[test]
+    fn config_number_2_job_2() {
+        let actual = ModuleRenderer::new("jobs")
+            .config(toml::toml! {
+                [jobs]
+                number_threshold = 2
+            })
+            .jobs(2)
+            .collect();
+
+        let expected = Some(format!("{} ", Color::Blue.bold().paint("✦2")));
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn config_number_2_symbol_3_job_2() {
+        let actual = ModuleRenderer::new("jobs")
+            .config(toml::toml! {
+                [jobs]
+                number_threshold = 2
+                symbol_threshold = 3
+            })
+            .jobs(2)
+            .collect();
+
+        let expected = Some(format!("{} ", Color::Blue.bold().paint("2")));
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
     fn config_2_job_3() {
         let actual = ModuleRenderer::new("jobs")
             .config(toml::toml! {
@@ -153,6 +276,36 @@ mod test {
             .collect();
 
         let expected = Some(format!("{} ", Color::Blue.bold().paint("✦3")));
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn config_thresholds_0_jobs_0() {
+        let actual = ModuleRenderer::new("jobs")
+            .config(toml::toml! {
+                [jobs]
+                number_threshold = 0
+                symbol_threshold = 0
+            })
+            .jobs(0)
+            .collect();
+
+        let expected = Some(format!("{} ", Color::Blue.bold().paint("✦0")));
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn config_thresholds_0_jobs_1() {
+        let actual = ModuleRenderer::new("jobs")
+            .config(toml::toml! {
+                [jobs]
+                number_threshold = 0
+                symbol_threshold = 0
+            })
+            .jobs(1)
+            .collect();
+
+        let expected = Some(format!("{} ", Color::Blue.bold().paint("✦1")));
         assert_eq!(expected, actual);
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR adds two new config options (`number_threshold` and `symbol_threshold`) to fix the current behavior of `threshold` in the `jobs` module. The main issue is that *greater than* is a bit confusing. We now allow a *greater or equal than* logic that simplifies configuring the behavior of the module.

Namely, we follow:

> The two thresholds would be the minimum value at which they're shown.
> The default functionality is:
> • 0 jobs -> nothing
> • 1 job -> symbol
> • 2 jobs or more -> symbol + number

Which covers all of the use cases by separating the symbol and number thresholds. This PR adds several more tests to ensure the correctness of the feature.

One thing to note is that the `threshold` option will be deprecated and a warning is issued if its value in the config is different from the default of `1`.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/starship/starship/issues/2688

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
