### PR TITLE
docs: fix shlvl module's symbol

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2621,7 +2621,7 @@ set to a number and meets or exceeds the specified threshold.
 | ----------- | ---------------------------- | ------------------------------------------------------------- |
 | `threshold` | `2`                          | Display threshold.                                            |
 | `format`    | `"[$symbol$shlvl]($style) "` | The format for the module.                                    |
-| `symbol`    | `"↕️ "`                       | The symbol used to represent the `SHLVL`.                     |
+| `symbol`    | `"↕️  "`                       | The symbol used to represent the `SHLVL`.                     |
 | `repeat`    | `false`                      | Causes `symbol` to be repeated by the current `SHLVL` amount. |
 | `style`     | `"bold yellow"`              | The style for the module.                                     |
 | `disabled`  | `true`                       | Disables the `shlvl` module.                                  |


### PR DESCRIPTION

#### Description
fix the shlvl module's symbol in the docs

#### Motivation and Context
Closes #1925 

#### Screenshots (if appropriate):

#### How Has This Been Tested?

- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
