### PR TITLE
feat: Meteor support

### DIFF
--- a/src/modules/nodejs.rs
+++ b/src/modules/nodejs.rs
@@ -32,11 +32,33 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         return None;
     }
 
+    let is_meteor_project = context
+        .try_begin_scan()?
+        .set_folders(&[".meteor"])
+        .is_match();
+
+    let is_meteor_installed = context
+        .try_begin_scan()?
+        .set_files(&[utils::home_dir()
+            .expect("couldn't find home directory")
+            .join(".meteor")
+            .join("meteor")
+            .to_str()
+            .expect("couldn't convert meteor executable path to str")])
+        .is_match();
+
     let nodejs_version = Lazy::new(|| {
-        context
-            .exec_cmd("node", &["--version"])
-            .map(|cmd| cmd.stdout)
+        if is_meteor_project && is_meteor_installed {
+            context
+                .exec_cmd("meteor", &["node", "--version"])
+                .map(|cmd| cmd.stdout)
+        } else {
+            context
+                .exec_cmd("node", &["--version"])
+                .map(|cmd| cmd.stdout)
+        }
     });
+
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter
             .map_meta(|var, _| match var {


### PR DESCRIPTION
#### Description

The final goal of this PR would be to support Meteor projects by, for instance:
  - displaying the node version linked to the Meteor version of the project
  - display the Meteor version of the project
  - displaying the mongodb version (vague: DB version? Driver version? API version?)

Currently this PR only contains a proof of concept to display correct node version information inside a Meteor project.

#### Motivation and Context

The current implementation of the nodejs module displays incorrect node version information inside a Meteor project. There exists no Meteor support in starship other than through custom commands.

#### How Has This Been Tested?

No tests yet.

#### Checklist:
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
