### PR TITLE
ci: disable dependabot cron on starship forks

### DIFF
--- a/.github/workflows/merge-dependabot.yml
+++ b/.github/workflows/merge-dependabot.yml
@@ -4,6 +4,7 @@ on:
     - cron: "0 * * * *"
 jobs:
   auto_merge:
+    if: (github.event_name == 'schedule' && github.repository == 'starship/starship') || (github.event_name != 'schedule')
     name: Auto-merge Dependabot PRs
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description

Check for the primary fork of starship and only run the merge-dependabot job on
that fork.

#### Motivation and Context

The CI workflow that merges dependabot PRs will run even on forks of starship,
which probably don't have valid GH tokens. Certainly mine doesn't!

#### Screenshots (if appropriate):

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
