### PR TITLE
perf(rust): additionally check `rustup default` for faster result.

### DIFF
--- a/src/modules/rust.rs
+++ b/src/modules/rust.rs
@@ -75,9 +75,9 @@ fn get_module_version(context: &Context, config: &RustConfig) -> Option<String> 
     // - `rustup show active-toolchain`
     // - `rustup which`
     if let Some(toolchain) = env_rustup_toolchain(context)
-        .or_else(|| execute_rustup_override_list(&context.current_dir))
+        .or_else(|| execute_rustup_override_list(context))
         .or_else(|| find_rust_toolchain_file(context))
-        .or_else(execute_rustup_default)
+        .or_else(|| execute_rustup_default(context))
     {
         match execute_rustup_run_rustc_version(&toolchain) {
             RustupRunRustcVersionOutcome::RustcVersion(rustc_version) => {
@@ -101,25 +101,22 @@ fn env_rustup_toolchain(context: &Context) -> Option<String> {
     Some(val.trim().to_owned())
 }
 
-fn execute_rustup_override_list(cwd: &Path) -> Option<String> {
-    let Output { stdout, .. } = create_command("rustup")
-        .ok()?
-        .args(&["override", "list"])
-        .output()
-        .ok()?;
-    let stdout = String::from_utf8(stdout).ok()?;
-    extract_toolchain_from_rustup_override_list(&stdout, cwd)
+fn execute_rustup_override_list(context: &Context) -> Option<String> {
+    extract_toolchain_from_rustup_override_list(
+        &context.exec_cmd("rustup", &["override", "list"])?.stdout,
+        &context.current_dir,
+    )
 }
 
-fn execute_rustup_default() -> Option<String> {
-    let Output { stdout, .. } = create_command("rustup")
-        .ok()?
-        .args(&["default"])
-        .output()
-        .ok()?;
-    let stdout = String::from_utf8(stdout).ok()?;
-
-    stdout.split_whitespace().next().map(str::to_owned)
+fn execute_rustup_default(context: &Context) -> Option<String> {
+    // `rustup default` output is:
+    //    stable-x86_64-apple-darwin (default)
+    context
+        .exec_cmd("rustup", &["default"])?
+        .stdout
+        .split_whitespace()
+        .next()
+        .map(str::to_owned)
 }
 
 fn extract_toolchain_from_rustup_override_list(stdout: &str, cwd: &Path) -> Option<String> {


### PR DESCRIPTION
#### Description

After checking directory overrides we were directly falling back to the
relatively slow call to `rustc --version`.

Inserting a call to `rustup default` leads to a quicker response when using `rustup`.

The only way to make this even faster would be to try to read
`.rustup/settings.toml`, though [this is not part of the official `rustup`
API](https://rust-lang.github.io/rustup/configuration.html). Also we might safe the second call to `rustup` when we find out it doesn't exist in the first call. 

I'm not sure about the classification (`perf`/`fix`), I'm happy to change it if
needed. Same goes for any other implementation parts, or when I might have
missed something that made `rustup default` give us the wrong result? I checked
<https://github.com/starship/starship/pull/426> and didn't find any reasoning
why we cannot use `rustup default`.

From looking at the current rust-module tests and how command-output mocking is built inside `utils::exec_cmd` I don't see how we can write a clean test of the adaptions (or the untested rest of the rust module). I would propose to leave this as a later task with a more flexible command-output mocking. 

#### Motivation and Context

This should help with (or fix?) #2004.

Fixes #2004

I found myself generally calling `rustup override stable` for any new rust repo because it was faster.

#### screenshots

before:
<img width="556" alt="grafik" src="https://user-images.githubusercontent.com/540890/147475923-7a39769d-a67f-4e25-b7a4-c33ae77bb5d8.png">
 after:
<img width="712" alt="grafik" src="https://user-images.githubusercontent.com/540890/147476338-cbf636f7-b2a8-4d5f-b93b-efa9a7fdeef1.png">

#### How Has This Been Tested?
I did a manual test with mac OS and rustup, and tested if `rustup default` leads to a toolchain install in a fresh debian docker container (it doesn't). 

- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
