### PR TITLE
feat(cmd_duration): Make notification timeout configurable

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -597,16 +597,16 @@ running `eval $(starship init $0)`, and then proceed as normal.
 
 ### Options
 
-| Option                 | Default                       | Description                                                                                          |
-| ---------------------- | ----------------------------- | ---------------------------------------------------------------------------------------------------- |
-| `min_time`             | `2_000`                       | Shortest duration to show time for (in milliseconds).                                                |
-| `show_milliseconds`    | `false`                       | Show milliseconds in addition to seconds for the duration.                                           |
-| `format`               | `"took [$duration]($style) "` | The format for the module.                                                                           |
-| `style`                | `"bold yellow"`               | The style for the module.                                                                            |
-| `disabled`             | `false`                       | Disables the `cmd_duration` module.                                                                  |
-| `show_notifications`   | `false`                       | Show desktop notifications when command completes.                                                   |
-| `min_time_to_notify`   | `45_000`                      | Shortest duration for notification (in milliseconds).                                                |
-| `notification_timeout` | `750`                         | Duration to show notification for (in milliseconds). Not all notification daemons honor this option. |
+| Option                 | Default                       | Description                                                                                                                                                       |
+| ---------------------- | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `min_time`             | `2_000`                       | Shortest duration to show time for (in milliseconds).                                                                                                             |
+| `show_milliseconds`    | `false`                       | Show milliseconds in addition to seconds for the duration.                                                                                                        |
+| `format`               | `"took [$duration]($style) "` | The format for the module.                                                                                                                                        |
+| `style`                | `"bold yellow"`               | The style for the module.                                                                                                                                         |
+| `disabled`             | `false`                       | Disables the `cmd_duration` module.                                                                                                                               |
+| `show_notifications`   | `false`                       | Show desktop notifications when command completes.                                                                                                                |
+| `min_time_to_notify`   | `45_000`                      | Shortest duration for notification (in milliseconds).                                                                                                             |
+| `notification_timeout` | Unset                         | Duration to show notification for (in milliseconds). If unset, notification timeout will be determined by daemon. Not all notification daemons honor this option. |
 
 ::: tip
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -606,7 +606,7 @@ running `eval $(starship init $0)`, and then proceed as normal.
 | `disabled`             | `false`                       | Disables the `cmd_duration` module.                                                                                                                               |
 | `show_notifications`   | `false`                       | Show desktop notifications when command completes.                                                                                                                |
 | `min_time_to_notify`   | `45_000`                      | Shortest duration for notification (in milliseconds).                                                                                                             |
-| `notification_timeout` | Unset                         | Duration to show notification for (in milliseconds). If unset, notification timeout will be determined by daemon. Not all notification daemons honor this option. |
+| `notification_timeout` |                               | Duration to show notification for (in milliseconds). If unset, notification timeout will be determined by daemon. Not all notification daemons honor this option. |
 
 ::: tip
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -597,16 +597,16 @@ running `eval $(starship init $0)`, and then proceed as normal.
 
 ### Options
 
-| Option                 | Default                       | Description                                                |
-| ---------------------- | ----------------------------- | ---------------------------------------------------------- |
-| `min_time`             | `2_000`                       | Shortest duration to show time for (in milliseconds).      |
-| `show_milliseconds`    | `false`                       | Show milliseconds in addition to seconds for the duration. |
-| `format`               | `"took [$duration]($style) "` | The format for the module.                                 |
-| `style`                | `"bold yellow"`               | The style for the module.                                  |
-| `disabled`             | `false`                       | Disables the `cmd_duration` module.                        |
-| `show_notifications`   | `false`                       | Show desktop notifications when command completes.         |
-| `min_time_to_notify`   | `45_000`                      | Shortest duration for notification (in milliseconds).      |
-| `notification_timeout` | `750`                         | Duration to show notification for (in milliseconds).       |
+| Option                 | Default                       | Description                                                                                          |
+| ---------------------- | ----------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `min_time`             | `2_000`                       | Shortest duration to show time for (in milliseconds).                                                |
+| `show_milliseconds`    | `false`                       | Show milliseconds in addition to seconds for the duration.                                           |
+| `format`               | `"took [$duration]($style) "` | The format for the module.                                                                           |
+| `style`                | `"bold yellow"`               | The style for the module.                                                                            |
+| `disabled`             | `false`                       | Disables the `cmd_duration` module.                                                                  |
+| `show_notifications`   | `false`                       | Show desktop notifications when command completes.                                                   |
+| `min_time_to_notify`   | `45_000`                      | Shortest duration for notification (in milliseconds).                                                |
+| `notification_timeout` | `750`                         | Duration to show notification for (in milliseconds). Not all notification daemons honor this option. |
 
 ::: tip
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -597,15 +597,16 @@ running `eval $(starship init $0)`, and then proceed as normal.
 
 ### Options
 
-| Option               | Default                       | Description                                                |
-| -------------------- | ----------------------------- | ---------------------------------------------------------- |
-| `min_time`           | `2_000`                       | Shortest duration to show time for (in milliseconds).      |
-| `show_milliseconds`  | `false`                       | Show milliseconds in addition to seconds for the duration. |
-| `format`             | `"took [$duration]($style) "` | The format for the module.                                 |
-| `style`              | `"bold yellow"`               | The style for the module.                                  |
-| `disabled`           | `false`                       | Disables the `cmd_duration` module.                        |
-| `show_notifications` | `false`                       | Show desktop notifications when command completes.         |
-| `min_time_to_notify` | `45_000`                      | Shortest duration for notification (in milliseconds).      |
+| Option                 | Default                       | Description                                                |
+| ---------------------- | ----------------------------- | ---------------------------------------------------------- |
+| `min_time`             | `2_000`                       | Shortest duration to show time for (in milliseconds).      |
+| `show_milliseconds`    | `false`                       | Show milliseconds in addition to seconds for the duration. |
+| `format`               | `"took [$duration]($style) "` | The format for the module.                                 |
+| `style`                | `"bold yellow"`               | The style for the module.                                  |
+| `disabled`             | `false`                       | Disables the `cmd_duration` module.                        |
+| `show_notifications`   | `false`                       | Show desktop notifications when command completes.         |
+| `min_time_to_notify`   | `45_000`                      | Shortest duration for notification (in milliseconds).      |
+| `notification_timeout` | `750`                         | Duration to show notification for (in milliseconds).       |
 
 ::: tip
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -109,6 +109,23 @@ impl<'a> ModuleConfig<'a> for f64 {
     }
 }
 
+impl<'a> ModuleConfig<'a> for u32 {
+    fn from_config(config: &Value) -> Option<Self> {
+        match config {
+            Value::Integer(value) => {
+                // Converting i64 to u32
+                if *value > 0 && *value <= u32::MAX.into() {
+                    Some(*value as Self)
+                } else {
+                    None
+                }
+            }
+            Value::String(value) => value.parse::<Self>().ok(),
+            _ => None,
+        }
+    }
+}
+
 impl<'a> ModuleConfig<'a> for usize {
     fn from_config(config: &Value) -> Option<Self> {
         match config {

--- a/src/configs/cmd_duration.rs
+++ b/src/configs/cmd_duration.rs
@@ -12,7 +12,9 @@ pub struct CmdDurationConfig<'a> {
     pub disabled: bool,
     pub show_notifications: bool,
     pub min_time_to_notify: i64,
-    pub notification_timeout: u32,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub notification_timeout: Option<u32>,
 }
 
 impl<'a> Default for CmdDurationConfig<'a> {
@@ -25,7 +27,7 @@ impl<'a> Default for CmdDurationConfig<'a> {
             disabled: false,
             show_notifications: false,
             min_time_to_notify: 45_000,
-            notification_timeout: 750,
+            notification_timeout: None,
         }
     }
 }

--- a/src/configs/cmd_duration.rs
+++ b/src/configs/cmd_duration.rs
@@ -12,7 +12,7 @@ pub struct CmdDurationConfig<'a> {
     pub disabled: bool,
     pub show_notifications: bool,
     pub min_time_to_notify: i64,
-    pub notification_timeout: u64,
+    pub notification_timeout: u32,
 }
 
 impl<'a> Default for CmdDurationConfig<'a> {

--- a/src/configs/cmd_duration.rs
+++ b/src/configs/cmd_duration.rs
@@ -12,6 +12,7 @@ pub struct CmdDurationConfig<'a> {
     pub disabled: bool,
     pub show_notifications: bool,
     pub min_time_to_notify: i64,
+    pub notification_timeout: u64,
 }
 
 impl<'a> Default for CmdDurationConfig<'a> {
@@ -24,6 +25,7 @@ impl<'a> Default for CmdDurationConfig<'a> {
             disabled: false,
             show_notifications: false,
             min_time_to_notify: 45_000,
+            notification_timeout: 750,
         }
     }
 }

--- a/src/modules/cmd_duration.rs
+++ b/src/modules/cmd_duration.rs
@@ -79,24 +79,12 @@ fn undistract_me<'a, 'b>(
             unstyle(&ANSIStrings(&module.ansi_strings()))
         );
 
-        let timeout: u32 = match u32::try_from(config.notification_timeout) {
-            Ok(v) => v,
-            Err(_) => {
-                let v: u32 = CmdDurationConfig::default().notification_timeout as u32;
-                log::trace!(
-                    "Configured notification timeout not within bounds. Defaulting to {} ms",
-                    v
-                );
-                v
-            }
-        };
-
         let mut notification = Notification::new();
         notification
             .summary("Command finished")
             .body(&body)
             .icon("utilities-terminal")
-            .timeout(Timeout::Milliseconds(timeout));
+            .timeout(Timeout::Milliseconds(config.notification_timeout as u32));
 
         if let Err(err) = notification.show() {
             log::trace!("Cannot show notification: {}", err);
@@ -108,7 +96,6 @@ fn undistract_me<'a, 'b>(
 
 #[cfg(test)]
 mod tests {
-    use crate::configs::cmd_duration::CmdDurationConfig;
     use crate::test::ModuleRenderer;
     use ansi_term::Color;
 
@@ -186,15 +173,5 @@ mod tests {
 
         let expected = Some(format!("underwent {} ", Color::Yellow.bold().paint("5s")));
         assert_eq!(expected, actual);
-    }
-
-    #[test]
-    fn config_notification_timeout_within_bounds() {
-        assert!(
-            match u32::try_from(CmdDurationConfig::default().notification_timeout) {
-                Ok(_) => true,
-                Err(_) => false,
-            }
-        );
     }
 }

--- a/src/modules/cmd_duration.rs
+++ b/src/modules/cmd_duration.rs
@@ -84,7 +84,7 @@ fn undistract_me<'a, 'b>(
             .summary("Command finished")
             .body(&body)
             .icon("utilities-terminal")
-            .timeout(Timeout::Milliseconds(config.notification_timeout as u32));
+            .timeout(Timeout::Milliseconds(config.notification_timeout));
 
         if let Err(err) = notification.show() {
             log::trace!("Cannot show notification: {}", err);

--- a/src/modules/cmd_duration.rs
+++ b/src/modules/cmd_duration.rs
@@ -79,12 +79,24 @@ fn undistract_me<'a, 'b>(
             unstyle(&ANSIStrings(&module.ansi_strings()))
         );
 
+        let timeout: u32 = match u32::try_from(config.notification_timeout) {
+            Ok(v) => v,
+            Err(_) => {
+                let v: u32 = CmdDurationConfig::default().notification_timeout as u32;
+                log::trace!(
+                    "Configured notification timeout not within bounds. Defaulting to {} ms",
+                    v
+                );
+                v
+            }
+        };
+
         let mut notification = Notification::new();
         notification
             .summary("Command finished")
             .body(&body)
             .icon("utilities-terminal")
-            .timeout(Timeout::Milliseconds(config.notification_timeout as u32));
+            .timeout(Timeout::Milliseconds(timeout));
 
         if let Err(err) = notification.show() {
             log::trace!("Cannot show notification: {}", err);
@@ -96,6 +108,7 @@ fn undistract_me<'a, 'b>(
 
 #[cfg(test)]
 mod tests {
+    use crate::configs::cmd_duration::CmdDurationConfig;
     use crate::test::ModuleRenderer;
     use ansi_term::Color;
 
@@ -173,5 +186,15 @@ mod tests {
 
         let expected = Some(format!("underwent {} ", Color::Yellow.bold().paint("5s")));
         assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn config_notification_timeout_within_bounds() {
+        assert!(
+            match u32::try_from(CmdDurationConfig::default().notification_timeout) {
+                Ok(_) => true,
+                Err(_) => false,
+            }
+        );
     }
 }

--- a/src/modules/cmd_duration.rs
+++ b/src/modules/cmd_duration.rs
@@ -84,7 +84,7 @@ fn undistract_me<'a, 'b>(
             .summary("Command finished")
             .body(&body)
             .icon("utilities-terminal")
-            .timeout(Timeout::Milliseconds(750));
+            .timeout(Timeout::Milliseconds(config.notification_timeout as u32));
 
         if let Err(err) = notification.show() {
             log::trace!("Cannot show notification: {}", err);

--- a/src/modules/cmd_duration.rs
+++ b/src/modules/cmd_duration.rs
@@ -79,12 +79,17 @@ fn undistract_me<'a, 'b>(
             unstyle(&ANSIStrings(&module.ansi_strings()))
         );
 
+        let timeout = match config.notification_timeout {
+            Some(v) => Timeout::Milliseconds(v),
+            None => Timeout::Default,
+        };
+
         let mut notification = Notification::new();
         notification
             .summary("Command finished")
             .body(&body)
             .icon("utilities-terminal")
-            .timeout(Timeout::Milliseconds(config.notification_timeout));
+            .timeout(timeout);
 
         if let Err(err) = notification.show() {
             log::trace!("Cannot show notification: {}", err);


### PR DESCRIPTION
The default hard-coded notification timeout is very brief. This PR allows it to be configured.

<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR adds the notification_timeout option to cmd_duration. This allows for the notification timeout to be configured by the user if starship is compiled with notify-rust support. The default value is equal to the previous hardcoded value.

The notification_timeout is coded as a u64, but the notify-rust TImeout::Milliseconds is coded to take u32, so the u64 is cast down. If there is a better way to handle this I am open to suggestions.

#### Motivation and Context
The hardcoded notification timeout was brief and lacked customization. Making this option configurable will allow the notification feature to be more useful.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #2194
Closes #2268

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Make sure starship is compiled with ```--features "notify-rust"```
Run ```STARSHIP_LOG=debug /path/to/starship module cmd_duration -d 60000``` to simulate a long-running program. Test it with and without the option specified in the configuration file. Observe the amount of time it takes for the notification to dismiss automatically.

This was tested on NixOS 21.11 using the mako notification daemon in the Sway window manager. Tested with bash and zsh.
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
