### PR TITLE
fix: allow unset KEYMAP and STARSHIP_DURATION in zsh

### DIFF
--- a/src/init/starship.zsh
+++ b/src/init/starship.zsh
@@ -91,5 +91,5 @@ export STARSHIP_SESSION_KEY=${STARSHIP_SESSION_KEY:0:16}; # Trim to 16-digits if
 VIRTUAL_ENV_DISABLE_PROMPT=1
 
 setopt promptsubst
-PROMPT='$(::STARSHIP:: prompt --keymap="$KEYMAP" --status="$STARSHIP_CMD_STATUS" --pipestatus ${STARSHIP_PIPE_STATUS[@]} --cmd-duration="$STARSHIP_DURATION" --jobs="$STARSHIP_JOBS_COUNT")'
-RPROMPT='$(::STARSHIP:: prompt --right --keymap="$KEYMAP" --status="$STARSHIP_CMD_STATUS" --pipestatus ${STARSHIP_PIPE_STATUS[@]} --cmd-duration="$STARSHIP_DURATION" --jobs="$STARSHIP_JOBS_COUNT")'
+PROMPT='$(::STARSHIP:: prompt --keymap="${KEYMAP:-}" --status="$STARSHIP_CMD_STATUS" --pipestatus ${STARSHIP_PIPE_STATUS[@]} --cmd-duration="${STARSHIP_DURATION:-}" --jobs="$STARSHIP_JOBS_COUNT")'
+RPROMPT='$(::STARSHIP:: prompt --right --keymap="${KEYMAP:-}" --status="$STARSHIP_CMD_STATUS" --pipestatus ${STARSHIP_PIPE_STATUS[@]} --cmd-duration="${STARSHIP_DURATION:-}" --jobs="$STARSHIP_JOBS_COUNT")'


### PR DESCRIPTION
which prevents errors if a user has `set -u` on in there terminal.

<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description

In my terminal I have `set -u` on which I find really helpful to catch typos I make when using env variables. However, because the prompt is run in the context of my shell the `set -u` applies to it too.

In a couple of places, the starship zsh prompt uses possibly unset variables relying on their value falling back to an empy string if they are unset. This PR uses bash parameter expansion to do this explicitly.


#### Screenshots (if appropriate):

current behaviour:

![image](https://user-images.githubusercontent.com/16308754/135975161-9c2c9d75-4c53-4226-a598-9caed0d10c71.png)

#### How Has This Been Tested?
 I have tested on linux by `cargo install`ing from this PR branch.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
