### PR TITLE
fix: init script line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-/src/init/ text eol=lf
+/src/init/* text eol=lf
 *.sh text eol=lf


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description

The .gitattributes file says `/src/init/ text eol=lf`, which applies the `text eol=lf` only to the directory, not to the files in the directory.

```
$ git check-attr -a src/init/starship.zsh
```

(no output)

By changing the rule to `/src/init/* text eol=lf`, it is applied to all files within the directory instead.

```
$ git check-attr -a src/init/starship.zsh
src/init/starship.zsh: text: set
src/init/starship.zsh: eol: lf
```

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #3099

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

I don't actually have zsh on Windows, but I can see the problem using xxd.

Before:

```
$ starship init zsh --print-full-init | xxd | tail -n 1
00001180: 4253 5f43 4f55 4e54 2229 270d 0a         BS_COUNT")'..
```

(note the 0d 0a sequence at the end)

After changing .gitattributes and doing a clean checkout of the init directory:

```
$ starship init zsh --print-full-init | xxd | tail -n 1
00001190: 4253 5f43 4f55 4e54 2229 270a 0a         BS_COUNT")'..
```

(now it's 0a 0a. The second 0a was introduced two weeks ago. The before test was with the release version so the second line feed was not present.)

Since this also applies to starship.ps1 I checked on Windows PowerShell 5.1 and PowerShell 7.1 (on Windows) and neither seem to care about the missing carriage returns.

On Linux and OS X, I expect the files have always had LF line endings and this change has no impact because that's the default behavior when checking out Git repositories on non-Windows build machines.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
