### PR TITLE
fix: ignore scan_dir timeout in tests

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -351,7 +351,8 @@ impl DirContents {
         fs::read_dir(base)?
             .enumerate()
             .take_while(|(n, _)| {
-                n & 0xFF != 0 // only check timeout once every 2^8 entries
+                cfg!(test) // ignore timeout during tests
+                || n & 0xFF != 0 // only check timeout once every 2^8 entries
                 || start.elapsed() < timeout
             })
             .filter_map(|(_, entry)| entry.ok())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
I noticed that recent intermittent test failures have logged that file scanning takes longer than 20ms. In these cases, `ScanDir` is likely aborted because it takes longer than `scan_timeout` (20ms). This PR disables the scan timeout entirely in testing.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related #886

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
