### PR TITLE
docs: Specify MSRV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ keywords = ["prompt", "shell", "bash", "fish", "zsh"]
 license = "ISC"
 readme = "README.md"
 repository = "https://github.com/starship/starship"
+# MSRV is specified to use std::thread::availabe_parallelism, which was stablizized in Rust version 1.59
+# Note: MSRV is only intended as a hint, and only the latest version is officially supported in starship.
+rust-version = "1.59"
 description = """
 The minimal, blazing-fast, and infinitely customizable prompt for any shell! ☄🌌️
 """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
starship now uses `std::thread::available_parallelism` which stablized at Rust version 1.59.
https://github.com/starship/starship/blob/master/src/main.rs#L235
therefore, This PR sets MSRV to 1.59 to make sure everyone can build.

Does same thing as #3722 , but I deleted forked repository because I thought #3719 would be merged.
Let me know if my English is wrong in the comments with correct sentense. I will fix it quickly.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #3716
Closed #3719

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
