### PR TITLE
Add option gcloud.project_aliases

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1224,13 +1224,14 @@ This is based on the `~/.config/gcloud/active_config` file and the `~/.config/gc
 
 ### Options
 
-| Option           | Default                                                  | Description                                                     |
-| ---------------- | -------------------------------------------------------- | --------------------------------------------------------------- |
-| `format`         | `'on [$symbol$account(@$domain)(\($region\))]($style) '` | The format for the module.                                      |
-| `symbol`         | `"☁️  "`                                                 | The symbol used before displaying the current GCP profile.      |
-| `region_aliases` |                                                          | Table of region aliases to display in addition to the GCP name. |
-| `style`          | `"bold blue"`                                            | The style for the module.                                       |
-| `disabled`       | `false`                                                  | Disables the `gcloud` module.                                   |
+| Option            | Default                                                  | Description                                                      |
+| ----------------- | -------------------------------------------------------- | ---------------------------------------------------------------- |
+| `format`          | `'on [$symbol$account(@$domain)(\($region\))]($style) '` | The format for the module.                                       |
+| `symbol`          | `"☁️  "`                                                 | The symbol used before displaying the current GCP profile.       |
+| `region_aliases`  |                                                          | Table of region aliases to display in addition to the GCP name.  |
+| `project_aliases` |                                                          | Table of project aliases to display in addition to the GCP name. |
+| `style`           | `"bold blue"`                                            | The style for the module.                                        |
+| `disabled`        | `false`                                                  | Disables the `gcloud` module.                                    |
 
 ### Variables
 
@@ -1277,6 +1278,17 @@ symbol = "️🇬️ "
 [gcloud.region_aliases]
 us-central1 = "uc1"
 asia-northeast1 = "an1"
+```
+
+#### Display account and aliased project
+
+```toml
+# ~/.config/starship.toml
+
+[gcloud]
+format = 'on [$symbol$account(@$domain)(\($project\))]($style) '
+[gcloud.project_aliases]
+very-long-project-name = "vlpn"
 ```
 
 ## Git Branch

--- a/src/configs/gcloud.rs
+++ b/src/configs/gcloud.rs
@@ -10,6 +10,7 @@ pub struct GcloudConfig<'a> {
     pub style: &'a str,
     pub disabled: bool,
     pub region_aliases: HashMap<String, &'a str>,
+    pub project_aliases: HashMap<String, &'a str>,
 }
 
 impl<'a> Default for GcloudConfig<'a> {
@@ -20,6 +21,7 @@ impl<'a> Default for GcloudConfig<'a> {
             style: "bold blue",
             disabled: false,
             region_aliases: HashMap::new(),
+            project_aliases: HashMap::new(),
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

Add option `gcloud.project_aliases`, replace the GCP project name with configured alias, like `gcloud.region_aliases`. 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #3538 

#### Screenshots (if appropriate):

<img width="289" alt="スクリーンショット 2022-02-12 14 55 08" src="https://user-images.githubusercontent.com/20609790/153699062-d69e0e9c-7324-42cd-99c7-98873bf6cb75.png">


#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

related configs:

```
❯ cat ~/.config/gcloud/active_config
minecraft

❯ cat ~/.config/gcloud/configurations/config_minecraft
[core]
account = example@example.com # replaced
project = minecraft-abekoh

[compute]
zone = asia-northeast1-b
region = asia-northeast1

❯ cat ~/.config/starship.toml
[gcloud]
format = 'on [$symbol($project)]($style)'
[gcloud.project_aliases]
minecraft-abekoh = "mc"
```

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
