### PR TITLE
fix(dart): detect version output in stdout with dart 2.15+

### DIFF
--- a/src/modules/dart.rs
+++ b/src/modules/dart.rs
@@ -3,6 +3,7 @@ use super::{Context, Module, RootModuleConfig};
 use crate::configs::dart::DartConfig;
 use crate::formatter::StringFormatter;
 use crate::formatter::VersionFormatter;
+use crate::utils::get_command_string_output;
 
 /// Creates a module with the current Dart version
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
@@ -32,8 +33,9 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             })
             .map(|variable| match variable {
                 "version" => {
+                    let command = context.exec_cmd("dart", &["--version"])?;
                     let dart_version =
-                        parse_dart_version(&context.exec_cmd("dart", &["--version"])?.stderr)?;
+                        parse_dart_version(&get_command_string_output(command))?;
                     VersionFormatter::format_module_version(
                         module.get_name(),
                         &dart_version,

--- a/src/modules/dart.rs
+++ b/src/modules/dart.rs
@@ -34,8 +34,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             .map(|variable| match variable {
                 "version" => {
                     let command = context.exec_cmd("dart", &["--version"])?;
-                    let dart_version =
-                        parse_dart_version(&get_command_string_output(command))?;
+                    let dart_version = parse_dart_version(&get_command_string_output(command))?;
                     VersionFormatter::format_module_version(
                         module.get_name(),
                         &dart_version,

--- a/src/modules/dart.rs
+++ b/src/modules/dart.rs
@@ -72,6 +72,7 @@ fn parse_dart_version(dart_version: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use crate::test::ModuleRenderer;
+    use crate::utils::CommandOutput;
     use ansi_term::Color;
     use std::fs::{self, File};
     use std::io;
@@ -136,6 +137,27 @@ mod tests {
 
         let actual = ModuleRenderer::new("dart").path(dir.path()).collect();
         let expected = Some(format!("via {}", Color::Blue.bold().paint("🎯 v2.8.4 ")));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn detect_version_output_in_stdout() -> io::Result<()> {
+        // after dart 2.15.0, version info output in stdout.
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join("any.dart"))?.sync_all()?;
+
+        let actual = ModuleRenderer::new("dart")
+            .cmd(
+                "dart --version",
+                Some(CommandOutput {
+                    stdout: String::from("Dart SDK version: 2.15.1 (stable) (Tue Dec 14 13:32:21 2021 +0100) on \"linux_x64\""),
+                    stderr: String::default(),
+                }),
+            )
+            .path(dir.path())
+            .collect();
+        let expected = Some(format!("via {}", Color::Blue.bold().paint("🎯 v2.15.1 ")));
         assert_eq!(expected, actual);
         dir.close()
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
flutter 2.8.0 updated with dart 2.15, command `dart --version` will output in stdout.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #3341 

#### Screenshots (if appropriate):
![2021-12-24 16-51-18 的屏幕截图](https://user-images.githubusercontent.com/3883767/147336756-68d6578b-fec6-4125-b489-93347725b209.png)


#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.

