### PR TITLE
feat(git_branch): add 'ignore_branches' option

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1374,6 +1374,7 @@ The `git_branch` module shows the active branch of the repo in your current dire
 | `truncation_length`  | `2^63 - 1`                       | Truncates a git branch to `N` graphemes.                                                 |
 | `truncation_symbol`  | `"…"`                            | The symbol used to indicate a branch name was truncated. You can use `""` for no symbol. |
 | `only_attached`      | `false`                          | Only show the branch name when not in a detached `HEAD` state.                           |
+| `ignore_branches`    | `""`                             | A list of comma-separated names to avoid displaying. Useful for "master" or "main".     |
 | `disabled`           | `false`                          | Disables the `git_branch` module.                                                        |
 
 ### Variables
@@ -1397,6 +1398,7 @@ The `git_branch` module shows the active branch of the repo in your current dire
 symbol = "🌱 "
 truncation_length = 4
 truncation_symbol = ""
+ignore_branches = "master,main"
 ```
 
 ## Git Commit

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1374,7 +1374,7 @@ The `git_branch` module shows the active branch of the repo in your current dire
 | `truncation_length`  | `2^63 - 1`                       | Truncates a git branch to `N` graphemes.                                                 |
 | `truncation_symbol`  | `"…"`                            | The symbol used to indicate a branch name was truncated. You can use `""` for no symbol. |
 | `only_attached`      | `false`                          | Only show the branch name when not in a detached `HEAD` state.                           |
-| `ignore_branches`    | `""`                             | A list of comma-separated names to avoid displaying. Useful for "master" or "main".     |
+| `ignore_branches`    | `[""]`                           | A list of names to avoid displaying. Useful for "master" or "main".                      |
 | `disabled`           | `false`                          | Disables the `git_branch` module.                                                        |
 
 ### Variables
@@ -1398,7 +1398,7 @@ The `git_branch` module shows the active branch of the repo in your current dire
 symbol = "🌱 "
 truncation_length = 4
 truncation_symbol = ""
-ignore_branches = "master,main"
+ignore_branches = ["master","main"]
 ```
 
 ## Git Commit

--- a/src/configs/git_branch.rs
+++ b/src/configs/git_branch.rs
@@ -12,7 +12,7 @@ pub struct GitBranchConfig<'a> {
     pub truncation_symbol: &'a str,
     pub only_attached: bool,
     pub always_show_remote: bool,
-    pub ignore_branches: &'a str,
+    pub ignore_branches: Vec<&'a str>,
     pub disabled: bool,
 }
 
@@ -26,7 +26,7 @@ impl<'a> Default for GitBranchConfig<'a> {
             truncation_symbol: "…",
             only_attached: false,
             always_show_remote: false,
-            ignore_branches: "",
+            ignore_branches: vec![""],
             disabled: false,
         }
     }

--- a/src/configs/git_branch.rs
+++ b/src/configs/git_branch.rs
@@ -12,6 +12,7 @@ pub struct GitBranchConfig<'a> {
     pub truncation_symbol: &'a str,
     pub only_attached: bool,
     pub always_show_remote: bool,
+    pub ignore_branches: &'a str,
     pub disabled: bool,
 }
 
@@ -25,6 +26,7 @@ impl<'a> Default for GitBranchConfig<'a> {
             truncation_symbol: "…",
             only_attached: false,
             always_show_remote: false,
+            ignore_branches: "",
             disabled: false,
         }
     }

--- a/src/modules/git_branch.rs
+++ b/src/modules/git_branch.rs
@@ -385,7 +385,7 @@ mod tests {
         let actual = ModuleRenderer::new("git_branch")
             .config(toml::toml! {
                 [git_branch]
-                    ignore_branches = "dummy,test_branch"
+                    ignore_branches = ["dummy", "test_branch"]
             })
             .path(&repo_dir.path())
             .collect();

--- a/src/modules/git_branch.rs
+++ b/src/modules/git_branch.rs
@@ -37,7 +37,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let branch_name = repo.branch.as_ref()?;
     let mut graphemes: Vec<&str> = branch_name.graphemes(true).collect();
     
-    for ignore_branch in config.ignore_branch.split(',') {
+    for ignore_branch in config.ignore_branches.split(',') {
         let ignore_graphemes: Vec<&str> = UnicodeSegmentation::graphemes(ignore_branch, true).collect();
         
         if graphemes.eq(&ignore_graphemes) {
@@ -368,6 +368,29 @@ mod tests {
             "on {} ",
             Color::Purple.bold().paint(format!("\u{e0a0} {}", "main")),
         ));
+
+        assert_eq!(expected, actual);
+        repo_dir.close()
+    }
+    
+    #[test]
+    fn test_ignore_branches() -> io::Result<()> {
+        let repo_dir = fixture_repo(FixtureProvider::Git)?;
+
+        create_command("git")?
+            .args(&["checkout", "-b", "test_branch"])
+            .current_dir(repo_dir.path())
+            .output()?;
+
+        let actual = ModuleRenderer::new("git_branch")
+            .config(toml::toml! {
+                [git_branch]
+                    ignore_branches = "dummy,test_branch"
+            })
+            .path(&repo_dir.path())
+            .collect();
+
+        let expected = None;
 
         assert_eq!(expected, actual);
         repo_dir.close()

--- a/src/modules/git_branch.rs
+++ b/src/modules/git_branch.rs
@@ -36,7 +36,15 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
     let branch_name = repo.branch.as_ref()?;
     let mut graphemes: Vec<&str> = branch_name.graphemes(true).collect();
-
+    
+    for ignore_branch in config.ignore_branch.split(',') {
+        let ignore_graphemes: Vec<&str> = UnicodeSegmentation::graphemes(ignore_branch, true).collect();
+        
+        if graphemes.eq(&ignore_graphemes) {
+            return None;
+        }
+    }
+        
     let mut remote_branch_graphemes: Vec<&str> = Vec::new();
     let mut remote_name_graphemes: Vec<&str> = Vec::new();
     if let Some(remote) = repo.remote.as_ref() {

--- a/src/modules/git_branch.rs
+++ b/src/modules/git_branch.rs
@@ -37,7 +37,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let branch_name = repo.branch.as_ref()?;
     let mut graphemes: Vec<&str> = branch_name.graphemes(true).collect();
     
-    for ignore_branch in config.ignore_branches.split(',') {
+    for ignore_branch in config.ignore_branches {
         let ignore_graphemes: Vec<&str> = UnicodeSegmentation::graphemes(ignore_branch, true).collect();
         
         if graphemes.eq(&ignore_graphemes) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
This PR adds an ignore_branches option to the git_branch module in starship.toml. The option is a toml array of git branch names that the module will not display, e.g.

```
[git_branch]
ignore_branches = ["master", "main"]
```

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #3689 

The intention here is to allow starship to hide displaying your default branch when you're on it, for cleanliness. Since the git initialization system creates `master` by default, but it's not required to be a branch, I chose to allow the user to ignore whichever names they wish.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
