### PR TITLE
fix(pwsh): Avoid polluting the global function namespace

### DIFF
--- a/src/init/starship.ps1
+++ b/src/init/starship.ps1
@@ -132,14 +132,6 @@ $null = New-Module starship {
 
     }
 
-    # Invoke Starship and set continuation prompt
-    Set-PSReadLineOption -ContinuationPrompt (
-        Invoke-Native -Executable ::STARSHIP:: -Arguments @(
-            "prompt",
-            "--continuation"
-        )
-    )
-
     # Disable virtualenv prompt, it breaks starship
     $ENV:VIRTUAL_ENV_DISABLE_PROMPT=1
 
@@ -147,6 +139,14 @@ $null = New-Module starship {
 
     # Set up the session key that will be used to store logs
     $ENV:STARSHIP_SESSION_KEY = -join ((48..57) + (65..90) + (97..122) | Get-Random -Count 16 | ForEach-Object { [char]$_ })
+
+    # Invoke Starship and set continuation prompt
+    Set-PSReadLineOption -ContinuationPrompt (
+        Invoke-Native -Executable ::STARSHIP:: -Arguments @(
+            "prompt",
+            "--continuation"
+        )
+    )
 
     Export-ModuleMember
 }

--- a/src/init/starship.ps1
+++ b/src/init/starship.ps1
@@ -1,153 +1,157 @@
 #!/usr/bin/env pwsh
 
-function Get-Arguments {
-    function Get-Cwd {
-        $cwd = Get-Location
-        $provider_prefix = "$($cwd.Provider.ModuleName)\$($cwd.Provider.Name)::"
-        return @{
-            # Resolve the actual/physical path
-            # NOTE: ProviderPath is only a physical filesystem path for the "FileSystem" provider
-            # E.g. `Dev:\` -> `C:\Users\Joe Bloggs\Dev\`
-            Path = $cwd.ProviderPath;
-            # Resolve the provider-logical path 
-            # NOTE: Attempt to trim any "provider prefix" from the path string.
-            # E.g. `Microsoft.PowerShell.Core\FileSystem::Dev:\` -> `Dev:\`
-            LogicalPath =
-                if ($cwd.Path.StartsWith($provider_prefix)) {
-                    $cwd.Path.Substring($provider_prefix.Length)
-                } else {
-                    $cwd.Path
-                };
+$null = New-Module starship {
+    function Get-Arguments {
+        function Get-Cwd {
+            $cwd = Get-Location
+            $provider_prefix = "$($cwd.Provider.ModuleName)\$($cwd.Provider.Name)::"
+            return @{
+                # Resolve the actual/physical path
+                # NOTE: ProviderPath is only a physical filesystem path for the "FileSystem" provider
+                # E.g. `Dev:\` -> `C:\Users\Joe Bloggs\Dev\`
+                Path = $cwd.ProviderPath;
+                # Resolve the provider-logical path
+                # NOTE: Attempt to trim any "provider prefix" from the path string.
+                # E.g. `Microsoft.PowerShell.Core\FileSystem::Dev:\` -> `Dev:\`
+                LogicalPath =
+                    if ($cwd.Path.StartsWith($provider_prefix)) {
+                        $cwd.Path.Substring($provider_prefix.Length)
+                    } else {
+                        $cwd.Path
+                    };
+            }
         }
+
+        # @ makes sure the result is an array even if single or no values are returned
+        $jobs = @(Get-Job | Where-Object { $_.State -eq 'Running' }).Count
+
+        $cwd = Get-Cwd
+        $arguments = @(
+            "prompt"
+            "--path=$($cwd.Path)",
+            "--logical-path=$($cwd.LogicalPath)",
+            "--terminal-width=$($Host.UI.RawUI.WindowSize.Width)",
+            "--jobs=$($jobs)"
+        )
+
+        # Whe start from the premise that the command executed correctly, which covers also the fresh console.
+        $lastExitCodeForPrompt = 0
+        if ($lastCmd = Get-History -Count 1) {
+            # In case we have a False on the Dollar hook, we know there's an error.
+            if (-not $origDollarQuestion) {
+                # We retrieve the InvocationInfo from the most recent error using $error[0]
+                $lastCmdletError = try { $error[0] |  Where-Object { $_ -ne $null } | Select-Object -ExpandProperty InvocationInfo } catch { $null }
+                # We check if the last command executed matches the line that caused the last error, in which case we know
+                # it was an internal Powershell command, otherwise, there MUST be an error code.
+                $lastExitCodeForPrompt = if ($null -ne $lastCmdletError -and $lastCmd.CommandLine -eq $lastCmdletError.Line) { 1 } else { $origLastExitCode }
+            }
+            $duration = [math]::Round(($lastCmd.EndExecutionTime - $lastCmd.StartExecutionTime).TotalMilliseconds)
+
+            $arguments += "--cmd-duration=$($duration)"
+        }
+
+        $arguments += "--status=$($lastExitCodeForPrompt)"
+
+        return $arguments
     }
 
-    # @ makes sure the result is an array even if single or no values are returned
-    $jobs = @(Get-Job | Where-Object { $_.State -eq 'Running' }).Count
-    
-    $cwd = Get-Cwd
-    $arguments = @(
-        "prompt"
-        "--path=$($cwd.Path)",
-        "--logical-path=$($cwd.LogicalPath)",
-        "--terminal-width=$($Host.UI.RawUI.WindowSize.Width)",
-        "--jobs=$($jobs)"
-    )
-    
-    # Whe start from the premise that the command executed correctly, which covers also the fresh console.
-    $lastExitCodeForPrompt = 0
-    if ($lastCmd = Get-History -Count 1) {
-        # In case we have a False on the Dollar hook, we know there's an error.
-        if (-not $origDollarQuestion) {
-            # We retrieve the InvocationInfo from the most recent error using $error[0]
-            $lastCmdletError = try { $error[0] |  Where-Object { $_ -ne $null } | Select-Object -ExpandProperty InvocationInfo } catch { $null }
-            # We check if the last command executed matches the line that caused the last error, in which case we know
-            # it was an internal Powershell command, otherwise, there MUST be an error code.
-            $lastExitCodeForPrompt = if ($null -ne $lastCmdletError -and $lastCmd.CommandLine -eq $lastCmdletError.Line) { 1 } else { $origLastExitCode }
+    function Invoke-Native {
+        param($Executable, $Arguments)
+        $startInfo = New-Object System.Diagnostics.ProcessStartInfo -ArgumentList $Executable -Property @{
+            StandardOutputEncoding = [System.Text.Encoding]::UTF8;
+            RedirectStandardOutput = $true;
+            RedirectStandardError = $true;
+            CreateNoWindow = $true;
+            UseShellExecute = $false;
+        };
+        if ($startInfo.ArgumentList.Add) {
+            # PowerShell 6+ uses .NET 5+ and supports the ArgumentList property
+            # which bypasses the need for manually escaping the argument list into
+            # a command string.
+            foreach ($arg in $Arguments) {
+                $startInfo.ArgumentList.Add($arg);
+            }
         }
-        $duration = [math]::Round(($lastCmd.EndExecutionTime - $lastCmd.StartExecutionTime).TotalMilliseconds)
-        
-        $arguments += "--cmd-duration=$($duration)"
+        else {
+            # Build an arguments string which follows the C++ command-line argument quoting rules
+            # See: https://docs.microsoft.com/en-us/previous-versions//17w5ykft(v=vs.85)?redirectedfrom=MSDN
+            $escaped = $Arguments | ForEach-Object {
+                $s = $_ -Replace '(\\+)"','$1$1"'; # Escape backslash chains immediately preceding quote marks.
+                $s = $s -Replace '(\\+)$','$1$1';  # Escape backslash chains immediately preceding the end of the string.
+                $s = $s -Replace '"','\"';         # Escape quote marks.
+                "`"$s`""                           # Quote the argument.
+            }
+            $startInfo.Arguments = $escaped -Join ' ';
+        }
+        $process = [System.Diagnostics.Process]::Start($startInfo)
+
+        # stderr isn't displayed with this style of invocation
+        # Manually write it to console
+        $stderr = $process.StandardError.ReadToEnd().Trim()
+        if ($stderr -ne '') {
+            # Write-Error doesn't work here
+            $host.ui.WriteErrorLine($stderr)
+        }
+
+        $process.StandardOutput.ReadToEnd();
     }
 
-    $arguments += "--status=$($lastExitCodeForPrompt)"
+    function global:prompt {
+        $origDollarQuestion = $global:?
+        $origLastExitCode = $global:LASTEXITCODE
 
-	return $arguments
-}
+        # Invoke precmd, if specified
+        try {
+            if (Test-Path function:Invoke-Starship-PreCommand) {
+                Invoke-Starship-PreCommand
+            }
+        } catch {}
 
-function Invoke-Native {
-	param($Executable, $Arguments)
-	$startInfo = New-Object System.Diagnostics.ProcessStartInfo -ArgumentList $Executable -Property @{
-		StandardOutputEncoding = [System.Text.Encoding]::UTF8;
-		RedirectStandardOutput = $true;
-		RedirectStandardError = $true;
-		CreateNoWindow = $true;
-		UseShellExecute = $false;
-	};
-	if ($startInfo.ArgumentList.Add) {
-		# PowerShell 6+ uses .NET 5+ and supports the ArgumentList property
-		# which bypasses the need for manually escaping the argument list into
-		# a command string.
-		foreach ($arg in $Arguments) {
-			$startInfo.ArgumentList.Add($arg);
-		}
-	}
-	else {
-		# Build an arguments string which follows the C++ command-line argument quoting rules
-		# See: https://docs.microsoft.com/en-us/previous-versions//17w5ykft(v=vs.85)?redirectedfrom=MSDN
-		$escaped = $Arguments | ForEach-Object {
-			$s = $_ -Replace '(\\+)"','$1$1"'; # Escape backslash chains immediately preceding quote marks.
-			$s = $s -Replace '(\\+)$','$1$1';  # Escape backslash chains immediately preceding the end of the string.
-			$s = $s -Replace '"','\"';         # Escape quote marks.
-			"`"$s`""                           # Quote the argument.
-		}
-		$startInfo.Arguments = $escaped -Join ' ';
-	}
-	$process = [System.Diagnostics.Process]::Start($startInfo)
+        # Get arguments for starship prompt
+        $arguments = Get-Arguments
 
-	# stderr isn't displayed with this style of invocation
-	# Manually write it to console
-	$stderr = $process.StandardError.ReadToEnd().Trim()
-	if ($stderr -ne '') {
-		# Write-Error doesn't work here
-		$host.ui.WriteErrorLine($stderr)
-	}
+        # Invoke Starship
+        Invoke-Native -Executable ::STARSHIP:: -Arguments $arguments
 
-	$process.StandardOutput.ReadToEnd();
-}
+        # Propagate the original $LASTEXITCODE from before the prompt function was invoked.
+        $global:LASTEXITCODE = $origLastExitCode
 
-function global:prompt {
-    $origDollarQuestion = $global:?
-    $origLastExitCode = $global:LASTEXITCODE
-
-    # Invoke precmd, if specified
-    try {
-        if (Test-Path function:Invoke-Starship-PreCommand) {
-            Invoke-Starship-PreCommand
+        # Propagate the original $? automatic variable value from before the prompt function was invoked.
+        #
+        # $? is a read-only or constant variable so we can't directly override it.
+        # In order to propagate up its original boolean value we will take an action
+        # which will produce the desired value.
+        #
+        # This has to be the very last thing that happens in the prompt function
+        # since every PowerShell command sets the $? variable.
+        if ($global:? -ne $origDollarQuestion) {
+            if ($origDollarQuestion) {
+                 # Simple command which will execute successfully and set $? = True without any other side affects.
+                1+1
+            } else {
+                # Write-Error will set $? to False.
+                # ErrorAction Ignore will prevent the error from being added to the $Error collection.
+                Write-Error '' -ErrorAction 'Ignore'
+            }
         }
-    } catch {}
 
-	# Get arguments for starship prompt
-	$arguments = Get-Arguments
-
-    # Invoke Starship
-    Invoke-Native -Executable ::STARSHIP:: -Arguments $arguments
-
-    # Propagate the original $LASTEXITCODE from before the prompt function was invoked.
-    $global:LASTEXITCODE = $origLastExitCode
-
-    # Propagate the original $? automatic variable value from before the prompt function was invoked.
-    #
-    # $? is a read-only or constant variable so we can't directly override it.
-    # In order to propagate up its original boolean value we will take an action
-    # which will produce the desired value.
-    #
-    # This has to be the very last thing that happens in the prompt function
-    # since every PowerShell command sets the $? variable.
-    if ($global:? -ne $origDollarQuestion) {
-        if ($origDollarQuestion) {
-             # Simple command which will execute successfully and set $? = True without any other side affects.
-            1+1
-        } else {
-            # Write-Error will set $? to False.
-            # ErrorAction Ignore will prevent the error from being added to the $Error collection.
-            Write-Error '' -ErrorAction 'Ignore'
-        }
     }
 
+    # Get arguments for starship continuation prompt
+    $arguments = Get-Arguments
+    $arguments += "--continuation"
+
+    # Invoke Starship and set continuation prompt
+    $continuation = Invoke-Native -Executable ::STARSHIP:: -Arguments $arguments
+    Set-PSReadLineOption -ContinuationPrompt $continuation
+
+    # Disable virtualenv prompt, it breaks starship
+    $ENV:VIRTUAL_ENV_DISABLE_PROMPT=1
+
+    $ENV:STARSHIP_SHELL = "powershell"
+
+    # Set up the session key that will be used to store logs
+    $ENV:STARSHIP_SESSION_KEY = -join ((48..57) + (65..90) + (97..122) | Get-Random -Count 16 | ForEach-Object { [char]$_ })
+
+    Export-ModuleMember
 }
-
-# Get arguments for starship continuation prompt
-$arguments = Get-Arguments
-$arguments += "--continuation"
-
-# Invoke Starship and set continuation prompt
-$continuation = Invoke-Native -Executable ::STARSHIP:: -Arguments $arguments
-Set-PSReadLineOption -ContinuationPrompt $continuation
-
-# Disable virtualenv prompt, it breaks starship
-$ENV:VIRTUAL_ENV_DISABLE_PROMPT=1
-
-$ENV:STARSHIP_SHELL = "powershell"
-
-# Set up the session key that will be used to store logs
-$ENV:STARSHIP_SESSION_KEY = -join ((48..57) + (65..90) + (97..122) | Get-Random -Count 16 | ForEach-Object { [char]$_ })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
This is an alternative to #3386 using `New-Module` to create a new dynamic script module and `Export-ModuleMemeber` to make it not export anything, other than the global prompt function, instead of prefixing the functions.

> #3322 changed the PowerShell init in order to pass the current starship arguments to starship prompt --continuation. This PR reverts these changes and just uses plain &starship prompt --continuation (Invoke-Native isn't really needed there, and the zsh init does not pass along the arguments either) to avoid polluting the global function namespace with Invoke-Native and Get-Arguments. I also moved the continuation prompt code to ensure $STARSHIP_SHELL and $STARSHIP_SESSION_KEY are set beforehand.
> 
> To avoid putting functions into the user scope with common names, this PR prefixes all of these functions with __Starship-. Get-Arguments is removed because it isn't needed for the continuation prompt.

cc @davidkna 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See above.
Closes #3386

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
