### PR TITLE
fix(configure): preserve formatting and comments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1968,9 +1968,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a0ddb4919e3b49fe9e08e7921d69445bb00ce95a2ea807bb8826cde6610455"
+checksum = "b46c9238346fec3169f99251eda26e918ab71cdf382a660e46076ff1b1b16729"
 dependencies = [
  "combine",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ shadow-rs = "0.7.1"
 versions = "3.0.3"
 strsim = "0.10.0"
 sha-1 = "0.9.8"
-toml_edit = "0.5.0"
+toml_edit = "0.6.0"
 
 process_control = { version = "3.1.0", features = ["crossbeam-channel"] }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR ensures that formatting (comments, whitespace) is preserved when starship edits `starship.toml` with `starship toggle` and `starship config` by using `toml_edit` instead of `toml` for this task.
Additionally, the `starship config` command can now edit root-level and deeper option levels instead of only the second level.

Benchmark `starship toggle scala`:
| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `toml` | 14.8 ± 1.0 | 13.1 | 17.8 | 1.00 |
| `toml_edit`  | 15.1 ± 1.1 | 13.2 | 19.4 | 1.02 ± 0.10 |

Benchmark `starship config scala.disabled true`:
| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `toml` | 14.8 ± 0.9 | 12.8 | 17.7 | 1.00 |
| `toml_edit` | 15.3 ± 4.0 | 13.3 | 60.5 | 1.03 ± 0.28 |

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #2992

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
