### PR TITLE
ci: Fix aws::expiration_date_set_from_file race

### DIFF
--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -554,14 +554,19 @@ expiration={}
                 credentials_path.to_string_lossy().as_ref(),
             )
             .collect();
-        let expected = Some(format!(
-            "on {}",
-            Color::Yellow
-                .bold()
-                .paint("☁️  astronauts (ap-northeast-2) [30m]")
-        ));
 
-        assert_eq!(expected, actual);
+        // In principle, "30m" should be exact However, bad luck in scheduling
+        // on shared runners may delay it. Allow for up to 2 seconds of delay.
+        let possible_values = ["30m", "29m59s", "29m58s"];
+        let possible_values = possible_values.map(|duration| {
+            let segment_colored = format!("☁️  astronauts (ap-northeast-2) [{}]", duration);
+            Some(format!(
+                "on {}",
+                Color::Yellow.bold().paint(segment_colored)
+            ))
+        });
+
+        assert!(possible_values.contains(&actual));
 
         dir.close()
     }

--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -555,7 +555,7 @@ expiration={}
             )
             .collect();
 
-        // In principle, "30m" should be exact However, bad luck in scheduling
+        // In principle, "30m" should be correct. However, bad luck in scheduling
         // on shared runners may delay it. Allow for up to 2 seconds of delay.
         let possible_values = ["30m", "29m59s", "29m58s"];
         let possible_values = possible_values.map(|duration| {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
Adds multiple allowed values to the aws::expiration_date_set_from_file, allowing for up to a two-second delay between when the config file is written and when the module is rendered.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #3377

While `aws::expiration_date_set_from_file` will almost-always work
perfectly locally, it is theoretically possible for the thread running
the test to be scheduled away betwen writing the file with timing
information and then actually reading it, resulting in a
shorter-than-expected time appearing in the module. This can also happen
if the test triggers right at the very end of a second (e.g. at
10:45:47.999995).

This appears to actually happen sometimes on heavily-loaded GitHub
Actions runners. To fix this issue, we allow for up to a two-second
delay between when the file is written and when the test actually fires
(allowing "30m", "29m59s", and "29m58s" as possible values).

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
