### PR TITLE
fix(aws): Make AWS_REGION orverrides AWS_DEFAULT_REGION (#3619)

### DIFF
--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -68,8 +68,8 @@ fn get_aws_profile_and_region(context: &Context) -> (Option<Profile>, Option<Reg
         .iter()
         .find_map(|env_var| context.get_env(env_var));
     let region = context
-        .get_env("AWS_DEFAULT_REGION")
-        .or_else(|| context.get_env("AWS_REGION"));
+        .get_env("AWS_REGION")
+        .or_else(|| context.get_env("AWS_DEFAULT_REGION"));
     match (profile, region) {
         (Some(p), Some(r)) => (Some(p), Some(r)),
         (None, Some(r)) => (None, Some(r)),
@@ -224,7 +224,7 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "on {}",
-            Color::Yellow.bold().paint("☁️  (ap-northeast-1) ")
+            Color::Yellow.bold().paint("☁️  (ap-northeast-2) ")
         ));
 
         assert_eq!(expected, actual);

--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -64,12 +64,13 @@ fn get_aws_region_from_config(context: &Context, aws_profile: Option<&str>) -> O
 
 fn get_aws_profile_and_region(context: &Context) -> (Option<Profile>, Option<Region>) {
     let profile_env_vars = vec!["AWSU_PROFILE", "AWS_VAULT", "AWSUME_PROFILE", "AWS_PROFILE"];
+    let region_env_vars = vec!["AWS_REGION", "AWS_DEFAULT_REGION"];
     let profile = profile_env_vars
         .iter()
         .find_map(|env_var| context.get_env(env_var));
-    let region = context
-        .get_env("AWS_REGION")
-        .or_else(|| context.get_env("AWS_DEFAULT_REGION"));
+    let region = region_env_vars
+        .iter()
+        .find_map(|env_var| context.get_env(env_var));
     match (profile, region) {
         (Some(p), Some(r)) => (Some(p), Some(r)),
         (None, Some(r)) => (None, Some(r)),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
Making environmental values `AWS_REGION` overrides `AWS_DEFAULT_REGION`, if both values is existing.


#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #3619

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
