### PR TITLE
docs: Specify minimum supported rust version (MSRV) to 1.59

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,8 @@ name = "starship"
 version = "1.4.0"
 authors = ["Starship Contributors"]
 build = "build.rs"
+# MSRV is specified to use std::thread::available_parallelism, which was stabilized in Rust version 1.59
+rust-version = "1.59"
 categories = ["command-line-utilities"]
 documentation = "https://starship.rs/guide/"
 edition = "2021"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
starship now uses `std::thread::available_parallelism` which stablized at Rust version 1.59.
https://github.com/starship/starship/blob/master/src/main.rs#L235
therefore, This PR sets MSRV to 1.59 to make sure everyone can build.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #3716

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
