### PR TITLE
fix: Exclude vuepress output from dprint

### DIFF
--- a/.dprint.json
+++ b/.dprint.json
@@ -11,6 +11,7 @@
     "**/*.{md,toml,json}"
   ],
   "excludes": [
+    "docs/.vuepress/dist/**",
     "**/node_modules",
     "**/*-lock.json",
     ".github/*",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
Removes vuepress generated files from dprint formatting to avoid a potential OOM condition when running dprint locally.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Avoids triggering https://github.com/dprint/dprint/issues/472

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
