### PR TITLE
docs: Fix incorrect variables for hostname module

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1587,10 +1587,10 @@ The `hostname` module shows the system hostname.
 
 ### Variables
 
-| Variable | Example | Description                          |
-| -------- | ------- | ------------------------------------ |
-| symbol   |         | Mirrors the value of option `symbol` |
-| style\*  |         | Mirrors the value of option `style`  |
+| Variable | Example    | Description                          |
+| -------- | ---------- | ------------------------------------ |
+| hostname | `computer` | The hostname of the computer         |
+| style\*  |            | Mirrors the value of option `style`  |
 
 \*: This variable can only be used as a part of a style string
 


### PR DESCRIPTION
#### Description

Fixes the variable docs for hostname, which appear to have been accidentally copied from a language module. Specifically, the `symbol` variable does not exist for hostnames.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
