### PR TITLE
fix(clippy): fix new clippy lints

### DIFF
--- a/src/bug_report.rs
+++ b/src/bug_report.rs
@@ -15,7 +15,7 @@ pub fn create() {
 
     let environment = Environment {
         os_type: os_info.os_type(),
-        os_version: os_info.version().to_owned(),
+        os_version: os_info.version().clone(),
         shell_info: get_shell_info(),
         terminal_info: get_terminal_info(),
         starship_config: get_starship_config(),
@@ -151,14 +151,17 @@ fn get_shell_info() -> ShellInfo {
 
     let shell = shell.unwrap();
 
-    let version = exec_cmd(&shell, &["--version"], Duration::from_millis(500))
-        .map(|output| output.stdout.trim().to_string())
-        .unwrap_or_else(|| UNKNOWN_VERSION.to_string());
+    let version = exec_cmd(&shell, &["--version"], Duration::from_millis(500)).map_or_else(
+        || UNKNOWN_VERSION.to_string(),
+        |output| output.stdout.trim().to_string(),
+    );
 
     let config = get_config_path(&shell)
         .and_then(|config_path| fs::read_to_string(config_path).ok())
-        .map(|config| config.trim().to_string())
-        .unwrap_or_else(|| UNKNOWN_CONFIG.to_string());
+        .map_or_else(
+            || UNKNOWN_CONFIG.to_string(),
+            |config| config.trim().to_string(),
+        );
 
     ShellInfo {
         name: shell,

--- a/src/config.rs
+++ b/src/config.rs
@@ -87,12 +87,12 @@ impl<'a> ModuleConfig<'a> for u64 {
             Value::Integer(value) => {
                 // Converting i64 to u64
                 if *value > 0 {
-                    Some(*value as u64)
+                    Some(*value as Self)
                 } else {
                     None
                 }
             }
-            Value::String(value) => value.parse::<u64>().ok(),
+            Value::String(value) => value.parse::<Self>().ok(),
             _ => None,
         }
     }
@@ -109,12 +109,12 @@ impl<'a> ModuleConfig<'a> for usize {
         match config {
             Value::Integer(value) => {
                 if *value > 0 {
-                    Some(*value as usize)
+                    Some(*value as Self)
                 } else {
                     None
                 }
             }
-            Value::String(value) => value.parse::<usize>().ok(),
+            Value::String(value) => value.parse::<Self>().ok(),
             _ => None,
         }
     }
@@ -139,7 +139,7 @@ where
     S: Clone,
 {
     fn from_config(config: &'a Value) -> Option<Self> {
-        let mut hm = HashMap::default();
+        let mut hm = Self::default();
 
         for (x, y) in config.as_table()?.iter() {
             hm.insert(x.clone(), T::from_config(y)?);
@@ -155,7 +155,7 @@ where
     S: Clone,
 {
     fn from_config(config: &'a Value) -> Option<Self> {
-        let mut im = IndexMap::default();
+        let mut im = Self::default();
 
         for (x, y) in config.as_table()?.iter() {
             im.insert(x.clone(), T::from_config(y)?);
@@ -185,7 +185,7 @@ where
 {
     fn from_config(config: &'a Value) -> Option<Self> {
         if let Some(item) = T::from_config(config) {
-            return Some(VecOr(vec![item]));
+            return Some(Self(vec![item]));
         }
 
         let vec = config
@@ -194,7 +194,7 @@ where
             .map(|value| T::from_config(value))
             .collect::<Option<Vec<T>>>()?;
 
-        Some(VecOr(vec))
+        Some(Self(vec))
     }
 }
 
@@ -207,11 +207,11 @@ impl StarshipConfig {
     /// Initialize the Config struct
     pub fn initialize() -> Self {
         if let Some(file_data) = Self::config_from_file() {
-            StarshipConfig {
+            Self {
                 config: Some(file_data),
             }
         } else {
-            StarshipConfig {
+            Self {
                 config: Some(Value::Table(toml::value::Table::new())),
             }
         }

--- a/src/context.rs
+++ b/src/context.rs
@@ -150,7 +150,9 @@ impl<'a> Context<'a> {
     // Retrives a environment variable from the os or from a table if in testing mode
     #[cfg(test)]
     pub fn get_env<K: AsRef<str>>(&self, key: K) -> Option<String> {
-        self.env.get(key.as_ref()).map(|val| val.to_string())
+        self.env
+            .get(key.as_ref())
+            .map(std::string::ToString::to_string)
     }
 
     #[cfg(not(test))]
@@ -233,7 +235,7 @@ impl<'a> Context<'a> {
                 let root = repository
                     .as_ref()
                     .and_then(|repo| repo.workdir().map(Path::to_path_buf));
-                let state = repository.as_ref().map(|repo| repo.state());
+                let state = repository.as_ref().map(git2::Repository::state);
                 let remote = repository
                     .as_ref()
                     .and_then(|repo| get_remote_repository_info(repo));
@@ -344,7 +346,7 @@ impl DirContents {
             start.elapsed()
         );
 
-        Ok(DirContents {
+        Ok(Self {
             files,
             file_names,
             folders,
@@ -459,7 +461,7 @@ fn get_current_branch(repository: &Repository) -> Option<String> {
                     .trim()
                     .split('/')
                     .last()
-                    .map(|r| r.to_owned())
+                    .map(std::borrow::ToOwned::to_owned)
             } else {
                 None
             };

--- a/src/formatter/parser.rs
+++ b/src/formatter/parser.rs
@@ -39,8 +39,7 @@ fn parse_variable(variable: Pair<Rule>) -> &str {
 
 fn parse_text(text: Pair<Rule>) -> String {
     text.into_inner()
-        .map(|pair| pair.as_str().chars())
-        .flatten()
+        .flat_map(|pair| pair.as_str().chars())
         .collect()
 }
 

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -39,7 +39,7 @@ impl Default for StarshipLogger {
             log_file_content: fs::read_to_string(&session_log_file)
                 .unwrap_or_default()
                 .lines()
-                .map(|line| line.to_string())
+                .map(std::string::ToString::to_string)
                 .collect(),
             log_file: OnceCell::new(),
             log_file_path: session_log_file,

--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -44,9 +44,9 @@ fn get_aws_region_from_config(context: &Context, aws_profile: Option<&str>) -> O
     let reader = BufReader::new(file);
     let lines = reader.lines().filter_map(Result::ok);
 
-    let region_line = if let Some(ref aws_profile) = aws_profile {
+    let region_line = if let Some(aws_profile) = aws_profile {
         lines
-            .skip_while(|line| line != &format!("[profile {}]", aws_profile))
+            .skip_while(|line| line != &format!("[profile {}]", &aws_profile))
             .skip(1)
             .take_while(|line| !line.starts_with('['))
             .find(|line| line.starts_with("region"))
@@ -76,7 +76,7 @@ fn get_aws_profile_and_region(context: &Context) -> (Option<Profile>, Option<Reg
         (Some(p), Some(r)) => (Some(p), Some(r)),
         (None, Some(r)) => (None, Some(r)),
         (Some(ref p), None) => (
-            Some(p.to_owned()),
+            Some(p.clone()),
             get_aws_region_from_config(context, Some(p)),
         ),
         (None, None) => (None, get_aws_region_from_config(context, None)),

--- a/src/modules/character.rs
+++ b/src/modules/character.rs
@@ -22,8 +22,8 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let config: CharacterConfig = CharacterConfig::try_load(module.config);
 
     let props = &context.properties;
-    let exit_code = props.get("status_code").map(String::as_str).unwrap_or("0");
-    let keymap = props.get("keymap").map(String::as_str).unwrap_or("viins");
+    let exit_code = props.get("status_code").map_or("0", String::as_str);
+    let keymap = props.get("keymap").map_or("viins", String::as_str);
     let exit_success = exit_code == "0";
 
     // Match shell "keymap" names to normalized vi modes

--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -58,12 +58,12 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let dir_string = repo
         .and_then(|r| r.root.as_ref())
         .filter(|root| *root != &home_dir)
-        .and_then(|root| contract_repo_path(&display_dir, root));
+        .and_then(|root| contract_repo_path(display_dir, root));
 
     // Otherwise use the logical path, automatically contracting
     // the home directory if required.
     let dir_string =
-        dir_string.unwrap_or_else(|| contract_path(&display_dir, &home_dir, &home_symbol));
+        dir_string.unwrap_or_else(|| contract_path(display_dir, &home_dir, &home_symbol));
 
     #[cfg(windows)]
     let dir_string = remove_extended_path_prefix(dir_string);
@@ -79,7 +79,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         // fish-style path contraction together
         if config.fish_style_pwd_dir_length > 0 && config.substitutions.is_empty() {
             // If user is using fish style path, we need to add the segment first
-            let contracted_home_dir = contract_path(&display_dir, &home_dir, &home_symbol);
+            let contracted_home_dir = contract_path(display_dir, &home_dir, &home_symbol);
             to_fish_style(
                 config.fish_style_pwd_dir_length as usize,
                 contracted_home_dir,
@@ -105,7 +105,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             .map(|variable| match variable {
                 "path" => Some(Ok(&displayed_path)),
                 "read_only" => {
-                    if is_readonly_dir(&physical_dir) {
+                    if is_readonly_dir(physical_dir) {
                         Some(Ok(&lock_symbol))
                     } else {
                         None
@@ -330,7 +330,7 @@ mod tests {
         let repo_variations = [repo_dir.clone(), repo_dir.canonicalize().unwrap()];
         for src_dir in &src_variations {
             for repo_dir in &repo_variations {
-                let output = contract_repo_path(&src_dir, &repo_dir);
+                let output = contract_repo_path(src_dir, repo_dir);
                 assert_eq!(output, Some("rocket-controls/src".to_string()));
             }
         }
@@ -494,7 +494,7 @@ mod tests {
             let tmp_dir = TempDir::new_in(home_dir().unwrap().as_path())?;
             let dir = tmp_dir.path().join("src/fuel-gauge");
             fs::create_dir_all(&dir)?;
-            init_repo(&tmp_dir.path())?;
+            init_repo(tmp_dir.path())?;
 
             let actual = ModuleRenderer::new("directory")
                 .config(toml::toml! {

--- a/src/modules/dotnet.rs
+++ b/src/modules/dotnet.rs
@@ -175,7 +175,7 @@ fn estimate_dotnet_version(
 ///     - The root of the git repository
 ///       (If there is one)
 fn try_find_nearby_global_json(current_dir: &Path, repo_root: Option<&Path>) -> Option<String> {
-    let current_dir_is_repo_root = repo_root.map(|r| r == current_dir).unwrap_or(false);
+    let current_dir_is_repo_root = repo_root.map_or(false, |r| r == current_dir);
     let parent_dir = if current_dir_is_repo_root {
         // Don't scan the parent directory if it's above the root of a git repository
         None
@@ -274,8 +274,8 @@ fn get_dotnet_file_type(path: &Path) -> Option<FileType> {
 
     match extension_lower.as_ref().map(|f| f.as_ref()) {
         Some("sln") => return Some(FileType::SolutionFile),
-        Some("csproj") | Some("fsproj") | Some("xproj") => return Some(FileType::ProjectFile),
-        Some("props") | Some("targets") => return Some(FileType::MsBuildFile),
+        Some("csproj" | "fsproj" | "xproj") => return Some(FileType::ProjectFile),
+        Some("props" | "targets") => return Some(FileType::MsBuildFile),
         _ => (),
     };
 
@@ -354,7 +354,7 @@ mod tests {
     #[test]
     fn shows_nothing_in_directory_with_zero_relevant_files() -> io::Result<()> {
         let workspace = create_workspace(false)?;
-        expect_output(&workspace.path(), None);
+        expect_output(workspace.path(), None);
         workspace.close()
     }
 
@@ -363,7 +363,7 @@ mod tests {
         let workspace = create_workspace(false)?;
         touch_path(&workspace, "Directory.Build.props", None)?;
         expect_output(
-            &workspace.path(),
+            workspace.path(),
             Some(format!(
                 "via {}",
                 Color::Blue.bold().paint(".NET v3.1.103 ")
@@ -377,7 +377,7 @@ mod tests {
         let workspace = create_workspace(false)?;
         touch_path(&workspace, "Directory.Build.targets", None)?;
         expect_output(
-            &workspace.path(),
+            workspace.path(),
             Some(format!(
                 "via {}",
                 Color::Blue.bold().paint(".NET v3.1.103 ")
@@ -391,7 +391,7 @@ mod tests {
         let workspace = create_workspace(false)?;
         touch_path(&workspace, "Packages.props", None)?;
         expect_output(
-            &workspace.path(),
+            workspace.path(),
             Some(format!(
                 "via {}",
                 Color::Blue.bold().paint(".NET v3.1.103 ")
@@ -404,7 +404,7 @@ mod tests {
     fn shows_latest_in_directory_with_solution() -> io::Result<()> {
         let workspace = create_workspace(false)?;
         touch_path(&workspace, "solution.sln", None)?;
-        expect_output(&workspace.path(), None);
+        expect_output(workspace.path(), None);
         workspace.close()
     }
 
@@ -414,7 +414,7 @@ mod tests {
         let csproj = make_csproj_with_tfm("TargetFramework", "netstandard2.0");
         touch_path(&workspace, "project.csproj", Some(&csproj))?;
         expect_output(
-            &workspace.path(),
+            workspace.path(),
             Some(format!(
                 "via {}",
                 Color::Blue.bold().paint(".NET v3.1.103 🎯 netstandard2.0 ")
@@ -428,7 +428,7 @@ mod tests {
         let workspace = create_workspace(false)?;
         touch_path(&workspace, "project.fsproj", None)?;
         expect_output(
-            &workspace.path(),
+            workspace.path(),
             Some(format!(
                 "via {}",
                 Color::Blue.bold().paint(".NET v3.1.103 ")
@@ -442,7 +442,7 @@ mod tests {
         let workspace = create_workspace(false)?;
         touch_path(&workspace, "project.xproj", None)?;
         expect_output(
-            &workspace.path(),
+            workspace.path(),
             Some(format!(
                 "via {}",
                 Color::Blue.bold().paint(".NET v3.1.103 ")
@@ -456,7 +456,7 @@ mod tests {
         let workspace = create_workspace(false)?;
         touch_path(&workspace, "project.json", None)?;
         expect_output(
-            &workspace.path(),
+            workspace.path(),
             Some(format!(
                 "via {}",
                 Color::Blue.bold().paint(".NET v3.1.103 ")
@@ -471,7 +471,7 @@ mod tests {
         let global_json = make_pinned_sdk_json("1.2.3");
         touch_path(&workspace, "global.json", Some(&global_json))?;
         expect_output(
-            &workspace.path(),
+            workspace.path(),
             Some(format!("via {}", Color::Blue.bold().paint(".NET v1.2.3 "))),
         );
         workspace.close()

--- a/src/modules/elixir.rs
+++ b/src/modules/elixir.rs
@@ -43,7 +43,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                     .map(|elixir_version| {
                         VersionFormatter::format_module_version(
                             module.get_name(),
-                            &elixir_version,
+                            elixir_version,
                             config.version_format,
                         )
                     })?

--- a/src/modules/elm.rs
+++ b/src/modules/elm.rs
@@ -35,7 +35,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                     let elm_version = context.exec_cmd("elm", &["--version"])?.stdout;
                     VersionFormatter::format_module_version(
                         module.get_name(),
-                        &elm_version.trim(),
+                        elm_version.trim(),
                         config.version_format,
                     )
                     .map(Ok)

--- a/src/modules/env_var.rs
+++ b/src/modules/env_var.rs
@@ -98,7 +98,7 @@ fn get_variable_name<'a>(
 fn get_env_value(context: &Context, name: &str, default: Option<&str>) -> Option<String> {
     match context.get_env(name) {
         Some(value) => Some(value),
-        None => default.map(|value| value.to_owned()),
+        None => default.map(std::borrow::ToOwned::to_owned),
     }
 }
 

--- a/src/modules/gcloud.rs
+++ b/src/modules/gcloud.rs
@@ -128,12 +128,12 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 "account" => account
                     .deref()
                     .as_ref()
-                    .map(|(account, _)| (*account).to_owned())
+                    .map(|(account, _)| (*account).clone())
                     .map(Ok),
                 "domain" => account
                     .deref()
                     .as_ref()
-                    .and_then(|(_, domain)| (*domain).to_owned())
+                    .and_then(|(_, domain)| (*domain).clone())
                     .map(Ok),
                 "region" => gcloud_context
                     .get_region()
@@ -141,15 +141,14 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                         config
                             .region_aliases
                             .get(&region)
-                            .map(|alias| (*alias).to_owned())
-                            .unwrap_or(region)
+                            .map_or(region, |alias| (*alias).to_owned())
                     })
                     .map(Ok),
                 "project" => context
                     .get_env("CLOUDSDK_CORE_PROJECT")
                     .or_else(|| gcloud_context.get_project())
                     .map(Ok),
-                "active" => Some(Ok(gcloud_context.config_name.to_owned())),
+                "active" => Some(Ok(gcloud_context.config_name.clone())),
                 _ => None,
             })
             .parse(None)

--- a/src/modules/git_branch.rs
+++ b/src/modules/git_branch.rs
@@ -50,13 +50,11 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     }
 
     // Truncate fields if need be
-    for e in [
+    for e in &mut [
         &mut graphemes,
         &mut remote_branch_graphemes,
         &mut remote_name_graphemes,
-    ]
-    .iter_mut()
-    {
+    ] {
         let e = &mut **e;
         let trunc_len = len.min(e.len());
         if trunc_len < e.len() {

--- a/src/modules/git_status.rs
+++ b/src/modules/git_status.rs
@@ -259,12 +259,12 @@ impl RepoStatus {
     }
 
     fn add(&mut self, s: &str) {
-        self.conflicted += RepoStatus::is_conflicted(s) as usize;
-        self.deleted += RepoStatus::is_deleted(s) as usize;
-        self.renamed += RepoStatus::is_renamed(s) as usize;
-        self.modified += RepoStatus::is_modified(s) as usize;
-        self.staged += RepoStatus::is_staged(s) as usize;
-        self.untracked += RepoStatus::is_untracked(s) as usize;
+        self.conflicted += Self::is_conflicted(s) as usize;
+        self.deleted += Self::is_deleted(s) as usize;
+        self.renamed += Self::is_renamed(s) as usize;
+        self.modified += Self::is_modified(s) as usize;
+        self.staged += Self::is_staged(s) as usize;
+        self.untracked += Self::is_untracked(s) as usize;
     }
 
     fn set_ahead_behind(&mut self, s: &str) {
@@ -350,7 +350,7 @@ mod tests {
     fn shows_behind() -> io::Result<()> {
         let repo_dir = fixture_repo(FixtureProvider::Git)?;
 
-        behind(&repo_dir.path())?;
+        behind(repo_dir.path())?;
 
         let actual = ModuleRenderer::new("git_status")
             .path(repo_dir.path())
@@ -365,7 +365,7 @@ mod tests {
     fn shows_behind_with_count() -> io::Result<()> {
         let repo_dir = fixture_repo(FixtureProvider::Git)?;
 
-        behind(&repo_dir.path())?;
+        behind(repo_dir.path())?;
 
         let actual = ModuleRenderer::new("git_status")
             .config(toml::toml! {
@@ -385,7 +385,7 @@ mod tests {
         let repo_dir = fixture_repo(FixtureProvider::Git)?;
 
         File::create(repo_dir.path().join("readme.md"))?.sync_all()?;
-        ahead(&repo_dir.path())?;
+        ahead(repo_dir.path())?;
 
         let actual = ModuleRenderer::new("git_status")
             .path(&repo_dir.path())
@@ -401,7 +401,7 @@ mod tests {
         let repo_dir = fixture_repo(FixtureProvider::Git)?;
 
         File::create(repo_dir.path().join("readme.md"))?.sync_all()?;
-        ahead(&repo_dir.path())?;
+        ahead(repo_dir.path())?;
 
         let actual = ModuleRenderer::new("git_status")
             .config(toml::toml! {
@@ -420,7 +420,7 @@ mod tests {
     fn shows_diverged() -> io::Result<()> {
         let repo_dir = fixture_repo(FixtureProvider::Git)?;
 
-        diverge(&repo_dir.path())?;
+        diverge(repo_dir.path())?;
 
         let actual = ModuleRenderer::new("git_status")
             .path(&repo_dir.path())
@@ -435,7 +435,7 @@ mod tests {
     fn shows_diverged_with_count() -> io::Result<()> {
         let repo_dir = fixture_repo(FixtureProvider::Git)?;
 
-        diverge(&repo_dir.path())?;
+        diverge(repo_dir.path())?;
 
         let actual = ModuleRenderer::new("git_status")
             .config(toml::toml! {
@@ -454,7 +454,7 @@ mod tests {
     fn shows_conflicted() -> io::Result<()> {
         let repo_dir = fixture_repo(FixtureProvider::Git)?;
 
-        create_conflict(&repo_dir.path())?;
+        create_conflict(repo_dir.path())?;
 
         let actual = ModuleRenderer::new("git_status")
             .path(&repo_dir.path())
@@ -469,7 +469,7 @@ mod tests {
     fn shows_conflicted_with_count() -> io::Result<()> {
         let repo_dir = fixture_repo(FixtureProvider::Git)?;
 
-        create_conflict(&repo_dir.path())?;
+        create_conflict(repo_dir.path())?;
 
         let actual = ModuleRenderer::new("git_status")
             .config(toml::toml! {
@@ -488,7 +488,7 @@ mod tests {
     fn shows_untracked_file() -> io::Result<()> {
         let repo_dir = fixture_repo(FixtureProvider::Git)?;
 
-        create_untracked(&repo_dir.path())?;
+        create_untracked(repo_dir.path())?;
 
         let actual = ModuleRenderer::new("git_status")
             .path(&repo_dir.path())
@@ -503,7 +503,7 @@ mod tests {
     fn shows_untracked_file_with_count() -> io::Result<()> {
         let repo_dir = fixture_repo(FixtureProvider::Git)?;
 
-        create_untracked(&repo_dir.path())?;
+        create_untracked(repo_dir.path())?;
 
         let actual = ModuleRenderer::new("git_status")
             .config(toml::toml! {
@@ -522,7 +522,7 @@ mod tests {
     fn doesnt_show_untracked_file_if_disabled() -> io::Result<()> {
         let repo_dir = fixture_repo(FixtureProvider::Git)?;
 
-        create_untracked(&repo_dir.path())?;
+        create_untracked(repo_dir.path())?;
 
         create_command("git")?
             .args(&["config", "status.showUntrackedFiles", "no"])
@@ -544,7 +544,7 @@ mod tests {
         let repo_dir = fixture_repo(FixtureProvider::Git)?;
         barrier();
 
-        create_stash(&repo_dir.path())?;
+        create_stash(repo_dir.path())?;
 
         create_command("git")?
             .args(&["reset", "--hard", "HEAD"])
@@ -566,7 +566,7 @@ mod tests {
         let repo_dir = fixture_repo(FixtureProvider::Git)?;
         barrier();
 
-        create_stash(&repo_dir.path())?;
+        create_stash(repo_dir.path())?;
         barrier();
 
         create_command("git")?
@@ -592,7 +592,7 @@ mod tests {
     fn shows_modified() -> io::Result<()> {
         let repo_dir = fixture_repo(FixtureProvider::Git)?;
 
-        create_modified(&repo_dir.path())?;
+        create_modified(repo_dir.path())?;
 
         let actual = ModuleRenderer::new("git_status")
             .path(&repo_dir.path())
@@ -607,7 +607,7 @@ mod tests {
     fn shows_modified_with_count() -> io::Result<()> {
         let repo_dir = fixture_repo(FixtureProvider::Git)?;
 
-        create_modified(&repo_dir.path())?;
+        create_modified(repo_dir.path())?;
 
         let actual = ModuleRenderer::new("git_status")
             .config(toml::toml! {
@@ -626,7 +626,7 @@ mod tests {
     fn shows_added() -> io::Result<()> {
         let repo_dir = fixture_repo(FixtureProvider::Git)?;
 
-        create_added(&repo_dir.path())?;
+        create_added(repo_dir.path())?;
 
         let actual = ModuleRenderer::new("git_status")
             .path(&repo_dir.path())
@@ -641,7 +641,7 @@ mod tests {
     fn shows_staged_file() -> io::Result<()> {
         let repo_dir = fixture_repo(FixtureProvider::Git)?;
 
-        create_staged(&repo_dir.path())?;
+        create_staged(repo_dir.path())?;
 
         let actual = ModuleRenderer::new("git_status")
             .path(&repo_dir.path())
@@ -656,7 +656,7 @@ mod tests {
     fn shows_staged_file_with_count() -> io::Result<()> {
         let repo_dir = fixture_repo(FixtureProvider::Git)?;
 
-        create_staged(&repo_dir.path())?;
+        create_staged(repo_dir.path())?;
 
         let actual = ModuleRenderer::new("git_status")
             .config(toml::toml! {
@@ -682,7 +682,7 @@ mod tests {
     fn shows_renamed_file() -> io::Result<()> {
         let repo_dir = fixture_repo(FixtureProvider::Git)?;
 
-        create_renamed(&repo_dir.path())?;
+        create_renamed(repo_dir.path())?;
 
         let actual = ModuleRenderer::new("git_status")
             .path(&repo_dir.path())
@@ -697,7 +697,7 @@ mod tests {
     fn shows_renamed_file_with_count() -> io::Result<()> {
         let repo_dir = fixture_repo(FixtureProvider::Git)?;
 
-        create_renamed(&repo_dir.path())?;
+        create_renamed(repo_dir.path())?;
 
         let actual = ModuleRenderer::new("git_status")
             .config(toml::toml! {
@@ -716,7 +716,7 @@ mod tests {
     fn shows_deleted_file() -> io::Result<()> {
         let repo_dir = fixture_repo(FixtureProvider::Git)?;
 
-        create_deleted(&repo_dir.path())?;
+        create_deleted(repo_dir.path())?;
 
         let actual = ModuleRenderer::new("git_status")
             .path(&repo_dir.path())
@@ -731,7 +731,7 @@ mod tests {
     fn shows_deleted_file_with_count() -> io::Result<()> {
         let repo_dir = fixture_repo(FixtureProvider::Git)?;
 
-        create_deleted(&repo_dir.path())?;
+        create_deleted(repo_dir.path())?;
 
         let actual = ModuleRenderer::new("git_status")
             .config(toml::toml! {

--- a/src/modules/hg_branch.rs
+++ b/src/modules/hg_branch.rs
@@ -76,8 +76,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
 fn get_hg_branch_name(ctx: &Context) -> String {
     std::fs::read_to_string(ctx.current_dir.join(".hg").join("branch"))
-        .map(|s| s.trim().into())
-        .unwrap_or_else(|_| "default".to_string())
+        .map_or_else(|_| "default".to_string(), |s| s.trim().into())
 }
 
 fn get_hg_current_bookmark(ctx: &Context) -> Option<String> {
@@ -134,9 +133,9 @@ mod tests {
     fn test_hg_disabled_per_default() -> io::Result<()> {
         let tempdir = fixture_repo(FixtureProvider::Hg)?;
         let repo_dir = tempdir.path();
-        run_hg(&["whatever", "blubber"], &repo_dir)?;
+        run_hg(&["whatever", "blubber"], repo_dir)?;
         expect_hg_branch_with_config(
-            &repo_dir,
+            repo_dir,
             // no "disabled=false" in config!
             Some(toml::toml! {
                 [hg_branch]
@@ -160,7 +159,7 @@ mod tests {
         expect_hg_branch_with_config(
             tempdir.path(),
             None,
-            &[Expect::BranchName(&"default"), Expect::NoTruncation],
+            &[Expect::BranchName("default"), Expect::NoTruncation],
         );
         tempdir.close()
     }
@@ -178,11 +177,11 @@ mod tests {
     fn test_hg_bookmark() -> io::Result<()> {
         let tempdir = fixture_repo(FixtureProvider::Hg)?;
         let repo_dir = tempdir.path();
-        run_hg(&["bookmark", "bookmark-101"], &repo_dir)?;
+        run_hg(&["bookmark", "bookmark-101"], repo_dir)?;
         expect_hg_branch_with_config(
-            &repo_dir,
+            repo_dir,
             None,
-            &[Expect::BranchName(&"bookmark-101"), Expect::NoTruncation],
+            &[Expect::BranchName("bookmark-101"), Expect::NoTruncation],
         );
         tempdir.close()
     }
@@ -192,7 +191,7 @@ mod tests {
     fn test_default_truncation_symbol() -> io::Result<()> {
         let tempdir = fixture_repo(FixtureProvider::Hg)?;
         let repo_dir = tempdir.path();
-        run_hg(&["branch", "-f", "branch-name-101"], &repo_dir)?;
+        run_hg(&["branch", "-f", "branch-name-101"], repo_dir)?;
         run_hg(
             &[
                 "commit",
@@ -201,16 +200,16 @@ mod tests {
                 "-u",
                 "fake user <fake@user>",
             ],
-            &repo_dir,
+            repo_dir,
         )?;
         expect_hg_branch_with_config(
-            &repo_dir,
+            repo_dir,
             Some(toml::toml! {
                 [hg_branch]
                 truncation_length = 14
                 disabled = false
             }),
-            &[Expect::BranchName(&"branch-name-10")],
+            &[Expect::BranchName("branch-name-10")],
         );
         tempdir.close()
     }
@@ -220,7 +219,7 @@ mod tests {
     fn test_configured_symbols() -> io::Result<()> {
         let tempdir = fixture_repo(FixtureProvider::Hg)?;
         let repo_dir = tempdir.path();
-        run_hg(&["branch", "-f", "branch-name-121"], &repo_dir)?;
+        run_hg(&["branch", "-f", "branch-name-121"], repo_dir)?;
         run_hg(
             &[
                 "commit",
@@ -229,10 +228,10 @@ mod tests {
                 "-u",
                 "fake user <fake@user>",
             ],
-            &repo_dir,
+            repo_dir,
         )?;
         expect_hg_branch_with_config(
-            &repo_dir,
+            repo_dir,
             Some(toml::toml! {
                 [hg_branch]
                 symbol = "B "
@@ -241,9 +240,9 @@ mod tests {
                 disabled = false
             }),
             &[
-                Expect::BranchName(&"branch-name-12"),
-                Expect::Symbol(&"B"),
-                Expect::TruncationSymbol(&"%"),
+                Expect::BranchName("branch-name-12"),
+                Expect::Symbol("B"),
+                Expect::TruncationSymbol("%"),
             ],
         );
         tempdir.close()
@@ -254,7 +253,7 @@ mod tests {
     fn test_configured_style() -> io::Result<()> {
         let tempdir = fixture_repo(FixtureProvider::Hg)?;
         let repo_dir = tempdir.path();
-        run_hg(&["branch", "-f", "branch-name-131"], &repo_dir)?;
+        run_hg(&["branch", "-f", "branch-name-131"], repo_dir)?;
         run_hg(
             &[
                 "commit",
@@ -263,20 +262,20 @@ mod tests {
                 "-u",
                 "fake user <fake@user>",
             ],
-            &repo_dir,
+            repo_dir,
         )?;
 
         expect_hg_branch_with_config(
-            &repo_dir,
+            repo_dir,
             Some(toml::toml! {
                 [hg_branch]
                 style = "underline blue"
                 disabled = false
             }),
             &[
-                Expect::BranchName(&"branch-name-131"),
+                Expect::BranchName("branch-name-131"),
                 Expect::Style(Color::Blue.underline()),
-                Expect::TruncationSymbol(&""),
+                Expect::TruncationSymbol(""),
             ],
         );
         tempdir.close()

--- a/src/modules/jobs.rs
+++ b/src/modules/jobs.rs
@@ -11,8 +11,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let props = &context.properties;
     let num_of_jobs = props
         .get("jobs")
-        .map(String::as_str)
-        .unwrap_or("0")
+        .map_or("0", String::as_str)
         .trim()
         .parse::<i64>()
         .ok()?;

--- a/src/modules/kotlin.rs
+++ b/src/modules/kotlin.rs
@@ -35,7 +35,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             })
             .map(|variable| match variable {
                 "version" => {
-                    let kotlin_version = get_kotlin_version(context, &config.kotlin_binary)?;
+                    let kotlin_version = get_kotlin_version(context, config.kotlin_binary)?;
                     VersionFormatter::format_module_version(
                         module.get_name(),
                         &kotlin_version,

--- a/src/modules/lua.rs
+++ b/src/modules/lua.rs
@@ -32,7 +32,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             })
             .map(|variable| match variable {
                 "version" => {
-                    let lua_version = get_lua_version(context, &config.lua_binary)?;
+                    let lua_version = get_lua_version(context, config.lua_binary)?;
                     VersionFormatter::format_module_version(
                         module.get_name(),
                         &lua_version,

--- a/src/modules/ocaml.rs
+++ b/src/modules/ocaml.rs
@@ -66,7 +66,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                     };
                     VersionFormatter::format_module_version(
                         module.get_name(),
-                        &ocaml_version.trim(),
+                        ocaml_version.trim(),
                         config.version_format,
                     )
                     .map(Ok)
@@ -92,7 +92,7 @@ fn get_opam_switch(context: &Context) -> Option<OpamSwitch> {
         .exec_cmd("opam", &["switch", "show", "--safe"])?
         .stdout;
 
-    parse_opam_switch(&opam_switch.trim())
+    parse_opam_switch(opam_switch.trim())
 }
 
 fn parse_opam_switch(opam_switch: &str) -> Option<OpamSwitch> {

--- a/src/modules/openstack.rs
+++ b/src/modules/openstack.rs
@@ -41,7 +41,7 @@ fn get_osp_cloud_and_project(context: &Context) -> (Option<Cloud>, Option<Projec
     ) {
         (Some(p), Some(r)) => (Some(p), Some(r)),
         (None, Some(r)) => (None, Some(r)),
-        (Some(ref p), None) => (Some(p.to_owned()), get_osp_project_from_config(context, p)),
+        (Some(ref p), None) => (Some(p.clone()), get_osp_project_from_config(context, p)),
         (None, None) => (None, None),
     }
 }

--- a/src/modules/package.rs
+++ b/src/modules/package.rs
@@ -207,7 +207,7 @@ fn extract_vpkg_version(file_contents: &str) -> Option<String> {
     if version == "null" {
         return None;
     }
-    let formatted_version = format_version(&version);
+    let formatted_version = format_version(version);
     Some(formatted_version)
 }
 
@@ -313,7 +313,7 @@ license = "MIT"
 "##;
 
         let project_dir = create_project_dir()?;
-        fill_config(&project_dir, config_name, Some(&config_content))?;
+        fill_config(&project_dir, config_name, Some(config_content))?;
 
         let starship_config = toml::toml! {
             [package]
@@ -373,7 +373,7 @@ license = "MIT"
 "##;
 
         let project_dir = create_project_dir()?;
-        fill_config(&project_dir, config_name, Some(&config_content))?;
+        fill_config(&project_dir, config_name, Some(config_content))?;
 
         let starship_config = toml::toml! {
             [package]
@@ -622,7 +622,7 @@ java {
 }";
 
         let project_dir = create_project_dir()?;
-        fill_config(&project_dir, config_name, Some(&config_content))?;
+        fill_config(&project_dir, config_name, Some(config_content))?;
         expect_output(&project_dir, Some("v0.1.0"), None);
         project_dir.close()
     }
@@ -641,7 +641,7 @@ java {
 }";
 
         let project_dir = create_project_dir()?;
-        fill_config(&project_dir, config_name, Some(&config_content))?;
+        fill_config(&project_dir, config_name, Some(config_content))?;
         expect_output(&project_dir, Some("v0.1.0"), None);
         project_dir.close()
     }
@@ -660,7 +660,7 @@ java {
 }";
 
         let project_dir = create_project_dir()?;
-        fill_config(&project_dir, config_name, Some(&config_content))?;
+        fill_config(&project_dir, config_name, Some(config_content))?;
         expect_output(&project_dir, Some("v0.1.0-rc1"), None);
         project_dir.close()
     }
@@ -678,7 +678,7 @@ java {
 }";
 
         let project_dir = create_project_dir()?;
-        fill_config(&project_dir, config_name, Some(&config_content))?;
+        fill_config(&project_dir, config_name, Some(config_content))?;
         expect_output(&project_dir, None, None);
         project_dir.close()
     }
@@ -711,7 +711,7 @@ java {
 end";
 
         let project_dir = create_project_dir()?;
-        fill_config(&project_dir, config_name, Some(&config_content))?;
+        fill_config(&project_dir, config_name, Some(config_content))?;
         expect_output(&project_dir, Some("v1.2.3"), None);
         project_dir.close()
     }
@@ -722,7 +722,7 @@ end";
         let config_content = "  def project, do: [app: :my_app,version: \"3.2.1\"]";
 
         let project_dir = create_project_dir()?;
-        fill_config(&project_dir, config_name, Some(&config_content))?;
+        fill_config(&project_dir, config_name, Some(config_content))?;
         expect_output(&project_dir, Some("v3.2.1"), None);
         project_dir.close()
     }
@@ -738,7 +738,7 @@ end";
   end";
 
         let project_dir = create_project_dir()?;
-        fill_config(&project_dir, config_name, Some(&config_content))?;
+        fill_config(&project_dir, config_name, Some(config_content))?;
         expect_output(&project_dir, Some("v1.0.0-alpha.3"), None);
         project_dir.close()
     }
@@ -754,7 +754,7 @@ end";
   end";
 
         let project_dir = create_project_dir()?;
-        fill_config(&project_dir, config_name, Some(&config_content))?;
+        fill_config(&project_dir, config_name, Some(config_content))?;
         expect_output(&project_dir, Some("v0.9.9-dev+20130417140000.amd64"), None);
         project_dir.close()
     }
@@ -769,7 +769,7 @@ end";
         ";
 
         let project_dir = create_project_dir()?;
-        fill_config(&project_dir, config_name, Some(&config_content))?;
+        fill_config(&project_dir, config_name, Some(config_content))?;
         expect_output(&project_dir, Some("v0.2.0"), None);
         project_dir.close()
     }
@@ -901,7 +901,7 @@ end";
             </project>";
 
         let project_dir = create_project_dir()?;
-        fill_config(&project_dir, "pom.xml", Some(&pom))?;
+        fill_config(&project_dir, "pom.xml", Some(pom))?;
         expect_output(&project_dir, Some("0.3.20-SNAPSHOT"), None);
         project_dir.close()
     }
@@ -925,7 +925,7 @@ end";
             </project>";
 
         let project_dir = create_project_dir()?;
-        fill_config(&project_dir, "pom.xml", Some(&pom))?;
+        fill_config(&project_dir, "pom.xml", Some(pom))?;
         expect_output(&project_dir, None, None);
         project_dir.close()
     }
@@ -942,7 +942,7 @@ end";
             </project>";
 
         let project_dir = create_project_dir()?;
-        fill_config(&project_dir, "pom.xml", Some(&pom))?;
+        fill_config(&project_dir, "pom.xml", Some(pom))?;
         expect_output(&project_dir, None, None);
         project_dir.close()
     }
@@ -963,7 +963,7 @@ end";
             </project>";
 
         let project_dir = create_project_dir()?;
-        fill_config(&project_dir, "pom.xml", Some(&pom))?;
+        fill_config(&project_dir, "pom.xml", Some(pom))?;
         expect_output(&project_dir, None, None);
         project_dir.close()
     }
@@ -1012,7 +1012,7 @@ Module {
     version: '1.2.3'
 }";
         let project_dir = create_project_dir()?;
-        fill_config(&project_dir, config_name, Some(&config_content))?;
+        fill_config(&project_dir, config_name, Some(config_content))?;
         expect_output(&project_dir, Some("v1.2.3"), None);
         project_dir.close()
     }

--- a/src/modules/purescript.rs
+++ b/src/modules/purescript.rs
@@ -34,7 +34,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                     let purs_version = context.exec_cmd("purs", &["--version"])?.stdout;
                     VersionFormatter::format_module_version(
                         module.get_name(),
-                        &purs_version.trim(),
+                        purs_version.trim(),
                         config.version_format,
                     )
                     .map(Ok)

--- a/src/modules/rust.rs
+++ b/src/modules/rust.rs
@@ -75,7 +75,7 @@ fn get_module_version(context: &Context, config: &RustConfig) -> Option<String> 
     // - `rustup which`
     if let Some(toolchain) = env_rustup_toolchain(context)
         .or_else(|| execute_rustup_override_list(&context.current_dir))
-        .or_else(|| find_rust_toolchain_file(&context))
+        .or_else(|| find_rust_toolchain_file(context))
     {
         match execute_rustup_run_rustc_version(&toolchain) {
             RustupRunRustcVersionOutcome::RustcVersion(rustc_version) => {
@@ -115,7 +115,7 @@ fn extract_toolchain_from_rustup_override_list(stdout: &str, cwd: &Path) -> Opti
     }
     stdout
         .lines()
-        .flat_map(|line| {
+        .filter_map(|line| {
             let mut words = line.split_whitespace();
             let dir = words.next()?;
             let toolchain = words.next()?;

--- a/src/modules/status.rs
+++ b/src/modules/status.rs
@@ -27,7 +27,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let pipestatus_status = match &context.pipestatus {
         None => PipeStatusStatus::Disabled,
         Some(ps) => match ps.len() > 1 {
-            true => PipeStatusStatus::Pipe(&ps),
+            true => PipeStatusStatus::Pipe(ps),
             false => PipeStatusStatus::NoPipe,
         },
     };
@@ -255,7 +255,7 @@ mod tests {
     fn failure_status() {
         let exit_values = [1, 2, 130];
 
-        for status in exit_values.iter() {
+        for status in &exit_values {
             let expected = Some(format!(
                 "{} ",
                 Color::Red.bold().paint(format!("✖{}", status))
@@ -285,7 +285,7 @@ mod tests {
         ];
 
         for (status, name) in exit_values.iter().zip(exit_values_name.iter()) {
-            let expected = name.map(|n| n.to_string());
+            let expected = name.map(std::string::ToString::to_string);
             let actual = ModuleRenderer::new("status")
                 .config(toml::toml! {
                     [status]
@@ -312,7 +312,7 @@ mod tests {
         ];
 
         for (status, name) in exit_values.iter().zip(exit_values_name.iter()) {
-            let expected = name.map(|n| n.to_string());
+            let expected = name.map(std::string::ToString::to_string);
             let actual = ModuleRenderer::new("status")
                 .config(toml::toml! {
                     [status]
@@ -341,7 +341,7 @@ mod tests {
         ];
 
         for (status, name) in exit_values.iter().zip(exit_values_name.iter()) {
-            let expected = name.map(|n| n.to_string());
+            let expected = name.map(std::string::ToString::to_string);
             let actual = ModuleRenderer::new("status")
                 .config(toml::toml! {
                     [status]
@@ -360,7 +360,7 @@ mod tests {
         let exit_values_name = ["🔴", "🚫", "🔍", "🧱", "⚡"];
 
         for (status, name) in exit_values.iter().zip(exit_values_name.iter()) {
-            let expected = Some(name.to_string());
+            let expected = Some((*name).to_string());
             let actual = ModuleRenderer::new("status")
                 .config(toml::toml! {
                     [status]
@@ -386,7 +386,7 @@ mod tests {
         let exit_values_name = ["🔴", "🚫", "🔍", "🔴", "🔴"];
 
         for (status, name) in exit_values.iter().zip(exit_values_name.iter()) {
-            let expected = Some(name.to_string());
+            let expected = Some((*name).to_string());
             let actual = ModuleRenderer::new("status")
                 .config(toml::toml! {
                     [status]
@@ -425,7 +425,7 @@ mod tests {
             let main_exit_code = status[0];
             let pipe_exit_code = &status[1..];
 
-            let expected = Some(rendered.to_string());
+            let expected = Some((*rendered).to_string());
             let actual = ModuleRenderer::new("status")
                 .config(toml::toml! {
                     [status]
@@ -469,7 +469,7 @@ mod tests {
             let main_exit_code = status[0];
             let pipe_exit_code = &status[1..];
 
-            let expected = Some(rendered.to_string());
+            let expected = Some((*rendered).to_string());
             let actual = ModuleRenderer::new("status")
                 .config(toml::toml! {
                     [status]
@@ -508,7 +508,7 @@ mod tests {
             let main_exit_code = status[0];
             let pipe_exit_code = &status[1..];
 
-            let expected = Some(rendered.to_string());
+            let expected = Some((*rendered).to_string());
             let actual = ModuleRenderer::new("status")
                 .config(toml::toml! {
                     [status]
@@ -548,7 +548,7 @@ mod tests {
             let main_exit_code = status[0];
             let pipe_exit_code = &status[1..];
 
-            let expected = Some(rendered.to_string());
+            let expected = Some((*rendered).to_string());
             let actual = ModuleRenderer::new("status")
                 .config(toml::toml! {
                     [status]

--- a/src/modules/terraform.rs
+++ b/src/modules/terraform.rs
@@ -37,7 +37,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             .map(|variable| match variable {
                 "version" => {
                     let terraform_version = get_terraform_version(
-                        &context.exec_cmd("terraform", &["version"])?.stdout.as_str(),
+                        context.exec_cmd("terraform", &["version"])?.stdout.as_str(),
                     )?;
                     VersionFormatter::format_module_version(
                         module.get_name(),

--- a/src/modules/time.rs
+++ b/src/modules/time.rs
@@ -31,17 +31,17 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     );
 
     let formatted_time_string = if config.utc_time_offset != "local" {
-        match create_offset_time_string(Utc::now(), &config.utc_time_offset, &time_format) {
+        match create_offset_time_string(Utc::now(), config.utc_time_offset, time_format) {
             Ok(formatted_string) => formatted_string,
             Err(_) => {
                 log::warn!(
                     "Invalid utc_time_offset configuration provided! Falling back to \"local\"."
                 );
-                format_time(&time_format, Local::now())
+                format_time(time_format, Local::now())
             }
         }
     } else {
-        format_time(&time_format, Local::now())
+        format_time(time_format, Local::now())
     };
 
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
@@ -86,7 +86,7 @@ fn create_offset_time_string(
         let target_time = utc_time.with_timezone(&timezone_offset);
         log::trace!("Time in target timezone now is {}", target_time);
 
-        Ok(format_time_fixed_offset(&time_format, target_time))
+        Ok(format_time_fixed_offset(time_format, target_time))
     } else {
         Err("Invalid timezone offset.")
     }
@@ -290,7 +290,7 @@ mod tests {
         let utc_time: DateTime<Utc> = Utc.ymd(2014, 7, 8).and_hms(15, 36, 47);
         let utc_time_offset_str = "-3";
 
-        let actual = create_offset_time_string(utc_time, &utc_time_offset_str, FMT_12).unwrap();
+        let actual = create_offset_time_string(utc_time, utc_time_offset_str, FMT_12).unwrap();
         assert_eq!(actual, "12:36:47 PM");
     }
 
@@ -299,7 +299,7 @@ mod tests {
         let utc_time: DateTime<Utc> = Utc.ymd(2014, 7, 8).and_hms(15, 36, 47);
         let utc_time_offset_str = "+5";
 
-        let actual = create_offset_time_string(utc_time, &utc_time_offset_str, FMT_12).unwrap();
+        let actual = create_offset_time_string(utc_time, utc_time_offset_str, FMT_12).unwrap();
         assert_eq!(actual, "08:36:47 PM");
     }
 
@@ -308,7 +308,7 @@ mod tests {
         let utc_time: DateTime<Utc> = Utc.ymd(2014, 7, 8).and_hms(15, 36, 47);
         let utc_time_offset_str = "+9.5";
 
-        let actual = create_offset_time_string(utc_time, &utc_time_offset_str, FMT_12).unwrap();
+        let actual = create_offset_time_string(utc_time, utc_time_offset_str, FMT_12).unwrap();
         assert_eq!(actual, "01:06:47 AM");
     }
 
@@ -317,7 +317,7 @@ mod tests {
         let utc_time: DateTime<Utc> = Utc.ymd(2014, 7, 8).and_hms(15, 36, 47);
         let utc_time_offset_str = "+5.75";
 
-        let actual = create_offset_time_string(utc_time, &utc_time_offset_str, FMT_12).unwrap();
+        let actual = create_offset_time_string(utc_time, utc_time_offset_str, FMT_12).unwrap();
         assert_eq!(actual, "09:21:47 PM");
     }
 
@@ -326,7 +326,7 @@ mod tests {
         let utc_time: DateTime<Utc> = Utc.ymd(2014, 7, 8).and_hms(15, 36, 47);
         let utc_time_offset_str = "+24";
 
-        create_offset_time_string(utc_time, &utc_time_offset_str, FMT_12)
+        create_offset_time_string(utc_time, utc_time_offset_str, FMT_12)
             .err()
             .expect("Invalid timezone offset.");
     }
@@ -336,7 +336,7 @@ mod tests {
         let utc_time: DateTime<Utc> = Utc.ymd(2014, 7, 8).and_hms(15, 36, 47);
         let utc_time_offset_str = "-24";
 
-        create_offset_time_string(utc_time, &utc_time_offset_str, FMT_12)
+        create_offset_time_string(utc_time, utc_time_offset_str, FMT_12)
             .err()
             .expect("Invalid timezone offset.");
     }
@@ -346,7 +346,7 @@ mod tests {
         let utc_time: DateTime<Utc> = Utc.ymd(2014, 7, 8).and_hms(15, 36, 47);
         let utc_time_offset_str = "+9001";
 
-        create_offset_time_string(utc_time, &utc_time_offset_str, FMT_12)
+        create_offset_time_string(utc_time, utc_time_offset_str, FMT_12)
             .err()
             .expect("Invalid timezone offset.");
     }
@@ -356,7 +356,7 @@ mod tests {
         let utc_time: DateTime<Utc> = Utc.ymd(2014, 7, 8).and_hms(15, 36, 47);
         let utc_time_offset_str = "-4242";
 
-        create_offset_time_string(utc_time, &utc_time_offset_str, FMT_12)
+        create_offset_time_string(utc_time, utc_time_offset_str, FMT_12)
             .err()
             .expect("Invalid timezone offset.");
     }
@@ -366,7 +366,7 @@ mod tests {
         let utc_time: DateTime<Utc> = Utc.ymd(2014, 7, 8).and_hms(15, 36, 47);
         let utc_time_offset_str = "completely wrong config";
 
-        create_offset_time_string(utc_time, &utc_time_offset_str, FMT_12)
+        create_offset_time_string(utc_time, utc_time_offset_str, FMT_12)
             .err()
             .expect("Invalid timezone offset.");
     }

--- a/src/modules/username.rs
+++ b/src/modules/username.rs
@@ -24,8 +24,8 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let is_root = is_root_user();
     let show_username = config.show_always
         || is_root // [1]
-        || !is_login_user(&context, &username) // [2]
-        || is_ssh_session(&context); // [3]
+        || !is_login_user(context, &username) // [2]
+        || is_ssh_session(context); // [3]
 
     if !show_username {
         return None;
@@ -64,8 +64,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 fn is_login_user(context: &Context, username: &str) -> bool {
     context
         .get_env("LOGNAME")
-        .map(|logname| logname == username)
-        .unwrap_or(true)
+        .map_or(true, |logname| logname == username)
 }
 
 #[cfg(target_os = "windows")]

--- a/src/modules/utils/directory_nix.rs
+++ b/src/modules/utils/directory_nix.rs
@@ -36,7 +36,7 @@ pub fn is_write_allowed(folder_path: &Path) -> Result<bool, &'static str> {
 fn get_supplementary_groups() -> Vec<u32> {
     match nix::unistd::getgroups() {
         Err(_) => Vec::new(),
-        Ok(v) => v.into_iter().map(|i| i.as_raw()).collect(),
+        Ok(v) => v.into_iter().map(nix::unistd::Gid::as_raw).collect(),
     }
 }
 

--- a/src/modules/utils/directory_win.rs
+++ b/src/modules/utils/directory_win.rs
@@ -4,7 +4,7 @@ use std::iter;
 use std::mem;
 use std::os::windows::ffi::OsStrExt;
 use std::path::Path;
-use winapi::ctypes::c_void;
+
 use winapi::shared::minwindef::{BOOL, DWORD};
 use winapi::um::handleapi;
 use winapi::um::processthreadsapi;
@@ -13,7 +13,7 @@ use winapi::um::winnt::{
     SecurityImpersonation, BOOLEAN, DACL_SECURITY_INFORMATION, FILE_ALL_ACCESS,
     FILE_GENERIC_EXECUTE, FILE_GENERIC_READ, FILE_GENERIC_WRITE, GENERIC_MAPPING,
     GROUP_SECURITY_INFORMATION, HANDLE, LPCWSTR, OWNER_SECURITY_INFORMATION, PRIVILEGE_SET,
-    PSECURITY_DESCRIPTOR, STANDARD_RIGHTS_READ, TOKEN_DUPLICATE, TOKEN_IMPERSONATE, TOKEN_QUERY,
+    STANDARD_RIGHTS_READ, TOKEN_DUPLICATE, TOKEN_IMPERSONATE, TOKEN_QUERY,
 };
 
 /// Checks if the current user has write access right to the `folder_path`
@@ -59,7 +59,7 @@ pub fn is_write_allowed(folder_path: &Path) -> std::result::Result<bool, &'stati
         securitybaseapi::GetFileSecurityW(
             folder_name.as_ptr(),
             OWNER_SECURITY_INFORMATION | GROUP_SECURITY_INFORMATION | DACL_SECURITY_INFORMATION,
-            buf.as_mut_ptr() as *mut c_void,
+            buf.as_mut_ptr().cast::<std::ffi::c_void>(),
             length,
             &mut length,
         )
@@ -105,7 +105,7 @@ pub fn is_write_allowed(folder_path: &Path) -> std::result::Result<bool, &'stati
     unsafe { securitybaseapi::MapGenericMask(&mut access_rights, &mut mapping) };
     let rc = unsafe {
         securitybaseapi::AccessCheck(
-            buf.as_mut_ptr() as PSECURITY_DESCRIPTOR,
+            buf.as_mut_ptr().cast::<std::ffi::c_void>(),
             impersonated_token,
             access_rights,
             &mut mapping,

--- a/src/modules/utils/path.rs
+++ b/src/modules/utils/path.rs
@@ -54,7 +54,7 @@ mod normalize {
     pub fn normalize_path(path: &Path) -> (NormalizedPrefix, &Path) {
         let mut components = path.components();
         if let Some(Component::Prefix(prefix)) = components.next() {
-            return (normalize_prefix(prefix.kind()), &components.as_path());
+            return (normalize_prefix(prefix.kind()), components.as_path());
         }
         (NormalizedPrefix::None, path)
     }
@@ -78,7 +78,7 @@ impl PathExt for Path {
 
     fn without_prefix(&self) -> &Path {
         let (_, path) = normalize::normalize_path(self);
-        &path
+        path
     }
 }
 
@@ -110,40 +110,40 @@ mod windows {
     #[test]
     fn normalised_equals() {
         fn test_equals(a: &Path, b: &Path) {
-            assert!(a.normalised_equals(&b));
-            assert!(b.normalised_equals(&a));
+            assert!(a.normalised_equals(b));
+            assert!(b.normalised_equals(a));
         }
 
         // UNC paths
         let verbatim_unc = Path::new(r"\\?\UNC\server\share\sub\path");
         let unc = Path::new(r"\\server\share\sub\path");
-        test_equals(&verbatim_unc, &verbatim_unc);
-        test_equals(&verbatim_unc, &unc);
-        test_equals(&unc, &unc);
-        test_equals(&unc, &verbatim_unc);
+        test_equals(verbatim_unc, verbatim_unc);
+        test_equals(verbatim_unc, unc);
+        test_equals(unc, unc);
+        test_equals(unc, verbatim_unc);
 
         // Disk paths
         let verbatim_disk = Path::new(r"\\?\C:\test\path");
         let disk = Path::new(r"C:\test\path");
-        test_equals(&verbatim_disk, &verbatim_disk);
-        test_equals(&verbatim_disk, &disk);
-        test_equals(&disk, &disk);
-        test_equals(&disk, &verbatim_disk);
+        test_equals(verbatim_disk, verbatim_disk);
+        test_equals(verbatim_disk, disk);
+        test_equals(disk, disk);
+        test_equals(disk, verbatim_disk);
 
         // Other paths
         let verbatim = Path::new(r"\\?\cat_pics");
         let no_prefix = Path::new(r"\cat_pics");
         let device_ns = Path::new(r"\\.\COM42");
-        test_equals(&verbatim, &verbatim);
-        test_equals(&no_prefix, &no_prefix);
-        test_equals(&device_ns, &device_ns);
+        test_equals(verbatim, verbatim);
+        test_equals(no_prefix, no_prefix);
+        test_equals(device_ns, device_ns);
     }
 
     #[test]
     fn normalised_equals_differing_prefixes() {
         fn test_not_equals(a: &Path, b: &Path) {
-            assert!(!a.normalised_equals(&b));
-            assert!(!b.normalised_equals(&a));
+            assert!(!a.normalised_equals(b));
+            assert!(!b.normalised_equals(a));
         }
 
         let verbatim_unc = Path::new(r"\\?\UNC\server\share\sub\path");
@@ -154,19 +154,19 @@ mod windows {
         let no_prefix = Path::new(r"\cat_pics");
         let device_ns = Path::new(r"\\.\COM42");
 
-        test_not_equals(&verbatim_unc, &verbatim_disk);
-        test_not_equals(&unc, &disk);
-        test_not_equals(&disk, &device_ns);
-        test_not_equals(&device_ns, &verbatim_disk);
-        test_not_equals(&no_prefix, &unc);
-        test_not_equals(&no_prefix, &verbatim);
+        test_not_equals(verbatim_unc, verbatim_disk);
+        test_not_equals(unc, disk);
+        test_not_equals(disk, device_ns);
+        test_not_equals(device_ns, verbatim_disk);
+        test_not_equals(no_prefix, unc);
+        test_not_equals(no_prefix, verbatim);
     }
 
     #[test]
     fn normalised_starts_with() {
         fn test_starts_with(a: &Path, b: &Path) {
-            assert!(a.normalised_starts_with(&b));
-            assert!(!b.normalised_starts_with(&a));
+            assert!(a.normalised_starts_with(b));
+            assert!(!b.normalised_starts_with(a));
         }
 
         // UNC paths
@@ -174,20 +174,20 @@ mod windows {
         let verbatim_unc_b = Path::new(r"\\?\UNC\server\share\a\b");
         let unc_a = Path::new(r"\\server\share\a\b\c\d");
         let unc_b = Path::new(r"\\server\share\a\b");
-        test_starts_with(&verbatim_unc_a, &verbatim_unc_b);
-        test_starts_with(&unc_a, &unc_b);
-        test_starts_with(&verbatim_unc_a, &unc_b);
-        test_starts_with(&unc_a, &verbatim_unc_b);
+        test_starts_with(verbatim_unc_a, verbatim_unc_b);
+        test_starts_with(unc_a, unc_b);
+        test_starts_with(verbatim_unc_a, unc_b);
+        test_starts_with(unc_a, verbatim_unc_b);
 
         // Disk paths
         let verbatim_disk_a = Path::new(r"\\?\C:\a\b\c\d");
         let verbatim_disk_b = Path::new(r"\\?\C:\a\b");
         let disk_a = Path::new(r"C:\a\b\c\d");
         let disk_b = Path::new(r"C:\a\b");
-        test_starts_with(&verbatim_disk_a, &verbatim_disk_b);
-        test_starts_with(&disk_a, &disk_b);
-        test_starts_with(&disk_a, &verbatim_disk_b);
-        test_starts_with(&verbatim_disk_a, &disk_b);
+        test_starts_with(verbatim_disk_a, verbatim_disk_b);
+        test_starts_with(disk_a, disk_b);
+        test_starts_with(disk_a, verbatim_disk_b);
+        test_starts_with(verbatim_disk_a, disk_b);
 
         // Other paths
         let verbatim_a = Path::new(r"\\?\cat_pics\a\b\c\d");
@@ -196,16 +196,16 @@ mod windows {
         let device_ns_b = Path::new(r"\\.\COM43\a\b");
         let no_prefix_a = Path::new(r"\a\b\c\d");
         let no_prefix_b = Path::new(r"\a\b");
-        test_starts_with(&verbatim_a, &verbatim_b);
-        test_starts_with(&device_ns_a, &device_ns_b);
-        test_starts_with(&no_prefix_a, &no_prefix_b);
+        test_starts_with(verbatim_a, verbatim_b);
+        test_starts_with(device_ns_a, device_ns_b);
+        test_starts_with(no_prefix_a, no_prefix_b);
     }
 
     #[test]
     fn normalised_starts_with_differing_prefixes() {
         fn test_not_starts_with(a: &Path, b: &Path) {
-            assert!(!a.normalised_starts_with(&b));
-            assert!(!b.normalised_starts_with(&a));
+            assert!(!a.normalised_starts_with(b));
+            assert!(!b.normalised_starts_with(a));
         }
 
         let verbatim_unc = Path::new(r"\\?\UNC\server\share\a\b\c\d");
@@ -216,12 +216,12 @@ mod windows {
         let device_ns = Path::new(r"\\.\COM43\a\b\c\d");
         let no_prefix = Path::new(r"\a\b\c\d");
 
-        test_not_starts_with(&verbatim_unc, &device_ns);
-        test_not_starts_with(&unc, &device_ns);
-        test_not_starts_with(&verbatim_disk, &verbatim);
-        test_not_starts_with(&disk, &verbatim);
-        test_not_starts_with(&disk, &unc);
-        test_not_starts_with(&verbatim_disk, &no_prefix);
+        test_not_starts_with(verbatim_unc, device_ns);
+        test_not_starts_with(unc, device_ns);
+        test_not_starts_with(verbatim_disk, verbatim);
+        test_not_starts_with(disk, verbatim);
+        test_not_starts_with(disk, unc);
+        test_not_starts_with(verbatim_disk, no_prefix);
     }
 
     #[test]
@@ -270,11 +270,11 @@ mod nix {
     fn normalised_equals() {
         let path_a = Path::new("/a/b/c/d");
         let path_b = Path::new("/a/b/c/d");
-        assert!(path_a.normalised_equals(&path_b));
-        assert!(path_b.normalised_equals(&path_a));
+        assert!(path_a.normalised_equals(path_b));
+        assert!(path_b.normalised_equals(path_a));
 
         let path_c = Path::new("/a/b");
-        assert!(!path_a.normalised_equals(&path_c));
+        assert!(!path_a.normalised_equals(path_c));
     }
 
     #[test]
@@ -282,18 +282,18 @@ mod nix {
         // Windows path prefixes are not parsed on *nix
         let path_a = Path::new(r"\\?\UNC\server\share\a\b\c\d");
         let path_b = Path::new(r"\\server\share\a\b\c\d");
-        assert!(!path_a.normalised_equals(&path_b));
-        assert!(!path_b.normalised_equals(&path_a));
+        assert!(!path_a.normalised_equals(path_b));
+        assert!(!path_b.normalised_equals(path_a));
 
-        assert!(path_a.normalised_equals(&path_a));
+        assert!(path_a.normalised_equals(path_a));
     }
 
     #[test]
     fn normalised_starts_with() {
         let path_a = Path::new("/a/b/c/d");
         let path_b = Path::new("/a/b");
-        assert!(path_a.normalised_starts_with(&path_b));
-        assert!(!path_b.normalised_starts_with(&path_a));
+        assert!(path_a.normalised_starts_with(path_b));
+        assert!(!path_b.normalised_starts_with(path_a));
     }
 
     #[test]
@@ -301,10 +301,10 @@ mod nix {
         // Windows path prefixes are not parsed on *nix
         let path_a = Path::new(r"\\?\UNC\server\share\a\b\c\d");
         let path_b = Path::new(r"\\server\share\a\b");
-        assert!(!path_a.normalised_starts_with(&path_b));
-        assert!(!path_b.normalised_starts_with(&path_a));
+        assert!(!path_a.normalised_starts_with(path_b));
+        assert!(!path_b.normalised_starts_with(path_a));
 
-        assert!(path_a.normalised_starts_with(&path_a));
+        assert!(path_a.normalised_starts_with(path_a));
     }
 
     #[test]

--- a/src/modules/zig.rs
+++ b/src/modules/zig.rs
@@ -35,7 +35,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                     let zig_version = context.exec_cmd("zig", &["version"])?.stdout;
                     VersionFormatter::format_module_version(
                         module.get_name(),
-                        &zig_version.trim(),
+                        zig_version.trim(),
                         config.version_format,
                     )
                     .map(Ok)

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -133,7 +133,12 @@ impl<'a> ModuleRenderer<'a> {
     }
 
     pub fn pipestatus(mut self, status: &[i32]) -> Self {
-        self.context.pipestatus = Some(status.iter().map(|i| i.to_string()).collect());
+        self.context.pipestatus = Some(
+            status
+                .iter()
+                .map(std::string::ToString::to_string)
+                .collect(),
+        );
         self
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -66,7 +66,7 @@ impl PartialEq for CommandOutput {
 /// Execute a command and return the output on stdout and stderr if successful
 #[cfg(not(test))]
 pub fn exec_cmd(cmd: &str, args: &[&str], time_limit: Duration) -> Option<CommandOutput> {
-    internal_exec_cmd(&cmd, &args, time_limit)
+    internal_exec_cmd(cmd, args, time_limit)
 }
 
 #[cfg(test)]
@@ -271,7 +271,7 @@ CMake suite maintained and supported by Kitware (kitware.com/cmake).\n",
             stderr: String::default(),
         }),
         // If we don't have a mocked command fall back to executing the command
-        _ => internal_exec_cmd(&cmd, &args, time_limit),
+        _ => internal_exec_cmd(cmd, args, time_limit),
     }
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR fixes the new stable rust 1.54 clippy lints. In addition to the regular fixes I also added `--fix`able fixes for the lint levels `clippy::nursery` and `clippy::pedantic` with some exceptions.

The changes in this PR were generated with this command, except for readding some comments that ended up removed:
`clippy --fix --all-targets --all-features -- -W clippy::pedantic -W clippy::nursery -A clippy::non_ascii_literal -A clippy::unicode_not_nfc -A clippy::must_use_candidate -A clippy::wildcard_imports`

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
