### PR TITLE
fix: Correctly handle durations of 0ms

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -479,19 +479,21 @@ pub fn render_time(raw_millis: u128, show_millis: bool) -> String {
     let mut rendered_components: Vec<String> = components
         .iter()
         .zip(&suffixes)
-        .map(render_time_component)
+        .map(|time_data| render_time_component(time_data, true))
         .collect();
     if show_millis || raw_millis < 1000 {
-        rendered_components.push(render_time_component((&millis, &"ms")));
+        let empty_if_zero = !rendered_components.is_empty();
+        rendered_components.push(render_time_component((&millis, &"ms"), empty_if_zero));
     }
     rendered_components.join("")
 }
 
 /// Render a single component of the time string, giving an empty string if component is zero
-fn render_time_component((component, suffix): (&u128, &&str)) -> String {
-    match component {
-        0 => String::new(),
-        n => format!("{}{}", n, suffix),
+fn render_time_component((component, suffix): (&u128, &&str), empty_if_zero: bool) -> String {
+    if *component == 0 && empty_if_zero {
+        String::new()
+    } else {
+        format!("{}{}", component, suffix)
     }
 }
 


### PR DESCRIPTION
fix: Correctly handle durations of 0ms (#3103) 

#### Description

Display when a command took 0ms to complete.

#### Motivation and Context

Closes #3103 


#### How Has This Been Tested?
Tested using cargo test and trying by hand using the config mentioned in the issue.
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
