### PR TITLE
feat: Enable Undistract Me for Linux

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -26,9 +26,6 @@ jobs:
           profile: minimal
           components: rustfmt
 
-      - name: Setup | libdbus (ubuntu)
-        run: sudo apt-get install libdbus-1-dev
-
       - name: Build | Format
         run: cargo fmt --all -- --check
 
@@ -45,10 +42,6 @@ jobs:
 
       - name: Setup | Cache
         uses: Swatinem/rust-cache@v1
-
-      - name: Setup | libdbus (ubuntu)
-        if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get install libdbus-1-dev
 
       - name: Setup | Rust
         uses: actions-rs/toolchain@v1.0.7
@@ -143,10 +136,6 @@ jobs:
     steps:
       - name: Setup | Checkout
         uses: actions/checkout@v2.4.0
-
-      - name: Setup | libdbus (ubuntu)
-        if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get install libdbus-1-dev
 
       - name: Setup | Cache
         uses: Swatinem/rust-cache@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ git2 = { version = "0.13.25", default-features = false }
 indexmap = { version = "1.8.0", features = ["serde"] }
 local_ipaddress = "0.1.3"
 log = { version = "0.4.14", features = ["std"] }
-notify-rust = { version = "4.5.5", optional = true }
+notify-rust = "4.5.5"
 once_cell = "1.9.0"
 open = "2.0.2"
 os_info = "3.1.0"

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -609,11 +609,6 @@ running `eval $(starship init $0)`, and then proceed as normal.
 | `min_time_to_notify`   | `45_000`                      | Shortest duration for notification (in milliseconds).                                                                                                             |
 | `notification_timeout` |                               | Duration to show notification for (in milliseconds). If unset, notification timeout will be determined by daemon. Not all notification daemons honor this option. |
 
-::: tip
-
-Showing desktop notifications requires starship to be built with `notify-rust` support. You check if your starship
-supports notifications by running `STARSHIP_LOG=debug starship module cmd_duration -d 60000` when `show_notifications` is set to `true`.
-
 :::
 
 ### Variables

--- a/src/modules/cmd_duration.rs
+++ b/src/modules/cmd_duration.rs
@@ -51,20 +51,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     Some(undistract_me(module, &config, elapsed))
 }
 
-#[cfg(not(feature = "notify-rust"))]
-fn undistract_me<'a, 'b>(
-    module: Module<'a>,
-    config: &'b CmdDurationConfig,
-    _elapsed: u128,
-) -> Module<'a> {
-    if config.show_notifications {
-        log::debug!("This version of starship was built without notification support.");
-    }
-
-    module
-}
-
-#[cfg(feature = "notify-rust")]
 fn undistract_me<'a, 'b>(
     module: Module<'a>,
     config: &'b CmdDurationConfig,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description

In #1019 the undistract feature has been added to starship without
enabling it by default due to the system dependency on libdbus. With
recent versions of notify-rust the dependency is no longer required and
the feature can be enabled by default.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
