### PR TITLE
build: bump shadow to 0.10.0 & git2 to 0.14.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,6 +332,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_format"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22bc6cd49b0ec407b680c3e380182b6ac63b73991cb7602de350352fc309b614"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef196d5d972878a48da7decb7686eded338b4858fbabeed513d63a7c98b2b82d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -687,9 +707,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.13.25"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29229cc1b24c0e6062f6e742aa3e256492a5323365e5ed3413599f8a5eff7d6"
+checksum = "3826a6e0e2215d7a41c2bfc7c9244123969273f3476b939a226aac0ab56e9e3c"
 dependencies = [
  "bitflags",
  "libc",
@@ -827,9 +847,9 @@ checksum = "ad5c14e80759d0939d013e6ca49930e59fc53dd8e5009132f76240c179380c09"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.12.26+1.3.0"
+version = "0.13.2+1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e1c899248e606fbfe68dcb31d8b0176ebab833b103824af31bddf4b7457494"
+checksum = "3a42de9a51a5c12e00fc0e4ca6bc2ea43582fc6418488e8f615e905d886f258b"
 dependencies = [
  "cc",
  "libc",
@@ -1569,11 +1589,12 @@ checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
 
 [[package]]
 name = "shadow-rs"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38aacac9d96bfdac3f00d2149fc2235f99b839f54f0bb18bea39c7749c97f709"
+checksum = "abd299dcd639f8d2dd009ca2439c78ca008d41f1ecde26655e73d5b3a8b9be21"
 dependencies = [
  "chrono",
+ "const_format",
  "git2",
  "is_debug",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ clap_complete = "3.1.1"
 directories-next = "2.0.0"
 dunce = "1.0.2"
 gethostname = "0.2.3"
-git2 = { version = "0.13.25", default-features = false }
+git2 = { version = "0.14.2", default-features = false }
 indexmap = { version = "1.8.0", features = ["serde"] }
 local_ipaddress = "0.1.3"
 log = { version = "0.4.14", features = ["std"] }
@@ -61,7 +61,7 @@ semver = "1.0.6"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
 sha-1 = "0.10.0"
-shadow-rs = "0.9.0"
+shadow-rs = "0.10.0"
 # battery is optional (on by default) because the crate doesn't currently build for Termux
 # see: https://github.com/svartalf/rust-battery/issues/33
 starship-battery = { version = "0.7.9", optional = true }
@@ -89,7 +89,7 @@ winapi = { version = "0.3.9", features = ["winuser", "securitybaseapi", "process
 nix = "0.23.1"
 
 [build-dependencies]
-shadow-rs = "0.9.0"
+shadow-rs = "0.10.0"
 
 [target.'cfg(windows)'.build-dependencies]
 winres = "0.1.12"

--- a/src/bug_report.rs
+++ b/src/bug_report.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 pub fn create() {
-    println!("{}\n", shadow::version().trim());
+    println!("{}\n", shadow::VERSION.trim());
     let os_info = os_info::get();
 
     let environment = Environment {

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,16 +13,11 @@ use starship::context::{Properties, Target};
 use starship::module::ALL_MODULES;
 use starship::*;
 
-fn long_version() -> &'static str {
-    let ver = Box::new(crate::shadow::clap_long_version());
-    Box::leak(ver).as_str()
-}
-
 #[derive(Parser, Debug)]
 #[clap(
     author=crate_authors!(),
     version=shadow::PKG_VERSION,
-    long_version=long_version(),
+    long_version=shadow::CLAP_LONG_VERSION,
     about="The cross-shell prompt for astronauts. ☄🌌️",
     subcommand_required=true,
     arg_required_else_help=true,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
The bump to shadow v0.10.0 allow getting rid of the `Box::leak`-hack (https://github.com/baoyachi/shadow-rs/issues/86). I also needed to bump `git2` to v0.14.2 to make it build, which raises libgit2 to v1.4.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
