### PR TITLE
fix(zsh init script): avoid adding preexec commands twice

### DIFF
--- a/src/init/starship.zsh
+++ b/src/init/starship.zsh
@@ -56,7 +56,7 @@ starship_preexec() {
 if [[ -z ${precmd_functions[(re)starship_precmd]} ]]; then
     precmd_functions+=(starship_precmd)
 fi
-if [[ -z ${preexec_function[(re)starship_preexec]} ]]; then
+if [[ -z ${preexec_functions[(re)starship_preexec]} ]]; then
     preexec_functions+=(starship_preexec)
 fi
 


### PR DESCRIPTION
#### Description
A typo in the zsh init script was breaking the predicate to prevent adding duplicate hooks.

#### Motivation and Context
Minor nuisance, but it was gumming up my shell while testing 

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
