### PR TITLE
fix: typo in starship.ps1

### DIFF
--- a/src/init/starship.ps1
+++ b/src/init/starship.ps1
@@ -43,8 +43,8 @@ function global:prompt {
             # Build an arguments string which follows the C++ command-line argument quoting rules
             # See: https://docs.microsoft.com/en-us/previous-versions//17w5ykft(v=vs.85)?redirectedfrom=MSDN
             $escaped = $Arguments | ForEach-Object {
-                $s = $_ -Replace '(\\+)"','$1$1"'; # Escape backslash chains immediately preceeding quote marks.
-                $s = $s -Replace '(\\+)$','$1$1';  # Escape backslash chains immediately preceeding the end of the string.
+                $s = $_ -Replace '(\\+)"','$1$1"'; # Escape backslash chains immediately preceding quote marks.
+                $s = $s -Replace '(\\+)$','$1$1';  # Escape backslash chains immediately preceding the end of the string.
                 $s = $s -Replace '"','\"';         # Escape quote marks.
                 "`"$s`""                           # Quote the argument.
             }


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
Fixed typo.
```
preceeding -> preceding
```

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
