### PR TITLE
fix(bash): Restore previous exit status in bash init

### DIFF
--- a/src/init/starship.bash
+++ b/src/init/starship.bash
@@ -12,6 +12,9 @@
 # drawn, and only start the timer if this flag is present. That way, timing is
 # for the entire command, and not just a portion of it.
 
+# A way to set '$?', since bash does not allow assigning to '$?' directly
+function _starship_set_return() { return "${1:-0}"; }
+
 # Will be run before *every* command (even ones in pipes!)
 starship_preexec() {
     # Save previous command's last argument, otherwise it will be set to "starship_preexec"
@@ -43,6 +46,10 @@ starship_precmd() {
     # Run the bash precmd function, if it's set. If not set, evaluates to no-op
     "${starship_precmd_user_func-:}"
 
+    # Set $? to the preserved value before running additional parts of the prompt
+    # command pipeline, which may rely on it.
+    _starship_set_return "$STARSHIP_CMD_STATUS"
+
     eval "$_PRESERVED_PROMPT_COMMAND"
 
     # Prepare the timer data, if needed.
@@ -55,9 +62,6 @@ starship_precmd() {
         PS1="$(::STARSHIP:: prompt --terminal-width="$COLUMNS" --status=$STARSHIP_CMD_STATUS --pipestatus="${STARSHIP_PIPE_STATUS[*]}" --jobs="$NUM_JOBS")"
     fi
     STARSHIP_PREEXEC_READY=true  # Signal that we can safely restart the timer
-
-    # Restore previous status for subsequent commands in the PROMPT_COMMAND pipeline.
-    return $STARSHIP_CMD_STATUS
 }
 
 # If the user appears to be using https://github.com/rcaloras/bash-preexec,

--- a/src/init/starship.bash
+++ b/src/init/starship.bash
@@ -55,6 +55,9 @@ starship_precmd() {
         PS1="$(::STARSHIP:: prompt --terminal-width="$COLUMNS" --status=$STARSHIP_CMD_STATUS --pipestatus="${STARSHIP_PIPE_STATUS[*]}" --jobs="$NUM_JOBS")"
     fi
     STARSHIP_PREEXEC_READY=true  # Signal that we can safely restart the timer
+
+    # Restore previous status for subsequent commands in the PROMPT_COMMAND pipeline.
+    return $STARSHIP_CMD_STATUS
 }
 
 # If the user appears to be using https://github.com/rcaloras/bash-preexec,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
Restore the previous exit status so that any subsequent hooks in the PROMPT_COMMAND pipeline can run with the correct return code.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #2918

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I've confirmed that this doesn't negatively affect bash init, but I haven't confirmed that this actually causes the behavior intended. The fix is based on a comment by lilyball on the linked issue.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
