### PR TITLE
ci: Change branch detection method for crowdin

### DIFF
--- a/.github/workflows/format-workflow.yml
+++ b/.github/workflows/format-workflow.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Prevent File Change
         uses: xalvarez/prevent-file-change-action@v1.2.0
-        if: ${{ env.GITHUB_HEAD_REF != 'i18n_master' }}
+        if: ${{ github.event.pull_request.head.ref != 'i18n_master' }}
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           pattern: docs/[a-z][a-z][a-z]?-[A-Z][A-Z]?/.*


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
Changes the branch detection method from an envar (which has [known issues](https://github.community/t/github-head-ref-is-inconsistent/185017)) to something API-based.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Hopefully fixes the issue with crowdin  PRs (e.g. #3460) where changes are being inappropriately blocked.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Checked that the appropriate properties exist and appear to match using the Github JSON API--unfortunately, these types of changes can really only be tested in production.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
