### PR TITLE
feat(cli): Print arguments if argument parsing fails

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -108,7 +108,23 @@ fn main() {
     let _ = ansi_term::enable_ansi_support();
     logger::init();
 
-    let args = Cli::parse();
+    let args = match Cli::try_parse() {
+        Ok(args) => args,
+        Err(e) => {
+            // print the error
+            e.print().expect("error while writing error");
+            // print the arguments
+            eprintln!(
+                "\nNOTE:\n    passed arguments: {:?}",
+                // collect into a vec to format args as a slice
+                std::env::args().skip(1).collect::<Vec<_>>()
+            );
+
+            // clap exits with status 2 on error: 
+            //  https://docs.rs/clap/latest/clap/struct.Error.html#method.exit
+            std::process::exit(2);
+        }
+    };
     log::trace!("Parsed arguments: {:#?}", args);
 
     match args.command {

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,15 +117,19 @@ fn main() {
                     | clap::ErrorKind::DisplayHelp
                     | clap::ErrorKind::DisplayVersion
             );
-            // print the error
-            e.print().expect("error while writing error");
+            // print the error and avoid panicking in case of stdout/stderr closing unexpectedly
+            let _ = e.print();
             // if there was no mistake by the user and we're only going to display information,
             // we won't put arguments or exit
             let exit_code = if is_info_only {
                 0
             } else {
                 // print the arguments
-                eprintln!(
+                // avoid panicking in case of stderr closing
+                let mut stderr = io::stderr();
+                use io::Write;
+                let _ = writeln!(
+                    stderr,
                     "\nNOTE:\n    passed arguments: {:?}",
                     // collect into a vec to format args as a slice
                     std::env::args().skip(1).collect::<Vec<_>>()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
I've changed `main` in `src/main.rs` to call `Cli::try_parse` instead
of `Cli::parse` to manage the error case manually and print the arguments passed
to starship when argv parsing error, just like the issue explains. Other code has not been touched;
thoughts on those changes are in the commit message.

I'm not sure how to test this properly, but I certainly want to discuss:
  - whether all arguments are printed correctly:
    - what does 'correctly' mean?
      - do we need any escaping?
      - do we need any measure of 'easy to read'?
  - exiting with code 2 when having an error (code 2 is what [`clap::Error`](https://docs.rs/clap/latest/clap/struct.Error.html#method.exit) uses)
  - exit 0 on `--help`/`-h`
  - whether to exit with code 2/print arguments if `ErrorKind` is `DisplayHelp*`
    - certainly, exiting with code 2 when help was wanted could be misleading and it currently exits w/ code 0
    - will printing arguments be useful here?

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #3554

#### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/54634335/152382386-9ccae3bf-8ccf-4a3a-9819-af1f4173fc6d.png)


#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**\*
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.

\*: As I've commented above, tests are incomplete. Though current tests (`cargo test`) have run OK.
EDIT: Added a screenshot of the error + note preview
