### PR TITLE
fix: Store $? and $LASTEXITCODE first in PowerShell

### DIFF
--- a/src/init/starship.ps1
+++ b/src/init/starship.ps1
@@ -63,15 +63,15 @@ function global:prompt {
         $process.StandardOutput.ReadToEnd();
     }
 
+    $origDollarQuestion = $global:?
+    $origLastExitCode = $global:LASTEXITCODE
+
     # Invoke precmd, if specified
     try {
         if (Test-Path function:Invoke-Starship-PreCommand) {
             Invoke-Starship-PreCommand
         }
     } catch {}
-
-    $origDollarQuestion = $global:?
-    $origLastExitCode = $global:LASTEXITCODE
 
     # @ makes sure the result is an array even if single or no values are returned
     $jobs = @(Get-Job | Where-Object { $_.State -eq 'Running' }).Count


### PR DESCRIPTION
#### Description
These need to be stored before calling any PowerShell function or executable.
Otherwise the values will be overwritten and cannot be properly restored
or passed to starship.

#### Motivation and Context
Fixes: #3315

#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
