### PR TITLE
fix(status): Enable to convert from i64 to hex_status by casting instead of parsing status.

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2922,6 +2922,7 @@ format = '[📦 \[$env\]]($style) '
 
 The `status` module displays the exit code of the previous command.
 The module will be shown only if the exit code is not `0`.
+The status code will cast to a signed 32-bit integer.
 
 ::: tip
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -569,7 +569,7 @@ pub enum Target {
 /// Properties as passed on from the shell as arguments
 #[derive(Parser, Debug)]
 pub struct Properties {
-    /// The status code of the previously run command, in unsigned or signed 32bit integer
+    /// The status code of the previously run command as an unsigned or signed 32bit integer
     #[clap(short = 's', long = "status")]
     pub status_code: Option<String>,
     /// Bash, Fish and Zsh support returning codes for each process in a pipeline.

--- a/src/context.rs
+++ b/src/context.rs
@@ -569,7 +569,7 @@ pub enum Target {
 /// Properties as passed on from the shell as arguments
 #[derive(Parser, Debug)]
 pub struct Properties {
-    /// The status code of the previously run command
+    /// The status code of the previously run command, in unsigned or signed 32bit integer
     #[clap(short = 's', long = "status")]
     pub status_code: Option<String>,
     /// Bash, Fish and Zsh support returning codes for each process in a pipeline.

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -122,7 +122,7 @@ impl<'a> ModuleRenderer<'a> {
         self
     }
 
-    pub fn status(mut self, status: i32) -> Self {
+    pub fn status(mut self, status: i64) -> Self {
         self.context.properties.status_code = Some(status.to_string());
         self
     }
@@ -136,7 +136,7 @@ impl<'a> ModuleRenderer<'a> {
         self
     }
 
-    pub fn pipestatus(mut self, status: &[i32]) -> Self {
+    pub fn pipestatus(mut self, status: &[i64]) -> Self {
         self.context.properties.pipestatus = Some(
             status
                 .iter()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->
This PR will enable to convert from i64 to hex_status by casting instead of parsing status.

#### Description
In elvish shell on Windows, the status code is passed as u32, and it can't parse as i32, so `hex_status` is same as `status`.
This PR will replace parsing status to i32 by casting from i64 to i32 and accept this.
The status code out of i32 will be rounded by underflow/overflow.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #
Related #3459

#### Screenshots (if appropriate):
| In powershell | In elvish before fix | In elvish after fix |
|-|-|-|
| ![A screenshot in powershell](https://user-images.githubusercontent.com/16546008/150048679-172e1ffe-8232-41de-8e38-7c89dd29ac1a.png) | ![A screenshot in elvish before fix](https://user-images.githubusercontent.com/16546008/150048683-fe2bbc9d-ede4-428b-86b3-75c6066c938b.png) | ![A screenshot in elvish after fix](https://user-images.githubusercontent.com/16546008/150048682-fa58ca33-2b3f-4a10-b241-a91d0c7cb96f.png) |

```toml
[status]
disabled = false
format = "[$symbol$status $hex_status]($style) "
```

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [X] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [X] I have updated the tests accordingly.
