### PR TITLE
fix(rust): overrides should only check full segments

### DIFF
--- a/src/modules/rust.rs
+++ b/src/modules/rust.rs
@@ -1,5 +1,7 @@
 use std::fs;
 use std::path::Path;
+#[cfg(windows)]
+use std::path::PathBuf;
 use std::process::Output;
 
 use serde::Deserialize;
@@ -123,11 +125,15 @@ fn extract_toolchain_from_rustup_override_list(stdout: &str, cwd: &Path) -> Opti
     if stdout == "no overrides\n" {
         return None;
     }
-    // use display version of path, also allows stripping \\?\
-    let cwd = cwd.to_string_lossy();
-    // rustup strips \\?\ prefix
+
     #[cfg(windows)]
-    let cwd = cwd.strip_prefix(r"\\?\").unwrap_or(&cwd);
+    let cwd = {
+        // use display version of path, also allows stripping \\?\
+        let cwd = cwd.to_string_lossy();
+        // rustup strips \\?\ prefix,
+        // so we do the same and convert back to a `Path`
+        PathBuf::from(cwd.strip_prefix(r"\\?\").unwrap_or(&cwd))
+    };
 
     stdout
         .lines()
@@ -295,6 +301,8 @@ mod tests {
         static OVERRIDES_CWD_B: &str = "/home/user/src/b/tests";
         static OVERRIDES_CWD_C: &str = "/home/user/src/c/examples";
         static OVERRIDES_CWD_D: &str = "/home/user/src/b/d c/spaces";
+        static OVERRIDES_CWD_E: &str = "/home/user/src/b_and_more";
+        static OVERRIDES_CWD_F: &str = "/home/user/src/b";
         assert_eq!(
             extract_toolchain_from_rustup_override_list(OVERRIDES_INPUT, OVERRIDES_CWD_A.as_ref()),
             Some("beta-x86_64-unknown-linux-gnu".to_owned()),
@@ -310,6 +318,14 @@ mod tests {
         assert_eq!(
             extract_toolchain_from_rustup_override_list(OVERRIDES_INPUT, OVERRIDES_CWD_D.as_ref()),
             Some("stable-x86_64-pc-windows-msvc".to_owned()),
+        );
+        assert_eq!(
+            extract_toolchain_from_rustup_override_list(OVERRIDES_INPUT, OVERRIDES_CWD_E.as_ref()),
+            None,
+        );
+        assert_eq!(
+            extract_toolchain_from_rustup_override_list(OVERRIDES_INPUT, OVERRIDES_CWD_F.as_ref()),
+            Some("nightly-x86_64-unknown-linux-gnu".to_owned()),
         );
     }
 


### PR DESCRIPTION
#### Description

Fix fixes a bug introduced in #3359, an override for `~/some/folder` was also used for `~/some/folder_with_suffix`. Not the first time that the difference of `Path::starts_with` and `str::starts_with` bites someone (`Path::starts_with` only matches full segments). 

#### How Has This Been Tested?
- [X] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [ ] I have updated the documentation accordingly.
- [X] I have updated the tests accordingly.
