### PR TITLE
feat(python): Show value of PYENV_VERSION when present

### DIFF
--- a/src/modules/python.rs
+++ b/src/modules/python.rs
@@ -76,12 +76,17 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 }
 
 fn get_pyenv_version(context: &Context) -> Option<String> {
-    let version_name = context
+    let mut version_name = context.get_env("PYENV_VERSION");
+
+    if version_name.is_none() {
+      version_name = Some(context
         .exec_cmd("pyenv", &["version-name"])?
         .stdout
         .trim()
-        .to_string();
-    Some(version_name)
+        .to_string())
+    }
+    
+    version_name
 }
 
 fn get_python_version(context: &Context, config: &PythonConfig) -> Option<String> {

--- a/src/modules/python.rs
+++ b/src/modules/python.rs
@@ -79,13 +79,15 @@ fn get_pyenv_version(context: &Context) -> Option<String> {
     let mut version_name = context.get_env("PYENV_VERSION");
 
     if version_name.is_none() {
-      version_name = Some(context
-        .exec_cmd("pyenv", &["version-name"])?
-        .stdout
-        .trim()
-        .to_string())
+        version_name = Some(
+            context
+                .exec_cmd("pyenv", &["version-name"])?
+                .stdout
+                .trim()
+                .to_string(),
+        )
     }
-    
+
     version_name
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
if config.pyenv_version_name is true and if there is a PYENV_VERSION environment present when executing starship module python the output uses the value of PYENV_VERSION otherwise it will show the version in the output of pyenv version-name.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #2872

#### How Has This Been Tested?
Executed these commands:
1. pyenv local 3.8.0
2. ./starship module python
3. export PYENV_VERSION="3.7.0"
4. ./starship module python
5. export PYENV_VERSION=""
6. ./starship module python

- [X] I have tested using **Linux**
