### PR TITLE
feat(docs): Add copy button for code snippets via plugin

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -287,6 +287,7 @@ module.exports = {
       {
         hostname: "https://starship.rs"
       }
-    ]
+    ],
+    ['vuepress-plugin-code-copy', true]
   ]
 };

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -7,6 +7,7 @@
       "devDependencies": {
         "@vuepress/plugin-google-analytics": "^1.8.2",
         "vuepress": "^1.8.2",
+        "vuepress-plugin-code-copy": "^1.0.6",
         "vuepress-plugin-sitemap": "^2.3.1",
         "vuepress-theme-default-prefers-color-scheme": "^2.0.0"
       }
@@ -11966,6 +11967,12 @@
         "object.getownpropertydescriptors": "^2.0.3"
       }
     },
+    "node_modules/vuepress-plugin-code-copy": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/vuepress-plugin-code-copy/-/vuepress-plugin-code-copy-1.0.6.tgz",
+      "integrity": "sha512-FiqwMtlb4rEsOI56O6sSkekcd3SlESxbkR2IaTIQxsMOMoalKfW5R9WlR1Pjm10v6jmU661Ex8MR11k9IzrNUg==",
+      "dev": true
+    },
     "node_modules/vuepress-plugin-container": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/vuepress-plugin-container/-/vuepress-plugin-container-2.1.5.tgz",
@@ -23119,6 +23126,12 @@
           }
         }
       }
+    },
+    "vuepress-plugin-code-copy": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/vuepress-plugin-code-copy/-/vuepress-plugin-code-copy-1.0.6.tgz",
+      "integrity": "sha512-FiqwMtlb4rEsOI56O6sSkekcd3SlESxbkR2IaTIQxsMOMoalKfW5R9WlR1Pjm10v6jmU661Ex8MR11k9IzrNUg==",
+      "dev": true
     },
     "vuepress-plugin-container": {
       "version": "2.1.5",

--- a/docs/package.json
+++ b/docs/package.json
@@ -6,6 +6,7 @@
   "devDependencies": {
     "@vuepress/plugin-google-analytics": "^1.8.2",
     "vuepress": "^1.8.2",
+    "vuepress-plugin-code-copy": "^1.0.6",
     "vuepress-plugin-sitemap": "^2.3.1",
     "vuepress-theme-default-prefers-color-scheme": "^2.0.0"
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
I added this [plugin](https://www.npmjs.com/package/vuepress-plugin-code-copy) to vuepress. This plugin adds a copy to clipboard button for all the code snippets. I think this a handy feature to have

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #3116
Closes #2960 

#### Screenshots (if appropriate):
![starshipfix](https://user-images.githubusercontent.com/66195934/135803915-9693d0e1-b7b2-4122-9dce-0e350bc09827.gif)

#### How Has This Been Tested?
- [ x] I have tested using **Linux**

