### PR TITLE
refactor(install): remove trailing slash from `BIN_DIR`

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -263,7 +263,7 @@ confirm() {
 }
 
 check_bin_dir() {
-  bin_dir="$1"
+  bin_dir="${1%/}"
 
   if [ ! -d "$BIN_DIR" ]; then
     error "Installation location $BIN_DIR does not appear to be a directory"
@@ -276,7 +276,7 @@ check_bin_dir() {
   good=$(
     IFS=:
     for path in $PATH; do
-      if [ "${path}" = "${bin_dir}" ]; then
+      if [ "${path%/}" = "${bin_dir}" ]; then
         printf 1
         break
       fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
The installation script warns about `BIN_DIR` not being found in `$PATH` when the users pass a trailing forward slash.

This has been discussed in #1310, #1341, and #3486.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #3493

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

As discussed in #1310, #1341, and #3486, we see that all users passed a trailing slash for `bin-dir`;`/usr/bin/`, `/c/Users/slapbot/starship/` and `"$HOME/.starship/bin/"`, respectively.

Since it is possible to have a trailing slash on a directory in `$PATH`, this prevents false-negatives when either or both directories contain a forward slash.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.

I couldn't find tests for this, but I'll be happy to add them if required.
