### PR TITLE
fix: pipestatus quoting on Zsh/Bash

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -115,10 +115,10 @@ impl<'a> Context<'a> {
 
         let pipestatus = arguments
             .values_of("pipestatus")
-            .map(|args| Context::get_and_flatten_pipestatus(args))
+            .map(Context::get_and_flatten_pipestatus)
             .flatten();
 
-        log::info!("Pipestatus is {:?}", pipestatus);
+        log::trace!("Received completed pipestatus of {:?}", pipestatus);
 
         // Canonicalize the current path to resolve symlinks, etc.
         // NOTE: On Windows this converts the path to extended-path syntax.

--- a/src/context.rs
+++ b/src/context.rs
@@ -113,10 +113,16 @@ impl<'a> Context<'a> {
             .map(|(a, b)| (*a, b.vals.first().cloned().unwrap().into_string().unwrap()))
             .collect();
 
-        // Pipestatus is an arguments list
-        let pipestatus = arguments
-            .values_of("pipestatus")
-            .map(|args| args.into_iter().map(String::from).collect());
+        // Due to shell differences, we can potentially receive individual or space
+        // separated inputs, e.g. "0", "1", "2", "0" is the same as "0 1 2 0" and 
+        // "0 1", "2 0". We need to be able to accept for all these formats
+        let pipestatus = arguments.values_of("pipestatus").map(|args| {
+            args.into_iter().map(|x| x.split_ascii_whitespace())
+                .flatten()
+                .map(|x| x.to_string())
+                .collect()
+        });
+        log::info!("Pipestatus is {:?}", pipestatus);
 
         // Canonicalize the current path to resolve symlinks, etc.
         // NOTE: On Windows this converts the path to extended-path syntax.

--- a/src/init/starship.bash
+++ b/src/init/starship.bash
@@ -49,10 +49,10 @@ starship_precmd() {
     if [[ $STARSHIP_START_TIME ]]; then
         STARSHIP_END_TIME=$(::STARSHIP:: time)
         STARSHIP_DURATION=$((STARSHIP_END_TIME - STARSHIP_START_TIME))
-        PS1="$(::STARSHIP:: prompt --status=$STARSHIP_CMD_STATUS  --pipestatus ${STARSHIP_PIPE_STATUS[@]} --jobs="$NUM_JOBS" --cmd-duration=$STARSHIP_DURATION)"
+        PS1="$(::STARSHIP:: prompt --status=$STARSHIP_CMD_STATUS  --pipestatus="${STARSHIP_PIPE_STATUS[*]}" --jobs="$NUM_JOBS" --cmd-duration=$STARSHIP_DURATION)"
         unset STARSHIP_START_TIME
     else
-        PS1="$(::STARSHIP:: prompt --status=$STARSHIP_CMD_STATUS --pipestatus ${STARSHIP_PIPE_STATUS[@]} --jobs="$NUM_JOBS")"
+        PS1="$(::STARSHIP:: prompt --status=$STARSHIP_CMD_STATUS --pipestatus="${STARSHIP_PIPE_STATUS[*]}" --jobs="$NUM_JOBS")"
     fi
     STARSHIP_PREEXEC_READY=true  # Signal that we can safely restart the timer
 }

--- a/src/init/starship.zsh
+++ b/src/init/starship.zsh
@@ -91,5 +91,5 @@ export STARSHIP_SESSION_KEY=${STARSHIP_SESSION_KEY:0:16}; # Trim to 16-digits if
 VIRTUAL_ENV_DISABLE_PROMPT=1
 
 setopt promptsubst
-PROMPT='$(::STARSHIP:: prompt --keymap="$KEYMAP" --status="$STARSHIP_CMD_STATUS" --pipestatus ${STARSHIP_PIPE_STATUS[@]} --cmd-duration="$STARSHIP_DURATION" --jobs="$STARSHIP_JOBS_COUNT")'
-RPROMPT='$(::STARSHIP:: prompt --right --keymap="$KEYMAP" --status="$STARSHIP_CMD_STATUS" --pipestatus ${STARSHIP_PIPE_STATUS[@]} --cmd-duration="$STARSHIP_DURATION" --jobs="$STARSHIP_JOBS_COUNT")'
+PROMPT='$(::STARSHIP:: prompt --keymap="$KEYMAP" --status="$STARSHIP_CMD_STATUS" --pipestatus="${STARSHIP_PIPE_STATUS[*]}" --cmd-duration="$STARSHIP_DURATION" --jobs="$STARSHIP_JOBS_COUNT")'
+RPROMPT='$(::STARSHIP:: prompt --right --keymap="$KEYMAP" --status="$STARSHIP_CMD_STATUS" --pipestatus="${STARSHIP_PIPE_STATUS[*]}" --cmd-duration="$STARSHIP_DURATION" --jobs="$STARSHIP_JOBS_COUNT")'


### PR DESCRIPTION
#### Description

Modifies pipestatus parsing for the starship binary and changes the initscripts for bash/zsh to quote pipestatus. This allows starship to start without errors in the case where pipestatus is empty (usually due to interactions with other shell frameworks).

#### Motivation and Context

The previous implementation of pipestatus assumed that the arguments to pipestatus would be word-split (bash, zsh) or repeated by the shell (fish). Unfortunately, this causes a shell parse error if pipestatus is not set on first invocation (which can apparently happen if other shell frameworks are present).

There are two ways to fix this:
  1. Modify the init scripts to not use `--pipestatus` at all when pipestatus is detected to be empty.
  2. Quote the arguments to `--pipestatus`, which allows clap to detect an empty argument, and then change the parsing code in starship to split the arguments ourselves.

I have implemented the second here, since the first requires significantly complicating the init scripts for bash/zsh.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

#### Screenshots (if appropriate):

#### How Has This Been Tested?

~I'll mark this as ready once I can confirm that this fixes the linked bug in the provided docker.~

Confirmed that this does solve the issue mentioned above. There is a separate issue which appears, where on shell startup, the exit status of the previous command is not defined, so starship prints a warning about not being able to parse the exit status. However, it's not as clear to me how to fix that issue, since we do want the warning to appear when a status cannot be parsed.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
