### PR TITLE
fix: update continuation prompt to be more minimal

### DIFF
--- a/docs/advanced-config/README.md
+++ b/docs/advanced-config/README.md
@@ -145,7 +145,7 @@ Produces a prompt like the following:
 
 Some shells support a continuation prompt along with the normal prompt. This prompt is rendered instead of the normal prompt when the user has entered an incomplete statement (such as a single left parenthesis or quote).
 
-Starship can set the continuation prompt using the `continuation_prompt` option. The default prompt is `"[•](bright-black)"`.
+Starship can set the continuation prompt using the `continuation_prompt` option. The default prompt is `"[•](bright-black) "`.
 
 Note: `continuation_prompt` should be set to a literal string without any variables.
 

--- a/docs/advanced-config/README.md
+++ b/docs/advanced-config/README.md
@@ -145,7 +145,7 @@ Produces a prompt like the following:
 
 Some shells support a continuation prompt along with the normal prompt. This prompt is rendered instead of the normal prompt when the user has entered an incomplete statement (such as a single left parenthesis or quote).
 
-Starship can set the continuation prompt using the `continuation_prompt` option. The default prompt is `"[❯](bold yellow)"`.
+Starship can set the continuation prompt using the `continuation_prompt` option. The default prompt is `"[•](bright-black)"`.
 
 Note: `continuation_prompt` should be set to a literal string without any variables.
 

--- a/docs/advanced-config/README.md
+++ b/docs/advanced-config/README.md
@@ -145,7 +145,7 @@ Produces a prompt like the following:
 
 Some shells support a continuation prompt along with the normal prompt. This prompt is rendered instead of the normal prompt when the user has entered an incomplete statement (such as a single left parenthesis or quote).
 
-Starship can set the continuation prompt using the `continuation_prompt` option. The default prompt is `"[•](bright-black) "`.
+Starship can set the continuation prompt using the `continuation_prompt` option. The default prompt is `"[∙](bright-black) "`.
 
 Note: `continuation_prompt` should be set to a literal string without any variables.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -524,7 +524,7 @@ mod tests {
 
         let config = toml::toml! {
             untracked.value = "x"
-            modified = { value = "•", style = "red" }
+            modified = { value = "∙", style = "red" }
         };
 
         let mut git_status_config = TestConfig {
@@ -549,7 +549,7 @@ mod tests {
         assert_eq!(
             git_status_config.modified,
             SegmentDisplayConfig {
-                value: "•",
+                value: "∙",
                 style: Color::Red.normal(),
             }
         );

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -159,7 +159,7 @@ impl<'a> Default for FullConfig<'a> {
         Self {
             format: "$all".to_string(),
             right_format: "".to_string(),
-            continuation_prompt: "[∙]](bright-black) ".to_string(),
+            continuation_prompt: "[∙](bright-black) ".to_string(),
             scan_timeout: 30,
             command_timeout: 500,
             add_newline: true,

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -159,7 +159,7 @@ impl<'a> Default for FullConfig<'a> {
         Self {
             format: "$all".to_string(),
             right_format: "".to_string(),
-            continuation_prompt: "[•](bright-black)".to_string(),
+            continuation_prompt: "[•](bright-black) ".to_string(),
             scan_timeout: 30,
             command_timeout: 500,
             add_newline: true,

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -159,7 +159,7 @@ impl<'a> Default for FullConfig<'a> {
         Self {
             format: "$all".to_string(),
             right_format: "".to_string(),
-            continuation_prompt: "[•](bright-black) ".to_string(),
+            continuation_prompt: "[∙]](bright-black) ".to_string(),
             scan_timeout: 30,
             command_timeout: 500,
             add_newline: true,

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -159,7 +159,7 @@ impl<'a> Default for FullConfig<'a> {
         Self {
             format: "$all".to_string(),
             right_format: "".to_string(),
-            continuation_prompt: "[❯](bold yellow)".to_string(),
+            continuation_prompt: "[•](bright-black)".to_string(),
             scan_timeout: 30,
             command_timeout: 500,
             add_newline: true,

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -96,7 +96,7 @@ impl<'a> Default for StarshipRootConfig {
         StarshipRootConfig {
             format: "$all".to_string(),
             right_format: "".to_string(),
-            continuation_prompt: "[•](bright-black) ".to_string(),
+            continuation_prompt: "[∙](bright-black) ".to_string(),
             scan_timeout: 30,
             command_timeout: 500,
             add_newline: true,

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -96,7 +96,7 @@ impl<'a> Default for StarshipRootConfig {
         StarshipRootConfig {
             format: "$all".to_string(),
             right_format: "".to_string(),
-            continuation_prompt: "[❯](bold yellow)".to_string(),
+            continuation_prompt: "[•](bright-black) ".to_string(),
             scan_timeout: 30,
             command_timeout: 500,
             add_newline: true,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

This PR updates the continuation prompt to be a more minimal alternative to the current yellow chevron.

I think the yellow chevron may be a little bold and visually loud for something that I feel is more of an accent than an actionable piece of information. Interested to hear your thoughts @raccog, @chipbuster, @davidkna.

**Changes**
- Replace the chevron with a gray (bright black) bullet
- Add a space after the prompt to better align with the default prompt

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

**Current continuation prompt defaults**
<img width="265" alt="CleanShot 2022-01-01 at 16 56 03@2x" src="https://user-images.githubusercontent.com/4658208/147852179-1cc2cfa9-1640-4e13-87c1-c6f76a94aaee.png">

**Proposed update**
<img width="327" alt="CleanShot 2022-01-01 at 16 57 23@2x" src="https://user-images.githubusercontent.com/4658208/147852210-45c6bfc2-c3b8-47c9-96d2-4b893e42c06f.png">


#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
