### PR TITLE
Revert "fix(zsh): always escape percent character (#3058)"

### DIFF
--- a/src/modules/battery.rs
+++ b/src/modules/battery.rs
@@ -1,4 +1,4 @@
-use super::{Context, Module, RootModuleConfig};
+use super::{Context, Module, RootModuleConfig, Shell};
 use crate::configs::battery::BatteryConfig;
 #[cfg(test)]
 use mockall::automock;
@@ -7,6 +7,13 @@ use crate::formatter::StringFormatter;
 
 /// Creates a module for the battery percentage and charging state
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    // TODO: Update when v1.0 printing refactor is implemented to only
+    // print escapes in a prompt context.
+    let percentage_char = match context.shell {
+        Shell::Zsh => "%%", // % is an escape in zsh, see PROMPT in `man zshmisc`
+        _ => "%",
+    };
+
     let battery_status = get_battery_status(context)?;
     let BatteryStatus { state, percentage } = battery_status;
 
@@ -48,7 +55,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                     _ => None,
                 })
                 .map(|variable| match variable {
-                    "percentage" => Some(Ok(format!("{}%", percentage.round()))),
+                    "percentage" => Some(Ok(format!("{}{}", percentage.round(), percentage_char))),
                     _ => None,
                 });
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -314,24 +314,15 @@ CMake suite maintained and supported by Kitware (kitware.com/cmake).\n",
     }
 }
 
-/// Wraps ANSI color escape sequences and other interpretable characters
-/// that need to be escaped in the shell-appropriate wrappers.
+/// Wraps ANSI color escape sequences in the shell-appropriate wrappers.
 pub fn wrap_colorseq_for_shell(mut ansi: String, shell: Shell) -> String {
-    // Handle other interpretable characters
-    match shell {
-        // Bash might interepret baskslashes, backticks and $
-        // see #658 for more details
-        Shell::Bash => {
-            ansi = ansi.replace('\\', r"\\");
-            ansi = ansi.replace('$', r"\$");
-            ansi = ansi.replace('`', r"\`");
-        }
-        Shell::Zsh => {
-            // % is an escape in zsh, see PROMPT in `man zshmisc`
-            ansi = ansi.replace('%', "%%");
-        }
-        _ => {}
-    };
+    // Bash might interepret baskslashes, backticks and $
+    // see #658 for more details
+    if shell == Shell::Bash {
+        ansi = ansi.replace('\\', r"\\");
+        ansi = ansi.replace('$', r"\$");
+        ansi = ansi.replace('`', r"\`");
+    }
 
     const ESCAPE_BEGIN: char = '\u{1b}';
     const ESCAPE_END: char = 'm';
@@ -682,15 +673,6 @@ mod tests {
             wrap_colorseq_for_shell(test.to_owned(), Shell::Bash),
             r"\`echo a\`"
         );
-        assert_eq!(
-            wrap_colorseq_for_shell(test.to_owned(), Shell::PowerShell),
-            test
-        );
-    }
-    #[test]
-    fn test_zsh_escape() {
-        let test = "10%";
-        assert_eq!(wrap_colorseq_for_shell(test.to_owned(), Shell::Zsh), "10%%");
         assert_eq!(
             wrap_colorseq_for_shell(test.to_owned(), Shell::PowerShell),
             test


### PR DESCRIPTION
This reverts commit 5ac7ad741fdcb199671c63ae215a06f216fa78b8.

#### Description

The commit causes a regression for all commands that are trying to send raw escape sequences to the shell. There are all now unconditionally escaped.

#### Motivation and Context

Closes # https://github.com/starship/starship/issues/3072

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
