### PR TITLE
fix: Do not panic in config if editor not found

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -187,11 +187,9 @@ fn main() {
                 if let Some(value) = value {
                     configure::update_configuration(&name, &value)
                 }
-            } else {
-                if let Err(reason) = configure::edit_configuration(None) {
-                    eprintln!("Could not edit configuration: {}", reason);
-                    std::process::exit(1);
-                }
+            } else if let Err(reason) = configure::edit_configuration(None) {
+                eprintln!("Could not edit configuration: {}", reason);
+                std::process::exit(1);
             }
         }
         Commands::PrintConfig { default, name } => configure::print_configuration(default, &name),

--- a/src/main.rs
+++ b/src/main.rs
@@ -188,7 +188,10 @@ fn main() {
                     configure::update_configuration(&name, &value)
                 }
             } else {
-                configure::edit_configuration()
+                if let Err(reason) = configure::edit_configuration(None) {
+                    eprintln!("Could not edit configuration: {}", reason);
+                    std::process::exit(1);
+                }
             }
         }
         Commands::PrintConfig { default, name } => configure::print_configuration(default, &name),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
Redoes error handling around `starship config` so that it will not panic if the editor cannot be found on the path.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #3758

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:

I have tested this by hand, but I'd like to insert an automated test in here (since this is not the first time we've had this issue). The problem is that get_editor_internal relies on global state (`env::var`) without an obvious way to inject artificial values, so I'm not sure what the best way is to rearchitect this.
