### PR TITLE
fix: ignore empty `--jobs` argument

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -18,6 +18,7 @@ use std::fs;
 use std::marker::PhantomData;
 use std::num::ParseIntError;
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 use std::string::String;
 use std::time::{Duration, Instant};
 use terminal_size::terminal_size;
@@ -617,8 +618,17 @@ impl Default for Properties {
     }
 }
 
+/// Parse String, but treat empty strings as `None`
+fn parse_trim<F: FromStr>(value: &str) -> Option<Result<F, F::Err>> {
+    let value = value.trim();
+    if value.is_empty() {
+        return None;
+    }
+    Some(F::from_str(value))
+}
+
 fn parse_jobs(jobs: &str) -> Result<i64, ParseIntError> {
-    jobs.trim().parse::<i64>()
+    parse_trim(jobs).unwrap_or(Ok(0))
 }
 
 fn default_width() -> usize {
@@ -626,10 +636,7 @@ fn default_width() -> usize {
 }
 
 fn parse_width(width: &str) -> Result<usize, ParseIntError> {
-    if width.is_empty() {
-        return Ok(default_width());
-    }
-    width.trim().parse::<usize>()
+    parse_trim(width).unwrap_or_else(|| Ok(default_width()))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
In some instances, shell managers might prevent shell hooks from running before the first prompt draw, causing the starship CLI args like `--jobs=` to be empty and fail at argument parsing. To improve robustness, treat empty `--jobs` arguments as 0. This PR handles this with a new `parse_trim` function used for both `--jobs` and the prior `--cmd-duration` parsing.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related #3480

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
