### PR TITLE
fix: Modules not working in fish RPROMPT

### DIFF
--- a/src/init/starship.fish
+++ b/src/init/starship.fish
@@ -13,6 +13,16 @@ function fish_prompt
 end
 
 function fish_right_prompt
+    switch "$fish_key_bindings"
+        case fish_hybrid_key_bindings fish_vi_key_bindings
+            set STARSHIP_KEYMAP "$fish_bind_mode"
+        case '*'
+            set STARSHIP_KEYMAP insert
+    end
+    set STARSHIP_CMD_STATUS $status
+    # Account for changes in variable name between v2.7 and v3.0
+    set STARSHIP_DURATION "$CMD_DURATION$cmd_duration"
+    set STARSHIP_JOBS (count (jobs -p))
     ::STARSHIP:: prompt --right --terminal-width="$COLUMNS" --status=$STARSHIP_CMD_STATUS --pipestatus=$pipestatus --keymap=$STARSHIP_KEYMAP --cmd-duration=$STARSHIP_DURATION --jobs=$STARSHIP_JOBS
 end
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This should fix some modules not working correctly in the fish
`RPROMPT`. I have done this the very naive way by simply duplicating the
code that is currently in the `fish_prompt` function to avoid having to
change the scope of any of the variables (currently all local) but happy to
change this if someone has a better suggestion.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #3137

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
