### PR TITLE
feat(terraform): Support tfenv version files

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -1316,12 +1316,15 @@
           "tfplan",
           "tfstate"
         ],
-        "detect_files": [],
+        "detect_files": [
+          ".tf",
+          ".terraform-version"
+        ],
         "detect_folders": [
           ".terraform"
         ],
         "disabled": false,
-        "format": "via [$symbol$workspace]($style) ",
+        "format": "via [$symbol$tfenvversion$workspace]($style) ",
         "style": "bold 105",
         "symbol": "💠 ",
         "version_format": "v${raw}"
@@ -4401,7 +4404,7 @@
       "type": "object",
       "properties": {
         "format": {
-          "default": "via [$symbol$workspace]($style) ",
+          "default": "via [$symbol$tfenvversion$workspace]($style) ",
           "type": "string"
         },
         "version_format": {
@@ -4432,7 +4435,10 @@
           }
         },
         "detect_files": {
-          "default": [],
+          "default": [
+            ".tf",
+            ".terraform-version"
+          ],
           "type": "array",
           "items": {
             "type": "string"

--- a/src/configs/terraform.rs
+++ b/src/configs/terraform.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+pub const TFENV_VERSION_FILE: &str = ".terraform-version";
 #[derive(Clone, Deserialize, Serialize)]
 #[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
@@ -17,13 +18,13 @@ pub struct TerraformConfig<'a> {
 impl<'a> Default for TerraformConfig<'a> {
     fn default() -> Self {
         TerraformConfig {
-            format: "via [$symbol$workspace]($style) ",
+            format: "via [$symbol$tfenvversion$workspace]($style) ",
             version_format: "v${raw}",
             symbol: "💠 ",
             style: "bold 105",
             disabled: false,
             detect_extensions: vec!["tf", "tfplan", "tfstate"],
-            detect_files: vec![],
+            detect_files: vec![".tf", TFENV_VERSION_FILE],
             detect_folders: vec![".terraform"],
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
This draft PR adds support for `tfenv` version files. This means that if the `.terraform-version` file is present, then the terraform module will be rendered. 

The way it obtains the version is by first trying to read `TFENV_TERRAFORM_VERSION` env variable and if it's not present, then it tries to read the `.terraform-version` file. Now, `.terraform-version` contains the plain versions which are expected by starship, like: `0.6.18` or `1.0.8`. 
It is possible to have a version like `latest:^0.8` but in this draft, I'm leaving it as is, because the exact version which is picked is decided by `terraform`, but I want to skip the call to `terraform` for performance reasons. TBD if this is acceptable because it will look a bit ugly like `💠 vlatest:^0.8 default` but it is precise. Happy to change the implementation in this PR or create a separate issue for that if needed.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #2199. Thanks to those changes we can get terraform version without using `terraform` binary which is often slow.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows** - *unfortunately, don't have Windows right now*

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] ~~I have updated the documentation accordingly.~~ - *N/A*
- [x] I have updated the tests accordingly.
