### PR TITLE
docs: fix custom commands example

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -3392,12 +3392,12 @@ with shell details and starship configuration if you hit such scenario.
 
 [custom.foo]
 command = "echo foo"  # shows output of command
-files = ["foo"]       # can specify filters
+files = ["foo"]       # can specify filters but wildcards are not supported
 when = """ test "$HOME" == "$PWD" """
 format = " transcending [$output]($style)"
 
 [custom.time]
 command = "time /T"
-files = ["*.pst"]
+extensions = ["pst"]  # filters *.pst files
 shell = ["pwsh.exe", "-NoProfile", "-Command", "-"]
 ```


### PR DESCRIPTION
#### Description
Fix the wrong example in custom commands docs

#### Motivation and Context
Closes #3123 

#### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/45752299/136243657-0b35c293-1ffd-4584-8ae5-d71f3b7bf300.png)

