### PR TITLE
chore(directory): fix typo

### DIFF
--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -327,7 +327,7 @@ fn to_fish_style(pwd_dir_length: usize, dir_string: String, truncated_dir_string
         .join("/")
 }
 
-/// Convert the path seperators in `path` to the OS specific path seperators.
+/// Convert the path separators in `path` to the OS specific path separators.
 fn convert_path_sep(path: &str) -> String {
     return PathBuf::from_slash(path).to_string_lossy().into_owned();
 }


### PR DESCRIPTION

#### Description
Fixed typo.
```
seperators -> separators
```

#### Motivation and Context


#### Screenshots (if appropriate):

#### How Has This Been Tested?


- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:

- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
