### PR TITLE
fix(fish): Emit clear-screen escape sequence only in left prompt

### DIFF
--- a/src/print.rs
+++ b/src/print.rs
@@ -75,7 +75,7 @@ pub fn get_prompt(context: Context) -> String {
 
     // A workaround for a fish bug (see #739,#279). Applying it to all shells
     // breaks things (see #808,#824,#834). Should only be printed in fish.
-    if let Shell::Fish = context.shell {
+    if Shell::Fish == context.shell && context.target == Target::Main {
         buf.push_str("\x1b[J"); // An ASCII control code to clear screen
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Emitting the `[J` escape sequence in right prompt caused problems with fish text rendering, like during multiline input and during menu-completion. This PR restricts the escape sequence to just the left prompt part.


#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #3305
Closes #3603

#### Screenshots (if appropriate):

See the linked issue for more details.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
