### PR TITLE
Enable reproducible builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1660,9 +1660,9 @@ dependencies = [
 
 [[package]]
 name = "shadow-rs"
-version = "0.6.4"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781b59cf09391a3657672076913dbb5d8488a0165d6ffe4fb2909499a215d66"
+checksum = "e48e814827e6c79f18e529790a63731266172880f70ac3be44be3fe3c9d3f870"
 dependencies = [
  "chrono",
  "git2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ indexmap = { version ="1.7.0", features = ["serde"] }
 notify-rust = { version = "4.5.1", optional = true }
 semver = "1.0.4"
 which = "4.2.2"
-shadow-rs = "0.6.4"
+shadow-rs = "0.6.6"
 versions = "3.0.2"
 strsim = "0.10.0"
 
@@ -90,7 +90,7 @@ winapi = { version = "0.3.9", features = [
 nix = "0.22.0"
 
 [build-dependencies]
-shadow-rs = "0.6.4"
+shadow-rs = "0.6.6"
 
 [dev-dependencies]
 tempfile = "3.2.0"


### PR DESCRIPTION
I recently filed [this issue](https://github.com/baoyachi/shadow-rs/issues/61) with shadow-rs because it seemed to be the one blocked keeping starship [builds from being reproducibly](https://reproducible-builds.org/). My subsequent PR was merged a new release cut.

This PR bumps the starship dependency to the latest library version. Merging this should make future starship releases reproducible (provided there isn't something else overlooked, testing this is relatively hard until it gets to the packaging stage).

Closes #2975