### PR TITLE
fix: Allows the use of git worktrees together with sparse-checkout.

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -257,6 +257,10 @@ impl<'a> Context<'a> {
     /// Will lazily get repo root and branch when a module requests it.
     pub fn get_repo(&self) -> Result<&Repo, git2::Error> {
         self.repo.get_or_try_init(|| -> Result<Repo, git2::Error> {
+            // git2 matches the extensions in normalized lowercase versions
+            // In order to support `worktreeConfig` we must provide `worktreeconfig`
+            // SAFETY: OnceCell makes sure that this is called only once and never in parallel
+            unsafe { git2::opts::set_extensions(&["worktreeconfig"]) }?;
             let repository = if env::var("GIT_DIR").is_ok() {
                 Repository::open_from_env()
             } else {

--- a/src/modules/git_branch.rs
+++ b/src/modules/git_branch.rs
@@ -432,6 +432,33 @@ mod tests {
         remote_dir.close()
     }
 
+    #[test]
+    fn test_works_with_worktree_config() -> io::Result<()> {
+        let repo_dir = fixture_repo(FixtureProvider::Git)?;
+
+        create_command("git")?
+            .args(&["worktree", "add", "test"])
+            .current_dir(repo_dir.path())
+            .output()?;
+
+        create_command("git")?
+            .args(&["sparse-checkout", "init"])
+            .current_dir(repo_dir.path().join("test"))
+            .output()?;
+
+        let actual = ModuleRenderer::new("git_branch")
+            .path(&repo_dir.path().join("test"))
+            .collect();
+
+        let expected = Some(format!(
+            "on {} ",
+            Color::Purple.bold().paint(format!("\u{e0a0} {}", "test")),
+        ));
+
+        assert_eq!(expected, actual);
+        repo_dir.close()
+    }
+
     // This test is not possible until we switch to `git status --porcelain`
     // where we can mock the env for the specific git process. This is because
     // git2 does not care about our mocking and when we set the real `GIT_DIR`


### PR DESCRIPTION
Note: This PR requires https://github.com/rust-lang/git2-rs/pull/791
Will update this PR once that one has been merged and released.


<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Calling [git sparse-checkout init](https://git-scm.com/docs/git-sparse-checkout#Documentation/git-sparse-checkout.txt-eminitem) on a [git worktree](https://git-scm.com/docs/git-worktree#_name) will reconfigure the repository to use worktree specific configs.
This is done by enabling the [`worktreeConfig`](https://git-scm.com/docs/git-worktree#_configuration_file) extension.
The default behavior for git2 is to refuse to open any repository with an extension, which in turn disables all git-related features in starship.



#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #3245

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
