### PR TITLE
docs: Fixed starship config location

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -24,7 +24,7 @@ disabled = true
 You can change default configuration file location with `STARSHIP_CONFIG` environment variable:
 
 ```sh
-export STARSHIP_CONFIG=~/.config/starship.toml
+export STARSHIP_CONFIG=~/example/non/default/path/starship.toml
 ```
 
 Equivalently in PowerShell (Windows) would be adding this line to your `$PROFILE`:

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1,9 +1,9 @@
 # Configuration
 
-To get started configuring starship, create the following file: `~/.starship/config.toml`.
+To get started configuring starship, create the following file: `~/.config/starship.toml`.
 
 ```sh
-mkdir -p ~/.starship && touch ~/.starship/config.toml
+mkdir -p ~/.config && touch ~/.config/starship.toml
 ```
 
 All configuration for starship is done in this [TOML](https://github.com/toml-lang/toml) file:
@@ -24,19 +24,19 @@ disabled = true
 You can change default configuration file location with `STARSHIP_CONFIG` environment variable:
 
 ```sh
-export STARSHIP_CONFIG=~/.starship/config.toml
+export STARSHIP_CONFIG=~/.config/starship.toml
 ```
 
 Equivalently in PowerShell (Windows) would be adding this line to your `$PROFILE`:
 
 ```powershell
-$ENV:STARSHIP_CONFIG = "$HOME\.starship\config.toml"
+$ENV:STARSHIP_CONFIG = "$HOME\.config/starship.toml"
 ```
 
 Or for Cmd (Windows) would be adding this line to your `starship.lua`:
 
 ```lua
-os.setenv('STARSHIP_CONFIG', 'C:\\Users\\user\\.starship\\config.toml')
+os.setenv('STARSHIP_CONFIG', 'C:\\Users\\user\\.config\\starship.toml')
 ```
 
 ### Logging

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -30,7 +30,7 @@ export STARSHIP_CONFIG=~/.config/starship.toml
 Equivalently in PowerShell (Windows) would be adding this line to your `$PROFILE`:
 
 ```powershell
-$ENV:STARSHIP_CONFIG = "$HOME\.config/starship.toml"
+$ENV:STARSHIP_CONFIG = "$HOME\example\non\default\path\starship.toml"
 ```
 
 Or for Cmd (Windows) would be adding this line to your `starship.lua`:

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1,9 +1,9 @@
 # Configuration
 
-To get started configuring starship, create the following file: `~/.config/starship.toml`.
+To get started configuring starship, create the following file: `~/.starship/config.toml`.
 
 ```sh
-mkdir -p ~/.config && touch ~/.config/starship.toml
+mkdir -p ~/.starship && touch ~/.starship/config.toml
 ```
 
 All configuration for starship is done in this [TOML](https://github.com/toml-lang/toml) file:

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -36,7 +36,7 @@ $ENV:STARSHIP_CONFIG = "$HOME\.config/starship.toml"
 Or for Cmd (Windows) would be adding this line to your `starship.lua`:
 
 ```lua
-os.setenv('STARSHIP_CONFIG', 'C:\\Users\\user\\.config\\starship.toml')
+os.setenv('STARSHIP_CONFIG', 'C:\\Users\\user\\example\\non\\default\\path\\starship.toml')
 ```
 
 ### Logging


### PR DESCRIPTION

#### Description
config file during creation and when used as export variable into shells are different.
Fixed to make it uniform and avoid errors

#### Motivation and Context
I was installing starship today while reading the documentation for the same.
The configuration file location while creation and when it was exported to shells were different.
[here](https://starship.rs/config/#configuration)  

#### Checklist:
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
