### PR TITLE
test(hostname): fix `trim_at` test with unicode hostname

### DIFF
--- a/src/modules/hostname.rs
+++ b/src/modules/hostname.rs
@@ -69,6 +69,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 mod tests {
     use crate::test::ModuleRenderer;
     use ansi_term::{Color, Style};
+    use unicode_segmentation::UnicodeSegmentation;
 
     macro_rules! get_hostname {
         () => {
@@ -146,7 +147,9 @@ mod tests {
     #[test]
     fn trim_at() {
         let hostname = get_hostname!();
-        let (remainder, trim_at) = hostname.split_at(1);
+        let mut hostname_iter = hostname.graphemes(true);
+        let remainder = hostname_iter.next().unwrap_or_default();
+        let trim_at = hostname_iter.collect::<String>();
         let actual = ModuleRenderer::new("hostname")
             .config(toml::toml! {
                 [hostname]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR ensures the `trim_at` test handles unicode and does not panic if the chosen position is not a valid character boundary.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
