### PR TITLE
refactor: fix new clippy/compiler warnings

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -475,16 +475,19 @@ pub struct ScanDir<'a> {
 }
 
 impl<'a> ScanDir<'a> {
+    #[must_use]
     pub const fn set_files(mut self, files: &'a [&'a str]) -> Self {
         self.files = files;
         self
     }
 
+    #[must_use]
     pub const fn set_extensions(mut self, extensions: &'a [&'a str]) -> Self {
         self.extensions = extensions;
         self
     }
 
+    #[must_use]
     pub const fn set_folders(mut self, folders: &'a [&'a str]) -> Self {
         self.folders = folders;
         self

--- a/src/formatter/string_formatter.rs
+++ b/src/formatter/string_formatter.rs
@@ -111,6 +111,7 @@ impl<'a> StringFormatter<'a> {
     ///
     /// - `Some(Ok(_))`: The value of this variable will be displayed in the format string.
     ///
+    #[must_use]
     pub fn map<T, M>(mut self, mapper: M) -> Self
     where
         T: Into<Cow<'a, str>>,
@@ -131,6 +132,7 @@ impl<'a> StringFormatter<'a> {
     ///
     /// See `StringFormatter::map` for description on the parameters.
     ///
+    #[must_use]
     pub fn map_no_escaping<T, M>(mut self, mapper: M) -> Self
     where
         T: Into<Cow<'a, str>>,
@@ -152,6 +154,7 @@ impl<'a> StringFormatter<'a> {
     /// the format strings of meta-variables can be cached properly.
     ///
     /// See `StringFormatter::map` for description on the parameters.
+    #[must_use]
     pub fn map_meta<M>(mut self, mapper: M) -> Self
     where
         M: Fn(&str, &BTreeSet<String>) -> Option<&'a str> + Sync,
@@ -193,6 +196,7 @@ impl<'a> StringFormatter<'a> {
     /// Maps variable name to an array of segments
     ///
     /// See `StringFormatter::map` for description on the parameters.
+    #[must_use]
     pub fn map_variables_to_segments<M>(mut self, mapper: M) -> Self
     where
         M: Fn(&str) -> Option<Result<Vec<Segment>, StringFormatterError>> + Sync,
@@ -209,6 +213,7 @@ impl<'a> StringFormatter<'a> {
     /// Maps variable name in a style string to its value
     ///
     /// See `StringFormatter::map` for description on the parameters.
+    #[must_use]
     pub fn map_style<T, M>(mut self, mapper: M) -> Self
     where
         T: Into<Cow<'a, str>>,

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -43,7 +43,7 @@ impl StarshipPath {
     /// PowerShell specific path escaping
     fn sprint_pwsh(&self) -> io::Result<String> {
         self.str_path()
-            .map(|s| s.replace("'", "''"))
+            .map(|s| s.replace('\'', "''"))
             .map(|s| format!("'{}'", s))
     }
     /// Command Shell specific path escaping

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![warn(clippy::disallowed_method)]
+#![warn(clippy::disallowed_methods)]
 
 #[macro_use]
 extern crate shadow_rs;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-#![warn(clippy::disallowed_method)]
+#![warn(clippy::disallowed_methods)]
 
 use clap::crate_authors;
 use std::io;

--- a/src/module.rs
+++ b/src/module.rs
@@ -209,8 +209,7 @@ where
         current
     } else {
         let fill_size = term_width
-            .map(|tw| if tw > used { Some(tw - used) } else { None })
-            .flatten()
+            .and_then(|tw| if tw > used { Some(tw - used) } else { None })
             .map(|remaining| remaining / chunks.len());
         chunks
             .into_iter()
@@ -229,7 +228,7 @@ mod tests {
 
     #[test]
     fn test_all_modules_is_in_alphabetical_order() {
-        let mut sorted_modules: Vec<&str> = ALL_MODULES.iter().copied().collect();
+        let mut sorted_modules: Vec<&str> = ALL_MODULES.to_vec();
         sorted_modules.sort_unstable();
         assert_eq!(sorted_modules.as_slice(), ALL_MODULES);
     }

--- a/src/modules/custom.rs
+++ b/src/modules/custom.rs
@@ -123,7 +123,7 @@ fn shell_command(cmd: &str, shell_args: &[&str]) -> Option<Output> {
                 "Could not launch command with given shell or STARSHIP_SHELL env variable, retrying with /usr/bin/env sh"
             );
 
-            #[allow(clippy::disallowed_method)]
+            #[allow(clippy::disallowed_methods)]
             Command::new("/usr/bin/env")
                 .arg("sh")
                 .stdin(Stdio::piped())

--- a/src/modules/docker_context.rs
+++ b/src/modules/docker_context.rs
@@ -41,9 +41,9 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     )
     .join("config.json");
 
-    let docker_context_env =
-        std::array::IntoIter::new(["DOCKER_MACHINE_NAME", "DOCKER_HOST", "DOCKER_CONTEXT"])
-            .find_map(|env| context.get_env(env));
+    let docker_context_env = ["DOCKER_MACHINE_NAME", "DOCKER_HOST", "DOCKER_CONTEXT"]
+        .into_iter()
+        .find_map(|env| context.get_env(env));
 
     let ctx = match docker_context_env {
         Some(data) => data,

--- a/src/modules/pulumi.rs
+++ b/src/modules/pulumi.rs
@@ -158,7 +158,7 @@ fn get_pulumi_workspace(context: &Context, name: &str, project_file: &Path) -> O
     } else {
         let mut hasher = Sha1::new();
         hasher.update(project_file.to_str()?.as_bytes());
-        crate::utils::encode_to_hex(&hasher.finalize().to_vec())
+        crate::utils::encode_to_hex(&hasher.finalize())
     };
     let unique_file_name = format!("{}-{}-workspace.json", name, project_file);
     let mut path = pulumi_home_dir(context)?;

--- a/src/modules/status.rs
+++ b/src/modules/status.rs
@@ -76,13 +76,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         PipeStatusStatus::Pipe(_) => config.pipestatus_format,
         _ => config.format,
     };
-    let parsed = format_exit_code(
-        &exit_code.to_string(),
-        main_format,
-        Some(&pipestatus),
-        &config,
-        context,
-    );
+    let parsed = format_exit_code(exit_code, main_format, Some(&pipestatus), &config, context);
 
     module.set_segments(match parsed {
         Ok(segments) => segments,
@@ -119,8 +113,8 @@ fn format_exit_code<'a>(
         false => None,
     };
     let signal_number = raw_signal_number.map(|sn| sn.to_string());
-    let signal_name = raw_signal_number
-        .and_then(|sn| status_signal_name(sn).or_else(|| signal_number.as_deref()));
+    let signal_name =
+        raw_signal_number.and_then(|sn| status_signal_name(sn).or(signal_number.as_deref()));
 
     // If not a signal and not a common meaning, it should at least print the raw exit code number
     let maybe_exit_code_number = match common_meaning.is_none() && signal_name.is_none() {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -75,7 +75,7 @@ pub fn create_command<T: AsRef<OsStr>>(binary_name: T) -> Result<Command> {
         }
     };
 
-    #[allow(clippy::disallowed_method)]
+    #[allow(clippy::disallowed_methods)]
     let mut cmd = Command::new(full_path);
     cmd.stderr(Stdio::piped())
         .stdout(Stdio::piped())


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR fixes the new Rust 1.59 compiler and clippy warnings. This release also adds `strip =` to release profiles in `Cargo.toml`, but this printed some warnings on macOS, so I've kept that as-is for now.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
