### PR TITLE
perf(rayon): restrict thread count

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 
 use clap::crate_authors;
 use std::io;
+use std::thread::available_parallelism;
 use std::time::SystemTime;
 
 use clap::{IntoApp, Parser, Subcommand};
@@ -108,6 +109,7 @@ fn main() {
     #[cfg(windows)]
     let _ = ansi_term::enable_ansi_support();
     logger::init();
+    init_global_threadpool();
 
     let args = match Cli::try_parse() {
         Ok(args) => args,
@@ -220,4 +222,20 @@ fn main() {
                 .collect::<String>()
         ),
     }
+}
+
+/// Intialize global `rayon` thread pool
+fn init_global_threadpool() {
+    // Allow overriding the number of threads
+    let num_threads = std::env::var("STARSHIP_NUM_THREADS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        // Default to the number of logical cores,
+        // but restrict the number of threads to 8
+        .unwrap_or_else(|| available_parallelism().map(usize::from).unwrap_or(1).min(8));
+
+    rayon::ThreadPoolBuilder::new()
+        .num_threads(num_threads)
+        .build_global()
+        .expect("Failed to initialize worker thread pool");
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Currently, [starship will spawn a thread for each logical cpu core](https://docs.rs/rayon/latest/rayon/struct.ThreadPoolBuilder.html#method.num_threads). On systems with high core counts, this can be expensive.

Thus, limit the maximum core count to 8. This is still cheap if there is nothing to do, but it doesn't seem to performance when a high number of modules are enabled.

Right now, different thread counts can also be set with the `RAYON_NUM_THREADS` variable.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related #3180

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
