### PR TITLE
perf(node): on windows try getting version without cmd execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,6 +277,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-sha1"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb58b6451e8c2a812ad979ed1d83378caa5e927eef2622017a45f251457c2c9d"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1738,6 +1744,7 @@ dependencies = [
  "versions",
  "which",
  "winapi",
+ "windows",
  "yaml-rust",
 ]
 
@@ -2093,6 +2100,51 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef84dd25f4c69a271b1bba394532bf400523b43169de21dfc715e8f8e491053d"
+dependencies = [
+ "const-sha1",
+ "windows_gen",
+ "windows_macros",
+]
+
+[[package]]
+name = "windows_gen"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac7bb21b8ff5e801232b72a6ff554b4cc0cef9ed9238188c3ca78fe3968a7e5d"
+dependencies = [
+ "windows_quote",
+ "windows_reader",
+]
+
+[[package]]
+name = "windows_macros"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5566b8c51118769e4a9094a688bf1233a3f36aacbfc78f3b15817fe0b6e0442f"
+dependencies = [
+ "syn 1.0.72",
+ "windows_gen",
+ "windows_quote",
+ "windows_reader",
+]
+
+[[package]]
+name = "windows_quote"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4af8236a9493c38855f95cdd11b38b342512a5df4ee7473cffa828b5ebb0e39c"
+
+[[package]]
+name = "windows_reader"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8d5cf83fb08083438c5c46723e6206b2970da57ce314f80b57724439aaacab"
 
 [[package]]
 name = "winrt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,12 +85,16 @@ winapi = { version = "0.3.9", features = [
   "handleapi",
   "impl-default",
 ] }
+windows = "0.19.0"
 
 [target.'cfg(not(windows))'.dependencies]
 nix = "0.22.1"
 
 [build-dependencies]
 shadow-rs = "0.6.12"
+
+[target.'cfg(windows)'.build-dependencies]
+windows = "0.19.0"
 
 [dev-dependencies]
 tempfile = "3.2.0"

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,8 @@
 fn main() -> shadow_rs::SdResult<()> {
+    #[cfg(windows)]
+    windows::build! {
+        Windows::Win32::Storage::FileSystem::{GetFileVersionInfoSizeW, GetFileVersionInfoW, VerQueryValueW, VS_FIXEDFILEINFO},
+        Windows::Win32::Foundation::PWSTR,
+    };
     shadow_rs::new()
 }

--- a/src/modules/utils/mod.rs
+++ b/src/modules/utils/mod.rs
@@ -6,4 +6,7 @@ pub mod directory_win;
 #[cfg(not(target_os = "windows"))]
 pub mod directory_nix;
 
+#[cfg(target_os = "windows")]
+pub mod version_win;
+
 pub mod path;

--- a/src/modules/utils/version_win.rs
+++ b/src/modules/utils/version_win.rs
@@ -1,0 +1,124 @@
+use std::iter;
+use std::os::windows::ffi::OsStrExt;
+use std::{ffi::c_void, io::Error, path::Path, ptr};
+
+mod bindings {
+    windows::include_bindings!();
+}
+
+use bindings::{
+    Windows::Win32::Foundation::PWSTR,
+    Windows::Win32::Storage::FileSystem::{
+        GetFileVersionInfoSizeW, GetFileVersionInfoW, VerQueryValueW, VS_FIXEDFILEINFO,
+    },
+};
+
+/// Attempt to get version information for an executable located in `path`
+/// from the exe-file version metadata
+pub fn from_metadata<P: AsRef<Path>>(path: P) -> std::io::Result<String> {
+    log::debug!(
+        "Getting version of {:?} from executable metadata",
+        path.as_ref()
+    );
+
+    let mut path_wide: Vec<u16> = path
+        .as_ref()
+        .as_os_str()
+        .encode_wide()
+        .chain(iter::once(0))
+        .collect();
+    let path_pwstr = PWSTR(path_wide.as_mut_ptr());
+
+    // handle is set to 0 and ignored later
+    let mut handle = 0;
+
+    // Get size of version information buffer for `GetFileVersionInfoW`
+    let size = unsafe { GetFileVersionInfoSizeW(path_pwstr, &mut handle) };
+    if size == 0 {
+        log::error!("Failed to call GetFileVersionInfoSizeW");
+        return Err(Error::last_os_error());
+    }
+
+    // Fill version information buffer
+    let mut buffer = vec![0u8; size as usize];
+    let rc = unsafe {
+        GetFileVersionInfoW(
+            path_pwstr,
+            handle,
+            size,
+            buffer.as_mut_ptr().cast::<c_void>(),
+        )
+    };
+
+    if rc.ok().is_err() {
+        log::error!("Failed to call GetFileVersionW");
+        return Err(Error::last_os_error());
+    }
+
+    // Will be set to point to VS_FIXEDFILEINFO struct in `buffer`
+    let version_ptr: *mut VS_FIXEDFILEINFO = ptr::null_mut();
+    let mut version_len = 0u32;
+
+    // Query root (\) language-independent version information
+    let rc = unsafe {
+        VerQueryValueW(
+            buffer.as_ptr().cast::<c_void>(),
+            r"\",
+            ptr::addr_of!(version_ptr) as *mut *mut c_void,
+            &mut version_len,
+        )
+    };
+
+    if rc.ok().is_err() || version_len == 0 || version_ptr.is_null() {
+        log::error!("Failed to call VerQueryValueW: {:?}", rc.ok());
+        return Err(Error::last_os_error());
+    }
+
+    let version = unsafe { &*version_ptr };
+
+    let out = if (version.dwFileVersionLS) as u16 > 0 {
+        format!(
+            "{}.{}.{}.{}",
+            (version.dwFileVersionMS >> 16) as u16,
+            (version.dwFileVersionMS) as u16,
+            (version.dwFileVersionLS >> 16) as u16,
+            (version.dwFileVersionLS) as u16
+        )
+    } else {
+        format!(
+            "{}.{}.{}",
+            (version.dwFileVersionMS >> 16) as u16,
+            (version.dwFileVersionMS) as u16,
+            (version.dwFileVersionLS >> 16) as u16,
+        )
+    };
+
+    log::debug!("Version of \"{:?}\" resolved to \"{}\"", path.as_ref(), out);
+
+    Ok(out)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::utils;
+
+    #[test]
+    #[ignore]
+    fn cli_and_metadata_same() {
+        let output = utils::create_command(r"C:\Program Files\nodejs\node.exe")
+            .unwrap()
+            .arg("--version")
+            .output()
+            .unwrap();
+        let cli_version = std::str::from_utf8(&output.stdout).unwrap().trim();
+
+        assert_eq!(
+            cli_version,
+            format!(
+                "v{}",
+                from_metadata(r"C:\Program Files\nodejs\node.exe").unwrap()
+            )
+        )
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->


If the node.js executable is located at `C:\Program Files\nodejs\node.EXE` (and the executable is likely not a shim) attempt to get the file version from the executable metadata with the Windows file version APIs instead of executing `node --version`.

This improves `nodejs` modules performance from 30-100ms to about 10ms on my system.

I used `windows` over `winapi` because `winapi` was missing some bindings, and I was having issues with the `winapi`-version of `VerQueryValueW`. It might make sense to switch to `windows` completely in the future.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
