### PR TITLE
feat(status): Add hex_status

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2941,6 +2941,7 @@ This module is not supported on elvish and nu shell.
 | Variable                | Example | Description                                                             |
 | ----------------------- | ------- | ----------------------------------------------------------------------- |
 | status                  | `127`   | The exit code of the last command                                       |
+| hex_status              | `0x7F`  | The exit code of the last command in hex                                |
 | int                     | `127`   | The exit code of the last command                                       |
 | common_meaning          | `ERROR` | Meaning of the code if not a signal                                     |
 | signal_number           | `9`     | Signal number corresponding to the exit code, only if signalled         |


### PR DESCRIPTION
#### Description
Add hex_status variable to status module containing the exit code in hex format.

#### Motivation and Context
This is useful on windows because many NTSTATUS codes have high bits set leading to large negative numbers (see below).
Refs: https://github.com/starship/starship/pull/2025

#### Screenshots (if appropriate):
Before:
💥 -1073741510❯
After:
💥 0xC000013A❯

#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
