### PR TITLE
refactor: fix typo in main.rs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -224,7 +224,7 @@ fn main() {
     }
 }
 
-/// Intialize global `rayon` thread pool
+/// Initialize global `rayon` thread pool
 fn init_global_threadpool() {
     // Allow overriding the number of threads
     let num_threads = std::env::var("STARSHIP_NUM_THREADS")


### PR DESCRIPTION


#### Description
Fixed typo.
```
Intialize -> Initialize
```

#### Motivation and Context


#### Screenshots (if appropriate):

#### How Has This Been Tested?


- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:

- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
