### PR TITLE
fix: grammar and layout of CN

### DIFF
--- a/docs/zh-CN/guide/README.md
+++ b/docs/zh-CN/guide/README.md
@@ -298,7 +298,7 @@
 
 ## 🤝 贡献
 
-我们一直在寻找贡献者！你都可以参与贡献 ** 不论你的技能如何 **。 如果您希望快速为项目作出贡献，请尝试解决 [good first issue](https://github.com/starship/starship/labels/🌱%20good%20first%20issue)。
+我们一直在寻找贡献者！**不论你的技能如何**你都可以参与贡献。 如果您希望快速为项目作出贡献，请尝试解决 [good first issue](https://github.com/starship/starship/labels/🌱%20good%20first%20issue)。
 
 If you are fluent in a non-English language, we greatly appreciate any help keeping our docs translated and up-to-date in other languages. If you would like to help, translations can be contributed on the [Starship Crowdin](https://translate.starship.rs/).
 


### PR DESCRIPTION
#### Description

There's a grammar error in original text. In Chinese we express in different sequence.

Also, I believe the linter made Markdown syntax wrong which caused wrong highlighted words.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Just help maintain README in my language.
