### PR TITLE
Changed 'which' to 'command -v' which is more general, and available …

### DIFF
--- a/docs/faq/README.md
+++ b/docs/faq/README.md
@@ -143,5 +143,5 @@ If Starship was installed using the install script, the following command will d
 
 ```sh
 # Locate and delete the starship binary
-sh -c 'rm "$(which starship)"'
+sh -c 'rm "$(command -v starship)"'
 ```

--- a/docs/faq/README.md
+++ b/docs/faq/README.md
@@ -143,5 +143,5 @@ If Starship was installed using the install script, the following command will d
 
 ```sh
 # Locate and delete the starship binary
-sh -c 'rm "$(command -v starship)"'
+sh -c 'rm "$(command -v 'starship')"'
 ```


### PR DESCRIPTION
…on more systems in docs/faq/README.md

<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This changes the shell command for removing the starship binary on UNIX-like systems.
It changes the command `which` to `command -v`.
These two commands do the exact same thing.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This will make sure that starship works on more systems, since the command `which` is not universal, while `command` is.
`command -v` is a part of POSIX and is also a drop-in replacement for `which`.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
