### PR TITLE
fix(init): Change Elvish init to `catch` for elvish 0.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ Add the following to the end of `~/.elvish/rc.elv`:
 eval (starship init elvish)
 ```
 
-Note: Only Elvish v0.17+ is supported
+Note: Only Elvish v0.18+ is supported
 
 </details>
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -111,7 +111,7 @@ description: Starship is the minimal, blazing fast, and extremely customizable p
    #### Elvish
 
    ::: warning
-   Only elvish v0.17 or higher is supported.
+   Only elvish v0.18 or higher is supported.
    :::
 
    Add the following to the end of `~/.elvish/rc.elv`:

--- a/src/init/starship.elv
+++ b/src/init/starship.elv
@@ -11,7 +11,7 @@ fn starship-after-command-hook {|m|
     } else {
         try {
             set cmd-status-code = $error[reason][exit-status]
-        } except {
+        } catch {
             # The error is from the built-in commands and they have no status code.
             set cmd-status-code = 1
         }


### PR DESCRIPTION
#### Description
Change `except` to `catch` in the elvish init script and updates the appropriate documentation, in anticipation of the upcoming [elvish v0.18 release](https://github.com/elves/elvish/blob/master/website/blog/0.18.0-release-notes.md)

#### Motivation and Context
Elvish v0.18 (which is now in rc2) has deprecated the use of `except` in favor of `catch`. Anyone using the current init system with v0.18 will see the following message when using the current init script:

```
deprecation: "except" is deprecated; use "catch" instead
[eval 13], line 14:         } except {
```

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
