### PR TITLE
fix: typo in docker_context.rs

### DIFF
--- a/src/modules/docker_context.rs
+++ b/src/modules/docker_context.rs
@@ -9,8 +9,8 @@ use crate::utils;
 /// Creates a module with the currently active Docker context
 ///
 /// Will display the Docker context if the following criteria are met:
-///     - There is a non-empty enviroment variable named DOCKER_HOST
-///     - Or there is a non-empty enviroment variable named DOCKER_CONTEXT
+///     - There is a non-empty environment variable named DOCKER_HOST
+///     - Or there is a non-empty environment variable named DOCKER_CONTEXT
 ///     - Or there is a file named `$HOME/.docker/config.json`
 ///     - Or a file named `$DOCKER_CONFIG/config.json`
 ///     - The file is JSON and contains a field named `currentContext`


### PR DESCRIPTION

#### Description
Fixed typo.
```
enviroment -> environment
```

#### Motivation and Context


#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
