### PR TITLE
docs: add funtoo linux install steps

### DIFF
--- a/docs/installing/README.md
+++ b/docs/installing/README.md
@@ -39,6 +39,16 @@ pkg install getconf
 sh -c "$(curl -fsSL https://starship.rs/install.sh)" -- --bin-dir /data/data/com.termux/files/usr/bin
 ```
 
+## [Funtoo Linux](https://www.funtoo.org/Welcome)
+
+### Installation
+
+On Funtoo Linux, starship can be installed from [core-kit](https://github.com/funtoo/core-kit/tree/1.4-release/app-shells/starship) via Portage:
+
+```sh
+emerge app-shells/starship
+```
+
 ## [Nix](https://nixos.wiki/wiki/Nix)
 
 ### Getting the Binary


### PR DESCRIPTION
#### Description
Since I maintain the starship package over at Funtoo Linux, I thought I might as well mention that in the installation page in the docs :^)

#### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/38114607/135755716-cb8f9c7c-d551-4eea-8dff-489e72a4f11b.png)

#### How Has This Been Tested?
I've ran the docs website locally to verify the changes are visually consistent with the rest of the installing page.
