### PR TITLE
feat: also read from DOCKER_MACHINE_NAME

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -836,9 +836,10 @@ truncation_symbol = "…/"
 ## Docker Context
 
 The `docker_context` module shows the currently active
-[Docker context](https://docs.docker.com/engine/context/working-with-contexts/) if it's not set to
-`default` or if the `DOCKER_HOST` or `DOCKER_CONTEXT` environment variables are set (as they are meant
-to override the context in use).
+[Docker context](https://docs.docker.com/engine/context/working-with-contexts/)
+if it's not set to `default` or if the `DOCKER_MACHINE_NAME`, `DOCKER_HOST` or
+`DOCKER_CONTEXT` environment variables are set (as they are meant to override
+the context in use).
 
 ### Options
 

--- a/src/modules/docker_context.rs
+++ b/src/modules/docker_context.rs
@@ -41,8 +41,9 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     )
     .join("config.json");
 
-    let docker_context_env = std::array::IntoIter::new(["DOCKER_HOST", "DOCKER_CONTEXT"])
-        .find_map(|env| context.get_env(env));
+    let docker_context_env =
+        std::array::IntoIter::new(["DOCKER_MACHINE_NAME", "DOCKER_HOST", "DOCKER_CONTEXT"])
+            .find_map(|env| context.get_env(env));
 
     let ctx = match docker_context_env {
         Some(data) => data,
@@ -361,6 +362,39 @@ mod tests {
         let expected = Some(format!(
             "via {} ",
             Color::Blue.bold().paint("🐳 udp://starship@127.0.0.1:53")
+        ));
+
+        assert_eq!(expected, actual);
+
+        cfg_dir.close()
+    }
+    #[test]
+    fn test_docker_machine_name_overrides_other_env_vars_and_conf() -> io::Result<()> {
+        let cfg_dir = tempfile::tempdir()?;
+
+        let cfg_file = cfg_dir.path().join("config.json");
+
+        let config_content = serde_json::json!({
+            "currentContext": "starship"
+        });
+
+        let mut docker_config = File::create(&cfg_file)?;
+        docker_config.write_all(config_content.to_string().as_bytes())?;
+        docker_config.sync_all()?;
+
+        let actual = ModuleRenderer::new("docker_context")
+            .env("DOCKER_MACHINE_NAME", "machine_name")
+            .env("DOCKER_HOST", "udp://starship@127.0.0.1:53")
+            .env("DOCKER_CONTEXT", "starship")
+            .env("DOCKER_CONFIG", cfg_dir.path().to_string_lossy())
+            .config(toml::toml! {
+                [docker_context]
+                only_with_files = false
+            })
+            .collect();
+        let expected = Some(format!(
+            "via {} ",
+            Color::Blue.bold().paint("🐳 machine_name")
         ));
 
         assert_eq!(expected, actual);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This adds support to also read the context from `DOCKER_MACHINE_NAME`
since it is a bit more user friendly.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #3174

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
