### PR TITLE
docs(config): Add missing double quotes to default value strings

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1001,7 +1001,7 @@ default = "unknown user"
 
 | Option     | Default                        | Description                                                                  |
 | ---------- | ------------------------------ | ---------------------------------------------------------------------------- |
-| `symbol`   |                                | The symbol used before displaying the variable value.                        |
+| `symbol`   | `""`                           | The symbol used before displaying the variable value.                        |
 | `variable` |                                | The environment variable to be displayed.                                    |
 | `default`  |                                | The default value to be displayed when the selected variable is not defined. |
 | `format`   | `"with [$env_value]($style) "` | The format for the module.                                                   |

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -3157,7 +3157,7 @@ If you have an interesting example not covered there, feel free to share it ther
 
 | Option        | Default                         | Description                                                                                                                |
 | ------------- | ------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `command`     |                                 | The command whose output should be printed. The command will be passed on stdin to the shell.                              |
+| `command`     | `""`                            | The command whose output should be printed. The command will be passed on stdin to the shell.                              |
 | `when`        |                                 | A shell command used as a condition to show the module. The module will be shown if the command returns a `0` status code. |
 | `shell`       |                                 | [See below](#custom-command-shell)                                                                                         |
 | `description` | `"<custom module>"`             | The description of the module that is shown when running `starship explain`.                                               |

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2609,19 +2609,19 @@ To enable it, set `disabled` to `false` in your configuration file.
 
 ### Options
 
-| Option                 | Default       | Description                                                  |
-| ---------------------- | ------------- | ------------------------------------------------------------ |
-| `bash_indicator`       | `bsh`         | A format string used to represent bash.                      |
-| `fish_indicator`       | `fsh`         | A format string used to represent fish.                      |
-| `zsh_indicator`        | `zsh`         | A format string used to represent zsh.                       |
-| `powershell_indicator` | `psh`         | A format string used to represent powershell.                |
-| `ion_indicator`        | `ion`         | A format string used to represent ion.                       |
-| `elvish_indicator`     | `esh`         | A format string used to represent elvish.                    |
-| `tcsh_indicator`       | `tsh`         | A format string used to represent tcsh.                      |
-| `xonsh_indicator`      | `xsh`         | A format string used to represent xonsh.                     |
-| `unknown_indicator`    |               | The default value to be displayed when the shell is unknown. |
-| `format`               | `$indicator ` | The format for the module.                                   |
-| `disabled`             | `true`        | Disables the `shell` module.                                 |
+| Option                 | Default         | Description                                                  |
+| ---------------------- | --------------- | ------------------------------------------------------------ |
+| `bash_indicator`       | `"bsh"`         | A format string used to represent bash.                      |
+| `fish_indicator`       | `"fsh"`         | A format string used to represent fish.                      |
+| `zsh_indicator`        | `"zsh"`         | A format string used to represent zsh.                       |
+| `powershell_indicator` | `"psh"`         | A format string used to represent powershell.                |
+| `ion_indicator`        | `"ion"`         | A format string used to represent ion.                       |
+| `elvish_indicator`     | `"esh"`         | A format string used to represent elvish.                    |
+| `tcsh_indicator`       | `"tsh"`         | A format string used to represent tcsh.                      |
+| `xonsh_indicator`      | `"xsh"`         | A format string used to represent xonsh.                     |
+| `unknown_indicator`    | `""`            | The default value to be displayed when the shell is unknown. |
+| `format`               | `"$indicator "` | The format for the module.                                   |
+| `disabled`             | `true`          | Disables the `shell` module.                                 |
 
 ### Variables
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Add missing double quotes to default value strings for Shell, Environment Variable, and Custom modules.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/starship/starship/issues/2935

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [X] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
