### PR TITLE
feat(elvish): last command status

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -447,7 +447,7 @@ look at [this example](#with-custom-error-shape).
 
 ::: warning
 
-`error_symbol` is not supported on elvish and nu shell.
+`error_symbol` is not supported on nu shell.
 
 :::
 
@@ -2918,7 +2918,7 @@ To enable it, set `disabled` to `false` in your configuration file.
 :::
 
 ::: warning
-This module is not supported on elvish and nu shell.
+This module is not supported on nu shell.
 :::
 
 ### Options

--- a/src/init/starship.elv
+++ b/src/init/starship.elv
@@ -1,17 +1,33 @@
 set-env STARSHIP_SHELL "elvish"
 set-env STARSHIP_SESSION_KEY (::STARSHIP:: session)
 
+# Define Hooks
+var cmd-status-code = 0
+
+fn starship-after-command-hook {|m|
+    var error = $m[error]
+    if (is $error $nil) {
+        set cmd-status-code = 0
+    } else {
+        try {
+            set cmd-status-code = $error[reason][exit-status]
+        } except {
+            # The error is from the built-in commands and they have no status code.
+            set cmd-status-code = 1
+        }
+    }
+}
+
+# Install Hooks
+set edit:after-command = [ $@edit:after-command $starship-after-command-hook~ ]
+
 # Install starship
 set edit:prompt = {
-    # Note:
-    # Elvish does not appear to support exit status codes (--status)
     var cmd-duration = (printf "%.0f" (* $edit:command-duration 1000))
-    ::STARSHIP:: prompt --jobs=$num-bg-jobs --cmd-duration=$cmd-duration
+    ::STARSHIP:: prompt --jobs=$num-bg-jobs --cmd-duration=$cmd-duration --status $cmd-status-code
 }
 
 set edit:rprompt = {
-    # Note:
-    # Elvish does not appear to support exit status codes (--status)
     var cmd-duration = (printf "%.0f" (* $edit:command-duration 1000))
-    ::STARSHIP:: prompt --right --jobs=$num-bg-jobs --cmd-duration=$cmd-duration
+    ::STARSHIP:: prompt --right --jobs=$num-bg-jobs --cmd-duration=$cmd-duration --status $cmd-status-code
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
This PR adds showing last command status in elvish.

Elvish's built-in commands have no status code, but the error passed to `edit:after-command` has a status code when the external command fails.
This PR uses the `edit:after-command` hook and treat the error.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):
Taken on windows, with status package:
![A screenshot for this issue](https://user-images.githubusercontent.com/16546008/148437740-6439961a-a5b0-465f-bd47-a426243c19f0.png)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [X] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
