### PR TITLE
feat: allow printing config file schema

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 /src/init/* text eol=lf
 *.sh text eol=lf
+/.github/config-schema.json text eol=lf

--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -1,0 +1,4711 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "FullConfig",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "default": "https://starship.rs/config-schema.json",
+      "type": "string"
+    },
+    "aws": {
+      "default": {
+        "disabled": false,
+        "expiration_symbol": "X",
+        "force_display": false,
+        "format": "on [$symbol($profile )(\\($region\\) )(\\[$duration\\])]($style)",
+        "profile_aliases": {},
+        "region_aliases": {},
+        "style": "bold yellow",
+        "symbol": "☁️  "
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/AwsConfig"
+        }
+      ]
+    },
+    "azure": {
+      "default": {
+        "disabled": true,
+        "format": "on [$symbol($subscription)]($style) ",
+        "style": "blue bold",
+        "symbol": "ﴃ "
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/AzureConfig"
+        }
+      ]
+    },
+    "battery": {
+      "default": {
+        "charging_symbol": " ",
+        "disabled": false,
+        "discharging_symbol": " ",
+        "display": [
+          {
+            "charging_symbol": null,
+            "discharging_symbol": null,
+            "style": "red bold",
+            "threshold": 10
+          }
+        ],
+        "empty_symbol": " ",
+        "format": "[$symbol$percentage]($style) ",
+        "full_symbol": " ",
+        "unknown_symbol": " "
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/BatteryConfig"
+        }
+      ]
+    },
+    "buf": {
+      "default": {
+        "detect_extensions": [],
+        "detect_files": [
+          "buf.yaml",
+          "buf.gen.yaml",
+          "buf.work.yaml"
+        ],
+        "detect_folders": [],
+        "disabled": false,
+        "format": "with [$symbol ($version)]($style)",
+        "style": "bold blue",
+        "symbol": "",
+        "version_format": "v${raw}"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/BufConfig"
+        }
+      ]
+    },
+    "c": {
+      "default": {
+        "commands": [
+          [
+            "cc",
+            "--version"
+          ],
+          [
+            "gcc",
+            "--version"
+          ],
+          [
+            "clang",
+            "--version"
+          ]
+        ],
+        "detect_extensions": [
+          "c",
+          "h"
+        ],
+        "detect_files": [],
+        "detect_folders": [],
+        "disabled": false,
+        "format": "via [$symbol($version(-$name) )]($style)",
+        "style": "149 bold",
+        "symbol": "C ",
+        "version_format": "v${raw}"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/CConfig"
+        }
+      ]
+    },
+    "character": {
+      "default": {
+        "disabled": false,
+        "error_symbol": "[❯](bold red)",
+        "format": "$symbol ",
+        "success_symbol": "[❯](bold green)",
+        "vicmd_symbol": "[❮](bold green)"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/CharacterConfig"
+        }
+      ]
+    },
+    "cmake": {
+      "default": {
+        "detect_extensions": [],
+        "detect_files": [
+          "CMakeLists.txt",
+          "CMakeCache.txt"
+        ],
+        "detect_folders": [],
+        "disabled": false,
+        "format": "via [$symbol($version )]($style)",
+        "style": "bold blue",
+        "symbol": "△ ",
+        "version_format": "v${raw}"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/CMakeConfig"
+        }
+      ]
+    },
+    "cmd_duration": {
+      "default": {
+        "disabled": false,
+        "format": "took [$duration]($style) ",
+        "min_time": 2000,
+        "min_time_to_notify": 45000,
+        "show_milliseconds": false,
+        "show_notifications": false,
+        "style": "yellow bold"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/CmdDurationConfig"
+        }
+      ]
+    },
+    "cobol": {
+      "default": {
+        "detect_extensions": [
+          "cbl",
+          "cob",
+          "CBL",
+          "COB"
+        ],
+        "detect_files": [],
+        "detect_folders": [],
+        "disabled": false,
+        "format": "via [$symbol($version )]($style)",
+        "style": "bold blue",
+        "symbol": "⚙️ ",
+        "version_format": "v${raw}"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/CobolConfig"
+        }
+      ]
+    },
+    "conda": {
+      "default": {
+        "disabled": false,
+        "format": "via [$symbol$environment]($style) ",
+        "ignore_base": true,
+        "style": "green bold",
+        "symbol": "🅒 ",
+        "truncation_length": 1
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/CondaConfig"
+        }
+      ]
+    },
+    "container": {
+      "default": {
+        "disabled": false,
+        "format": "[$symbol \\[$name\\]]($style) ",
+        "style": "red bold dimmed",
+        "symbol": "⬢"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ContainerConfig"
+        }
+      ]
+    },
+    "crystal": {
+      "default": {
+        "detect_extensions": [
+          "cr"
+        ],
+        "detect_files": [
+          "shard.yml"
+        ],
+        "detect_folders": [],
+        "disabled": false,
+        "format": "via [$symbol($version )]($style)",
+        "style": "bold red",
+        "symbol": "🔮 ",
+        "version_format": "v${raw}"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/CrystalConfig"
+        }
+      ]
+    },
+    "dart": {
+      "default": {
+        "detect_extensions": [
+          "dart"
+        ],
+        "detect_files": [
+          "pubspec.yaml",
+          "pubspec.yml",
+          "pubspec.lock"
+        ],
+        "detect_folders": [
+          ".dart_tool"
+        ],
+        "disabled": false,
+        "format": "via [$symbol($version )]($style)",
+        "style": "bold blue",
+        "symbol": "🎯 ",
+        "version_format": "v${raw}"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/DartConfig"
+        }
+      ]
+    },
+    "deno": {
+      "default": {
+        "detect_extensions": [],
+        "detect_files": [
+          "deno.json",
+          "deno.jsonc",
+          "mod.ts",
+          "deps.ts",
+          "mod.js",
+          "deps.js"
+        ],
+        "detect_folders": [],
+        "disabled": false,
+        "format": "via [$symbol($version )]($style)",
+        "style": "green bold",
+        "symbol": "🦕 ",
+        "version_format": "v${raw}"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/DenoConfig"
+        }
+      ]
+    },
+    "directory": {
+      "default": {
+        "disabled": false,
+        "fish_style_pwd_dir_length": 0,
+        "format": "[$path]($style)[$read_only]($read_only_style) ",
+        "home_symbol": "~",
+        "read_only": "🔒",
+        "read_only_style": "red",
+        "repo_root_format": "[$before_root_path]($style)[$repo_root]($repo_root_style)[$path]($style)[$read_only]($read_only_style) ",
+        "repo_root_style": null,
+        "style": "cyan bold",
+        "substitutions": {},
+        "truncate_to_repo": true,
+        "truncation_length": 3,
+        "truncation_symbol": "",
+        "use_logical_path": true,
+        "use_os_path_sep": true
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/DirectoryConfig"
+        }
+      ]
+    },
+    "docker_context": {
+      "default": {
+        "detect_extensions": [],
+        "detect_files": [
+          "docker-compose.yml",
+          "docker-compose.yaml",
+          "Dockerfile"
+        ],
+        "detect_folders": [],
+        "disabled": false,
+        "format": "via [$symbol$context]($style) ",
+        "only_with_files": true,
+        "style": "blue bold",
+        "symbol": "🐳 "
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/DockerContextConfig"
+        }
+      ]
+    },
+    "dotnet": {
+      "default": {
+        "detect_extensions": [
+          "csproj",
+          "fsproj",
+          "xproj"
+        ],
+        "detect_files": [
+          "global.json",
+          "project.json",
+          "Directory.Build.props",
+          "Directory.Build.targets",
+          "Packages.props"
+        ],
+        "detect_folders": [],
+        "disabled": false,
+        "format": "via [$symbol($version )(🎯 $tfm )]($style)",
+        "heuristic": true,
+        "style": "blue bold",
+        "symbol": ".NET ",
+        "version_format": "v${raw}"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/DotnetConfig"
+        }
+      ]
+    },
+    "elixir": {
+      "default": {
+        "detect_extensions": [],
+        "detect_files": [
+          "mix.exs"
+        ],
+        "detect_folders": [],
+        "disabled": false,
+        "format": "via [$symbol($version \\(OTP $otp_version\\) )]($style)",
+        "style": "bold purple",
+        "symbol": "💧 ",
+        "version_format": "v${raw}"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ElixirConfig"
+        }
+      ]
+    },
+    "elm": {
+      "default": {
+        "detect_extensions": [
+          "elm"
+        ],
+        "detect_files": [
+          "elm.json",
+          "elm-package.json",
+          ".elm-version"
+        ],
+        "detect_folders": [
+          "elm-stuff"
+        ],
+        "disabled": false,
+        "format": "via [$symbol($version )]($style)",
+        "style": "cyan bold",
+        "symbol": "🌳 ",
+        "version_format": "v${raw}"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ElmConfig"
+        }
+      ]
+    },
+    "env_var": {
+      "default": {},
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/EnvVarConfig"
+      }
+    },
+    "erlang": {
+      "default": {
+        "detect_extensions": [],
+        "detect_files": [
+          "rebar.config",
+          "erlang.mk"
+        ],
+        "detect_folders": [],
+        "disabled": false,
+        "format": "via [$symbol($version )]($style)",
+        "style": "bold red",
+        "symbol": " ",
+        "version_format": "v${raw}"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ErlangConfig"
+        }
+      ]
+    },
+    "fill": {
+      "default": {
+        "disabled": false,
+        "style": "bold black",
+        "symbol": "."
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/FillConfig"
+        }
+      ]
+    },
+    "gcloud": {
+      "default": {
+        "disabled": false,
+        "format": "on [$symbol$account(@$domain)(\\($region\\))]($style) ",
+        "project_aliases": {},
+        "region_aliases": {},
+        "style": "bold blue",
+        "symbol": "☁️  "
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/GcloudConfig"
+        }
+      ]
+    },
+    "git_branch": {
+      "default": {
+        "always_show_remote": false,
+        "disabled": false,
+        "format": "on [$symbol$branch]($style)(:[$remote]($style)) ",
+        "ignore_branches": [],
+        "only_attached": false,
+        "style": "bold purple",
+        "symbol": " ",
+        "truncation_length": 9223372036854775807,
+        "truncation_symbol": "…"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/GitBranchConfig"
+        }
+      ]
+    },
+    "git_commit": {
+      "default": {
+        "commit_hash_length": 7,
+        "disabled": false,
+        "format": "[\\($hash$tag\\)]($style) ",
+        "only_detached": true,
+        "style": "green bold",
+        "tag_disabled": true,
+        "tag_symbol": " 🏷  "
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/GitCommitConfig"
+        }
+      ]
+    },
+    "git_metrics": {
+      "default": {
+        "added_style": "bold green",
+        "deleted_style": "bold red",
+        "disabled": true,
+        "format": "([+$added]($added_style) )([-$deleted]($deleted_style) )",
+        "only_nonzero_diffs": true
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/GitMetricsConfig"
+        }
+      ]
+    },
+    "git_state": {
+      "default": {
+        "am": "AM",
+        "am_or_rebase": "AM/REBASE",
+        "bisect": "BISECTING",
+        "cherry_pick": "CHERRY-PICKING",
+        "disabled": false,
+        "format": "\\([$state( $progress_current/$progress_total)]($style)\\) ",
+        "merge": "MERGING",
+        "rebase": "REBASING",
+        "revert": "REVERTING",
+        "style": "bold yellow"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/GitStateConfig"
+        }
+      ]
+    },
+    "git_status": {
+      "default": {
+        "ahead": "⇡",
+        "behind": "⇣",
+        "conflicted": "=",
+        "deleted": "✘",
+        "disabled": false,
+        "diverged": "⇕",
+        "format": "([\\[$all_status$ahead_behind\\]]($style) )",
+        "ignore_submodules": false,
+        "modified": "!",
+        "renamed": "»",
+        "staged": "+",
+        "stashed": "\\$",
+        "style": "red bold",
+        "untracked": "?",
+        "up_to_date": ""
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/GitStatusConfig"
+        }
+      ]
+    },
+    "golang": {
+      "default": {
+        "detect_extensions": [
+          "go"
+        ],
+        "detect_files": [
+          "go.mod",
+          "go.sum",
+          "glide.yaml",
+          "Gopkg.yml",
+          "Gopkg.lock",
+          ".go-version"
+        ],
+        "detect_folders": [
+          "Godeps"
+        ],
+        "disabled": false,
+        "format": "via [$symbol($version )]($style)",
+        "style": "bold cyan",
+        "symbol": "🐹 ",
+        "version_format": "v${raw}"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/GoConfig"
+        }
+      ]
+    },
+    "haskell": {
+      "default": {
+        "detect_extensions": [
+          "hs",
+          "cabal",
+          "hs-boot"
+        ],
+        "detect_files": [
+          "stack.yaml",
+          "cabal.project"
+        ],
+        "detect_folders": [],
+        "disabled": false,
+        "format": "via [$symbol($version )]($style)",
+        "style": "bold purple",
+        "symbol": "λ ",
+        "version_format": "v${raw}"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/HaskellConfig"
+        }
+      ]
+    },
+    "helm": {
+      "default": {
+        "detect_extensions": [],
+        "detect_files": [
+          "helmfile.yaml",
+          "Chart.yaml"
+        ],
+        "detect_folders": [],
+        "disabled": false,
+        "format": "via [$symbol($version )]($style)",
+        "style": "bold white",
+        "symbol": "⎈ ",
+        "version_format": "v${raw}"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/HelmConfig"
+        }
+      ]
+    },
+    "hg_branch": {
+      "default": {
+        "disabled": true,
+        "format": "on [$symbol$branch]($style) ",
+        "style": "bold purple",
+        "symbol": " ",
+        "truncation_length": 9223372036854775807,
+        "truncation_symbol": "…"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/HgBranchConfig"
+        }
+      ]
+    },
+    "hostname": {
+      "default": {
+        "disabled": false,
+        "format": "[$hostname]($style) in ",
+        "ssh_only": true,
+        "style": "green dimmed bold",
+        "trim_at": "."
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/HostnameConfig"
+        }
+      ]
+    },
+    "java": {
+      "default": {
+        "detect_extensions": [
+          "java",
+          "class",
+          "jar",
+          "gradle",
+          "clj",
+          "cljc"
+        ],
+        "detect_files": [
+          "pom.xml",
+          "build.gradle.kts",
+          "build.sbt",
+          ".java-version",
+          "deps.edn",
+          "project.clj",
+          "build.boot"
+        ],
+        "detect_folders": [],
+        "disabled": false,
+        "format": "via [$symbol($version )]($style)",
+        "style": "red dimmed",
+        "symbol": "☕ ",
+        "version_format": "v${raw}"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/JavaConfig"
+        }
+      ]
+    },
+    "jobs": {
+      "default": {
+        "disabled": false,
+        "format": "[$symbol$number]($style) ",
+        "number_threshold": 2,
+        "style": "bold blue",
+        "symbol": "✦",
+        "symbol_threshold": 1,
+        "threshold": 1
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/JobsConfig"
+        }
+      ]
+    },
+    "julia": {
+      "default": {
+        "detect_extensions": [
+          "jl"
+        ],
+        "detect_files": [
+          "Project.toml",
+          "Manifest.toml"
+        ],
+        "detect_folders": [],
+        "disabled": false,
+        "format": "via [$symbol($version )]($style)",
+        "style": "bold purple",
+        "symbol": "ஃ ",
+        "version_format": "v${raw}"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/JuliaConfig"
+        }
+      ]
+    },
+    "kotlin": {
+      "default": {
+        "detect_extensions": [
+          "kt",
+          "kts"
+        ],
+        "detect_files": [],
+        "detect_folders": [],
+        "disabled": false,
+        "format": "via [$symbol($version )]($style)",
+        "kotlin_binary": "kotlin",
+        "style": "bold blue",
+        "symbol": "🅺 ",
+        "version_format": "v${raw}"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/KotlinConfig"
+        }
+      ]
+    },
+    "kubernetes": {
+      "default": {
+        "context_aliases": {},
+        "disabled": true,
+        "format": "[$symbol$context( \\($namespace\\))]($style) in ",
+        "style": "cyan bold",
+        "symbol": "☸ "
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/KubernetesConfig"
+        }
+      ]
+    },
+    "line_break": {
+      "default": {
+        "disabled": false
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/LineBreakConfig"
+        }
+      ]
+    },
+    "localip": {
+      "default": {
+        "disabled": true,
+        "format": "[$localipv4]($style) ",
+        "ssh_only": true,
+        "style": "yellow bold"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/LocalipConfig"
+        }
+      ]
+    },
+    "lua": {
+      "default": {
+        "detect_extensions": [
+          "lua"
+        ],
+        "detect_files": [
+          ".lua-version"
+        ],
+        "detect_folders": [
+          "lua"
+        ],
+        "disabled": false,
+        "format": "via [$symbol($version )]($style)",
+        "lua_binary": "lua",
+        "style": "bold blue",
+        "symbol": "🌙 ",
+        "version_format": "v${raw}"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/LuaConfig"
+        }
+      ]
+    },
+    "memory_usage": {
+      "default": {
+        "disabled": true,
+        "format": "via $symbol[$ram( | $swap)]($style) ",
+        "style": "white bold dimmed",
+        "symbol": "🐏 ",
+        "threshold": 75
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/MemoryConfig"
+        }
+      ]
+    },
+    "nim": {
+      "default": {
+        "detect_extensions": [
+          "nim",
+          "nims",
+          "nimble"
+        ],
+        "detect_files": [
+          "nim.cfg"
+        ],
+        "detect_folders": [],
+        "disabled": false,
+        "format": "via [$symbol($version )]($style)",
+        "style": "yellow bold",
+        "symbol": "👑 ",
+        "version_format": "v${raw}"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/NimConfig"
+        }
+      ]
+    },
+    "nix_shell": {
+      "default": {
+        "disabled": false,
+        "format": "via [$symbol$state( \\($name\\))]($style) ",
+        "impure_msg": "impure",
+        "pure_msg": "pure",
+        "style": "bold blue",
+        "symbol": "❄️  "
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/NixShellConfig"
+        }
+      ]
+    },
+    "nodejs": {
+      "default": {
+        "detect_extensions": [
+          "js",
+          "mjs",
+          "cjs",
+          "ts",
+          "mts",
+          "cts"
+        ],
+        "detect_files": [
+          "package.json",
+          ".node-version",
+          ".nvmrc"
+        ],
+        "detect_folders": [
+          "node_modules"
+        ],
+        "disabled": false,
+        "format": "via [$symbol($version )]($style)",
+        "not_capable_style": "bold red",
+        "style": "bold green",
+        "symbol": " ",
+        "version_format": "v${raw}"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/NodejsConfig"
+        }
+      ]
+    },
+    "ocaml": {
+      "default": {
+        "detect_extensions": [
+          "opam",
+          "ml",
+          "mli",
+          "re",
+          "rei"
+        ],
+        "detect_files": [
+          "dune",
+          "dune-project",
+          "jbuild",
+          "jbuild-ignore",
+          ".merlin"
+        ],
+        "detect_folders": [
+          "_opam",
+          "esy.lock"
+        ],
+        "disabled": false,
+        "format": "via [$symbol($version )(\\($switch_indicator$switch_name\\) )]($style)",
+        "global_switch_indicator": "",
+        "local_switch_indicator": "*",
+        "style": "bold yellow",
+        "symbol": "🐫 ",
+        "version_format": "v${raw}"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/OCamlConfig"
+        }
+      ]
+    },
+    "openstack": {
+      "default": {
+        "disabled": false,
+        "format": "on [$symbol$cloud(\\($project\\))]($style) ",
+        "style": "bold yellow",
+        "symbol": "☁️  "
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/OspConfig"
+        }
+      ]
+    },
+    "package": {
+      "default": {
+        "disabled": false,
+        "display_private": false,
+        "format": "is [$symbol$version]($style) ",
+        "style": "208 bold",
+        "symbol": "📦 ",
+        "version_format": "v${raw}"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/PackageConfig"
+        }
+      ]
+    },
+    "perl": {
+      "default": {
+        "detect_extensions": [
+          "pl",
+          "pm",
+          "pod"
+        ],
+        "detect_files": [
+          "Makefile.PL",
+          "Build.PL",
+          "cpanfile",
+          "cpanfile.snapshot",
+          "META.json",
+          "META.yml",
+          ".perl-version"
+        ],
+        "detect_folders": [],
+        "disabled": false,
+        "format": "via [$symbol($version )]($style)",
+        "style": "149 bold",
+        "symbol": "🐪 ",
+        "version_format": "v${raw}"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/PerlConfig"
+        }
+      ]
+    },
+    "php": {
+      "default": {
+        "detect_extensions": [
+          "php"
+        ],
+        "detect_files": [
+          "composer.json",
+          ".php-version"
+        ],
+        "detect_folders": [],
+        "disabled": false,
+        "format": "via [$symbol($version )]($style)",
+        "style": "147 bold",
+        "symbol": "🐘 ",
+        "version_format": "v${raw}"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/PhpConfig"
+        }
+      ]
+    },
+    "pulumi": {
+      "default": {
+        "disabled": false,
+        "format": "via [$symbol($username@)$stack]($style) ",
+        "style": "bold 5",
+        "symbol": " ",
+        "version_format": "v${raw}"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/PulumiConfig"
+        }
+      ]
+    },
+    "purescript": {
+      "default": {
+        "detect_extensions": [
+          "purs"
+        ],
+        "detect_files": [
+          "spago.dhall"
+        ],
+        "detect_folders": [],
+        "disabled": false,
+        "format": "via [$symbol($version )]($style)",
+        "style": "bold white",
+        "symbol": "<=> ",
+        "version_format": "v${raw}"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/PureScriptConfig"
+        }
+      ]
+    },
+    "python": {
+      "default": {
+        "detect_extensions": [
+          "py"
+        ],
+        "detect_files": [
+          "requirements.txt",
+          ".python-version",
+          "pyproject.toml",
+          "Pipfile",
+          "tox.ini",
+          "setup.py",
+          "__init__.py"
+        ],
+        "detect_folders": [],
+        "disabled": false,
+        "format": "via [${symbol}${pyenv_prefix}(${version} )(\\($virtualenv\\) )]($style)",
+        "pyenv_prefix": "pyenv ",
+        "pyenv_version_name": false,
+        "python_binary": [
+          "python",
+          "python3",
+          "python2"
+        ],
+        "style": "yellow bold",
+        "symbol": "🐍 ",
+        "version_format": "v${raw}"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/PythonConfig"
+        }
+      ]
+    },
+    "red": {
+      "default": {
+        "detect_extensions": [
+          "red",
+          "reds"
+        ],
+        "detect_files": [],
+        "detect_folders": [],
+        "disabled": false,
+        "format": "via [$symbol($version )]($style)",
+        "style": "red bold",
+        "symbol": "🔺 ",
+        "version_format": "v${raw}"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/RedConfig"
+        }
+      ]
+    },
+    "rlang": {
+      "default": {
+        "detect_extensions": [
+          "R",
+          "Rd",
+          "Rmd",
+          "Rproj",
+          "Rsx"
+        ],
+        "detect_files": [
+          ".Rprofile"
+        ],
+        "detect_folders": [
+          ".Rproj.user"
+        ],
+        "disabled": false,
+        "format": "via [$symbol($version )]($style)",
+        "style": "blue bold",
+        "symbol": "📐 ",
+        "version_format": "v${raw}"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/RLangConfig"
+        }
+      ]
+    },
+    "ruby": {
+      "default": {
+        "detect_extensions": [
+          "rb"
+        ],
+        "detect_files": [
+          "Gemfile",
+          ".ruby-version"
+        ],
+        "detect_folders": [],
+        "detect_variables": [
+          "RUBY_VERSION",
+          "RBENV_VERSION"
+        ],
+        "disabled": false,
+        "format": "via [$symbol($version )]($style)",
+        "style": "bold red",
+        "symbol": "💎 ",
+        "version_format": "v${raw}"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/RubyConfig"
+        }
+      ]
+    },
+    "rust": {
+      "default": {
+        "detect_extensions": [
+          "rs"
+        ],
+        "detect_files": [
+          "Cargo.toml"
+        ],
+        "detect_folders": [],
+        "disabled": false,
+        "format": "via [$symbol($version )]($style)",
+        "style": "bold red",
+        "symbol": "🦀 ",
+        "version_format": "v${raw}"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/RustConfig"
+        }
+      ]
+    },
+    "scala": {
+      "default": {
+        "detect_extensions": [
+          "sbt",
+          "scala"
+        ],
+        "detect_files": [
+          ".scalaenv",
+          ".sbtenv",
+          "build.sbt"
+        ],
+        "detect_folders": [
+          ".metals"
+        ],
+        "disabled": false,
+        "format": "via [$symbol($version )]($style)",
+        "style": "red bold",
+        "symbol": "🆂 ",
+        "version_format": "v${raw}"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ScalaConfig"
+        }
+      ]
+    },
+    "shell": {
+      "default": {
+        "bash_indicator": "bsh",
+        "cmd_indicator": "cmd",
+        "disabled": true,
+        "elvish_indicator": "esh",
+        "fish_indicator": "fsh",
+        "format": "[$indicator]($style) ",
+        "ion_indicator": "ion",
+        "nu_indicator": "nu",
+        "powershell_indicator": "psh",
+        "style": "white bold",
+        "tcsh_indicator": "tsh",
+        "unknown_indicator": "",
+        "xonsh_indicator": "xsh",
+        "zsh_indicator": "zsh"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ShellConfig"
+        }
+      ]
+    },
+    "shlvl": {
+      "default": {
+        "disabled": true,
+        "format": "[$symbol$shlvl]($style) ",
+        "repeat": false,
+        "style": "bold yellow",
+        "symbol": "↕️  ",
+        "threshold": 2
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ShLvlConfig"
+        }
+      ]
+    },
+    "singularity": {
+      "default": {
+        "disabled": false,
+        "format": "[$symbol\\[$env\\]]($style) ",
+        "style": "blue bold dimmed",
+        "symbol": ""
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/SingularityConfig"
+        }
+      ]
+    },
+    "status": {
+      "default": {
+        "disabled": true,
+        "format": "[$symbol$status]($style) ",
+        "map_symbol": false,
+        "not_executable_symbol": "🚫",
+        "not_found_symbol": "🔍",
+        "pipestatus": false,
+        "pipestatus_format": "\\[$pipestatus\\] => [$symbol$common_meaning$signal_name$maybe_int]($style)",
+        "pipestatus_separator": "|",
+        "recognize_signal_code": true,
+        "sigint_symbol": "🧱",
+        "signal_symbol": "⚡",
+        "style": "bold red",
+        "success_symbol": "",
+        "symbol": "✖"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/StatusConfig"
+        }
+      ]
+    },
+    "sudo": {
+      "default": {
+        "allow_windows": false,
+        "disabled": true,
+        "format": "[as $symbol]($style)",
+        "style": "bold blue",
+        "symbol": "🧙 "
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/SudoConfig"
+        }
+      ]
+    },
+    "swift": {
+      "default": {
+        "detect_extensions": [
+          "swift"
+        ],
+        "detect_files": [
+          "Package.swift"
+        ],
+        "detect_folders": [],
+        "disabled": false,
+        "format": "via [$symbol($version )]($style)",
+        "style": "bold 202",
+        "symbol": "🐦 ",
+        "version_format": "v${raw}"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/SwiftConfig"
+        }
+      ]
+    },
+    "terraform": {
+      "default": {
+        "detect_extensions": [
+          "tf",
+          "tfplan",
+          "tfstate"
+        ],
+        "detect_files": [],
+        "detect_folders": [
+          ".terraform"
+        ],
+        "disabled": false,
+        "format": "via [$symbol$workspace]($style) ",
+        "style": "bold 105",
+        "symbol": "💠 ",
+        "version_format": "v${raw}"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/TerraformConfig"
+        }
+      ]
+    },
+    "time": {
+      "default": {
+        "disabled": true,
+        "format": "at [$time]($style) ",
+        "style": "bold yellow",
+        "time_range": "-",
+        "use_12hr": false,
+        "utc_time_offset": "local"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/TimeConfig"
+        }
+      ]
+    },
+    "username": {
+      "default": {
+        "disabled": false,
+        "format": "[$user]($style) in ",
+        "show_always": false,
+        "style_root": "red bold",
+        "style_user": "yellow bold"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/UsernameConfig"
+        }
+      ]
+    },
+    "vagrant": {
+      "default": {
+        "detect_extensions": [],
+        "detect_files": [
+          "Vagrantfile"
+        ],
+        "detect_folders": [],
+        "disabled": false,
+        "format": "via [$symbol($version )]($style)",
+        "style": "cyan bold",
+        "symbol": "⍱ ",
+        "version_format": "v${raw}"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/VagrantConfig"
+        }
+      ]
+    },
+    "vcsh": {
+      "default": {
+        "disabled": false,
+        "format": "vcsh [$symbol$repo]($style) ",
+        "style": "bold yellow",
+        "symbol": ""
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/VcshConfig"
+        }
+      ]
+    },
+    "vlang": {
+      "default": {
+        "detect_extensions": [
+          "v"
+        ],
+        "detect_files": [
+          "v.mod",
+          "vpkg.json",
+          ".vpkg-lock.json"
+        ],
+        "detect_folders": [],
+        "disabled": false,
+        "format": "via [$symbol($version )]($style)",
+        "style": "blue bold",
+        "symbol": "V ",
+        "version_format": "v${raw}"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/VConfig"
+        }
+      ]
+    },
+    "zig": {
+      "default": {
+        "detect_extensions": [
+          "zig"
+        ],
+        "detect_files": [],
+        "detect_folders": [],
+        "disabled": false,
+        "format": "via [$symbol($version )]($style)",
+        "style": "bold yellow",
+        "symbol": "↯ ",
+        "version_format": "v${raw}"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ZigConfig"
+        }
+      ]
+    },
+    "custom": {
+      "default": {},
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/CustomConfig"
+      }
+    },
+    "format": {
+      "default": "$all",
+      "type": "string"
+    },
+    "right_format": {
+      "default": "",
+      "type": "string"
+    },
+    "continuation_prompt": {
+      "default": "[∙](bright-black) ",
+      "type": "string"
+    },
+    "scan_timeout": {
+      "default": 30,
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
+    },
+    "command_timeout": {
+      "default": 500,
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
+    },
+    "add_newline": {
+      "default": true,
+      "type": "boolean"
+    }
+  },
+  "definitions": {
+    "AwsConfig": {
+      "title": "AWS",
+      "description": "The `aws` module shows the current AWS region and profile when credentials or a `credential_process` have been setup. This is based on `AWS_REGION`, `AWS_DEFAULT_REGION`, and `AWS_PROFILE` env var with `~/.aws/config` file. This module also shows an expiration timer when using temporary credentials.\n\nThe module will display a profile only if its credentials are present in `~/.aws/credentials` or a `credential_process` is defined in `~/.aws/config`. Alternatively, having any of the `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, or `AWS_SESSION_TOKEN` env vars defined will also suffice.\n\nWhen using [aws-vault](https://github.com/99designs/aws-vault) the profile is read from the `AWS_VAULT` env var and the credentials expiration date is read from the `AWS_SESSION_EXPIRATION` env var.\n\nWhen using [awsu](https://github.com/kreuzwerker/awsu) the profile is read from the `AWSU_PROFILE` env var.\n\nWhen using [AWSume](https://awsu.me) the profile is read from the `AWSUME_PROFILE` env var and the credentials expiration date is read from the `AWSUME_EXPIRATION` env var.",
+      "type": "object",
+      "properties": {
+        "format": {
+          "description": "The format for the module.",
+          "default": "on [$symbol($profile )(\\($region\\) )(\\[$duration\\])]($style)",
+          "type": "string"
+        },
+        "symbol": {
+          "description": "The symbol used before displaying the current AWS profile.",
+          "default": "☁️  ",
+          "type": "string"
+        },
+        "style": {
+          "description": "The style for the module.",
+          "default": "bold yellow",
+          "type": "string"
+        },
+        "disabled": {
+          "description": "Disables the AWS module.",
+          "default": false,
+          "type": "boolean"
+        },
+        "region_aliases": {
+          "description": "Table of region aliases to display in addition to the AWS name.",
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "profile_aliases": {
+          "description": "Table of profile aliases to display in addition to the AWS name.",
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "expiration_symbol": {
+          "description": "The symbol displayed when the temporary credentials have expired.",
+          "default": "X",
+          "type": "string"
+        },
+        "force_display": {
+          "description": "If true displays info even if `credentials`, `credential_process` or `sso_start_url` have not been setup.",
+          "default": false,
+          "type": "boolean"
+        }
+      }
+    },
+    "AzureConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "on [$symbol($subscription)]($style) ",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "ﴃ ",
+          "type": "string"
+        },
+        "style": {
+          "default": "blue bold",
+          "type": "string"
+        },
+        "disabled": {
+          "default": true,
+          "type": "boolean"
+        }
+      }
+    },
+    "BatteryConfig": {
+      "type": "object",
+      "properties": {
+        "full_symbol": {
+          "default": " ",
+          "type": "string"
+        },
+        "charging_symbol": {
+          "default": " ",
+          "type": "string"
+        },
+        "discharging_symbol": {
+          "default": " ",
+          "type": "string"
+        },
+        "unknown_symbol": {
+          "default": " ",
+          "type": "string"
+        },
+        "empty_symbol": {
+          "default": " ",
+          "type": "string"
+        },
+        "display": {
+          "default": [
+            {
+              "charging_symbol": null,
+              "discharging_symbol": null,
+              "style": "red bold",
+              "threshold": 10
+            }
+          ],
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/BatteryDisplayConfig"
+          }
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "format": {
+          "default": "[$symbol$percentage]($style) ",
+          "type": "string"
+        }
+      }
+    },
+    "BatteryDisplayConfig": {
+      "type": "object",
+      "properties": {
+        "threshold": {
+          "default": 10,
+          "type": "integer",
+          "format": "int64"
+        },
+        "style": {
+          "default": "red bold",
+          "type": "string"
+        },
+        "charging_symbol": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "discharging_symbol": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "BufConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "with [$symbol ($version)]($style)",
+          "type": "string"
+        },
+        "version_format": {
+          "default": "v${raw}",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "",
+          "type": "string"
+        },
+        "style": {
+          "default": "bold blue",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "detect_extensions": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_files": {
+          "default": [
+            "buf.yaml",
+            "buf.gen.yaml",
+            "buf.work.yaml"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_folders": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "CConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "via [$symbol($version(-$name) )]($style)",
+          "type": "string"
+        },
+        "version_format": {
+          "default": "v${raw}",
+          "type": "string"
+        },
+        "style": {
+          "default": "149 bold",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "C ",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "detect_extensions": {
+          "default": [
+            "c",
+            "h"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_files": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_folders": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "commands": {
+          "default": [
+            [
+              "cc",
+              "--version"
+            ],
+            [
+              "gcc",
+              "--version"
+            ],
+            [
+              "clang",
+              "--version"
+            ]
+          ],
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "CharacterConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "$symbol ",
+          "type": "string"
+        },
+        "success_symbol": {
+          "default": "[❯](bold green)",
+          "type": "string"
+        },
+        "error_symbol": {
+          "default": "[❯](bold red)",
+          "type": "string"
+        },
+        "vicmd_symbol": {
+          "default": "[❮](bold green)",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        }
+      }
+    },
+    "CMakeConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "via [$symbol($version )]($style)",
+          "type": "string"
+        },
+        "version_format": {
+          "default": "v${raw}",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "△ ",
+          "type": "string"
+        },
+        "style": {
+          "default": "bold blue",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "detect_extensions": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_files": {
+          "default": [
+            "CMakeLists.txt",
+            "CMakeCache.txt"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_folders": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "CmdDurationConfig": {
+      "type": "object",
+      "properties": {
+        "min_time": {
+          "default": 2000,
+          "type": "integer",
+          "format": "int64"
+        },
+        "format": {
+          "default": "took [$duration]($style) ",
+          "type": "string"
+        },
+        "style": {
+          "default": "yellow bold",
+          "type": "string"
+        },
+        "show_milliseconds": {
+          "default": false,
+          "type": "boolean"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "show_notifications": {
+          "default": false,
+          "type": "boolean"
+        },
+        "min_time_to_notify": {
+          "default": 45000,
+          "type": "integer",
+          "format": "int64"
+        },
+        "notification_timeout": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "minimum": 0.0
+        }
+      }
+    },
+    "CobolConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "via [$symbol($version )]($style)",
+          "type": "string"
+        },
+        "version_format": {
+          "default": "v${raw}",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "⚙️ ",
+          "type": "string"
+        },
+        "style": {
+          "default": "bold blue",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "detect_extensions": {
+          "default": [
+            "cbl",
+            "cob",
+            "CBL",
+            "COB"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_files": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_folders": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "CondaConfig": {
+      "type": "object",
+      "properties": {
+        "truncation_length": {
+          "default": 1,
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "format": {
+          "default": "via [$symbol$environment]($style) ",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "🅒 ",
+          "type": "string"
+        },
+        "style": {
+          "default": "green bold",
+          "type": "string"
+        },
+        "ignore_base": {
+          "default": true,
+          "type": "boolean"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        }
+      }
+    },
+    "ContainerConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "[$symbol \\[$name\\]]($style) ",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "⬢",
+          "type": "string"
+        },
+        "style": {
+          "default": "red bold dimmed",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        }
+      }
+    },
+    "CrystalConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "via [$symbol($version )]($style)",
+          "type": "string"
+        },
+        "version_format": {
+          "default": "v${raw}",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "🔮 ",
+          "type": "string"
+        },
+        "style": {
+          "default": "bold red",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "detect_extensions": {
+          "default": [
+            "cr"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_files": {
+          "default": [
+            "shard.yml"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_folders": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "DartConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "via [$symbol($version )]($style)",
+          "type": "string"
+        },
+        "version_format": {
+          "default": "v${raw}",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "🎯 ",
+          "type": "string"
+        },
+        "style": {
+          "default": "bold blue",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "detect_extensions": {
+          "default": [
+            "dart"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_files": {
+          "default": [
+            "pubspec.yaml",
+            "pubspec.yml",
+            "pubspec.lock"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_folders": {
+          "default": [
+            ".dart_tool"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "DenoConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "via [$symbol($version )]($style)",
+          "type": "string"
+        },
+        "version_format": {
+          "default": "v${raw}",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "🦕 ",
+          "type": "string"
+        },
+        "style": {
+          "default": "green bold",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "detect_extensions": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_files": {
+          "default": [
+            "deno.json",
+            "deno.jsonc",
+            "mod.ts",
+            "deps.ts",
+            "mod.js",
+            "deps.js"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_folders": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "DirectoryConfig": {
+      "type": "object",
+      "properties": {
+        "truncation_length": {
+          "default": 3,
+          "type": "integer",
+          "format": "int64"
+        },
+        "truncate_to_repo": {
+          "default": true,
+          "type": "boolean"
+        },
+        "substitutions": {
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "fish_style_pwd_dir_length": {
+          "default": 0,
+          "type": "integer",
+          "format": "int64"
+        },
+        "use_logical_path": {
+          "default": true,
+          "type": "boolean"
+        },
+        "format": {
+          "default": "[$path]($style)[$read_only]($read_only_style) ",
+          "type": "string"
+        },
+        "repo_root_format": {
+          "default": "[$before_root_path]($style)[$repo_root]($repo_root_style)[$path]($style)[$read_only]($read_only_style) ",
+          "type": "string"
+        },
+        "style": {
+          "default": "cyan bold",
+          "type": "string"
+        },
+        "repo_root_style": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "read_only": {
+          "default": "🔒",
+          "type": "string"
+        },
+        "read_only_style": {
+          "default": "red",
+          "type": "string"
+        },
+        "truncation_symbol": {
+          "default": "",
+          "type": "string"
+        },
+        "home_symbol": {
+          "default": "~",
+          "type": "string"
+        },
+        "use_os_path_sep": {
+          "default": true,
+          "type": "boolean"
+        }
+      }
+    },
+    "DockerContextConfig": {
+      "type": "object",
+      "properties": {
+        "symbol": {
+          "default": "🐳 ",
+          "type": "string"
+        },
+        "style": {
+          "default": "blue bold",
+          "type": "string"
+        },
+        "format": {
+          "default": "via [$symbol$context]($style) ",
+          "type": "string"
+        },
+        "only_with_files": {
+          "default": true,
+          "type": "boolean"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "detect_extensions": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_files": {
+          "default": [
+            "docker-compose.yml",
+            "docker-compose.yaml",
+            "Dockerfile"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_folders": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "DotnetConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "via [$symbol($version )(🎯 $tfm )]($style)",
+          "type": "string"
+        },
+        "version_format": {
+          "default": "v${raw}",
+          "type": "string"
+        },
+        "symbol": {
+          "default": ".NET ",
+          "type": "string"
+        },
+        "style": {
+          "default": "blue bold",
+          "type": "string"
+        },
+        "heuristic": {
+          "default": true,
+          "type": "boolean"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "detect_extensions": {
+          "default": [
+            "csproj",
+            "fsproj",
+            "xproj"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_files": {
+          "default": [
+            "global.json",
+            "project.json",
+            "Directory.Build.props",
+            "Directory.Build.targets",
+            "Packages.props"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_folders": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ElixirConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "via [$symbol($version \\(OTP $otp_version\\) )]($style)",
+          "type": "string"
+        },
+        "version_format": {
+          "default": "v${raw}",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "💧 ",
+          "type": "string"
+        },
+        "style": {
+          "default": "bold purple",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "detect_extensions": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_files": {
+          "default": [
+            "mix.exs"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_folders": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ElmConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "via [$symbol($version )]($style)",
+          "type": "string"
+        },
+        "version_format": {
+          "default": "v${raw}",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "🌳 ",
+          "type": "string"
+        },
+        "style": {
+          "default": "cyan bold",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "detect_extensions": {
+          "default": [
+            "elm"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_files": {
+          "default": [
+            "elm.json",
+            "elm-package.json",
+            ".elm-version"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_folders": {
+          "default": [
+            "elm-stuff"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "EnvVarConfig": {
+      "type": "object",
+      "properties": {
+        "symbol": {
+          "default": "",
+          "type": "string"
+        },
+        "style": {
+          "default": "black bold dimmed",
+          "type": "string"
+        },
+        "variable": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "default": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "format": {
+          "default": "with [$env_value]($style) ",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        }
+      }
+    },
+    "ErlangConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "via [$symbol($version )]($style)",
+          "type": "string"
+        },
+        "version_format": {
+          "default": "v${raw}",
+          "type": "string"
+        },
+        "symbol": {
+          "default": " ",
+          "type": "string"
+        },
+        "style": {
+          "default": "bold red",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "detect_extensions": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_files": {
+          "default": [
+            "rebar.config",
+            "erlang.mk"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_folders": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "FillConfig": {
+      "type": "object",
+      "properties": {
+        "style": {
+          "default": "bold black",
+          "type": "string"
+        },
+        "symbol": {
+          "default": ".",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        }
+      }
+    },
+    "GcloudConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "on [$symbol$account(@$domain)(\\($region\\))]($style) ",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "☁️  ",
+          "type": "string"
+        },
+        "style": {
+          "default": "bold blue",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "region_aliases": {
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "project_aliases": {
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "GitBranchConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "on [$symbol$branch]($style)(:[$remote]($style)) ",
+          "type": "string"
+        },
+        "symbol": {
+          "default": " ",
+          "type": "string"
+        },
+        "style": {
+          "default": "bold purple",
+          "type": "string"
+        },
+        "truncation_length": {
+          "default": 9223372036854775807,
+          "type": "integer",
+          "format": "int64"
+        },
+        "truncation_symbol": {
+          "default": "…",
+          "type": "string"
+        },
+        "only_attached": {
+          "default": false,
+          "type": "boolean"
+        },
+        "always_show_remote": {
+          "default": false,
+          "type": "boolean"
+        },
+        "ignore_branches": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        }
+      }
+    },
+    "GitCommitConfig": {
+      "type": "object",
+      "properties": {
+        "commit_hash_length": {
+          "default": 7,
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "format": {
+          "default": "[\\($hash$tag\\)]($style) ",
+          "type": "string"
+        },
+        "style": {
+          "default": "green bold",
+          "type": "string"
+        },
+        "only_detached": {
+          "default": true,
+          "type": "boolean"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "tag_symbol": {
+          "default": " 🏷  ",
+          "type": "string"
+        },
+        "tag_disabled": {
+          "default": true,
+          "type": "boolean"
+        }
+      }
+    },
+    "GitMetricsConfig": {
+      "type": "object",
+      "properties": {
+        "added_style": {
+          "default": "bold green",
+          "type": "string"
+        },
+        "deleted_style": {
+          "default": "bold red",
+          "type": "string"
+        },
+        "only_nonzero_diffs": {
+          "default": true,
+          "type": "boolean"
+        },
+        "format": {
+          "default": "([+$added]($added_style) )([-$deleted]($deleted_style) )",
+          "type": "string"
+        },
+        "disabled": {
+          "default": true,
+          "type": "boolean"
+        }
+      }
+    },
+    "GitStateConfig": {
+      "type": "object",
+      "properties": {
+        "rebase": {
+          "default": "REBASING",
+          "type": "string"
+        },
+        "merge": {
+          "default": "MERGING",
+          "type": "string"
+        },
+        "revert": {
+          "default": "REVERTING",
+          "type": "string"
+        },
+        "cherry_pick": {
+          "default": "CHERRY-PICKING",
+          "type": "string"
+        },
+        "bisect": {
+          "default": "BISECTING",
+          "type": "string"
+        },
+        "am": {
+          "default": "AM",
+          "type": "string"
+        },
+        "am_or_rebase": {
+          "default": "AM/REBASE",
+          "type": "string"
+        },
+        "style": {
+          "default": "bold yellow",
+          "type": "string"
+        },
+        "format": {
+          "default": "\\([$state( $progress_current/$progress_total)]($style)\\) ",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        }
+      }
+    },
+    "GitStatusConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "([\\[$all_status$ahead_behind\\]]($style) )",
+          "type": "string"
+        },
+        "style": {
+          "default": "red bold",
+          "type": "string"
+        },
+        "stashed": {
+          "default": "\\$",
+          "type": "string"
+        },
+        "ahead": {
+          "default": "⇡",
+          "type": "string"
+        },
+        "behind": {
+          "default": "⇣",
+          "type": "string"
+        },
+        "up_to_date": {
+          "default": "",
+          "type": "string"
+        },
+        "diverged": {
+          "default": "⇕",
+          "type": "string"
+        },
+        "conflicted": {
+          "default": "=",
+          "type": "string"
+        },
+        "deleted": {
+          "default": "✘",
+          "type": "string"
+        },
+        "renamed": {
+          "default": "»",
+          "type": "string"
+        },
+        "modified": {
+          "default": "!",
+          "type": "string"
+        },
+        "staged": {
+          "default": "+",
+          "type": "string"
+        },
+        "untracked": {
+          "default": "?",
+          "type": "string"
+        },
+        "ignore_submodules": {
+          "default": false,
+          "type": "boolean"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "windows_starship": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "GoConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "via [$symbol($version )]($style)",
+          "type": "string"
+        },
+        "version_format": {
+          "default": "v${raw}",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "🐹 ",
+          "type": "string"
+        },
+        "style": {
+          "default": "bold cyan",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "detect_extensions": {
+          "default": [
+            "go"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_files": {
+          "default": [
+            "go.mod",
+            "go.sum",
+            "glide.yaml",
+            "Gopkg.yml",
+            "Gopkg.lock",
+            ".go-version"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_folders": {
+          "default": [
+            "Godeps"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "HaskellConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "via [$symbol($version )]($style)",
+          "type": "string"
+        },
+        "version_format": {
+          "default": "v${raw}",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "λ ",
+          "type": "string"
+        },
+        "style": {
+          "default": "bold purple",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "detect_extensions": {
+          "default": [
+            "hs",
+            "cabal",
+            "hs-boot"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_files": {
+          "default": [
+            "stack.yaml",
+            "cabal.project"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_folders": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "HelmConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "via [$symbol($version )]($style)",
+          "type": "string"
+        },
+        "version_format": {
+          "default": "v${raw}",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "⎈ ",
+          "type": "string"
+        },
+        "style": {
+          "default": "bold white",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "detect_extensions": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_files": {
+          "default": [
+            "helmfile.yaml",
+            "Chart.yaml"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_folders": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "HgBranchConfig": {
+      "type": "object",
+      "properties": {
+        "symbol": {
+          "default": " ",
+          "type": "string"
+        },
+        "style": {
+          "default": "bold purple",
+          "type": "string"
+        },
+        "format": {
+          "default": "on [$symbol$branch]($style) ",
+          "type": "string"
+        },
+        "truncation_length": {
+          "default": 9223372036854775807,
+          "type": "integer",
+          "format": "int64"
+        },
+        "truncation_symbol": {
+          "default": "…",
+          "type": "string"
+        },
+        "disabled": {
+          "default": true,
+          "type": "boolean"
+        }
+      }
+    },
+    "HostnameConfig": {
+      "type": "object",
+      "properties": {
+        "ssh_only": {
+          "default": true,
+          "type": "boolean"
+        },
+        "trim_at": {
+          "default": ".",
+          "type": "string"
+        },
+        "format": {
+          "default": "[$hostname]($style) in ",
+          "type": "string"
+        },
+        "style": {
+          "default": "green dimmed bold",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        }
+      }
+    },
+    "JavaConfig": {
+      "type": "object",
+      "properties": {
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "format": {
+          "default": "via [$symbol($version )]($style)",
+          "type": "string"
+        },
+        "version_format": {
+          "default": "v${raw}",
+          "type": "string"
+        },
+        "style": {
+          "default": "red dimmed",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "☕ ",
+          "type": "string"
+        },
+        "detect_extensions": {
+          "default": [
+            "java",
+            "class",
+            "jar",
+            "gradle",
+            "clj",
+            "cljc"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_files": {
+          "default": [
+            "pom.xml",
+            "build.gradle.kts",
+            "build.sbt",
+            ".java-version",
+            "deps.edn",
+            "project.clj",
+            "build.boot"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_folders": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "JobsConfig": {
+      "type": "object",
+      "properties": {
+        "threshold": {
+          "default": 1,
+          "type": "integer",
+          "format": "int64"
+        },
+        "symbol_threshold": {
+          "default": 1,
+          "type": "integer",
+          "format": "int64"
+        },
+        "number_threshold": {
+          "default": 2,
+          "type": "integer",
+          "format": "int64"
+        },
+        "format": {
+          "default": "[$symbol$number]($style) ",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "✦",
+          "type": "string"
+        },
+        "style": {
+          "default": "bold blue",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        }
+      }
+    },
+    "JuliaConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "via [$symbol($version )]($style)",
+          "type": "string"
+        },
+        "version_format": {
+          "default": "v${raw}",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "ஃ ",
+          "type": "string"
+        },
+        "style": {
+          "default": "bold purple",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "detect_extensions": {
+          "default": [
+            "jl"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_files": {
+          "default": [
+            "Project.toml",
+            "Manifest.toml"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_folders": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "KotlinConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "via [$symbol($version )]($style)",
+          "type": "string"
+        },
+        "version_format": {
+          "default": "v${raw}",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "🅺 ",
+          "type": "string"
+        },
+        "style": {
+          "default": "bold blue",
+          "type": "string"
+        },
+        "kotlin_binary": {
+          "default": "kotlin",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "detect_extensions": {
+          "default": [
+            "kt",
+            "kts"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_files": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_folders": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "KubernetesConfig": {
+      "type": "object",
+      "properties": {
+        "symbol": {
+          "default": "☸ ",
+          "type": "string"
+        },
+        "format": {
+          "default": "[$symbol$context( \\($namespace\\))]($style) in ",
+          "type": "string"
+        },
+        "style": {
+          "default": "cyan bold",
+          "type": "string"
+        },
+        "disabled": {
+          "default": true,
+          "type": "boolean"
+        },
+        "context_aliases": {
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "LineBreakConfig": {
+      "type": "object",
+      "properties": {
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        }
+      }
+    },
+    "LocalipConfig": {
+      "type": "object",
+      "properties": {
+        "ssh_only": {
+          "default": true,
+          "type": "boolean"
+        },
+        "format": {
+          "default": "[$localipv4]($style) ",
+          "type": "string"
+        },
+        "style": {
+          "default": "yellow bold",
+          "type": "string"
+        },
+        "disabled": {
+          "default": true,
+          "type": "boolean"
+        }
+      }
+    },
+    "LuaConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "via [$symbol($version )]($style)",
+          "type": "string"
+        },
+        "version_format": {
+          "default": "v${raw}",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "🌙 ",
+          "type": "string"
+        },
+        "style": {
+          "default": "bold blue",
+          "type": "string"
+        },
+        "lua_binary": {
+          "default": "lua",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "detect_extensions": {
+          "default": [
+            "lua"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_files": {
+          "default": [
+            ".lua-version"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_folders": {
+          "default": [
+            "lua"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "MemoryConfig": {
+      "type": "object",
+      "properties": {
+        "threshold": {
+          "default": 75,
+          "type": "integer",
+          "format": "int64"
+        },
+        "format": {
+          "default": "via $symbol[$ram( | $swap)]($style) ",
+          "type": "string"
+        },
+        "style": {
+          "default": "white bold dimmed",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "🐏 ",
+          "type": "string"
+        },
+        "disabled": {
+          "default": true,
+          "type": "boolean"
+        }
+      }
+    },
+    "NimConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "via [$symbol($version )]($style)",
+          "type": "string"
+        },
+        "version_format": {
+          "default": "v${raw}",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "👑 ",
+          "type": "string"
+        },
+        "style": {
+          "default": "yellow bold",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "detect_extensions": {
+          "default": [
+            "nim",
+            "nims",
+            "nimble"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_files": {
+          "default": [
+            "nim.cfg"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_folders": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "NixShellConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "via [$symbol$state( \\($name\\))]($style) ",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "❄️  ",
+          "type": "string"
+        },
+        "style": {
+          "default": "bold blue",
+          "type": "string"
+        },
+        "impure_msg": {
+          "default": "impure",
+          "type": "string"
+        },
+        "pure_msg": {
+          "default": "pure",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        }
+      }
+    },
+    "NodejsConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "via [$symbol($version )]($style)",
+          "type": "string"
+        },
+        "version_format": {
+          "default": "v${raw}",
+          "type": "string"
+        },
+        "symbol": {
+          "default": " ",
+          "type": "string"
+        },
+        "style": {
+          "default": "bold green",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "not_capable_style": {
+          "default": "bold red",
+          "type": "string"
+        },
+        "detect_extensions": {
+          "default": [
+            "js",
+            "mjs",
+            "cjs",
+            "ts",
+            "mts",
+            "cts"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_files": {
+          "default": [
+            "package.json",
+            ".node-version",
+            ".nvmrc"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_folders": {
+          "default": [
+            "node_modules"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "OCamlConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "via [$symbol($version )(\\($switch_indicator$switch_name\\) )]($style)",
+          "type": "string"
+        },
+        "version_format": {
+          "default": "v${raw}",
+          "type": "string"
+        },
+        "global_switch_indicator": {
+          "default": "",
+          "type": "string"
+        },
+        "local_switch_indicator": {
+          "default": "*",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "🐫 ",
+          "type": "string"
+        },
+        "style": {
+          "default": "bold yellow",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "detect_extensions": {
+          "default": [
+            "opam",
+            "ml",
+            "mli",
+            "re",
+            "rei"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_files": {
+          "default": [
+            "dune",
+            "dune-project",
+            "jbuild",
+            "jbuild-ignore",
+            ".merlin"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_folders": {
+          "default": [
+            "_opam",
+            "esy.lock"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "OspConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "on [$symbol$cloud(\\($project\\))]($style) ",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "☁️  ",
+          "type": "string"
+        },
+        "style": {
+          "default": "bold yellow",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        }
+      }
+    },
+    "PackageConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "is [$symbol$version]($style) ",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "📦 ",
+          "type": "string"
+        },
+        "style": {
+          "default": "208 bold",
+          "type": "string"
+        },
+        "display_private": {
+          "default": false,
+          "type": "boolean"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "version_format": {
+          "default": "v${raw}",
+          "type": "string"
+        }
+      }
+    },
+    "PerlConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "via [$symbol($version )]($style)",
+          "type": "string"
+        },
+        "version_format": {
+          "default": "v${raw}",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "🐪 ",
+          "type": "string"
+        },
+        "style": {
+          "default": "149 bold",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "detect_extensions": {
+          "default": [
+            "pl",
+            "pm",
+            "pod"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_files": {
+          "default": [
+            "Makefile.PL",
+            "Build.PL",
+            "cpanfile",
+            "cpanfile.snapshot",
+            "META.json",
+            "META.yml",
+            ".perl-version"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_folders": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "PhpConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "via [$symbol($version )]($style)",
+          "type": "string"
+        },
+        "version_format": {
+          "default": "v${raw}",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "🐘 ",
+          "type": "string"
+        },
+        "style": {
+          "default": "147 bold",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "detect_extensions": {
+          "default": [
+            "php"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_files": {
+          "default": [
+            "composer.json",
+            ".php-version"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_folders": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "PulumiConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "via [$symbol($username@)$stack]($style) ",
+          "type": "string"
+        },
+        "version_format": {
+          "default": "v${raw}",
+          "type": "string"
+        },
+        "symbol": {
+          "default": " ",
+          "type": "string"
+        },
+        "style": {
+          "default": "bold 5",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        }
+      }
+    },
+    "PureScriptConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "via [$symbol($version )]($style)",
+          "type": "string"
+        },
+        "version_format": {
+          "default": "v${raw}",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "<=> ",
+          "type": "string"
+        },
+        "style": {
+          "default": "bold white",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "detect_extensions": {
+          "default": [
+            "purs"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_files": {
+          "default": [
+            "spago.dhall"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_folders": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "PythonConfig": {
+      "type": "object",
+      "properties": {
+        "pyenv_version_name": {
+          "default": false,
+          "type": "boolean"
+        },
+        "pyenv_prefix": {
+          "default": "pyenv ",
+          "type": "string"
+        },
+        "python_binary": {
+          "default": [
+            "python",
+            "python3",
+            "python2"
+          ],
+          "allOf": [
+            {
+              "$ref": "#/definitions/Either_for_String_and_Array_of_String"
+            }
+          ]
+        },
+        "format": {
+          "default": "via [${symbol}${pyenv_prefix}(${version} )(\\($virtualenv\\) )]($style)",
+          "type": "string"
+        },
+        "version_format": {
+          "default": "v${raw}",
+          "type": "string"
+        },
+        "style": {
+          "default": "yellow bold",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "🐍 ",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "detect_extensions": {
+          "default": [
+            "py"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_files": {
+          "default": [
+            "requirements.txt",
+            ".python-version",
+            "pyproject.toml",
+            "Pipfile",
+            "tox.ini",
+            "setup.py",
+            "__init__.py"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_folders": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "Either_for_String_and_Array_of_String": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "RedConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "via [$symbol($version )]($style)",
+          "type": "string"
+        },
+        "version_format": {
+          "default": "v${raw}",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "🔺 ",
+          "type": "string"
+        },
+        "style": {
+          "default": "red bold",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "detect_extensions": {
+          "default": [
+            "red",
+            "reds"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_files": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_folders": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "RLangConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "via [$symbol($version )]($style)",
+          "type": "string"
+        },
+        "version_format": {
+          "default": "v${raw}",
+          "type": "string"
+        },
+        "style": {
+          "default": "blue bold",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "📐 ",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "detect_extensions": {
+          "default": [
+            "R",
+            "Rd",
+            "Rmd",
+            "Rproj",
+            "Rsx"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_files": {
+          "default": [
+            ".Rprofile"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_folders": {
+          "default": [
+            ".Rproj.user"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "RubyConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "via [$symbol($version )]($style)",
+          "type": "string"
+        },
+        "version_format": {
+          "default": "v${raw}",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "💎 ",
+          "type": "string"
+        },
+        "style": {
+          "default": "bold red",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "detect_extensions": {
+          "default": [
+            "rb"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_files": {
+          "default": [
+            "Gemfile",
+            ".ruby-version"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_folders": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_variables": {
+          "default": [
+            "RUBY_VERSION",
+            "RBENV_VERSION"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "RustConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "via [$symbol($version )]($style)",
+          "type": "string"
+        },
+        "version_format": {
+          "default": "v${raw}",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "🦀 ",
+          "type": "string"
+        },
+        "style": {
+          "default": "bold red",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "detect_extensions": {
+          "default": [
+            "rs"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_files": {
+          "default": [
+            "Cargo.toml"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_folders": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ScalaConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "via [$symbol($version )]($style)",
+          "type": "string"
+        },
+        "version_format": {
+          "default": "v${raw}",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "style": {
+          "default": "red bold",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "🆂 ",
+          "type": "string"
+        },
+        "detect_extensions": {
+          "default": [
+            "sbt",
+            "scala"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_files": {
+          "default": [
+            ".scalaenv",
+            ".sbtenv",
+            "build.sbt"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_folders": {
+          "default": [
+            ".metals"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ShellConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "[$indicator]($style) ",
+          "type": "string"
+        },
+        "bash_indicator": {
+          "default": "bsh",
+          "type": "string"
+        },
+        "fish_indicator": {
+          "default": "fsh",
+          "type": "string"
+        },
+        "zsh_indicator": {
+          "default": "zsh",
+          "type": "string"
+        },
+        "powershell_indicator": {
+          "default": "psh",
+          "type": "string"
+        },
+        "ion_indicator": {
+          "default": "ion",
+          "type": "string"
+        },
+        "elvish_indicator": {
+          "default": "esh",
+          "type": "string"
+        },
+        "tcsh_indicator": {
+          "default": "tsh",
+          "type": "string"
+        },
+        "nu_indicator": {
+          "default": "nu",
+          "type": "string"
+        },
+        "xonsh_indicator": {
+          "default": "xsh",
+          "type": "string"
+        },
+        "cmd_indicator": {
+          "default": "cmd",
+          "type": "string"
+        },
+        "unknown_indicator": {
+          "default": "",
+          "type": "string"
+        },
+        "style": {
+          "default": "white bold",
+          "type": "string"
+        },
+        "disabled": {
+          "default": true,
+          "type": "boolean"
+        }
+      }
+    },
+    "ShLvlConfig": {
+      "type": "object",
+      "properties": {
+        "threshold": {
+          "default": 2,
+          "type": "integer",
+          "format": "int64"
+        },
+        "format": {
+          "default": "[$symbol$shlvl]($style) ",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "↕️  ",
+          "type": "string"
+        },
+        "repeat": {
+          "default": false,
+          "type": "boolean"
+        },
+        "style": {
+          "default": "bold yellow",
+          "type": "string"
+        },
+        "disabled": {
+          "default": true,
+          "type": "boolean"
+        }
+      }
+    },
+    "SingularityConfig": {
+      "type": "object",
+      "properties": {
+        "symbol": {
+          "default": "",
+          "type": "string"
+        },
+        "format": {
+          "default": "[$symbol\\[$env\\]]($style) ",
+          "type": "string"
+        },
+        "style": {
+          "default": "blue bold dimmed",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        }
+      }
+    },
+    "StatusConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "[$symbol$status]($style) ",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "✖",
+          "type": "string"
+        },
+        "success_symbol": {
+          "default": "",
+          "type": "string"
+        },
+        "not_executable_symbol": {
+          "default": "🚫",
+          "type": "string"
+        },
+        "not_found_symbol": {
+          "default": "🔍",
+          "type": "string"
+        },
+        "sigint_symbol": {
+          "default": "🧱",
+          "type": "string"
+        },
+        "signal_symbol": {
+          "default": "⚡",
+          "type": "string"
+        },
+        "style": {
+          "default": "bold red",
+          "type": "string"
+        },
+        "map_symbol": {
+          "default": false,
+          "type": "boolean"
+        },
+        "recognize_signal_code": {
+          "default": true,
+          "type": "boolean"
+        },
+        "pipestatus": {
+          "default": false,
+          "type": "boolean"
+        },
+        "pipestatus_separator": {
+          "default": "|",
+          "type": "string"
+        },
+        "pipestatus_format": {
+          "default": "\\[$pipestatus\\] => [$symbol$common_meaning$signal_name$maybe_int]($style)",
+          "type": "string"
+        },
+        "disabled": {
+          "default": true,
+          "type": "boolean"
+        }
+      }
+    },
+    "SudoConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "[as $symbol]($style)",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "🧙 ",
+          "type": "string"
+        },
+        "style": {
+          "default": "bold blue",
+          "type": "string"
+        },
+        "allow_windows": {
+          "default": false,
+          "type": "boolean"
+        },
+        "disabled": {
+          "default": true,
+          "type": "boolean"
+        }
+      }
+    },
+    "SwiftConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "via [$symbol($version )]($style)",
+          "type": "string"
+        },
+        "version_format": {
+          "default": "v${raw}",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "🐦 ",
+          "type": "string"
+        },
+        "style": {
+          "default": "bold 202",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "detect_extensions": {
+          "default": [
+            "swift"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_files": {
+          "default": [
+            "Package.swift"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_folders": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "TerraformConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "via [$symbol$workspace]($style) ",
+          "type": "string"
+        },
+        "version_format": {
+          "default": "v${raw}",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "💠 ",
+          "type": "string"
+        },
+        "style": {
+          "default": "bold 105",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "detect_extensions": {
+          "default": [
+            "tf",
+            "tfplan",
+            "tfstate"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_files": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_folders": {
+          "default": [
+            ".terraform"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "TimeConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "at [$time]($style) ",
+          "type": "string"
+        },
+        "style": {
+          "default": "bold yellow",
+          "type": "string"
+        },
+        "use_12hr": {
+          "default": false,
+          "type": "boolean"
+        },
+        "time_format": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "disabled": {
+          "default": true,
+          "type": "boolean"
+        },
+        "utc_time_offset": {
+          "default": "local",
+          "type": "string"
+        },
+        "time_range": {
+          "default": "-",
+          "type": "string"
+        }
+      }
+    },
+    "UsernameConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "[$user]($style) in ",
+          "type": "string"
+        },
+        "style_root": {
+          "default": "red bold",
+          "type": "string"
+        },
+        "style_user": {
+          "default": "yellow bold",
+          "type": "string"
+        },
+        "show_always": {
+          "default": false,
+          "type": "boolean"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        }
+      }
+    },
+    "VagrantConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "via [$symbol($version )]($style)",
+          "type": "string"
+        },
+        "version_format": {
+          "default": "v${raw}",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "⍱ ",
+          "type": "string"
+        },
+        "style": {
+          "default": "cyan bold",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "detect_extensions": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_files": {
+          "default": [
+            "Vagrantfile"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_folders": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "VcshConfig": {
+      "type": "object",
+      "properties": {
+        "symbol": {
+          "default": "",
+          "type": "string"
+        },
+        "style": {
+          "default": "bold yellow",
+          "type": "string"
+        },
+        "format": {
+          "default": "vcsh [$symbol$repo]($style) ",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        }
+      }
+    },
+    "VConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "via [$symbol($version )]($style)",
+          "type": "string"
+        },
+        "version_format": {
+          "default": "v${raw}",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "V ",
+          "type": "string"
+        },
+        "style": {
+          "default": "blue bold",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "detect_extensions": {
+          "default": [
+            "v"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_files": {
+          "default": [
+            "v.mod",
+            "vpkg.json",
+            ".vpkg-lock.json"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_folders": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ZigConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "via [$symbol($version )]($style)",
+          "type": "string"
+        },
+        "version_format": {
+          "default": "v${raw}",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "↯ ",
+          "type": "string"
+        },
+        "style": {
+          "default": "bold yellow",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "detect_extensions": {
+          "default": [
+            "zig"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_files": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_folders": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "CustomConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "[$symbol($output )]($style)",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "",
+          "type": "string"
+        },
+        "command": {
+          "default": "",
+          "type": "string"
+        },
+        "when": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "shell": {
+          "default": [],
+          "allOf": [
+            {
+              "$ref": "#/definitions/Either_for_String_and_Array_of_String"
+            }
+          ]
+        },
+        "description": {
+          "default": "<custom config>",
+          "type": "string"
+        },
+        "style": {
+          "default": "green bold",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "files": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "extensions": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "directories": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "os": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -129,6 +129,31 @@ jobs:
       - name: Build | Check
         run: cargo check --workspace --locked --all-features
 
+  # Check if config schema needs to be updated to reflect updated configuration options
+  check_if_config_schema_up_to_date:
+    name: Check if config schema is up to date
+    needs: cargo_check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup | Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup | Cache
+        uses: Swatinem/rust-cache@v1
+
+      - name: Setup | Rust
+        uses: actions-rs/toolchain@v1.0.7
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+
+      - name: Run | Generate Schema
+        run: cargo run --locked --features config-schema -- config-schema > .github/config-schema.json
+
+      - name: Check | Detect Changes
+        run: git diff --exit-code .github/config-schema.json
+
   # Run tests on Linux, macOS, and Windows
   # On both Rust stable and Rust nightly
   test:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,6 +154,8 @@ dprint fmt
 
 Editor plugins/functionality may help you run these automatically so that you don't accidentally create a PR that fails.
 
+If your changes cause changes to the configuration, you will need to update the configuration schema in `.github/config-schema.json` with `cargo run --features config-schema -- config-schema > .github/config-schema.json`.
+
 ## Testing
 
 Testing is critical to making sure starship works as intended on systems big and small. Starship interfaces with many applications and system APIs when generating the prompt, so there's a lot of room for bugs to slip in.
@@ -291,6 +293,7 @@ everyone remember what they are. Don't worry: most of them are quite simple!
 - [ ] Add the variable to the appropriate location in the "Default Prompt
       Format" section of the documentation
 - [ ] Add an appropriate choice of options to each preset in `docs/presets/README.md`
+- [ ] Update the config file schema by running `cargo run --features config-schema -- config-schema > .github/config-schema.json`
 - [ ] Create configs structs/traits in `src/configs/<module>.rs` and add the
       following:
   - [ ] An entry in `PROMPT_ORDER` (`src/configs/starship_root.rs`)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -477,6 +477,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453440c271cf5577fd2a40e4942540cb7d0d2f85e27c8d07dd0023c925a67541"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee2626afccd7561a06cf1367e2950c4718ea04565e20fb5029b6c7d8ad09abcf"
+
+[[package]]
 name = "easy-parallel"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1420,6 +1426,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
+name = "schemars"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6b5a3c80cea1ab61f4260238409510e814e38b4b563c06044edf91e7dc070e3"
+dependencies = [
+ "dyn-clone",
+ "indexmap",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41ae4dce13e8614c46ac3c38ef1c0d668b101df6ac39817aebdaa26642ddae9b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1445,6 +1476,17 @@ name = "serde_derive"
 version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dbab34ca63057a1f15280bdf3c39f2b1eb1b54c17e98360e511637aef7418c6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1576,6 +1618,7 @@ dependencies = [
  "rayon",
  "regex",
  "rust-ini",
+ "schemars",
  "semver",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ include = [
   "LICENSE",
   "/README.md",
   "docs/.vuepress/public/presets/toml/",
+  ".github/config-schema.json",
 ]
 keywords = ["prompt", "shell", "bash", "fish", "zsh"]
 license = "ISC"
@@ -31,6 +32,7 @@ The minimal, blazing-fast, and infinitely customizable prompt for any shell! ☄
 [features]
 default = ["battery"]
 battery = ["starship-battery"]
+config-schema = ["schemars"]
 
 [dependencies]
 ansi_term = "0.12.1"
@@ -80,6 +82,11 @@ yaml-rust = "0.4.5"
 process_control = { version = "3.3.0", features = ["crossbeam-channel"] }
 
 shell-words = "1.1.0"
+
+[dependencies.schemars]
+version = "0.8.8"
+optional = true
+features = ["preserve_order", "indexmap"]
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.9", features = ["winuser", "securitybaseapi", "processthreadsapi", "handleapi", "impl-default"] }

--- a/docs/.vuepress/public/config-schema.json
+++ b/docs/.vuepress/public/config-schema.json
@@ -1,0 +1,1 @@
+../../../.github/config-schema.json

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -9,6 +9,9 @@ mkdir -p ~/.config && touch ~/.config/starship.toml
 All configuration for starship is done in this [TOML](https://github.com/toml-lang/toml) file:
 
 ```toml
+# Get editor completions based on the config schema
+"$schema" = 'https://starship.rs/config-schema.json'
+
 # Inserts a blank line between shell prompts
 add_newline = true
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -50,6 +50,7 @@ impl<'a, T: Deserialize<'a> + Default> ModuleConfig<'a, ValueError> for T {
 }
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(untagged)]
 pub enum Either<A, B> {
     First(A),
@@ -74,6 +75,24 @@ where
             Either::First(v) => Ok(VecOr(v)),
             Either::Second(s) => Ok(VecOr(vec![s])),
         }
+    }
+}
+
+#[cfg(feature = "config-schema")]
+impl<T> schemars::JsonSchema for VecOr<T>
+where
+    T: schemars::JsonSchema + Sized,
+{
+    fn schema_name() -> String {
+        Either::<T, Vec<T>>::schema_name()
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        Either::<T, Vec<T>>::json_schema(gen)
+    }
+
+    fn is_referenceable() -> bool {
+        Either::<T, Vec<T>>::is_referenceable()
     }
 }
 

--- a/src/configs/aws.rs
+++ b/src/configs/aws.rs
@@ -2,15 +2,48 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
+/// ## AWS
+///
+/// The `aws` module shows the current AWS region and profile when
+/// credentials or a `credential_process` have been setup. This is based on
+/// `AWS_REGION`, `AWS_DEFAULT_REGION`, and `AWS_PROFILE` env var with
+/// `~/.aws/config` file. This module also shows an expiration timer when using temporary
+/// credentials.
+///
+/// The module will display a profile only if its credentials are present in
+/// `~/.aws/credentials` or a `credential_process` is defined in
+/// `~/.aws/config`. Alternatively, having any of the `AWS_ACCESS_KEY_ID`,
+/// `AWS_SECRET_ACCESS_KEY`, or `AWS_SESSION_TOKEN` env vars defined will
+/// also suffice.
+///
+/// When using [aws-vault](https://github.com/99designs/aws-vault) the profile
+/// is read from the `AWS_VAULT` env var and the credentials expiration date
+/// is read from the `AWS_SESSION_EXPIRATION` env var.
+///
+/// When using [awsu](https://github.com/kreuzwerker/awsu) the profile
+/// is read from the `AWSU_PROFILE` env var.
+///
+/// When using [AWSume](https://awsu.me) the profile
+/// is read from the `AWSUME_PROFILE` env var and the credentials expiration
+/// date is read from the `AWSUME_EXPIRATION` env var.
 pub struct AwsConfig<'a> {
+    /// The format for the module.
     pub format: &'a str,
+    /// The symbol used before displaying the current AWS profile.
     pub symbol: &'a str,
+    /// The style for the module.
     pub style: &'a str,
+    /// Disables the AWS module.
     pub disabled: bool,
+    /// Table of region aliases to display in addition to the AWS name.
     pub region_aliases: HashMap<String, &'a str>,
+    /// Table of profile aliases to display in addition to the AWS name.
     pub profile_aliases: HashMap<String, &'a str>,
+    /// The symbol displayed when the temporary credentials have expired.
     pub expiration_symbol: &'a str,
+    /// If true displays info even if `credentials`, `credential_process` or `sso_start_url` have not been setup.
     pub force_display: bool,
 }
 

--- a/src/configs/azure.rs
+++ b/src/configs/azure.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct AzureConfig<'a> {
     pub format: &'a str,

--- a/src/configs/battery.rs
+++ b/src/configs/battery.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct BatteryConfig<'a> {
     pub full_symbol: &'a str,
@@ -30,6 +31,7 @@ impl<'a> Default for BatteryConfig<'a> {
 }
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct BatteryDisplayConfig<'a> {
     pub threshold: i64,

--- a/src/configs/buf.rs
+++ b/src/configs/buf.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct BufConfig<'a> {
     pub format: &'a str,

--- a/src/configs/c.rs
+++ b/src/configs/c.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct CConfig<'a> {
     pub format: &'a str,

--- a/src/configs/character.rs
+++ b/src/configs/character.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct CharacterConfig<'a> {
     pub format: &'a str,

--- a/src/configs/cmake.rs
+++ b/src/configs/cmake.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct CMakeConfig<'a> {
     pub format: &'a str,

--- a/src/configs/cmd_duration.rs
+++ b/src/configs/cmd_duration.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct CmdDurationConfig<'a> {
     pub min_time: i64,

--- a/src/configs/cobol.rs
+++ b/src/configs/cobol.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct CobolConfig<'a> {
     pub format: &'a str,

--- a/src/configs/conda.rs
+++ b/src/configs/conda.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct CondaConfig<'a> {
     pub truncation_length: usize,

--- a/src/configs/container.rs
+++ b/src/configs/container.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct ContainerConfig<'a> {
     pub format: &'a str,

--- a/src/configs/crystal.rs
+++ b/src/configs/crystal.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct CrystalConfig<'a> {
     pub format: &'a str,

--- a/src/configs/custom.rs
+++ b/src/configs/custom.rs
@@ -3,6 +3,7 @@ use crate::config::VecOr;
 use serde::{self, Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct CustomConfig<'a> {
     pub format: &'a str,

--- a/src/configs/dart.rs
+++ b/src/configs/dart.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct DartConfig<'a> {
     pub format: &'a str,

--- a/src/configs/deno.rs
+++ b/src/configs/deno.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct DenoConfig<'a> {
     pub format: &'a str,

--- a/src/configs/directory.rs
+++ b/src/configs/directory.rs
@@ -3,6 +3,7 @@ use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct DirectoryConfig<'a> {
     pub truncation_length: i64,

--- a/src/configs/docker_context.rs
+++ b/src/configs/docker_context.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct DockerContextConfig<'a> {
     pub symbol: &'a str,

--- a/src/configs/dotnet.rs
+++ b/src/configs/dotnet.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct DotnetConfig<'a> {
     pub format: &'a str,

--- a/src/configs/elixir.rs
+++ b/src/configs/elixir.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct ElixirConfig<'a> {
     pub format: &'a str,

--- a/src/configs/elm.rs
+++ b/src/configs/elm.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct ElmConfig<'a> {
     pub format: &'a str,

--- a/src/configs/env_var.rs
+++ b/src/configs/env_var.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct EnvVarConfig<'a> {
     pub symbol: &'a str,

--- a/src/configs/erlang.rs
+++ b/src/configs/erlang.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct ErlangConfig<'a> {
     pub format: &'a str,

--- a/src/configs/fill.rs
+++ b/src/configs/fill.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct FillConfig<'a> {
     pub style: &'a str,

--- a/src/configs/gcloud.rs
+++ b/src/configs/gcloud.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct GcloudConfig<'a> {
     pub format: &'a str,

--- a/src/configs/git_branch.rs
+++ b/src/configs/git_branch.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct GitBranchConfig<'a> {
     pub format: &'a str,

--- a/src/configs/git_commit.rs
+++ b/src/configs/git_commit.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct GitCommitConfig<'a> {
     pub commit_hash_length: usize,

--- a/src/configs/git_metrics.rs
+++ b/src/configs/git_metrics.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct GitMetricsConfig<'a> {
     pub added_style: &'a str,

--- a/src/configs/git_state.rs
+++ b/src/configs/git_state.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct GitStateConfig<'a> {
     pub rebase: &'a str,

--- a/src/configs/git_status.rs
+++ b/src/configs/git_status.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct GitStatusConfig<'a> {
     pub format: &'a str,

--- a/src/configs/go.rs
+++ b/src/configs/go.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct GoConfig<'a> {
     pub format: &'a str,

--- a/src/configs/haskell.rs
+++ b/src/configs/haskell.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct HaskellConfig<'a> {
     pub format: &'a str,

--- a/src/configs/helm.rs
+++ b/src/configs/helm.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct HelmConfig<'a> {
     pub format: &'a str,

--- a/src/configs/hg_branch.rs
+++ b/src/configs/hg_branch.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct HgBranchConfig<'a> {
     pub symbol: &'a str,

--- a/src/configs/hostname.rs
+++ b/src/configs/hostname.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct HostnameConfig<'a> {
     pub ssh_only: bool,

--- a/src/configs/java.rs
+++ b/src/configs/java.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct JavaConfig<'a> {
     pub disabled: bool,

--- a/src/configs/jobs.rs
+++ b/src/configs/jobs.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct JobsConfig<'a> {
     pub threshold: i64,

--- a/src/configs/julia.rs
+++ b/src/configs/julia.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct JuliaConfig<'a> {
     pub format: &'a str,

--- a/src/configs/kotlin.rs
+++ b/src/configs/kotlin.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct KotlinConfig<'a> {
     pub format: &'a str,

--- a/src/configs/kubernetes.rs
+++ b/src/configs/kubernetes.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct KubernetesConfig<'a> {
     pub symbol: &'a str,

--- a/src/configs/line_break.rs
+++ b/src/configs/line_break.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize, Default)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
+#[serde(default)]
 pub struct LineBreakConfig {
     pub disabled: bool,
 }

--- a/src/configs/localip.rs
+++ b/src/configs/localip.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct LocalipConfig<'a> {
     pub ssh_only: bool,

--- a/src/configs/lua.rs
+++ b/src/configs/lua.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct LuaConfig<'a> {
     pub format: &'a str,

--- a/src/configs/memory_usage.rs
+++ b/src/configs/memory_usage.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct MemoryConfig<'a> {
     pub threshold: i64,

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -78,8 +78,12 @@ pub mod zig;
 pub use starship_root::*;
 
 #[derive(Serialize, Deserialize, Clone, Default)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct FullConfig<'a> {
+    // Meta
+    #[serde(rename = "$schema")]
+    schema: String,
     // Root config
     #[serde(flatten)]
     root: StarshipRootConfig,

--- a/src/configs/nim.rs
+++ b/src/configs/nim.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct NimConfig<'a> {
     pub format: &'a str,

--- a/src/configs/nix_shell.rs
+++ b/src/configs/nix_shell.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct NixShellConfig<'a> {
     pub format: &'a str,

--- a/src/configs/nodejs.rs
+++ b/src/configs/nodejs.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct NodejsConfig<'a> {
     pub format: &'a str,

--- a/src/configs/ocaml.rs
+++ b/src/configs/ocaml.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct OCamlConfig<'a> {
     pub format: &'a str,

--- a/src/configs/openstack.rs
+++ b/src/configs/openstack.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct OspConfig<'a> {
     pub format: &'a str,

--- a/src/configs/package.rs
+++ b/src/configs/package.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct PackageConfig<'a> {
     pub format: &'a str,

--- a/src/configs/perl.rs
+++ b/src/configs/perl.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct PerlConfig<'a> {
     pub format: &'a str,

--- a/src/configs/php.rs
+++ b/src/configs/php.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct PhpConfig<'a> {
     pub format: &'a str,

--- a/src/configs/pulumi.rs
+++ b/src/configs/pulumi.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct PulumiConfig<'a> {
     pub format: &'a str,

--- a/src/configs/purescript.rs
+++ b/src/configs/purescript.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct PureScriptConfig<'a> {
     pub format: &'a str,

--- a/src/configs/python.rs
+++ b/src/configs/python.rs
@@ -3,6 +3,7 @@ use crate::config::VecOr;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct PythonConfig<'a> {
     pub pyenv_version_name: bool,

--- a/src/configs/red.rs
+++ b/src/configs/red.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct RedConfig<'a> {
     pub format: &'a str,

--- a/src/configs/rlang.rs
+++ b/src/configs/rlang.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct RLangConfig<'a> {
     pub format: &'a str,

--- a/src/configs/ruby.rs
+++ b/src/configs/ruby.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct RubyConfig<'a> {
     pub format: &'a str,

--- a/src/configs/rust.rs
+++ b/src/configs/rust.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct RustConfig<'a> {
     pub format: &'a str,

--- a/src/configs/scala.rs
+++ b/src/configs/scala.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct ScalaConfig<'a> {
     pub format: &'a str,

--- a/src/configs/shell.rs
+++ b/src/configs/shell.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct ShellConfig<'a> {
     pub format: &'a str,

--- a/src/configs/shlvl.rs
+++ b/src/configs/shlvl.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct ShLvlConfig<'a> {
     pub threshold: i64,

--- a/src/configs/singularity.rs
+++ b/src/configs/singularity.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct SingularityConfig<'a> {
     pub symbol: &'a str,

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -1,8 +1,11 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Serialize, Deserialize, Debug)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct StarshipRootConfig {
+    #[serde(rename = "$schema")]
+    schema: String,
     pub format: String,
     pub right_format: String,
     pub continuation_prompt: String,
@@ -96,6 +99,7 @@ pub const PROMPT_ORDER: &[&str] = &[
 impl<'a> Default for StarshipRootConfig {
     fn default() -> Self {
         StarshipRootConfig {
+            schema: "https://starship.rs/config-schema.json".to_string(),
             format: "$all".to_string(),
             right_format: "".to_string(),
             continuation_prompt: "[∙](bright-black) ".to_string(),

--- a/src/configs/status.rs
+++ b/src/configs/status.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct StatusConfig<'a> {
     pub format: &'a str,

--- a/src/configs/sudo.rs
+++ b/src/configs/sudo.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct SudoConfig<'a> {
     pub format: &'a str,

--- a/src/configs/swift.rs
+++ b/src/configs/swift.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct SwiftConfig<'a> {
     pub format: &'a str,

--- a/src/configs/terraform.rs
+++ b/src/configs/terraform.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct TerraformConfig<'a> {
     pub format: &'a str,

--- a/src/configs/time.rs
+++ b/src/configs/time.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct TimeConfig<'a> {
     pub format: &'a str,

--- a/src/configs/username.rs
+++ b/src/configs/username.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct UsernameConfig<'a> {
     pub format: &'a str,

--- a/src/configs/v.rs
+++ b/src/configs/v.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct VConfig<'a> {
     pub format: &'a str,

--- a/src/configs/vagrant.rs
+++ b/src/configs/vagrant.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct VagrantConfig<'a> {
     pub format: &'a str,

--- a/src/configs/vcsh.rs
+++ b/src/configs/vcsh.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct VcshConfig<'a> {
     pub symbol: &'a str,

--- a/src/configs/zig.rs
+++ b/src/configs/zig.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
 #[serde(default)]
 pub struct ZigConfig<'a> {
     pub format: &'a str,

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,6 +97,9 @@ enum Commands {
         #[clap(default_value = "disabled")]
         value: String,
     },
+    #[cfg(feature = "config-schema")]
+    /// Generate a schema for the starship configuration as JSON-schema
+    ConfigSchema,
 }
 
 fn main() {
@@ -216,6 +219,8 @@ fn main() {
                 .map(char::from)
                 .collect::<String>()
         ),
+        #[cfg(feature = "config-schema")]
+        Commands::ConfigSchema => print::print_schema(),
     }
 }
 

--- a/src/print.rs
+++ b/src/print.rs
@@ -444,6 +444,12 @@ fn load_formatter_and_modules<'a>(context: &'a Context) -> (StringFormatter<'a>,
     }
 }
 
+#[cfg(feature = "config-schema")]
+pub fn print_schema() {
+    let schema = schemars::schema_for!(crate::configs::FullConfig);
+    println!("{}", serde_json::to_string_pretty(&schema).unwrap());
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -482,5 +488,11 @@ mod test {
         let expected = String::from("><>");
         let actual = get_prompt(context);
         assert_eq!(expected, actual);
+    }
+
+    #[test]
+    #[cfg(feature = "config-schema")]
+    fn print_schema_does_not_panic() {
+        print_schema();
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR adds a `config-schema` command which generates a [JSON-schema](https://json-schema.org/) config schema with [schemars](https://crates.io/crates/schemars). I've added schemars as an optional dependency, that is disabled by default. The generated schema can be used in a supported editor by adding `$schema = url` to the file.

The `aws` module show how the configuration for a module could be added to the schema with comments. This does not yet handle documentation for available format string variables.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1951

#### Screenshots (if appropriate):
[Sample schema](https://gist.github.com/davidkna/9b8f6fe0ad64791e535389478a9a2c1c)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
