### PR TITLE
fix(elvish): fix too large status code on Windows

### DIFF
--- a/src/init/starship.elv
+++ b/src/init/starship.elv
@@ -11,6 +11,7 @@ fn starship-after-command-hook {|m|
     } else {
         try {
             set cmd-status-code = $error[reason][exit-status]
+            set cmd-status-code = (- (% (+ $cmd-status-code 0x80000000) 0x100000000) 0x80000000)
         } except {
             # The error is from the built-in commands and they have no status code.
             set cmd-status-code = 1
@@ -24,10 +25,10 @@ set edit:after-command = [ $@edit:after-command $starship-after-command-hook~ ]
 # Install starship
 set edit:prompt = {
     var cmd-duration = (printf "%.0f" (* $edit:command-duration 1000))
-    ::STARSHIP:: prompt --jobs=$num-bg-jobs --cmd-duration=$cmd-duration --status $cmd-status-code
+    ::STARSHIP:: prompt --jobs=$num-bg-jobs --cmd-duration=$cmd-duration --status=$cmd-status-code
 }
 
 set edit:rprompt = {
     var cmd-duration = (printf "%.0f" (* $edit:command-duration 1000))
-    ::STARSHIP:: prompt --right --jobs=$num-bg-jobs --cmd-duration=$cmd-duration --status $cmd-status-code
+    ::STARSHIP:: prompt --right --jobs=$num-bg-jobs --cmd-duration=$cmd-duration --status=$cmd-status-code
 }


### PR DESCRIPTION
This PR will fix too large status code on elvish shell on Windows.

#### Description
The status module parse received string status code as `i32`.
The range of the status code is `i32` in powershell, but it is `u32` in elvish.
On *nix that the status code is from 0 to 255, it does not cause the crash, but on Windows that the NTSTATUS is >= 0xC0000000, it causes crash.
This PR will add rounding status code to `i32`, fix crash, and make the behavior in elvish the same in powershell.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):
| In powershell | In elvish before fix | In elvish after fix |
|-|-|-|
![A screenshot in powershell](https://user-images.githubusercontent.com/16546008/149989038-4c6a8b94-2aea-4440-afe7-70da2d086a1e.png) | ![A screenshot in elvish before fix](https://user-images.githubusercontent.com/16546008/149989036-2e90cab1-0378-4ac4-9d44-93653e9870d1.png) | ![A screenshot in elvish after fix](https://user-images.githubusercontent.com/16546008/149989032-54cbaafa-58c8-46fd-8aa9-5da41abe6dec.png)

```toml
[status]
disabled = false
format = "[$symbol$status $hex_status]($style) "
```

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [X] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
