### PR TITLE
fix(zsh): always escape percent character

### DIFF
--- a/src/modules/battery.rs
+++ b/src/modules/battery.rs
@@ -1,4 +1,4 @@
-use super::{Context, Module, RootModuleConfig, Shell};
+use super::{Context, Module, RootModuleConfig};
 use crate::configs::battery::BatteryConfig;
 #[cfg(test)]
 use mockall::automock;
@@ -7,13 +7,6 @@ use crate::formatter::StringFormatter;
 
 /// Creates a module for the battery percentage and charging state
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
-    // TODO: Update when v1.0 printing refactor is implemented to only
-    // print escapes in a prompt context.
-    let percentage_char = match context.shell {
-        Shell::Zsh => "%%", // % is an escape in zsh, see PROMPT in `man zshmisc`
-        _ => "%",
-    };
-
     let battery_status = get_battery_status(context)?;
     let BatteryStatus { state, percentage } = battery_status;
 
@@ -55,7 +48,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                     _ => None,
                 })
                 .map(|variable| match variable {
-                    "percentage" => Some(Ok(format!("{}{}", percentage.round(), percentage_char))),
+                    "percentage" => Some(Ok(format!("{}%", percentage.round()))),
                     _ => None,
                 });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR makes sure `%`-characters are always escaped, by moving the handling from the battery module to `wrap_colorseq_for_shell` where interpretable characters are already being handled for bash.


#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #2891

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
