### PR TITLE
feat(red,vlang): Add version formatting

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -3044,21 +3044,22 @@ By default the module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Option              | Default                                      | Description                                  |
-| ------------------- | -------------------------------------------- | -------------------------------------------- |
-| `format`            | `"via [$symbol($version )]($style)"`         | The format for the module.                   |
-| `symbol`            | `"V "`                                       | A format string representing the symbol of V |
-| `detect_extensions` | `["v"]`                                      | Which extensions should trigger this module. |
-| `detect_files`      | `["v.mod", "vpkg.json", ".vpkg-lock.json" ]` | Which filenames should trigger this module.  |
-| `detect_folders`    | `[]`                                         | Which folders should trigger this module.    |
-| `style`             | `"blue bold"`                                | The style for the module.                    |
-| `disabled`          | `false`                                      | Disables the `vlang` module.                 |
+| Option              | Default                                      | Description                                                               |
+| ------------------- | -------------------------------------------- | ------------------------------------------------------------------------- |
+| `format`            | `"via [$symbol($version )]($style)"`         | The format for the module.                                                |
+| `version_format`    | `"v${raw}"`                                  | The version format. Available vars are `raw`, `major`, `minor`, & `patch` |
+| `symbol`            | `"V "`                                       | A format string representing the symbol of V                              |
+| `detect_extensions` | `["v"]`                                      | Which extensions should trigger this module.                              |
+| `detect_files`      | `["v.mod", "vpkg.json", ".vpkg-lock.json" ]` | Which filenames should trigger this module.                               |
+| `detect_folders`    | `[]`                                         | Which folders should trigger this module.                                 |
+| `style`             | `"blue bold"`                                | The style for the module.                                                 |
+| `disabled`          | `false`                                      | Disables the `vlang` module.                                              |
 
 ### Variables
 
 | Variable | Example  | Description                          |
 | -------- | -------- | ------------------------------------ |
-| version  | `v0.2` | The version of `v`                |
+| version  | `v0.2`   | The version of `v`                   |
 | symbol   |          | Mirrors the value of option `symbol` |
 | style\*  |          | Mirrors the value of option `style`  |
 

--- a/src/configs/red.rs
+++ b/src/configs/red.rs
@@ -6,6 +6,7 @@ use starship_module_config_derive::ModuleConfig;
 #[derive(Clone, ModuleConfig, Serialize)]
 pub struct RedConfig<'a> {
     pub format: &'a str,
+    pub version_format: &'a str,
     pub symbol: &'a str,
     pub style: &'a str,
     pub disabled: bool,
@@ -18,6 +19,7 @@ impl<'a> Default for RedConfig<'a> {
     fn default() -> Self {
         RedConfig {
             format: "via [$symbol($version )]($style)",
+            version_format: "v${raw}",
             symbol: "🔺 ",
             style: "red bold",
             disabled: false,

--- a/src/configs/v.rs
+++ b/src/configs/v.rs
@@ -6,6 +6,7 @@ use starship_module_config_derive::ModuleConfig;
 #[derive(Clone, ModuleConfig, Serialize)]
 pub struct VConfig<'a> {
     pub format: &'a str,
+    pub version_format: &'a str,
     pub symbol: &'a str,
     pub style: &'a str,
     pub disabled: bool,
@@ -18,6 +19,7 @@ impl<'a> Default for VConfig<'a> {
     fn default() -> Self {
         VConfig {
             format: "via [$symbol($version )]($style)",
+            version_format: "v${raw}",
             symbol: "V ",
             style: "blue bold",
             disabled: false,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Have added version formatting to the red and vlang modules. Note the
docs for red already mentioned the `version_format` string but it had
not actually been added.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #2236

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
