### PR TITLE
ci: deny warnings, useful env vars, do not cache deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,11 @@ on:
   push:
     tags:
       - "v*"
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  RUST_BACKTRACE: short
+  RUSTUP_MAX_RETRIES: 10
 
 jobs:
   # Build sources for every OS
@@ -61,15 +66,6 @@ jobs:
     steps:
       - name: Setup | Checkout
         uses: actions/checkout@v2.4.0
-
-      # Cache files between builds
-      - name: Setup | Cache Cargo
-        uses: actions/cache@v2.1.7
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Setup | Rust
         uses: actions-rs/toolchain@v1.0.7

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -9,6 +9,13 @@ on:
       - "docs/**"
       - "**.md"
 
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  RUST_BACKTRACE: short
+  RUSTFLAGS: "-D warnings"
+  RUSTUP_MAX_RETRIES: 10
+
 jobs:
   # Run the `rustfmt` code formatter
   rustfmt:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -163,3 +163,6 @@ jobs:
       # Run the ignored tests that expect the above setup
       - name: Build | Test
         run: cargo test --workspace --locked --all-features -- -Z unstable-options --include-ignored
+        env:
+          # Avoid -D warnings on nightly builds
+          RUSTFLAGS: ""


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
I noticed #3623 was green despite deprecation warnings from the rust compiler. This PR sets the `RUSTFLAGS` env var to `-Dwarnings` to make this fail in CI.
I also added some extra useful env vars used by some other rust projects to enable backtraces, increase cargo/rustup network retries and disable incremental compilation (less useful in a CI context, the cache action also sets this).

I did not add `-Dwarnings` to the deployment workflow to prevent it from breaking it. Furthermore, I also removed the cache action from `deploy.yml` because it is less useful in release builds, and it was still using the old cache action.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
