### PR TITLE
feat(directory): Allow to disable contractions

### DIFF
--- a/src/configs/directory.rs
+++ b/src/configs/directory.rs
@@ -20,6 +20,8 @@ pub struct DirectoryConfig<'a> {
     pub read_only_style: &'a str,
     pub truncation_symbol: &'a str,
     pub home_symbol: &'a str,
+    pub path_contraction: bool,
+    pub repo_contraction: bool,
 }
 
 impl<'a> Default for DirectoryConfig<'a> {
@@ -39,6 +41,8 @@ impl<'a> Default for DirectoryConfig<'a> {
             read_only_style: "red",
             truncation_symbol: "",
             home_symbol: "~",
+            path_contraction: true,
+            repo_contraction: true,
         }
     }
 }


### PR DESCRIPTION
#### Description

Add `path_contraction` and `repo_contraction` to control whether contractions are enabled for path and repos, respectively. Enabled by default (no behaviour change).

#### Motivation and Context

Closes #3249.

#### Screenshots (if appropriate):

TBC

#### How Has This Been Tested?
- [x] I have tested using **MacOS**

#### Checklist:

- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
