### PR TITLE
fix(pwsh): Use global:error[0] for most recent error in powershell

### DIFF
--- a/src/init/starship.ps1
+++ b/src/init/starship.ps1
@@ -87,13 +87,13 @@ $null = New-Module starship {
             "--jobs=$($jobs)"
         )
 
-        # Whe start from the premise that the command executed correctly, which covers also the fresh console.
+        # We start from the premise that the command executed correctly, which covers also the fresh console.
         $lastExitCodeForPrompt = 0
         if ($lastCmd = Get-History -Count 1) {
             # In case we have a False on the Dollar hook, we know there's an error.
             if (-not $origDollarQuestion) {
-                # We retrieve the InvocationInfo from the most recent error using $error[0]
-                $lastCmdletError = try { $error[0] |  Where-Object { $_ -ne $null } | Select-Object -ExpandProperty InvocationInfo } catch { $null }
+                # We retrieve the InvocationInfo from the most recent error using $global:error[0]
+                $lastCmdletError = try { $global:error[0] |  Where-Object { $_ -ne $null } | Select-Object -ExpandProperty InvocationInfo } catch { $null }
                 # We check if the last command executed matches the line that caused the last error, in which case we know
                 # it was an internal Powershell command, otherwise, there MUST be an error code.
                 $lastExitCodeForPrompt = if ($null -ne $lastCmdletError -and $lastCmd.CommandLine -eq $lastCmdletError.Line) { 1 } else { $origLastExitCode }


### PR DESCRIPTION
Use global:error[0] for most recent error in powershell

<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

Replace $error[0] with $global:error[0] to correctly obtain the most recent error in powershell
Comments are also updated

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #3485

The current version uses $error[0], which is for the module starship instead of the global status and is always $null, so the $lastExitCodeForPrompot is always $origLastExitCode and starship cannot correctly display error_symbol.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
