### PR TITLE
feat(install): Add posix shell check

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -40,6 +40,21 @@ has() {
   command -v "$1" 1>/dev/null 2>&1
 }
 
+# Make sure user is not using zsh or non-POSIX-mode bash, which can cause issues
+check_posix_shell() {
+  if [ -n "${ZSH_VERSION+x}" ]; then
+    error "Running installation script with \`zsh\` is known to cause errors."
+    error "Please use \`sh\` instead."
+    exit 1
+  elif [ -n "${BASH_VERSION+x}" ] && [ -z "${POSIXLY_CORRECT+x}" ]; then
+    error "Running installation script with non-POSIX \`bash\` may cause errors."
+    error "Please use \`sh\` instead."
+    exit 1
+  else
+    true  # No-op: no issues detected
+  fi
+}
+
 # Gets path to a temporary file, even if
 get_tmpfile() {
   suffix="$1"
@@ -398,6 +413,9 @@ fi
 if [ -z "${BASE_URL-}" ]; then
   BASE_URL="https://github.com/starship/starship/releases"
 fi
+
+# Check that the shell is POSIX compliant before continuing to avoid errors
+check_posix_shell
 
 # parse argv variables
 while [ "$#" -gt 0 ]; do

--- a/install/install.sh
+++ b/install/install.sh
@@ -41,7 +41,7 @@ has() {
 }
 
 # Make sure user is not using zsh or non-POSIX-mode bash, which can cause issues
-check_posix_shell() {
+verify_shell_is_posix_or_exit() {
   if [ -n "${ZSH_VERSION+x}" ]; then
     error "Running installation script with \`zsh\` is known to cause errors."
     error "Please use \`sh\` instead."
@@ -370,7 +370,6 @@ print_install() {
   printf "\n"
 }
 
-
 is_build_available() {
   arch="$1"
   platform="$2"
@@ -414,8 +413,8 @@ if [ -z "${BASE_URL-}" ]; then
   BASE_URL="https://github.com/starship/starship/releases"
 fi
 
-# Check that the shell is POSIX compliant before continuing to avoid errors
-check_posix_shell
+# Non-POSIX shells can break once executing code due to semantic differences
+verify_shell_is_posix_or_exit
 
 # parse argv variables
 while [ "$#" -gt 0 ]; do


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
This adds a POSIX check for the most common shells (`bash`, `zsh`) to try to ensure that the shell running the install script is POSIX-compliant

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

We have had at least one (I suspect two) issues recently where running the install script in `zsh` led to errors because of different semantics.

Closes #3468
Closes #3413

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
