### PR TITLE
feat(localip): add module to print the current ipv4 address

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -819,6 +819,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
+name = "local_ipaddress"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6a104730949fbc4c78e4fa98ed769ca0faa02e9818936b61032d2d77526afa9"
+
+[[package]]
 name = "log"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1605,6 +1611,7 @@ dependencies = [
  "gethostname",
  "git2",
  "indexmap",
+ "local_ipaddress",
  "log",
  "mockall",
  "nix 0.23.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ directories-next = "2.0.0"
 gethostname = "0.2.2"
 git2 = { version = "0.13.25", default-features = false }
 indexmap = { version = "1.8.0", features = ["serde"] }
+local_ipaddress = "0.1.3"
 log = { version = "0.4.14", features = ["std"] }
 notify-rust = { version = "4.5.5", optional = true }
 once_cell = "1.9.0"

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -192,7 +192,7 @@ format = "$all"
 format = """
 $username\
 $hostname\
-$localipv4\
+$localip\
 $shlvl\
 $singularity\
 $kubernetes\

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -192,7 +192,7 @@ format = "$all"
 format = """
 $username\
 $hostname\
-$localip\
+$localipv4\
 $shlvl\
 $singularity\
 $kubernetes\
@@ -1811,7 +1811,7 @@ The `localip` module shows the IPv4 address of the primary network interface.
 | Option     | Default                     | Description                                                                                                                          |
 | ---------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
 | `ssh_only` | `true`                      | Only show IP address when connected to an SSH session.                                                                               |
-| `format`   | `"[$hostname]($style)"`     | The format for the module.                                                                                                           |
+| `format`   | `"[$localipv4]($style) "`     | The format for the module.                                                                                                           |
 | `style`    | `"bold yellow"`              | The style for the module.                                                                                                            |
 | `disabled` | `false`                     | Disables the `localip` module.                                                                                                      |
 
@@ -1819,7 +1819,6 @@ The `localip` module shows the IPv4 address of the primary network interface.
 
 | Variable | Example | Description                          |
 | -------- | ------- | ------------------------------------ |
-| symbol   |         | Mirrors the value of option `symbol` |
 | style\*  |         | Mirrors the value of option `style`  |
 
 \*: This variable can only be used as a part of a style string
@@ -1831,7 +1830,7 @@ The `localip` module shows the IPv4 address of the primary network interface.
 
 [localip]
 ssh_only = false
-format =  "@[$localip](bold red) "
+format =  "@[$localipv4](bold red) "
 disabled = false
 ```
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1819,7 +1819,7 @@ The `localip` module shows the IPv4 address of the primary network interface.
 
 | Variable    | Example      | Description                          |
 | --------    | -------      | ------------------------------------ |
-| localipv4\* | 192.168.1.13 | Contains the primary IPv4 address    |
+| localipv4 | 192.168.1.13 | Contains the primary IPv4 address    |
 | style\*     |              | Mirrors the value of option `style`  |
 
 \*: This variable can only be used as a part of a style string

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -192,7 +192,7 @@ format = "$all"
 format = """
 $username\
 $hostname\
-$localip\
+$localipv4\
 $shlvl\
 $singularity\
 $kubernetes\

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -192,7 +192,7 @@ format = "$all"
 format = """
 $username\
 $hostname\
-$localipv4\
+$localip\
 $shlvl\
 $singularity\
 $kubernetes\
@@ -1817,9 +1817,10 @@ The `localip` module shows the IPv4 address of the primary network interface.
 
 ### Variables
 
-| Variable | Example | Description                          |
-| -------- | ------- | ------------------------------------ |
-| style\*  |         | Mirrors the value of option `style`  |
+| Variable    | Example      | Description                          |
+| --------    | -------      | ------------------------------------ |
+| localipv4\* | 192.168.1.13 | Contains the primary IPv4 address    |
+| style\*     |              | Mirrors the value of option `style`  |
 
 \*: This variable can only be used as a part of a style string
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -3005,12 +3005,22 @@ This module is not supported on nu shell.
 
 ### Options
 
-# | Option | Default | Description || ----------------------- | ----------------------------------------------------------------------------- | ------------------------------------------------------- | --------------------------------------------------- || `format` | `"[$symbol$status]($style) "` | The format of the module || `symbol` | `"✖"` | The symbol displayed on program error || `success_symbol` | `"✔️"` | The symbol displayed on program success || `not_executable_symbol` | `"🚫"` | The symbol displayed when file isn't executable || `not_found_symbol` | `"🔍"` | The symbol displayed when the command can't be found || `sigint_symbol` | `"🧱"` | The symbol displayed on SIGINT (Ctrl + c) || `signal_symbol` | `"⚡"` | The symbol displayed on any signal || `style` | `"bold red"` | The style for the module. || `recognize_signal_code` | `true` | Enable signal mapping from exit code || `map_symbol` | `false` | Enable symbols mapping from exit code || `pipestatus` | `false` | Enable pipestatus reporting |<<<<<<< HEAD| `pipestatus_separator` | `|` |
-
-| `pipestatus_separator` | `|` | The symbol that separate in pipe program exit codes |
->>>>>>> 7c1ac0c8 (feat(localip): add module to print the current ipv4 address)
-| `pipestatus_format` | `\\[$pipestatus\\] => [$symbol$common_meaning$signal_name$maybe_int]($style)` | The format of the module when the command is a pipeline |
-| `disabled` | `true` | Disables the `status` module. |
+| Option                  | Default                                                                       | Description                                             |
+| ----------------------- | ----------------------------------------------------------------------------- | ------------------------------------------------------- |
+| `format`                | `"[$symbol$status]($style) "`                                                 | The format of the module                                |
+| `symbol`                | `"✖"`                                                                         | The symbol displayed on program error                   |
+| `success_symbol`        | `"✔️"`                                                                        | The symbol displayed on program success                 |
+| `not_executable_symbol` | `"🚫"`                                                                         | The symbol displayed when file isn't executable         |
+| `not_found_symbol`      | `"🔍"`                                                                         | The symbol displayed when the command can't be found    |
+| `sigint_symbol`         | `"🧱"`                                                                         | The symbol displayed on SIGINT (Ctrl + c)               |
+| `signal_symbol`         | `"⚡"`                                                                         | The symbol displayed on any signal                      |
+| `style`                 | `"bold red"`                                                                  | The style for the module.                               |
+| `recognize_signal_code` | `true`                                                                        | Enable signal mapping from exit code                    |
+| `map_symbol`            | `false`                                                                       | Enable symbols mapping from exit code                   |
+| `pipestatus`            | `false`                                                                       | Enable pipestatus reporting                             |
+| `pipestatus_separator`  | `                                                                             | `                                                       |
+| `pipestatus_format`     | `\\[$pipestatus\\] => [$symbol$common_meaning$signal_name$maybe_int]($style)` | The format of the module when the command is a pipeline |
+| `disabled`              | `true`                                                                        | Disables the `status` module.                           |
 
 ### Variables
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -192,6 +192,7 @@ format = "$all"
 format = """
 $username\
 $hostname\
+$localip\
 $shlvl\
 $singularity\
 $kubernetes\
@@ -1799,6 +1800,39 @@ By default the module will be shown if any of the following conditions are met:
 
 [julia]
 symbol = "∴ "
+```
+
+## localip
+
+The `localip` module shows the IPv4 address of the primary network interface.
+
+### Options
+
+| Option     | Default                     | Description                                                                                                                          |
+| ---------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `ssh_only` | `true`                      | Only show IP address when connected to an SSH session.                                                                               |
+| `format`   | `"[$hostname]($style)"`     | The format for the module.                                                                                                           |
+| `style`    | `"bold yellow"`              | The style for the module.                                                                                                            |
+| `disabled` | `false`                     | Disables the `localip` module.                                                                                                      |
+
+### Variables
+
+| Variable | Example | Description                          |
+| -------- | ------- | ------------------------------------ |
+| symbol   |         | Mirrors the value of option `symbol` |
+| style\*  |         | Mirrors the value of option `style`  |
+
+\*: This variable can only be used as a part of a style string
+
+### Example
+
+```toml
+# ~/.config/starship.toml
+
+[localip]
+ssh_only = false
+format =  "@[$localip](bold red) "
+disabled = false
 ```
 
 ## Kotlin

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1234,7 +1234,7 @@ This is based on the `~/.config/gcloud/active_config` file and the `~/.config/gc
 | Option           | Default                                                  | Description                                                     |
 | ---------------- | -------------------------------------------------------- | --------------------------------------------------------------- |
 | `format`         | `'on [$symbol$account(@$domain)(\($region\))]($style) '` | The format for the module.                                      |
-| `symbol`         | `"☁️  "`                                                 | The symbol used before displaying the current GCP profile.      |
+| `symbol`         | `"☁️ "`                                                  | The symbol used before displaying the current GCP profile.      |
 | `region_aliases` |                                                          | Table of region aliases to display in addition to the GCP name. |
 | `style`          | `"bold blue"`                                            | The style for the module.                                       |
 | `disabled`       | `false`                                                  | Disables the `gcloud` module.                                   |
@@ -1729,16 +1729,17 @@ then the module will also show when there are 0 jobs running.
 
 ### Options
 
-| Option                                                                                                  | Default                       | Description                                                              |
-| ------------------------------------------------------------------------------------------------------- | ----------------------------- | ------------------------------------------------------------------------ |
-| `threshold`*                                                                                            | `1`                           | Show number of jobs if exceeded.                                         |
-| `symbol_threshold`                                                                                      | `1`                           | Show `symbol` if the job count is at least `symbol_threshold`.           |
-| `number_threshold`                                                                                      | `2`                           | Show the number of jobs if the job count is at least `number_threshold`. |
-| `format`                                                                                                | `"[$symbol$number]($style) "` | The format for the module.                                               |
-| `symbol`                                                                                                | `"✦"`                         | The string used to represent the `symbol` variable.                      |
-| `style`                                                                                                 | `"bold blue"`                 | The style for the module.                                                |
-| `disabled`                                                                                              | `false`                       | Disables the `jobs` module.                                              |
-| *: This option is deprecated, please use the `number_threshold` and `symbol_threshold` options instead. |                               |                                                                          |
+| Option             | Default                       | Description                                                              |
+| ------------------ | ----------------------------- | ------------------------------------------------------------------------ |
+| `threshold`*       | `1`                           | Show number of jobs if exceeded.                                         |
+| `symbol_threshold` | `1`                           | Show `symbol` if the job count is at least `symbol_threshold`.           |
+| `number_threshold` | `2`                           | Show the number of jobs if the job count is at least `number_threshold`. |
+| `format`           | `"[$symbol$number]($style) "` | The format for the module.                                               |
+| `symbol`           | `"✦"`                         | The string used to represent the `symbol` variable.                      |
+| `style`            | `"bold blue"`                 | The style for the module.                                                |
+| `disabled`         | `false`                       | Disables the `jobs` module.                                              |
+
+*: This option is deprecated, please use the `number_threshold` and `symbol_threshold` options instead.
 
 ### Variables
 
@@ -1808,21 +1809,21 @@ The `localip` module shows the IPv4 address of the primary network interface.
 
 ### Options
 
-| Option     | Default                     | Description                                                                                                                          |
-| ---------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `ssh_only` | `true`                      | Only show IP address when connected to an SSH session.                                                                               |
-| `format`   | `"[$localipv4]($style) "`     | The format for the module.                                                                                                           |
-| `style`    | `"bold yellow"`              | The style for the module.                                                                                                            |
-| `disabled` | `false`                     | Disables the `localip` module.                                                                                                      |
+| Option     | Default                   | Description                                            |
+| ---------- | ------------------------- | ------------------------------------------------------ |
+| `ssh_only` | `true`                    | Only show IP address when connected to an SSH session. |
+| `format`   | `"[$localipv4]($style) "` | The format for the module.                             |
+| `style`    | `"bold yellow"`           | The style for the module.                              |
+| `disabled` | `false`                   | Disables the `localip` module.                         |
 
 ### Variables
 
-| Variable    | Example      | Description                          |
-| --------    | -------      | ------------------------------------ |
-| localipv4 | 192.168.1.13 | Contains the primary IPv4 address    |
-| style\*     |              | Mirrors the value of option `style`  |
+| Variable  | Example      | Description                         |
+| --------- | ------------ | ----------------------------------- |
+| localipv4 | 192.168.1.13 | Contains the primary IPv4 address   |
+| style\*   |              | Mirrors the value of option `style` |
 
-\*: This variable can only be used as a part of a style string
+*: This variable can only be used as a part of a style string
 
 ### Example
 
@@ -1831,7 +1832,7 @@ The `localip` module shows the IPv4 address of the primary network interface.
 
 [localip]
 ssh_only = false
-format =  "@[$localipv4](bold red) "
+format = "@[$localipv4](bold red) "
 disabled = false
 ```
 
@@ -2927,7 +2928,7 @@ set to a number and meets or exceeds the specified threshold.
 | ----------- | ---------------------------- | ------------------------------------------------------------- |
 | `threshold` | `2`                          | Display threshold.                                            |
 | `format`    | `"[$symbol$shlvl]($style) "` | The format for the module.                                    |
-| `symbol`    | `"↕️  "`                     | The symbol used to represent the `SHLVL`.                     |
+| `symbol`    | `"↕️ "`                      | The symbol used to represent the `SHLVL`.                     |
 | `repeat`    | `false`                      | Causes `symbol` to be repeated by the current `SHLVL` amount. |
 | `style`     | `"bold yellow"`              | The style for the module.                                     |
 | `disabled`  | `true`                       | Disables the `shlvl` module.                                  |
@@ -3004,22 +3005,12 @@ This module is not supported on nu shell.
 
 ### Options
 
-| Option                  | Default                                                                       | Description                                             |
-| ----------------------- | ----------------------------------------------------------------------------- | ------------------------------------------------------- |
-| `format`                | `"[$symbol$status]($style) "`                                                 | The format of the module                                |
-| `symbol`                | `"✖"`                                                                         | The symbol displayed on program error                   |
-| `success_symbol`        | `"✔️"`                                                                        | The symbol displayed on program success                 |
-| `not_executable_symbol` | `"🚫"`                                                                         | The symbol displayed when file isn't executable         |
-| `not_found_symbol`      | `"🔍"`                                                                         | The symbol displayed when the command can't be found    |
-| `sigint_symbol`         | `"🧱"`                                                                         | The symbol displayed on SIGINT (Ctrl + c)               |
-| `signal_symbol`         | `"⚡"`                                                                         | The symbol displayed on any signal                      |
-| `style`                 | `"bold red"`                                                                  | The style for the module.                               |
-| `recognize_signal_code` | `true`                                                                        | Enable signal mapping from exit code                    |
-| `map_symbol`            | `false`                                                                       | Enable symbols mapping from exit code                   |
-| `pipestatus`            | `false`                                                                       | Enable pipestatus reporting                             |
-| `pipestatus_separator`  | `                                                                             | `                                                       |
-| `pipestatus_format`     | `\\[$pipestatus\\] => [$symbol$common_meaning$signal_name$maybe_int]($style)` | The format of the module when the command is a pipeline |
-| `disabled`              | `true`                                                                        | Disables the `status` module.                           |
+# | Option | Default | Description || ----------------------- | ----------------------------------------------------------------------------- | ------------------------------------------------------- | --------------------------------------------------- || `format` | `"[$symbol$status]($style) "` | The format of the module || `symbol` | `"✖"` | The symbol displayed on program error || `success_symbol` | `"✔️"` | The symbol displayed on program success || `not_executable_symbol` | `"🚫"` | The symbol displayed when file isn't executable || `not_found_symbol` | `"🔍"` | The symbol displayed when the command can't be found || `sigint_symbol` | `"🧱"` | The symbol displayed on SIGINT (Ctrl + c) || `signal_symbol` | `"⚡"` | The symbol displayed on any signal || `style` | `"bold red"` | The style for the module. || `recognize_signal_code` | `true` | Enable signal mapping from exit code || `map_symbol` | `false` | Enable symbols mapping from exit code || `pipestatus` | `false` | Enable pipestatus reporting |<<<<<<< HEAD| `pipestatus_separator` | `|` |
+
+| `pipestatus_separator` | `|` | The symbol that separate in pipe program exit codes |
+>>>>>>> 7c1ac0c8 (feat(localip): add module to print the current ipv4 address)
+| `pipestatus_format` | `\\[$pipestatus\\] => [$symbol$common_meaning$signal_name$maybe_int]($style)` | The format of the module when the command is a pipeline |
+| `disabled` | `true` | Disables the `status` module. |
 
 ### Variables
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1234,7 +1234,7 @@ This is based on the `~/.config/gcloud/active_config` file and the `~/.config/gc
 | Option           | Default                                                  | Description                                                     |
 | ---------------- | -------------------------------------------------------- | --------------------------------------------------------------- |
 | `format`         | `'on [$symbol$account(@$domain)(\($region\))]($style) '` | The format for the module.                                      |
-| `symbol`         | `"☁️ "`                                                  | The symbol used before displaying the current GCP profile.      |
+| `symbol`         | `"☁️  "`                                                 | The symbol used before displaying the current GCP profile.      |
 | `region_aliases` |                                                          | Table of region aliases to display in addition to the GCP name. |
 | `style`          | `"bold blue"`                                            | The style for the module.                                       |
 | `disabled`       | `false`                                                  | Disables the `gcloud` module.                                   |
@@ -1814,7 +1814,7 @@ The `localip` module shows the IPv4 address of the primary network interface.
 | `ssh_only` | `true`                    | Only show IP address when connected to an SSH session. |
 | `format`   | `"[$localipv4]($style) "` | The format for the module.                             |
 | `style`    | `"bold yellow"`           | The style for the module.                              |
-| `disabled` | `false`                   | Disables the `localip` module.                         |
+| `disabled` | `true`                    | Disables the `localip` module.                         |
 
 ### Variables
 
@@ -2928,7 +2928,7 @@ set to a number and meets or exceeds the specified threshold.
 | ----------- | ---------------------------- | ------------------------------------------------------------- |
 | `threshold` | `2`                          | Display threshold.                                            |
 | `format`    | `"[$symbol$shlvl]($style) "` | The format for the module.                                    |
-| `symbol`    | `"↕️ "`                      | The symbol used to represent the `SHLVL`.                     |
+| `symbol`    | `"↕️  "`                     | The symbol used to represent the `SHLVL`.                     |
 | `repeat`    | `false`                      | Causes `symbol` to be repeated by the current `SHLVL` amount. |
 | `style`     | `"bold yellow"`              | The style for the module.                                     |
 | `disabled`  | `true`                       | Disables the `shlvl` module.                                  |

--- a/src/configs/localip.rs
+++ b/src/configs/localip.rs
@@ -17,7 +17,7 @@ impl<'a> Default for LocalipConfig<'a> {
             ssh_only: true,
             format: "[$localipv4]($style) ",
             style: "yellow bold",
-            disabled: false,
+            disabled: true,
         }
     }
 }

--- a/src/configs/localip.rs
+++ b/src/configs/localip.rs
@@ -15,7 +15,7 @@ impl<'a> Default for LocalipConfig<'a> {
     fn default() -> Self {
         LocalipConfig {
             ssh_only: true,
-            format: "@[$localipv4]($style) ",
+            format: "[$localipv4]($style) ",
             style: "yellow bold",
             disabled: false,
         }

--- a/src/configs/localip.rs
+++ b/src/configs/localip.rs
@@ -15,7 +15,7 @@ impl<'a> Default for LocalipConfig<'a> {
     fn default() -> Self {
         LocalipConfig {
             ssh_only: true,
-            format: "@[$localip]($style)",
+            format: "@[$localipv4]($style) ",
             style: "yellow bold",
             disabled: false,
         }

--- a/src/configs/localip.rs
+++ b/src/configs/localip.rs
@@ -1,0 +1,23 @@
+use crate::config::ModuleConfig;
+
+use serde::Serialize;
+use starship_module_config_derive::ModuleConfig;
+
+#[derive(Clone, ModuleConfig, Serialize)]
+pub struct LocalipConfig<'a> {
+    pub ssh_only: bool,
+    pub format: &'a str,
+    pub style: &'a str,
+    pub disabled: bool,
+}
+
+impl<'a> Default for LocalipConfig<'a> {
+    fn default() -> Self {
+        LocalipConfig {
+            ssh_only: true,
+            format: "@[$localip]($style)",
+            style: "yellow bold",
+            disabled: false,
+        }
+    }
+}

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -40,6 +40,7 @@ pub mod julia;
 pub mod kotlin;
 pub mod kubernetes;
 pub mod line_break;
+pub mod localip;
 pub mod lua;
 pub mod memory_usage;
 pub mod nim;
@@ -122,6 +123,7 @@ pub struct FullConfig<'a> {
     kotlin: kotlin::KotlinConfig<'a>,
     kubernetes: kubernetes::KubernetesConfig<'a>,
     line_break: line_break::LineBreakConfig,
+    localip: localip::LocalipConfig<'a>,
     lua: lua::LuaConfig<'a>,
     memory_usage: memory_usage::MemoryConfig<'a>,
     nim: nim::NimConfig<'a>,
@@ -202,6 +204,7 @@ impl<'a> Default for FullConfig<'a> {
             kotlin: Default::default(),
             kubernetes: Default::default(),
             line_break: Default::default(),
+            localip: Default::default(),
             lua: Default::default(),
             memory_usage: Default::default(),
             nim: Default::default(),

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -20,6 +20,7 @@ pub struct StarshipRootConfig {
 pub const PROMPT_ORDER: &[&str] = &[
     "username",
     "hostname",
+    "localip",
     "shlvl",
     "singularity",
     "kubernetes",

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -20,7 +20,7 @@ pub struct StarshipRootConfig {
 pub const PROMPT_ORDER: &[&str] = &[
     "username",
     "hostname",
-    "localip",
+    "localipv4",
     "shlvl",
     "singularity",
     "kubernetes",

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -20,7 +20,7 @@ pub struct StarshipRootConfig {
 pub const PROMPT_ORDER: &[&str] = &[
     "username",
     "hostname",
-    "localipv4",
+    "localip",
     "shlvl",
     "singularity",
     "kubernetes",

--- a/src/module.rs
+++ b/src/module.rs
@@ -45,6 +45,7 @@ pub const ALL_MODULES: &[&str] = &[
     "kotlin",
     "kubernetes",
     "line_break",
+    "localip",
     "lua",
     "memory_usage",
     "nim",

--- a/src/modules/localip.rs
+++ b/src/modules/localip.rs
@@ -22,7 +22,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         return None;
     }
 
-    let localip = local_ipaddress::get().unwrap();
+    let localip = local_ipaddress::get().unwrap_or_default();
     if localip.is_empty() {
         log::warn!("unable to determine local ipv4 address");
         return None;
@@ -88,7 +88,7 @@ mod tests {
                 ssh_only = false
             })
             .collect();
-        let expected = Some(format!("@{}", style().paint(localip)));
+        let expected = Some(format!("{}", style().paint(localip)));
 
         assert_eq!(expected, actual);
     }
@@ -117,7 +117,7 @@ mod tests {
             })
             .env("SSH_CONNECTION", "something")
             .collect();
-        let expected = Some(format!("@{}", style().paint(localip)));
+        let expected = Some(format!("{}", style().paint(localip)));
 
         assert_eq!(expected, actual);
     }

--- a/src/modules/localip.rs
+++ b/src/modules/localip.rs
@@ -88,7 +88,7 @@ mod tests {
                 ssh_only = false
             })
             .collect();
-        let expected = Some(format!("{}", style().paint(localip)));
+        let expected = Some(format!("{} ", style().paint(localip)));
 
         assert_eq!(expected, actual);
     }
@@ -117,7 +117,7 @@ mod tests {
             })
             .env("SSH_CONNECTION", "something")
             .collect();
-        let expected = Some(format!("{}", style().paint(localip)));
+        let expected = Some(format!("{} ", style().paint(localip)));
 
         assert_eq!(expected, actual);
     }

--- a/src/modules/localip.rs
+++ b/src/modules/localip.rs
@@ -35,7 +35,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 _ => None,
             })
             .map(|variable| match variable {
-                "localip" => Some(Ok(&localip)),
+                "localipv4" => Some(Ok(&localip)),
                 _ => None,
             })
             .parse(None, Some(context))

--- a/src/modules/localip.rs
+++ b/src/modules/localip.rs
@@ -1,0 +1,128 @@
+use super::{Context, Module};
+
+use crate::config::RootModuleConfig;
+use crate::configs::localip::LocalipConfig;
+use crate::formatter::StringFormatter;
+
+/// Creates a module with the ipv4 address of the local machine.
+///
+/// The `local_ipaddress` crate is used to determine the local IP address of your machine.
+/// An accurate and fast way, especially if there are multiple IP addresses available,
+/// is to connect a UDP socket and then reading its local endpoint.
+///
+/// Will display the ip if all of the following criteria are met:
+///     - localip.disabled is absent or false
+///     - localip.ssh_only is false OR the user is currently connected as an SSH session (`$SSH_CONNECTION`)
+pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let mut module = context.new_module("localip");
+    let config: LocalipConfig = LocalipConfig::try_load(module.config);
+
+    let ssh_connection = context.get_env("SSH_CONNECTION");
+    if config.ssh_only && ssh_connection.is_none() {
+        return None;
+    }
+
+    let localip = local_ipaddress::get().unwrap();
+    if localip.is_empty() {
+        log::warn!("unable to determine local ipv4 address");
+        return None;
+    }
+
+    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
+        formatter
+            .map_style(|variable| match variable {
+                "style" => Some(Ok(config.style)),
+                _ => None,
+            })
+            .map(|variable| match variable {
+                "localip" => Some(Ok(&localip)),
+                _ => None,
+            })
+            .parse(None, Some(context))
+    });
+
+    module.set_segments(match parsed {
+        Ok(segments) => segments,
+        Err(error) => {
+            log::warn!("Error in module `localip`:\n{}", error);
+            return None;
+        }
+    });
+
+    Some(module)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::ModuleRenderer;
+    use ansi_term::{Color, Style};
+
+    macro_rules! get_localip {
+        () => {
+            if let Some(localip) = local_ipaddress::get() {
+                localip
+            } else {
+                println!(
+                    "localip was not tested because socket connection failed! \
+                     This could be caused by an unconventional network setup."
+                );
+                return;
+            }
+        };
+    }
+
+    #[test]
+    fn is_ipv4_format() {
+        let localip = get_localip!();
+        assert!(regex::Regex::new(r"^(?:[0-9]{1,3}\.){3}[0-9]{1,3}$")
+            .unwrap()
+            .is_match(&localip));
+    }
+
+    #[test]
+    fn ssh_only_false() {
+        let localip = get_localip!();
+        let actual = ModuleRenderer::new("localip")
+            .config(toml::toml! {
+                [localip]
+                ssh_only = false
+            })
+            .collect();
+        let expected = Some(format!("@{}", style().paint(localip)));
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn no_ssh() {
+        let actual = ModuleRenderer::new("localip")
+            .config(toml::toml! {
+                [localip]
+                ssh_only = true
+            })
+            .collect();
+        let expected = None;
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn ssh() {
+        let localip = get_localip!();
+        let actual = ModuleRenderer::new("localip")
+            .config(toml::toml! {
+                [localip]
+                ssh_only = true
+                trim_at = ""
+            })
+            .env("SSH_CONNECTION", "something")
+            .collect();
+        let expected = Some(format!("@{}", style().paint(localip)));
+
+        assert_eq!(expected, actual);
+    }
+
+    fn style() -> Style {
+        Color::Yellow.bold()
+    }
+}

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -35,6 +35,7 @@ mod julia;
 mod kotlin;
 mod kubernetes;
 mod line_break;
+mod localip;
 mod lua;
 mod memory_usage;
 mod nim;
@@ -121,6 +122,7 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
             "kotlin" => kotlin::module(context),
             "kubernetes" => kubernetes::module(context),
             "line_break" => line_break::module(context),
+            "localip" => localip::module(context),
             "lua" => lua::module(context),
             "memory_usage" => memory_usage::module(context),
             "nim" => nim::module(context),
@@ -212,6 +214,7 @@ pub fn description(module: &str) -> &'static str {
         "kotlin" => "The currently installed version of Kotlin",
         "kubernetes" => "The current Kubernetes context name and, if set, the namespace",
         "line_break" => "Separates the prompt into two lines",
+        "localip" => "The currently assigned ipv4 address",
         "lua" => "The currently installed version of Lua",
         "memory_usage" => "Current system memory and swap usage",
         "nim" => "The currently installed version of Nim",


### PR DESCRIPTION
#### Description
This PR adds support for printing your current ip to the prompt. By default it behaves like the hostname module and is therefore only rendered if an SSH session is present.

The way it obtains the localip is by opening a UDP socket to `8.8.8.8:80` and connecting to it. This is a very fast cross platform way to determine your primary interface's IP address.

#### Motivation and Context
Since I'm using SSH a lot, it is very handy to have the IP of the remote machine always shown. 

#### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1195919/144213092-8c10a909-d8b7-4355-9dae-3263524d9b11.png)

#### How Has This Been Tested?
- [X] I have tested using **MacOS** - _~I don't have a Mac, maybe someone can help out? The Unittests are working though.~_
- [X] I have tested using **Linux**
- [X] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have updated the documentation accordingly.
- [X] I have updated the tests accordingly.
