### PR TITLE
fix(windows): avoid verbatim paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -495,6 +495,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
+name = "dunce"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "453440c271cf5577fd2a40e4942540cb7d0d2f85e27c8d07dd0023c925a67541"
+
+[[package]]
 name = "easy-parallel"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1609,6 +1615,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "directories-next",
+ "dunce",
  "gethostname",
  "git2",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ chrono = "0.4.19"
 clap = { version = "3.1.0", features = ["derive", "cargo", "unicode"] }
 clap_complete = "3.1.0"
 directories-next = "2.0.0"
+dunce = "1.0.2"
 gethostname = "0.2.2"
 git2 = { version = "0.13.25", default-features = false }
 indexmap = { version = "1.8.0", features = ["serde"] }

--- a/clippy.toml
+++ b/clippy.toml
@@ -3,4 +3,6 @@ disallowed-methods = [
   "std::process::Command::new",
   # Setting environment variables can cause issues with non-rust code
   "std::env::set_var",
+  # use `dunce` to avoid UNC/verbatim paths, where possible
+  "std::fs::canonicalize",
 ]

--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -364,8 +364,8 @@ mod tests {
         fs::create_dir_all(&src_dir)?;
         init_repo(&repo_dir)?;
 
-        let src_variations = [src_dir.clone(), src_dir.canonicalize().unwrap()];
-        let repo_variations = [repo_dir.clone(), repo_dir.canonicalize().unwrap()];
+        let src_variations = [src_dir.clone(), dunce::canonicalize(src_dir).unwrap()];
+        let repo_variations = [repo_dir.clone(), dunce::canonicalize(repo_dir).unwrap()];
         for src_dir in &src_variations {
             for repo_dir in &repo_variations {
                 let output = contract_repo_path(src_dir, repo_dir);
@@ -1590,7 +1590,7 @@ mod tests {
     #[test]
     #[cfg(windows)]
     fn windows_trims_extended_unc_path_prefix() {
-        // Under Windows, path canonicalization returns UNC paths using extended-path prefixes `\\?\UNC\`
+        // Under Windows, path canonicalization may return UNC paths using extended-path prefixes `\\?\UNC\`
         // We expect this prefix to be trimmed before being rendered.
         let unc_path = Path::new(r"\\?\UNC\server\share\a\b\c");
 

--- a/src/modules/pulumi.rs
+++ b/src/modules/pulumi.rs
@@ -270,7 +270,7 @@ mod tests {
     fn render_valid_paths() -> io::Result<()> {
         use io::Write;
         let dir = tempfile::tempdir()?;
-        let root = std::fs::canonicalize(dir.path())?;
+        let root = dunce::canonicalize(dir.path())?;
         let mut yaml = File::create(root.join("Pulumi.yml"))?;
         yaml.write_all("name: starship\nruntime: nodejs\ndescription: A thing\n".as_bytes())?;
         yaml.sync_all()?;
@@ -337,7 +337,7 @@ mod tests {
     fn partial_login() -> io::Result<()> {
         use io::Write;
         let dir = tempfile::tempdir()?;
-        let root = std::fs::canonicalize(dir.path())?;
+        let root = dunce::canonicalize(dir.path())?;
         let mut yaml = File::create(root.join("Pulumi.yml"))?;
         yaml.write_all("name: starship\nruntime: nodejs\ndescription: A thing\n".as_bytes())?;
         yaml.sync_all()?;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR replaces `std::fs::canonicalize` with `dunce::canonicalize` which will strip extended paths prefixes from verbatim paths if the paths also works without the prefix (long paths, reserved names). Paths without the prefix are more widely compatible.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #3582

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
