### PR TITLE
feat(aws): Add profile aliases

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -300,6 +300,7 @@ date is read from the `AWSUME_EXPIRATION` env var.
 | `format`            | `'on [$symbol($profile )(\($region\) )(\[$duration\])]($style)'` | The format for the module.                                        |
 | `symbol`            | `"☁️ "`                                                          | The symbol used before displaying the current AWS profile.        |
 | `region_aliases`    |                                                                  | Table of region aliases to display in addition to the AWS name.   |
+| `profile_aliases`   |                                                                  | Table of profile aliases to display in addition to the AWS name.  |
 | `style`             | `"bold yellow"`                                                  | The style for the module.                                         |
 | `expiration_symbol` | `X`                                                              | The symbol displayed when the temporary credentials have expired. |
 | `disabled`          | `false`                                                          | Disables the `AWS` module.                                        |
@@ -330,6 +331,8 @@ symbol = "🅰 "
 [aws.region_aliases]
 ap-southeast-2 = "au"
 us-east-1 = "va"
+[aws.profile_aliases]
+CompanyGroupFrobozzOnCallAccess = 'Frobozz'
 ```
 
 #### Display region
@@ -355,6 +358,8 @@ us-east-1 = "va"
 format = "on [$symbol$profile]($style) "
 style = "bold blue"
 symbol = "🅰 "
+[aws.profile_aliases]
+Enterprise_Naming_Scheme-voidstars = 'void**'
 ```
 
 ## Azure

--- a/src/configs/aws.rs
+++ b/src/configs/aws.rs
@@ -10,6 +10,7 @@ pub struct AwsConfig<'a> {
     pub style: &'a str,
     pub disabled: bool,
     pub region_aliases: HashMap<String, &'a str>,
+    pub profile_aliases: HashMap<String, &'a str>,
     pub expiration_symbol: &'a str,
 }
 
@@ -21,6 +22,7 @@ impl<'a> Default for AwsConfig<'a> {
             style: "bold yellow",
             disabled: false,
             region_aliases: HashMap::new(),
+            profile_aliases: HashMap::new(),
             expiration_symbol: "X",
         }
     }

--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -376,6 +376,46 @@ mod tests {
     }
 
     #[test]
+    fn profile_set_with_alias() {
+        let actual = ModuleRenderer::new("aws")
+            .env("AWS_PROFILE", "CORPORATION-CORP_astronauts_ACCESS_GROUP")
+            .env("AWS_REGION", "ap-northeast-2")
+            .env("AWS_ACCESS_KEY_ID", "dummy")
+            .config(toml::toml! {
+                [aws.profile_aliases]
+                CORPORATION-CORP_astronauts_ACCESS_GROUP = "astro"
+            })
+            .collect();
+        let expected = Some(format!(
+            "on {}",
+            Color::Yellow.bold().paint("☁️  astro (ap-northeast-2) ")
+        ));
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn region_and_profile_both_set_with_alias() {
+        let actual = ModuleRenderer::new("aws")
+            .env("AWS_PROFILE", "CORPORATION-CORP_astronauts_ACCESS_GROUP")
+            .env("AWS_REGION", "ap-southeast-2")
+            .env("AWS_ACCESS_KEY_ID", "dummy")
+            .config(toml::toml! {
+                [aws.profile_aliases]
+                CORPORATION-CORP_astronauts_ACCESS_GROUP = "astro"
+                [aws.region_aliases]
+                ap-southeast-2 = "au"
+            })
+            .collect();
+        let expected = Some(format!(
+            "on {}",
+            Color::Yellow.bold().paint("☁️  astro (au) ")
+        ));
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
     fn credentials_file_is_ignored_when_is_directory() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         let config_path = dir.path().join("credentials");

--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -111,9 +111,9 @@ fn get_credentials_duration(context: &Context, aws_profile: Option<&Profile>) ->
     Some(expiration_date.timestamp() - chrono::Local::now().timestamp())
 }
 
-fn alias_region(region: String, aliases: &HashMap<String, &str>) -> String {
-    match aliases.get(&region) {
-        None => region,
+fn alias_name(name: String, aliases: &HashMap<String, &str>) -> String {
+    match aliases.get(&name) {
+        None => name,
         Some(alias) => (*alias).to_string(),
     }
 }
@@ -188,7 +188,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     }
 
     let mapped_region = if let Some(aws_region) = aws_region {
-        Some(alias_region(aws_region, &config.region_aliases))
+        Some(alias_name(aws_region, &config.region_aliases))
     } else {
         None
     };

--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -111,11 +111,11 @@ fn get_credentials_duration(context: &Context, aws_profile: Option<&Profile>) ->
     Some(expiration_date.timestamp() - chrono::Local::now().timestamp())
 }
 
-fn alias_name(name: String, aliases: &HashMap<String, &str>) -> String {
-    match aliases.get(&name) {
-        None => name,
-        Some(alias) => (*alias).to_string(),
-    }
+fn alias_name(name: Option<String>, aliases: &HashMap<String, &str>) -> Option<String> {
+    name.as_ref()
+        .and_then(|n| aliases.get(n))
+        .map(|&a| a.to_string())
+        .or(name)
 }
 
 fn get_credential_process(context: &Context, aws_profile: Option<&Profile>) -> Option<String> {
@@ -197,17 +197,9 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         })
     };
 
-    let mapped_region = if let Some(aws_region) = aws_region {
-        Some(alias_name(aws_region, &config.region_aliases))
-    } else {
-        None
-    };
+    let mapped_region = alias_name(aws_region, &config.region_aliases);
 
-    let mapped_profile = if let Some(aws_profile) = aws_profile {
-        Some(alias_name(aws_profile, &config.profile_aliases))
-    } else {
-        None
-    };
+    let mapped_profile = alias_name(aws_profile, &config.profile_aliases);
 
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter

--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -187,12 +187,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         return None;
     }
 
-    let mapped_region = if let Some(aws_region) = aws_region {
-        Some(alias_name(aws_region, &config.region_aliases))
-    } else {
-        None
-    };
-
     let duration = {
         get_credentials_duration(context, aws_profile.as_ref()).map(|duration| {
             if duration > 0 {
@@ -201,6 +195,18 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 config.expiration_symbol.to_string()
             }
         })
+    };
+
+    let mapped_region = if let Some(aws_region) = aws_region {
+        Some(alias_name(aws_region, &config.region_aliases))
+    } else {
+        None
+    };
+
+    let mapped_profile = if let Some(aws_profile) = aws_profile {
+        Some(alias_name(aws_profile, &config.profile_aliases))
+    } else {
+        None
     };
 
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
@@ -214,7 +220,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 _ => None,
             })
             .map(|variable| match variable {
-                "profile" => aws_profile.as_ref().map(Ok),
+                "profile" => mapped_profile.as_ref().map(Ok),
                 "region" => mapped_region.as_ref().map(Ok),
                 "duration" => duration.as_ref().map(Ok),
                 _ => None,


### PR DESCRIPTION
#### Description
Add an aws.profile_aliases feature just like aws.region_aliases

#### Motivation and Context
AWS regions might have slightly irritating names, but it's nothing compared to the enterprise naming schemes sometimes applied to team profile names.

#### How Has This Been Tested?
Added two simple unit tests, one with and one without similar alias used for region.
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
