### PR TITLE
docs: break installation instructions to collapsable sections 

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,8 +189,6 @@ Install Starship using any of the following package managers:
 
 Install Starship using any of the following package managers:
 
-#### Install via package manager
-
 | Distribution | Repository      | Instructions             |
 | ------------ | --------------- | ------------------------ |
 | **_Any_**    | **[crates.io]** | `cargo install starship` |

--- a/README.md
+++ b/README.md
@@ -424,6 +424,7 @@ This project is [ISC](https://github.com/starship/starship/blob/master/LICENSE) 
 
 [alpine linux packages]: https://pkgs.alpinelinux.org/packages?name=starship
 [arch linux community]: https://archlinux.org/packages/community/x86_64/starship
+[chocolatey]: https://community.chocolatey.org/packages/starship
 [conda-forge]: https://anaconda.org/conda-forge/starship
 [copr]: https://copr.fedorainfracloud.org/coprs/atim/starship
 [crates.io]: https://crates.io/crates/starship
@@ -432,6 +433,7 @@ This project is [ISC](https://github.com/starship/starship/blob/master/LICENSE) 
 [gentoo packages]: https://packages.gentoo.org/packages/app-shells/starship
 [linuxbrew]: https://formulae.brew.sh/formula/starship
 [homebrew]: https://formulae.brew.sh/formula/starship
+[macports]: https://ports.macports.org/port/starship
 [nixpkgs]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/tools/misc/starship/default.nix
 [pkgsrc]: https://pkgsrc.se/shells/starship
 [scoop]: https://github.com/ScoopInstaller/Main/blob/master/bucket/starship.json

--- a/README.md
+++ b/README.md
@@ -189,11 +189,11 @@ Install Starship using any of the following package managers:
 
 Install Starship using any of the following package managers:
 
-| Distribution | Repository      | Instructions             |
-| ------------ | --------------- | ------------------------ |
-| **_Any_**    | **[crates.io]** | `cargo install starship` |
-| FreeBSD      | [FreshPorts]    | `pkg install starship`   |
-| NetBSD       | [pkgsrc]        | `pkgin install starship` |
+| Distribution | Repository      | Instructions                      |
+| ------------ | --------------- | --------------------------------- |
+| **_Any_**    | **[crates.io]** | `cargo install starship --locked` |
+| FreeBSD      | [FreshPorts]    | `pkg install starship`            |
+| NetBSD       | [pkgsrc]        | `pkgin install starship`          |
 
 </details>
 
@@ -210,7 +210,7 @@ Alternatively, install Starship using any of the following package managers:
 
 | Distribution       | Repository              | Instructions                                                  |
 | ------------------ | ----------------------- | ------------------------------------------------------------- |
-| **_Any_**          | **[crates.io]**         | `cargo install starship`                                      |
+| **_Any_**          | **[crates.io]**         | `cargo install starship --locked`                             |
 | _Any_              | [conda-forge]           | `conda install -c conda-forge starship`                       |
 | _Any_              | [Linuxbrew]             | `brew install starship`                                       |
 | Alpine Linux 3.13+ | [Alpine Linux Packages] | `apk add starship`                                            |
@@ -238,7 +238,7 @@ Alternatively, install Starship using any of the following package managers:
 
 | Repository      | Instructions                            |
 | --------------- | --------------------------------------- |
-| **[crates.io]** | `cargo install starship`                |
+| **[crates.io]** | `cargo install starship --locked`       |
 | [conda-forge]   | `conda install -c conda-forge starship` |
 | [Homebrew]      | `brew install starship`                 |
 | [MacPorts]      | `port install starship`                 |
@@ -252,7 +252,7 @@ Install Starship using any of the following package managers:
 
 | Repository      | Instructions                            |
 | --------------- | --------------------------------------- |
-| **[crates.io]** | `cargo install starship`                |
+| **[crates.io]** | `cargo install starship --locked`       |
 | [Chocolatey]    | `choco install starship`                |
 | [conda-forge]   | `conda install -c conda-forge starship` |
 | [Scoop]         | `scoop install starship`                |

--- a/README.md
+++ b/README.md
@@ -406,11 +406,11 @@ If you are interested in helping contribute to starship, please take a look at o
 
 Please check out these previous works that helped inspire the creation of starship. 🙏
 
-- **[denysdovhan/spaceship-prompt](https://github.com/denysdovhan/spaceship-prompt)** - A ZSH prompt for astronauts.
+- **[denysdovhan/spaceship-prompt](https://github.com/denysdovhan/spaceship-prompt)** – A ZSH prompt for astronauts.
 
-- **[denysdovhan/robbyrussell-node](https://github.com/denysdovhan/robbyrussell-node)** - Cross-shell robbyrussell theme written in JavaScript.
+- **[denysdovhan/robbyrussell-node](https://github.com/denysdovhan/robbyrussell-node)** – Cross-shell robbyrussell theme written in JavaScript.
 
-- **[reujab/silver](https://github.com/reujab/silver)** - A cross-shell customizable powerline-like prompt with icons.
+- **[reujab/silver](https://github.com/reujab/silver)** – A cross-shell customizable powerline-like prompt with icons.
 
 <p align="center">
     <br>

--- a/README.md
+++ b/README.md
@@ -174,6 +174,32 @@
 Select your operating system from the list below to view installation instructions:
 
 <details>
+<summary>Android</summary>
+
+Install Starship using any of the following package managers:
+
+| Repository | Instructions           |
+| ---------- | ---------------------- |
+| [Termux]   | `pkg install starship` |
+
+</details>
+
+<details>
+<summary>BSD</summary>
+
+Install Starship using any of the following package managers:
+
+#### Install via package manager
+
+| Distribution | Repository      | Instructions             |
+| ------------ | --------------- | ------------------------ |
+| **_Any_**    | **[crates.io]** | `cargo install starship` |
+| FreeBSD      | [FreshPorts]    | `pkg install starship`   |
+| NetBSD       | [pkgsrc]        | `pkgin install starship` |
+
+</details>
+
+<details>
 <summary>Linux</summary>
 
 Install the latest version for your system:
@@ -235,32 +261,6 @@ Install Starship using any of the following package managers:
 
 </details>
 
-<details>
-<summary>BSD</summary>
-
-Install Starship using any of the following package managers:
-
-#### Install via package manager
-
-| Distribution | Repository      | Instructions             |
-| ------------ | --------------- | ------------------------ |
-| **_Any_**    | **[crates.io]** | `cargo install starship` |
-| FreeBSD      | [FreshPorts]    | `pkg install starship`   |
-| NetBSD       | [pkgsrc]        | `pkgin install starship` |
-
-</details>
-
-<details>
-<summary>Android</summary>
-
-Install Starship using any of the following package managers:
-
-| Repository | Instructions         |
-| ---------- | -------------------- |
-| [Termux]   | `pkg install zoxide` |
-
-</details>
-
 ### Step 2. Setup your shell to use Starship
 
 Configure your shell to initialize starship. Select yours from the list below:
@@ -277,34 +277,37 @@ eval "$(starship init bash)"
 </details>
 
 <details>
+<summary>Cmd</summary>
+
+You need to use [Clink](https://chrisant996.github.io/clink/clink.html) (v1.2.30+) with Cmd.
+Create a file at this path `%LocalAppData%\clink\starship.lua` with the following contents:
+
+```lua
+load(io.popen('starship init cmd'):read("*a"))()
+```
+
+</details>
+
+<details>
+<summary>Elvish</summary>
+
+Add the following to the end of `~/.elvish/rc.elv`:
+
+```sh
+eval (starship init elvish)
+```
+
+Note: Only Elvish v0.17+ is supported
+
+</details>
+
+<details>
 <summary>Fish</summary>
 
 Add the following to the end of `~/.config/fish/config.fish`:
 
 ```fish
 starship init fish | source
-```
-
-</details>
-
-<details>
-<summary>Zsh</summary>
-
-Add the following to the end of `~/.zshrc`:
-
-```sh
-eval "$(starship init zsh)"
-```
-
-</details>
-
-<details>
-<summary>PowerShell</summary>
-
-Add the following to the end of your PowerShell configuration (find it by running `echo $profile`):
-
-```powershell
-Invoke-Expression (&starship init powershell)
 ```
 
 </details>
@@ -321,15 +324,29 @@ eval $(starship init ion)
 </details>
 
 <details>
-<summary>Elvish</summary>
+<summary>Nushell</summary>
 
-Add the following to the end of `~/.elvish/rc.elv`:
+Add the following to the end of your Nushell configuration (find it by running `config path`):
 
-```sh
-eval (starship init elvish)
+```toml
+startup = [
+ "mkdir ~/.cache/starship",
+ "starship init nu | save ~/.cache/starship/init.nu",
+ "source ~/.cache/starship/init.nu"
+]
+prompt = "starship_prompt"
 ```
 
-Note: Only Elvish v0.17+ is supported
+</details>
+
+<details>
+<summary>PowerShell</summary>
+
+Add the following to the end of your PowerShell configuration (find it by running `echo $profile`):
+
+```powershell
+Invoke-Expression (&starship init powershell)
+```
 
 </details>
 
@@ -356,29 +373,12 @@ execx($(starship init xonsh))
 </details>
 
 <details>
-<summary>Cmd</summary>
+<summary>Zsh</summary>
 
-You need to use [Clink](https://chrisant996.github.io/clink/clink.html) (v1.2.30+) with Cmd.
-Create a file at this path `%LocalAppData%\clink\starship.lua` with the following contents:
+Add the following to the end of `~/.zshrc`:
 
-```lua
-load(io.popen('starship init cmd'):read("*a"))()
-```
-
-</details>
-
-<details>
-<summary>Nushell</summary>
-
-Add the following to the end of your Nushell configuration (find it by running `config path`):
-
-```toml
-startup = [
- "mkdir ~/.cache/starship",
- "starship init nu | save ~/.cache/starship/init.nu",
- "source ~/.cache/starship/init.nu"
-]
-prompt = "starship_prompt"
+```sh
+eval "$(starship init zsh)"
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -169,148 +169,217 @@
 
 - A [Nerd Font](https://www.nerdfonts.com/) installed and enabled in your terminal (for example, try the [Fira Code Nerd Font](https://www.nerdfonts.com/font-downloads)).
 
-### Getting Started
+### Step 1. Install Starship
 
-**Note**: due to the proliferation of different platforms, only a subset of supported platforms are
-shown below. Can't see yours? Have a look at the [extra platform instructions](https://starship.rs/installing/).
+Select your operating system from the list below to view installation instructions:
 
-1. Install the **starship** binary:
+<details>
+<summary>Linux</summary>
 
-   #### Install Latest Version
+Install the latest version for your system:
 
-   ##### From prebuilt binary, with Shell:
+```sh
+sh -c "$(curl -fsSL https://starship.rs/install.sh)"
+```
 
-   ```sh
-   sh -c "$(curl -fsSL https://starship.rs/install.sh)"
-   ```
+Alternatively, install Starship using any of the following package managers:
 
-   To update the Starship itself, rerun the above script. It will replace the current version without touching Starship's configuration.
+| Distribution       | Repository              | Instructions                                                  |
+| ------------------ | ----------------------- | ------------------------------------------------------------- |
+| **_Any_**          | **[crates.io]**         | `cargo install starship`                                      |
+| _Any_              | [conda-forge]           | `conda install -c conda-forge starship`                       |
+| _Any_              | [Linuxbrew]             | `brew install starship`                                       |
+| Alpine Linux 3.13+ | [Alpine Linux Packages] | `apk add starship`                                            |
+| Arch Linux         | [Arch Linux Community]  | `pacman -S starship`                                          |
+| CentOS 7+          | [Copr]                  | `dnf copr enable atim/starship` <br /> `dnf install starship` |
+| Fedora 31+         | [Fedora Packages]       | `dnf install starship`                                        |
+| NixOS              | [nixpkgs]               | `nix-env -iA nixos.starship`                                  |
+| Gentoo             | [Gentoo Packages]       | `emerge app-shells/starship`                                  |
+| Manjaro            |                         | `pacman -S starship`                                          |
+| NixOS              | [nixpkgs]               | `nix-env -iA nixpkgs.starship`                                |
+| Void Linux         | [Void Linux Packages]   | `xbps-install -S starship`                                    |
 
-   **Note** - The defaults of the install script can be overridden see the built-in help.
+</details>
 
-   ```sh
-   sh -c "$(curl -fsSL https://starship.rs/install.sh)" -- --help
-   ```
+<details>
+<summary>macOS</summary>
 
-   #### Install via Package Manager
+Install the latest version for your system:
 
-   ##### With [Homebrew](https://brew.sh/):
+```sh
+sh -c "$(curl -fsSL https://starship.rs/install.sh)"
+```
 
-   ```sh
-   brew install starship
-   ```
+Alternatively, install Starship using any of the following package managers:
 
-   ##### With [Scoop](https://scoop.sh):
+| Repository      | Instructions                            |
+| --------------- | --------------------------------------- |
+| **[crates.io]** | `cargo install starship`                |
+| [conda-forge]   | `conda install -c conda-forge starship` |
+| [Homebrew]      | `brew install starship`                 |
+| [MacPorts]      | `port install starship`                 |
 
-   ```powershell
-   scoop install starship
-   ```
+</details>
 
-2. Add the init script to your shell's config file:
+<details>
+<summary>Windows</summary>
 
-   #### Bash
+Install Starship using any of the following package managers:
 
-   Add the following to the end of `~/.bashrc`:
+| Repository      | Instructions                            |
+| --------------- | --------------------------------------- |
+| **[crates.io]** | `cargo install starship`                |
+| [Chocolatey]    | `choco install starship`                |
+| [conda-forge]   | `conda install -c conda-forge starship` |
+| [Scoop]         | `scoop install starship`                |
 
-   ```sh
-   # ~/.bashrc
+</details>
 
-   eval "$(starship init bash)"
-   ```
+<details>
+<summary>BSD</summary>
 
-   #### Fish
+Install Starship using any of the following package managers:
 
-   Add the following to the end of `~/.config/fish/config.fish`:
+#### Install via package manager
 
-   ```sh
-   # ~/.config/fish/config.fish
+| Distribution | Repository      | Instructions             |
+| ------------ | --------------- | ------------------------ |
+| **_Any_**    | **[crates.io]** | `cargo install starship` |
+| FreeBSD      | [FreshPorts]    | `pkg install starship`   |
+| NetBSD       | [pkgsrc]        | `pkgin install starship` |
 
-   starship init fish | source
-   ```
+</details>
 
-   #### Zsh
+<details>
+<summary>Android</summary>
 
-   Add the following to the end of `~/.zshrc`:
+Install Starship using any of the following package managers:
 
-   ```sh
-   # ~/.zshrc
+| Repository | Instructions         |
+| ---------- | -------------------- |
+| [Termux]   | `pkg install zoxide` |
 
-   eval "$(starship init zsh)"
-   ```
+</details>
 
-   #### PowerShell
+### Step 2. Setup your shell to use Starship
 
-   Add the following to the end of `Microsoft.PowerShell_profile.ps1`. You can check the location of this file by querying the `$PROFILE` variable in PowerShell. Typically the path is `~\Documents\PowerShell\Microsoft.PowerShell_profile.ps1` or `~/.config/powershell/Microsoft.PowerShell_profile.ps1` on -Nix.
+<details>
+<summary>Bash</summary>
 
-   ```powershell
-   Invoke-Expression (&starship init powershell)
-   ```
+Add the following to the end of `~/.bashrc`:
 
-   #### Ion
+```sh
+eval "$(starship init bash)"
+```
 
-   Add the following to the end of `~/.config/ion/initrc`:
+</details>
 
-   ```sh
-   # ~/.config/ion/initrc
+<details>
+<summary>Fish</summary>
 
-   eval $(starship init ion)
-   ```
+Add the following to the end of `~/.config/fish/config.fish`:
 
-   #### Elvish
+```fish
+starship init fish | source
+```
 
-   **Warning** Only elvish v0.17 or higher is supported.
-   Add the following to the end of `~/.elvish/rc.elv`:
+</details>
 
-   ```sh
-   # ~/.elvish/rc.elv
+<details>
+<summary>Zsh</summary>
 
-   eval (starship init elvish)
-   ```
+Add the following to the end of `~/.zshrc`:
 
-   #### Tcsh
+```sh
+eval "$(starship init zsh)"
+```
 
-   Add the following to the end of `~/.tcshrc`:
+</details>
 
-   ```sh
-   # ~/.tcshrc
+<details>
+<summary>PowerShell</summary>
 
-   eval `starship init tcsh`
-   ```
+Add the following to the end of your PowerShell configuration (find it by running `echo $profile`):
 
-   #### Xonsh
+```powershell
+Invoke-Expression (&starship init powershell)
+```
 
-   Add the following to the end of `~/.xonshrc`:
+</details>
 
-   ```sh
-   # ~/.xonshrc
+<details>
+<summary>Ion</summary>
 
-   execx($(starship init xonsh))
-   ```
+Add the following to the end of `~/.config/ion/initrc`:
 
-   #### Cmd
+```sh
+eval $(starship init ion)
+```
 
-   You need to use [Clink](https://chrisant996.github.io/clink/clink.html) (v1.2.30+) with Cmd. Add the following to a file `starship.lua` and place this file in Clink scripts directory:
+</details>
 
-   ```lua
-   -- starship.lua
+<details>
+<summary>Elvish</summary>
 
-   load(io.popen('starship init cmd'):read("*a"))()
-   ```
+Add the following to the end of `~/.elvish/rc.elv`:
 
-   #### Nushell
+```sh
+eval (starship init elvish)
+```
 
-   **Warning** This will change in the future. Only nu version v0.33 or higher is supported.
-   Add the following to your nu config file. You can check the location of this
-   file by running `config path` in nu.
+Note: Only Elvish v0.17+ is supported
 
-   ```toml
-   startup = [
-    "mkdir ~/.cache/starship",
-    "starship init nu | save ~/.cache/starship/init.nu",
-    "source ~/.cache/starship/init.nu"
-   ]
-   prompt = "starship_prompt"
-   ```
+</details>
+
+<details>
+<summary>Tcsh</summary>
+
+Add the following to the end of `~/.tcshrc`:
+
+```sh
+eval `starship init tcsh`
+```
+
+</details>
+
+<details>
+<summary>Xonsh</summary>
+
+Add the following to the end of `~/.xonshrc`:
+
+```python
+execx($(starship init xonsh))
+```
+
+</details>
+
+<details>
+<summary>Cmd</summary>
+
+You need to use [Clink](https://chrisant996.github.io/clink/clink.html) (v1.2.30+) with Cmd.
+Create a file at this path `%LocalAppData%\clink\starship.lua` with the following contents:
+
+```lua
+load(io.popen('starship init cmd'):read("*a"))()
+```
+
+</details>
+
+<details>
+<summary>Nushell</summary>
+
+Add the following to the end of your Nushell configuration (find it by running `config path`):
+
+```toml
+startup = [
+ "mkdir ~/.cache/starship",
+ "starship init nu | save ~/.cache/starship/init.nu",
+ "source ~/.cache/starship/init.nu"
+]
+prompt = "starship_prompt"
+```
+
+</details>
 
 ## 🤝 Contributing
 
@@ -339,3 +408,19 @@ Please check out these previous works that helped inspire the creation of starsh
 
 Copyright © 2019-present, [Starship Contributors](https://github.com/starship/starship/graphs/contributors).<br>
 This project is [ISC](https://github.com/starship/starship/blob/master/LICENSE) licensed.
+
+[alpine linux packages]: https://pkgs.alpinelinux.org/packages?name=starship
+[arch linux community]: https://archlinux.org/packages/community/x86_64/starship
+[conda-forge]: https://anaconda.org/conda-forge/starship
+[copr]: https://copr.fedorainfracloud.org/coprs/atim/starship
+[crates.io]: https://crates.io/crates/starship
+[fedora packages]: https://src.fedoraproject.org/rpms/rust-starship
+[freshports]: https://www.freshports.org/shells/starship
+[gentoo packages]: https://packages.gentoo.org/packages/app-shells/starship
+[linuxbrew]: https://formulae.brew.sh/formula/starship
+[homebrew]: https://formulae.brew.sh/formula/starship
+[nixpkgs]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/tools/misc/starship/default.nix
+[pkgsrc]: https://pkgsrc.se/shells/starship
+[scoop]: https://github.com/ScoopInstaller/Main/blob/master/bucket/starship.json
+[termux]: https://github.com/termux/termux-packages/tree/master/packages/starship
+[void linux packages]: https://github.com/void-linux/void-packages/tree/master/srcpkgs/starship

--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ prompt = "starship_prompt"
 <details>
 <summary>PowerShell</summary>
 
-Add the following to the end of your PowerShell configuration (find it by running `echo $profile`):
+Add the following to the end of your PowerShell configuration (find it by running `$PROFILE`):
 
 ```powershell
 Invoke-Expression (&starship init powershell)

--- a/README.md
+++ b/README.md
@@ -263,6 +263,8 @@ Install Starship using any of the following package managers:
 
 ### Step 2. Setup your shell to use Starship
 
+Configure your shell to initialize starship. Select yours from the list below:
+
 <details>
 <summary>Bash</summary>
 
@@ -380,6 +382,17 @@ prompt = "starship_prompt"
 ```
 
 </details>
+
+### Setup 3. Configure Starship
+
+Start a new shell instance, and you should see your beautiful new shell prompt.
+If you're happy with the defaults, enjoy!
+
+If you're looking to further customize Starship:
+
+- **[Configuration](https://starship.rs/config/)** – learn how to configure Starship to tweak your prompt to your liking
+
+- **[Presets](https://starship.rs/presets/)** – get inspired by the pre-built configuration of others
 
 ## 🤝 Contributing
 

--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ prompt = "starship_prompt"
 
 </details>
 
-### Setup 3. Configure Starship
+### Step 3. Configure Starship
 
 Start a new shell instance, and you should see your beautiful new shell prompt.
 If you're happy with the defaults, enjoy!


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

As the number of supported systems and shells has grown, we've had to hand-pick what installation methods would be the "blessed" ones to show on our README. This change changes that to include _all_ installation methods, but hides them each into OS and shell-specific collapsed sections, as is done by the excellent [ajeetdsouza/zoxide](https://github.com/ajeetdsouza/zoxide).

**👉 [Preview the changes here](https://github.com/starship/starship/blob/rework-readme/README.md)**