### PR TITLE
docs: fix typo in config/README.md

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -846,7 +846,7 @@ it would have been `nixpkgs/pkgs`.
 | `truncation_symbol` | `""`                                               | The symbol to prefix to truncated paths. eg: "…/"                                      |
 | `repo_root_style`   | `None`                                             | The style for the root of the git repo when `truncate_to_repo` option is set to false. |
 | `home_symbol`       | `"~"`                                              | The symbol indicating home directory.                                                  |
-| `use_os_path_sep`   | `true`                                             | Use the OS specific path seperator instead of always using `/` (e.g. `\` on Windows)   |
+| `use_os_path_sep`   | `true`                                             | Use the OS specific path separator instead of always using `/` (e.g. `\` on Windows)   |
 
 <details>
 <summary>This module has a few advanced configuration options that control how the directory is displayed.</summary>


### PR DESCRIPTION

#### Description
Fixed typo.
```
seperator -> separator
```

#### Motivation and Context


#### Screenshots (if appropriate):

#### How Has This Been Tested?


- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:

- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
