### PR TITLE
docs(3070): add some precision on how to hide non installed plugins

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -112,6 +112,18 @@ For example:
 - When `$all` is a shortcut for `\[$a$b\] `, `($all)` will show nothing only if `$a` and `$b` are both `None`.
   This works the same as `(\[$a$b\] )`.
 
+::: tip
+
+By default, icons tools will still be displayed, even if the tool is not installed on your system. If you do not want this behaviour, you can edit the configuration file to replace `via [$symbol($version )]($style)` with `(via [$symbol$version]($style))` so that the icon will only be displayed if you have it installed on your system (meaning that `$version` is not `None`).
+
+You will find below an example command to update your configuration file and apply this behaviour to all plugins.
+
+```bash
+starship print-config | sed -E 's/(format.*=.*)(via.*\$version.*)'\''/\1(\2)'\''/' > ~/.config/starship.toml
+```
+
+:::
+
 #### Escapable characters
 
 The following symbols have special usage in a format string.


### PR DESCRIPTION
#### Description

Update configuration documentation to indicate how to hide plugin which are not installed. 

#### Motivation and Context

Closes #3070

I'm not sure if this is the best way to address this issue, I tried to find an "update all configuration" method with a regex matching most of the plugin but there is maybe a better way.

#### How Has This Been Tested?

Only documentation have been changed. 

#### Checklist:

- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly
