### PR TITLE
feat(module): Add `sudo` module

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2954,24 +2954,28 @@ To enable it, set `disabled` to `false` in your configuration file.
 
 ### Options
 
-| Option     | Default                 | Description                           |
-| -----------| ------------------------| --------------------------------------|
-| `format`   | `[as $symbol]($style)"` | The format of the module              |
-| `symbol`   | `"🧙‍ "`                | The symbol displayed on program error |
-| `style`    | `"bold blue"`           | The style for the module.             |
-| `disabled` | `true`                  | Disables the `sudo` module.           |
+| Option         | Default                 | Description                                                  |
+| -------------- | ----------------------- | ------------------------------------------------------------ |
+| `format`       | `[as $symbol]($style)"` | The format of the module                                     |
+| `symbol`       | `"🧙‍ "`                 | The symbol displayed when credentials are cached             |
+| `style`        | `"bold blue"`           | The style for the module.                                    |
+| `binary`       | `sudo`                  | The binary executed to verify credentials.                   |
+| `allow_windows`| `false`                 | Since windows has no default sudo, default is disabled.      |
+| `disabled`     | `true`                  | Disables the `sudo` module.                                  |
 
 ### Variables
 
-| Variable  | Example | Description                           |
-| --------- | ------- | ------------------------------------- |
-| symbol    |         | Mirrors the value of option `symbol`  |
-| style\*   |         | Mirrors the value of option `style`   |
+| Variable  | Example | Description                          |
+| --------- | ------- | ------------------------------------ |
+| binary    |         | Mirrors the value of option `binary` |
+| symbol    |         | Mirrors the value of option `symbol` |
+| style\*   |         | Mirrors the value of option `style`  |
 
 \*: This variable can only be used as a part of a style string
 
 ### Example
 
+#### With `sudo`
 ```toml
 
 # ~/.config/starship.toml
@@ -2979,6 +2983,26 @@ To enable it, set `disabled` to `false` in your configuration file.
 [sudo]
 style = "bold green"
 symbol = "👩‍💻 "
+disabled = false
+```
+
+#### With `doas`
+```toml
+
+# ~/.config/starship.toml
+
+[sudo]
+binary = "doas"
+disabled = false
+```
+
+#### On Windows
+```toml
+
+# ~/.config/starship.toml
+
+[sudo]
+allow_windows = true
 disabled = false
 ```
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -243,6 +243,7 @@ $openstack\
 $env_var\
 $crystal\
 $custom\
+$sudo\
 $cmd_duration\
 $line_break\
 $jobs\
@@ -2937,6 +2938,48 @@ format = '[\[$symbol $common_meaning$signal_name$maybe_int\]]($style) '
 map_symbol = true
 disabled = false
 
+```
+
+## Sudo
+
+The `sudo` module displays if sudo credentials are currently cached.
+The module will only be shown if credentials are cached.
+
+::: tip
+
+This module is disabled by default.
+To enable it, set `disabled` to `false` in your configuration file.
+
+:::
+
+### Options
+
+| Option     | Default                 | Description                           |
+| -----------| ------------------------| --------------------------------------|
+| `format`   | `[as $symbol]($style)"` | The format of the module              |
+| `symbol`   | `"🧙‍ "`                | The symbol displayed on program error |
+| `style`    | `"bold blue"`           | The style for the module.             |
+| `disabled` | `true`                  | Disables the `sudo` module.           |
+
+### Variables
+
+| Variable  | Example | Description                           |
+| --------- | ------- | ------------------------------------- |
+| symbol    |         | Mirrors the value of option `symbol`  |
+| style\*   |         | Mirrors the value of option `style`   |
+
+\*: This variable can only be used as a part of a style string
+
+### Example
+
+```toml
+
+# ~/.config/starship.toml
+
+[sudo]
+style = "bold green"
+symbol = "👩‍💻 "
+disabled = false
 ```
 
 ## Swift

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2957,9 +2957,8 @@ To enable it, set `disabled` to `false` in your configuration file.
 | Option         | Default                 | Description                                                  |
 | -------------- | ----------------------- | ------------------------------------------------------------ |
 | `format`       | `[as $symbol]($style)"` | The format of the module                                     |
-| `symbol`       | `"🧙‍ "`                 | The symbol displayed when credentials are cached             |
+| `symbol`       | `"🧙 "`                 | The symbol displayed when credentials are cached             |
 | `style`        | `"bold blue"`           | The style for the module.                                    |
-| `binary`       | `sudo`                  | The binary executed to verify credentials.                   |
 | `allow_windows`| `false`                 | Since windows has no default sudo, default is disabled.      |
 | `disabled`     | `true`                  | Disables the `sudo` module.                                  |
 
@@ -2967,7 +2966,6 @@ To enable it, set `disabled` to `false` in your configuration file.
 
 | Variable  | Example | Description                          |
 | --------- | ------- | ------------------------------------ |
-| binary    |         | Mirrors the value of option `binary` |
 | symbol    |         | Mirrors the value of option `symbol` |
 | style\*   |         | Mirrors the value of option `style`  |
 
@@ -2975,7 +2973,6 @@ To enable it, set `disabled` to `false` in your configuration file.
 
 ### Example
 
-#### With `sudo`
 ```toml
 
 # ~/.config/starship.toml
@@ -2986,20 +2983,9 @@ symbol = "👩‍💻 "
 disabled = false
 ```
 
-#### With `doas`
 ```toml
-
-# ~/.config/starship.toml
-
-[sudo]
-binary = "doas"
-disabled = false
-```
-
-#### On Windows
-```toml
-
-# ~/.config/starship.toml
+# On windows
+# $HOME\.starship\config.toml
 
 [sudo]
 allow_windows = true

--- a/docs/presets/README.md
+++ b/docs/presets/README.md
@@ -226,6 +226,9 @@ format = '\[[$symbol($version)]($style)\]'
 [scala]
 format = '\[[$symbol($version)]($style)\]'
 
+[sudo]
+format = '\[[as $symbol]\]
+
 [swift]
 format = '\[[$symbol($version)]($style)\]'
 
@@ -374,6 +377,9 @@ symbol = "rs "
 
 [scala]
 symbol = "scala "
+
+[sudo]
+symbol = "sudo "
 
 [swift]
 symbol = "swift "

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -61,6 +61,7 @@ pub mod shlvl;
 pub mod singularity;
 mod starship_root;
 pub mod status;
+pub mod sudo;
 pub mod swift;
 pub mod terraform;
 pub mod time;
@@ -138,6 +139,7 @@ pub struct FullConfig<'a> {
     shlvl: shlvl::ShLvlConfig<'a>,
     singularity: singularity::SingularityConfig<'a>,
     status: status::StatusConfig<'a>,
+    sudo: sudo::SudoConfig<'a>,
     swift: swift::SwiftConfig<'a>,
     terraform: terraform::TerraformConfig<'a>,
     time: time::TimeConfig<'a>,
@@ -214,6 +216,7 @@ impl<'a> Default for FullConfig<'a> {
             shlvl: Default::default(),
             singularity: Default::default(),
             status: Default::default(),
+            sudo: Default::default(),
             swift: Default::default(),
             terraform: Default::default(),
             time: Default::default(),

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -76,6 +76,7 @@ pub const PROMPT_ORDER: &[&str] = &[
     "env_var",
     "crystal",
     "custom",
+    "sudo",
     "cmd_duration",
     "line_break",
     "jobs",

--- a/src/configs/sudo.rs
+++ b/src/configs/sudo.rs
@@ -9,7 +9,6 @@ pub struct SudoConfig<'a> {
     pub symbol: &'a str,
     pub style: &'a str,
     pub allow_windows: bool,
-    pub binary: &'a str,
     pub disabled: bool,
 }
 
@@ -20,7 +19,6 @@ impl<'a> Default for SudoConfig<'a> {
             symbol: "🧙‍ ",
             style: "bold blue",
             allow_windows: false,
-            binary: "sudo",
             disabled: true,
         }
     }

--- a/src/configs/sudo.rs
+++ b/src/configs/sudo.rs
@@ -16,7 +16,7 @@ impl<'a> Default for SudoConfig<'a> {
     fn default() -> Self {
         SudoConfig {
             format: "[as $symbol]($style)",
-            symbol: "🧙‍ ",
+            symbol: "🧙 ",
             style: "bold blue",
             allow_windows: false,
             disabled: true,

--- a/src/configs/sudo.rs
+++ b/src/configs/sudo.rs
@@ -8,6 +8,8 @@ pub struct SudoConfig<'a> {
     pub format: &'a str,
     pub symbol: &'a str,
     pub style: &'a str,
+    pub allow_windows: bool,
+    pub binary: &'a str,
     pub disabled: bool,
 }
 
@@ -17,6 +19,8 @@ impl<'a> Default for SudoConfig<'a> {
             format: "[as $symbol]($style)",
             symbol: "🧙‍ ",
             style: "bold blue",
+            allow_windows: false,
+            binary: "sudo",
             disabled: true,
         }
     }

--- a/src/configs/sudo.rs
+++ b/src/configs/sudo.rs
@@ -1,0 +1,23 @@
+use crate::config::ModuleConfig;
+
+use serde::Serialize;
+use starship_module_config_derive::ModuleConfig;
+
+#[derive(Clone, ModuleConfig, Serialize)]
+pub struct SudoConfig<'a> {
+    pub format: &'a str,
+    pub symbol: &'a str,
+    pub style: &'a str,
+    pub disabled: bool,
+}
+
+impl<'a> Default for SudoConfig<'a> {
+    fn default() -> Self {
+        SudoConfig {
+            format: "[as $symbol]($style)",
+            symbol: "🧙‍ ",
+            style: "bold blue",
+            disabled: true,
+        }
+    }
+}

--- a/src/module.rs
+++ b/src/module.rs
@@ -65,6 +65,7 @@ pub const ALL_MODULES: &[&str] = &[
     "shlvl",
     "singularity",
     "status",
+    "sudo",
     "swift",
     "terraform",
     "time",

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -55,6 +55,7 @@ mod shell;
 mod shlvl;
 mod singularity;
 mod status;
+mod sudo;
 mod swift;
 mod terraform;
 mod time;
@@ -139,6 +140,7 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
             "singularity" => singularity::module(context),
             "swift" => swift::module(context),
             "status" => status::module(context),
+            "sudo" => sudo::module(context),
             "terraform" => terraform::module(context),
             "time" => time::module(context),
             "crystal" => crystal::module(context),
@@ -226,6 +228,7 @@ pub fn description(module: &str) -> &'static str {
         "shlvl" => "The current value of SHLVL",
         "singularity" => "The currently used Singularity image",
         "status" => "The status of the last command",
+        "sudo" => "The current status of sudo cached credentials",
         "swift" => "The currently installed version of Swift",
         "terraform" => "The currently selected terraform workspace and version",
         "time" => "The current local time",

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -228,7 +228,7 @@ pub fn description(module: &str) -> &'static str {
         "shlvl" => "The current value of SHLVL",
         "singularity" => "The currently used Singularity image",
         "status" => "The status of the last command",
-        "sudo" => "The current status of sudo cached credentials",
+        "sudo" => "The sudo credentials are currently cached",
         "swift" => "The currently installed version of Swift",
         "terraform" => "The currently selected terraform workspace and version",
         "time" => "The current local time",

--- a/src/modules/sudo.rs
+++ b/src/modules/sudo.rs
@@ -99,7 +99,7 @@ mod tests {
                     stdout: "".to_owned(),
                     stderr: "".to_owned(),
                 }),
-             )
+            )
             .config(toml::toml! {
                 [sudo]
                 disabled = false

--- a/src/modules/sudo.rs
+++ b/src/modules/sudo.rs
@@ -61,6 +61,7 @@ mod tests {
             .config(toml::toml! {
                 [sudo]
                 disabled = false
+                allow_windows = true
             })
             .collect();
         let expected = None;
@@ -82,6 +83,7 @@ mod tests {
             .config(toml::toml! {
                 [sudo]
                 disabled = false
+                allow_windows = true
             })
             .collect();
         let expected = Some(format!("{}", Color::Blue.bold().paint("as 🧙 ")));

--- a/src/modules/sudo.rs
+++ b/src/modules/sudo.rs
@@ -79,7 +79,7 @@ mod tests {
                 disabled = false
             })
             .collect();
-        let expected = Some(format!("{}", Color::Blue.bold().paint("as 🧙‍ ")));
+        let expected = Some(format!("{}", Color::Blue.bold().paint("as 🧙 ")));
 
         assert_eq!(expected, actual);
     }

--- a/src/modules/sudo.rs
+++ b/src/modules/sudo.rs
@@ -104,7 +104,7 @@ mod tests {
     #[cfg(not(windows))]
     fn test_doas_cached() {
         let actual = ModuleRenderer::new("sudo")
-            .cmd("doas true", None)
+            .cmd("doas -n true", None)
             .config(toml::toml! {
                 [sudo]
                 disabled = false

--- a/src/modules/sudo.rs
+++ b/src/modules/sudo.rs
@@ -1,0 +1,68 @@
+use super::{Context, Module, RootModuleConfig};
+
+use crate::configs::sudo::SudoConfig;
+use crate::formatter::StringFormatter;
+
+/// Creates a module with sudo credential cache status
+pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let mut module = context.new_module("sudo");
+    let config = SudoConfig::try_load(module.config);
+
+    if config.disabled {
+        return None;
+    }
+
+    let is_sudo_cached = context.exec_cmd("sudo", &["-n", "true"]).is_some();
+
+    if !is_sudo_cached {
+        return None;
+    }
+
+    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
+        formatter
+            .map_meta(|variable, _| match variable {
+                "symbol" => Some(config.symbol),
+                _ => None,
+            })
+            .map_style(|variable| match variable {
+                "style" => Some(Ok(config.style)),
+                _ => None,
+            })
+            .parse(None)
+    });
+
+    module.set_segments(match parsed {
+        Ok(segments) => segments,
+        Err(error) => {
+            log::warn!("Error in module `sudo`:\n{}", error);
+            return None;
+        }
+    });
+
+    Some(module)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{test::ModuleRenderer, utils::CommandOutput};
+
+    #[test]
+    fn test_sudo_not_cached() {
+        let actual = ModuleRenderer::new("sudo")
+            .cmd(
+                "command -v sudo",
+                Some(CommandOutput {
+                    stdout: "/usr/bin/sudo".to_string(),
+                    stderr: "".to_string(),
+                }),
+            )
+            .config(toml::toml! {
+                [sudo]
+                disabled = false
+            })
+            .collect();
+        let expected = None;
+
+        assert_eq!(expected, actual);
+    }
+}

--- a/src/modules/sudo.rs
+++ b/src/modules/sudo.rs
@@ -45,6 +45,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 #[cfg(test)]
 mod tests {
     use crate::{test::ModuleRenderer, utils::CommandOutput};
+    use ansi_term::Color;
 
     #[test]
     fn test_sudo_not_cached() {
@@ -59,6 +60,23 @@ mod tests {
             })
             .collect();
         let expected = None;
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn test_sudo_cached() {
+        let actual = ModuleRenderer::new("sudo")
+            .cmd(
+                "sudo -v",
+                None,
+            )
+            .config(toml::toml! {
+                [sudo]
+                disabled = false
+            })
+            .collect();
+        let expected = Some(format!("{}",Color::Blue.bold().paint("as 🧙‍ ")));
 
         assert_eq!(expected, actual);
     }

--- a/src/modules/sudo.rs
+++ b/src/modules/sudo.rs
@@ -1,3 +1,5 @@
+use std::env;
+
 use super::{Context, Module, RootModuleConfig};
 
 use crate::configs::sudo::SudoConfig;
@@ -12,7 +14,12 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         return None;
     }
 
-    let is_sudo_cached = context.exec_cmd("sudo", &["-n", "true"]).is_some();
+    if !config.allow_windows && env::consts::FAMILY == "windows" {
+        return None;
+    }
+
+    let binary = config.binary.trim();
+    let is_sudo_cached = context.exec_cmd(binary, &["-n", "true"]).is_some();
 
     if !is_sudo_cached {
         return None;

--- a/src/modules/sudo.rs
+++ b/src/modules/sudo.rs
@@ -34,7 +34,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 "style" => Some(Ok(config.style)),
                 _ => None,
             })
-            .parse(None)
+            .parse(None, Some(context))
     });
 
     module.set_segments(match parsed {
@@ -54,7 +54,6 @@ mod tests {
     use ansi_term::Color;
 
     #[test]
-    #[cfg(not(windows))]
     fn test_sudo_not_cached() {
         let actual = ModuleRenderer::new("sudo")
             .cmd("sudo -n true", None)
@@ -70,7 +69,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(windows))]
     fn test_sudo_cached() {
         let actual = ModuleRenderer::new("sudo")
             .cmd(

--- a/src/modules/sudo.rs
+++ b/src/modules/sudo.rs
@@ -50,11 +50,8 @@ mod tests {
     fn test_sudo_not_cached() {
         let actual = ModuleRenderer::new("sudo")
             .cmd(
-                "command -v sudo",
-                Some(CommandOutput {
-                    stdout: "/usr/bin/sudo".to_string(),
-                    stderr: "".to_string(),
-                }),
+                "sudo -n true",
+                None,
             )
             .config(toml::toml! {
                 [sudo]

--- a/src/modules/sudo.rs
+++ b/src/modules/sudo.rs
@@ -51,16 +51,14 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{test::ModuleRenderer, utils::CommandOutput};
+    use crate::test::ModuleRenderer;
     use ansi_term::Color;
 
     #[test]
+    #[cfg(not(windows))]
     fn test_sudo_not_cached() {
         let actual = ModuleRenderer::new("sudo")
-            .cmd(
-                "sudo -n true",
-                None,
-            )
+            .cmd("sudo -n true", None)
             .config(toml::toml! {
                 [sudo]
                 disabled = false
@@ -72,18 +70,16 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(windows))]
     fn test_sudo_cached() {
         let actual = ModuleRenderer::new("sudo")
-            .cmd(
-                "sudo -v",
-                None,
-            )
+            .cmd("sudo -v", None)
             .config(toml::toml! {
                 [sudo]
                 disabled = false
             })
             .collect();
-        let expected = Some(format!("{}",Color::Blue.bold().paint("as 🧙‍ ")));
+        let expected = Some(format!("{}", Color::Blue.bold().paint("as 🧙‍ ")));
 
         assert_eq!(expected, actual);
     }

--- a/src/modules/sudo.rs
+++ b/src/modules/sudo.rs
@@ -18,8 +18,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         return None;
     }
 
-    let binary = config.binary.trim();
-    let is_sudo_cached = context.exec_cmd(binary, &["-n", "true"]).is_some();
+    let is_sudo_cached = context.exec_cmd("sudo", &["-n", "true"]).is_some();
 
     if !is_sudo_cached {
         return None;
@@ -58,6 +57,7 @@ mod tests {
     #[cfg(not(windows))]
     fn test_sudo_not_cached() {
         let actual = ModuleRenderer::new("sudo")
+            .cmd("sudo -k", None)
             .cmd("sudo -n true", None)
             .config(toml::toml! {
                 [sudo]
@@ -77,38 +77,6 @@ mod tests {
             .config(toml::toml! {
                 [sudo]
                 disabled = false
-            })
-            .collect();
-        let expected = Some(format!("{}", Color::Blue.bold().paint("as 🧙‍ ")));
-
-        assert_eq!(expected, actual);
-    }
-
-    #[test]
-    #[cfg(not(windows))]
-    fn test_doas_not_cached() {
-        let actual = ModuleRenderer::new("sudo")
-            .cmd("doas -n true", None)
-            .config(toml::toml! {
-                [sudo]
-                disabled = false
-                binary = "doas"
-            })
-            .collect();
-        let expected = None;
-
-        assert_eq!(expected, actual);
-    }
-
-    #[test]
-    #[cfg(not(windows))]
-    fn test_doas_cached() {
-        let actual = ModuleRenderer::new("sudo")
-            .cmd("doas -n true", None)
-            .config(toml::toml! {
-                [sudo]
-                disabled = false
-                binary = "doas"
             })
             .collect();
         let expected = Some(format!("{}", Color::Blue.bold().paint("as 🧙‍ ")));

--- a/src/modules/sudo.rs
+++ b/src/modules/sudo.rs
@@ -83,4 +83,20 @@ mod tests {
 
         assert_eq!(expected, actual);
     }
+
+    #[test]
+    #[cfg(windows)]
+    fn test_allow_windows_disabled_blocks_windows() {
+        let actual = ModuleRenderer::new("sudo")
+            .cmd("sudo -v", None)
+            .config(toml::toml! {
+                [sudo]
+                disabled = false
+                allow_windows = false
+            })
+            .collect();
+        let expected = None;
+
+        assert_eq!(expected, actual);
+    }
 }

--- a/src/modules/sudo.rs
+++ b/src/modules/sudo.rs
@@ -50,7 +50,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
 #[cfg(test)]
 mod tests {
-    use crate::test::ModuleRenderer;
+    use crate::{test::ModuleRenderer, utils::CommandOutput};
     use ansi_term::Color;
 
     #[test]
@@ -72,7 +72,13 @@ mod tests {
     #[cfg(not(windows))]
     fn test_sudo_cached() {
         let actual = ModuleRenderer::new("sudo")
-            .cmd("sudo -n true", None)
+            .cmd(
+                "sudo -n true",
+                Some(CommandOutput {
+                    stdout: "".to_owned(),
+                    stderr: "".to_owned(),
+                }),
+            )
             .config(toml::toml! {
                 [sudo]
                 disabled = false

--- a/src/modules/sudo.rs
+++ b/src/modules/sudo.rs
@@ -93,7 +93,13 @@ mod tests {
     #[cfg(windows)]
     fn test_allow_windows_disabled_blocks_windows() {
         let actual = ModuleRenderer::new("sudo")
-            .cmd("sudo -n true", None)
+            .cmd(
+                "sudo -n true",
+                Some(CommandOutput {
+                    stdout: "".to_owned(),
+                    stderr: "".to_owned(),
+                }),
+             )
             .config(toml::toml! {
                 [sudo]
                 disabled = false

--- a/src/modules/sudo.rs
+++ b/src/modules/sudo.rs
@@ -57,7 +57,6 @@ mod tests {
     #[cfg(not(windows))]
     fn test_sudo_not_cached() {
         let actual = ModuleRenderer::new("sudo")
-            .cmd("sudo -k", None)
             .cmd("sudo -n true", None)
             .config(toml::toml! {
                 [sudo]
@@ -73,7 +72,7 @@ mod tests {
     #[cfg(not(windows))]
     fn test_sudo_cached() {
         let actual = ModuleRenderer::new("sudo")
-            .cmd("sudo -v", None)
+            .cmd("sudo -n true", None)
             .config(toml::toml! {
                 [sudo]
                 disabled = false
@@ -88,7 +87,7 @@ mod tests {
     #[cfg(windows)]
     fn test_allow_windows_disabled_blocks_windows() {
         let actual = ModuleRenderer::new("sudo")
-            .cmd("sudo -v", None)
+            .cmd("sudo -n true", None)
             .config(toml::toml! {
                 [sudo]
                 disabled = false

--- a/src/modules/sudo.rs
+++ b/src/modules/sudo.rs
@@ -85,6 +85,38 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(windows))]
+    fn test_doas_not_cached() {
+        let actual = ModuleRenderer::new("sudo")
+            .cmd("doas -n true", None)
+            .config(toml::toml! {
+                [sudo]
+                disabled = false
+                binary = "doas"
+            })
+            .collect();
+        let expected = None;
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    #[cfg(not(windows))]
+    fn test_doas_cached() {
+        let actual = ModuleRenderer::new("sudo")
+            .cmd("doas true", None)
+            .config(toml::toml! {
+                [sudo]
+                disabled = false
+                binary = "doas"
+            })
+            .collect();
+        let expected = Some(format!("{}", Color::Blue.bold().paint("as 🧙‍ ")));
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
     #[cfg(windows)]
     fn test_allow_windows_disabled_blocks_windows() {
         let actual = ModuleRenderer::new("sudo")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
Add a sudo credential caching hint module. It's disabled by default to avoid cluttering the prompt too much, however users that want this feature only need to change `disabled = "false"`.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #816 

#### Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/64982761/136653294-8b0e38a1-7e41-4424-ac46-ef644d1c8a72.png)


#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

I was only able to create one test.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
