### PR TITLE
feat(module): added iterm2_mark module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1660,6 +1660,7 @@ dependencies = [
  "shell-words",
  "starship-battery",
  "starship_module_config_derive",
+ "strip-ansi-escapes",
  "strsim",
  "sys-info",
  "tempfile",
@@ -1707,6 +1708,15 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strip-ansi-escapes"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "011cbb39cf7c1f62871aea3cc46e5817b0937b49e9447370c93cacbe93a766d8"
+dependencies = [
+ "vte",
+]
 
 [[package]]
 name = "strsim"
@@ -1961,6 +1971,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cf7d77f457ef8dfa11e4cd5933c5ddb5dc52a94664071951219a97710f0a32b"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1980,6 +1996,27 @@ checksum = "d5276c151793dde1cc57e08123f36f96e662a9f2532060c677612bf0e2c604d4"
 dependencies = [
  "itertools",
  "nom",
+]
+
+[[package]]
+name = "vte"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cbce692ab4ca2f1f3047fcf732430249c0e971bfdd2b234cf2c47ad93af5983"
+dependencies = [
+ "arrayvec",
+ "utf8parse",
+ "vte_generate_state_changes",
+]
+
+[[package]]
+name = "vte_generate_state_changes"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d257817081c7dffcdbab24b9e62d2def62e2ff7d00b1c20062551e6cccc145ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ shadow-rs = "0.10.0"
 starship-battery = { version = "0.7.9", optional = true }
 starship_module_config_derive = { version = "0.2.1", path = "starship_module_config_derive" }
 strsim = "0.10.0"
+strip-ansi-escapes = "0.1.1"
 sys-info = "0.9.1"
 terminal_size = "0.1.17"
 toml = { version = "0.5.8", features = ["preserve_order"] }

--- a/src/configs/iterm2_mark.rs
+++ b/src/configs/iterm2_mark.rs
@@ -1,0 +1,36 @@
+use crate::config::ModuleConfig;
+
+use serde::Serialize;
+use starship_module_config_derive::ModuleConfig;
+
+#[derive(Clone, ModuleConfig, Serialize)]
+pub struct ITerm2MarkConfig<'a> {
+    /// A vector of supported terminal application names.
+    /// The iTerm2 set an environment variable named 'TERM_PROGRAM' when it starts.
+    /// We check this environment variable to determine if this module should be activated.
+    /// Currently, the value of TERM_PROGRAM is set to 'iTerm.app'. (see Default trait below)
+    /// In case of changing, we let user to specify the value of TERM_PROGRAM.
+    pub term_programs: Vec<&'a str>,
+
+    /// Activate this module by force or not.
+    /// Sometimes it is not reliable by the environment variable 'TERM_PROGRAM'
+    /// to activate this module. For example, the iTerm.app failed to set the environment variable
+    /// when remote login by ssh. Users could set the `force` flag to true in the config file under
+    /// the 'iterm2_mark' section.
+    /// Note the differences between `force` and `disabled`. When `disabled` is set to be true,
+    /// this module will not run at all.
+    pub force: bool,
+
+    /// Disable this module or not.
+    pub disabled: bool,
+}
+
+impl<'a> Default for ITerm2MarkConfig<'a> {
+    fn default() -> Self {
+        ITerm2MarkConfig {
+            term_programs: vec!["iTerm.app"],
+            force: false,
+            disabled: false,
+        }
+    }
+}

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -36,6 +36,7 @@ pub mod haskell;
 pub mod helm;
 pub mod hg_branch;
 pub mod hostname;
+pub mod iterm2_mark;
 pub mod java;
 pub mod jobs;
 pub mod julia;
@@ -121,6 +122,7 @@ pub struct FullConfig<'a> {
     helm: helm::HelmConfig<'a>,
     hg_branch: hg_branch::HgBranchConfig<'a>,
     hostname: hostname::HostnameConfig<'a>,
+    iterm2_mark: iterm2_mark::ITerm2MarkConfig<'a>,
     java: java::JavaConfig<'a>,
     jobs: jobs::JobsConfig<'a>,
     julia: julia::JuliaConfig<'a>,
@@ -204,6 +206,7 @@ impl<'a> Default for FullConfig<'a> {
             helm: Default::default(),
             hg_branch: Default::default(),
             hostname: Default::default(),
+            iterm2_mark: Default::default(),
             java: Default::default(),
             jobs: Default::default(),
             julia: Default::default(),

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -18,6 +18,7 @@ pub struct StarshipRootConfig {
 // NOTE: If this const value is changed then Default prompt order subheading inside
 // prompt heading of config docs needs to be updated according to changes made here.
 pub const PROMPT_ORDER: &[&str] = &[
+    "iterm2_mark",
     "username",
     "hostname",
     "localip",

--- a/src/module.rs
+++ b/src/module.rs
@@ -41,6 +41,7 @@ pub const ALL_MODULES: &[&str] = &[
     "helm",
     "hg_branch",
     "hostname",
+    "iterm2_mark",
     "java",
     "jobs",
     "julia",

--- a/src/modules/iterm2_mark.rs
+++ b/src/modules/iterm2_mark.rs
@@ -1,0 +1,141 @@
+use super::{Context, Module, RootModuleConfig};
+use crate::configs::iterm2_mark::ITerm2MarkConfig;
+use crate::segment::Segment;
+
+/// The Control Sequence used by iTerm2.app
+const MARKER: &str = "\x1b]133;A\x07 ";
+
+/// Creates a module for the prompt character
+///
+/// The character segment prints a marker at the beginning of the prompt.
+/// The marker is recognizable by iTerm2.app on macOS, such that we can
+/// navigate between the marked lines by keystroke Cmd+Shift+Up/Down.
+pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let mut module_ = context.new_module("iterm2_mark");
+    let config: ITerm2MarkConfig = ITerm2MarkConfig::try_load(module_.config);
+
+    // When using tmux, the TERM_PROGRAM value will be set to 'tmux' instead of 'iTerm.app'.
+    // It is more reliable to checking the ITERM_PROFILE environment variable.
+    let iterm_profile = context.get_env("ITERM_PROFILE");
+    // If this module is activated forcedly, or the ITERM_PROFILE env variable exists,
+    // there is no need to activate it by looking the TERM_PROGRAM env variable.
+    if config.force || iterm_profile.is_some() {
+        module_.set_segments(Segment::from_text(None, MARKER));
+        return Some(module_);
+    }
+
+    let term_program = context.get_env("TERM_PROGRAM");
+    if let Some(program) = &term_program {
+        // This module works only in iTerm2.
+        // Make sure that the 'iTerm.app' always exists in the supported program list.
+        // Even if the user makes a wrong configuration by `term_programs',
+        // it still works correctly.
+        let term_programs = {
+            let mut tmp = config.term_programs.clone();
+            tmp.push("iTerm.app");
+            tmp
+        };
+        if term_programs.contains(&program.as_str()) || config.force {
+            module_.set_segments(Segment::from_text(None, MARKER));
+            return Some(module_);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod test {
+    use super::MARKER;
+    use crate::test::ModuleRenderer;
+
+    #[test]
+    fn iterm2_app() {
+        let expected = Some(MARKER.to_string());
+
+        // Status code 0
+        let actual = ModuleRenderer::new("iterm2_mark")
+            .status(0)
+            .env("TERM_PROGRAM", "iTerm.app")
+            .collect();
+        assert_eq!(expected, actual);
+
+        // No status code
+        let actual = ModuleRenderer::new("iterm2_mark")
+            .status(127)
+            .env("TERM_PROGRAM", "iTerm.app")
+            .collect();
+        assert_eq!(expected, actual);
+
+        // No status code
+        let actual = ModuleRenderer::new("iterm2_mark")
+            .env("TERM_PROGRAM", "iTerm.app")
+            .collect();
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn non_iterm2_app() {
+        let expected = None;
+
+        // For macOS Terminal.app with success exit.
+        let actual = ModuleRenderer::new("iterm2_mark")
+            .status(0)
+            .env("TERM_PROGRAM", "Apple_Terminal")
+            .collect();
+        assert_eq!(expected, actual);
+
+        // For macOS Terminal.app with failure exit.
+        let actual = ModuleRenderer::new("iterm2_mark")
+            .status(127)
+            .env("TERM_PROGRAM", "Apple_Terminal")
+            .collect();
+        assert_eq!(expected, actual);
+
+        // For macOS Terminal.app with default exit status.
+        let actual = ModuleRenderer::new("iterm2_mark")
+            .env("TERM_PROGRAM", "Apple_Terminal")
+            .collect();
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn non_iterm2_app_enabled_by_env() {
+        let expected = Some(MARKER.to_string());
+
+        let actual = ModuleRenderer::new("iterm2_mark")
+            .env("ITERM_PROFILE", "Default")
+            .collect();
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn non_iterm2_app_enabled_by_extra_programs() {
+        let expected = Some(MARKER.to_string());
+        // Add extra supported Terminal program names.
+        let config = toml::toml! {
+            iterm2_mark = { term_programs = ["iTerm.app", "Apple_Terminal"] }
+        };
+        let actual = ModuleRenderer::new("iterm2_mark")
+            .status(0)
+            .env("TERM_PROGRAM", "Apple_Terminal")
+            .config(config)
+            .collect();
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn non_iterm2_app_force() {
+        let expected = Some(MARKER.to_string());
+
+        let config = toml::toml! {
+            iterm2_mark = { force = true }
+        };
+
+        let actual = ModuleRenderer::new("iterm2_mark")
+            .status(0)
+            .env("TERM_PROGRAM", "Apple_Terminal")
+            .config(config)
+            .collect();
+        assert_eq!(expected, actual);
+    }
+}

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -31,6 +31,7 @@ mod haskell;
 mod helm;
 mod hg_branch;
 mod hostname;
+mod iterm2_mark;
 mod java;
 mod jobs;
 mod julia;
@@ -88,6 +89,7 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
         match module {
             // Keep these ordered alphabetically.
             // Default ordering is handled in configs/starship_root.rs
+            "iterm2_mark" => iterm2_mark::module(context),
             "aws" => aws::module(context),
             "azure" => azure::module(context),
             #[cfg(feature = "battery")]
@@ -180,6 +182,10 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
 
 pub fn description(module: &str) -> &'static str {
     match module {
+        "iterm2_mark" => {
+            "The marker for iTerm2 on macOS. \
+            You can navigate marks with Cmd-Shift-Up and Down-arrow keys."
+        }
         "aws" => "The current AWS region and profile",
         "azure" => "The current Azure subscription",
         "battery" => "The current charge of the device's battery and its current charging status",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Adds support to display the iTerm2's marker, so that the users can navigate marks with Cmd-Shift-Up and Down-arrow keys.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This feature makes it easier for iTerm2 users on macOS to jump between prompts.
For non-iTerm2 users, this module displays nothing. 
The module automatically detects whether the user uses iTerm2 according to the environment variables ITERM_PROFILE, TERM_PROGRAM, and then decides whether to display the marker. 

#### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/18525479/131218912-f82e9920-7dd2-4022-a743-5f70085f84ff.png)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
