### PR TITLE
feat(aws): add option to force AWS display

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -300,16 +300,16 @@ date is read from the `AWSUME_EXPIRATION` env var.
 
 ### Options
 
-| Option                | Default                                                          | Description                                                                          |
-| --------------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| `format`              | `'on [$symbol($profile )(\($region\) )(\[$duration\])]($style)'` | The format for the module.                                                           |
-| `symbol`              | `"☁️ "`                                                          | The symbol used before displaying the current AWS profile.                           |
-| `region_aliases`      |                                                                  | Table of region aliases to display in addition to the AWS name.                      |
-| `profile_aliases`     |                                                                  | Table of profile aliases to display in addition to the AWS name.                     |
-| `style`               | `"bold yellow"`                                                  | The style for the module.                                                            |
-| `expiration_symbol`   | `X`                                                              | The symbol displayed when the temporary credentials have expired.                    |
-| `disabled`            | `false`                                                          | Disables the `AWS` module.                                                           |
-| `display_empty_creds` | `false`                                                          | If true displays info even if credentials or credential_process have not been setup. |
+| Option                | Default                                                          | Description                                                                                               |
+| --------------------- | ---------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `format`              | `'on [$symbol($profile )(\($region\) )(\[$duration\])]($style)'` | The format for the module.                                                                                |
+| `symbol`              | `"☁️ "`                                                          | The symbol used before displaying the current AWS profile.                                                |
+| `region_aliases`      |                                                                  | Table of region aliases to display in addition to the AWS name.                                           |
+| `profile_aliases`     |                                                                  | Table of profile aliases to display in addition to the AWS name.                                          |
+| `style`               | `"bold yellow"`                                                  | The style for the module.                                                                                 |
+| `expiration_symbol`   | `X`                                                              | The symbol displayed when the temporary credentials have expired.                                         |
+| `disabled`            | `false`                                                          | Disables the `AWS` module.                                                                                |
+| `display_empty_creds` | `false`                                                          | If true displays info even if `credentials`, `credential_process` or `sso_start_url` have not been setup. |
 
 ### Variables
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -274,7 +274,7 @@ format = "$all$directory$character"
 The `aws` module shows the current AWS region and profile when
 credentials, a `credential_process` or a `sso_start_url` have been setup. Alternatively, you can force this
 module to show the region and profile event when the credentials have not been setup
-with the `display_empty_creds` option. This is based on
+with the `force_display` option. This is based on
 `AWS_REGION`, `AWS_DEFAULT_REGION`, and `AWS_PROFILE` env var with
 `~/.aws/config` file. This module also shows an expiration timer when using temporary
 credentials.
@@ -284,7 +284,7 @@ The module will display a profile only if its credentials are present in
 `~/.aws/config`. Alternatively, having any of the `AWS_ACCESS_KEY_ID`,
 `AWS_SECRET_ACCESS_KEY`, or `AWS_SESSION_TOKEN` env vars defined will
 also suffice.
-If the option `display_empty_creds` is set to `true`, all available information will be
+If the option `force_display` is set to `true`, all available information will be
 displayed even if the conditions above are not respected.
 
 When using [aws-vault](https://github.com/99designs/aws-vault) the profile
@@ -300,16 +300,16 @@ date is read from the `AWSUME_EXPIRATION` env var.
 
 ### Options
 
-| Option                | Default                                                          | Description                                                                                               |
-| --------------------- | ---------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| `format`              | `'on [$symbol($profile )(\($region\) )(\[$duration\])]($style)'` | The format for the module.                                                                                |
-| `symbol`              | `"☁️ "`                                                          | The symbol used before displaying the current AWS profile.                                                |
-| `region_aliases`      |                                                                  | Table of region aliases to display in addition to the AWS name.                                           |
-| `profile_aliases`     |                                                                  | Table of profile aliases to display in addition to the AWS name.                                          |
-| `style`               | `"bold yellow"`                                                  | The style for the module.                                                                                 |
-| `expiration_symbol`   | `X`                                                              | The symbol displayed when the temporary credentials have expired.                                         |
-| `disabled`            | `false`                                                          | Disables the `AWS` module.                                                                                |
-| `display_empty_creds` | `false`                                                          | If true displays info even if `credentials`, `credential_process` or `sso_start_url` have not been setup. |
+| Option              | Default                                                          | Description                                                                                               |
+| ------------------- | ---------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `format`            | `'on [$symbol($profile )(\($region\) )(\[$duration\])]($style)'` | The format for the module.                                                                                |
+| `symbol`            | `"☁️ "`                                                          | The symbol used before displaying the current AWS profile.                                                |
+| `region_aliases`    |                                                                  | Table of region aliases to display in addition to the AWS name.                                           |
+| `profile_aliases`   |                                                                  | Table of profile aliases to display in addition to the AWS name.                                          |
+| `style`             | `"bold yellow"`                                                  | The style for the module.                                                                                 |
+| `expiration_symbol` | `X`                                                              | The symbol displayed when the temporary credentials have expired.                                         |
+| `disabled`          | `false`                                                          | Disables the `AWS` module.                                                                                |
+| `force_display`     | `false`                                                          | If true displays info even if `credentials`, `credential_process` or `sso_start_url` have not been setup. |
 
 ### Variables
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -272,7 +272,8 @@ format = "$all$directory$character"
 ## AWS
 
 The `aws` module shows the current AWS region and profile when
-credentials, a `credential_process` or a `sso_start_url` have been setup. This is based on
+credentials, a `credential_process` or a `sso_start_url` have been setup. You can also force it even
+when creds have not been setup with the `display_empty_creds` option. This is based on
 `AWS_REGION`, `AWS_DEFAULT_REGION`, and `AWS_PROFILE` env var with
 `~/.aws/config` file. This module also shows an expiration timer when using temporary
 credentials.
@@ -282,6 +283,8 @@ The module will display a profile only if its credentials are present in
 `~/.aws/config`. Alternatively, having any of the `AWS_ACCESS_KEY_ID`,
 `AWS_SECRET_ACCESS_KEY`, or `AWS_SESSION_TOKEN` env vars defined will
 also suffice.
+If the option `display_empty_creds` is set to `true`, all available information will be
+displayed even if the conditions above are not respected.
 
 When using [aws-vault](https://github.com/99designs/aws-vault) the profile
 is read from the `AWS_VAULT` env var and the credentials expiration date
@@ -296,15 +299,16 @@ date is read from the `AWSUME_EXPIRATION` env var.
 
 ### Options
 
-| Option              | Default                                                          | Description                                                       |
-| ------------------- | ---------------------------------------------------------------- | ----------------------------------------------------------------- |
-| `format`            | `'on [$symbol($profile )(\($region\) )(\[$duration\])]($style)'` | The format for the module.                                        |
-| `symbol`            | `"☁️ "`                                                          | The symbol used before displaying the current AWS profile.        |
-| `region_aliases`    |                                                                  | Table of region aliases to display in addition to the AWS name.   |
-| `profile_aliases`   |                                                                  | Table of profile aliases to display in addition to the AWS name.  |
-| `style`             | `"bold yellow"`                                                  | The style for the module.                                         |
-| `expiration_symbol` | `X`                                                              | The symbol displayed when the temporary credentials have expired. |
-| `disabled`          | `false`                                                          | Disables the `AWS` module.                                        |
+| Option                | Default                                                          | Description                                                                          |
+| --------------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `format`              | `'on [$symbol($profile )(\($region\) )(\[$duration\])]($style)'` | The format for the module.                                                           |
+| `symbol`              | `"☁️ "`                                                          | The symbol used before displaying the current AWS profile.                           |
+| `region_aliases`      |                                                                  | Table of region aliases to display in addition to the AWS name.                      |
+| `profile_aliases`     |                                                                  | Table of profile aliases to display in addition to the AWS name.                     |
+| `style`               | `"bold yellow"`                                                  | The style for the module.                                                            |
+| `expiration_symbol`   | `X`                                                              | The symbol displayed when the temporary credentials have expired.                    |
+| `disabled`            | `false`                                                          | Disables the `AWS` module.                                                           |
+| `display_empty_creds` | `false`                                                          | If true displays info even if credentials or credential_process have not been setup. |
 
 ### Variables
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -272,8 +272,9 @@ format = "$all$directory$character"
 ## AWS
 
 The `aws` module shows the current AWS region and profile when
-credentials, a `credential_process` or a `sso_start_url` have been setup. You can also force it even
-when creds have not been setup with the `display_empty_creds` option. This is based on
+credentials, a `credential_process` or a `sso_start_url` have been setup. Alternatively, you can force this
+module to show the region and profile event when the credentials have not been setup
+with the `display_empty_creds` option. This is based on
 `AWS_REGION`, `AWS_DEFAULT_REGION`, and `AWS_PROFILE` env var with
 `~/.aws/config` file. This module also shows an expiration timer when using temporary
 credentials.

--- a/src/configs/aws.rs
+++ b/src/configs/aws.rs
@@ -12,6 +12,7 @@ pub struct AwsConfig<'a> {
     pub region_aliases: HashMap<String, &'a str>,
     pub profile_aliases: HashMap<String, &'a str>,
     pub expiration_symbol: &'a str,
+    pub display_empty_creds: bool,
 }
 
 impl<'a> Default for AwsConfig<'a> {
@@ -24,6 +25,7 @@ impl<'a> Default for AwsConfig<'a> {
             region_aliases: HashMap::new(),
             profile_aliases: HashMap::new(),
             expiration_symbol: "X",
+            display_empty_creds: false,
         }
     }
 }

--- a/src/configs/aws.rs
+++ b/src/configs/aws.rs
@@ -12,7 +12,7 @@ pub struct AwsConfig<'a> {
     pub region_aliases: HashMap<String, &'a str>,
     pub profile_aliases: HashMap<String, &'a str>,
     pub expiration_symbol: &'a str,
-    pub display_empty_creds: bool,
+    pub force_display: bool,
 }
 
 impl<'a> Default for AwsConfig<'a> {
@@ -25,7 +25,7 @@ impl<'a> Default for AwsConfig<'a> {
             region_aliases: HashMap::new(),
             profile_aliases: HashMap::new(),
             expiration_symbol: "X",
-            display_empty_creds: false,
+            force_display: false,
         }
     }
 }

--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -186,7 +186,8 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     }
 
     // only display if credential_process is defined or has valid credentials
-    if !has_credential_process_or_sso(context, aws_profile.as_ref())
+    if !config.display_empty_creds
+        && !has_credential_process_or_sso(context, aws_profile.as_ref())
         && get_defined_credentials(context, aws_profile.as_ref()).is_none()
     {
         return None;
@@ -782,6 +783,36 @@ region = us-east-2
             .env("AWS_CONFIG_FILE", config_path.to_string_lossy().as_ref())
             .collect();
         let expected = None;
+
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn missing_any_credentials_but_display_empty() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let config_path = dir.path().join("config");
+        let mut file = File::create(&config_path)?;
+
+        file.write_all(
+            "[profile astronauts]
+region = us-east-2
+"
+            .as_bytes(),
+        )?;
+
+        let actual = ModuleRenderer::new("aws")
+            .config(toml::toml! {
+                [aws]
+                display_empty_creds = true
+            })
+            .env("AWS_CONFIG_FILE", config_path.to_string_lossy().as_ref())
+            .env("AWS_PROFILE", "astronauts")
+            .collect();
+        let expected = Some(format!(
+            "on {}",
+            Color::Yellow.bold().paint("☁️  astronauts (us-east-2) ")
+        ));
 
         assert_eq!(expected, actual);
         dir.close()

--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -186,7 +186,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     }
 
     // only display if credential_process is defined or has valid credentials
-    if !config.display_empty_creds
+    if !config.force_display
         && !has_credential_process_or_sso(context, aws_profile.as_ref())
         && get_defined_credentials(context, aws_profile.as_ref()).is_none()
     {
@@ -804,7 +804,7 @@ region = us-east-2
         let actual = ModuleRenderer::new("aws")
             .config(toml::toml! {
                 [aws]
-                display_empty_creds = true
+                force_display = true
             })
             .env("AWS_CONFIG_FILE", config_path.to_string_lossy().as_ref())
             .env("AWS_PROFILE", "astronauts")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add an option in the AWS module to force displaying AWS info, even if there is no credentials or credential_process defined for this profile.
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
The option is called: `force_display` and its default value is `false`.
When this option is set to `true` the profile info are displayed in the prompt even if there is no creds directly associated.
It's a kind of bypass of the feature merged in the PR #3504.
When leaved to `false` it doesn't change the behaviour: if no creds are found, no info are displayed in the prompt.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Closes #3762

After the PR #3504 has been merged, if there is no credentials nor credential_process defined for the profile, nothing is displayed. But I heavily use the `source_profile` feature for profiles. 

Example of `~/.aws/config` and `~/.aws/credentials`:
```ini
#~/.aws/config

[profile admin]
region=eu-west-3

[profile default]
region=eu-west-3

# Reader
[profile reader-dev]
role_arn=arn:aws:iam::111111111111:role/reader
source_profile=default

[profile reader-prod]
role_arn=arn:aws:iam::222222222222:role/reader
source_profile=default

# Admin
[profile admin-dev]
role_arn=arn:aws:iam::111111111111:role/admin
source_profile=admin

[profile admin-prod]
role_arn=arn:aws:iam::222222222222:role/admin
source_profile=admin
```

```ini
#~/.aws/credentials

[admin]
credential_process=aws-vault exec admin --no-session --json
[default]
credential_process=aws-vault exec default --no-session --json
```

In this case credential_process (aws-vault) is defined only for the profile `admin` and `default`. So when I export `AWS_PROFILE` to `admin-dev` there is nothing displayed in the prompt as there is no "direct" credential_process in this profile.

<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I've tested with the `~/.aws/config` and `~/.aws/credentials` above with both `force_display` to `true` and `false`.
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
