### PR TITLE
fix(print-config): add missing `format_right` to `FullConfig`

### DIFF
--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -76,6 +76,7 @@ pub use starship_root::*;
 pub struct FullConfig<'a> {
     // Root config
     pub format: &'a str,
+    pub right_format: &'a str,
     pub scan_timeout: u64,
     pub command_timeout: u64,
     pub add_newline: bool,
@@ -150,6 +151,7 @@ impl<'a> Default for FullConfig<'a> {
     fn default() -> Self {
         Self {
             format: "$all",
+            right_format: "",
             scan_timeout: 30,
             command_timeout: 500,
             add_newline: true,
@@ -234,6 +236,19 @@ mod test {
         let cfg_table = full_cfg.as_table().unwrap();
         for module in ALL_MODULES {
             assert!(cfg_table.contains_key(*module));
+        }
+    }
+
+    #[test]
+    fn root_in_full_config() {
+        let full_cfg = Value::try_from(FullConfig::default()).unwrap();
+        let cfg_table = full_cfg.as_table().unwrap();
+
+        let root_cfg = Value::try_from(StarshipRootConfig::default()).unwrap();
+        let root_table = root_cfg.as_table().unwrap();
+        for (option, default_value) in root_table.iter() {
+            assert!(cfg_table.contains_key(option));
+            assert_eq!(&cfg_table[option], default_value);
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
#3026 didn't add `format_right` to `FullConfig` meaning it was missing in the `starship print-config` output. I also added a test to ensure this doesn't happen again in the future.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
