### PR TITLE
feat(cobol): added COBOL module

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -521,7 +521,7 @@ By default, the module will be shown if any of the following conditions are met:
 | `detect_extensions` | `["cbl", "cob", "CBL", "COB"]`       | Which extensions should trigger this module.                             |
 | `detect_files`      | `[]`                                 | Which filenames should trigger this module.                              |
 | `detect_folders`    | `[]`                                 | Which folders should trigger this module.                                |
-| `disabled`          | `false`                              | Disables the `cobol` module.                                           |
+| `disabled`          | `false`                              | Disables the `cobol` module.                                             |
 
 ### Variables
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -502,6 +502,37 @@ the module will be activated if any of the following conditions are met:
 
 \*: This variable can only be used as a part of a style string
 
+## COBOL / GNUCOBOL
+
+The `cobol` module shows the currently installed version of COBOL.
+By default, the module will be shown if any of the following conditions are met:
+
+- The current directory contains any files ending in `.cob` or `.COB`
+- The current directory contains any files ending in `.cbl` or `.CBL`
+
+### Options
+
+| Option              | Default                              | Description                                                              |
+| ------------------- | ------------------------------------ | ------------------------------------------------------------------------ |
+| `symbol`            | `"🔷 "`                              | The symbol used before displaying the version of COBOL.                  |
+| `format`            | `"via [$symbol($version )]($style)"` | The format for the module.                                               |
+| `version_format`    | `"v${raw}"`                          | The version format. Available vars are `raw`, `major`, `minor`, & `patch`|
+| `style`             | `"bold blue"`                        | The style for the module.                                                |
+| `detect_extensions` | `["cbl", "cob", "CBL", "COB"]`       | Which extensions should trigger this module.                             |
+| `detect_files`      | `[]`                                 | Which filenames should trigger this module.                              |
+| `detect_folders`    | `[]`                                 | Which folders should trigger this module.                                |
+| `disabled`          | `false`                              | Disables the `cobol` module.                                           |
+
+### Variables
+
+| Variable | Example   | Description                          |
+| -------- | --------- | ------------------------------------ |
+| version  | `v3.1.2.0`| The version of `cobol`             |
+| symbol   |           | Mirrors the value of option `symbol` |
+| style\*  |           | Mirrors the value of option `style`  |
+
+\*: This variable can only be used as a part of a style string
+
 ## Command Duration
 
 The `cmd_duration` module shows how long the last command took to execute.

--- a/docs/presets/README.md
+++ b/docs/presets/README.md
@@ -115,6 +115,9 @@ format = '\[[$symbol($version)]($style)\]'
 [cmd_duration]
 format = "[⏱ $duration]($style)"
 
+[cobol]
+format = '\[[$symbol($version)]($style)\]'
+
 [conda]
 format = '\[[$symbol$environment]($style)\]'
 
@@ -276,6 +279,9 @@ deleted = "x"
 [aws]
 symbol = "aws "
 
+[cobol]
+symbol = "cobol "
+
 [conda]
 symbol = "conda "
 
@@ -377,6 +383,9 @@ This preset hides the version of language runtimes. If you work in containers or
 
 ```toml
 [cmake]
+format = "via [$symbol]($style)"
+
+[cobol]
 format = "via [$symbol]($style)"
 
 [crystal]

--- a/src/configs/cobol.rs
+++ b/src/configs/cobol.rs
@@ -1,0 +1,31 @@
+use crate::config::ModuleConfig;
+
+use serde::Serialize;
+use starship_module_config_derive::ModuleConfig;
+
+#[derive(Clone, ModuleConfig, Serialize)]
+pub struct CobolConfig<'a> {
+    pub format: &'a str,
+    pub version_format: &'a str,
+    pub symbol: &'a str,
+    pub style: &'a str,
+    pub disabled: bool,
+    pub detect_extensions: Vec<&'a str>,
+    pub detect_files: Vec<&'a str>,
+    pub detect_folders: Vec<&'a str>,
+}
+
+impl<'a> Default for CobolConfig<'a> {
+    fn default() -> Self {
+        CobolConfig {
+            format: "via [$symbol($version )]($style)",
+            version_format: "v${raw}",
+            symbol: "🔷 ",
+            style: "bold blue",
+            disabled: false,
+            detect_extensions: vec!["cbl", "cob", "CBL", "COB"],
+            detect_files: vec![],
+            detect_folders: vec![],
+        }
+    }
+}

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -8,6 +8,7 @@ pub mod battery;
 pub mod character;
 pub mod cmake;
 pub mod cmd_duration;
+pub mod cobol;
 pub mod conda;
 pub mod crystal;
 pub mod custom;
@@ -83,6 +84,7 @@ pub struct FullConfig<'a> {
     character: character::CharacterConfig<'a>,
     cmake: cmake::CMakeConfig<'a>,
     cmd_duration: cmd_duration::CmdDurationConfig<'a>,
+    cobol: cobol::CobolConfig<'a>,
     conda: conda::CondaConfig<'a>,
     crystal: crystal::CrystalConfig<'a>,
     dart: dart::DartConfig<'a>,
@@ -155,6 +157,7 @@ impl<'a> Default for FullConfig<'a> {
             character: Default::default(),
             cmake: Default::default(),
             cmd_duration: Default::default(),
+            cobol: Default::default(),
             conda: Default::default(),
             crystal: Default::default(),
             dart: Default::default(),

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -34,6 +34,7 @@ pub const PROMPT_ORDER: &[&str] = &[
     // ↓ Toolchain version modules ↓
     // (Let's keep these sorted alphabetically)
     "cmake",
+    "cobol",
     "dart",
     "deno",
     "dotnet",

--- a/src/module.rs
+++ b/src/module.rs
@@ -14,6 +14,7 @@ pub const ALL_MODULES: &[&str] = &[
     "character",
     "cmake",
     "cmd_duration",
+    "cobol",
     "conda",
     "crystal",
     "dart",

--- a/src/modules/cobol.rs
+++ b/src/modules/cobol.rs
@@ -1,0 +1,141 @@
+use super::{Context, Module, RootModuleConfig};
+
+use crate::configs::cobol::CobolConfig;
+use crate::formatter::StringFormatter;
+use crate::formatter::VersionFormatter;
+
+/// Creates a module with the current COBOL version
+pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let mut module = context.new_module("cobol");
+    let config = CobolConfig::try_load(module.config);
+    let is_cobol_project = context
+        .try_begin_scan()?
+        .set_files(&config.detect_files)
+        .set_extensions(&config.detect_extensions)
+        .set_folders(&config.detect_folders)
+        .is_match();
+
+    if !is_cobol_project {
+        return None;
+    }
+
+    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
+        formatter
+            .map_meta(|var, _| match var {
+                "symbol" => Some(config.symbol),
+                _ => None,
+            })
+            .map_style(|variable| match variable {
+                "style" => Some(Ok(config.style)),
+                _ => None,
+            })
+            .map(|variable| match variable {
+                "version" => {
+                    let cobol_version =
+                        get_cobol_version(&context.exec_cmd("cobc", &["-version"])?.stdout)?;
+
+                    VersionFormatter::format_module_version(
+                        module.get_name(),
+                        &cobol_version,
+                        config.version_format,
+                    )
+                    .map(Ok)
+                }
+                _ => None,
+            })
+            .parse(None)
+    });
+
+    module.set_segments(match parsed {
+        Ok(segments) => segments,
+        Err(error) => {
+            log::warn!("Error in module `cobol`:\n{}", error);
+            return None;
+        }
+    });
+
+    Some(module)
+}
+
+fn get_cobol_version(cobol_stdout: &str) -> Option<String> {
+    // cobol output looks like this:
+    // cobc (GnuCOBOL) 3.1.2.0
+    // ...
+
+    Some(
+        cobol_stdout
+            // split into ["cobc", "(GNUCOBOL)", "3.1.2.0"...]
+            .split_whitespace()
+            // return "3.1.2.0"
+            .nth(2)?
+            .to_string(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::ModuleRenderer;
+    use ansi_term::Color;
+    use std::fs::File;
+    use std::io;
+
+    #[test]
+    fn folder_without_cobol_files() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+
+        let actual = ModuleRenderer::new("cobol").path(dir.path()).collect();
+
+        let expected = None;
+
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn folder_with_lowercase_cob_files() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join("main.cob"))?.sync_all()?;
+
+        let actual = ModuleRenderer::new("cobol").path(dir.path()).collect();
+
+        let expected = Some(format!("via {}", Color::Blue.bold().paint("🔷 v3.1.2.0 ")));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn folder_with_lowercase_cbl_files() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join("main.cbl"))?.sync_all()?;
+
+        let actual = ModuleRenderer::new("cobol").path(dir.path()).collect();
+
+        let expected = Some(format!("via {}", Color::Blue.bold().paint("🔷 v3.1.2.0 ")));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn folder_with_capital_cob_files() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join("MAIN.COB"))?.sync_all()?;
+
+        let actual = ModuleRenderer::new("cobol").path(dir.path()).collect();
+
+        let expected = Some(format!("via {}", Color::Blue.bold().paint("🔷 v3.1.2.0 ")));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn folder_with_capital_cbl_files() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join("MAIN.CBL"))?.sync_all()?;
+
+        let actual = ModuleRenderer::new("cobol").path(dir.path()).collect();
+
+        let expected = Some(format!("via {}", Color::Blue.bold().paint("🔷 v3.1.2.0 ")));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+}

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -3,6 +3,7 @@ mod aws;
 mod character;
 mod cmake;
 mod cmd_duration;
+mod cobol;
 mod conda;
 mod crystal;
 pub(crate) mod custom;
@@ -85,6 +86,7 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
             "character" => character::module(context),
             "cmake" => cmake::module(context),
             "cmd_duration" => cmd_duration::module(context),
+            "cobol" => cobol::module(context),
             "conda" => conda::module(context),
             "dart" => dart::module(context),
             "deno" => deno::module(context),
@@ -169,6 +171,7 @@ pub fn description(module: &str) -> &'static str {
         }
         "cmake" => "The currently installed version of CMake",
         "cmd_duration" => "How long the last command took to execute",
+        "cobol" => "The currently installed version of COBOL/GNUCOBOL",
         "conda" => "The current conda environment, if $CONDA_DEFAULT_ENV is set",
         "crystal" => "The currently installed version of Crystal",
         "dart" => "The currently installed version of Dart",


### PR DESCRIPTION
#### Description
Adds support for the COBOL / GNUCOBOL language, displaying the currently installed version in the prompt.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #2377

#### Screenshots (if appropriate):
![COBOL Prompt](https://user-images.githubusercontent.com/24847734/129922057-d1a34559-da11-4cf9-a581-962d51e38151.png)


#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [X] I have tested using **Linux**
- [ ] I have tested using **Windows**
Tested on Arch Linux using the `alacritty` terminal, wrote unit tests to cover each of the different file extensions that the module detects.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have updated the documentation accordingly.
- [X] I have updated the tests accordingly.
