### PR TITLE
feat(directory): Allows to highlight the last component of the pwd

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -884,10 +884,12 @@ a single character. For `fish_style_pwd_dir_length = 2`, it would be `/bu/th/ci/
 
 ### Variables
 
-| Variable | Example               | Description                         |
-| -------- | --------------------- | ----------------------------------- |
-| path     | `"D:/Projects"`       | The current directory path          |
-| style\*  | `"black bold dimmed"` | Mirrors the value of option `style` |
+| Variable       | Example                  | Description                                                   |
+| -------------- | ------------------------ | ------------------------------------------------------------- |
+| path           | `"D:/Projects/starship"` | The current directory path                                    |
+| path_base      | `"D:/Projects/"`         | The last component of `path`                                  |
+| last_component | `"starship"`             | The remainder of the `path` after removing the last component |
+| style\*        | `"black bold dimmed"`    | Mirrors the value of option `style`                           |
 
 *: This variable can only be used as a part of a style string
 
@@ -896,13 +898,15 @@ a single character. For `fish_style_pwd_dir_length = 2`, it would be `/bu/th/ci/
 
 Let us consider the path `/path/to/home/git_repo/src/lib`
 
-| Variable         | Example               | Description                             |
-| ---------------- | --------------------- | --------------------------------------- |
-| before_root_path | `"/path/to/home/"`    | The path before git root directory path |
-| repo_root        | `"git_repo"`          | The git root directory name             |
-| path             | `"/src/lib"`          | The remaining path                      |
-| style            | `"black bold dimmed"` | Mirrors the value of option `style`     |
-| repo_root_style  | `"underline white"`   | Style for git root directory name       |
+| Variable         | Example               | Description                                                   |
+| ---------------- | --------------------- | ------------------------------------------------------------- |
+| before_root_path | `"/path/to/home/"`    | The path before git root directory path                       |
+| repo_root        | `"git_repo"`          | The git root directory name                                   |
+| path             | `"/src/lib"`          | The remaining path                                            |
+| path_base        | `"/src/"`             | The last component of `path`                                  |
+| last_component   | `"lib"`               | The remainder of the `path` after removing the last component |
+| style            | `"black bold dimmed"` | Mirrors the value of option `style`                           |
+| repo_root_style  | `"underline white"`   | Style for git root directory name                             |
 
 </details>
 

--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -99,7 +99,15 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         String::from("")
     };
 
-    let path_vec = match &repo.and_then(|r| r.workdir.as_ref()) {
+    const BEFORE_ROOT_PATH: usize = 0;
+    const REPO_ROOT: usize = 1;
+    const PATH: usize = 2;
+    const PATH_BASE: usize = 3;
+    const LAST_COMPONENT: usize = 4;
+
+    let mut path_vec = [0; 5].map(|_| String::new());
+
+    match &repo.and_then(|r| r.workdir.as_ref()) {
         Some(repo_root) if config.repo_root_style.is_some() => {
             let contracted_path = contract_repo_path(display_dir, repo_root)?;
             let repo_path_vec: Vec<&str> = contracted_path.split('/').collect();
@@ -109,13 +117,36 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             if ((num_segments_after_root - 1) as i64) < config.truncation_length {
                 let root = repo_path_vec[0];
                 let before = dir_string.replace(&contracted_path, "");
-                [prefix + &before, root.to_string(), after_repo_root]
+                path_vec[BEFORE_ROOT_PATH] = prefix + &before;
+                path_vec[REPO_ROOT] = root.to_string();
+                path_vec[PATH] = after_repo_root;
             } else {
-                ["".to_string(), "".to_string(), prefix + &dir_string]
+                path_vec[PATH] = prefix + &dir_string;
             }
         }
-        _ => ["".to_string(), "".to_string(), prefix + &dir_string],
+        _ => {
+            path_vec[PATH] = prefix + &dir_string;
+        }
     };
+
+    (path_vec[PATH_BASE], path_vec[LAST_COMPONENT]) =
+        path_vec[PATH]
+            .rfind('/')
+            .map_or(("".to_string(), path_vec[PATH][..].to_string()), |pos| {
+                (
+                    path_vec[PATH][..pos].to_string(),
+                    path_vec[PATH][pos + 1..].to_string(),
+                )
+            });
+
+    if path_vec[LAST_COMPONENT] != home_symbol
+        && (!path_vec[LAST_COMPONENT].is_empty()
+            || path_vec[BEFORE_ROOT_PATH].is_empty()
+                && path_vec[REPO_ROOT].is_empty()
+                && path_vec[PATH_BASE].is_empty())
+    {
+        path_vec[PATH_BASE] = format!("{}/", path_vec[PATH_BASE]);
+    }
 
     let path_vec = if config.use_os_path_sep {
         path_vec.map(|i| convert_path_sep(&i))
@@ -124,7 +155,8 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     };
 
     let lock_symbol = String::from(config.read_only);
-    let display_format = if path_vec[0].is_empty() && path_vec[1].is_empty() {
+    let display_format = if path_vec[BEFORE_ROOT_PATH].is_empty() && path_vec[REPO_ROOT].is_empty()
+    {
         config.format
     } else {
         config.repo_root_format
@@ -140,9 +172,11 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 _ => None,
             })
             .map(|variable| match variable {
-                "path" => Some(Ok(&path_vec[2])),
-                "before_root_path" => Some(Ok(&path_vec[0])),
-                "repo_root" => Some(Ok(&path_vec[1])),
+                "before_root_path" => Some(Ok(&path_vec[BEFORE_ROOT_PATH])),
+                "repo_root" => Some(Ok(&path_vec[REPO_ROOT])),
+                "path" => Some(Ok(&path_vec[PATH])),
+                "path_base" => Some(Ok(&path_vec[PATH_BASE])),
+                "last_component" => Some(Ok(&path_vec[LAST_COMPONENT])),
                 "read_only" => {
                     if is_readonly_dir(physical_dir) {
                         Some(Ok(&lock_symbol))


### PR DESCRIPTION
sell also #3653

#### Description

* `src/modules/directory.rs`
* `docs/config/README.md`

added two variables, `$last_component` and `$path_base` in module `directory`.

#### Motivation and Context

This PR allows to highlight the last component of the pwd.
It can close the gap between starship and p10k at this point.

Closes #3653

#### Screenshots (if appropriate):

![](https://raw.githubusercontent.com/romkatv/powerlevel10k-media/master/directory-truncation.gif)

#### How Has This Been Tested?

- [X] I have tested using **MacOS**
- [X] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:

- [X] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
