### PR TITLE
docs: remove enableZshIntegration from homemanager installation

### DIFF
--- a/docs/installing/README.md
+++ b/docs/installing/README.md
@@ -67,7 +67,6 @@ Enable the `programs.starship` module in your `home.nix` file, and add your sett
 {
   programs.starship = {
     enable = true;
-    enableZshIntegration = true;
     # Configuration written to ~/.config/starship.toml
     settings = {
       # add_newline = false;


### PR DESCRIPTION
(it's true by default)

<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
