### PR TITLE
fix(config): make terminal editors work again when launched by `starship config`

### DIFF
--- a/src/configure.rs
+++ b/src/configure.rs
@@ -2,6 +2,7 @@ use std::env;
 use std::ffi::OsString;
 use std::io::ErrorKind;
 use std::process;
+use std::process::Stdio;
 
 use crate::config::RootModuleConfig;
 use crate::config::StarshipConfig;
@@ -158,6 +159,9 @@ pub fn edit_configuration() {
 
     let command = utils::create_command(&editor_cmd[0])
         .expect("Unable to locate editor in $PATH.")
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
         .args(&editor_cmd[1..])
         .arg(config_path)
         .status();


### PR DESCRIPTION
Due to the introduction of `utils::create_command`, commands now have stdin set to null, and stdout and stderr set to piped.
This prevented console editors from working when invoked via `starship config`

<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
This just changes the io streams of the editor command back to inherit from piped/null.

#### Motivation and Context
In starship 0.56 `starship config` worked fine with vim
In starship 0.57 `starship config` does not display the editor UI in the terminal.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
