### PR TITLE
feat(status): Add os_abort_name

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -4097,18 +4097,19 @@ To enable it, set `disabled` to `false` in your configuration file.
 
 ### Variables
 
-| Variable       | Example | Description                                                                                |
-| -------------- | ------- | ------------------------------------------------------------------------------------------ |
-| status         | `127`   | The exit code of the last command                                                          |
-| hex_status     | `0x7F`  | The exit code of the last command in hex                                                   |
-| int            | `127`   | The exit code of the last command                                                          |
-| common_meaning | `ERROR` | Meaning of the code if not a signal                                                        |
-| signal_number  | `9`     | Signal number corresponding to the exit code, only if signalled                            |
-| signal_name    | `KILL`  | Name of the signal corresponding to the exit code, only if signalled                       |
-| maybe_int      | `7`     | Contains the exit code number when no meaning has been found                               |
-| pipestatus     |         | Rendering of in pipeline programs' exit codes, this is only available in pipestatus_format |
-| symbol         |         | Mirrors the value of option `symbol`                                                       |
-| style\*        |         | Mirrors the value of option `style`                                                        |
+| Variable       | Example          | Description                                                                                                  |
+| -------------- | ---------------- | ------------------------------------------------------------------------------------------------------------ |
+| status         | `127`            | The exit code of the last command                                                                            |
+| hex_status     | `0x7F`           | The exit code of the last command in hex                                                                     |
+| int            | `127`            | The exit code of the last command                                                                            |
+| common_meaning | `ERROR`          | Meaning of the code if not a signal                                                                          |
+| signal_number  | `9`              | Signal number corresponding to the exit code, only if signalled                                              |
+| signal_name    | `KILL`           | Name of the signal corresponding to the exit code, only if signalled                                         |
+| maybe_int      | `7`              | Contains the exit code number when no meaning has been found                                                 |
+| os_abort_name  | `CONTROL_C_EXIT` | Signal name (POSIX) or NTSTATUS name (Windows) if process was aborted by signal / OS, otherwise empty string |
+| pipestatus     |                  | Rendering of in pipeline programs' exit codes, this is only available in pipestatus_format                   |
+| symbol         |                  | Mirrors the value of option `symbol`                                                                         |
+| style\*        |                  | Mirrors the value of option `style`                                                                          |
 
 *: This variable can only be used as a part of a style string
 


### PR DESCRIPTION
#### Description
os_abort_name is non-empty if the process was aborted via signal (POSIX) or was aborted with an NTSTATUS exit code (Windows).

#### Motivation and Context
Refs: https://github.com/starship/starship/pull/2025

Note that this is based on https://github.com/starship/starship/pull/3312

#### Screenshots (if appropriate):
Before:
💥 0xC000013A❯
After:
💥 0xC000013A (CONTROL_C_EXIT)❯

#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
