### PR TITLE
fix(fish): allow generating session keys in older versions of fish

### DIFF
--- a/src/init/starship.fish
+++ b/src/init/starship.fish
@@ -37,6 +37,4 @@ builtin functions -e fish_mode_prompt
 set -gx STARSHIP_SHELL "fish"
 
 # Set up the session key that will be used to store logs
-set STARSHIP_SESSION_KEY (random)(random)(random)(random)(random) # Random generates a number b/w 0 - 32767
-set STARSHIP_SESSION_KEY "$STARSHIP_SESSION_KEY"0000000000000000 # Pad it to 16+ chars.
-set -gx STARSHIP_SESSION_KEY (echo "$STARSHIP_SESSION_KEY" | cut -c 1-16) # Trim to 16-digits if excess.
+set -gx STARSHIP_SESSION_KEY (string sub -s1 -l16 (random)(random)(random)(random)(random)0000000000000000)

--- a/src/init/starship.fish
+++ b/src/init/starship.fish
@@ -37,4 +37,6 @@ builtin functions -e fish_mode_prompt
 set -gx STARSHIP_SHELL "fish"
 
 # Set up the session key that will be used to store logs
-set -gx STARSHIP_SESSION_KEY (random 10000000000000 9999999999999999)
+set STARSHIP_SESSION_KEY (random)(random)(random)(random)(random) # Random generates a number b/w 0 - 32767
+set STARSHIP_SESSION_KEY "$STARSHIP_SESSION_KEY"0000000000000000 # Pad it to 16+ chars.
+set -gx STARSHIP_SESSION_KEY (echo "$STARSHIP_SESSION_KEY" | cut -c 1-16) # Trim to 16-digits if excess.

--- a/src/init/starship.fish
+++ b/src/init/starship.fish
@@ -37,4 +37,5 @@ builtin functions -e fish_mode_prompt
 set -gx STARSHIP_SHELL "fish"
 
 # Set up the session key that will be used to store logs
+# We don't use `random [min] [max]` because it is unavailable in older versions of fish shell
 set -gx STARSHIP_SESSION_KEY (string sub -s1 -l16 (random)(random)(random)(random)(random)0000000000000000)


### PR DESCRIPTION
To prevent initialization errors with older fish shell, I modified the way to generate random session keys.

#### Description
`random` in older fish shell cannot generate random integers within the specified range, so executing `starship init fish | source` with fish shell will output some errors.
I modified the init script to generate random integers without range specification.
Session keys will be generated in the manner same as `src/init/starship.bash`.

#### Motivation and Context
Closes #3696 

#### How Has This Been Tested?
- [x] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
