### PR TITLE
feat(ruby): Add environment variable checks to ruby module

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2644,6 +2644,8 @@ The module will be shown if any of the following conditions are met:
 - The current directory contains a `.rb` file
 - The environment variables `RUBY_VERSION` or `RBENV_VERSION` are set
 
+Starship gets the current Ruby version by running `ruby -v`.
+
 ### Options
 
 | Option              | Default                              | Description                                                               |

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2642,6 +2642,7 @@ The module will be shown if any of the following conditions are met:
 - The current directory contains a `Gemfile` file
 - The current directory contains a `.ruby-version` file
 - The current directory contains a `.rb` file
+- The environment variables `RUBY_VERSION` or `RBENV_VERSION` are set
 
 ### Options
 
@@ -2653,6 +2654,7 @@ The module will be shown if any of the following conditions are met:
 | `detect_extensions` | `["rb"]`                             | Which extensions should trigger this module.                              |
 | `detect_files`      | `["Gemfile", ".ruby-version"]`       | Which filenames should trigger this module.                               |
 | `detect_folders`    | `[]`                                 | Which folders should trigger this module.                                 |
+| `detect_variables`  | `["RUBY_VERSION", "RBENV_VERSION"]`  | Which environment variables should trigger this module.                   |
 | `style`             | `"bold red"`                         | The style for the module.                                                 |
 | `disabled`          | `false`                              | Disables the `ruby` module.                                               |
 

--- a/src/configs/ruby.rs
+++ b/src/configs/ruby.rs
@@ -13,6 +13,7 @@ pub struct RubyConfig<'a> {
     pub detect_extensions: Vec<&'a str>,
     pub detect_files: Vec<&'a str>,
     pub detect_folders: Vec<&'a str>,
+    pub detect_variables: Vec<&'a str>,
 }
 
 impl<'a> Default for RubyConfig<'a> {
@@ -26,6 +27,7 @@ impl<'a> Default for RubyConfig<'a> {
             detect_extensions: vec!["rb"],
             detect_files: vec!["Gemfile", ".ruby-version"],
             detect_folders: vec![],
+            detect_variables: vec!["RUBY_VERSION", "RBENV_VERSION"],
         }
     }
 }

--- a/src/modules/ruby.rs
+++ b/src/modules/ruby.rs
@@ -8,6 +8,7 @@ use crate::formatter::{StringFormatter, VersionFormatter};
 /// Will display the Ruby version if any of the following criteria are met:
 ///     - Current directory contains a `.rb` file
 ///     - Current directory contains a `Gemfile` or `.ruby-version` file
+///     - The environment variables `RUBY_VERSION` or `RBENV_VERSION` are set
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let mut module = context.new_module("ruby");
     let config = RubyConfig::try_load(module.config);
@@ -19,7 +20,12 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         .set_folders(&config.detect_folders)
         .is_match();
 
-    if !is_rb_project {
+    let is_rb_env = &config
+        .detect_variables
+        .iter()
+        .any(|variable| context.get_env(variable).is_some());
+
+    if !is_rb_project && !is_rb_env {
         return None;
     }
 
@@ -125,6 +131,33 @@ mod tests {
 
         let actual = ModuleRenderer::new("ruby").path(dir.path()).collect();
 
+        let expected = Some(format!("via {}", Color::Red.bold().paint("💎 v2.5.1 ")));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn with_ruby_version_env() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let actual = ModuleRenderer::new("ruby")
+            .path(dir.path())
+            .env("RUBY_VERSION", "2.5.1")
+            .collect();
+
+        let expected = Some(format!("via {}", Color::Red.bold().paint("💎 v2.5.1 ")));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn with_rbenv_version_env() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let actual = ModuleRenderer::new("ruby")
+            .path(dir.path())
+            .env("RBENV_VERSION", "2.6.8")
+            .collect();
+
+        // rbenv variable is only detected; its value is not used
         let expected = Some(format!("via {}", Color::Red.bold().paint("💎 v2.5.1 ")));
         assert_eq!(expected, actual);
         dir.close()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR adds a check in the ruby module for the environment variables `RUBY_VERSION` and `RBENV_VERSION`, which indicate that ruby is currently activated with RVM or rbenv (respectively). 
The variables to check are configurable with the `detect_variables` option.

#### Motivation and Context
Starship does not detect ruby environments activated with environment variables.
See my [comment](https://github.com/starship/starship/issues/698#issuecomment-961592678) in #698

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

I've tested this with rbenv and RVM.
##### rbenv (1.2.0)
```
brew install rbenv ruby-build
rbenv install 3.0.2
```
In a new terminal, `rbenv shell 3.0.2` adds the correct ruby version to the prompt (3.0.2).

##### RVM (rvm 1.29.12-next)
```
\curl -sSL https://get.rvm.io | bash -s -- --ignore-dotfiles
source $HOME/.rvm/scripts/rvm
rvm install 3.0.1
```
In a new terminal, `source $HOME/.rvm/scripts/rvm` adds the correct ruby version to the prompt (3.0.1).

One issue with RVM is that by default, it is activated permanently through the user's `.profile` files. If someone has a ruby env activated this way, they may not want to see the ruby version all the time, so I added the detect_variables option to make this check configurable.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly
(but only `docs/config/README.md`, not the internationalizations).
- [x] I have updated the tests accordingly.
though the tests don't actually use a ruby environment, so only the presence of the relevant variable matters. I suppose that matches how the code works at the moment.