### PR TITLE
docs: Rename Heading localip -> Local IP

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1808,7 +1808,7 @@ By default the module will be shown if any of the following conditions are met:
 symbol = "∴ "
 ```
 
-## localip
+## Local IP
 
 The `localip` module shows the IPv4 address of the primary network interface.
 


### PR DESCRIPTION
I misread the lowercase l as uppercase I because all other headings are uppercase.