### PR TITLE
build: bump toml_edit from 0.6.0 to 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1950,9 +1950,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b46c9238346fec3169f99251eda26e918ab71cdf382a660e46076ff1b1b16729"
+checksum = "8c29c21e11af3c58476a1063cb550e255c45c60928bf7f272462a533e7a2b406"
 dependencies = [
  "combine",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ shadow-rs = "0.7.2"
 versions = "3.0.3"
 strsim = "0.10.0"
 sha-1 = "0.9.8"
-toml_edit = "0.6.0"
+toml_edit = "0.8.0"
 
 process_control = { version = "3.1.0", features = ["crossbeam-channel"] }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR updates `toml_edit` to `0.8.0` and updates the code accordingly.

Because there is no longer an obvious way to coerce a `toml_edit::Document` into an `toml_edit::Item`, the first loop iteration over the configuration keys is essentially handled manually now.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #3202

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
