### PR TITLE
feat: Add a Windows application manifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,17 +507,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
-name = "embed-resource"
-version = "1.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85505eb239fc952b300f29f0556d2d884082a83566768d980278d8faf38c780d"
-dependencies = [
- "cc",
- "vswhom",
- "winreg",
-]
-
-[[package]]
 name = "enumflags2"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1624,7 +1613,6 @@ dependencies = [
  "clap",
  "clap_complete",
  "directories-next",
- "embed-resource",
  "gethostname",
  "git2",
  "indexmap",
@@ -1665,6 +1653,7 @@ dependencies = [
  "versions",
  "which",
  "winapi",
+ "winres",
  "yaml-rust",
 ]
 
@@ -1975,26 +1964,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "vswhom"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be979b7f07507105799e854203b470ff7c78a1639e330a58f183b5fea574608b"
-dependencies = [
- "libc",
- "vswhom-sys",
-]
-
-[[package]]
-name = "vswhom-sys"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc2f5402d3d0e79a069714f7b48e3ecc60be7775a2c049cb839457457a239532"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
 name = "waker-fn"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2143,12 +2112,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08cabc9f0066848fef4bc6a1c1668e6efce38b661d2aeec75d18d8617eebb5f1"
 
 [[package]]
-name = "winreg"
-version = "0.10.1"
+name = "winres"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+checksum = "b68db261ef59e9e52806f688020631e987592bd83619edccda9c47d42cde4f6c"
 dependencies = [
- "winapi",
+ "toml",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,6 +507,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
+name = "embed-resource"
+version = "1.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85505eb239fc952b300f29f0556d2d884082a83566768d980278d8faf38c780d"
+dependencies = [
+ "cc",
+ "vswhom",
+ "winreg",
+]
+
+[[package]]
 name = "enumflags2"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1613,6 +1624,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "directories-next",
+ "embed-resource",
  "gethostname",
  "git2",
  "indexmap",
@@ -1963,6 +1975,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "vswhom"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be979b7f07507105799e854203b470ff7c78a1639e330a58f183b5fea574608b"
+dependencies = [
+ "libc",
+ "vswhom-sys",
+]
+
+[[package]]
+name = "vswhom-sys"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc2f5402d3d0e79a069714f7b48e3ecc60be7775a2c049cb839457457a239532"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "waker-fn"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2109,6 +2141,15 @@ name = "windows_x86_64_msvc"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08cabc9f0066848fef4bc6a1c1668e6efce38b661d2aeec75d18d8617eebb5f1"
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winrt-notification"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ nix = "0.23.1"
 
 [build-dependencies]
 shadow-rs = "0.8.1"
+embed-resource = "1.6.5"
 
 [dev-dependencies]
 mockall = "0.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ nix = "0.23.1"
 
 [build-dependencies]
 shadow-rs = "0.8.1"
-embed-resource = "1.6.5"
+winres = "0.1.12"
 
 [dev-dependencies]
 mockall = "0.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,8 @@ nix = "0.23.1"
 
 [build-dependencies]
 shadow-rs = "0.8.1"
+
+[target.'cfg(windows)'.build-dependencies]
 winres = "0.1.12"
 
 [dev-dependencies]

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,5 @@
 fn main() -> shadow_rs::SdResult<()> {
-    shadow_rs::new()
+    shadow_rs::new()?;
+    embed_resource::compile("starship-res.rc");
+    Ok(())
 }

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,13 @@
-fn main() -> shadow_rs::SdResult<()> {
-    shadow_rs::new()?;
-    embed_resource::compile("starship-res.rc");
+use std::error::Error;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    shadow_rs::new().map_err(|err| err.to_string())?;
+
+    if cfg!(target_os = "windows") {
+        let mut res = winres::WindowsResource::new();
+        res.set_manifest_file("starship.exe.manifest");
+        res.compile()?;
+    }
+
     Ok(())
 }

--- a/build.rs
+++ b/build.rs
@@ -3,7 +3,8 @@ use std::error::Error;
 fn main() -> Result<(), Box<dyn Error>> {
     shadow_rs::new().map_err(|err| err.to_string())?;
 
-    if cfg!(target_os = "windows") {
+    #[cfg(windows)]
+    {
         let mut res = winres::WindowsResource::new();
         res.set_manifest_file("starship.exe.manifest");
         res.compile()?;

--- a/starship-res.rc
+++ b/starship-res.rc
@@ -1,0 +1,3 @@
+#include <Windows.h>
+
+CREATEPROCESS_MANIFEST_RESOURCE_ID RT_MANIFEST "starship.exe.manifest"

--- a/starship-res.rc
+++ b/starship-res.rc
@@ -1,3 +1,0 @@
-#include <Windows.h>
-
-CREATEPROCESS_MANIFEST_RESOURCE_ID RT_MANIFEST "starship.exe.manifest"

--- a/starship.exe.manifest
+++ b/starship.exe.manifest
@@ -12,7 +12,7 @@
     </trustInfo>
     <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
         <application>
-            <!-- Windows 10 -->
+            <!-- Windows 10 & 11 -->
             <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
             <!-- Windows 8.1 -->
             <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
@@ -24,4 +24,9 @@
             <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
         </application>
     </compatibility>
+    <application xmlns="urn:schemas-microsoft-com:asm.v3">
+        <windowsSettings xmlns:ws2="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
+            <ws2:longPathAware>true</ws2:longPathAware>
+        </windowsSettings>
+    </application>
 </assembly>

--- a/starship.exe.manifest
+++ b/starship.exe.manifest
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+    <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+        <security>
+            <requestedPrivileges>
+                <requestedExecutionLevel
+                    level="asInvoker"
+                    uiAccess="false"
+                />
+            </requestedPrivileges>
+        </security>
+    </trustInfo>
+    <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+        <application>
+            <!-- Windows 10 -->
+            <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+            <!-- Windows 8.1 -->
+            <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+            <!-- Windows 8 -->
+            <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+            <!-- Windows 7 -->
+            <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+            <!-- Windows Vista -->
+            <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
+        </application>
+    </compatibility>
+</assembly>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
Add a Windows application manifest using [`embed-resource`](https://crates.io/crates/embed-resource). This should disable any Windows compatibility shims/switchback which could possibly slow down process startup, and also UAC virtualization for 32-bit, if anyone is still on 32-bit Windows that is.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #3589

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
