### PR TITLE
feat(gcloud): created a function to validate config name in GCloud module

### DIFF
--- a/src/modules/gcloud.rs
+++ b/src/modules/gcloud.rs
@@ -106,6 +106,16 @@ fn get_active_config(context: &Context, config_dir: &Path) -> Option<String> {
     })
 }
 
+fn get_active_config_name(config_name: String) -> String {
+    let name = if config_name == "NONE" {
+        log::error!("Error in module `gcloud`: No config ");
+        config_name
+    } else {
+        config_name
+    };
+    name
+}
+
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let mut module = context.new_module("gcloud");
     let config: GcloudConfig = GcloudConfig::try_load(module.config);
@@ -154,7 +164,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                             .map_or(project, |alias| (*alias).to_owned())
                     })
                     .map(Ok),
-                "active" => Some(Ok(gcloud_context.config_name.clone())),
+                "active" => Some(Ok(get_active_config_name(gcloud_context.config_name.clone()))),
                 _ => None,
             })
             .parse(None, Some(context))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
related to this [issue](https://github.com/starship/starship/issues/3658)
_Still draft of PR_ I'm stuck with the last part of the issue, how could I make sure that nothing is sent to the console when in google cloud module config is set to "NONE"

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

As said in Issue, when the config is none it should not show up in the console, in this PR I have done the first part that is creating s function to validate when this happens.

<!--- If it fixes an open issue, please link to the issue here. -->
Closes #3658 
Closes  #4092

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
All tests in Google Cloud Module still passes.
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:

Maybe create tests as the ones that name projects as ABC for testing this new issue ?
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
