### PR TITLE
feat!: Use pure symbols, emoji and Powerline glyphs only by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,13 @@
 
 ### Prerequisites
 
-- A [Nerd Font](https://www.nerdfonts.com/) installed and enabled in your terminal (for example, try the [Fira Code Nerd Font](https://www.nerdfonts.com/font-downloads)).
+- A [Powerline Font](https://github.com/powerline/fonts) installed and enabled in your terminal.
+  Many coding fonts already include Powerline symbols or have official variants with them included.
+  (For example [Fira Code](https://github.com/tonsky/FiraCode) or [Cascadia Code/Mono PL](https://github.com/microsoft/cascadia-code/releases))
+
+  You can also use a [Nerd Font](https://www.nerdfonts.com/). (for example, try the [Fira Code Nerd Font](https://www.nerdfonts.com/font-downloads)).
+  Checkout [Presets](https://starship.rs/presets/#nerd-font-symbols) for a configuration that uses
+  Nerd Font symbols.
 
 ### Step 1. Install Starship
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,7 +28,13 @@ description: Starship is the minimal, blazing fast, and extremely customizable p
 
 ### Prerequisites
 
-- A [Nerd Font](https://www.nerdfonts.com/) installed and enabled in your terminal.
+- A [Powerline Font](https://github.com/powerline/fonts) installed and enabled in your terminal.
+  Many coding fonts already include Powerline symbols or have official variants with them included.
+  (For example [Fira Code](https://github.com/tonsky/FiraCode) or [Cascadia Code/Mono PL](https://github.com/microsoft/cascadia-code/releases))
+
+  You can also use a [Nerd Font](https://www.nerdfonts.com/). (for example, try the [Fira Code Nerd Font](https://www.nerdfonts.com/font-downloads)).
+  Checkout [Presets](https://starship.rs/presets/#nerd-font-symbols) for a configuration that uses
+  Nerd Font symbols.
 
 ### Quick Install
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -359,7 +359,7 @@ The `azure` module shows the current Azure Subscription. This is based on showin
 | Variable   | Default                                  | Description                                |
 | ---------- | ---------------------------------------- | ------------------------------------------ |
 | `format`   | `"on [$symbol($subscription)]($style) "` | The format for the Azure module to render. |
-| `symbol`   | `"ﴃ "`                                   | The symbol used in the format.             |
+| `symbol`   | `"🅰 "`                                   | The symbol used in the format.             |
 | `style`    | `"blue bold"`                            | The style used in the format.              |
 | `disabled` | `true`                                   | Disables the `azure` module.               |
 
@@ -384,11 +384,11 @@ The module is only visible when the device's battery is below 10%.
 
 | Option               | Default                           | Description                                         |
 | -------------------- | --------------------------------- | --------------------------------------------------- |
-| `full_symbol`        | `" "`                            | The symbol shown when the battery is full.          |
-| `charging_symbol`    | `" "`                            | The symbol shown when the battery is charging.      |
-| `discharging_symbol` | `" "`                            | The symbol shown when the battery is discharging.   |
-| `unknown_symbol`     | `" "`                            | The symbol shown when the battery state is unknown. |
-| `empty_symbol`       | `" "`                            | The symbol shown when the battery state is empty.   |
+| `full_symbol`        | `"• "`                            | The symbol shown when the battery is full.          |
+| `charging_symbol`    | `"⇡ "`                            | The symbol shown when the battery is charging.      |
+| `discharging_symbol` | `"⇣ "`                            | The symbol shown when the battery is discharging.   |
+| `unknown_symbol`     | `"❓ "`                            | The symbol shown when the battery state is unknown. |
+| `empty_symbol`       | `"❗ "`                            | The symbol shown when the battery state is empty.   |
 | `format`             | `"[$symbol$percentage]($style) "` | The format for the module.                          |
 | `display`            | [link](#battery-display)          | Display threshold and style for the module.         |
 | `disabled`           | `false`                           | Disables the `battery` module.                      |
@@ -1167,7 +1167,7 @@ By default the module will be shown if any of the following conditions are met:
 | ------------------- | ------------------------------------ | ------------------------------------------------------------------------- |
 | `format`            | `"via [$symbol($version )]($style)"` | The format for the module.                                                |
 | `version_format`    | `"v${raw}"`                          | The version format. Available vars are `raw`, `major`, `minor`, & `patch` |
-| `symbol`            | `" "`                               | The symbol used before displaying the version of erlang.                  |
+| `symbol`            | `"e "`                               | The symbol used before displaying the version of erlang.                  |
 | `style`             | `"bold red"`                         | The style for the module.                                                 |
 | `detect_extensions` | `[]`                                 | Which extensions should trigger this module.                              |
 | `detect_files`      | `["rebar.config", "elang.mk"]`       | Which filenames should trigger this module.                               |
@@ -2204,7 +2204,7 @@ By default the module will be shown if any of the following conditions are met:
 | ------------------- | ------------------------------------ | ----------------------------------------------------------------------------------------------------- |
 | `format`            | `"via [$symbol($version )]($style)"` | The format for the module.                                                                            |
 | `version_format`    | `"v${raw}"`                          | The version format. Available vars are `raw`, `major`, `minor`, & `patch`                             |
-| `symbol`            | `" "`                               | A format string representing the symbol of Node.js.                                                   |
+| `symbol`            | `"⬢ "`                               | A format string representing the symbol of Node.js.                                                   |
 | `detect_extensions` | `["js", "mjs", "cjs", "ts"]`         | Which extensions should trigger this module.                                                          |
 | `detect_files`      | `["package.json", ".node-version"]`  | Which filenames should trigger this module.                                                           |
 | `detect_folders`    | `["node_modules"]`                   | Which folders should trigger this module.                                                             |
@@ -2480,7 +2480,7 @@ By default the module will be shown if any of the following conditions are met:
 | ---------------- | -------------------------------------------- | ------------------------------------------------------------------------- |
 | `format`         | `"via [$symbol($username@)$stack]($style) "` | The format string for the module.                                         |
 | `version_format` | `"v${raw}"`                                  | The version format. Available vars are `raw`, `major`, `minor`, & `patch` |
-| `symbol`         | `" "`                                       | A format string shown before the Pulumi stack.                            |
+| `symbol`         | `"⠿ "`                                       | A format string shown before the Pulumi stack.                            |
 | `style`          | `"bold 5"`                                   | The style for the module.                                                 |
 | `disabled`       | `false`                                      | Disables the `pulumi` module.                                             |
 

--- a/docs/faq/README.md
+++ b/docs/faq/README.md
@@ -112,7 +112,7 @@ particular do not come with font support out-of-the-box. You need to ensure that
 - You have an emoji font installed. Most systems come with an emoji font by default, but
   some (notably Arch Linux) do not. You can usually install one through your system's
   package manager--[noto emoji](https://www.google.com/get/noto/help/emoji/) is a popular choice.
-- You are using a [Nerd Font](https://www.nerdfonts.com/).
+- You are using a [Powerline Font](https://github.com/powerline/fonts) or a [Nerd Font](https://www.nerdfonts.com/).
 
 To test your system, run the following commands in a terminal:
 

--- a/docs/presets/README.md
+++ b/docs/presets/README.md
@@ -20,6 +20,16 @@ If emojis aren't your thing, this might catch your eye!
 [aws]
 symbol = "  "
 
+[azure]
+symbol = "ﴃ "
+
+[battery]
+full_symbol = " "
+charging_symbol = " "
+discharging_symbol = " "
+unknown_symbol = " "
+empty_symbol = " "
+
 [conda]
 symbol = " "
 
@@ -73,6 +83,9 @@ symbol = " "
 
 [php]
 symbol = " "
+
+[pulumi]
+symbol = " "
 
 [python]
 symbol = " "

--- a/src/configs/azure.rs
+++ b/src/configs/azure.rs
@@ -14,7 +14,7 @@ impl<'a> Default for AzureConfig<'a> {
     fn default() -> Self {
         AzureConfig {
             format: "on [$symbol($subscription)]($style) ",
-            symbol: "ﴃ ",
+            symbol: "🅰 ",
             style: "blue bold",
             disabled: true,
         }

--- a/src/configs/battery.rs
+++ b/src/configs/battery.rs
@@ -18,11 +18,11 @@ pub struct BatteryConfig<'a> {
 impl<'a> Default for BatteryConfig<'a> {
     fn default() -> Self {
         BatteryConfig {
-            full_symbol: " ",
-            charging_symbol: " ",
-            discharging_symbol: " ",
-            unknown_symbol: " ",
-            empty_symbol: " ",
+            full_symbol: "• ",
+            charging_symbol: "⇡ ",
+            discharging_symbol: "⇣ ",
+            unknown_symbol: "❓ ",
+            empty_symbol: "❗ ",
             format: "[$symbol$percentage]($style) ",
             display: vec![BatteryDisplayConfig::default()],
             disabled: false,

--- a/src/configs/erlang.rs
+++ b/src/configs/erlang.rs
@@ -20,7 +20,7 @@ impl<'a> Default for ErlangConfig<'a> {
         ErlangConfig {
             format: "via [$symbol($version )]($style)",
             version_format: "v${raw}",
-            symbol: " ",
+            symbol: "e ",
             style: "bold red",
             disabled: false,
             detect_extensions: vec![],

--- a/src/configs/nodejs.rs
+++ b/src/configs/nodejs.rs
@@ -21,7 +21,7 @@ impl<'a> Default for NodejsConfig<'a> {
         NodejsConfig {
             format: "via [$symbol($version )]($style)",
             version_format: "v${raw}",
-            symbol: " ",
+            symbol: "⬢ ",
             style: "bold green",
             disabled: false,
             not_capable_style: "bold red",

--- a/src/configs/pulumi.rs
+++ b/src/configs/pulumi.rs
@@ -17,7 +17,7 @@ impl<'a> Default for PulumiConfig<'a> {
         PulumiConfig {
             format: "via [$symbol($username@)$stack]($style) ",
             version_format: "v${raw}",
-            symbol: " ",
+            symbol: "⠿ ",
             style: "bold 5",
             disabled: false,
         }

--- a/src/modules/azure.rs
+++ b/src/modules/azure.rs
@@ -188,7 +188,7 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "on {} ",
-            Color::Blue.bold().paint("ﴃ Subscription 1")
+            Color::Blue.bold().paint("🅰 Subscription 1")
         ));
         assert_eq!(actual, expected);
         dir.close()

--- a/src/modules/battery.rs
+++ b/src/modules/battery.rs
@@ -238,7 +238,7 @@ mod tests {
             })
             .battery_info_provider(&mock)
             .collect();
-        let expected = Some(String::from(" 100% "));
+        let expected = Some(String::from("• 100% "));
 
         assert_eq!(expected, actual);
     }
@@ -263,7 +263,7 @@ mod tests {
             })
             .battery_info_provider(&mock)
             .collect();
-        let expected = Some(String::from(" 80% "));
+        let expected = Some(String::from("⇡ 80% "));
 
         assert_eq!(expected, actual);
     }
@@ -288,7 +288,7 @@ mod tests {
             })
             .battery_info_provider(&mock)
             .collect();
-        let expected = Some(String::from(" 80% "));
+        let expected = Some(String::from("⇣ 80% "));
 
         assert_eq!(expected, actual);
     }
@@ -313,7 +313,7 @@ mod tests {
             })
             .battery_info_provider(&mock)
             .collect();
-        let expected = Some(String::from(" 0% "));
+        let expected = Some(String::from("❓ 0% "));
 
         assert_eq!(expected, actual);
     }
@@ -338,7 +338,7 @@ mod tests {
             })
             .battery_info_provider(&mock)
             .collect();
-        let expected = Some(String::from(" 0% "));
+        let expected = Some(String::from("❗ 0% "));
 
         assert_eq!(expected, actual);
     }
@@ -388,7 +388,7 @@ mod tests {
             })
             .battery_info_provider(&mock)
             .collect();
-        let expected = Some(format!("{} ", Color::Red.bold().paint(" 40%")));
+        let expected = Some(format!("{} ", Color::Red.bold().paint("⇣ 40%")));
 
         assert_eq!(expected, actual);
     }
@@ -413,7 +413,7 @@ mod tests {
             })
             .battery_info_provider(&mock)
             .collect();
-        let expected = Some(String::from(" 13% "));
+        let expected = Some(String::from("⇣ 13% "));
 
         assert_eq!(expected, actual);
     }

--- a/src/modules/erlang.rs
+++ b/src/modules/erlang.rs
@@ -94,7 +94,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("rebar.config"))?.sync_all()?;
 
-        let expected = Some(format!("via {}", Color::Red.bold().paint(" v22.1.3 ")));
+        let expected = Some(format!("via {}", Color::Red.bold().paint("e v22.1.3 ")));
         let output = ModuleRenderer::new("erlang").path(dir.path()).collect();
 
         assert_eq!(output, expected);

--- a/src/modules/nodejs.rs
+++ b/src/modules/nodejs.rs
@@ -139,7 +139,7 @@ mod tests {
         File::create(dir.path().join("package.json"))?.sync_all()?;
 
         let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Green.bold().paint(" v12.0.0 ")));
+        let expected = Some(format!("via {}", Color::Green.bold().paint("⬢ v12.0.0 ")));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -163,7 +163,7 @@ mod tests {
         File::create(dir.path().join(".node-version"))?.sync_all()?;
 
         let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Green.bold().paint(" v12.0.0 ")));
+        let expected = Some(format!("via {}", Color::Green.bold().paint("⬢ v12.0.0 ")));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -174,7 +174,7 @@ mod tests {
         File::create(dir.path().join(".nvmrc"))?.sync_all()?;
 
         let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Green.bold().paint(" v12.0.0 ")));
+        let expected = Some(format!("via {}", Color::Green.bold().paint("⬢ v12.0.0 ")));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -185,7 +185,7 @@ mod tests {
         File::create(dir.path().join("index.js"))?.sync_all()?;
 
         let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Green.bold().paint(" v12.0.0 ")));
+        let expected = Some(format!("via {}", Color::Green.bold().paint("⬢ v12.0.0 ")));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -196,7 +196,7 @@ mod tests {
         File::create(dir.path().join("index.mjs"))?.sync_all()?;
 
         let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Green.bold().paint(" v12.0.0 ")));
+        let expected = Some(format!("via {}", Color::Green.bold().paint("⬢ v12.0.0 ")));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -207,7 +207,7 @@ mod tests {
         File::create(dir.path().join("index.cjs"))?.sync_all()?;
 
         let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Green.bold().paint(" v12.0.0 ")));
+        let expected = Some(format!("via {}", Color::Green.bold().paint("⬢ v12.0.0 ")));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -218,7 +218,7 @@ mod tests {
         File::create(dir.path().join("index.ts"))?.sync_all()?;
 
         let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Green.bold().paint(" v12.0.0 ")));
+        let expected = Some(format!("via {}", Color::Green.bold().paint("⬢ v12.0.0 ")));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -230,7 +230,7 @@ mod tests {
         fs::create_dir_all(&node_modules)?;
 
         let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Green.bold().paint(" v12.0.0 ")));
+        let expected = Some(format!("via {}", Color::Green.bold().paint("⬢ v12.0.0 ")));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -249,7 +249,7 @@ mod tests {
         file.sync_all()?;
 
         let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Green.bold().paint(" v12.0.0 ")));
+        let expected = Some(format!("via {}", Color::Green.bold().paint("⬢ v12.0.0 ")));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -268,7 +268,7 @@ mod tests {
         file.sync_all()?;
 
         let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Red.bold().paint(" v12.0.0 ")));
+        let expected = Some(format!("via {}", Color::Red.bold().paint("⬢ v12.0.0 ")));
         assert_eq!(expected, actual);
         dir.close()
     }

--- a/src/modules/pulumi.rs
+++ b/src/modules/pulumi.rs
@@ -324,7 +324,7 @@ mod tests {
             .collect();
         let expected = format!(
             "via {} ",
-            Color::Fixed(5).bold().paint(" test-user@launch")
+            Color::Fixed(5).bold().paint("⠿ test-user@launch")
         );
         assert_eq!(expected, rendered.expect("a result"));
         dir.close()?;
@@ -384,7 +384,7 @@ mod tests {
             })
             .env("HOME", root.to_str().unwrap())
             .collect();
-        let expected = format!("via {} ", Color::Fixed(5).bold().paint(" launch"));
+        let expected = format!("via {} ", Color::Fixed(5).bold().paint("⠿ launch"));
         assert_eq!(expected, rendered.expect("a result"));
         dir.close()?;
         Ok(())
@@ -404,7 +404,7 @@ mod tests {
                 format = "in [$symbol($stack)]($style) "
             })
             .collect();
-        let expected = format!("in {} ", Color::Fixed(5).bold().paint(" "));
+        let expected = format!("in {} ", Color::Fixed(5).bold().paint("⠿ "));
         assert_eq!(expected, rendered.expect("a result"));
         dir.close()?;
         Ok(())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Use pure symbols, emoji and Powerline glyphs only by default. This is due to various issues with the Nerd Fonts and to be consistent as we have a Nerd Fonts preset but somehow still use a few Nerd Fonts symbols by default. See #2563 for more details.

Existing Nerd Fonts symbols used by default are moved to the Nerd Fonts preset.

After this starship should only require a powerline font, which are readily available. And even included by default in some coding fonts or some coding fonts having official variants with them. This doesn't include website updates to reflect this. And there might be places in the documentation that should also be updated to reflect this.

The exact symbol choices are, of course, subjective and up for debate. And we do need to make sure we aren't using a symbol that isn't commonly available in fonts.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #2563

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly. (Is there any installation docs that need updating to state a Nerd Font isn't required? If so, what should the text say or recommended to install?)
- [x] I have updated the tests accordingly.

@chipbuster 