### PR TITLE
feat(explain): quote module values

### DIFF
--- a/src/print.rs
+++ b/src/print.rs
@@ -177,10 +177,10 @@ pub fn timings(args: ArgMatches) {
     println!("\n Here are the timings of modules in your prompt (>=1ms or output):");
 
     // for now we do not expect a wrap around at the end... famous last words
-    // Overall a line looks like this: " {module name}  -  {duration}  -  {module value}".
+    // Overall a line looks like this: " {module name}  -  {duration}  -  "{module value}"".
     for timing in &modules {
         println!(
-            " {}{}  -  {}{}  -   {}",
+            " {}{}  -  {}{}  -   \"{}\"",
             timing.name,
             " ".repeat(max_name_width - (timing.name_len)),
             " ".repeat(max_duration_width - (timing.duration_len)),
@@ -222,8 +222,8 @@ pub fn explain(args: ArgMatches) {
     let max_module_width = modules.iter().map(|i| i.value_len).max().unwrap_or(0);
 
     // In addition to the module width itself there are also 9 padding characters in each line.
-    // Overall a line looks like this: " {module value} ({xxxms})  -  {description}".
-    const PADDING_WIDTH: usize = 9;
+    // Overall a line looks like this: " "{module value}" ({xxxms})  -  {description}".
+    const PADDING_WIDTH: usize = 11;
 
     let desc_width = term_size::dimensions()
         .map(|(w, _)| w)
@@ -238,7 +238,7 @@ pub fn explain(args: ArgMatches) {
             let mut escaping = false;
             // Print info
             print!(
-                " {} ({}){}  -  ",
+                " \"{}\" ({}){}  -  ",
                 info.value,
                 info.duration,
                 " ".repeat(max_module_width - (info.value_len))

--- a/src/print.rs
+++ b/src/print.rs
@@ -221,7 +221,7 @@ pub fn explain(args: ArgMatches) {
 
     let max_module_width = modules.iter().map(|i| i.value_len).max().unwrap_or(0);
 
-    // In addition to the module width itself there are also 9 padding characters in each line.
+    // In addition to the module width itself there are also 11 padding characters in each line.
     // Overall a line looks like this: " "{module value}" ({xxxms})  -  {description}".
     const PADDING_WIDTH: usize = 11;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR changes the `explain` and `timings` commands to add quotes around the module outputs to make spaces inside the modules output more obvious.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #2928

#### Screenshots (if appropriate):
Before:
```
 ❯  (<1ms)                             -  A character (usually an arrow) beside where the text is entered in your terminal
 starship  (6ms)                       -  The current working directory
```
After:
```
 "❯ " (<1ms)                             -  A character (usually an arrow) beside where the text is entered in your terminal
 "starship " (8ms)                       -  The current working directory
```


#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
