### PR TITLE
fix(fill): Add `terminal-width` argument to explicitly define terminal's width

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -128,6 +128,17 @@ impl<'a> Context<'a> {
 
         let right = arguments.is_present("right");
 
+        let mut width = term_size::dimensions()
+            .map(|(width, _)| width)
+            .unwrap_or_default();
+        if width == 0 {
+            width = arguments
+                .value_of("terminal_width")
+                .unwrap_or("0")
+                .parse()
+                .unwrap_or(0);
+        }
+
         Context {
             config,
             properties,
@@ -138,9 +149,7 @@ impl<'a> Context<'a> {
             repo: OnceCell::new(),
             shell,
             right,
-            width: term_size::dimensions()
-                .map(|(width, _)| width)
-                .unwrap_or_default(),
+            width,
             #[cfg(test)]
             env: HashMap::new(),
             #[cfg(test)]

--- a/src/init/starship.bash
+++ b/src/init/starship.bash
@@ -12,6 +12,8 @@
 # drawn, and only start the timer if this flag is present. That way, timing is
 # for the entire command, and not just a portion of it.
 
+STARSHIP_EXE=::STARSHIP::
+
 # Will be run before *every* command (even ones in pipes!)
 starship_preexec() {
     # Save previous command's last argument, otherwise it will be set to "starship_preexec"
@@ -20,7 +22,7 @@ starship_preexec() {
     # Avoid restarting the timer for commands in the same pipeline
     if [ "$STARSHIP_PREEXEC_READY" = "true" ]; then
         STARSHIP_PREEXEC_READY=false
-        STARSHIP_START_TIME=$(::STARSHIP:: time)
+        STARSHIP_START_TIME=$($STARSHIP_EXE time)
     fi
 
     : "$PREV_LAST_ARG"
@@ -47,12 +49,12 @@ starship_precmd() {
 
     # Prepare the timer data, if needed.
     if [[ $STARSHIP_START_TIME ]]; then
-        STARSHIP_END_TIME=$(::STARSHIP:: time)
+        STARSHIP_END_TIME=$($STARSHIP_EXE time)
         STARSHIP_DURATION=$((STARSHIP_END_TIME - STARSHIP_START_TIME))
-        PS1="$(::STARSHIP:: prompt --status=$STARSHIP_CMD_STATUS  --pipestatus ${STARSHIP_PIPE_STATUS[@]} --jobs="$NUM_JOBS" --cmd-duration=$STARSHIP_DURATION)"
+        PS1="$($STARSHIP_EXE prompt --terminal-width=$COLUMNS --status=$STARSHIP_CMD_STATUS  --pipestatus ${STARSHIP_PIPE_STATUS[@]} --jobs="$NUM_JOBS" --cmd-duration=$STARSHIP_DURATION)"
         unset STARSHIP_START_TIME
     else
-        PS1="$(::STARSHIP:: prompt --status=$STARSHIP_CMD_STATUS --pipestatus ${STARSHIP_PIPE_STATUS[@]} --jobs="$NUM_JOBS")"
+        PS1="$($STARSHIP_EXE prompt --terminal-width=$COLUMNS --status=$STARSHIP_CMD_STATUS --pipestatus ${STARSHIP_PIPE_STATUS[@]} --jobs="$NUM_JOBS")"
     fi
     STARSHIP_PREEXEC_READY=true  # Signal that we can safely restart the timer
 }
@@ -93,7 +95,7 @@ else
 fi
 
 # Set up the start time and STARSHIP_SHELL, which controls shell-specific sequences
-STARSHIP_START_TIME=$(::STARSHIP:: time)
+STARSHIP_START_TIME=$($STARSHIP_EXE time)
 export STARSHIP_SHELL="bash"
 
 # Set up the session key that will be used to store logs

--- a/src/init/starship.fish
+++ b/src/init/starship.fish
@@ -9,11 +9,11 @@ function fish_prompt
     # Account for changes in variable name between v2.7 and v3.0
     set STARSHIP_DURATION "$CMD_DURATION$cmd_duration"
     set STARSHIP_JOBS (count (jobs -p))
-    ::STARSHIP:: prompt --status=$STARSHIP_CMD_STATUS --pipestatus=$pipestatus --keymap=$STARSHIP_KEYMAP --cmd-duration=$STARSHIP_DURATION --jobs=$STARSHIP_JOBS
+    ::STARSHIP:: prompt --terminal-width=$COLUMNS --status=$STARSHIP_CMD_STATUS --pipestatus=$pipestatus --keymap=$STARSHIP_KEYMAP --cmd-duration=$STARSHIP_DURATION --jobs=$STARSHIP_JOBS
 end
 
 function fish_right_prompt
-    ::STARSHIP:: prompt --right --status=$STARSHIP_CMD_STATUS --pipestatus=$pipestatus --keymap=$STARSHIP_KEYMAP --cmd-duration=$STARSHIP_DURATION --jobs=$STARSHIP_JOBS
+    ::STARSHIP:: prompt --right --terminal-width=$COLUMNS --status=$STARSHIP_CMD_STATUS --pipestatus=$pipestatus --keymap=$STARSHIP_KEYMAP --cmd-duration=$STARSHIP_DURATION --jobs=$STARSHIP_JOBS
 end
 
 # Disable virtualenv prompt, it breaks starship

--- a/src/init/starship.ps1
+++ b/src/init/starship.ps1
@@ -73,6 +73,7 @@ function global:prompt {
         "prompt"
         "--path=$($cwd.Path)",
         "--logical-path=$($cwd.LogicalPath)",
+        "--terminal-width=$($Host.UI.RawUI.WindowSize.Width)",
         "--jobs=$($jobs)"
     )
     

--- a/src/init/starship.zsh
+++ b/src/init/starship.zsh
@@ -91,5 +91,5 @@ export STARSHIP_SESSION_KEY=${STARSHIP_SESSION_KEY:0:16}; # Trim to 16-digits if
 VIRTUAL_ENV_DISABLE_PROMPT=1
 
 setopt promptsubst
-PROMPT='$(::STARSHIP:: prompt --keymap="$KEYMAP" --status="$STARSHIP_CMD_STATUS" --pipestatus ${STARSHIP_PIPE_STATUS[@]} --cmd-duration="$STARSHIP_DURATION" --jobs="$STARSHIP_JOBS_COUNT")'
-RPROMPT='$(::STARSHIP:: prompt --right --keymap="$KEYMAP" --status="$STARSHIP_CMD_STATUS" --pipestatus ${STARSHIP_PIPE_STATUS[@]} --cmd-duration="$STARSHIP_DURATION" --jobs="$STARSHIP_JOBS_COUNT")'
+PROMPT='$(::STARSHIP:: prompt --terminal-width="$COLUMNS" --keymap="$KEYMAP" --status="$STARSHIP_CMD_STATUS" --pipestatus ${STARSHIP_PIPE_STATUS[@]} --cmd-duration="$STARSHIP_DURATION" --jobs="$STARSHIP_JOBS_COUNT")'
+RPROMPT='$(::STARSHIP:: prompt --right --terminal-width="$COLUMNS" --keymap="$KEYMAP" --status="$STARSHIP_CMD_STATUS" --pipestatus ${STARSHIP_PIPE_STATUS[@]} --cmd-duration="$STARSHIP_DURATION" --jobs="$STARSHIP_JOBS_COUNT")'

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,13 @@ fn main() {
         .long_help("Bash and Zsh supports returning codes for each process in a pipeline.")
         .multiple(true);
 
+    let terminal_width_arg = Arg::with_name("terminal_width")
+        .short("t")
+        .long("terminal-width")
+        .value_name("TERMINAL_WIDTH")
+        .help("The width of the current interactive terminal.")
+        .takes_value(true);
+
     let path_arg = Arg::with_name("path")
         .short("p")
         .long("path")
@@ -106,6 +113,7 @@ fn main() {
                 )
                 .arg(&status_code_arg)
                 .arg(&pipestatus_arg)
+                .arg(&terminal_width_arg)
                 .arg(&path_arg)
                 .arg(&logical_path_arg)
                 .arg(&cmd_duration_arg)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
This adds a new commandline option for the `prompt` subcommand, called `--terminal-width`. Without this fix, the fill module does not work on Windows as the prompt functions (of any shell) always assume a non-interactive terminal, which leads to `term_size` crate reporting a zero width.

This argument's value is only used as a fallback, so it will likely not affect macOS/Linux.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #3086 

#### Screenshots (if appropriate):
_None_

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
