### PR TITLE
fix: Correctly detect older versions of powershell in bug-report

### DIFF
--- a/src/bug_report.rs
+++ b/src/bug_report.rs
@@ -142,10 +142,7 @@ fn get_shell_info() -> ShellInfo {
 
     let shell = shell.unwrap();
 
-    let version = exec_cmd(&shell, &["--version"], Duration::from_millis(500)).map_or_else(
-        || UNKNOWN_VERSION.to_string(),
-        |output| output.stdout.trim().to_string(),
-    );
+    let version = get_shell_version(&shell);
 
     let config = get_config_path(&shell)
         .and_then(|config_path| fs::read_to_string(config_path).ok())
@@ -223,6 +220,22 @@ fn get_starship_config() -> String {
         })
         .and_then(|config_path| fs::read_to_string(config_path).ok())
         .unwrap_or_else(|| UNKNOWN_CONFIG.to_string())
+}
+
+fn get_shell_version(shell: &str) -> String {
+    let time_limit = Duration::from_millis(500);
+    match shell {
+        "powershell" => exec_cmd(
+            &shell,
+            &["Get-Host", "|", "Select-Object Version"],
+            time_limit,
+        ),
+        _ => exec_cmd(&shell, &["--version"], time_limit),
+    }
+    .map_or_else(
+        || UNKNOWN_VERSION.to_string(),
+        |output| output.stdout.trim().to_string(),
+    )
 }
 
 #[cfg(test)]

--- a/src/bug_report.rs
+++ b/src/bug_report.rs
@@ -227,7 +227,7 @@ fn get_shell_version(shell: &str) -> String {
     match shell {
         "powershell" => exec_cmd(
             &shell,
-            &["Get-Host", "|", "Select-Object Version"],
+            &["(Get-Host | Select Version | Format-Table -HideTableHeaders | Out-String).trim()"],
             time_limit,
         ),
         _ => exec_cmd(&shell, &["--version"], time_limit),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
Will lead to correct detection of older versions of powershell using starship bug-report. Special-cases the version code on `powershell` (can be extended to any shell, but all the others support `--version` for now).

Has been tested in a Windows VM against powershell 5.1 and the most recent version of pwsh available on the store.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #3531

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
