### PR TITLE
fix(escaping): move escaping to individual variables

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -3316,6 +3316,19 @@ If you have an interesting example not covered there, feel free to share it ther
 
 :::
 
+::: warning Command output is printed unescaped to the prompt
+
+Whatever output the command generates is printed unmodified in the prompt. This means if the output
+contains special sequences that are interpreted by your shell they will be expanded when displayed.
+These special sequences are shell specific, e.g. you can write a command module that writes bash sequences,
+e.g. `\h`, but this module will not work in a fish or zsh shell.
+
+Format strings can also contain shell specific prompt sequences, e.g.
+[Bash](https://www.gnu.org/software/bash/manual/html_node/Controlling-the-Prompt.html),
+[Zsh](https://zsh.sourceforge.io/Doc/Release/Prompt-Expansion.html).
+
+:::
+
 ### Options
 
 | Option        | Default                         | Description                                                                                                                |

--- a/src/formatter/string_formatter.rs
+++ b/src/formatter/string_formatter.rs
@@ -7,6 +7,7 @@ use std::error::Error;
 use std::fmt;
 
 use crate::config::parse_style_string;
+use crate::context::{Context, Shell};
 use crate::segment::Segment;
 
 use super::model::*;
@@ -15,6 +16,7 @@ use super::parser::{parse, Rule};
 #[derive(Clone)]
 enum VariableValue<'a> {
     Plain(Cow<'a, str>),
+    NoEscapingPlain(Cow<'a, str>),
     Styled(Vec<Segment>),
     Meta(Vec<FormatElement<'a>>),
 }
@@ -123,6 +125,27 @@ impl<'a> StringFormatter<'a> {
         self
     }
 
+    /// Maps variable name into a value which is wrapped to prevent escaping later
+    ///
+    /// This should be used for variables that should not be escaped before inclusion in the prompt
+    ///
+    /// See `StringFormatter::map` for description on the parameters.
+    ///
+    pub fn map_no_escaping<T, M>(mut self, mapper: M) -> Self
+    where
+        T: Into<Cow<'a, str>>,
+        M: Fn(&str) -> Option<Result<T, StringFormatterError>> + Sync,
+    {
+        self.variables
+            .par_iter_mut()
+            .filter(|(_, value)| value.is_none())
+            .for_each(|(key, value)| {
+                *value = mapper(key)
+                    .map(|var| var.map(|var| VariableValue::NoEscapingPlain(var.into())));
+            });
+        self
+    }
+
     /// Maps a meta-variable to a format string containing other variables.
     ///
     /// This function should be called **before** other map methods so that variables found in
@@ -206,11 +229,16 @@ impl<'a> StringFormatter<'a> {
     ///
     /// - Format string in meta variables fails to parse
     /// - Variable mapper returns an error.
-    pub fn parse(self, default_style: Option<Style>) -> Result<Vec<Segment>, StringFormatterError> {
+    pub fn parse(
+        self,
+        default_style: Option<Style>,
+        context: Option<&Context>,
+    ) -> Result<Vec<Segment>, StringFormatterError> {
         fn parse_textgroup<'a>(
             textgroup: TextGroup<'a>,
             variables: &'a VariableMapType<'a>,
             style_variables: &'a StyleVariableMapType<'a>,
+            context: Option<&Context>,
         ) -> Result<Vec<Segment>, StringFormatterError> {
             let style = parse_style(textgroup.style, style_variables);
             parse_format(
@@ -218,6 +246,7 @@ impl<'a> StringFormatter<'a> {
                 style.transpose()?,
                 variables,
                 style_variables,
+                context,
             )
         }
 
@@ -252,6 +281,7 @@ impl<'a> StringFormatter<'a> {
             style: Option<Style>,
             variables: &'a VariableMapType<'a>,
             style_variables: &'a StyleVariableMapType<'a>,
+            context: Option<&Context>,
         ) -> Result<Vec<Segment>, StringFormatterError> {
             let results: Result<Vec<Vec<Segment>>, StringFormatterError> = format
                 .into_iter()
@@ -263,7 +293,7 @@ impl<'a> StringFormatter<'a> {
                                 format: textgroup.format,
                                 style: textgroup.style,
                             };
-                            parse_textgroup(textgroup, variables, style_variables)
+                            parse_textgroup(textgroup, variables, style_variables, context)
                         }
                         FormatElement::Variable(name) => variables
                             .get(name.as_ref())
@@ -278,14 +308,26 @@ impl<'a> StringFormatter<'a> {
                                         segment
                                     })
                                     .collect()),
-                                VariableValue::Plain(text) => Ok(Segment::from_text(style, text)),
+                                VariableValue::Plain(text) => Ok(Segment::from_text(
+                                    style,
+                                    shell_prompt_escape(
+                                        text,
+                                        match context {
+                                            None => Shell::Unknown,
+                                            Some(c) => c.shell,
+                                        },
+                                    ),
+                                )),
+                                VariableValue::NoEscapingPlain(text) => {
+                                    Ok(Segment::from_text(style, text))
+                                }
                                 VariableValue::Meta(format) => {
                                     let formatter = StringFormatter {
                                         format,
                                         variables: clone_without_meta(variables),
                                         style_variables: style_variables.clone(),
                                     };
-                                    formatter.parse(style)
+                                    formatter.parse(style, context)
                                 }
                             })
                             .unwrap_or_else(|| Ok(Vec::new())),
@@ -320,6 +362,9 @@ impl<'a> StringFormatter<'a> {
                                                     VariableValue::Plain(plain_value) => {
                                                         !plain_value.is_empty()
                                                     }
+                                                    VariableValue::NoEscapingPlain(
+                                                        no_escaping_plain_value,
+                                                    ) => !no_escaping_plain_value.is_empty(),
                                                     VariableValue::Styled(segments) => segments
                                                         .iter()
                                                         .any(|x| !x.value().is_empty()),
@@ -331,7 +376,7 @@ impl<'a> StringFormatter<'a> {
                             let should_show: bool = should_show_elements(&format, variables);
 
                             if should_show {
-                                parse_format(format, style, variables, style_variables)
+                                parse_format(format, style, variables, style_variables, context)
                             } else {
                                 Ok(Vec::new())
                             }
@@ -347,6 +392,7 @@ impl<'a> StringFormatter<'a> {
             default_style,
             &self.variables,
             &self.style_variables,
+            context,
         )
     }
 }
@@ -380,6 +426,28 @@ fn clone_without_meta<'a>(variables: &VariableMapType<'a>) -> VariableMapType<'a
         .collect()
 }
 
+/// Escape interpretable characters for the shell prompt
+pub fn shell_prompt_escape<T>(text: T, shell: Shell) -> String
+where
+    T: Into<String>,
+{
+    // Handle other interpretable characters
+    match shell {
+        // Bash might interepret baskslashes, backticks and $
+        // see #658 for more details
+        Shell::Bash => text
+            .into()
+            .replace('\\', r"\\")
+            .replace('$', r"\$")
+            .replace('`', r"\`"),
+        Shell::Zsh => {
+            // % is an escape in zsh, see PROMPT in `man zshmisc`
+            text.into().replace('%', "%%")
+        }
+        _ => text.into(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -404,7 +472,7 @@ mod tests {
         let style = Some(Color::Red.bold());
 
         let formatter = StringFormatter::new(FORMAT_STR).unwrap().map(empty_mapper);
-        let result = formatter.parse(style).unwrap();
+        let result = formatter.parse(style, None).unwrap();
         let mut result_iter = result.iter();
         match_next!(result_iter, "text", style);
     }
@@ -413,7 +481,7 @@ mod tests {
     fn test_textgroup_text_only() {
         const FORMAT_STR: &str = "[text](red bold)";
         let formatter = StringFormatter::new(FORMAT_STR).unwrap().map(empty_mapper);
-        let result = formatter.parse(None).unwrap();
+        let result = formatter.parse(None, None).unwrap();
         let mut result_iter = result.iter();
         match_next!(result_iter, "text", Some(Color::Red.bold()));
     }
@@ -428,7 +496,7 @@ mod tests {
                 "var1" => Some(Ok("text1".to_owned())),
                 _ => None,
             });
-        let result = formatter.parse(None).unwrap();
+        let result = formatter.parse(None, None).unwrap();
         let mut result_iter = result.iter();
         match_next!(result_iter, "text1", None);
     }
@@ -444,7 +512,7 @@ mod tests {
                 "style" => Some(Ok("red bold".to_owned())),
                 _ => None,
             });
-        let result = formatter.parse(None).unwrap();
+        let result = formatter.parse(None, None).unwrap();
         let mut result_iter = result.iter();
         match_next!(result_iter, "root", root_style);
     }
@@ -456,7 +524,7 @@ mod tests {
         let formatter = StringFormatter::new(FORMAT_STR)
             .unwrap()
             .map(|variable| Some(Ok(format!("${{{}}}", variable))));
-        let result = formatter.parse(None).unwrap();
+        let result = formatter.parse(None, None).unwrap();
         let mut result_iter = result.iter();
         match_next!(result_iter, "${env:PWD}", None);
     }
@@ -466,7 +534,7 @@ mod tests {
         const FORMAT_STR: &str = r#"\\\[\$text\]\(red bold\)"#;
 
         let formatter = StringFormatter::new(FORMAT_STR).unwrap().map(empty_mapper);
-        let result = formatter.parse(None).unwrap();
+        let result = formatter.parse(None, None).unwrap();
         let mut result_iter = result.iter();
         match_next!(result_iter, r#"\[$text](red bold)"#, None);
     }
@@ -479,7 +547,7 @@ mod tests {
         let inner_style = Some(Color::Blue.normal());
 
         let formatter = StringFormatter::new(FORMAT_STR).unwrap().map(empty_mapper);
-        let result = formatter.parse(outer_style).unwrap();
+        let result = formatter.parse(outer_style, None).unwrap();
         let mut result_iter = result.iter();
         match_next!(result_iter, "outer ", outer_style);
         match_next!(result_iter, "middle ", middle_style);
@@ -497,7 +565,7 @@ mod tests {
                 "var" => Some(Ok("text".to_owned())),
                 _ => None,
             });
-        let result = formatter.parse(None).unwrap();
+        let result = formatter.parse(None, None).unwrap();
         let mut result_iter = result.iter();
         match_next!(result_iter, "text", var_style);
     }
@@ -523,7 +591,7 @@ mod tests {
                 "var" => Some(Ok(segments.clone())),
                 _ => None,
             });
-        let result = formatter.parse(None).unwrap();
+        let result = formatter.parse(None, None).unwrap();
         let mut result_iter = result.iter();
         match_next!(result_iter, "styless", var_style);
         match_next!(result_iter, "styled", styled_style);
@@ -546,7 +614,7 @@ mod tests {
                 "b" => Some(Ok("$b")),
                 _ => None,
             });
-        let result = formatter.parse(None).unwrap();
+        let result = formatter.parse(None, None).unwrap();
         let mut result_iter = result.iter();
         match_next!(result_iter, "$a", None);
         match_next!(result_iter, "$b", None);
@@ -568,7 +636,7 @@ mod tests {
                 "c" => Some(Ok("$c")),
                 _ => None,
             });
-        let result = formatter.parse(None).unwrap();
+        let result = formatter.parse(None, None).unwrap();
         let mut result_iter = result.iter();
         match_next!(result_iter, "$a", None);
         match_next!(result_iter, "$b", None);
@@ -585,7 +653,7 @@ mod tests {
                 "some" => Some(Ok("$some")),
                 _ => None,
             });
-        let result = formatter.parse(None).unwrap();
+        let result = formatter.parse(None, None).unwrap();
         let mut result_iter = result.iter();
         match_next!(result_iter, "$some", None);
         match_next!(result_iter, " should render but ", None);
@@ -602,7 +670,7 @@ mod tests {
                 "empty" => Some(Ok("")),
                 _ => None,
             });
-        let result = formatter.parse(None).unwrap();
+        let result = formatter.parse(None, None).unwrap();
         assert_eq!(result.len(), 0);
     }
 
@@ -616,7 +684,7 @@ mod tests {
                 "empty" => Some(Ok("")),
                 _ => None,
             });
-        let result = formatter.parse(None).unwrap();
+        let result = formatter.parse(None, None).unwrap();
         assert_eq!(result.len(), 0);
     }
 
@@ -630,7 +698,7 @@ mod tests {
                 "some" => Some(Ok("$some")),
                 _ => None,
             });
-        let result = formatter.parse(None).unwrap();
+        let result = formatter.parse(None, None).unwrap();
         let mut result_iter = result.iter();
         match_next!(result_iter, "$some", None);
         match_next!(result_iter, " ", None);
@@ -649,7 +717,7 @@ mod tests {
                 "all" => Some("$some"),
                 _ => None,
             });
-        let result = formatter.parse(None).unwrap();
+        let result = formatter.parse(None, None).unwrap();
         let mut result_iter = result.iter();
         match_next!(result_iter, " ", None);
     }
@@ -703,8 +771,50 @@ mod tests {
                     "never" => Some(Err(never_error.clone())),
                     _ => None,
                 })
-                .parse(None)
+                .parse(None, None)
         });
         assert!(segments.is_err());
+    }
+
+    #[test]
+    fn test_bash_escape() {
+        let test = "$(echo a)";
+        assert_eq!(
+            shell_prompt_escape(test.to_owned(), Shell::Bash),
+            r"\$(echo a)"
+        );
+        assert_eq!(
+            shell_prompt_escape(test.to_owned(), Shell::PowerShell),
+            test
+        );
+
+        let test = r"\$(echo a)";
+        assert_eq!(
+            shell_prompt_escape(test.to_owned(), Shell::Bash),
+            r"\\\$(echo a)"
+        );
+        assert_eq!(
+            shell_prompt_escape(test.to_owned(), Shell::PowerShell),
+            test
+        );
+
+        let test = r"`echo a`";
+        assert_eq!(
+            shell_prompt_escape(test.to_owned(), Shell::Bash),
+            r"\`echo a\`"
+        );
+        assert_eq!(
+            shell_prompt_escape(test.to_owned(), Shell::PowerShell),
+            test
+        );
+    }
+    #[test]
+    fn test_zsh_escape() {
+        let test = "10%";
+        assert_eq!(shell_prompt_escape(test.to_owned(), Shell::Zsh), "10%%");
+        assert_eq!(
+            shell_prompt_escape(test.to_owned(), Shell::PowerShell),
+            test
+        );
     }
 }

--- a/src/formatter/version.rs
+++ b/src/formatter/version.rs
@@ -51,7 +51,7 @@ impl<'a> VersionFormatter<'a> {
                 },
                 _ => None,
             })
-            .parse(None);
+            .parse(None, None);
 
         formatted.map(|segments| {
             segments

--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -164,7 +164,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 "duration" => duration.as_ref().map(Ok),
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     module.set_segments(match parsed {

--- a/src/modules/battery.rs
+++ b/src/modules/battery.rs
@@ -52,7 +52,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                     _ => None,
                 });
 
-            match formatter.parse(None) {
+            match formatter.parse(None, Some(context)) {
                 Ok(format_string) => {
                     module.set_segments(format_string);
                     Some(module)

--- a/src/modules/character.rs
+++ b/src/modules/character.rs
@@ -53,7 +53,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 "symbol" => Some(symbol),
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     module.set_segments(match parsed {

--- a/src/modules/cmake.rs
+++ b/src/modules/cmake.rs
@@ -43,7 +43,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 }
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     module.set_segments(match parsed {

--- a/src/modules/cmd_duration.rs
+++ b/src/modules/cmd_duration.rs
@@ -37,7 +37,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 "duration" => Some(Ok(render_time(elapsed, config.show_milliseconds))),
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     module.set_segments(match parsed {

--- a/src/modules/cobol.rs
+++ b/src/modules/cobol.rs
@@ -43,7 +43,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 }
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     module.set_segments(match parsed {

--- a/src/modules/conda.rs
+++ b/src/modules/conda.rs
@@ -37,7 +37,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 "environment" => Some(Ok(conda_env.as_str())),
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     module.set_segments(match parsed {

--- a/src/modules/crystal.rs
+++ b/src/modules/crystal.rs
@@ -44,7 +44,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 .map(Ok),
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     module.set_segments(match parsed {

--- a/src/modules/custom.rs
+++ b/src/modules/custom.rs
@@ -56,7 +56,7 @@ pub fn module<'a>(name: &str, context: &'a Context) -> Option<Module<'a>> {
                 "style" => Some(Ok(config.style)),
                 _ => None,
             })
-            .map(|variable| match variable {
+            .map_no_escaping(|variable| match variable {
                 "output" => {
                     let output = exec_command(config.command, &config.shell.0)?;
                     let trimmed = output.trim();
@@ -69,7 +69,7 @@ pub fn module<'a>(name: &str, context: &'a Context) -> Option<Module<'a>> {
                 }
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     match parsed {

--- a/src/modules/dart.rs
+++ b/src/modules/dart.rs
@@ -43,7 +43,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 }
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     module.set_segments(match parsed {

--- a/src/modules/deno.rs
+++ b/src/modules/deno.rs
@@ -42,7 +42,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 }
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     module.set_segments(match parsed {

--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -113,7 +113,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 }
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     module.set_segments(match parsed {

--- a/src/modules/docker_context.rs
+++ b/src/modules/docker_context.rs
@@ -70,7 +70,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 "context" => Some(Ok(ctx.as_str())),
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     module.set_segments(match parsed {

--- a/src/modules/dotnet.rs
+++ b/src/modules/dotnet.rs
@@ -74,7 +74,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 "tfm" => find_current_tfm(&dotnet_files).map(Ok),
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     module.set_segments(match parsed {

--- a/src/modules/elixir.rs
+++ b/src/modules/elixir.rs
@@ -55,7 +55,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                     .map(Ok),
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     module.set_segments(match parsed {

--- a/src/modules/elm.rs
+++ b/src/modules/elm.rs
@@ -42,7 +42,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 }
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     module.set_segments(match parsed {

--- a/src/modules/env_var.rs
+++ b/src/modules/env_var.rs
@@ -68,7 +68,7 @@ fn env_var_module<'a>(module_config_path: Vec<&str>, context: &'a Context) -> Op
                 "env_value" => Some(Ok(&env_value)),
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     module.set_segments(match parsed {

--- a/src/modules/erlang.rs
+++ b/src/modules/erlang.rs
@@ -42,7 +42,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 }
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     module.set_segments(match parsed {

--- a/src/modules/gcloud.rs
+++ b/src/modules/gcloud.rs
@@ -151,7 +151,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 "active" => Some(Ok(gcloud_context.config_name.clone())),
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     module.set_segments(match parsed {

--- a/src/modules/git_branch.rs
+++ b/src/modules/git_branch.rs
@@ -95,7 +95,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 }
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     module.set_segments(match parsed {

--- a/src/modules/git_commit.rs
+++ b/src/modules/git_commit.rs
@@ -68,7 +68,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 "tag" => format_tag(config.tag_symbol, &tag_name),
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     module.set_segments(match parsed {

--- a/src/modules/git_metrics.rs
+++ b/src/modules/git_metrics.rs
@@ -50,7 +50,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 "deleted" => GitDiff::get_variable(config.only_nonzero_diffs, stats.deleted),
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     module.set_segments(match parsed {

--- a/src/modules/git_state.rs
+++ b/src/modules/git_state.rs
@@ -34,7 +34,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 "progress_total" => state_description.total.as_ref().map(Ok),
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     module.set_segments(match parsed {

--- a/src/modules/golang.rs
+++ b/src/modules/golang.rs
@@ -43,7 +43,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 }
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     module.set_segments(match parsed {

--- a/src/modules/helm.rs
+++ b/src/modules/helm.rs
@@ -46,7 +46,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 }
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     module.set_segments(match parsed {

--- a/src/modules/hg_branch.rs
+++ b/src/modules/hg_branch.rs
@@ -60,7 +60,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 "branch" => Some(Ok(truncated_and_symbol.as_str())),
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     module.set_segments(match parsed {

--- a/src/modules/hostname.rs
+++ b/src/modules/hostname.rs
@@ -51,7 +51,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 "hostname" => Some(Ok(host)),
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     module.set_segments(match parsed {

--- a/src/modules/java.rs
+++ b/src/modules/java.rs
@@ -45,7 +45,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 }
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     module.set_segments(match parsed {

--- a/src/modules/jobs.rs
+++ b/src/modules/jobs.rs
@@ -88,7 +88,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 "number" => Some(Ok(module_number.clone())),
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     module.set_segments(match parsed {

--- a/src/modules/julia.rs
+++ b/src/modules/julia.rs
@@ -43,7 +43,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 }
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     module.set_segments(match parsed {

--- a/src/modules/kotlin.rs
+++ b/src/modules/kotlin.rs
@@ -46,7 +46,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 }
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     module.set_segments(match parsed {

--- a/src/modules/kubernetes.rs
+++ b/src/modules/kubernetes.rs
@@ -104,7 +104,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 "namespace" => kube_ns.as_ref().map(|s| Ok(Cow::Borrowed(s.as_str()))),
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     module.set_segments(match parsed {

--- a/src/modules/lua.rs
+++ b/src/modules/lua.rs
@@ -45,7 +45,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 }
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     module.set_segments(match parsed {

--- a/src/modules/memory_usage.rs
+++ b/src/modules/memory_usage.rs
@@ -86,7 +86,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 "swap_pct" if total_swap_kib > 0 => Some(Ok(&swap_pct)),
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     module.set_segments(match parsed {

--- a/src/modules/nim.rs
+++ b/src/modules/nim.rs
@@ -44,7 +44,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                     .map(Ok),
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     module.set_segments(match parsed {

--- a/src/modules/nix_shell.rs
+++ b/src/modules/nix_shell.rs
@@ -46,7 +46,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 "name" => shell_name.as_ref().map(Ok),
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     module.set_segments(match parsed {

--- a/src/modules/nodejs.rs
+++ b/src/modules/nodejs.rs
@@ -73,7 +73,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 }
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     module.set_segments(match parsed {

--- a/src/modules/ocaml.rs
+++ b/src/modules/ocaml.rs
@@ -73,7 +73,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 }
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     module.set_segments(match parsed {

--- a/src/modules/openstack.rs
+++ b/src/modules/openstack.rs
@@ -69,7 +69,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 "project" => osp_project.as_ref().map(Ok),
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     module.set_segments(match parsed {

--- a/src/modules/package.rs
+++ b/src/modules/package.rs
@@ -29,7 +29,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 "version" => Some(Ok(&module_version)),
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     module.set_segments(match parsed {

--- a/src/modules/perl.rs
+++ b/src/modules/perl.rs
@@ -43,7 +43,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 }
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     module.set_segments(match parsed {

--- a/src/modules/php.rs
+++ b/src/modules/php.rs
@@ -42,7 +42,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 }
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     module.set_segments(match parsed {

--- a/src/modules/pulumi.rs
+++ b/src/modules/pulumi.rs
@@ -43,7 +43,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 "stack" => stack_name(&project_file, context).map(Ok),
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     match parsed {

--- a/src/modules/purescript.rs
+++ b/src/modules/purescript.rs
@@ -41,7 +41,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 }
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     module.set_segments(match parsed {

--- a/src/modules/python.rs
+++ b/src/modules/python.rs
@@ -61,7 +61,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 "pyenv_prefix" => Some(Ok(pyenv_prefix.to_string())),
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     module.set_segments(match parsed {

--- a/src/modules/red.rs
+++ b/src/modules/red.rs
@@ -41,7 +41,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                     .map(Ok),
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     module.set_segments(match parsed {

--- a/src/modules/rlang.rs
+++ b/src/modules/rlang.rs
@@ -43,7 +43,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 }
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     module.set_segments(match parsed {

--- a/src/modules/ruby.rs
+++ b/src/modules/ruby.rs
@@ -41,7 +41,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 .map(Ok),
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     module.set_segments(match parsed {

--- a/src/modules/rust.rs
+++ b/src/modules/rust.rs
@@ -42,7 +42,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 "version" => get_module_version(context, &config).map(Ok),
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     module.set_segments(match parsed {

--- a/src/modules/scala.rs
+++ b/src/modules/scala.rs
@@ -42,7 +42,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 }
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     module.set_segments(match parsed {

--- a/src/modules/shell.rs
+++ b/src/modules/shell.rs
@@ -46,7 +46,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 "unknown_indicator" => Some(Ok(config.unknown_indicator)),
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     module.set_segments(match parsed {

--- a/src/modules/shlvl.rs
+++ b/src/modules/shlvl.rs
@@ -47,7 +47,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 "shlvl" => Some(Ok(shlvl_str)),
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     module.set_segments(match parsed {

--- a/src/modules/singularity.rs
+++ b/src/modules/singularity.rs
@@ -26,7 +26,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 "env" => Some(Ok(&singularity_env)),
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     module.set_segments(match parsed {

--- a/src/modules/status.rs
+++ b/src/modules/status.rs
@@ -61,7 +61,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         PipeStatusStatus::Pipe(pipestatus) => pipestatus
             .iter()
             .map(
-                |ec| match format_exit_code(ec.as_str(), config.format, None, &config) {
+                |ec| match format_exit_code(ec.as_str(), config.format, None, &config, context) {
                     Ok(segments) => segments
                         .into_iter()
                         .map(|s| s.to_string())
@@ -79,7 +79,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         PipeStatusStatus::Pipe(_) => config.pipestatus_format,
         _ => config.format,
     };
-    let parsed = format_exit_code(exit_code, main_format, Some(&pipestatus), &config);
+    let parsed = format_exit_code(exit_code, main_format, Some(&pipestatus), &config, context);
 
     module.set_segments(match parsed {
         Ok(segments) => segments,
@@ -96,6 +96,7 @@ fn format_exit_code<'a>(
     format: &'a str,
     pipestatus: Option<&str>,
     config: &'a StatusConfig,
+    context: &'a Context,
 ) -> Result<Vec<Segment>, StringFormatterError> {
     let exit_code_int: ExitCode = match exit_code.parse() {
         Ok(i) => i,
@@ -164,7 +165,7 @@ fn format_exit_code<'a>(
                 }
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     })
 }
 

--- a/src/modules/swift.rs
+++ b/src/modules/swift.rs
@@ -43,7 +43,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 }
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     module.set_segments(match parsed {

--- a/src/modules/terraform.rs
+++ b/src/modules/terraform.rs
@@ -49,7 +49,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 "workspace" => get_terraform_workspace(context).map(Ok),
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     module.set_segments(match parsed {

--- a/src/modules/time.rs
+++ b/src/modules/time.rs
@@ -54,7 +54,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 "time" => Some(Ok(&formatted_time_string)),
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     module.set_segments(match parsed {

--- a/src/modules/username.rs
+++ b/src/modules/username.rs
@@ -48,7 +48,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 "user" => Some(Ok(&username)),
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
     module.set_segments(match parsed {
         Ok(segments) => segments,

--- a/src/modules/vagrant.rs
+++ b/src/modules/vagrant.rs
@@ -44,7 +44,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 .map(Ok),
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     module.set_segments(match parsed {

--- a/src/modules/vcsh.rs
+++ b/src/modules/vcsh.rs
@@ -30,7 +30,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 "repo" => Some(Ok(&repo)),
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     module.set_segments(match parsed {

--- a/src/modules/vlang.rs
+++ b/src/modules/vlang.rs
@@ -42,7 +42,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                     .map(Ok),
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     module.set_segments(match parsed {

--- a/src/modules/zig.rs
+++ b/src/modules/zig.rs
@@ -42,7 +42,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 }
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     module.set_segments(match parsed {

--- a/src/print.rs
+++ b/src/print.rs
@@ -109,7 +109,7 @@ pub fn get_prompt(context: Context) -> String {
     let mut root_module = Module::new("Starship Root", "The root module", None);
     root_module.set_segments(
         formatter
-            .parse(None)
+            .parse(None, Some(&context))
             .expect("Unexpected error returned in root format variables"),
     );
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -318,25 +318,8 @@ CMake suite maintained and supported by Kitware (kitware.com/cmake).\n",
     }
 }
 
-/// Wraps ANSI color escape sequences and other interpretable characters
-/// that need to be escaped in the shell-appropriate wrappers.
-pub fn wrap_colorseq_for_shell(mut ansi: String, shell: Shell) -> String {
-    // Handle other interpretable characters
-    match shell {
-        // Bash might interepret baskslashes, backticks and $
-        // see #658 for more details
-        Shell::Bash => {
-            ansi = ansi.replace('\\', r"\\");
-            ansi = ansi.replace('$', r"\$");
-            ansi = ansi.replace('`', r"\`");
-        }
-        Shell::Zsh => {
-            // % is an escape in zsh, see PROMPT in `man zshmisc`
-            ansi = ansi.replace('%', "%%");
-        }
-        _ => {}
-    };
-
+/// Wraps ANSI color escape sequences in the shell-appropriate wrappers.
+pub fn wrap_colorseq_for_shell(ansi: String, shell: Shell) -> String {
     const ESCAPE_BEGIN: char = '\u{1b}';
     const ESCAPE_END: char = 'm';
     wrap_seq_for_shell(ansi, shell, ESCAPE_BEGIN, ESCAPE_END)
@@ -674,47 +657,6 @@ mod tests {
         assert_eq!(&bresult5, "");
     }
 
-    #[test]
-    fn test_bash_escape() {
-        let test = "$(echo a)";
-        assert_eq!(
-            wrap_colorseq_for_shell(test.to_owned(), Shell::Bash),
-            r"\$(echo a)"
-        );
-        assert_eq!(
-            wrap_colorseq_for_shell(test.to_owned(), Shell::PowerShell),
-            test
-        );
-
-        let test = r"\$(echo a)";
-        assert_eq!(
-            wrap_colorseq_for_shell(test.to_owned(), Shell::Bash),
-            r"\\\$(echo a)"
-        );
-        assert_eq!(
-            wrap_colorseq_for_shell(test.to_owned(), Shell::PowerShell),
-            test
-        );
-
-        let test = r"`echo a`";
-        assert_eq!(
-            wrap_colorseq_for_shell(test.to_owned(), Shell::Bash),
-            r"\`echo a\`"
-        );
-        assert_eq!(
-            wrap_colorseq_for_shell(test.to_owned(), Shell::PowerShell),
-            test
-        );
-    }
-    #[test]
-    fn test_zsh_escape() {
-        let test = "10%";
-        assert_eq!(wrap_colorseq_for_shell(test.to_owned(), Shell::Zsh), "10%%");
-        assert_eq!(
-            wrap_colorseq_for_shell(test.to_owned(), Shell::PowerShell),
-            test
-        );
-    }
     #[test]
     fn test_get_command_string_output() {
         let case1 = CommandOutput {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description

Moves shell prompt escaping to the level of individual format variables

#### Motivation and Context

Several previous attempts to fix this have been made, with different levels of success.

This version means that the user can have special prompt chars in expected places, e.g. `format` setting and also in the output of custom commands. But at the same time protects against injections from outside sources, e.g. git branch names or special chars in folder names.

As all the module expose outside data though variables this is a good place to do the escaping, whilst still allowing purposeful special chars in the format string.

Closes #3072
Also see context #3058 and #658

Unfortunately its quite large because of the need to pass the `context.shell` var into the string formatter.

#### Screenshots (if appropriate):

Fixed special chars (% in this case for zsh) not interpreteted:

<img width="670" alt="Screenshot 2021-09-30 at 12 41 59" src="https://user-images.githubusercontent.com/704356/135428734-0a4b5970-0979-403b-b375-2a843e9d4710.png">

Previously (the green is a custom command that outputs control sequences: 

<img width="705" alt="Screenshot 2021-09-30 at 16 37 56" src="https://user-images.githubusercontent.com/704356/135465835-e8235387-9cbd-4b96-a50e-0db1f6521ee6.png">

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [X] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [X] I have updated the tests accordingly.
