### PR TITLE
refactor: replace `term_size` with `terminal_size`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1705,7 +1705,7 @@ dependencies = [
  "strsim 0.10.0",
  "sys-info",
  "tempfile",
- "term_size",
+ "terminal_size",
  "toml",
  "unicode-segmentation",
  "unicode-width",
@@ -1815,10 +1815,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "term_size"
-version = "0.3.2"
+name = "terminal_size"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e4129646ca0ed8f45d09b929036bafad5377103edd06e50bf574b353d2b08d9"
+checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
 dependencies = [
  "libc",
  "winapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ os_info = "3.0.7"
 urlencoding = "2.1.0"
 open = "2.0.1"
 unicode-width = "0.1.9"
-term_size = "0.3.2"
+terminal_size = "0.1.17"
 quick-xml = "0.22.0"
 rand = "0.8.4"
 serde = { version = "1.0.130", features = ["derive"] }

--- a/src/context.rs
+++ b/src/context.rs
@@ -15,6 +15,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::string::String;
 use std::time::{Duration, Instant};
+use terminal_size::terminal_size;
 
 /// Context contains data or common methods that may be used by multiple modules.
 /// The data contained within Context will be relevant to this particular rendering
@@ -138,8 +139,8 @@ impl<'a> Context<'a> {
             repo: OnceCell::new(),
             shell,
             right,
-            width: term_size::dimensions()
-                .map(|(width, _)| width)
+            width: terminal_size()
+                .map(|(w, _)| w.0 as usize)
                 .unwrap_or_default(),
             #[cfg(test)]
             env: HashMap::new(),

--- a/src/print.rs
+++ b/src/print.rs
@@ -5,6 +5,7 @@ use std::collections::BTreeSet;
 use std::fmt::{self, Debug, Write as FmtWrite};
 use std::io::{self, Write};
 use std::time::Duration;
+use terminal_size::terminal_size;
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthChar;
 
@@ -224,8 +225,8 @@ pub fn explain(args: ArgMatches) {
     // Overall a line looks like this: " "{module value}" ({xxxms})  -  {description}".
     const PADDING_WIDTH: usize = 11;
 
-    let desc_width = term_size::dimensions()
-        .map(|(w, _)| w)
+    let desc_width = terminal_size()
+        .map(|(w, _)| w.0 as usize)
         // Add padding length to module length to avoid text overflow. This line also assures desc_width >= 0.
         .map(|width| width - std::cmp::min(width, max_module_width + PADDING_WIDTH));
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR replaces `term_size` with `terminal_size`. `term_size` has become unmaintained, and `terminal_size` is the suggested replacement. Another option would have been `crossterm`, but that would have been a much larger  dependency.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
