### PR TITLE
feat: starship bug-report sets syntax highlighting for config file

### DIFF
--- a/src/bug_report.rs
+++ b/src/bug_report.rs
@@ -53,7 +53,7 @@ fn get_pkg_branch_tag() -> &'static str {
 
 fn make_github_issue_link(environment: Environment) -> String {
     let shell_syntax = match environment.shell_info.name.as_ref() {
-        "powershell" => "pwsh",
+        "powershell" | "pwsh" => "pwsh",
         "fish" => "fish",
         "cmd" => "lua",
         // GitHub does not seem to support elvish syntax highlighting.
@@ -193,7 +193,7 @@ fn get_config_path(shell: &str) -> Option<PathBuf> {
             "bash" => Some(".bashrc"),
             "fish" => Some(".config/fish/config.fish"),
             "ion" => Some(".config/ion/initrc"),
-            "powershell" => {
+            "powershell" | "pwsh" => {
                 if cfg!(windows) {
                     Some("Documents/PowerShell/Microsoft.PowerShell_profile.ps1")
                 } else {

--- a/src/bug_report.rs
+++ b/src/bug_report.rs
@@ -52,6 +52,15 @@ fn get_pkg_branch_tag() -> &'static str {
 }
 
 fn make_github_issue_link(environment: Environment) -> String {
+    let shell_syntax = match environment.shell_info.name.as_ref() {
+        "powershell" => "pwsh",
+        "fish" => "fish",
+        "cmd" => "lua",
+        // GitHub does not seem to support elvish syntax highlighting.
+        "elvish" => "bash",
+        _ => "bash",
+    };
+
     let body = urlencoding::encode(&format!("#### Current Behavior
 <!-- A clear and concise description of the behavior. -->
 
@@ -76,7 +85,7 @@ fn make_github_issue_link(environment: Environment) -> String {
 - Build Time: {build_time}
 #### Relevant Shell Configuration
 
-```bash
+```{shell_syntax}
 {shell_config}
 ```
 
@@ -100,6 +109,7 @@ fn make_github_issue_link(environment: Environment) -> String {
         rust_channel =  shadow::RUST_CHANNEL,
         build_rust_channel =  shadow::BUILD_RUST_CHANNEL,
         build_time =  shadow::BUILD_TIME,
+        shell_syntax = shell_syntax,
     ))
         .replace("%20", "+");
 


### PR DESCRIPTION
#### Description
Set the syntax highlighting for the config file in starship bug-report, using the triple backtick syntax.

#### Motivation and Context
It seemed unintuitive that the syntax highlighting for the config file was set to bash even when it was known that it was in another language, such as powershell or lua.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
I have confirmed that this works for powershell, and all tests that pass on master pass on this branch. 

#### Checklist:
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.