### PR TITLE
fix: set cwd for command execution

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -38,7 +38,7 @@ pub fn get_command_string_output(command: CommandOutput) -> String {
 /// This function also initialises std{err,out,in} to protect against processes changing the console mode
 pub fn create_command<T: AsRef<OsStr>>(binary_name: T) -> Result<Command> {
     let binary_name = binary_name.as_ref();
-    log::trace!("Creating Command struct with binary name {:?}", binary_name);
+    log::trace!("Creating Command for binary {:?}", binary_name);
 
     let full_path = match which::which(binary_name) {
         Ok(full_path) => {
@@ -85,23 +85,26 @@ pub fn display_command<T: AsRef<OsStr> + Debug, U: AsRef<OsStr> + Debug>(
 }
 
 /// Execute a command and return the output on stdout and stderr if successful
-#[cfg(not(test))]
 pub fn exec_cmd<T: AsRef<OsStr> + Debug, U: AsRef<OsStr> + Debug>(
     cmd: T,
     args: &[U],
     time_limit: Duration,
 ) -> Option<CommandOutput> {
+    log::trace!("Executing command {:?} with args {:?}", cmd, args);
+    #[cfg(test)]
+    if let Some(o) = mock_cmd(&cmd, args) {
+        return o;
+    }
     internal_exec_cmd(cmd, args, time_limit)
 }
 
 #[cfg(test)]
-pub fn exec_cmd<T: AsRef<OsStr> + Debug, U: AsRef<OsStr> + Debug>(
+pub fn mock_cmd<T: AsRef<OsStr> + Debug, U: AsRef<OsStr> + Debug>(
     cmd: T,
     args: &[U],
-    time_limit: Duration,
-) -> Option<CommandOutput> {
+) -> Option<Option<CommandOutput>> {
     let command = display_command(&cmd, args);
-    match command.as_str() {
+    let out = match command.as_str() {
         "cobc -version" => Some(CommandOutput {
             stdout: String::from("\
 cobc (GnuCOBOL) 3.1.2.0
@@ -313,9 +316,9 @@ CMake suite maintained and supported by Kitware (kitware.com/cmake).\n",
             stdout: String::from("22.1.3\n"),
             stderr: String::default(),
         }),
-        // If we don't have a mocked command fall back to executing the command
-        _ => internal_exec_cmd(&cmd, args, time_limit),
-    }
+        _ => return None,
+    };
+    Some(out)
 }
 
 /// Wraps ANSI color escape sequences in the shell-appropriate wrappers.
@@ -376,36 +379,20 @@ fn internal_exec_cmd<T: AsRef<OsStr> + Debug, U: AsRef<OsStr> + Debug>(
     args: &[U],
     time_limit: Duration,
 ) -> Option<CommandOutput> {
-    log::trace!("Executing command {:?} with args {:?}", cmd, args);
+    let mut cmd = create_command(cmd).ok()?;
+    cmd.args(args);
+    exec_timeout(&mut cmd, time_limit)
+}
 
-    let full_path = match which::which(&cmd) {
-        Ok(full_path) => {
-            log::trace!("Using {:?} as {:?}", full_path, cmd);
-            full_path
-        }
-        Err(error) => {
-            log::trace!("Unable to find {:?} in PATH, {:?}", cmd, error);
-            return None;
-        }
-    };
-
+pub fn exec_timeout(cmd: &mut Command, time_limit: Duration) -> Option<CommandOutput> {
     let start = Instant::now();
-
-    #[allow(clippy::disallowed_method)]
-    let process = match Command::new(full_path)
-        .args(args)
-        .stderr(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stdin(Stdio::null())
-        .spawn()
-    {
+    let process = match cmd.spawn() {
         Ok(process) => process,
         Err(error) => {
-            log::info!("Unable to run {:?}, {:?}", cmd, error);
+            log::info!("Unable to run {:?}, {:?}", cmd.get_program(), error);
             return None;
         }
     };
-
     match process.with_output_timeout(time_limit).terminating().wait() {
         Ok(Some(output)) => {
             let stdout_string = match String::from_utf8(output.stdout) {
@@ -441,12 +428,16 @@ fn internal_exec_cmd<T: AsRef<OsStr> + Debug, U: AsRef<OsStr> + Debug>(
             })
         }
         Ok(None) => {
-            log::warn!("Executing command {:?} timed out.", cmd);
+            log::warn!("Executing command {:?} timed out.", cmd.get_program());
             log::warn!("You can set command_timeout in your config to a higher value to allow longer-running commands to keep executing.");
             None
         }
         Err(error) => {
-            log::info!("Executing command {:?} failed by: {:?}", cmd, error);
+            log::info!(
+                "Executing command {:?} failed by: {:?}",
+                cmd.get_program(),
+                error
+            );
             None
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Explicitly set cwd for external commands, because some command outputs may depend on it.

I split up  `utils::exec_cmd` into `exec_timeout` and `mock_cmd` and made `context.exec_cmd` and `utils::exec_cmd` use these new functions and `create_command`.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #2869

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
