### PR TITLE
docs(chglog): Change release page title order (#3038)

### DIFF
--- a/.github/chglog/release.yml
+++ b/.github/chglog/release.yml
@@ -11,6 +11,19 @@ options:
     #     - perf
     #     - refactor
   commit_groups:
+    sort_by: Custom
+    title_order:
+      - feat
+      - fix
+      - docs
+      - style
+      - refactor
+      - perf
+      - test
+      - build
+      - ci
+      - chore
+      - revert
     title_maps:
       feat: Features
       fix: Bug Fixes


### PR DESCRIPTION
#### Description

Changed release page commit group title order from alphabetical to 
 1. feat
 2. fix
 3. docs
 4. style
 5. refactor
 6. pref
 7. test
 8. build
 9. ci
10. chore
11. revert

Now it closely matches Semantic PR conventional commit types.

Closes  #3038 

#### How Has This Been Tested?
Tested on release v0.57.0, here is a truncated version of new release file it generates

```

## [v0.57.0](https://github.com/starship/starship/compare/v0.56.0...v0.57.0) (2021-08-26)

### Features

* add support for xonsh ([#2807](https://github.com/starship/starship/issues/2807))
* **explain:** quote module values ([#2931](https://github.com/starship/starship/issues/2931))
...

### Bug Fixes

* **clippy:** fix new clippy lints ([#2939](https://github.com/starship/starship/issues/2939))
* **git_status:** show working tree status if index status is present ([#2973](https://github.com/starship/starship/issues/2973))
...

### Docs

* Fix typo ([#2900](https://github.com/starship/starship/issues/2900))
* update git_commit default format ([#2898](https://github.com/starship/starship/issues/2898))
...

### Style

* Improve modules consistency ([#3006](https://github.com/starship/starship/issues/3006))

### Code Refactoring

* allow passing OsStr as-is to `exec_cmd` ([#2997](https://github.com/starship/starship/issues/2997))

### Build

* bump versions from 3.0.2 to 3.0.3 ([#3003](https://github.com/starship/starship/issues/3003))
* bump serde from 1.0.128 to 1.0.129 ([#3002](https://github.com/starship/starship/issues/3002))
...

### Continuous Integration

* disable dependabot cron on starship forks ([#2993](https://github.com/starship/starship/issues/2993))
* Use default token for release action ([#2920](https://github.com/starship/starship/issues/2920))

### Chore

* **release:** v0.57.0
```

