### PR TITLE
fix(windows): make powershell init work on windows 8 again

### DIFF
--- a/src/init/starship.ps1
+++ b/src/init/starship.ps1
@@ -24,12 +24,13 @@ function global:prompt {
 
     function Invoke-Native {
         param($Executable, $Arguments)
-        $startInfo = [System.Diagnostics.ProcessStartInfo]::new($Executable);
-        $startInfo.StandardOutputEncoding = [System.Text.Encoding]::UTF8;
-        $startInfo.RedirectStandardOutput = $true;
-        $startInfo.RedirectStandardError = $true;
-        $startInfo.CreateNoWindow = $true;
-        $startInfo.UseShellExecute = $false;
+        $startInfo = New-Object System.Diagnostics.ProcessStartInfo -ArgumentList $Executable -Property @{
+            StandardOutputEncoding = [System.Text.Encoding]::UTF8;
+            RedirectStandardOutput = $true;
+            RedirectStandardError = $true;
+            CreateNoWindow = $true;
+            UseShellExecute = $false;
+        };
         if ($startInfo.ArgumentList.Add) {
             # PowerShell 6+ uses .NET 5+ and supports the ArgumentList property
             # which bypasses the need for manually escaping the argument list into


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
`[System.Diagnostics.ProcessStartInfo]::new` which was introduced #2104 doesn't exist on Windows 8, but  `New-Object` works instead. Using the implementation from on older suggestion of mine https://github.com/starship/starship/pull/2104#discussion_r558873960.


#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #3064

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
