### PR TITLE
ci: Correct dependencies for deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -202,7 +202,7 @@ jobs:
   # Create GitHub release with Rust build targets and release notes
   github_release:
     name: Create GitHub Release
-    needs: github_build
+    needs: [github_build, notarize_and_pkgbuild]
     runs-on: ubuntu-latest
     steps:
       - name: Setup | Checkout


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
Changes the github release dependencies to include the notarization step so that notarized binaries get properly deployed

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #3714 
