### PR TITLE
fix(elvish): Reset time for cmd_duration after each prompt

### DIFF
--- a/src/init/starship.elv
+++ b/src/init/starship.elv
@@ -3,6 +3,7 @@ set-env STARSHIP_SESSION_KEY (::STARSHIP:: session)
 
 # Define Hooks
 var cmd-status-code = 0
+var cmd-duration = 0
 
 fn starship-after-command-hook {|m|
     var error = $m[error]
@@ -16,6 +17,7 @@ fn starship-after-command-hook {|m|
             set cmd-status-code = 1
         }
     }
+    set cmd-duration = (printf "%.0f" (* $m[duration] 1000))
 }
 
 # Install Hooks
@@ -23,11 +25,11 @@ set edit:after-command = [ $@edit:after-command $starship-after-command-hook~ ]
 
 # Install starship
 set edit:prompt = {
-    var cmd-duration = (printf "%.0f" (* $edit:command-duration 1000))
     ::STARSHIP:: prompt --jobs=$num-bg-jobs --cmd-duration=$cmd-duration --status $cmd-status-code
+    set cmd-duration = 0
 }
 
 set edit:rprompt = {
-    var cmd-duration = (printf "%.0f" (* $edit:command-duration 1000))
     ::STARSHIP:: prompt --right --jobs=$num-bg-jobs --cmd-duration=$cmd-duration --status $cmd-status-code
+    set cmd-duration = 0
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->
This PR will make the starship reset the time for cmd_duration after each prompt on elvish.

#### Description
<!--- Describe your changes in detail -->
In bash, cmd_duration module shows the duration from the last prompt, but in elvish, it shows the duration from the last command run.
When inserting newline, the behavior in elvish differ from bash.
This PR will fix this.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):
| In bash | In elvish before fix | In elvish after fix |
| -- | -- | -- |
|![behavior in bash](https://user-images.githubusercontent.com/16546008/148952969-0f78e8c4-7000-43d9-a955-22e177855534.png) | ![behavior in elvish before fix](https://user-images.githubusercontent.com/16546008/148953105-2b00e18e-d040-4069-ace8-4b4a259759fc.png) | ![behavior in elvish after fix](https://user-images.githubusercontent.com/16546008/148953336-e9230c1c-2714-406a-bc8d-1203133b5b09.png) |




#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [X] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
