### PR TITLE
fix: Remove duplicate space in default symbol for the Gcloud plugin

### DIFF
--- a/src/configs/gcloud.rs
+++ b/src/configs/gcloud.rs
@@ -16,7 +16,7 @@ impl<'a> Default for GcloudConfig<'a> {
     fn default() -> Self {
         GcloudConfig {
             format: "on [$symbol$account(@$domain)(\\($region\\))]($style) ",
-            symbol: "☁️  ",
+            symbol: "☁️ ",
             style: "bold blue",
             disabled: false,
             region_aliases: HashMap::new(),


### PR DESCRIPTION
The default symbol value has an extra space, making it look different than other default configurations.

#### Description

The default symbol value has an extra space, making it look different than other default configurations.

#### Motivation and Context

The default looks mis-aligned and doesn't fit with the other defaults as far as I can tell.  It also doesn't match what the documents claim that it is (cloud icon with a single space).

#### Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/5611490/150865465-61758216-a9ba-416f-8ae4-f4632a1ede6b.png)


#### How Has This Been Tested?

I have not manually built starship, so I have not tested this change directly.  I have tested the corrected symbol by overriding in my toml file, which works as expected.

- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
