### PR TITLE
feat: add a module for Ansible

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -267,6 +267,10 @@ modules you explicitly add to the format will not be duplicated. Eg.
 format = "$all$directory$character"
 ```
 
+## Ansible
+
+The `ansible` module shows the current Ansible context.
+
 ## AWS
 
 The `aws` module shows the current AWS region and profile. This is based on

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -205,6 +205,7 @@ $git_status\
 $hg_branch\
 $docker_context\
 $package\
+$ansible\
 $cmake\
 $cobol\
 $container\

--- a/docs/presets/README.md
+++ b/docs/presets/README.md
@@ -106,6 +106,9 @@ After:
 ### Configuration
 
 ```toml
+[ansible]
+format = '\[[$symbol($version)]($style)\]'
+
 [aws]
 format = '\[[$symbol($profile)(\($region\))(\[$duration\])]($style)\]'
 
@@ -281,6 +284,9 @@ behind = "<"
 diverged = "<>"
 renamed = "r"
 deleted = "x"
+
+[ansible]
+symbol = "ansible "
 
 [aws]
 symbol = "aws "

--- a/src/configs/ansible.rs
+++ b/src/configs/ansible.rs
@@ -1,0 +1,31 @@
+use crate::config::ModuleConfig;
+
+use serde::Serialize;
+use starship_module_config_derive::ModuleConfig;
+
+#[derive(Clone, ModuleConfig, Serialize)]
+pub struct AnsibleConfig<'a> {
+    pub format: &'a str,
+    pub version_format: &'a str,
+    pub symbol: &'a str,
+    pub style: &'a str,
+    pub disabled: bool,
+    pub detect_extensions: Vec<&'a str>,
+    pub detect_files: Vec<&'a str>,
+    pub detect_folders: Vec<&'a str>,
+}
+
+impl <'a> Default for AnsibleConfig<'a> {
+    fn default() -> Self {
+        AnsibleConfig {
+            format: "via [$symbol($version )]($style) ",
+            version_format: "v${raw}",
+            symbol: "💠 ",
+            style: "bold white",
+            disabled: false,
+            detect_extensions: vec![],
+            detect_files: vec!["ansible.cfg"],
+            detect_folders: vec![],
+        }
+    }
+}

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -3,6 +3,7 @@ use indexmap::IndexMap;
 use serde::{self, Serialize};
 use starship_module_config_derive::ModuleConfig;
 
+pub mod ansible;
 pub mod aws;
 pub mod azure;
 pub mod battery;
@@ -86,6 +87,7 @@ pub struct FullConfig<'a> {
     pub command_timeout: u64,
     pub add_newline: bool,
     // modules
+    ansible: ansible::AnsibleConfig<'a>,
     aws: aws::AwsConfig<'a>,
     azure: azure::AzureConfig<'a>,
     battery: battery::BatteryConfig<'a>,
@@ -166,6 +168,7 @@ impl<'a> Default for FullConfig<'a> {
             command_timeout: 500,
             add_newline: true,
 
+            ansible: Default::default(),
             aws: Default::default(),
             azure: Default::default(),
             battery: Default::default(),

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -35,6 +35,7 @@ pub const PROMPT_ORDER: &[&str] = &[
     "package",
     // ↓ Toolchain version modules ↓
     // (Let's keep these sorted alphabetically)
+    "ansible",
     "cmake",
     "cobol",
     "dart",

--- a/src/module.rs
+++ b/src/module.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 // List of all modules
 // Default ordering is handled in configs/starship_root.rs
 pub const ALL_MODULES: &[&str] = &[
+    "ansible",
     "aws",
     "azure",
     #[cfg(feature = "battery")]

--- a/src/modules/ansible.rs
+++ b/src/modules/ansible.rs
@@ -1,0 +1,79 @@
+use super::{Context, Module, RootModuleConfig};
+use crate::configs::ansible::AnsibleConfig;
+use crate::formatter::{StringFormatter, VersionFormatter};
+
+/// Creates a module with the current Ansible version.
+pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let mut module = context.new_module("ansible");
+    let config = AnsibleConfig::try_load(module.config);
+
+    let is_ansible_project = context
+        .try_begin_scan()?
+        .set_files(&config.detect_files)
+        .set_extensions(&config.detect_extensions)
+        .set_folders(&config.detect_folders)
+        .is_match();
+    
+    if !is_ansible_project {
+        return None;
+    }
+
+    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
+        formatter
+            .map_meta(|var, _| match var {
+                "symbol" => Some(config.symbol),
+                _ => None,
+            })
+            .map_style(|variable| match variable {
+                "style" => Some(Ok(config.style)),
+                _ => None
+            })
+            .map(|variable| match variable {
+                "version" => {
+                    let ansible_version =
+                        parse_ansible_version(&context.exec_cmd("ansible", &["--version"])?.stdout)?;
+                    VersionFormatter::format_module_version(
+                        module.get_name(),
+                        &ansible_version,
+                        config.version_format,
+                    )
+                    .map(Ok)
+                }
+                _ => None,
+            })
+            .parse(None, Some(context))
+    });
+
+    module.set_segments(match parsed {
+        Ok(segments) => segments,
+        Err(error) => {
+            log::warn!("Error in module `ansible`:\n{}", error);
+            return None;
+        }
+    });
+
+    Some(module)
+}
+
+fn parse_ansible_version(ansible_stdout: &str) -> Option<String> {
+    // ansible version output looks like this:
+    // ansible [core X.Y.Z]
+    //   config file = /config/file/ansible.cfg
+    //   configured module search path = /path/to/modules
+    //   ansible python module location = /path/to/ansible/python
+    //   ansible collection location = /path/to/ansible/collections
+    //   executable location = /path/to/ansible
+    //   python version = x.y.z
+    //   jinja version = a.b.c
+    //   libyaml = True
+
+    return Some(
+        ansible_stdout
+            .split_whitespace()
+            .nth(2)
+            .unwrap()
+            .strip_suffix("]")
+            .unwrap()
+            .to_string()
+    );
+}

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -1,4 +1,5 @@
 // While adding out new module add out module to src/module.rs ALL_MODULES const array also.
+mod ansible;
 mod aws;
 mod azure;
 mod character;
@@ -85,6 +86,7 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
         match module {
             // Keep these ordered alphabetically.
             // Default ordering is handled in configs/starship_root.rs
+            "ansible" => ansible::module(context),
             "aws" => aws::module(context),
             "azure" => azure::module(context),
             #[cfg(feature = "battery")]
@@ -174,6 +176,7 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
 
 pub fn description(module: &str) -> &'static str {
     match module {
+        "ansible" => "The current Ansible version",
         "aws" => "The current AWS region and profile",
         "azure" => "The current Azure subscription",
         "battery" => "The current charge of the device's battery and its current charging status",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

This PR introduces a new module for Ansible. Ansible is an open source orchestration tool sponsored by Red Hat and is written in Python. This PR adds a module to the Starship prompt which displays the currently installed Ansible version when an `ansible.cfg` is found in the current directory.

#### Description
<!--- Describe your changes in detail -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I have found a few instances where I am working with Ansible and I think having that information in the prompt provides a nice guide to the user.

#### Screenshots (if appropriate):

Not yet 😅 

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
