### PR TITLE
chore: hide warnings for additional known advisories

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -2,8 +2,17 @@
 ignore = [
     # difference is unmaintained
     # Only used in test code
+    # Tracked in #2835
     "RUSTSEC-2020-0095",
     # Out-of-bounds write in nix::unistd::getgrouplist
     # Tracked in #3140
-    "RUSTSEC-2021-0119"
+    "RUSTSEC-2021-0119",
+    # Potential segfault in the time crate
+    # chrono dependency, but vulnerable function is never called
+    # Tacked in #3163
+    "RUSTSEC-2020-0071",
+    # chrono: Potential segfault in localtime_r invocations
+    # starship avoids setting any environment variables to avoid this issue
+    # Tracked in #3166
+    "RUSTSEC-2020-0159",
 ]

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,2 +1,6 @@
-# std::process::Command::new may inadvertly run executables from the current working directory
-disallowed-methods = ["std::process::Command::new"]
+disallowed-methods = [
+    # std::process::Command::new may inadvertly run executables from the current working directory
+    "std::process::Command::new",
+    # Setting environment variables can cause issues with non-rust code
+    "std::env::set_var"
+]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR adds the recent `localtime_r` advisories to the list of ignored advisories until chrono is updated. I also added a reference to the tracking issue for `RUSTSEC-2020-0095` (difference is unmaintained) and added `std::env::set_var` to the list of disallowed methods in clippy to prevent triggering this and similar issues in the future.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Related #2835 #3163 #3166

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
