### PR TITLE
fix: only print root level config logs a single time

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,3 @@
-use crate::configs::StarshipRootConfig;
 use crate::utils;
 use ansi_term::{Color, Style};
 use indexmap::IndexMap;
@@ -60,6 +59,12 @@ where
 impl<'a> ModuleConfig<'a> for &'a str {
     fn from_config(config: &'a Value) -> Option<Self> {
         config.as_str()
+    }
+}
+
+impl<'a> ModuleConfig<'a> for String {
+    fn from_config(config: &'a Value) -> Option<Self> {
+        config.as_str().map(std::borrow::ToOwned::to_owned)
     }
 }
 
@@ -345,14 +350,6 @@ impl StarshipConfig {
     /// Get the table of all the registered env_var modules, if any
     pub fn get_env_var_modules(&self) -> Option<&toml::value::Table> {
         self.get_config(&["env_var"])?.as_table()
-    }
-
-    pub fn get_root_config(&self) -> StarshipRootConfig {
-        if let Some(root_config) = &self.config {
-            StarshipRootConfig::load(root_config)
-        } else {
-            StarshipRootConfig::default()
-        }
     }
 }
 

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -76,8 +76,8 @@ pub use starship_root::*;
 #[serde(default)]
 pub struct FullConfig<'a> {
     // Root config
-    pub format: &'a str,
-    pub right_format: &'a str,
+    pub format: String,
+    pub right_format: String,
     pub scan_timeout: u64,
     pub command_timeout: u64,
     pub add_newline: bool,
@@ -152,8 +152,8 @@ pub struct FullConfig<'a> {
 impl<'a> Default for FullConfig<'a> {
     fn default() -> Self {
         Self {
-            format: "$all",
-            right_format: "",
+            format: "$all".to_string(),
+            right_format: "".to_string(),
             scan_timeout: 30,
             command_timeout: 500,
             add_newline: true,

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -5,9 +5,9 @@ use std::cmp::Ordering;
 
 // On changes please also update the `FullConfig` struct in `mod.rs`
 #[derive(Clone, Serialize)]
-pub struct StarshipRootConfig<'a> {
-    pub format: &'a str,
-    pub right_format: &'a str,
+pub struct StarshipRootConfig {
+    pub format: String,
+    pub right_format: String,
     pub scan_timeout: u64,
     pub command_timeout: u64,
     pub add_newline: bool,
@@ -88,11 +88,11 @@ pub const PROMPT_ORDER: &[&str] = &[
 ];
 
 // On changes please also update `Default` for the `FullConfig` struct in `mod.rs`
-impl<'a> Default for StarshipRootConfig<'a> {
+impl<'a> Default for StarshipRootConfig {
     fn default() -> Self {
         StarshipRootConfig {
-            format: "$all",
-            right_format: "",
+            format: "$all".to_string(),
+            right_format: "".to_string(),
             scan_timeout: 30,
             command_timeout: 500,
             add_newline: true,
@@ -100,7 +100,7 @@ impl<'a> Default for StarshipRootConfig<'a> {
     }
 }
 
-impl<'a> ModuleConfig<'a> for StarshipRootConfig<'a> {
+impl<'a> ModuleConfig<'a> for StarshipRootConfig {
     fn load_config(&mut self, config: &'a toml::Value) {
         if let toml::Value::Table(config) = config {
             config.iter().for_each(|(k, v)| match k.as_str() {

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,4 +1,5 @@
-use crate::config::StarshipConfig;
+use crate::config::{RootModuleConfig, StarshipConfig};
+use crate::configs::StarshipRootConfig;
 use crate::module::Module;
 use crate::utils::{exec_cmd, CommandOutput};
 
@@ -64,8 +65,8 @@ pub struct Context<'a> {
     #[cfg(feature = "battery")]
     pub battery_info_provider: &'a (dyn crate::modules::BatteryInfoProvider + Send + Sync),
 
-    /// Timeout for the execution of commands
-    cmd_timeout: Duration,
+    /// Starship root config
+    pub root_config: StarshipRootConfig,
 }
 
 impl<'a> Context<'a> {
@@ -127,7 +128,10 @@ impl<'a> Context<'a> {
         let current_dir = current_dir.canonicalize().unwrap_or(current_dir);
         let logical_dir = logical_path;
 
-        let cmd_timeout = Duration::from_millis(config.get_root_config().command_timeout);
+        let root_config = config
+            .config
+            .as_ref()
+            .map_or_else(StarshipRootConfig::default, StarshipRootConfig::load);
 
         let right = arguments.is_present("right");
 
@@ -154,7 +158,7 @@ impl<'a> Context<'a> {
             cmd: HashMap::new(),
             #[cfg(feature = "battery")]
             battery_info_provider: &crate::modules::BatteryInfoProviderImpl,
-            cmd_timeout,
+            root_config,
         }
     }
 
@@ -279,8 +283,8 @@ impl<'a> Context<'a> {
 
     pub fn dir_contents(&self) -> Result<&DirContents, std::io::Error> {
         self.dir_contents.get_or_try_init(|| {
-            let timeout = Duration::from_millis(self.config.get_root_config().scan_timeout);
-            DirContents::from_path_with_timeout(&self.current_dir, timeout)
+            let timeout = self.root_config.scan_timeout;
+            DirContents::from_path_with_timeout(&self.current_dir, Duration::from_millis(timeout))
         })
     }
 
@@ -318,7 +322,11 @@ impl<'a> Context<'a> {
                 return output.clone();
             }
         }
-        exec_cmd(&cmd, args, self.cmd_timeout)
+        exec_cmd(
+            &cmd,
+            args,
+            Duration::from_millis(self.root_config.command_timeout),
+        )
     }
 }
 

--- a/src/print.rs
+++ b/src/print.rs
@@ -62,7 +62,7 @@ pub fn prompt(args: ArgMatches) {
 }
 
 pub fn get_prompt(context: Context) -> String {
-    let config = context.config.get_root_config();
+    let config = &context.root_config;
     let mut buf = String::new();
 
     match std::env::var_os("TERM") {
@@ -412,10 +412,10 @@ fn all_modules_uniq(module_list: &BTreeSet<String>) -> Vec<String> {
 /// Load the correct formatter for the context (ie left prompt or right prompt)
 /// and the list of all modules used in a format string
 fn load_formatter_and_modules<'a>(context: &'a Context) -> (StringFormatter<'a>, BTreeSet<String>) {
-    let config = context.config.get_root_config();
+    let config = &context.root_config;
 
-    let lformatter = StringFormatter::new(config.format);
-    let rformatter = StringFormatter::new(config.right_format);
+    let lformatter = StringFormatter::new(&config.format);
+    let rformatter = StringFormatter::new(&config.right_format);
     if lformatter.is_err() {
         log::error!("Error parsing `format`")
     }
@@ -454,6 +454,7 @@ mod test {
                 format=">\n>"
             }),
         };
+        context.root_config.right_format = "$character".to_string();
         context.right = true;
 
         let expected = String::from(">>"); // should strip new lines

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -1,7 +1,8 @@
 use crate::context::{Context, Shell};
 use crate::logger::StarshipLogger;
 use crate::{
-    config::StarshipConfig,
+    config::{RootModuleConfig, StarshipConfig},
+    configs::StarshipRootConfig,
     utils::{create_command, CommandOutput},
 };
 use log::{Level, LevelFilter};
@@ -78,6 +79,7 @@ impl<'a> ModuleRenderer<'a> {
 
     /// Sets the config of the underlying context
     pub fn config(mut self, config: toml::Value) -> Self {
+        self.context.root_config = StarshipRootConfig::load(&config);
         self.context.config = StarshipConfig {
             config: Some(config),
         };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR removes `get_root_config()` from `StarshipConfig` and saves the root config in `Context` instead, to avoid having multiple evaluations log the same messages.
To avoid ownership issues, I also replace `&str` with `String` in the `StarshipRootConfig`.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
