### PR TITLE
perf(git_status): tweak exec flags to omit unnecessary info

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1388,22 +1388,23 @@ current directory.
 
 ### Options
 
-| Option       | Default                                       | Description                         |
-| ------------ | --------------------------------------------- | ----------------------------------- |
-| `format`     | `'([\[$all_status$ahead_behind\]]($style) )'` | The default format for `git_status` |
-| `conflicted` | `"="`                                         | This branch has merge conflicts.    |
-| `ahead`      | `"⇡"`                                         | The format of `ahead`               |
-| `behind`     | `"⇣"`                                         | The format of `behind`              |
-| `diverged`   | `"⇕"`                                         | The format of `diverged`            |
-| `up_to_date` | `""`                                          | The format of `up_to_date`          |
-| `untracked`  | `"?"`                                         | The format of `untracked`           |
-| `stashed`    | `"$"`                                         | The format of `stashed`             |
-| `modified`   | `"!"`                                         | The format of `modified`            |
-| `staged`     | `"+"`                                         | The format of `staged`              |
-| `renamed`    | `"»"`                                         | The format of `renamed`             |
-| `deleted`    | `"✘"`                                         | The format of `deleted`             |
-| `style`      | `"bold red"`                                  | The style for the module.           |
-| `disabled`   | `false`                                       | Disables the `git_status` module.   |
+| Option              | Default                                       | Description                         |
+| ------------------- | --------------------------------------------- | ----------------------------------- |
+| `format`            | `'([\[$all_status$ahead_behind\]]($style) )'` | The default format for `git_status` |
+| `conflicted`        | `"="`                                         | This branch has merge conflicts.    |
+| `ahead`             | `"⇡"`                                         | The format of `ahead`               |
+| `behind`            | `"⇣"`                                         | The format of `behind`              |
+| `diverged`          | `"⇕"`                                         | The format of `diverged`            |
+| `up_to_date`        | `""`                                          | The format of `up_to_date`          |
+| `untracked`         | `"?"`                                         | The format of `untracked`           |
+| `stashed`           | `"$"`                                         | The format of `stashed`             |
+| `modified`          | `"!"`                                         | The format of `modified`            |
+| `staged`            | `"+"`                                         | The format of `staged`              |
+| `renamed`           | `"»"`                                         | The format of `renamed`             |
+| `deleted`           | `"✘"`                                         | The format of `deleted`             |
+| `style`             | `"bold red"`                                  | The style for the module.           |
+| `ignore_submodules` | `false`                                       | Ignore changes to submodules.       |
+| `disabled`          | `false`                                       | Disables the `git_status` module.   |
 
 ### Variables
 

--- a/src/configs/git_status.rs
+++ b/src/configs/git_status.rs
@@ -18,6 +18,7 @@ pub struct GitStatusConfig<'a> {
     pub modified: &'a str,
     pub staged: &'a str,
     pub untracked: &'a str,
+    pub ignore_submodules: bool,
     pub disabled: bool,
 }
 
@@ -37,6 +38,7 @@ impl<'a> Default for GitStatusConfig<'a> {
             modified: "!",
             staged: "+",
             untracked: "?",
+            ignore_submodules: false,
             disabled: false,
         }
     }


### PR DESCRIPTION
`git status` can be prohibitively slow on some repos, so allow the config to influence what flags are passed to git. For instance, if there is no configured symbol for untracked files, tell git to omit them from its output.

#### Description

Note that since this requires the user to opt-in to omitting certain details from the module (and does not change the defaults), this is not really a "fix" for #2625.

A follow-up to this might be to read `git config` data to customize this behaviour per-repo. There is precedent for this in [oh-my-zsh git prompts](https://github.com/ohmyzsh/ohmyzsh/blob/e86c6f5e7fc9f024a427e2870ab70644b5454725/lib/git.zsh#L40), so looking for the config entries that people are already using in the wild might be nice.

#### Motivation and Context

With the repos I mentioned in [my comment](https://github.com/starship/starship/issues/2625#issuecomment-982206526) as a test case, here are some random before and after comparisons:

- small repo with 5 submodules of varying sizes: **163.2ms** on 1.0.0 vs **5.3ms** with this patch
- small repo with no submodules: **5.2ms** vs **5.1ms**
- medium repo with no submodules: **10.2ms** vs **3.9ms**
- large repo with no submodules: **164.8ms** vs **18.7ms**

(testing done with ahead/behind/up_to_date/diverged/untracked cleared and ignore_submodules=true)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
