### PR TITLE
refactor: Improve compatibility with Zsh prompt theme system

### DIFF
--- a/src/init/starship.zsh
+++ b/src/init/starship.zsh
@@ -23,8 +23,13 @@ else
     }
 fi
 
-# Will be run before every prompt draw
-starship_precmd() {
+
+# The two functions below follow the naming convention `prompt_<theme>_<hook>`
+# for compatibility with Zsh's prompt system. See
+# https://github.com/zsh-users/zsh/blob/2876c25a28b8052d6683027998cc118fc9b50157/Functions/Prompts/promptinit#L155
+
+# Runs before each new command line.
+prompt_starship_precmd() {
     # Save the status, because commands in this pipeline will change $?
     STARSHIP_CMD_STATUS=$? STARSHIP_PIPE_STATUS=(${pipestatus[@]})
 
@@ -41,23 +46,26 @@ starship_precmd() {
     # quotes so we set it here and then use the value later on.
     STARSHIP_JOBS_COUNT=${#jobstates}
 }
-starship_preexec() {
+
+# Runs after the user submits the command line, but before it is executed.
+prompt_starship_preexec() {
     __starship_get_time && STARSHIP_START_TIME=$STARSHIP_CAPTURED_TIME
 }
 
+
 # If precmd/preexec arrays are not already set, set them. If we don't do this,
-# the code to detect whether starship_precmd is already in precmd_functions will
-# fail because the array doesn't exist (and same for starship_preexec)
+# the code to detect whether prompt_starship_precmd is already in precmd_functions will
+# fail because the array doesn't exist (and same for prompt_starship_preexec)
 (( ! ${+precmd_functions} )) && precmd_functions=()
 (( ! ${+preexec_functions} )) && preexec_functions=()
 
 # If starship precmd/preexec functions are already hooked, don't double-hook them
 # to avoid unnecessary performance degradation in nested shells
-if [[ -z ${precmd_functions[(re)starship_precmd]} ]]; then
-    precmd_functions+=(starship_precmd)
+if [[ -z ${precmd_functions[(re)prompt_starship_precmd]} ]]; then
+    precmd_functions+=(prompt_starship_precmd)
 fi
-if [[ -z ${preexec_functions[(re)starship_preexec]} ]]; then
-    preexec_functions+=(starship_preexec)
+if [[ -z ${preexec_functions[(re)prompt_starship_preexec]} ]]; then
+    preexec_functions+=(prompt_starship_preexec)
 fi
 
 # Set up a function to redraw the prompt if the user switches vi modes


### PR DESCRIPTION
Zsh's `promptinit` expects a theme's hook functions to be named `prompt_<theme>_<hook>`. See https://github.com/zsh-users/zsh/blob/2876c25a28b8052d6683027998cc118fc9b50157/Functions/Prompts/promptinit#L155

<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
* Rename `starship_precmd` to `prompt_starship_precmd`.
* Rename `starship_preexec` to `prompt_starship_preexec`.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Adhering to this de facto standard makes it easier for `promptinit` and other Zsh software following these conventions (such as [Znap's `prompt` command](https://github.com/marlonrichert/zsh-snap/issues/163)) to interact correctly with Starship.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

I started Zsh with the new output of `starship init zsh --print-full-init` and it works the same as the old one.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.

This does not cause any changes in documentation or tests.
