### PR TITLE
feat(juju): Add Juju module

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1614,6 +1614,40 @@ number_threshold = 4
 symbol_threshold = 0
 ```
 
+## Juju
+
+The `juju` module shows the currently installed version of [Juju](https://juju.is/),
+along with the active controller and model, if set.
+
+### Options
+
+| Option     | Default                                  | Description                                      |
+| ---------- | ---------------------------------------- | ------------------------------------------------ |
+| `format`   | `"via [$symbol$version$model]($style) "` | The format for the module.                       |
+| `symbol`   | `"🔮 "`                                  | A format string representing the symbol of Juju. |
+| `style`    | `"fg:#E95420"`                           | The style for the module.                        |
+| `disabled` | `true`                                   | Disables the `juju` module.                      |
+
+### Variables
+
+| Variable | Example      | Description                          |
+| -------- | ------------ | ------------------------------------ |
+| version  | `1.2.3`      | The version of `juju`                |
+| model    | `(foo:bar)`  | The active controller and model      |
+| symbol   |              | Mirrors the value of option `symbol` |
+| style\*  |              | Mirrors the value of option `style`  |
+
+\*: This variable can only be used as a part of a style string
+
+### Example
+
+```toml
+# ~/.config/starship.toml
+
+[juju]
+symbol = "🐼 "
+```
+
 ## Julia
 
 The `julia` module shows the currently installed version of [Julia](https://julialang.org/).

--- a/src/configs/juju.rs
+++ b/src/configs/juju.rs
@@ -1,0 +1,23 @@
+use crate::config::ModuleConfig;
+
+use serde::Serialize;
+use starship_module_config_derive::ModuleConfig;
+
+#[derive(Clone, ModuleConfig, Serialize)]
+pub struct JujuConfig<'a> {
+    pub format: &'a str,
+    pub symbol: &'a str,
+    pub style: &'a str,
+    pub disabled: bool,
+}
+
+impl<'a> Default for JujuConfig<'a> {
+    fn default() -> Self {
+        JujuConfig {
+            format: "via [$symbol$version$model]($style) ",
+            symbol: "🔮 ",
+            style: "fg:#E95420",
+            disabled: true,
+        }
+    }
+}

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -32,6 +32,7 @@ pub mod hg_branch;
 pub mod hostname;
 pub mod java;
 pub mod jobs;
+pub mod juju;
 pub mod julia;
 pub mod kotlin;
 pub mod kubernetes;
@@ -106,6 +107,7 @@ pub struct FullConfig<'a> {
     hostname: hostname::HostnameConfig<'a>,
     java: java::JavaConfig<'a>,
     jobs: jobs::JobsConfig<'a>,
+    juju: juju::JujuConfig<'a>,
     julia: julia::JuliaConfig<'a>,
     kotlin: kotlin::KotlinConfig<'a>,
     kubernetes: kubernetes::KubernetesConfig<'a>,
@@ -178,6 +180,7 @@ impl<'a> Default for FullConfig<'a> {
             hostname: Default::default(),
             java: Default::default(),
             jobs: Default::default(),
+            juju: Default::default(),
             julia: Default::default(),
             kotlin: Default::default(),
             kubernetes: Default::default(),

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -43,6 +43,7 @@ pub const PROMPT_ORDER: &[&str] = &[
     "golang",
     "helm",
     "java",
+    "juju",
     "julia",
     "kotlin",
     "lua",

--- a/src/module.rs
+++ b/src/module.rs
@@ -37,6 +37,7 @@ pub const ALL_MODULES: &[&str] = &[
     "hostname",
     "java",
     "jobs",
+    "juju",
     "julia",
     "kotlin",
     "kubernetes",

--- a/src/modules/juju.rs
+++ b/src/modules/juju.rs
@@ -1,0 +1,182 @@
+use std::fs::read_to_string;
+use std::path::PathBuf;
+
+use super::{Context, Module, RootModuleConfig};
+
+use crate::configs::juju::JujuConfig;
+use crate::formatter::StringFormatter;
+
+use yaml_rust::{Yaml, YamlLoader};
+
+fn get_yaml<P: Into<PathBuf>>(path: P) -> Option<Yaml> {
+    let contents = read_to_string(path.into()).ok()?;
+    Some(YamlLoader::load_from_str(&contents).ok()?.get(0)?.clone())
+}
+
+/// Creates a module that display the current Juju version and model
+///
+/// Will display the Juju version if the Juju snap is installed.
+/// Will also display the active controller and model if they exist.
+pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let mut module = context.new_module("juju");
+    let config = JujuConfig::try_load(module.config);
+
+    // Read version information directly from the snap directory,
+    // instead of querying the CLI about version information.
+    // JUJU_SNAP_DIR is not something actually set by snapcraft,
+    // but is used for unit testing.
+    let snap_dir = context
+        .get_env("JUJU_SNAP_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| "/snap/juju/current".into());
+
+    let doc = get_yaml(snap_dir.join("meta/snap.yaml"))?;
+    let version = doc["version"].as_str()?;
+
+    // Optionally, calculate the controller and model, and display
+    // it in parentheses. The user may not have an active model,
+    // in which case we just show the version number.
+    let model = context
+        .get_home()
+        .map(|d| d.join(".local/share/juju/"))
+        .and_then(|d| {
+            let doc = get_yaml(d.join("controllers.yaml"))?;
+            doc["current-controller"].as_str().and_then(|c| {
+                let doc = get_yaml(d.join("models.yaml"))?;
+                let model = doc["controllers"][c]["current-model"].as_str()?;
+                Some(format!(" ({}:{})", c, model))
+            })
+        });
+
+    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
+        formatter
+            .map_meta(|var, _| match var {
+                "symbol" => Some(config.symbol),
+                _ => None,
+            })
+            .map_style(|variable| match variable {
+                "style" => Some(Ok(config.style)),
+                _ => None,
+            })
+            .map(|variable| match variable {
+                "version" => Some(Ok(version)),
+                "model" => model.as_ref().map(|m| Ok(m.as_str())),
+                _ => None,
+            })
+            .parse(None)
+    });
+
+    module.set_segments(match parsed {
+        Ok(segments) => segments,
+        Err(error) => {
+            log::error!("Error in module `juju`: \n{}", error);
+            return None;
+        }
+    });
+
+    Some(module)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::ModuleRenderer;
+    use ansi_term::Color;
+    use std::fs::{create_dir_all, write};
+    use std::io;
+    use std::path::PathBuf;
+
+    fn write_file(path: PathBuf, contents: &[u8]) {
+        create_dir_all(path.parent().unwrap()).unwrap();
+        write(path, contents).unwrap();
+    }
+
+    #[test]
+    fn test_none() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+
+        let actual = ModuleRenderer::new("juju")
+            .env("HOME", dir.path().to_str().unwrap())
+            .env("JUJU_SNAP_DIR", dir.path().to_str().unwrap())
+            .path(dir.path())
+            .collect();
+
+        assert_eq!(None, actual);
+
+        dir.close()
+    }
+
+    #[test]
+    fn test_version_only() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+
+        write_file(dir.path().join("meta/snap.yaml"), b"version: 1.2.3");
+
+        let actual = ModuleRenderer::new("juju")
+            .env("HOME", dir.path().to_str().unwrap())
+            .env("JUJU_SNAP_DIR", dir.path().to_str().unwrap())
+            .path(dir.path())
+            .collect();
+
+        let expected = Some(format!(
+            "via {} ",
+            Color::RGB(0xE9, 0x54, 0x20).paint("🔮 1.2.3")
+        ));
+        assert_eq!(expected, actual);
+
+        dir.close()
+    }
+
+    #[test]
+    fn test_controller_only() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+
+        write_file(dir.path().join("meta/snap.yaml"), b"version: 1.2.3");
+        write_file(
+            dir.path().join(".local/share/juju/controllers.yaml"),
+            b"current-controller: foo",
+        );
+
+        let actual = ModuleRenderer::new("juju")
+            .env("HOME", dir.path().to_str().unwrap())
+            .env("JUJU_SNAP_DIR", dir.path().to_str().unwrap())
+            .path(dir.path())
+            .collect();
+
+        let expected = Some(format!(
+            "via {} ",
+            Color::RGB(0xE9, 0x54, 0x20).paint("🔮 1.2.3")
+        ));
+        assert_eq!(expected, actual);
+
+        dir.close()
+    }
+
+    #[test]
+    fn test_controller_and_model() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+
+        write_file(dir.path().join("meta/snap.yaml"), b"version: 1.2.3");
+        write_file(
+            dir.path().join(".local/share/juju/controllers.yaml"),
+            b"current-controller: foo",
+        );
+        write_file(
+            dir.path().join(".local/share/juju/models.yaml"),
+            b"controllers: { foo: { current-model: bar } }",
+        );
+
+        let actual = ModuleRenderer::new("juju")
+            .env("HOME", dir.path().to_str().unwrap())
+            .env("JUJU_SNAP_DIR", dir.path().to_str().unwrap())
+            .path(dir.path())
+            .collect();
+
+        let expected = Some(format!(
+            "via {} ",
+            Color::RGB(0xE9, 0x54, 0x20).paint("🔮 1.2.3 (foo:bar)")
+        ));
+        assert_eq!(expected, actual);
+
+        dir.close()
+    }
+}

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -27,6 +27,7 @@ mod hg_branch;
 mod hostname;
 mod java;
 mod jobs;
+mod juju;
 mod julia;
 mod kotlin;
 mod kubernetes;
@@ -107,6 +108,7 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
             "hostname" => hostname::module(context),
             "java" => java::module(context),
             "jobs" => jobs::module(context),
+            "juju" => juju::module(context),
             "julia" => julia::module(context),
             "kotlin" => kotlin::module(context),
             "kubernetes" => kubernetes::module(context),
@@ -190,6 +192,7 @@ pub fn description(module: &str) -> &'static str {
         "hostname" => "The system hostname",
         "java" => "The currently installed version of Java",
         "jobs" => "The current number of jobs running",
+        "juju" => "The current version and active model of Juju",
         "julia" => "The currently installed version of Julia",
         "kotlin" => "The currently installed version of Kotlin",
         "kubernetes" => "The current Kubernetes context name and, if set, the namespace",


### PR DESCRIPTION
#### Description

Adds support for https://juju.is/

Displays version information as well as active controller/model.

#### Motivation and Context

The motivation is that it is useful to see what Juju version and/or active controller you have

#### Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/20422884/132078146-01e79fb9-866a-45b3-86ca-469229a6aca7.png)

#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

Tested by adding unit tests, as well as extensive dogfooding.

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
