### PR TITLE
fix(aws): Only display AWS if there are credentials configured

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -276,8 +276,10 @@ credentials or a `credential_process` have been setup. This is based on
 credentials.
 
 The module will display a profile only if its credentials are present in
-`~/.aws/credentials` or, alternatively, a `credential_process` is defined in
-`~/.aws/config`.
+`~/.aws/credentials` or a `credential_process` is defined in
+`~/.aws/config`. Alternatively, having any of the `AWS_ACCESS_KEY_ID`,
+`AWS_SECRET_ACCESS_KEY`, or `AWS_SESSION_TOKEN` env vars defined will
+also suffice.
 
 When using [aws-vault](https://github.com/99designs/aws-vault) the profile
 is read from the `AWS_VAULT` env var and the credentials expiration date

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -270,10 +270,14 @@ format = "$all$directory$character"
 ## AWS
 
 The `aws` module shows the current AWS region and profile when
-valid credentials or a credential_process have been setup. This is based on
+credentials or a `credential_process` have been setup. This is based on
 `AWS_REGION`, `AWS_DEFAULT_REGION`, and `AWS_PROFILE` env var with
 `~/.aws/config` file. This module also shows an expiration timer when using temporary
 credentials.
+
+The module will display a profile only if its credentials are present in
+`~/.aws/credentials` or, alternatively, a `credential_process` is defined in
+`~/.aws/config`.
 
 When using [aws-vault](https://github.com/99designs/aws-vault) the profile
 is read from the `AWS_VAULT` env var and the credentials expiration date

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -269,7 +269,8 @@ format = "$all$directory$character"
 
 ## AWS
 
-The `aws` module shows the current AWS region and profile. This is based on
+The `aws` module shows the current AWS region and profile when
+valid credentials or a credential_process have been setup. This is based on
 `AWS_REGION`, `AWS_DEFAULT_REGION`, and `AWS_PROFILE` env var with
 `~/.aws/config` file. This module also shows an expiration timer when using temporary
 credentials.

--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -122,6 +122,10 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let mut module = context.new_module("aws");
     let config: AwsConfig = AwsConfig::try_load(module.config);
 
+    if context.get_env("credential_process").is_none() {
+        return None;
+    }
+
     let (aws_profile, aws_region) = get_aws_profile_and_region(context);
     if aws_profile.is_none() && aws_region.is_none() {
         return None;
@@ -193,6 +197,7 @@ mod tests {
     fn region_set() {
         let actual = ModuleRenderer::new("aws")
             .env("AWS_REGION", "ap-northeast-2")
+            .env("credential_process", "/opt/bin/awscreds-custom")
             .collect();
         let expected = Some(format!(
             "on {}",
@@ -206,6 +211,7 @@ mod tests {
     fn region_set_with_alias() {
         let actual = ModuleRenderer::new("aws")
             .env("AWS_REGION", "ap-southeast-2")
+            .env("credential_process", "/opt/bin/awscreds-custom")
             .config(toml::toml! {
                 [aws.region_aliases]
                 ap-southeast-2 = "au"
@@ -221,6 +227,7 @@ mod tests {
         let actual = ModuleRenderer::new("aws")
             .env("AWS_REGION", "ap-northeast-2")
             .env("AWS_DEFAULT_REGION", "ap-northeast-1")
+            .env("credential_process", "/opt/bin/awscreds-custom")
             .collect();
         let expected = Some(format!(
             "on {}",
@@ -234,6 +241,7 @@ mod tests {
     fn profile_set() {
         let actual = ModuleRenderer::new("aws")
             .env("AWS_PROFILE", "astronauts")
+            .env("credential_process", "/opt/bin/awscreds-custom")
             .collect();
         let expected = Some(format!(
             "on {}",
@@ -248,6 +256,7 @@ mod tests {
         let actual = ModuleRenderer::new("aws")
             .env("AWS_VAULT", "astronauts-vault")
             .env("AWS_PROFILE", "astronauts-profile")
+            .env("credential_process", "/opt/bin/awscreds-custom")
             .collect();
         let expected = Some(format!(
             "on {}",
@@ -262,6 +271,7 @@ mod tests {
         let actual = ModuleRenderer::new("aws")
             .env("AWSU_PROFILE", "astronauts-awsu")
             .env("AWS_PROFILE", "astronauts-profile")
+            .env("credential_process", "/opt/bin/awscreds-custom")
             .collect();
         let expected = Some(format!(
             "on {}",
@@ -276,6 +286,7 @@ mod tests {
         let actual = ModuleRenderer::new("aws")
             .env("AWSUME_PROFILE", "astronauts-awsume")
             .env("AWS_PROFILE", "astronauts-profile")
+            .env("credential_process", "/opt/bin/awscreds-custom")
             .collect();
         let expected = Some(format!(
             "on {}",
@@ -290,6 +301,7 @@ mod tests {
         let actual = ModuleRenderer::new("aws")
             .env("AWS_PROFILE", "astronauts")
             .env("AWS_REGION", "ap-northeast-2")
+            .env("credential_process", "/opt/bin/awscreds-custom")
             .collect();
         let expected = Some(format!(
             "on {}",
@@ -344,12 +356,14 @@ region = us-east-1
 
 [profile astronauts]
 region = us-east-2
+credential_process = /opt/bin/awscreds-custom --username monty
 "
             .as_bytes(),
         )?;
 
         let actual = ModuleRenderer::new("aws")
             .env("AWS_CONFIG_FILE", config_path.to_string_lossy().as_ref())
+            .env("credential_process", "/opt/bin/awscreds-custom")
             .collect();
         let expected = Some(format!(
             "on {}",
@@ -379,6 +393,7 @@ region = us-east-2
         let actual = ModuleRenderer::new("aws")
             .env("AWS_CONFIG_FILE", config_path.to_string_lossy().as_ref())
             .env("AWS_PROFILE", "astronauts")
+            .env("credential_process", "/opt/bin/awscreds-custom")
             .config(toml::toml! {
                 [aws]
             })
@@ -397,6 +412,7 @@ region = us-east-2
         let actual = ModuleRenderer::new("aws")
             .env("AWS_PROFILE", "astronauts")
             .env("AWS_REGION", "ap-northeast-1")
+            .env("credential_process", "/opt/bin/awscreds-custom")
             .collect();
         let expected = Some(format!(
             "on {}",
@@ -412,6 +428,7 @@ region = us-east-2
     fn profile_set_with_display_all() {
         let actual = ModuleRenderer::new("aws")
             .env("AWS_PROFILE", "astronauts")
+            .env("credential_process", "/opt/bin/awscreds-custom")
             .collect();
         let expected = Some(format!(
             "on {}",
@@ -425,6 +442,7 @@ region = us-east-2
     fn region_set_with_display_all() {
         let actual = ModuleRenderer::new("aws")
             .env("AWS_REGION", "ap-northeast-1")
+            .env("credential_process", "/opt/bin/awscreds-custom")
             .collect();
         let expected = Some(format!(
             "on {}",
@@ -439,6 +457,7 @@ region = us-east-2
         let actual = ModuleRenderer::new("aws")
             .env("AWS_PROFILE", "astronauts")
             .env("AWS_DEFAULT_REGION", "ap-northeast-1")
+            .env("credential_process", "/opt/bin/awscreds-custom")
             .config(toml::toml! {
                 [aws]
                 format = "on [$symbol$region]($style) "
@@ -457,6 +476,7 @@ region = us-east-2
         let actual = ModuleRenderer::new("aws")
             .env("AWS_PROFILE", "astronauts")
             .env("AWS_REGION", "ap-northeast-1")
+            .env("credential_process", "/opt/bin/awscreds-custom")
             .config(toml::toml! {
                 [aws]
                 format = "on [$symbol$profile]($style) "
@@ -474,6 +494,7 @@ region = us-east-2
     fn region_set_with_display_profile() {
         let actual = ModuleRenderer::new("aws")
             .env("AWS_REGION", "ap-northeast-1")
+            .env("credential_process", "/opt/bin/awscreds-custom")
             .config(toml::toml! {
                 [aws]
                 format = "on [$symbol$profile]($style) "
@@ -500,6 +521,7 @@ region = us-east-2
             })
             .env("AWS_PROFILE", "astronauts")
             .env("AWS_REGION", "ap-northeast-2")
+            .env("credential_process", "/opt/bin/awscreds-custom")
             .env(
                 "AWS_SESSION_EXPIRATION",
                 now_plus_half_hour.to_rfc3339_opts(SecondsFormat::Secs, true),
@@ -549,6 +571,7 @@ expiration={}
             })
             .env("AWS_PROFILE", "astronauts")
             .env("AWS_REGION", "ap-northeast-2")
+            .env("credential_process", "/opt/bin/awscreds-custom")
             .env(
                 "AWS_CREDENTIALS_FILE",
                 credentials_path.to_string_lossy().as_ref(),
@@ -575,6 +598,7 @@ expiration={}
             })
             .env("AWS_PROFILE", "astronauts")
             .env("AWS_REGION", "ap-northeast-2")
+            .env("credential_process", "/opt/bin/awscreds-custom")
             .collect();
         let expected = Some(format!(
             "on {}",
@@ -605,6 +629,7 @@ expiration={}
             })
             .env("AWS_PROFILE", "astronauts")
             .env("AWS_REGION", "ap-northeast-2")
+            .env("credential_process", "/opt/bin/awscreds-custom")
             .env(
                 "AWS_SESSION_EXPIRATION",
                 now.to_rfc3339_opts(SecondsFormat::Secs, true),

--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -119,10 +119,6 @@ fn alias_region(region: String, aliases: &HashMap<String, &str>) -> String {
 }
 
 fn get_credential_process(context: &Context, aws_profile: Option<&Profile>) -> Option<String> {
-    if let Some(cred_proc) = context.get_env("credential_process") {
-        return Some(cred_proc);
-    }
-
     let contents = read_file(get_config_file_path(context)?).ok()?;
 
     let profile_line = if let Some(aws_profile) = aws_profile {
@@ -257,7 +253,7 @@ mod tests {
     fn region_set() {
         let actual = ModuleRenderer::new("aws")
             .env("AWS_REGION", "ap-northeast-2")
-            .env("credential_process", "/opt/bin/awscreds-retriever")
+            .env("AWS_ACCESS_KEY_ID", "dummy")
             .collect();
         let expected = Some(format!(
             "on {}",
@@ -271,7 +267,7 @@ mod tests {
     fn region_set_with_alias() {
         let actual = ModuleRenderer::new("aws")
             .env("AWS_REGION", "ap-southeast-2")
-            .env("credential_process", "/opt/bin/awscreds-retriever")
+            .env("AWS_ACCESS_KEY_ID", "dummy")
             .config(toml::toml! {
                 [aws.region_aliases]
                 ap-southeast-2 = "au"
@@ -287,7 +283,7 @@ mod tests {
         let actual = ModuleRenderer::new("aws")
             .env("AWS_REGION", "ap-northeast-2")
             .env("AWS_DEFAULT_REGION", "ap-northeast-1")
-            .env("credential_process", "/opt/bin/awscreds-retriever")
+            .env("AWS_ACCESS_KEY_ID", "dummy")
             .collect();
         let expected = Some(format!(
             "on {}",
@@ -301,7 +297,7 @@ mod tests {
     fn profile_set() {
         let actual = ModuleRenderer::new("aws")
             .env("AWS_PROFILE", "astronauts")
-            .env("credential_process", "/opt/bin/awscreds-retriever")
+            .env("AWS_ACCESS_KEY_ID", "dummy")
             .collect();
         let expected = Some(format!(
             "on {}",
@@ -316,7 +312,7 @@ mod tests {
         let actual = ModuleRenderer::new("aws")
             .env("AWS_VAULT", "astronauts-vault")
             .env("AWS_PROFILE", "astronauts-profile")
-            .env("credential_process", "/opt/bin/awscreds-retriever")
+            .env("AWS_ACCESS_KEY_ID", "dummy")
             .collect();
         let expected = Some(format!(
             "on {}",
@@ -331,7 +327,7 @@ mod tests {
         let actual = ModuleRenderer::new("aws")
             .env("AWSU_PROFILE", "astronauts-awsu")
             .env("AWS_PROFILE", "astronauts-profile")
-            .env("credential_process", "/opt/bin/awscreds-retriever")
+            .env("AWS_ACCESS_KEY_ID", "dummy")
             .collect();
         let expected = Some(format!(
             "on {}",
@@ -346,7 +342,7 @@ mod tests {
         let actual = ModuleRenderer::new("aws")
             .env("AWSUME_PROFILE", "astronauts-awsume")
             .env("AWS_PROFILE", "astronauts-profile")
-            .env("credential_process", "/opt/bin/awscreds-retriever")
+            .env("AWS_ACCESS_KEY_ID", "dummy")
             .collect();
         let expected = Some(format!(
             "on {}",
@@ -361,7 +357,7 @@ mod tests {
         let actual = ModuleRenderer::new("aws")
             .env("AWS_PROFILE", "astronauts")
             .env("AWS_REGION", "ap-northeast-2")
-            .env("credential_process", "/opt/bin/awscreds-retriever")
+            .env("AWS_ACCESS_KEY_ID", "dummy")
             .collect();
         let expected = Some(format!(
             "on {}",
@@ -471,7 +467,7 @@ credential_process = /opt/bin/awscreds-retriever
         let actual = ModuleRenderer::new("aws")
             .env("AWS_PROFILE", "astronauts")
             .env("AWS_REGION", "ap-northeast-1")
-            .env("credential_process", "/opt/bin/awscreds-retriever")
+            .env("AWS_ACCESS_KEY_ID", "dummy")
             .collect();
         let expected = Some(format!(
             "on {}",
@@ -487,7 +483,7 @@ credential_process = /opt/bin/awscreds-retriever
     fn profile_set_with_display_all() {
         let actual = ModuleRenderer::new("aws")
             .env("AWS_PROFILE", "astronauts")
-            .env("credential_process", "/opt/bin/awscreds-retriever")
+            .env("AWS_ACCESS_KEY_ID", "dummy")
             .collect();
         let expected = Some(format!(
             "on {}",
@@ -501,7 +497,7 @@ credential_process = /opt/bin/awscreds-retriever
     fn region_set_with_display_all() {
         let actual = ModuleRenderer::new("aws")
             .env("AWS_REGION", "ap-northeast-1")
-            .env("credential_process", "/opt/bin/awscreds-retriever")
+            .env("AWS_ACCESS_KEY_ID", "dummy")
             .collect();
         let expected = Some(format!(
             "on {}",
@@ -516,7 +512,7 @@ credential_process = /opt/bin/awscreds-retriever
         let actual = ModuleRenderer::new("aws")
             .env("AWS_PROFILE", "astronauts")
             .env("AWS_DEFAULT_REGION", "ap-northeast-1")
-            .env("credential_process", "/opt/bin/awscreds-retriever")
+            .env("AWS_ACCESS_KEY_ID", "dummy")
             .config(toml::toml! {
                 [aws]
                 format = "on [$symbol$region]($style) "
@@ -535,7 +531,7 @@ credential_process = /opt/bin/awscreds-retriever
         let actual = ModuleRenderer::new("aws")
             .env("AWS_PROFILE", "astronauts")
             .env("AWS_REGION", "ap-northeast-1")
-            .env("credential_process", "/opt/bin/awscreds-retriever")
+            .env("AWS_ACCESS_KEY_ID", "dummy")
             .config(toml::toml! {
                 [aws]
                 format = "on [$symbol$profile]($style) "
@@ -553,7 +549,7 @@ credential_process = /opt/bin/awscreds-retriever
     fn region_set_with_display_profile() {
         let actual = ModuleRenderer::new("aws")
             .env("AWS_REGION", "ap-northeast-1")
-            .env("credential_process", "/opt/bin/awscreds-retriever")
+            .env("AWS_ACCESS_KEY_ID", "dummy")
             .config(toml::toml! {
                 [aws]
                 format = "on [$symbol$profile]($style) "
@@ -580,7 +576,7 @@ credential_process = /opt/bin/awscreds-retriever
             })
             .env("AWS_PROFILE", "astronauts")
             .env("AWS_REGION", "ap-northeast-2")
-            .env("credential_process", "/opt/bin/awscreds-retriever")
+            .env("AWS_ACCESS_KEY_ID", "dummy")
             .env(
                 "AWS_SESSION_EXPIRATION",
                 now_plus_half_hour.to_rfc3339_opts(SecondsFormat::Secs, true),
@@ -661,7 +657,7 @@ expiration={}
             })
             .env("AWS_PROFILE", "astronauts")
             .env("AWS_REGION", "ap-northeast-2")
-            .env("credential_process", "/opt/bin/awscreds-retriever")
+            .env("AWS_ACCESS_KEY_ID", "dummy")
             .collect();
         let expected = Some(format!(
             "on {}",
@@ -692,7 +688,7 @@ expiration={}
             })
             .env("AWS_PROFILE", "astronauts")
             .env("AWS_REGION", "ap-northeast-2")
-            .env("credential_process", "/opt/bin/awscreds-retriever")
+            .env("AWS_ACCESS_KEY_ID", "dummy")
             .env(
                 "AWS_SESSION_EXPIRATION",
                 now.to_rfc3339_opts(SecondsFormat::Secs, true),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Adds guard, and relevant tests to only display AWS data if either a credential_process is defined in `.aws/config` or there are valid credentials for the same profile in `.aws/credentials`.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #3457
Closes #2184
Closes #2871
Closes #2461

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I've tested these changes on WSL2 (Ubuntu 18.04 and 20.04)
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.

I'm not sure if this change requires the documentation to be updated.
If so, please let me know where I should change it.