### PR TITLE
docs(directory): add missing doc on option directory.repo_root_format

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -835,17 +835,17 @@ it would have been `nixpkgs/pkgs`.
 ### Options
 
 | Option              | Default                                                                                                     | Description                                                                          |
-| ------------------- |-------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|
+| ------------------- | ----------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
 | `truncation_length` | `3`                                                                                                         | The number of parent folders that the current directory should be truncated to.      |
 | `truncate_to_repo`  | `true`                                                                                                      | Whether or not to truncate to the root of the git repo that you're currently in.     |
 | `format`            | `"[$path]($style)[$read_only]($read_only_style) "`                                                          | The format for the module.                                                           |
 | `style`             | `"bold cyan"`                                                                                               | The style for the module.                                                            |
 | `disabled`          | `false`                                                                                                     | Disables the `directory` module.                                                     |
-| `read_only`         | `"🔒"`                                                                                                      | The symbol indicating current directory is read only.                                |
+| `read_only`         | `"🔒"`                                                                                                       | The symbol indicating current directory is read only.                                |
 | `read_only_style`   | `"red"`                                                                                                     | The style for the read only symbol.                                                  |
 | `truncation_symbol` | `""`                                                                                                        | The symbol to prefix to truncated paths. eg: "…/"                                    |
 | `repo_root_style`   | `None`                                                                                                      | The style for the root of the git repo. The default value is equivalent to `style`.  |
-| `repo_root_format`  | `"[$before_root_path]($style)[$repo_root]($repo_root_style)[$path]($style)[$read_only]($read_only_style) "` | The format of a git repo when `repo_root_style` is defined.                          | 
+| `repo_root_format`  | `"[$before_root_path]($style)[$repo_root]($repo_root_style)[$path]($style)[$read_only]($read_only_style) "` | The format of a git repo when `repo_root_style` is defined.                          |
 | `home_symbol`       | `"~"`                                                                                                       | The symbol indicating home directory.                                                |
 | `use_os_path_sep`   | `true`                                                                                                      | Use the OS specific path separator instead of always using `/` (e.g. `\` on Windows) |
 
@@ -887,10 +887,10 @@ a single character. For `fish_style_pwd_dir_length = 2`, it would be `/bu/th/ci/
 <details>
 <summary>The git repos have additional variables.</summary>
 
-Let us consider the path `/path/to/home/git_repo/src/lib` 
+Let us consider the path `/path/to/home/git_repo/src/lib`
 
 | Variable         | Example               | Description                             |
-|------------------|-----------------------|-----------------------------------------|
+| ---------------- | --------------------- | --------------------------------------- |
 | before_root_path | `"/path/to/home/"`    | The path before git root directory path |
 | repo_root        | `"git_repo"`          | The git root directory name             |
 | path             | `"/src/lib"`          | The remaining path                      |

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -834,19 +834,20 @@ it would have been `nixpkgs/pkgs`.
 
 ### Options
 
-| Option              | Default                                            | Description                                                                            |
-| ------------------- | -------------------------------------------------- | -------------------------------------------------------------------------------------- |
-| `truncation_length` | `3`                                                | The number of parent folders that the current directory should be truncated to.        |
-| `truncate_to_repo`  | `true`                                             | Whether or not to truncate to the root of the git repo that you're currently in.       |
-| `format`            | `"[$path]($style)[$read_only]($read_only_style) "` | The format for the module.                                                             |
-| `style`             | `"bold cyan"`                                      | The style for the module.                                                              |
-| `disabled`          | `false`                                            | Disables the `directory` module.                                                       |
-| `read_only`         | `"🔒"`                                              | The symbol indicating current directory is read only.                                  |
-| `read_only_style`   | `"red"`                                            | The style for the read only symbol.                                                    |
-| `truncation_symbol` | `""`                                               | The symbol to prefix to truncated paths. eg: "…/"                                      |
-| `repo_root_style`   | `None`                                             | The style for the root of the git repo when `truncate_to_repo` option is set to false. |
-| `home_symbol`       | `"~"`                                              | The symbol indicating home directory.                                                  |
-| `use_os_path_sep`   | `true`                                             | Use the OS specific path separator instead of always using `/` (e.g. `\` on Windows)   |
+| Option              | Default                                                                                                     | Description                                                                          |
+| ------------------- |-------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|
+| `truncation_length` | `3`                                                                                                         | The number of parent folders that the current directory should be truncated to.      |
+| `truncate_to_repo`  | `true`                                                                                                      | Whether or not to truncate to the root of the git repo that you're currently in.     |
+| `format`            | `"[$path]($style)[$read_only]($read_only_style) "`                                                          | The format for the module.                                                           |
+| `style`             | `"bold cyan"`                                                                                               | The style for the module.                                                            |
+| `disabled`          | `false`                                                                                                     | Disables the `directory` module.                                                     |
+| `read_only`         | `"🔒"`                                                                                                      | The symbol indicating current directory is read only.                                |
+| `read_only_style`   | `"red"`                                                                                                     | The style for the read only symbol.                                                  |
+| `truncation_symbol` | `""`                                                                                                        | The symbol to prefix to truncated paths. eg: "…/"                                    |
+| `repo_root_style`   | `None`                                                                                                      | The style for the root of the git repo. The default value is equivalent to `style`.  |
+| `repo_root_format`  | `"[$before_root_path]($style)[$repo_root]($repo_root_style)[$path]($style)[$read_only]($read_only_style) "` | The format of a git repo when `repo_root_style` is defined.                          | 
+| `home_symbol`       | `"~"`                                                                                                       | The symbol indicating home directory.                                                |
+| `use_os_path_sep`   | `true`                                                                                                      | Use the OS specific path separator instead of always using `/` (e.g. `\` on Windows) |
 
 <details>
 <summary>This module has a few advanced configuration options that control how the directory is displayed.</summary>
@@ -882,6 +883,21 @@ a single character. For `fish_style_pwd_dir_length = 2`, it would be `/bu/th/ci/
 | style\*  | `"black bold dimmed"` | Mirrors the value of option `style` |
 
 *: This variable can only be used as a part of a style string
+
+<details>
+<summary>The git repos have additional variables.</summary>
+
+Let us consider the path `/path/to/home/git_repo/src/lib` 
+
+| Variable         | Example               | Description                             |
+|------------------|-----------------------|-----------------------------------------|
+| before_root_path | `"/path/to/home/"`    | The path before git root directory path |
+| repo_root        | `"git_repo"`          | The git root directory name             |
+| path             | `"/src/lib"`          | The remaining path                      |
+| style            | `"black bold dimmed"` | Mirrors the value of option `style`     |
+| repo_root_style  | `"underline white"`   | Style for git root directory name       |
+
+</details>
 
 ### Example
 


### PR DESCRIPTION
#### Description
This commit adds an entry for this option and a *details* section for its variables.

#### Motivation and Context
Thinking there was a bug in the formatting of git directories (my format was not respected), I realized that the option `directory.repo_root_format` was not documented. 

Also, the doc entry of `directory.repo_root_style` was not the actual behavior of the code. I update it.

#### Screenshots (if appropriate):
<img width="771" alt="Snapshot 4" src="https://user-images.githubusercontent.com/26146722/152037080-f196144b-50a3-46de-93a3-988c222da74f.png">

#### How Has This Been Tested?
Documentation changes. Doc rendering using `npm run dev` as shown above.

#### Checklist:
- [X] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
