### PR TITLE
fix(docs): remove superfluous space

### DIFF
--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -27,3 +27,12 @@
 code
   font-family: 'Nerd Font', source-code-pro, Menlo, Monaco, Consolas, "Courier New", monospace;
   overflow-wrap: break-word
+
+@media (prefers-color-scheme: light)
+  :root
+    --languageTextColor: rgba(255,255,255,0.4)
+
+.code-copy
+  position: absolute
+  right: 0
+  bottom: 1px


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description

- Removed superfluous bottom space in code blocks
- Also fixed the indistinguishable color of language text

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
N/A

#### Screenshots (if appropriate):

Before:
![image](https://user-images.githubusercontent.com/44045911/145719892-3d9a559d-3b3b-4bdf-8ab7-ceb9fafa9f18.png)
After:
![image](https://user-images.githubusercontent.com/44045911/145719893-d38cafc1-f1e6-4cb2-8f11-e7315b38c741.png)


#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
