### PR TITLE
feat: add container_only config option to hostname.

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1627,7 +1627,7 @@ The `hostname` module shows the system hostname.
 | Option           | Default                     | Description                                                                                                                          |
 | ---------------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
 | `ssh_only`       | `true`                      | Only show hostname when connected to an SSH session.                                                                                 |
-| `container_only` | `false`                     | Only show hostname in a container.
+| `container_only` | `false`                     | Only show hostname in a container.                                                                                                   |
 | `trim_at`        | `"."`                       | String that the hostname is cut off at, after the first match. `"."` will stop after the first dot. `""` will disable any truncation |
 | `format`         | `"[$hostname]($style) in "` | The format for the module.                                                                                                           |
 | `style`          | `"bold dimmed green"`       | The style for the module.                                                                                                            |

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1624,13 +1624,14 @@ The `hostname` module shows the system hostname.
 
 ### Options
 
-| Option     | Default                     | Description                                                                                                                          |
-| ---------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `ssh_only` | `true`                      | Only show hostname when connected to an SSH session.                                                                                 |
-| `trim_at`  | `"."`                       | String that the hostname is cut off at, after the first match. `"."` will stop after the first dot. `""` will disable any truncation |
-| `format`   | `"[$hostname]($style) in "` | The format for the module.                                                                                                           |
-| `style`    | `"bold dimmed green"`       | The style for the module.                                                                                                            |
-| `disabled` | `false`                     | Disables the `hostname` module.                                                                                                      |
+| Option           | Default                     | Description                                                                                                                          |
+| ---------------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `ssh_only`       | `true`                      | Only show hostname when connected to an SSH session.                                                                                 |
+| `container_only` | `false`                     | Only show hostname in a container.
+| `trim_at`        | `"."`                       | String that the hostname is cut off at, after the first match. `"."` will stop after the first dot. `""` will disable any truncation |
+| `format`         | `"[$hostname]($style) in "` | The format for the module.                                                                                                           |
+| `style`          | `"bold dimmed green"`       | The style for the module.                                                                                                            |
+| `disabled`       | `false`                     | Disables the `hostname` module.                                                                                                      |
 
 ### Variables
 

--- a/src/configs/hostname.rs
+++ b/src/configs/hostname.rs
@@ -6,6 +6,7 @@ use starship_module_config_derive::ModuleConfig;
 #[derive(Clone, ModuleConfig, Serialize)]
 pub struct HostnameConfig<'a> {
     pub ssh_only: bool,
+    pub container_only: bool,
     pub trim_at: &'a str,
     pub format: &'a str,
     pub style: &'a str,
@@ -16,6 +17,7 @@ impl<'a> Default for HostnameConfig<'a> {
     fn default() -> Self {
         HostnameConfig {
             ssh_only: true,
+            container_only: false,
             trim_at: ".",
             format: "[$hostname]($style) in ",
             style: "green dimmed bold",

--- a/src/modules/hostname.rs
+++ b/src/modules/hostname.rs
@@ -10,6 +10,7 @@ use crate::formatter::StringFormatter;
 /// Will display the hostname if all of the following criteria are met:
 ///     - hostname.disabled is absent or false
 ///     - hostname.ssh_only is false OR the user is currently connected as an SSH session (`$SSH_CONNECTION`)
+///     - hostname.container_only is false OR the user is not in a containerized session
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let mut module = context.new_module("hostname");
     let config: HostnameConfig = HostnameConfig::try_load(module.config);

--- a/src/modules/hostname.rs
+++ b/src/modules/hostname.rs
@@ -14,6 +14,14 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let mut module = context.new_module("hostname");
     let config: HostnameConfig = HostnameConfig::try_load(module.config);
 
+    use crate::utils::context_path;
+    let podman_env = context_path(context, "/run/.containerenv");
+    let docker_env = context_path(context, "/.dockerenv");
+
+    if config.container_only && !(podman_env.exists() || docker_env.exists()) {
+        return None;
+    }
+
     let ssh_connection = context.get_env("SSH_CONNECTION");
     if config.ssh_only && ssh_connection.is_none() {
         return None;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
I have added `container_only` option to the `hostname` module. It works by checking for `/run/.containerenv` or `/.dockerenv`.


#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I'm sharing my home folder between my host machine and containers and I wanted to easily see the hostname inside my containers without seeing it on the host. Supports podman/docker.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [X] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
