### PR TITLE
perf(elvish): Use built-in `randint` instead of `starship session`.

### DIFF
--- a/src/init/starship.elv
+++ b/src/init/starship.elv
@@ -1,5 +1,5 @@
 set-env STARSHIP_SHELL "elvish"
-set-env STARSHIP_SESSION_KEY (::STARSHIP:: session)
+set-env STARSHIP_SESSION_KEY (to-string (randint 10000000000000 10000000000000000))
 
 # Define Hooks
 var cmd-status-code = 0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Use built-in `randint` to create STARSHIP_SESSION_KEY and reduce `starship session` call, like in fish.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [X] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
