### PR TITLE
feat(print-config): list expanded `$all` variable

### DIFF
--- a/src/configure.rs
+++ b/src/configure.rs
@@ -84,7 +84,7 @@ pub fn print_configuration(use_default: bool) {
     let custom_modules = config.get("custom").unwrap().as_table().unwrap();
     if !use_default && !custom_modules.is_empty() {
         println!(
-            "# $custom is shorthand for {}",
+            "# $custom (excluding any modules already listed in `format`) is shorthand for {}",
             custom_modules
                 .keys()
                 .map(|module_name| format!("${{custom.{}}}", module_name))

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -79,6 +79,18 @@ pub fn print_configuration(use_default: bool) {
             .map(|module_name| format!("${}", module_name))
             .collect::<String>()
     );
+
+    // Unwrapping is fine because config is based on FullConfig
+    let custom_modules = config.get("custom").unwrap().as_table().unwrap();
+    if !use_default && !custom_modules.is_empty() {
+        println!(
+            "# $custom is shorthand for {}",
+            custom_modules
+                .keys()
+                .map(|module_name| format!("${{custom.{}}}", module_name))
+                .collect::<String>()
+        );
+    }
     println!("{}", string_config);
 }
 

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -5,6 +5,7 @@ use std::process;
 
 use crate::config::RootModuleConfig;
 use crate::config::StarshipConfig;
+use crate::configs::PROMPT_ORDER;
 use crate::utils;
 use std::fs::File;
 use std::io::Write;
@@ -70,7 +71,14 @@ pub fn print_configuration(use_default: bool) {
 
     let string_config = toml::to_string_pretty(&config).unwrap();
 
-    println!("# Warning: This config does not include keys that have an unset value");
+    println!("# Warning: This config does not include keys that have an unset value\n");
+    println!(
+        "# $all is shorthand for {}",
+        PROMPT_ORDER
+            .iter()
+            .map(|module_name| format!("${}", module_name))
+            .collect::<String>()
+    );
     println!("{}", string_config);
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
In addition to the comment about missing unset values add a comment at the top of the `print-confg` that shows how `$all` is expanded.
This works, but I'm not too happy with the output because it results in a very long line.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #2923

#### Screenshots (if appropriate):
New output:

```toml
# Warning: This config does not include keys that have an unset value

# $all is shorthand for $username$hostname$shlvl$singularity$kubernetes$directory$vcsh$git_branch$git_commit$git_state$git_metrics$git_status$hg_branch$docker_context$package$cmake$dart$deno$dotnet$elixir$elm$erlang$golang$helm$java$julia$kotlin$lua$nim$nodejs$ocaml$perl$php$purescript$python$rlang$red$ruby$rust$scala$swift$terraform$vlang$vagrant$zig$nix_shell$conda$memory_usage$aws$gcloud$openstack$env_var$crystal$custom$cmd_duration$line_break$jobs$battery$time$status$shell$character
format = '$all'      
scan_timeout = 30
command_timeout = 500
add_newline = true
```

If customer modules are present:
```toml
# Warning: This config does not include keys that have an unset value

# $all is shorthand for $username$hostname$shlvl$singularity$kubernetes$directory$vcsh$git_branch$git_commit$git_state$git_metrics$git_status$hg_branch$docker_context$package$cmake$dart$deno$dotnet$elixir$elm$erlang$golang$helm$java$julia$kotlin$lua$nim$nodejs$ocaml$perl$php$purescript$python$rlang$red$ruby$rust$scala$swift$terraform$vlang$vagrant$zig$nix_shell$conda$memory_usage$aws$gcloud$openstack$env_var$crystal$custom$cmd_duration$line_break$jobs$battery$time$status$shell$character
# $custom (excluding any modules already listed in `format`) is shorthand for ${custom.foo}
format = '$all'      
scan_timeout = 30
command_timeout = 500
add_newline = true
```

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
