### PR TITLE
feat(spack): Add `Spack` module

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -1237,6 +1237,20 @@
         }
       ]
     },
+    "spack": {
+      "default": {
+        "disabled": false,
+        "format": "via [$symbol$environment]($style) ",
+        "style": "blue bold",
+        "symbol": "🅢 ",
+        "truncation_length": 1
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/SpackConfig"
+        }
+      ]
+    },
     "status": {
       "default": {
         "disabled": true,
@@ -4212,6 +4226,33 @@
         },
         "style": {
           "default": "blue bold dimmed",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        }
+      }
+    },
+    "SpackConfig": {
+      "type": "object",
+      "properties": {
+        "truncation_length": {
+          "default": 1,
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "format": {
+          "default": "via [$symbol$environment]($style) ",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "🅢 ",
+          "type": "string"
+        },
+        "style": {
+          "default": "blue bold",
           "type": "string"
         },
         "disabled": {

--- a/docs/.vuepress/public/presets/toml/bracketed-segments.toml
+++ b/docs/.vuepress/public/presets/toml/bracketed-segments.toml
@@ -124,6 +124,9 @@ format = '\[[$symbol($version)]($style)\]'
 [scala]
 format = '\[[$symbol($version)]($style)\]'
 
+[spack]
+format = '\[[$symbol$environment]($style)\]'
+
 [sudo]
 format = '\[[as $symbol]\]'
 

--- a/docs/.vuepress/public/presets/toml/nerd-font-symbols.toml
+++ b/docs/.vuepress/public/presets/toml/nerd-font-symbols.toml
@@ -58,5 +58,8 @@ symbol = " "
 [package]
 symbol = " "
 
+[spack]
+symbol = "🅢 "
+
 [rust]
 symbol = " "

--- a/docs/.vuepress/public/presets/toml/plain-text-symbols.toml
+++ b/docs/.vuepress/public/presets/toml/plain-text-symbols.toml
@@ -112,6 +112,9 @@ symbol = "rs "
 [scala]
 symbol = "scala "
 
+[spack]
+symbol = "spack "
+
 [sudo]
 symbol = "sudo "
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -3172,16 +3172,15 @@ format = '[📦 \[$env\]]($style) '
 
 The `spack` module shows the current [Spack](https://spack.readthedocs.io/en/latest/) environment, if `$SPACK_ENV` is set.
 
-
 ### Options
 
-| Option              | Default                                | Description                                                                                                                                                                                                 |
-| ------------------- | -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Option              | Default                                | Description                                                                                                                                     |
+| ------------------- | -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
 | `truncation_length` | `1`                                    | The number of directories the environment path should be truncated to/. `0` means no truncation. Also see the [`directory`](#directory) module. |
-| `symbol`            | `"🅢  "`                                 | The symbol used before the environment name.                                                                                                                                                                |
-| `style`             | `"bold blue"`                         | The style for the module.                                                                                                                                                                                   |
-| `format`            | `"via [$symbol$environment]($style) "` | The format for the module.                                                                                                                                                                                  |
-| `disabled`          | `false`                                | Disables the `spack` module.                                                                                                                                                                                |
+| `symbol`            | `"🅢  "`                                | The symbol used before the environment name.                                                                                                    |
+| `style`             | `"bold blue"`                          | The style for the module.                                                                                                                       |
+| `format`            | `"via [$symbol$environment]($style) "` | The format for the module.                                                                                                                      |
+| `disabled`          | `false`                                | Disables the `spack` module.                                                                                                                    |
 
 ### Variables
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -3174,13 +3174,13 @@ The `spack` module shows the current [Spack](https://spack.readthedocs.io/en/lat
 
 ### Options
 
-| Option              | Default                                | Description                                                                                                                                     |
-| ------------------- | -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| Option              | Default                                | Description                                                                                                                                    |
+| ------------------- | -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
 | `truncation_length` | `1`                                    | The number of directories the environment path should be truncated to. `0` means no truncation. Also see the [`directory`](#directory) module. |
-| `symbol`            | `"🅢  "`                                | The symbol used before the environment name.                                                                                                    |
-| `style`             | `"bold blue"`                          | The style for the module.                                                                                                                       |
-| `format`            | `"via [$symbol$environment]($style) "` | The format for the module.                                                                                                                      |
-| `disabled`          | `false`                                | Disables the `spack` module.                                                                                                                    |
+| `symbol`            | `"🅢  "`                                | The symbol used before the environment name.                                                                                                   |
+| `style`             | `"bold blue"`                          | The style for the module.                                                                                                                      |
+| `format`            | `"via [$symbol$environment]($style) "` | The format for the module.                                                                                                                     |
+| `disabled`          | `false`                                | Disables the `spack` module.                                                                                                                   |
 
 ### Variables
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -247,6 +247,7 @@ $vagrant\
 $zig\
 $nix_shell\
 $conda\
+$spack\
 $memory_usage\
 $aws\
 $gcloud\
@@ -3165,6 +3166,40 @@ and `$SINGULARITY_NAME` is set.
 
 [singularity]
 format = '[📦 \[$env\]]($style) '
+```
+
+## Spack
+
+The `spack` module shows the current [Spack](https://spack.readthedocs.io/en/latest/) environment, if `$SPACK_ENV` is set.
+
+
+### Options
+
+| Option              | Default                                | Description                                                                                                                                                                                                 |
+| ------------------- | -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `truncation_length` | `1`                                    | The number of directories the environment path should be truncated to/. `0` means no truncation. Also see the [`directory`](#directory) module. |
+| `symbol`            | `"🅢  "`                                 | The symbol used before the environment name.                                                                                                                                                                |
+| `style`             | `"bold blue"`                         | The style for the module.                                                                                                                                                                                   |
+| `format`            | `"via [$symbol$environment]($style) "` | The format for the module.                                                                                                                                                                                  |
+| `disabled`          | `false`                                | Disables the `spack` module.                                                                                                                                                                                |
+
+### Variables
+
+| Variable    | Example      | Description                          |
+| ----------- | ------------ | ------------------------------------ |
+| environment | `astronauts` | The current spack environment        |
+| symbol      |              | Mirrors the value of option `symbol` |
+| style\*     |              | Mirrors the value of option `style`  |
+
+*: This variable can only be used as a part of a style string
+
+### Example
+
+```toml
+# ~/.config/starship.toml
+
+[spack]
+format = "[$symbol$environment](dimmed blue) "
 ```
 
 ## Status

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -3176,7 +3176,7 @@ The `spack` module shows the current [Spack](https://spack.readthedocs.io/en/lat
 
 | Option              | Default                                | Description                                                                                                                                     |
 | ------------------- | -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| `truncation_length` | `1`                                    | The number of directories the environment path should be truncated to/. `0` means no truncation. Also see the [`directory`](#directory) module. |
+| `truncation_length` | `1`                                    | The number of directories the environment path should be truncated to. `0` means no truncation. Also see the [`directory`](#directory) module. |
 | `symbol`            | `"🅢  "`                                | The symbol used before the environment name.                                                                                                    |
 | `style`             | `"bold blue"`                          | The style for the module.                                                                                                                       |
 | `format`            | `"via [$symbol$environment]($style) "` | The format for the module.                                                                                                                      |

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -63,6 +63,7 @@ pub mod scala;
 pub mod shell;
 pub mod shlvl;
 pub mod singularity;
+pub mod spack;
 mod starship_root;
 pub mod status;
 pub mod sudo;
@@ -209,6 +210,8 @@ pub struct FullConfig<'a> {
     shlvl: shlvl::ShLvlConfig<'a>,
     #[serde(borrow)]
     singularity: singularity::SingularityConfig<'a>,
+    #[serde(borrow)]
+    spack: spack::SpackConfig<`a>,
     #[serde(borrow)]
     status: status::StatusConfig<'a>,
     #[serde(borrow)]

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -211,7 +211,7 @@ pub struct FullConfig<'a> {
     #[serde(borrow)]
     singularity: singularity::SingularityConfig<'a>,
     #[serde(borrow)]
-    spack: spack::SpackConfig<`a>,
+    spack: spack::SpackConfig<'a>,
     #[serde(borrow)]
     status: status::StatusConfig<'a>,
     #[serde(borrow)]

--- a/src/configs/spack.rs
+++ b/src/configs/spack.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct SpackConfig<'a> {
     pub truncation_length: usize,

--- a/src/configs/spack.rs
+++ b/src/configs/spack.rs
@@ -1,9 +1,7 @@
-use crate::config::ModuleConfig;
+use serde::{Deserialize, Serialize};
 
-use serde::Serialize;
-use starship_module_config_derive::ModuleConfig;
-
-#[derive(Clone, ModuleConfig, Serialize)]
+#[derive(Clone, Deserialize, Serialize)]
+#[serde(default)]
 pub struct SpackConfig<'a> {
     pub truncation_length: usize,
     pub format: &'a str,

--- a/src/configs/spack.rs
+++ b/src/configs/spack.rs
@@ -1,0 +1,25 @@
+use crate::config::ModuleConfig;
+
+use serde::Serialize;
+use starship_module_config_derive::ModuleConfig;
+
+#[derive(Clone, ModuleConfig, Serialize)]
+pub struct SpackConfig<'a> {
+    pub truncation_length: usize,
+    pub format: &'a str,
+    pub symbol: &'a str,
+    pub style: &'a str,
+    pub disabled: bool,
+}
+
+impl<'a> Default for SpackConfig<'a> {
+    fn default() -> Self {
+        SpackConfig {
+            truncation_length: 1,
+            format: "via [$symbol$environment]($style) ",
+            symbol: "🅢 ",
+            style: "blue bold",
+            disabled: false,
+        }
+    }
+}

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -74,6 +74,7 @@ pub const PROMPT_ORDER: &[&str] = &[
     "buf",
     "nix_shell",
     "conda",
+    "spack",
     "memory_usage",
     "aws",
     "gcloud",

--- a/src/module.rs
+++ b/src/module.rs
@@ -70,6 +70,7 @@ pub const ALL_MODULES: &[&str] = &[
     "shell",
     "shlvl",
     "singularity",
+    "spack",
     "status",
     "sudo",
     "swift",

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -60,6 +60,7 @@ mod scala;
 mod shell;
 mod shlvl;
 mod singularity;
+mod spack;
 mod status;
 mod sudo;
 mod swift;
@@ -150,6 +151,7 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
             "shell" => shell::module(context),
             "shlvl" => shlvl::module(context),
             "singularity" => singularity::module(context),
+            "spack" => spack::module(context),
             "swift" => swift::module(context),
             "status" => status::module(context),
             "sudo" => sudo::module(context),
@@ -245,6 +247,7 @@ pub fn description(module: &str) -> &'static str {
         "shell" => "The currently used shell indicator",
         "shlvl" => "The current value of SHLVL",
         "singularity" => "The currently used Singularity image",
+        "spack" => "The current spack environment, if $SPACK_ENV is set",
         "status" => "The status of the last command",
         "sudo" => "The sudo credentials are currently cached",
         "swift" => "The currently installed version of Swift",

--- a/src/modules/spack.rs
+++ b/src/modules/spack.rs
@@ -1,0 +1,84 @@
+use super::{Context, Module, RootModuleConfig};
+
+use super::utils::directory::truncate;
+use crate::configs::spack::SpackConfig;
+use crate::formatter::StringFormatter;
+
+/// Creates a module with the current Spack environment
+///
+/// Will display the Spack environment if `$SPACK_ENV` is set.
+pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let spack_env = context.get_env("SPACK_ENV").unwrap_or_default();
+    if spack_env.trim().is_empty() {
+        return None;
+    }
+
+    let mut module = context.new_module("spack");
+    let config: SpackConfig = SpackConfig::try_load(module.config);
+
+    let spack_env = truncate(&spack_env, config.truncation_length).unwrap_or(spack_env);
+
+    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
+        formatter
+            .map_meta(|variable, _| match variable {
+                "symbol" => Some(config.symbol),
+                _ => None,
+            })
+            .map_style(|variable| match variable {
+                "style" => Some(Ok(config.style)),
+                _ => None,
+            })
+            .map(|variable| match variable {
+                "environment" => Some(Ok(spack_env.as_str())),
+                _ => None,
+            })
+            .parse(None, Some(context))
+    });
+
+    module.set_segments(match parsed {
+        Ok(segments) => segments,
+        Err(error) => {
+            log::warn!("Error in module `spack`:\n{}", error);
+            return None;
+        }
+    });
+
+    Some(module)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::ModuleRenderer;
+    use ansi_term::Color;
+
+    #[test]
+    fn not_in_env() {
+        let actual = ModuleRenderer::new("spack").collect();
+
+        let expected = None;
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn env_set() {
+        let actual = ModuleRenderer::new("spack")
+            .env("SPACK_ENV", "astronauts")
+            .collect();
+
+        let expected = Some(format!("via {} ", Color::Blue.bold().paint("🅢 astronauts")));
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn truncate() {
+        let actual = ModuleRenderer::new("spack")
+            .env("SPACK_ENV", "/some/really/long/and/really/annoying/path/that/shouldnt/be/displayed/fully/spack/my_env")
+            .collect();
+
+        let expected = Some(format!("via {} ", Color::Blue.bold().paint("🅢 my_env")));
+
+        assert_eq!(expected, actual);
+    }
+}

--- a/src/modules/spack.rs
+++ b/src/modules/spack.rs
@@ -1,4 +1,4 @@
-use super::{Context, Module, RootModuleConfig};
+use super::{Context, Module, ModuleConfig};
 
 use super::utils::directory::truncate;
 use crate::configs::spack::SpackConfig;


### PR DESCRIPTION
#### Description
Adds support for the [Spack](https://spack.io/) package manager, displaying the name of the spack environment based on `$SPACK_ENV` env variable.

#### Motivation and Context
Closes https://github.com/starship/starship/issues/3446

#### Screenshots (if appropriate):
![Screenshot from 2022-02-22 00-09-36](https://user-images.githubusercontent.com/55138489/155036577-35a3004f-b0e8-49be-9348-579d970b0673.png)

#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**
Tested on Fedora 35 using Gnome Terminal. Wrote unit tests to test rendering of the module based on presence of `$SPACK_ENV` env variable.

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
