### PR TITLE
chore(chglog): undo changes to chglog configuration

### DIFF
--- a/.github/chglog/changelog.yml
+++ b/.github/chglog/changelog.yml
@@ -1,25 +1,17 @@
----
 style: github
 template: CHANGELOG.tpl.md
 info:
   title: CHANGELOG
   repository_url: https://github.com/starship/starship
 options:
-  commits: {}
+  commits:
+    # filters:
+    #   Type:
+    #     - feat
+    #     - fix
+    #     - perf
+    #     - refactor
   commit_groups:
-    sort_by: Custom
-    title_order:
-      - feat
-      - fix
-      - docs
-      - style
-      - refactor
-      - perf
-      - test
-      - build
-      - ci
-      - chore
-      - revert
     title_maps:
       feat: Features
       fix: Bug Fixes

--- a/.github/chglog/release.yml
+++ b/.github/chglog/release.yml
@@ -1,10 +1,15 @@
----
 style: github
 template: RELEASE.tpl.md
 info:
   repository_url: https://github.com/starship/starship
 options:
-  commits: {}
+  commits:
+    # filters:
+    #   Type:
+    #     - feat
+    #     - fix
+    #     - perf
+    #     - refactor
   commit_groups:
     sort_by: Custom
     title_order:


### PR DESCRIPTION
Reverts starship/starship#3205

Chglog did not respect the changelog section order defined in the configuration in the last release, so it's being temporarily undone as we work out why.