### PR TITLE
ci: Use default token for release action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -144,8 +144,6 @@ jobs:
         with:
           files: starship-*/starship-*
           body_path: RELEASE.md
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # Publish starship to Crates.io
   cargo_publish:


### PR DESCRIPTION
See upstream: https://github.com/softprops/action-gh-release/pull/83
