### PR TITLE
ci: Add jobs for `cargo check` with all features and no features

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -88,6 +88,7 @@ jobs:
   # Ensure that the project could be successfully compiled with no features enabled
   cargo_check_no_features:
     name: Compile with no features enabled
+    needs: cargo_check
     runs-on: ubuntu-latest
     steps:
       - name: Setup | Checkout
@@ -109,6 +110,7 @@ jobs:
   # Ensure that the project could be successfully compiled with all features enabled
   cargo_check_all_features:
     name: Compile with all features enabled
+    needs: cargo_check
     runs-on: ubuntu-latest
     steps:
       - name: Setup | Checkout

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -87,7 +87,7 @@ jobs:
 
   # Ensure that the project could be successfully compiled with no features enabled
   cargo_check_no_features:
-    name: Compile
+    name: Compile with no features enabled
     runs-on: ubuntu-latest
     steps:
       - name: Setup | Checkout
@@ -108,7 +108,7 @@ jobs:
 
   # Ensure that the project could be successfully compiled with all features enabled
   cargo_check_all_features:
-    name: Compile
+    name: Compile with all features enabled
     runs-on: ubuntu-latest
     steps:
       - name: Setup | Checkout

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -85,6 +85,48 @@ jobs:
       - name: Build | Check
         run: cargo check --workspace --locked
 
+  # Ensure that the project could be successfully compiled with no features enabled
+  cargo_check_no_features:
+    name: Compile
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup | Checkout
+        uses: actions/checkout@v2.4.0
+
+      - name: Setup | Cache
+        uses: Swatinem/rust-cache@v1
+
+      - name: Setup | Rust
+        uses: actions-rs/toolchain@v1.0.7
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+
+      - name: Build | Check
+        run: cargo check --workspace --locked --no-default-features
+
+  # Ensure that the project could be successfully compiled with all features enabled
+  cargo_check_all_features:
+    name: Compile
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup | Checkout
+        uses: actions/checkout@v2.4.0
+
+      - name: Setup | Cache
+        uses: Swatinem/rust-cache@v1
+
+      - name: Setup | Rust
+        uses: actions-rs/toolchain@v1.0.7
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+
+      - name: Build | Check
+        run: cargo check --workspace --locked --all-features
+
   # Run tests on Linux, macOS, and Windows
   # On both Rust stable and Rust nightly
   test:


### PR DESCRIPTION
#### Description
Augmenting #3435: These jobs will check that compilation still succeeds when no features are selected and with all features selected.

#### Motivation and Context
I was also hit by #3434, and quickly #3435 was added, so I figured this would be useful. The idea would be that, when in the future new features are added, these quick checks can prevent miss-compilation for users that like to tweak with feature sets.

While these CI operations can be run under the same `cargo_check` job, I decided to add two more independent jobs so they run in parallel. I'll be happy to roll them up into the `cargo_check` job if y'all decide it's not worth it.

#### How Has This Been Tested?
```
# This always compiles
$ cargo check --workspace --locked --all-features
# This would not compile before #3435
$ cargo check --workspace --locked --no-default-features
```
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
