### PR TITLE
refactor: Replace ansi_term with owo-colors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,15 +23,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -513,6 +504,15 @@ name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
+name = "enable-ansi-support"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d29d3ca9ba14c336417f8d7bc7f373e8c16d10c30cc0794b09d3cecab631ab"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "enumflags2"
@@ -1125,6 +1125,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "owo-colors"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e72e30578e0d0993c8ae20823dd9cff2bc5517d2f586a8aef462a581e8a03eb"
+
+[[package]]
 name = "parking"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1604,13 +1610,13 @@ dependencies = [
 name = "starship"
 version = "1.4.2"
 dependencies = [
- "ansi_term",
  "byte-unit",
  "chrono",
  "clap",
  "clap_complete",
  "directories-next",
  "dunce",
+ "enable-ansi-support",
  "gethostname",
  "git2",
  "indexmap",
@@ -1622,6 +1628,7 @@ dependencies = [
  "once_cell",
  "open",
  "os_info",
+ "owo-colors",
  "path-slash",
  "pest",
  "pest_derive",
@@ -1639,6 +1646,7 @@ dependencies = [
  "shell-words",
  "starship-battery",
  "starship_module_config_derive",
+ "strip-ansi-escapes",
  "strsim",
  "sys-info",
  "tempfile",
@@ -1686,6 +1694,15 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strip-ansi-escapes"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "011cbb39cf7c1f62871aea3cc46e5817b0937b49e9447370c93cacbe93a766d8"
+dependencies = [
+ "vte",
+]
 
 [[package]]
 name = "strsim"
@@ -1940,6 +1957,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cf7d77f457ef8dfa11e4cd5933c5ddb5dc52a94664071951219a97710f0a32b"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1959,6 +1982,27 @@ checksum = "d5276c151793dde1cc57e08123f36f96e662a9f2532060c677612bf0e2c604d4"
 dependencies = [
  "itertools",
  "nom",
+]
+
+[[package]]
+name = "vte"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cbce692ab4ca2f1f3047fcf732430249c0e971bfdd2b234cf2c47ad93af5983"
+dependencies = [
+ "arrayvec",
+ "utf8parse",
+ "vte_generate_state_changes",
+]
+
+[[package]]
+name = "vte_generate_state_changes"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d257817081c7dffcdbab24b9e62d2def62e2ff7d00b1c20062551e6cccc145ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,13 +33,13 @@ default = ["battery"]
 battery = ["starship-battery"]
 
 [dependencies]
-ansi_term = "0.12.1"
 byte-unit = "4.0.14"
 chrono = "0.4.19"
 clap = { version = "3.1.6", features = ["derive", "cargo", "unicode"] }
 clap_complete = "3.1.1"
 directories-next = "2.0.0"
 dunce = "1.0.2"
+enable-ansi-support = "0.1.2"
 gethostname = "0.2.3"
 git2 = { version = "0.13.25", default-features = false }
 indexmap = { version = "1.8.0", features = ["serde"] }
@@ -49,6 +49,7 @@ notify-rust = "4.5.6"
 once_cell = "1.10.0"
 open = "2.1.1"
 os_info = "3.2.0"
+owo-colors = "3.3.0"
 path-slash = "0.1.4"
 pest = "2.1.3"
 pest_derive = "2.1.0"
@@ -66,6 +67,7 @@ shadow-rs = "0.9.0"
 # see: https://github.com/svartalf/rust-battery/issues/33
 starship-battery = { version = "0.7.9", optional = true }
 starship_module_config_derive = { version = "0.2.1", path = "starship_module_config_derive" }
+strip-ansi-escapes = "0.1.1"
 strsim = "0.10.0"
 sys-info = "0.9.1"
 terminal_size = "0.1.17"

--- a/src/config.rs
+++ b/src/config.rs
@@ -691,7 +691,7 @@ mod tests {
         let config = Value::from("#a12BcD");
         assert_eq!(
             <Style>::from_config(&config).unwrap(),
-            Style::new().bg_rgb::<0xA1, 0x2B, 0xCD>()
+            Style::new().fg_rgb::<0xA1, 0x2B, 0xCD>()
         );
     }
 

--- a/src/formatter/string_formatter.rs
+++ b/src/formatter/string_formatter.rs
@@ -1,4 +1,4 @@
-use ansi_term::Style;
+use owo_colors::Style;
 use pest::error::Error as PestError;
 use rayon::prelude::*;
 use std::borrow::Cow;
@@ -456,7 +456,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ansi_term::Color;
+    use owo_colors::Style;
 
     // match_next(result: IterMut<Segment>, value, style)
     macro_rules! match_next {
@@ -474,7 +474,7 @@ mod tests {
     #[test]
     fn test_default_style() {
         const FORMAT_STR: &str = "text";
-        let style = Some(Color::Red.bold());
+        let style = Some(Style::new().red().bold());
 
         let formatter = StringFormatter::new(FORMAT_STR).unwrap().map(empty_mapper);
         let result = formatter.parse(style, None).unwrap();
@@ -488,7 +488,7 @@ mod tests {
         let formatter = StringFormatter::new(FORMAT_STR).unwrap().map(empty_mapper);
         let result = formatter.parse(None, None).unwrap();
         let mut result_iter = result.iter();
-        match_next!(result_iter, "text", Some(Color::Red.bold()));
+        match_next!(result_iter, "text", Some(Style::new().red().bold()));
     }
 
     #[test]
@@ -509,7 +509,7 @@ mod tests {
     #[test]
     fn test_variable_in_style() {
         const FORMAT_STR: &str = "[root]($style)";
-        let root_style = Some(Color::Red.bold());
+        let root_style = Some(Style::new().red().bold());
 
         let formatter = StringFormatter::new(FORMAT_STR)
             .unwrap()
@@ -547,9 +547,9 @@ mod tests {
     #[test]
     fn test_nested_textgroup() {
         const FORMAT_STR: &str = "outer [middle [inner](blue)](red bold)";
-        let outer_style = Some(Color::Green.normal());
-        let middle_style = Some(Color::Red.bold());
-        let inner_style = Some(Color::Blue.normal());
+        let outer_style = Some(Style::new().green());
+        let middle_style = Some(Style::new().red().bold());
+        let inner_style = Some(Style::new().blue());
 
         let formatter = StringFormatter::new(FORMAT_STR).unwrap().map(empty_mapper);
         let result = formatter.parse(outer_style, None).unwrap();
@@ -562,7 +562,7 @@ mod tests {
     #[test]
     fn test_styled_variable_as_text() {
         const FORMAT_STR: &str = "[$var](red bold)";
-        let var_style = Some(Color::Red.bold());
+        let var_style = Some(Style::new().red().bold());
 
         let formatter = StringFormatter::new(FORMAT_STR)
             .unwrap()
@@ -578,9 +578,9 @@ mod tests {
     #[test]
     fn test_styled_variable_as_segments() {
         const FORMAT_STR: &str = "[$var](red bold)";
-        let var_style = Some(Color::Red.bold());
-        let styled_style = Some(Color::Green.italic());
-        let styled_no_modifier_style = Some(Color::Green.normal());
+        let var_style = Some(Style::new().red().bold());
+        let styled_style = Some(Style::new().green().italic());
+        let styled_no_modifier_style = Some(Style::new().green());
 
         let mut segments: Vec<Segment> = Vec::new();
         segments.extend(Segment::from_text(None, "styless"));

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,5 +1,4 @@
 use crate::utils;
-use ansi_term::Color;
 use log::{Level, LevelFilter, Metadata, Record};
 use once_cell::sync::OnceCell;
 use std::{
@@ -107,15 +106,20 @@ impl log::Log for StarshipLogger {
         }
 
         if self.enabled(record.metadata()) && !self.log_file_content.contains(to_print.as_str()) {
+            let style = owo_colors::Style::new();
+            let level = record.level();
+
+            let level_style = match level {
+                Level::Trace => style.blue().dimmed(),
+                Level::Debug => style.cyan(),
+                Level::Info => style.white(),
+                Level::Warn => style.yellow(),
+                Level::Error => style.red(),
+            };
+
             eprintln!(
                 "[{}] - ({}): {}",
-                match record.level() {
-                    Level::Trace => Color::Blue.dimmed().paint(format!("{}", record.level())),
-                    Level::Debug => Color::Cyan.paint(format!("{}", record.level())),
-                    Level::Info => Color::White.paint(format!("{}", record.level())),
-                    Level::Warn => Color::Yellow.paint(format!("{}", record.level())),
-                    Level::Error => Color::Red.paint(format!("{}", record.level())),
-                },
+                level_style.style(&level),
                 record.module_path().unwrap_or_default(),
                 record.args()
             );

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,7 +107,7 @@ enum Commands {
 fn main() {
     // Configure the current terminal on windows to support ANSI escape sequences.
     #[cfg(windows)]
-    let _ = ansi_term::enable_ansi_support();
+    let _ = enable_ansi_support::enable_ansi_support();
     logger::init();
     init_global_threadpool();
 

--- a/src/module.rs
+++ b/src/module.rs
@@ -126,7 +126,9 @@ impl<'a> Module<'a> {
     /// Set segments in module
     pub fn set_segments(&mut self, segments: Vec<Segment>) {
         let mut segments_new = Vec::new();
-        let mut segments = segments.into_iter();
+        let mut segments = segments
+            .into_iter()
+            .filter(|segment| !segment.value().is_empty());
 
         if let Some(mut current_segment) = segments.next() {
             for segment in segments {

--- a/src/module.rs
+++ b/src/module.rs
@@ -209,7 +209,7 @@ impl<'a> fmt::Display for Module<'a> {
 fn ansi_strings_modified(ansi_strings: Vec<String>, shell: Shell) -> Vec<String> {
     ansi_strings
         .into_iter()
-        .map(|ansi| wrap_colorseq_for_shell(ansi.to_string(), shell))
+        .map(|ansi| wrap_colorseq_for_shell(ansi, shell))
         .collect::<Vec<String>>()
 }
 

--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -239,7 +239,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 #[cfg(test)]
 mod tests {
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use owo_colors::Style;
     use std::fs::{create_dir, File};
     use std::io::{self, Write};
 
@@ -260,7 +260,7 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "on {}",
-            Color::Yellow.bold().paint("☁️  (ap-northeast-2) ")
+            Style::new().yellow().bold().style("☁️  (ap-northeast-2) ")
         ));
 
         assert_eq!(expected, actual);
@@ -276,7 +276,10 @@ mod tests {
                 ap-southeast-2 = "au"
             })
             .collect();
-        let expected = Some(format!("on {}", Color::Yellow.bold().paint("☁️  (au) ")));
+        let expected = Some(format!(
+            "on {}",
+            Style::new().yellow().bold().style("☁️  (au) ")
+        ));
 
         assert_eq!(expected, actual);
     }
@@ -290,7 +293,7 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "on {}",
-            Color::Yellow.bold().paint("☁️  (ap-northeast-2) ")
+            Style::new().yellow().bold().style("☁️  (ap-northeast-2) ")
         ));
 
         assert_eq!(expected, actual);
@@ -304,7 +307,7 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "on {}",
-            Color::Yellow.bold().paint("☁️  astronauts ")
+            Style::new().yellow().bold().style("☁️  astronauts ")
         ));
 
         assert_eq!(expected, actual);
@@ -319,7 +322,7 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "on {}",
-            Color::Yellow.bold().paint("☁️  astronauts-vault ")
+            Style::new().yellow().bold().style("☁️  astronauts-vault ")
         ));
 
         assert_eq!(expected, actual);
@@ -334,7 +337,7 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "on {}",
-            Color::Yellow.bold().paint("☁️  astronauts-awsu ")
+            Style::new().yellow().bold().style("☁️  astronauts-awsu ")
         ));
 
         assert_eq!(expected, actual);
@@ -349,7 +352,7 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "on {}",
-            Color::Yellow.bold().paint("☁️  astronauts-awsume ")
+            Style::new().yellow().bold().style("☁️  astronauts-awsume ")
         ));
 
         assert_eq!(expected, actual);
@@ -364,9 +367,10 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "on {}",
-            Color::Yellow
+            Style::new()
+                .yellow()
                 .bold()
-                .paint("☁️  astronauts (ap-northeast-2) ")
+                .style("☁️  astronauts (ap-northeast-2) ")
         ));
 
         assert_eq!(expected, actual);
@@ -385,7 +389,10 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "on {}",
-            Color::Yellow.bold().paint("☁️  astro (ap-northeast-2) ")
+            Style::new()
+                .yellow()
+                .bold()
+                .style("☁️  astro (ap-northeast-2) ")
         ));
 
         assert_eq!(expected, actual);
@@ -406,7 +413,7 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "on {}",
-            Color::Yellow.bold().paint("☁️  astro (au) ")
+            Style::new().yellow().bold().style("☁️  astro (au) ")
         ));
 
         assert_eq!(expected, actual);
@@ -465,7 +472,7 @@ region = us-east-2
             .collect();
         let expected = Some(format!(
             "on {}",
-            Color::Yellow.bold().paint("☁️  (us-east-1) ")
+            Style::new().yellow().bold().style("☁️  (us-east-1) ")
         ));
 
         assert_eq!(expected, actual);
@@ -498,7 +505,10 @@ credential_process = /opt/bin/awscreds-retriever
             .collect();
         let expected = Some(format!(
             "on {}",
-            Color::Yellow.bold().paint("☁️  astronauts (us-east-2) ")
+            Style::new()
+                .yellow()
+                .bold()
+                .style("☁️  astronauts (us-east-2) ")
         ));
 
         assert_eq!(expected, actual);
@@ -514,9 +524,10 @@ credential_process = /opt/bin/awscreds-retriever
             .collect();
         let expected = Some(format!(
             "on {}",
-            Color::Yellow
+            Style::new()
+                .yellow()
                 .bold()
-                .paint("☁️  astronauts (ap-northeast-1) ")
+                .style("☁️  astronauts (ap-northeast-1) ")
         ));
 
         assert_eq!(expected, actual);
@@ -530,7 +541,7 @@ credential_process = /opt/bin/awscreds-retriever
             .collect();
         let expected = Some(format!(
             "on {}",
-            Color::Yellow.bold().paint("☁️  astronauts ")
+            Style::new().yellow().bold().style("☁️  astronauts ")
         ));
 
         assert_eq!(expected, actual);
@@ -544,7 +555,7 @@ credential_process = /opt/bin/awscreds-retriever
             .collect();
         let expected = Some(format!(
             "on {}",
-            Color::Yellow.bold().paint("☁️  (ap-northeast-1) ")
+            Style::new().yellow().bold().style("☁️  (ap-northeast-1) ")
         ));
 
         assert_eq!(expected, actual);
@@ -563,7 +574,7 @@ credential_process = /opt/bin/awscreds-retriever
             .collect();
         let expected = Some(format!(
             "on {} ",
-            Color::Yellow.bold().paint("☁️  ap-northeast-1")
+            Style::new().yellow().bold().style("☁️  ap-northeast-1")
         ));
 
         assert_eq!(expected, actual);
@@ -582,7 +593,7 @@ credential_process = /opt/bin/awscreds-retriever
             .collect();
         let expected = Some(format!(
             "on {} ",
-            Color::Yellow.bold().paint("☁️  astronauts")
+            Style::new().yellow().bold().style("☁️  astronauts")
         ));
 
         assert_eq!(expected, actual);
@@ -598,7 +609,7 @@ credential_process = /opt/bin/awscreds-retriever
                 format = "on [$symbol$profile]($style) "
             })
             .collect();
-        let expected = Some(format!("on {} ", Color::Yellow.bold().paint("☁️  ")));
+        let expected = Some(format!("on {} ", Style::new().yellow().bold().style("☁️  ")));
 
         assert_eq!(expected, actual);
     }
@@ -627,9 +638,10 @@ credential_process = /opt/bin/awscreds-retriever
             .collect();
         let expected = Some(format!(
             "on {}",
-            Color::Yellow
+            Style::new()
+                .yellow()
                 .bold()
-                .paint("☁️  astronauts (ap-northeast-2) [30m]")
+                .style("☁️  astronauts (ap-northeast-2) [30m]")
         ));
 
         assert_eq!(expected, actual);
@@ -682,7 +694,7 @@ expiration={}
             let segment_colored = format!("☁️  astronauts (ap-northeast-2) [{}]", duration);
             Some(format!(
                 "on {}",
-                Color::Yellow.bold().paint(segment_colored)
+                Style::new().yellow().bold().style(segment_colored)
             ))
         });
 
@@ -704,9 +716,10 @@ expiration={}
             .collect();
         let expected = Some(format!(
             "on {}",
-            Color::Yellow
+            Style::new()
+                .yellow()
                 .bold()
-                .paint("☁️  astronauts (ap-northeast-2) ")
+                .style("☁️  astronauts (ap-northeast-2) ")
         ));
 
         assert_eq!(expected, actual);
@@ -739,9 +752,10 @@ expiration={}
             .collect();
         let expected = Some(format!(
             "on {}",
-            Color::Yellow
+            Style::new()
+                .yellow()
                 .bold()
-                .paint(format!("☁️  astronauts (ap-northeast-2) [{}]", symbol))
+                .style(format!("☁️  astronauts (ap-northeast-2) [{}]", symbol))
         ));
 
         assert_eq!(expected, actual);
@@ -812,9 +826,10 @@ aws_secret_access_key=dummy
 
         let expected = Some(format!(
             "on {}",
-            Color::Yellow
+            Style::new()
+                .yellow()
                 .bold()
-                .paint("☁️  astronauts (ap-northeast-2) ")
+                .style("☁️  astronauts (ap-northeast-2) ")
         ));
 
         assert_eq!(expected, actual);
@@ -841,7 +856,7 @@ credential_process = /opt/bin/awscreds-retriever
             .collect();
         let expected = Some(format!(
             "on {}",
-            Color::Yellow.bold().paint("☁️  (ap-northeast-2) ")
+            Style::new().yellow().bold().style("☁️  (ap-northeast-2) ")
         ));
 
         assert_eq!(expected, actual);
@@ -887,7 +902,7 @@ sso_role_name = <AWS-ROLE-NAME>
             .collect();
         let expected = Some(format!(
             "on {}",
-            Color::Yellow.bold().paint("☁️  astronauts ")
+            Style::new().yellow().bold().style("☁️  astronauts ")
         ));
 
         assert_eq!(expected, actual);
@@ -901,7 +916,7 @@ sso_role_name = <AWS-ROLE-NAME>
             .collect();
         let expected = Some(format!(
             "on {}",
-            Color::Yellow.bold().paint("☁️  astronauts ")
+            Style::new().yellow().bold().style("☁️  astronauts ")
         ));
 
         assert_eq!(expected, actual);
@@ -915,7 +930,7 @@ sso_role_name = <AWS-ROLE-NAME>
             .collect();
         let expected = Some(format!(
             "on {}",
-            Color::Yellow.bold().paint("☁️  astronauts ")
+            Style::new().yellow().bold().style("☁️  astronauts ")
         ));
 
         assert_eq!(expected, actual);

--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -887,7 +887,7 @@ sso_role_name = <AWS-ROLE-NAME>
             .collect();
         let expected = Some(format!(
             "on {}",
-            Color::Yellow.bold().paint("☁️  (ap-northeast-2) ")
+            Style::new().yellow().bold().style("☁️  (ap-northeast-2) ")
         ));
 
         assert_eq!(expected, actual);

--- a/src/modules/azure.rs
+++ b/src/modules/azure.rs
@@ -108,8 +108,8 @@ fn parse_json(json_file_path: &Path) -> Option<JValue> {
 mod tests {
     use crate::modules::azure::parse_json;
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
     use ini::Ini;
+    use owo_colors::Style;
     use std::fs::File;
     use std::io::{self, Write};
     use std::path::PathBuf;
@@ -188,7 +188,7 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "on {} ",
-            Color::Blue.bold().paint("ﴃ Subscription 1")
+            Style::new().blue().bold().style("ﴃ Subscription 1")
         ));
         assert_eq!(actual, expected);
         dir.close()

--- a/src/modules/battery.rs
+++ b/src/modules/battery.rs
@@ -172,7 +172,7 @@ impl BatteryInfoProvider for BatteryInfoProviderImpl {
 mod tests {
     use super::*;
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use owo_colors::Style;
 
     #[test]
     fn no_battery_status() {
@@ -388,7 +388,7 @@ mod tests {
             })
             .battery_info_provider(&mock)
             .collect();
-        let expected = Some(format!("{} ", Color::Red.bold().paint(" 40%")));
+        let expected = Some(format!("{} ", Style::new().red().bold().style(" 40%")));
 
         assert_eq!(expected, actual);
     }

--- a/src/modules/buf.rs
+++ b/src/modules/buf.rs
@@ -64,7 +64,7 @@ fn parse_buf_version(buf_version: &str) -> Option<String> {
 mod tests {
     use super::parse_buf_version;
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use owo_colors::Style;
     use std::fs::File;
     use std::io;
 
@@ -103,7 +103,10 @@ mod tests {
                 .sync_all()
                 .unwrap();
             let actual = ModuleRenderer::new("buf").path(dir.path()).collect();
-            let expected = Some(format!("with {}", Color::Blue.bold().paint(" v1.0.0")));
+            let expected = Some(format!(
+                "with {}",
+                Style::new().blue().bold().style(" v1.0.0")
+            ));
             assert_eq!(expected, actual);
             dir.close().unwrap();
         }

--- a/src/modules/character.rs
+++ b/src/modules/character.rs
@@ -73,11 +73,11 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 mod test {
     use crate::context::Shell;
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use owo_colors::Style;
 
     #[test]
     fn success_status() {
-        let expected = Some(format!("{} ", Color::Green.bold().paint("❯")));
+        let expected = Some(format!("{} ", Style::new().green().bold().style("❯")));
 
         // Status code 0
         let actual = ModuleRenderer::new("character").status(0).collect();
@@ -90,7 +90,7 @@ mod test {
 
     #[test]
     fn failure_status() {
-        let expected = Some(format!("{} ", Color::Red.bold().paint("❯")));
+        let expected = Some(format!("{} ", Style::new().red().bold().style("❯")));
 
         let exit_values = [1, 54321, -5000];
 
@@ -102,8 +102,8 @@ mod test {
 
     #[test]
     fn custom_symbol() {
-        let expected_fail = Some(format!("{} ", Color::Red.bold().paint("✖")));
-        let expected_success = Some(format!("{} ", Color::Green.bold().paint("➜")));
+        let expected_fail = Some(format!("{} ", Style::new().red().bold().style("✖")));
+        let expected_success = Some(format!("{} ", Style::new().green().bold().style("➜")));
 
         let exit_values = [1, 54321, -5000];
 
@@ -134,9 +134,9 @@ mod test {
 
     #[test]
     fn zsh_keymap() {
-        let expected_vicmd = Some(format!("{} ", Color::Green.bold().paint("❮")));
-        let expected_specified = Some(format!("{} ", Color::Green.bold().paint("V")));
-        let expected_other = Some(format!("{} ", Color::Green.bold().paint("❯")));
+        let expected_vicmd = Some(format!("{} ", Style::new().green().bold().style("❮")));
+        let expected_specified = Some(format!("{} ", Style::new().green().bold().style("V")));
+        let expected_other = Some(format!("{} ", Style::new().green().bold().style("❯")));
 
         // zle keymap is vicmd
         let actual = ModuleRenderer::new("character")
@@ -166,9 +166,9 @@ mod test {
 
     #[test]
     fn fish_keymap() {
-        let expected_vicmd = Some(format!("{} ", Color::Green.bold().paint("❮")));
-        let expected_specified = Some(format!("{} ", Color::Green.bold().paint("V")));
-        let expected_other = Some(format!("{} ", Color::Green.bold().paint("❯")));
+        let expected_vicmd = Some(format!("{} ", Style::new().green().bold().style("❮")));
+        let expected_specified = Some(format!("{} ", Style::new().green().bold().style("V")));
+        let expected_other = Some(format!("{} ", Style::new().green().bold().style("❯")));
 
         // fish keymap is default
         let actual = ModuleRenderer::new("character")
@@ -198,9 +198,9 @@ mod test {
 
     #[test]
     fn cmd_keymap() {
-        let expected_vicmd = Some(format!("{} ", Color::Green.bold().paint("❮")));
-        let expected_specified = Some(format!("{} ", Color::Green.bold().paint("V")));
-        let expected_other = Some(format!("{} ", Color::Green.bold().paint("❯")));
+        let expected_vicmd = Some(format!("{} ", Style::new().green().bold().style("❮")));
+        let expected_specified = Some(format!("{} ", Style::new().green().bold().style("V")));
+        let expected_other = Some(format!("{} ", Style::new().green().bold().style("❯")));
 
         // cmd keymap is vi
         let actual = ModuleRenderer::new("character")

--- a/src/modules/cmake.rs
+++ b/src/modules/cmake.rs
@@ -71,7 +71,7 @@ fn parse_cmake_version(cmake_version: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use owo_colors::Style;
     use std::fs::File;
     use std::io;
 
@@ -89,7 +89,10 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("CMakeLists.txt"))?.sync_all()?;
         let actual = ModuleRenderer::new("cmake").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Blue.bold().paint("△ v3.17.3 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().blue().bold().style("△ v3.17.3 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -99,7 +102,10 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("CMakeCache.txt"))?.sync_all()?;
         let actual = ModuleRenderer::new("cmake").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Blue.bold().paint("△ v3.17.3 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().blue().bold().style("△ v3.17.3 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }

--- a/src/modules/cobol.rs
+++ b/src/modules/cobol.rs
@@ -75,7 +75,7 @@ fn get_cobol_version(cobol_stdout: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use owo_colors::Style;
     use std::fs::File;
     use std::io;
 
@@ -98,7 +98,10 @@ mod tests {
 
         let actual = ModuleRenderer::new("cobol").path(dir.path()).collect();
 
-        let expected = Some(format!("via {}", Color::Blue.bold().paint("⚙️ v3.1.2.0 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().blue().bold().style("⚙️ v3.1.2.0 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -110,7 +113,10 @@ mod tests {
 
         let actual = ModuleRenderer::new("cobol").path(dir.path()).collect();
 
-        let expected = Some(format!("via {}", Color::Blue.bold().paint("⚙️ v3.1.2.0 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().blue().bold().style("⚙️ v3.1.2.0 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -122,7 +128,10 @@ mod tests {
 
         let actual = ModuleRenderer::new("cobol").path(dir.path()).collect();
 
-        let expected = Some(format!("via {}", Color::Blue.bold().paint("⚙️ v3.1.2.0 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().blue().bold().style("⚙️ v3.1.2.0 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -134,7 +143,10 @@ mod tests {
 
         let actual = ModuleRenderer::new("cobol").path(dir.path()).collect();
 
-        let expected = Some(format!("via {}", Color::Blue.bold().paint("⚙️ v3.1.2.0 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().blue().bold().style("⚙️ v3.1.2.0 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }

--- a/src/modules/conda.rs
+++ b/src/modules/conda.rs
@@ -54,7 +54,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 #[cfg(test)]
 mod tests {
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use owo_colors::Style;
 
     #[test]
     fn not_in_env() {
@@ -88,7 +88,7 @@ mod tests {
 
         let expected = Some(format!(
             "via {} ",
-            Color::Green.bold().paint("🅒 astronauts")
+            Style::new().green().bold().style("🅒 astronauts")
         ));
 
         assert_eq!(expected, actual);
@@ -100,7 +100,10 @@ mod tests {
             .env("CONDA_DEFAULT_ENV", "/some/really/long/and/really/annoying/path/that/shouldnt/be/displayed/fully/conda/my_env")
             .collect();
 
-        let expected = Some(format!("via {} ", Color::Green.bold().paint("🅒 my_env")));
+        let expected = Some(format!(
+            "via {} ",
+            Style::new().green().bold().style("🅒 my_env")
+        ));
 
         assert_eq!(expected, actual);
     }

--- a/src/modules/container.rs
+++ b/src/modules/container.rs
@@ -101,7 +101,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 #[cfg(test)]
 mod tests {
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use owo_colors::Style;
     use std::path::PathBuf;
 
     #[test]
@@ -152,10 +152,11 @@ mod tests {
         // The value that should be rendered by the module.
         let expected = Some(format!(
             "{} ",
-            Color::Red
+            Style::new()
+                .red()
                 .bold()
                 .dimmed()
-                .paint(format!("⬢ [{}]", name.unwrap_or("podman")))
+                .style(format!("⬢ [{}]", name.unwrap_or("podman")))
         ));
 
         Ok((actual, expected))

--- a/src/modules/crystal.rs
+++ b/src/modules/crystal.rs
@@ -72,7 +72,7 @@ fn parse_crystal_version(crystal_version: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use owo_colors::Style;
     use std::fs::File;
     use std::io;
 
@@ -92,7 +92,10 @@ mod tests {
         File::create(dir.path().join("shard.yml"))?.sync_all()?;
 
         let actual = ModuleRenderer::new("crystal").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Red.bold().paint("🔮 v0.35.1 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().red().bold().style("🔮 v0.35.1 ")
+        ));
         assert_eq!(expected, actual);
 
         dir.close()
@@ -104,7 +107,10 @@ mod tests {
         File::create(dir.path().join("main.cr"))?.sync_all()?;
 
         let actual = ModuleRenderer::new("crystal").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Red.bold().paint("🔮 v0.35.1 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().red().bold().style("🔮 v0.35.1 ")
+        ));
         assert_eq!(expected, actual);
 
         dir.close()

--- a/src/modules/dart.rs
+++ b/src/modules/dart.rs
@@ -73,7 +73,7 @@ fn parse_dart_version(dart_version: &str) -> Option<String> {
 mod tests {
     use crate::test::ModuleRenderer;
     use crate::utils::CommandOutput;
-    use ansi_term::Color;
+    use owo_colors::Style;
     use std::fs::{self, File};
     use std::io;
 
@@ -92,7 +92,10 @@ mod tests {
         File::create(dir.path().join("any.dart"))?.sync_all()?;
 
         let actual = ModuleRenderer::new("dart").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Blue.bold().paint("🎯 v2.8.4 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().blue().bold().style("🎯 v2.8.4 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -103,7 +106,10 @@ mod tests {
         fs::create_dir_all(dir.path().join(".dart_tool"))?;
 
         let actual = ModuleRenderer::new("dart").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Blue.bold().paint("🎯 v2.8.4 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().blue().bold().style("🎯 v2.8.4 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -114,7 +120,10 @@ mod tests {
         File::create(dir.path().join("pubspec.yaml"))?.sync_all()?;
 
         let actual = ModuleRenderer::new("dart").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Blue.bold().paint("🎯 v2.8.4 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().blue().bold().style("🎯 v2.8.4 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -125,7 +134,10 @@ mod tests {
         File::create(dir.path().join("pubspec.yml"))?.sync_all()?;
 
         let actual = ModuleRenderer::new("dart").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Blue.bold().paint("🎯 v2.8.4 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().blue().bold().style("🎯 v2.8.4 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -136,7 +148,10 @@ mod tests {
         File::create(dir.path().join("pubspec.lock"))?.sync_all()?;
 
         let actual = ModuleRenderer::new("dart").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Blue.bold().paint("🎯 v2.8.4 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().blue().bold().style("🎯 v2.8.4 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -157,7 +172,10 @@ mod tests {
             )
             .path(dir.path())
             .collect();
-        let expected = Some(format!("via {}", Color::Blue.bold().paint("🎯 v2.15.1 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().blue().bold().style("🎯 v2.15.1 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }

--- a/src/modules/deno.rs
+++ b/src/modules/deno.rs
@@ -70,7 +70,7 @@ fn parse_deno_version(deno_version: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use owo_colors::Style;
     use std::fs::File;
     use std::io;
 
@@ -88,7 +88,10 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("deno.json"))?.sync_all()?;
         let actual = ModuleRenderer::new("deno").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Green.bold().paint("🦕 v1.8.3 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().green().bold().style("🦕 v1.8.3 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -98,7 +101,10 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("deno.jsonc"))?.sync_all()?;
         let actual = ModuleRenderer::new("deno").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Green.bold().paint("🦕 v1.8.3 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().green().bold().style("🦕 v1.8.3 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -108,7 +114,10 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("mod.ts"))?.sync_all()?;
         let actual = ModuleRenderer::new("deno").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Green.bold().paint("🦕 v1.8.3 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().green().bold().style("🦕 v1.8.3 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -118,7 +127,10 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("mod.js"))?.sync_all()?;
         let actual = ModuleRenderer::new("deno").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Green.bold().paint("🦕 v1.8.3 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().green().bold().style("🦕 v1.8.3 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -128,7 +140,10 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("deps.ts"))?.sync_all()?;
         let actual = ModuleRenderer::new("deno").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Green.bold().paint("🦕 v1.8.3 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().green().bold().style("🦕 v1.8.3 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -138,7 +153,10 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("deps.js"))?.sync_all()?;
         let actual = ModuleRenderer::new("deno").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Green.bold().paint("🦕 v1.8.3 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().green().bold().style("🦕 v1.8.3 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }

--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -1680,7 +1680,10 @@ mod tests {
         let expected = Some(format!(
             "{}{} ",
             Style::new().red().bold().style("repo"),
-            Style::new().cyan().bold().style(convert_path_sep("/src/sub/path"))
+            Style::new()
+                .cyan()
+                .bold()
+                .style(convert_path_sep("/src/sub/path"))
         ));
         assert_eq!(expected, actual);
         tmp_dir.close()

--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -338,7 +338,7 @@ mod tests {
     use crate::test::ModuleRenderer;
     use crate::utils::create_command;
     use crate::utils::home_dir;
-    use ansi_term::Color;
+    use owo_colors::Style;
     #[cfg(not(target_os = "windows"))]
     use std::os::unix::fs::symlink;
     #[cfg(target_os = "windows")]
@@ -519,7 +519,10 @@ mod tests {
                 .env("HOME", tmp_dir.path().to_str().unwrap())
                 .path(symlink_dir)
                 .collect();
-            let expected = Some(format!("{} ", Color::Cyan.bold().paint("~/fuel-gauge")));
+            let expected = Some(format!(
+                "{} ",
+                Style::new().cyan().bold().style("~/fuel-gauge")
+            ));
 
             assert_eq!(expected, actual);
 
@@ -544,7 +547,10 @@ mod tests {
                 .path(dir)
                 .env("HOME", tmp_dir.path().to_str().unwrap())
                 .collect();
-            let expected = Some(format!("{} ", Color::Cyan.bold().paint("~/src/fuel-gauge")));
+            let expected = Some(format!(
+                "{} ",
+                Style::new().cyan().bold().style("~/src/fuel-gauge")
+            ));
 
             assert_eq!(expected, actual);
 
@@ -557,8 +563,8 @@ mod tests {
             let actual = ModuleRenderer::new("directory").path("/etc").collect();
             let expected = Some(format!(
                 "{}{} ",
-                Color::Cyan.bold().paint("/etc"),
-                Color::Red.normal().paint("🔒")
+                Style::new().cyan().bold().style("/etc"),
+                Style::new().red().style("🔒")
             ));
 
             assert_eq!(expected, actual);
@@ -570,7 +576,7 @@ mod tests {
         let actual = ModuleRenderer::new("directory")
             .path(home_dir().unwrap())
             .collect();
-        let expected = Some(format!("{} ", Color::Cyan.bold().paint("~")));
+        let expected = Some(format!("{} ", Style::new().cyan().bold().style("~")));
 
         assert_eq!(expected, actual);
     }
@@ -586,7 +592,7 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "{} ",
-            Color::Cyan.bold().paint(convert_path_sep("🚀"))
+            Style::new().cyan().bold().style(convert_path_sep("🚀"))
         ));
 
         assert_eq!(expected, actual);
@@ -603,9 +609,10 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "{} ",
-            Color::Cyan
+            Style::new()
+                .cyan()
                 .bold()
-                .paint(convert_path_sep("🚀/path/subpath"))
+                .style(convert_path_sep("🚀/path/subpath"))
         ));
 
         assert_eq!(expected, actual);
@@ -625,9 +632,10 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "{} ",
-            Color::Cyan
+            Style::new()
+                .cyan()
                 .bold()
-                .paint(convert_path_sep("net/workspace/d/dev"))
+                .style(convert_path_sep("net/workspace/d/dev"))
         ));
 
         assert_eq!(expected, actual);
@@ -645,7 +653,10 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "{} ",
-            Color::Cyan.bold().paint(convert_path_sep("/correct/order"))
+            Style::new()
+                .cyan()
+                .bold()
+                .style(convert_path_sep("/correct/order"))
         ));
 
         assert_eq!(expected, actual);
@@ -666,9 +677,10 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "{} ",
-            Color::Cyan
+            Style::new()
+                .cyan()
                 .bold()
-                .paint(convert_path_sep(&format!("/foo/bar/{}/path", strange_sub)))
+                .style(convert_path_sep(&format!("/foo/bar/{}/path", strange_sub)))
         ));
 
         assert_eq!(expected, actual);
@@ -683,9 +695,10 @@ mod tests {
         let actual = ModuleRenderer::new("directory").path(dir).collect();
         let expected = Some(format!(
             "{} ",
-            Color::Cyan
+            Style::new()
+                .cyan()
                 .bold()
-                .paint(convert_path_sep(&format!("~/{}/starship", name)))
+                .style(convert_path_sep(&format!("~/{}/starship", name)))
         ));
 
         assert_eq!(expected, actual);
@@ -701,9 +714,10 @@ mod tests {
         let actual = ModuleRenderer::new("directory").path(dir).collect();
         let expected = Some(format!(
             "{} ",
-            Color::Cyan
+            Style::new()
+                .cyan()
                 .bold()
-                .paint(convert_path_sep(&format!("{}/engine/schematics", name)))
+                .style(convert_path_sep(&format!("{}/engine/schematics", name)))
         ));
 
         assert_eq!(expected, actual);
@@ -726,7 +740,7 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "{} ",
-            Color::Cyan.bold().paint(convert_path_sep(&format!(
+            Style::new().cyan().bold().style(convert_path_sep(&format!(
                 "~/{}/st/schematics",
                 name.split_at(3).0
             )))
@@ -750,7 +764,7 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "{} ",
-            Color::Cyan.bold().paint(convert_path_sep("/"))
+            Style::new().cyan().bold().style(convert_path_sep("/"))
         ));
 
         assert_eq!(expected, actual);
@@ -765,9 +779,10 @@ mod tests {
         let actual = ModuleRenderer::new("directory").path(dir).collect();
         let expected = Some(format!(
             "{} ",
-            Color::Cyan
+            Style::new()
+                .cyan()
                 .bold()
-                .paint(convert_path_sep(&format!("{}/thrusters/rocket", name)))
+                .style(convert_path_sep(&format!("{}/thrusters/rocket", name)))
         ));
 
         assert_eq!(expected, actual);
@@ -790,7 +805,7 @@ mod tests {
         let dir_str = dir.to_slash_lossy();
         let expected = Some(format!(
             "{} ",
-            Color::Cyan.bold().paint(convert_path_sep(
+            Style::new().cyan().bold().style(convert_path_sep(
                 &truncate(&dir_str, 100).unwrap_or(dir_str)
             ))
         ));
@@ -815,11 +830,14 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "{} ",
-            Color::Cyan.bold().paint(convert_path_sep(&to_fish_style(
-                100,
-                dir.to_slash_lossy(),
-                ""
-            )))
+            Style::new()
+                .cyan()
+                .bold()
+                .style(convert_path_sep(&to_fish_style(
+                    100,
+                    dir.to_slash_lossy(),
+                    ""
+                )))
         ));
 
         assert_eq!(expected, actual);
@@ -841,9 +859,10 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "{} ",
-            Color::Cyan
+            Style::new()
+                .cyan()
                 .bold()
-                .paint(convert_path_sep(&format!("{}/rocket", name)))
+                .style(convert_path_sep(&format!("{}/rocket", name)))
         ));
 
         assert_eq!(expected, actual);
@@ -866,7 +885,7 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "{} ",
-            Color::Cyan.bold().paint(convert_path_sep(&format!(
+            Style::new().cyan().bold().style(convert_path_sep(&format!(
                 "{}/thrusters/rocket",
                 to_fish_style(1, dir.to_slash_lossy(), "/thrusters/rocket")
             )))
@@ -887,9 +906,10 @@ mod tests {
         let actual = ModuleRenderer::new("directory").path(repo_dir).collect();
         let expected = Some(format!(
             "{} ",
-            Color::Cyan
+            Style::new()
+                .cyan()
                 .bold()
-                .paint(convert_path_sep("rocket-controls"))
+                .style(convert_path_sep("rocket-controls"))
         ));
 
         assert_eq!(expected, actual);
@@ -908,9 +928,10 @@ mod tests {
         let actual = ModuleRenderer::new("directory").path(dir).collect();
         let expected = Some(format!(
             "{} ",
-            Color::Cyan
+            Style::new()
+                .cyan()
                 .bold()
-                .paint(convert_path_sep("rocket-controls/src"))
+                .style(convert_path_sep("rocket-controls/src"))
         ));
 
         assert_eq!(expected, actual);
@@ -929,9 +950,10 @@ mod tests {
         let actual = ModuleRenderer::new("directory").path(dir).collect();
         let expected = Some(format!(
             "{} ",
-            Color::Cyan
+            Style::new()
+                .cyan()
                 .bold()
-                .paint(convert_path_sep("src/meters/fuel-gauge"))
+                .style(convert_path_sep("src/meters/fuel-gauge"))
         ));
 
         assert_eq!(expected, actual);
@@ -958,7 +980,7 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "{} ",
-            Color::Cyan.bold().paint(convert_path_sep(
+            Style::new().cyan().bold().style(convert_path_sep(
                 "above-repo/rocket-controls/src/meters/fuel-gauge"
             ))
         ));
@@ -988,7 +1010,7 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "{} ",
-            Color::Cyan.bold().paint(convert_path_sep(&format!(
+            Style::new().cyan().bold().style(convert_path_sep(&format!(
                 "{}/above-repo/rocket-controls/src/meters/fuel-gauge",
                 to_fish_style(1, tmp_dir.path().to_slash_lossy(), "")
             )))
@@ -1019,7 +1041,7 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "{} ",
-            Color::Cyan.bold().paint(convert_path_sep(&format!(
+            Style::new().cyan().bold().style(convert_path_sep(&format!(
                 "{}/rocket-controls/src/meters/fuel-gauge",
                 to_fish_style(1, tmp_dir.path().join("above-repo").to_slash_lossy(), "")
             )))
@@ -1049,9 +1071,10 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "{} ",
-            Color::Cyan
+            Style::new()
+                .cyan()
                 .bold()
-                .paint(convert_path_sep("rocket-controls/src/meters/fuel-gauge"))
+                .style(convert_path_sep("rocket-controls/src/meters/fuel-gauge"))
         ));
 
         assert_eq!(expected, actual);
@@ -1071,9 +1094,10 @@ mod tests {
         let actual = ModuleRenderer::new("directory").path(symlink_dir).collect();
         let expected = Some(format!(
             "{} ",
-            Color::Cyan
+            Style::new()
+                .cyan()
                 .bold()
-                .paint(convert_path_sep("rocket-controls-symlink"))
+                .style(convert_path_sep("rocket-controls-symlink"))
         ));
 
         assert_eq!(expected, actual);
@@ -1097,9 +1121,10 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "{} ",
-            Color::Cyan
+            Style::new()
+                .cyan()
                 .bold()
-                .paint(convert_path_sep("rocket-controls-symlink/src"))
+                .style(convert_path_sep("rocket-controls-symlink/src"))
         ));
 
         assert_eq!(expected, actual);
@@ -1123,9 +1148,10 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "{} ",
-            Color::Cyan
+            Style::new()
+                .cyan()
                 .bold()
-                .paint(convert_path_sep("src/meters/fuel-gauge"))
+                .style(convert_path_sep("src/meters/fuel-gauge"))
         ));
 
         assert_eq!(expected, actual);
@@ -1158,7 +1184,7 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "{} ",
-            Color::Cyan.bold().paint(convert_path_sep(
+            Style::new().cyan().bold().style(convert_path_sep(
                 "above-repo/rocket-controls-symlink/src/meters/fuel-gauge"
             ))
         ));
@@ -1194,7 +1220,7 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "{} ",
-            Color::Cyan.bold().paint(convert_path_sep(&format!(
+            Style::new().cyan().bold().style(convert_path_sep(&format!(
                 "{}/above-repo/rocket-controls-symlink/src/meters/fuel-gauge",
                 to_fish_style(1, tmp_dir.path().to_slash_lossy(), "")
             )))
@@ -1231,7 +1257,7 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "{} ",
-            Color::Cyan.bold().paint(convert_path_sep(&format!(
+            Style::new().cyan().bold().style(convert_path_sep(&format!(
                 "{}/rocket-controls-symlink/src/meters/fuel-gauge",
                 to_fish_style(1, tmp_dir.path().join("above-repo").to_slash_lossy(), "")
             )))
@@ -1267,7 +1293,7 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "{} ",
-            Color::Cyan.bold().paint(convert_path_sep(
+            Style::new().cyan().bold().style(convert_path_sep(
                 "rocket-controls-symlink/src/meters/fuel-gauge"
             ))
         ));
@@ -1297,9 +1323,10 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "{} ",
-            Color::Cyan
+            Style::new()
+                .cyan()
                 .bold()
-                .paint(convert_path_sep("rocket-controls/src/loop/loop"))
+                .style(convert_path_sep("rocket-controls/src/loop/loop"))
         ));
 
         assert_eq!(expected, actual);
@@ -1318,9 +1345,10 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "{} ",
-            Color::Cyan
+            Style::new()
+                .cyan()
                 .bold()
-                .paint(convert_path_sep("…/four/element/path"))
+                .style(convert_path_sep("…/four/element/path"))
         ));
         assert_eq!(expected, actual);
     }
@@ -1337,9 +1365,10 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "{} ",
-            Color::Cyan
+            Style::new()
+                .cyan()
                 .bold()
-                .paint(convert_path_sep("/a/four/element/path"))
+                .style(convert_path_sep("/a/four/element/path"))
         ));
         assert_eq!(expected, actual);
     }
@@ -1360,9 +1389,10 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "{} ",
-            Color::Cyan
+            Style::new()
+                .cyan()
                 .bold()
-                .paint(convert_path_sep(&format!("…/{}/a/subpath", name)))
+                .style(convert_path_sep(&format!("…/{}/a/subpath", name)))
         ));
         assert_eq!(expected, actual);
         tmp_dir.close()
@@ -1385,9 +1415,10 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "{} ",
-            Color::Cyan
+            Style::new()
+                .cyan()
                 .bold()
-                .paint(convert_path_sep(&format!("~/{}/a/subpath", name)))
+                .style(convert_path_sep(&format!("~/{}/a/subpath", name)))
         ));
         assert_eq!(expected, actual);
         tmp_dir.close()
@@ -1411,7 +1442,10 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "{} ",
-            Color::Cyan.bold().paint(convert_path_sep("…/src/sub/path"))
+            Style::new()
+                .cyan()
+                .bold()
+                .style(convert_path_sep("…/src/sub/path"))
         ));
         assert_eq!(expected, actual);
         tmp_dir.close()
@@ -1436,9 +1470,10 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "{} ",
-            Color::Cyan
+            Style::new()
+                .cyan()
                 .bold()
-                .paint(convert_path_sep("…/repo/src/sub/path"))
+                .style(convert_path_sep("…/repo/src/sub/path"))
         ));
         assert_eq!(expected, actual);
         tmp_dir.close()
@@ -1458,7 +1493,10 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "{} ",
-            Color::Cyan.bold().paint(convert_path_sep("C:/temp"))
+            Style::new()
+                .cyan()
+                .bold()
+                .style(convert_path_sep("C:/temp"))
         ));
         assert_eq!(expected, actual);
     }
@@ -1477,7 +1515,7 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "{} ",
-            Color::Cyan.bold().paint(convert_path_sep("…/temp"))
+            Style::new().cyan().bold().style(convert_path_sep("…/temp"))
         ));
         assert_eq!(expected, actual);
     }
@@ -1496,7 +1534,10 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "{} ",
-            Color::Cyan.bold().paint(convert_path_sep("…\\temp"))
+            Style::new()
+                .cyan()
+                .bold()
+                .style(convert_path_sep("…\\temp"))
         ));
         assert_eq!(expected, actual);
     }
@@ -1510,9 +1551,10 @@ mod tests {
 
         let expected = Some(format!(
             "{} ",
-            Color::Cyan
+            Style::new()
+                .cyan()
                 .bold()
-                .paint(convert_path_sep("Logical:/fuel-gauge"))
+                .style(convert_path_sep("Logical:/fuel-gauge"))
         ));
 
         let actual = ModuleRenderer::new("directory")
@@ -1538,9 +1580,10 @@ mod tests {
 
         let expected = Some(format!(
             "{} ",
-            Color::Cyan
+            Style::new()
+                .cyan()
                 .bold()
-                .paint(convert_path_sep("src/meters/fuel-gauge"))
+                .style(convert_path_sep("src/meters/fuel-gauge"))
         ));
 
         let actual = ModuleRenderer::new("directory")
@@ -1566,9 +1609,10 @@ mod tests {
 
         let expected = Some(format!(
             "{} ",
-            Color::Cyan
+            Style::new()
+                .cyan()
                 .bold()
-                .paint(convert_path_sep("C:/Windows/System32"))
+                .style(convert_path_sep("C:/Windows/System32"))
         ));
 
         // Note: We have disable the read_only settings here due to false positives when running
@@ -1598,9 +1642,10 @@ mod tests {
         // which is why the first part of this string still includes backslashes
         let expected = Some(format!(
             "{} ",
-            Color::Cyan
+            Style::new()
+                .cyan()
                 .bold()
-                .paint(convert_path_sep(r"\\server\share/a/b/c"))
+                .style(convert_path_sep(r"\\server\share/a/b/c"))
         ));
 
         let actual = ModuleRenderer::new("directory")
@@ -1633,10 +1678,9 @@ mod tests {
             .path(dir)
             .collect();
         let expected = Some(format!(
-            "{}{}repo{} ",
-            Color::Cyan.bold().prefix(),
-            Color::Red.prefix(),
-            Color::Cyan.paint(convert_path_sep("/src/sub/path"))
+            "{}{} ",
+            Style::new().red().bold().style("repo"),
+            Style::new().cyan().bold().style(convert_path_sep("/src/sub/path"))
         ));
         assert_eq!(expected, actual);
         tmp_dir.close()
@@ -1661,10 +1705,16 @@ mod tests {
             .path(dir)
             .collect();
         let expected = Some(format!(
-            "{}{}repo{} ",
-            Color::Cyan.bold().paint(convert_path_sep("…/above/")),
-            Color::Green.prefix(),
-            Color::Cyan.bold().paint(convert_path_sep("/src/sub/path"))
+            "{}{}{} ",
+            Style::new()
+                .cyan()
+                .bold()
+                .style(convert_path_sep("…/above/")),
+            Style::new().green().style("repo"),
+            Style::new()
+                .cyan()
+                .bold()
+                .style(convert_path_sep("/src/sub/path"))
         ));
         assert_eq!(expected, actual);
         tmp_dir.close()
@@ -1704,7 +1754,7 @@ mod tests {
         let path = invalid_path();
         let expected = Some(format!(
             "{} ",
-            Color::Cyan.bold().paint(path.to_string_lossy())
+            Style::new().cyan().bold().style(path.to_string_lossy())
         ));
 
         let actual = ModuleRenderer::new("directory").path(path).collect();
@@ -1727,7 +1777,10 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "{} ",
-            Color::Cyan.bold().paint(format!("~/{}/starship", name))
+            Style::new()
+                .cyan()
+                .bold()
+                .style(format!("~/{}/starship", name))
         ));
 
         assert_eq!(expected, actual);

--- a/src/modules/docker_context.rs
+++ b/src/modules/docker_context.rs
@@ -87,7 +87,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 #[cfg(test)]
 mod tests {
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use owo_colors::Style;
     use std::fs::File;
     use std::io::{self, Write};
 
@@ -124,7 +124,10 @@ mod tests {
             .path(pwd.path())
             .collect();
 
-        let expected = Some(format!("via {} ", Color::Blue.bold().paint("🐳 starship")));
+        let expected = Some(format!(
+            "via {} ",
+            Style::new().blue().bold().style("🐳 starship")
+        ));
 
         assert_eq!(expected, actual);
 
@@ -153,7 +156,10 @@ mod tests {
             .path(pwd.path())
             .collect();
 
-        let expected = Some(format!("via {} ", Color::Blue.bold().paint("🐳 starship")));
+        let expected = Some(format!(
+            "via {} ",
+            Style::new().blue().bold().style("🐳 starship")
+        ));
 
         assert_eq!(expected, actual);
 
@@ -182,7 +188,10 @@ mod tests {
             .path(pwd.path())
             .collect();
 
-        let expected = Some(format!("via {} ", Color::Blue.bold().paint("🐳 starship")));
+        let expected = Some(format!(
+            "via {} ",
+            Style::new().blue().bold().style("🐳 starship")
+        ));
 
         assert_eq!(expected, actual);
 
@@ -235,7 +244,10 @@ mod tests {
             })
             .collect();
 
-        let expected = Some(format!("via {} ", Color::Blue.bold().paint("🐳 starship")));
+        let expected = Some(format!(
+            "via {} ",
+            Style::new().blue().bold().style("🐳 starship")
+        ));
 
         assert_eq!(expected, actual);
 
@@ -281,7 +293,10 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "via {} ",
-            Color::Blue.bold().paint("🐳 udp://starship@127.0.0.1:53")
+            Style::new()
+                .blue()
+                .bold()
+                .style("🐳 udp://starship@127.0.0.1:53")
         ));
 
         assert_eq!(expected, actual);
@@ -300,7 +315,10 @@ mod tests {
                 only_with_files = false
             })
             .collect();
-        let expected = Some(format!("via {} ", Color::Blue.bold().paint("🐳 starship")));
+        let expected = Some(format!(
+            "via {} ",
+            Style::new().blue().bold().style("🐳 starship")
+        ));
 
         assert_eq!(expected, actual);
 
@@ -329,7 +347,10 @@ mod tests {
                 only_with_files = false
             })
             .collect();
-        let expected = Some(format!("via {} ", Color::Blue.bold().paint("🐳 starship")));
+        let expected = Some(format!(
+            "via {} ",
+            Style::new().blue().bold().style("🐳 starship")
+        ));
 
         assert_eq!(expected, actual);
 
@@ -361,7 +382,10 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "via {} ",
-            Color::Blue.bold().paint("🐳 udp://starship@127.0.0.1:53")
+            Style::new()
+                .blue()
+                .bold()
+                .style("🐳 udp://starship@127.0.0.1:53")
         ));
 
         assert_eq!(expected, actual);
@@ -394,7 +418,7 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "via {} ",
-            Color::Blue.bold().paint("🐳 machine_name")
+            Style::new().blue().bold().style("🐳 machine_name")
         ));
 
         assert_eq!(expected, actual);

--- a/src/modules/dotnet.rs
+++ b/src/modules/dotnet.rs
@@ -346,7 +346,7 @@ mod tests {
     use super::*;
     use crate::test::ModuleRenderer;
     use crate::utils::create_command;
-    use ansi_term::Color;
+    use owo_colors::Style;
     use std::fs::{self, OpenOptions};
     use std::io::{self, Write};
     use tempfile::{self, TempDir};
@@ -366,7 +366,7 @@ mod tests {
             workspace.path(),
             Some(format!(
                 "via {}",
-                Color::Blue.bold().paint(".NET v3.1.103 ")
+                Style::new().blue().bold().style(".NET v3.1.103 ")
             )),
         );
         workspace.close()
@@ -380,7 +380,7 @@ mod tests {
             workspace.path(),
             Some(format!(
                 "via {}",
-                Color::Blue.bold().paint(".NET v3.1.103 ")
+                Style::new().blue().bold().style(".NET v3.1.103 ")
             )),
         );
         workspace.close()
@@ -394,7 +394,7 @@ mod tests {
             workspace.path(),
             Some(format!(
                 "via {}",
-                Color::Blue.bold().paint(".NET v3.1.103 ")
+                Style::new().blue().bold().style(".NET v3.1.103 ")
             )),
         );
         workspace.close()
@@ -417,7 +417,10 @@ mod tests {
             workspace.path(),
             Some(format!(
                 "via {}",
-                Color::Blue.bold().paint(".NET v3.1.103 🎯 netstandard2.0 ")
+                Style::new()
+                    .blue()
+                    .bold()
+                    .style(".NET v3.1.103 🎯 netstandard2.0 ")
             )),
         );
         workspace.close()
@@ -431,7 +434,7 @@ mod tests {
             workspace.path(),
             Some(format!(
                 "via {}",
-                Color::Blue.bold().paint(".NET v3.1.103 ")
+                Style::new().blue().bold().style(".NET v3.1.103 ")
             )),
         );
         workspace.close()
@@ -445,7 +448,7 @@ mod tests {
             workspace.path(),
             Some(format!(
                 "via {}",
-                Color::Blue.bold().paint(".NET v3.1.103 ")
+                Style::new().blue().bold().style(".NET v3.1.103 ")
             )),
         );
         workspace.close()
@@ -459,7 +462,7 @@ mod tests {
             workspace.path(),
             Some(format!(
                 "via {}",
-                Color::Blue.bold().paint(".NET v3.1.103 ")
+                Style::new().blue().bold().style(".NET v3.1.103 ")
             )),
         );
         workspace.close()
@@ -472,7 +475,10 @@ mod tests {
         touch_path(&workspace, "global.json", Some(&global_json))?;
         expect_output(
             workspace.path(),
-            Some(format!("via {}", Color::Blue.bold().paint(".NET v1.2.3 "))),
+            Some(format!(
+                "via {}",
+                Style::new().blue().bold().style(".NET v1.2.3 ")
+            )),
         );
         workspace.close()
     }
@@ -488,7 +494,10 @@ mod tests {
             &workspace.path().join("project"),
             Some(format!(
                 "via {}",
-                Color::Blue.bold().paint(".NET v1.2.3 🎯 netstandard2.0 ")
+                Style::new()
+                    .blue()
+                    .bold()
+                    .style(".NET v1.2.3 🎯 netstandard2.0 ")
             )),
         );
         workspace.close()
@@ -509,7 +518,10 @@ mod tests {
             &workspace.path().join("deep/path/to/project"),
             Some(format!(
                 "via {}",
-                Color::Blue.bold().paint(".NET v1.2.3 🎯 netstandard2.0 ")
+                Style::new()
+                    .blue()
+                    .bold()
+                    .style(".NET v1.2.3 🎯 netstandard2.0 ")
             )),
         );
         workspace.close()
@@ -524,7 +536,10 @@ mod tests {
             workspace.path(),
             Some(format!(
                 "via {}",
-                Color::Blue.bold().paint(".NET v3.1.103 🎯 netstandard2.0 ")
+                Style::new()
+                    .blue()
+                    .bold()
+                    .style(".NET v3.1.103 🎯 netstandard2.0 ")
             )),
         );
         workspace.close()
@@ -539,9 +554,10 @@ mod tests {
             workspace.path(),
             Some(format!(
                 "via {}",
-                Color::Blue
+                Style::new()
+                    .blue()
                     .bold()
-                    .paint(".NET v3.1.103 🎯 netstandard2.0;net461 ")
+                    .style(".NET v3.1.103 🎯 netstandard2.0;net461 ")
             )),
         );
         workspace.close()

--- a/src/modules/elixir.rs
+++ b/src/modules/elixir.rs
@@ -91,7 +91,7 @@ fn parse_elixir_version(version: &str) -> Option<(String, String)> {
 mod tests {
     use super::*;
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use owo_colors::Style;
     use std::fs::File;
     use std::io;
 
@@ -145,7 +145,7 @@ Elixir 1.13.0-dev (compiled with Erlang/OTP 23)
 
         let expected = Some(format!(
             "via {}",
-            Color::Purple.bold().paint("💧 v1.10 (OTP 22) ")
+            Style::new().purple().bold().style("💧 v1.10 (OTP 22) ")
         ));
         let output = ModuleRenderer::new("elixir").path(dir.path()).collect();
 

--- a/src/modules/elm.rs
+++ b/src/modules/elm.rs
@@ -59,7 +59,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 #[cfg(test)]
 mod tests {
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use owo_colors::Style;
     use std::fs::{self, File};
     use std::io;
 
@@ -77,7 +77,10 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("elm.json"))?.sync_all()?;
         let actual = ModuleRenderer::new("elm").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Cyan.bold().paint("🌳 v0.19.1 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().cyan().bold().style("🌳 v0.19.1 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -87,7 +90,10 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("elm-package.json"))?.sync_all()?;
         let actual = ModuleRenderer::new("elm").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Cyan.bold().paint("🌳 v0.19.1 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().cyan().bold().style("🌳 v0.19.1 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -97,7 +103,10 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join(".elm-version"))?.sync_all()?;
         let actual = ModuleRenderer::new("elm").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Cyan.bold().paint("🌳 v0.19.1 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().cyan().bold().style("🌳 v0.19.1 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -108,7 +117,10 @@ mod tests {
         let elmstuff = dir.path().join("elm-stuff");
         fs::create_dir_all(&elmstuff)?;
         let actual = ModuleRenderer::new("elm").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Cyan.bold().paint("🌳 v0.19.1 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().cyan().bold().style("🌳 v0.19.1 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -118,7 +130,10 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("main.elm"))?.sync_all()?;
         let actual = ModuleRenderer::new("elm").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Cyan.bold().paint("🌳 v0.19.1 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().cyan().bold().style("🌳 v0.19.1 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }

--- a/src/modules/env_var.rs
+++ b/src/modules/env_var.rs
@@ -105,7 +105,7 @@ fn get_env_value(context: &Context, name: &str, default: Option<&str>) -> Option
 #[cfg(test)]
 mod test {
     use crate::test::ModuleRenderer;
-    use ansi_term::{Color, Style};
+    use owo_colors::Style;
 
     const TEST_VAR_VALUE: &str = "astronauts";
 
@@ -126,7 +126,7 @@ mod test {
             })
             .env("TEST_VAR", TEST_VAR_VALUE)
             .collect();
-        let expected = Some(format!("with {} ", style().paint(TEST_VAR_VALUE)));
+        let expected = Some(format!("with {} ", style().style(TEST_VAR_VALUE)));
 
         assert_eq!(expected, actual);
     }
@@ -139,7 +139,7 @@ mod test {
             })
             .env("TEST_VAR", TEST_VAR_VALUE)
             .collect();
-        let expected = Some(format!("with {} ", style().paint(TEST_VAR_VALUE)));
+        let expected = Some(format!("with {} ", style().style(TEST_VAR_VALUE)));
 
         assert_eq!(expected, actual);
     }
@@ -165,7 +165,7 @@ mod test {
             })
             .env("TEST_VAR", TEST_VAR_VALUE)
             .collect();
-        let expected = Some(format!("with {} ", style().paint(TEST_VAR_VALUE)));
+        let expected = Some(format!("with {} ", style().style(TEST_VAR_VALUE)));
 
         assert_eq!(expected, actual);
     }
@@ -178,7 +178,7 @@ mod test {
                 default = "N/A"
             })
             .collect();
-        let expected = Some(format!("with {} ", style().paint("N/A")));
+        let expected = Some(format!("with {} ", style().style("N/A")));
 
         assert_eq!(expected, actual);
     }
@@ -194,7 +194,7 @@ mod test {
             .collect();
         let expected = Some(format!(
             "with {} ",
-            style().paint(format!("■ {}", TEST_VAR_VALUE))
+            style().style(format!("■ {}", TEST_VAR_VALUE))
         ));
 
         assert_eq!(expected, actual);
@@ -211,7 +211,7 @@ mod test {
             .collect();
         let expected = Some(format!(
             "with {} ",
-            style().paint(format!("_{}", TEST_VAR_VALUE))
+            style().style(format!("_{}", TEST_VAR_VALUE))
         ));
 
         assert_eq!(expected, actual);
@@ -228,7 +228,7 @@ mod test {
             .collect();
         let expected = Some(format!(
             "with {} ",
-            style().paint(format!("{}_", TEST_VAR_VALUE))
+            style().style(format!("{}_", TEST_VAR_VALUE))
         ));
 
         assert_eq!(expected, actual);
@@ -246,8 +246,8 @@ mod test {
             .collect();
         let expected = Some(format!(
             "with {} with {} ",
-            style().paint(TEST_VAR_VALUE),
-            style().paint(TEST_VAR_VALUE)
+            style().style(TEST_VAR_VALUE),
+            style().style(TEST_VAR_VALUE)
         ));
 
         assert_eq!(expected, actual);
@@ -255,6 +255,6 @@ mod test {
 
     fn style() -> Style {
         // default style
-        Color::Black.bold().dimmed()
+        Style::new().black().bold().dimmed()
     }
 }

--- a/src/modules/erlang.rs
+++ b/src/modules/erlang.rs
@@ -73,7 +73,7 @@ fn get_erlang_version(context: &Context) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use owo_colors::Style;
     use std::fs::File;
     use std::io;
 
@@ -94,7 +94,10 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("rebar.config"))?.sync_all()?;
 
-        let expected = Some(format!("via {}", Color::Red.bold().paint(" v22.1.3 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().red().bold().style(" v22.1.3 ")
+        ));
         let output = ModuleRenderer::new("erlang").path(dir.path()).collect();
 
         assert_eq!(output, expected);

--- a/src/modules/fill.rs
+++ b/src/modules/fill.rs
@@ -24,7 +24,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 #[cfg(test)]
 mod tests {
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use owo_colors::Style;
 
     #[test]
     fn basic() {
@@ -35,7 +35,7 @@ mod tests {
                 symbol = "*-"
             })
             .collect();
-        let expected = Some(format!("{}", Color::Green.bold().paint("*-")));
+        let expected = Some(format!("{}", Style::new().green().bold().style("*-")));
 
         assert_eq!(expected, actual);
     }
@@ -61,7 +61,7 @@ mod tests {
                 disabled = false
             })
             .collect();
-        let expected = Some(format!("{}", Color::Black.bold().paint(".")));
+        let expected = Some(format!("{}", Style::new().black().bold().style(".")));
 
         assert_eq!(expected, actual);
     }

--- a/src/modules/gcloud.rs
+++ b/src/modules/gcloud.rs
@@ -176,7 +176,7 @@ mod tests {
     use std::fs::{create_dir, File};
     use std::io::{self, Write};
 
-    use ansi_term::Color;
+    use owo_colors::Style;
 
     use crate::test::ModuleRenderer;
 
@@ -202,7 +202,7 @@ account = foo@example.com
             .collect();
         let expected = Some(format!(
             "on {} ",
-            Color::Blue.bold().paint("☁️  foo@example.com")
+            Style::new().blue().bold().style("☁️  foo@example.com")
         ));
 
         assert_eq!(actual, expected);
@@ -233,7 +233,10 @@ account = foo@example.com
                 format = "on [$symbol$account(\\($region\\))]($style) "
             })
             .collect();
-        let expected = Some(format!("on {} ", Color::Blue.bold().paint("☁️  foo")));
+        let expected = Some(format!(
+            "on {} ",
+            Style::new().blue().bold().style("☁️  foo")
+        ));
 
         assert_eq!(actual, expected);
         dir.close()
@@ -264,7 +267,10 @@ region = us-central1
             .collect();
         let expected = Some(format!(
             "on {} ",
-            Color::Blue.bold().paint("☁️  foo@example.com(us-central1)")
+            Style::new()
+                .blue()
+                .bold()
+                .style("☁️  foo@example.com(us-central1)")
         ));
 
         assert_eq!(actual, expected);
@@ -300,7 +306,7 @@ region = us-central1
             .collect();
         let expected = Some(format!(
             "on {} ",
-            Color::Blue.bold().paint("☁️  foo@example.com(uc1)")
+            Style::new().blue().bold().style("☁️  foo@example.com(uc1)")
         ));
 
         assert_eq!(actual, expected);
@@ -321,7 +327,10 @@ region = us-central1
                 format = "on [$symbol$active]($style) "
             })
             .collect();
-        let expected = Some(format!("on {} ", Color::Blue.bold().paint("☁️  default1")));
+        let expected = Some(format!(
+            "on {} ",
+            Style::new().blue().bold().style("☁️  default1")
+        ));
 
         assert_eq!(actual, expected);
         dir.close()
@@ -351,7 +360,10 @@ project = abc
                 format = "on [$symbol$project]($style) "
             })
             .collect();
-        let expected = Some(format!("on {} ", Color::Blue.bold().paint("☁️  abc")));
+        let expected = Some(format!(
+            "on {} ",
+            Style::new().blue().bold().style("☁️  abc")
+        ));
 
         assert_eq!(actual, expected);
         dir.close()
@@ -384,7 +396,7 @@ project = abc
             .collect();
         let expected = Some(format!(
             "on {} ",
-            Color::Blue.bold().paint("☁️  env_project")
+            Style::new().blue().bold().style("☁️  env_project")
         ));
 
         assert_eq!(actual, expected);
@@ -417,7 +429,10 @@ project = very-long-project-name
                 very-long-project-name = "vlpn"
             })
             .collect();
-        let expected = Some(format!("on {} ", Color::Blue.bold().paint("☁️  vlpn")));
+        let expected = Some(format!(
+            "on {} ",
+            Style::new().blue().bold().style("☁️  vlpn")
+        ));
 
         assert_eq!(actual, expected);
         dir.close()
@@ -473,7 +488,10 @@ project = overridden
                 format = "on [$symbol$project]($style) "
             })
             .collect();
-        let expected = Some(format!("on {} ", Color::Blue.bold().paint("☁️  overridden")));
+        let expected = Some(format!(
+            "on {} ",
+            Style::new().blue().bold().style("☁️  overridden")
+        ));
 
         assert_eq!(actual, expected);
         dir.close()

--- a/src/modules/git_branch.rs
+++ b/src/modules/git_branch.rs
@@ -124,7 +124,7 @@ fn get_first_grapheme(text: &str) -> &str {
 
 #[cfg(test)]
 mod tests {
-    use ansi_term::Color;
+    use owo_colors::Style;
     use std::io;
 
     use crate::test::{fixture_repo, FixtureProvider, ModuleRenderer};
@@ -237,7 +237,11 @@ mod tests {
             "1337_hello_world",
             "[$branch](bold blue)",
             "",
-            Color::Blue.bold().paint("1337_hello_world").to_string(),
+            Style::new()
+                .blue()
+                .bold()
+                .style("1337_hello_world")
+                .to_string(),
         )
     }
 
@@ -249,8 +253,8 @@ mod tests {
             "",
             format!(
                 "branch: {} {} ",
-                Color::Blue.bold().paint("1337_hello_world"),
-                Color::Red.paint("THE COLORS")
+                Style::new().blue().bold().style("1337_hello_world"),
+                Style::new().red().style("THE COLORS")
             ),
         )
     }
@@ -264,7 +268,7 @@ mod tests {
             symbol = "git: "
             style = "green"
         "#,
-            format!("git: {}", Color::Green.paint("1337_hello_world"),),
+            format!("git: {}", Style::new().green().style("1337_hello_world"),),
         )
     }
 
@@ -288,7 +292,10 @@ mod tests {
 
         let expected = Some(format!(
             "on {} ",
-            Color::Purple.bold().paint(format!("\u{e0a0} {}", "main")),
+            Style::new()
+                .purple()
+                .bold()
+                .style(format!("\u{e0a0} {}", "main")),
         ));
 
         assert_eq!(expected, actual);
@@ -314,9 +321,10 @@ mod tests {
 
         let expected = Some(format!(
             "on {} ",
-            Color::Purple
+            Style::new()
+                .purple()
                 .bold()
-                .paint(format!("\u{e0a0} {}", "test_branch")),
+                .style(format!("\u{e0a0} {}", "test_branch")),
         ));
 
         assert_eq!(expected, actual);
@@ -366,7 +374,10 @@ mod tests {
 
         let expected = Some(format!(
             "on {} ",
-            Color::Purple.bold().paint(format!("\u{e0a0} {}", "main")),
+            Style::new()
+                .purple()
+                .bold()
+                .style(format!("\u{e0a0} {}", "main")),
         ));
 
         assert_eq!(expected, actual);
@@ -418,7 +429,7 @@ mod tests {
 
     //     let expected = Some(format!(
     //         "on {} ",
-    //         Color::Purple.bold().paint(format!("\u{e0a0} {}", "master")),
+    //         Style::new().purple().bold().style(format!("\u{e0a0} {}", "master")),
     //     ));
 
     //     assert_eq!(expected, actual);
@@ -471,9 +482,10 @@ mod tests {
 
         let expected = Some(format!(
             "on {} ",
-            Color::Purple
+            Style::new()
+                .purple()
                 .bold()
-                .paint(format!("\u{e0a0} {}{}", expected_name, truncation_symbol)),
+                .style(format!("\u{e0a0} {}{}", expected_name, truncation_symbol)),
         ));
 
         assert_eq!(expected, actual);

--- a/src/modules/git_commit.rs
+++ b/src/modules/git_commit.rs
@@ -102,7 +102,7 @@ fn id_to_hex_abbrev(bytes: &[u8], len: usize) -> String {
 
 #[cfg(test)]
 mod tests {
-    use ansi_term::Color;
+    use owo_colors::Style;
     use std::{io, str};
 
     use crate::test::{fixture_repo, FixtureProvider, ModuleRenderer};
@@ -144,7 +144,10 @@ mod tests {
 
         let expected = Some(format!(
             "{} ",
-            Color::Green.bold().paint(format!("({})", expected_hash))
+            Style::new()
+                .green()
+                .bold()
+                .style(format!("({})", expected_hash))
         ));
 
         assert_eq!(expected, actual);
@@ -174,7 +177,10 @@ mod tests {
 
         let expected = Some(format!(
             "{} ",
-            Color::Green.bold().paint(format!("({})", expected_hash))
+            Style::new()
+                .green()
+                .bold()
+                .style(format!("({})", expected_hash))
         ));
 
         assert_eq!(expected, actual);
@@ -218,7 +224,10 @@ mod tests {
 
         let expected = Some(format!(
             "{} ",
-            Color::Green.bold().paint(format!("({})", expected_hash))
+            Style::new()
+                .green()
+                .bold()
+                .style(format!("({})", expected_hash))
         ));
 
         assert_eq!(expected, actual);
@@ -258,9 +267,10 @@ mod tests {
 
         let expected = Some(format!(
             "{} ",
-            Color::Green
+            Style::new()
+                .green()
                 .bold()
-                .paint(format!("({})", expected_output.trim()))
+                .style(format!("({})", expected_output.trim()))
         ));
 
         assert_eq!(expected, actual);
@@ -309,9 +319,10 @@ mod tests {
 
         let expected = Some(format!(
             "{} ",
-            Color::Green
+            Style::new()
+                .green()
                 .bold()
-                .paint(format!("({})", expected_output.trim()))
+                .style(format!("({})", expected_output.trim()))
         ));
 
         assert_eq!(expected, actual);
@@ -380,9 +391,10 @@ mod tests {
 
         let expected = Some(format!(
             "{} ",
-            Color::Green
+            Style::new()
+                .green()
                 .bold()
-                .paint(format!("({})", expected_output.trim()))
+                .style(format!("({})", expected_output.trim()))
         ));
 
         assert_eq!(expected, actual);

--- a/src/modules/git_metrics.rs
+++ b/src/modules/git_metrics.rs
@@ -116,7 +116,7 @@ mod tests {
     use std::path::{Path, PathBuf};
     use std::process::Stdio;
 
-    use ansi_term::Color;
+    use owo_colors::Style;
 
     use crate::test::ModuleRenderer;
 
@@ -145,7 +145,7 @@ mod tests {
 
         let actual = render_metrics(path);
 
-        let expected = Some(format!("{} ", Color::Green.bold().paint("+1"),));
+        let expected = Some(format!("{} ", Style::new().green().bold().style("+1"),));
 
         assert_eq!(expected, actual);
         repo_dir.close()
@@ -161,7 +161,7 @@ mod tests {
 
         let actual = render_metrics(path);
 
-        let expected = Some(format!("{} ", Color::Red.bold().paint("-1")));
+        let expected = Some(format!("{} ", Style::new().red().bold().style("-1")));
 
         assert_eq!(expected, actual);
         repo_dir.close()
@@ -179,8 +179,8 @@ mod tests {
 
         let expected = Some(format!(
             "{} {} ",
-            Color::Green.bold().paint("+4"),
-            Color::Red.bold().paint("-2")
+            Style::new().green().bold().style("+4"),
+            Style::new().red().bold().style("-2")
         ));
 
         assert_eq!(expected, actual);
@@ -220,8 +220,8 @@ mod tests {
 
         let expected = Some(format!(
             "{} {} ",
-            Color::Green.bold().paint("+1"),
-            Color::Red.bold().paint("-0")
+            Style::new().green().bold().style("+1"),
+            Style::new().red().bold().style("-0")
         ));
 
         assert_eq!(expected, actual);

--- a/src/modules/git_state.rs
+++ b/src/modules/git_state.rs
@@ -158,7 +158,7 @@ struct StateDescription<'a> {
 
 #[cfg(test)]
 mod tests {
-    use ansi_term::Color;
+    use owo_colors::Style;
     use std::ffi::OsStr;
     use std::fs::OpenOptions;
     use std::io::{self, Error, ErrorKind, Write};
@@ -191,7 +191,10 @@ mod tests {
 
         let actual = ModuleRenderer::new("git_state").path(path).collect();
 
-        let expected = Some(format!("({}) ", Color::Yellow.bold().paint("REBASING 1/1")));
+        let expected = Some(format!(
+            "({}) ",
+            Style::new().yellow().bold().style("REBASING 1/1")
+        ));
 
         assert_eq!(expected, actual);
         repo_dir.close()
@@ -206,7 +209,10 @@ mod tests {
 
         let actual = ModuleRenderer::new("git_state").path(path).collect();
 
-        let expected = Some(format!("({}) ", Color::Yellow.bold().paint("MERGING")));
+        let expected = Some(format!(
+            "({}) ",
+            Style::new().yellow().bold().style("MERGING")
+        ));
 
         assert_eq!(expected, actual);
         repo_dir.close()
@@ -223,7 +229,7 @@ mod tests {
 
         let expected = Some(format!(
             "({}) ",
-            Color::Yellow.bold().paint("CHERRY-PICKING")
+            Style::new().yellow().bold().style("CHERRY-PICKING")
         ));
 
         assert_eq!(expected, actual);
@@ -239,7 +245,10 @@ mod tests {
 
         let actual = ModuleRenderer::new("git_state").path(path).collect();
 
-        let expected = Some(format!("({}) ", Color::Yellow.bold().paint("BISECTING")));
+        let expected = Some(format!(
+            "({}) ",
+            Style::new().yellow().bold().style("BISECTING")
+        ));
 
         assert_eq!(expected, actual);
         repo_dir.close()
@@ -254,7 +263,10 @@ mod tests {
 
         let actual = ModuleRenderer::new("git_state").path(path).collect();
 
-        let expected = Some(format!("({}) ", Color::Yellow.bold().paint("REVERTING")));
+        let expected = Some(format!(
+            "({}) ",
+            Style::new().yellow().bold().style("REVERTING")
+        ));
 
         assert_eq!(expected, actual);
         repo_dir.close()

--- a/src/modules/git_status.rs
+++ b/src/modules/git_status.rs
@@ -1160,7 +1160,7 @@ mod tests {
             .output()?;
         barrier();
 
-        writeln!(&mut file, "modified")?;
+        writeln!(file, "modified")?;
         file.sync_all()?;
 
         Ok(())
@@ -1196,7 +1196,7 @@ mod tests {
         barrier();
 
         let mut file = File::create(repo_dir.join("readme.md.bak"))?;
-        writeln!(&mut file, "modified")?;
+        writeln!(file, "modified")?;
         file.sync_all()?;
 
         Ok(())
@@ -1210,7 +1210,7 @@ mod tests {
 
     fn create_staged_and_ignored(repo_dir: &Path) -> io::Result<()> {
         let mut file = File::create(repo_dir.join(".gitignore"))?;
-        writeln!(&mut file, "ignored.txt")?;
+        writeln!(file, "ignored.txt")?;
         file.sync_all()?;
 
         create_command("git")?
@@ -1220,7 +1220,7 @@ mod tests {
         barrier();
 
         let mut file = File::create(repo_dir.join("ignored.txt"))?;
-        writeln!(&mut file, "modified")?;
+        writeln!(file, "modified")?;
         file.sync_all()?;
 
         Ok(())

--- a/src/modules/git_status.rs
+++ b/src/modules/git_status.rs
@@ -844,9 +844,9 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "{}{}{} ",
-                Style::new().red().bold().style("[+"),
-                Style::new().green().style("1"),
-                Style::new().red().bold().style("]"),
+            Style::new().red().bold().style("[+"),
+            Style::new().green().style("1"),
+            Style::new().red().bold().style("]"),
         ));
 
         assert_eq!(expected, actual);

--- a/src/modules/git_status.rs
+++ b/src/modules/git_status.rs
@@ -464,7 +464,7 @@ fn git_status_wsl(_context: &Context, _conf: &GitStatusConfig) -> Option<String>
 
 #[cfg(test)]
 mod tests {
-    use ansi_term::{ANSIStrings, Color};
+    use owo_colors::Style;
     use std::ffi::OsStr;
     use std::fs::{self, File};
     use std::io::{self, prelude::*};
@@ -489,7 +489,7 @@ mod tests {
     fn format_output(symbols: &str) -> Option<String> {
         Some(format!(
             "{} ",
-            Color::Red.bold().paint(format!("[{}]", symbols))
+            Style::new().red().bold().style(format!("[{}]", symbols))
         ))
     }
 
@@ -843,12 +843,10 @@ mod tests {
             .path(&repo_dir.path())
             .collect();
         let expected = Some(format!(
-            "{} ",
-            ANSIStrings(&[
-                Color::Red.bold().paint("[+"),
-                Color::Green.paint("1"),
-                Color::Red.bold().paint("]"),
-            ])
+            "{}{}{} ",
+                Style::new().red().bold().style("[+"),
+                Style::new().green().style("1"),
+                Style::new().red().bold().style("]"),
         ));
 
         assert_eq!(expected, actual);

--- a/src/modules/golang.rs
+++ b/src/modules/golang.rs
@@ -78,7 +78,7 @@ fn parse_go_version(go_stdout: &str) -> Option<String> {
 mod tests {
     use super::*;
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use owo_colors::Style;
     use std::fs::{self, File};
     use std::io;
 
@@ -100,7 +100,10 @@ mod tests {
 
         let actual = ModuleRenderer::new("golang").path(dir.path()).collect();
 
-        let expected = Some(format!("via {}", Color::Cyan.bold().paint("🐹 v1.12.1 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().cyan().bold().style("🐹 v1.12.1 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -112,7 +115,10 @@ mod tests {
 
         let actual = ModuleRenderer::new("golang").path(dir.path()).collect();
 
-        let expected = Some(format!("via {}", Color::Cyan.bold().paint("🐹 v1.12.1 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().cyan().bold().style("🐹 v1.12.1 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -124,7 +130,10 @@ mod tests {
 
         let actual = ModuleRenderer::new("golang").path(dir.path()).collect();
 
-        let expected = Some(format!("via {}", Color::Cyan.bold().paint("🐹 v1.12.1 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().cyan().bold().style("🐹 v1.12.1 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -137,7 +146,10 @@ mod tests {
 
         let actual = ModuleRenderer::new("golang").path(dir.path()).collect();
 
-        let expected = Some(format!("via {}", Color::Cyan.bold().paint("🐹 v1.12.1 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().cyan().bold().style("🐹 v1.12.1 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -149,7 +161,10 @@ mod tests {
 
         let actual = ModuleRenderer::new("golang").path(dir.path()).collect();
 
-        let expected = Some(format!("via {}", Color::Cyan.bold().paint("🐹 v1.12.1 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().cyan().bold().style("🐹 v1.12.1 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -161,7 +176,10 @@ mod tests {
 
         let actual = ModuleRenderer::new("golang").path(dir.path()).collect();
 
-        let expected = Some(format!("via {}", Color::Cyan.bold().paint("🐹 v1.12.1 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().cyan().bold().style("🐹 v1.12.1 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -171,7 +189,10 @@ mod tests {
         File::create(dir.path().join("Gopkg.lock"))?.sync_all()?;
 
         let actual = ModuleRenderer::new("golang").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Cyan.bold().paint("🐹 v1.12.1 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().cyan().bold().style("🐹 v1.12.1 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -181,7 +202,10 @@ mod tests {
         File::create(dir.path().join(".go-version"))?.sync_all()?;
 
         let actual = ModuleRenderer::new("golang").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Cyan.bold().paint("🐹 v1.12.1 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().cyan().bold().style("🐹 v1.12.1 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }

--- a/src/modules/haskell.rs
+++ b/src/modules/haskell.rs
@@ -88,7 +88,7 @@ fn is_stack_project(context: &Context) -> bool {
 #[cfg(test)]
 mod tests {
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use owo_colors::Style;
     use std::fs::File;
     use std::io;
     use std::io::Write;
@@ -126,7 +126,10 @@ mod tests {
             let actual = ModuleRenderer::new("haskell").path(dir.path()).collect();
             let expected = Some(format!(
                 "via {}",
-                Color::Purple.bold().paint(format!("λ {} ", resolver))
+                Style::new()
+                    .purple()
+                    .bold()
+                    .style(format!("λ {} ", resolver))
             ));
             assert_eq!(expected, actual);
             dir.close()?;
@@ -141,7 +144,10 @@ mod tests {
             let dir = tempfile::tempdir()?;
             File::create(dir.path().join(hs_file))?.sync_all()?;
             let actual = ModuleRenderer::new("haskell").path(dir.path()).collect();
-            let expected = Some(format!("via {}", Color::Purple.bold().paint("λ 9.2.1 ")));
+            let expected = Some(format!(
+                "via {}",
+                Style::new().purple().bold().style("λ 9.2.1 ")
+            ));
             assert_eq!(expected, actual);
             dir.close()?;
         }

--- a/src/modules/helm.rs
+++ b/src/modules/helm.rs
@@ -83,7 +83,7 @@ fn parse_helm_version(helm_stdout: &str) -> Option<String> {
 mod tests {
     use super::*;
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use owo_colors::Style;
     use std::fs::File;
     use std::io;
 
@@ -105,7 +105,10 @@ mod tests {
 
         let actual = ModuleRenderer::new("helm").path(dir.path()).collect();
 
-        let expected = Some(format!("via {}", Color::White.bold().paint("⎈ v3.1.1 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().white().bold().style("⎈ v3.1.1 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -117,7 +120,10 @@ mod tests {
 
         let actual = ModuleRenderer::new("helm").path(dir.path()).collect();
 
-        let expected = Some(format!("via {}", Color::White.bold().paint("⎈ v3.1.1 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().white().bold().style("⎈ v3.1.1 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }

--- a/src/modules/hg_branch.rs
+++ b/src/modules/hg_branch.rs
@@ -98,7 +98,7 @@ fn graphemes_len(text: &str) -> usize {
 
 #[cfg(test)]
 mod tests {
-    use ansi_term::{Color, Style};
+    use owo_colors::Style;
     use std::fs;
     use std::io;
     use std::path::Path;
@@ -274,7 +274,7 @@ mod tests {
             }),
             &[
                 Expect::BranchName("branch-name-131"),
-                Expect::Style(Color::Blue.underline()),
+                Expect::Style(Style::new().blue().underline()),
                 Expect::TruncationSymbol(""),
             ],
         );
@@ -297,7 +297,7 @@ mod tests {
             .collect();
 
         let mut expect_branch_name = "default";
-        let mut expect_style = Color::Purple.bold();
+        let mut expect_style = Style::new().purple().bold();
         let mut expect_symbol = "\u{e0a0}";
         let mut expect_truncation_symbol = "…";
 
@@ -325,7 +325,7 @@ mod tests {
 
         let expected = Some(format!(
             "on {} ",
-            expect_style.paint(format!(
+            expect_style.style(format!(
                 "{} {}{}",
                 expect_symbol, expect_branch_name, expect_truncation_symbol
             )),

--- a/src/modules/hostname.rs
+++ b/src/modules/hostname.rs
@@ -68,7 +68,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 #[cfg(test)]
 mod tests {
     use crate::test::ModuleRenderer;
-    use ansi_term::{Color, Style};
+    use owo_colors::Style;
     use unicode_segmentation::UnicodeSegmentation;
 
     macro_rules! get_hostname {
@@ -95,7 +95,7 @@ mod tests {
                 trim_at = ""
             })
             .collect();
-        let expected = Some(format!("{} in ", style().paint(hostname)));
+        let expected = Some(format!("{} in ", style().style(hostname)));
 
         assert_eq!(expected, actual);
     }
@@ -124,7 +124,7 @@ mod tests {
             })
             .env("SSH_CONNECTION", "something")
             .collect();
-        let expected = Some(format!("{} in ", style().paint(hostname)));
+        let expected = Some(format!("{} in ", style().style(hostname)));
 
         assert_eq!(expected, actual);
     }
@@ -139,7 +139,7 @@ mod tests {
                 trim_at = ""
             })
             .collect();
-        let expected = Some(format!("{} in ", style().paint(hostname)));
+        let expected = Some(format!("{} in ", style().style(hostname)));
 
         assert_eq!(expected, actual);
     }
@@ -157,12 +157,12 @@ mod tests {
                 trim_at = trim_at
             })
             .collect();
-        let expected = Some(format!("{} in ", style().paint(remainder)));
+        let expected = Some(format!("{} in ", style().style(remainder)));
 
         assert_eq!(expected, actual);
     }
 
     fn style() -> Style {
-        Color::Green.bold().dimmed()
+        Style::new().green().bold().dimmed()
     }
 }

--- a/src/modules/java.rs
+++ b/src/modules/java.rs
@@ -90,7 +90,7 @@ fn parse_java_version(java_version_string: &str) -> Option<String> {
 mod tests {
     use super::*;
     use crate::{test::ModuleRenderer, utils::CommandOutput};
-    use ansi_term::Color;
+    use owo_colors::Style;
     use std::fs::File;
     use std::io;
 
@@ -172,7 +172,10 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("Main.java"))?.sync_all()?;
         let actual = ModuleRenderer::new("java").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Red.dimmed().paint("☕ v13.0.2 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().red().dimmed().style("☕ v13.0.2 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -185,7 +188,10 @@ mod tests {
             stdout: "OpenJDK 64-Bit Server VM (16+14) for bsd-aarch64 JRE (16+14), built on Jan 17 2021 07:19:47 by \"brew\" with clang Apple LLVM 12.0.0 (clang-1200.0.32.28)\n".to_owned(),
             stderr: "".to_owned()
         })).path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Red.dimmed().paint("☕ v16 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().red().dimmed().style("☕ v16 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -198,7 +204,7 @@ mod tests {
             .cmd("java -Xinternalversion", None)
             .path(dir.path())
             .collect();
-        let expected = Some(format!("via {}", Color::Red.dimmed().paint("☕ ")));
+        let expected = Some(format!("via {}", Style::new().red().dimmed().style("☕ ")));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -208,7 +214,10 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("Main.class"))?.sync_all()?;
         let actual = ModuleRenderer::new("java").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Red.dimmed().paint("☕ v13.0.2 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().red().dimmed().style("☕ v13.0.2 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -218,7 +227,10 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("build.gradle"))?.sync_all()?;
         let actual = ModuleRenderer::new("java").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Red.dimmed().paint("☕ v13.0.2 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().red().dimmed().style("☕ v13.0.2 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -228,7 +240,10 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("test.jar"))?.sync_all()?;
         let actual = ModuleRenderer::new("java").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Red.dimmed().paint("☕ v13.0.2 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().red().dimmed().style("☕ v13.0.2 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -238,7 +253,10 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("pom.xml"))?.sync_all()?;
         let actual = ModuleRenderer::new("java").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Red.dimmed().paint("☕ v13.0.2 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().red().dimmed().style("☕ v13.0.2 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -248,7 +266,10 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("build.gradle.kts"))?.sync_all()?;
         let actual = ModuleRenderer::new("java").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Red.dimmed().paint("☕ v13.0.2 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().red().dimmed().style("☕ v13.0.2 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -258,7 +279,10 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("build.gradle.kts"))?.sync_all()?;
         let actual = ModuleRenderer::new("java").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Red.dimmed().paint("☕ v13.0.2 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().red().dimmed().style("☕ v13.0.2 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -268,7 +292,10 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join(".java-version"))?.sync_all()?;
         let actual = ModuleRenderer::new("java").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Red.dimmed().paint("☕ v13.0.2 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().red().dimmed().style("☕ v13.0.2 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -289,7 +316,10 @@ mod tests {
             }))
             .path(dir.path())
             .collect();
-        let expected = Some(format!("via {}", Color::Red.dimmed().paint("☕ v11.0.4 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().red().dimmed().style("☕ v11.0.4 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }

--- a/src/modules/jobs.rs
+++ b/src/modules/jobs.rs
@@ -100,7 +100,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 #[cfg(test)]
 mod test {
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use owo_colors::Style;
 
     #[test]
     fn config_blank_job_0() {
@@ -114,7 +114,7 @@ mod test {
     fn config_blank_job_1() {
         let actual = ModuleRenderer::new("jobs").jobs(1).collect();
 
-        let expected = Some(format!("{} ", Color::Blue.bold().paint("✦")));
+        let expected = Some(format!("{} ", Style::new().blue().bold().style("✦")));
         assert_eq!(expected, actual);
     }
 
@@ -122,7 +122,7 @@ mod test {
     fn config_blank_job_2() {
         let actual = ModuleRenderer::new("jobs").jobs(2).collect();
 
-        let expected = Some(format!("{} ", Color::Blue.bold().paint("✦2")));
+        let expected = Some(format!("{} ", Style::new().blue().bold().style("✦2")));
         assert_eq!(expected, actual);
     }
 
@@ -136,7 +136,7 @@ mod test {
             .jobs(1)
             .collect();
 
-        let expected = Some(format!("{} ", Color::Blue.bold().paint("✦")));
+        let expected = Some(format!("{} ", Style::new().blue().bold().style("✦")));
         assert_eq!(expected, actual);
     }
 
@@ -150,7 +150,7 @@ mod test {
             .jobs(2)
             .collect();
 
-        let expected = Some(format!("{} ", Color::Blue.bold().paint("✦2")));
+        let expected = Some(format!("{} ", Style::new().blue().bold().style("✦2")));
         assert_eq!(expected, actual);
     }
 
@@ -165,7 +165,7 @@ mod test {
             .jobs(1)
             .collect();
 
-        let expected = Some(format!("{} ", Color::Blue.bold().paint("✦")));
+        let expected = Some(format!("{} ", Style::new().blue().bold().style("✦")));
         assert_eq!(expected, actual);
     }
 
@@ -181,7 +181,7 @@ mod test {
             .jobs(1)
             .collect();
 
-        let expected = Some(format!("{} ", Color::Blue.bold().paint("✦")));
+        let expected = Some(format!("{} ", Style::new().blue().bold().style("✦")));
         assert_eq!(expected, actual);
     }
 
@@ -197,7 +197,7 @@ mod test {
             .jobs(1)
             .collect();
 
-        let expected = Some(format!("{} ", Color::Blue.bold().paint("✦1")));
+        let expected = Some(format!("{} ", Style::new().blue().bold().style("✦1")));
         assert_eq!(expected, actual);
     }
 
@@ -212,7 +212,7 @@ mod test {
             .jobs(2)
             .collect();
 
-        let expected = Some(format!("{} ", Color::Blue.bold().paint("✦2")));
+        let expected = Some(format!("{} ", Style::new().blue().bold().style("✦2")));
         assert_eq!(expected, actual);
     }
 
@@ -226,7 +226,7 @@ mod test {
             .jobs(2)
             .collect();
 
-        let expected = Some(format!("{} ", Color::Blue.bold().paint("✦")));
+        let expected = Some(format!("{} ", Style::new().blue().bold().style("✦")));
         assert_eq!(expected, actual);
     }
 
@@ -240,7 +240,7 @@ mod test {
             .jobs(2)
             .collect();
 
-        let expected = Some(format!("{} ", Color::Blue.bold().paint("✦2")));
+        let expected = Some(format!("{} ", Style::new().blue().bold().style("✦2")));
         assert_eq!(expected, actual);
     }
 
@@ -255,7 +255,7 @@ mod test {
             .jobs(2)
             .collect();
 
-        let expected = Some(format!("{} ", Color::Blue.bold().paint("2")));
+        let expected = Some(format!("{} ", Style::new().blue().bold().style("2")));
         assert_eq!(expected, actual);
     }
 
@@ -269,7 +269,7 @@ mod test {
             .jobs(3)
             .collect();
 
-        let expected = Some(format!("{} ", Color::Blue.bold().paint("✦3")));
+        let expected = Some(format!("{} ", Style::new().blue().bold().style("✦3")));
         assert_eq!(expected, actual);
     }
 
@@ -284,7 +284,7 @@ mod test {
             .jobs(0)
             .collect();
 
-        let expected = Some(format!("{} ", Color::Blue.bold().paint("✦0")));
+        let expected = Some(format!("{} ", Style::new().blue().bold().style("✦0")));
         assert_eq!(expected, actual);
     }
 
@@ -299,7 +299,7 @@ mod test {
             .jobs(1)
             .collect();
 
-        let expected = Some(format!("{} ", Color::Blue.bold().paint("✦1")));
+        let expected = Some(format!("{} ", Style::new().blue().bold().style("✦1")));
         assert_eq!(expected, actual);
     }
 
@@ -313,7 +313,7 @@ mod test {
             .jobs(0)
             .collect();
 
-        let expected = Some(format!("{} ", Color::Blue.bold().paint("✦0")));
+        let expected = Some(format!("{} ", Style::new().blue().bold().style("✦0")));
         assert_eq!(expected, actual);
     }
 
@@ -327,7 +327,7 @@ mod test {
             .jobs(1)
             .collect();
 
-        let expected = Some(format!("{} ", Color::Blue.bold().paint("✦1")));
+        let expected = Some(format!("{} ", Style::new().blue().bold().style("✦1")));
         assert_eq!(expected, actual);
     }
 }

--- a/src/modules/julia.rs
+++ b/src/modules/julia.rs
@@ -76,7 +76,7 @@ fn parse_julia_version(julia_stdout: &str) -> Option<String> {
 mod tests {
     use super::*;
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use owo_colors::Style;
     use std::fs::File;
     use std::io;
 
@@ -98,7 +98,10 @@ mod tests {
 
         let actual = ModuleRenderer::new("julia").path(dir.path()).collect();
 
-        let expected = Some(format!("via {}", Color::Purple.bold().paint("ஃ v1.4.0 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().purple().bold().style("ஃ v1.4.0 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -110,7 +113,10 @@ mod tests {
 
         let actual = ModuleRenderer::new("julia").path(dir.path()).collect();
 
-        let expected = Some(format!("via {}", Color::Purple.bold().paint("ஃ v1.4.0 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().purple().bold().style("ஃ v1.4.0 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -122,7 +128,10 @@ mod tests {
 
         let actual = ModuleRenderer::new("julia").path(dir.path()).collect();
 
-        let expected = Some(format!("via {}", Color::Purple.bold().paint("ஃ v1.4.0 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().purple().bold().style("ஃ v1.4.0 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }

--- a/src/modules/kotlin.rs
+++ b/src/modules/kotlin.rs
@@ -82,7 +82,7 @@ fn parse_kotlin_version(kotlin_stdout: &str) -> Option<String> {
 mod tests {
     use super::*;
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use owo_colors::Style;
     use std::fs::File;
     use std::io;
 
@@ -100,7 +100,10 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("main.kt"))?.sync_all()?;
         let actual = ModuleRenderer::new("kotlin").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Blue.bold().paint("🅺 v1.4.21 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().blue().bold().style("🅺 v1.4.21 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -110,7 +113,10 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("main.kts"))?.sync_all()?;
         let actual = ModuleRenderer::new("kotlin").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Blue.bold().paint("🅺 v1.4.21 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().blue().bold().style("🅺 v1.4.21 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -130,7 +136,10 @@ mod tests {
             .config(config)
             .collect();
 
-        let expected = Some(format!("via {}", Color::Blue.bold().paint("🅺 v1.4.21 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().blue().bold().style("🅺 v1.4.21 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -150,7 +159,10 @@ mod tests {
             .config(config)
             .collect();
 
-        let expected = Some(format!("via {}", Color::Blue.bold().paint("🅺 v1.4.21 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().blue().bold().style("🅺 v1.4.21 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }

--- a/src/modules/kubernetes.rs
+++ b/src/modules/kubernetes.rs
@@ -186,7 +186,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 #[cfg(test)]
 mod tests {
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use owo_colors::Style;
     use std::env;
     use std::fs::File;
     use std::io::{self, Write};
@@ -254,7 +254,10 @@ users: []
             .config(config)
             .collect();
 
-        let expected = Some(format!("{} in ", Color::Cyan.bold().paint(expected)));
+        let expected = Some(format!(
+            "{} in ",
+            Style::new().cyan().bold().style(expected)
+        ));
         assert_eq!(expected, actual);
 
         dir.close()
@@ -352,7 +355,7 @@ users: []
 
         let expected = Some(format!(
             "{} in ",
-            Color::Cyan.bold().paint("☸ test_context")
+            Style::new().cyan().bold().style("☸ test_context")
         ));
         assert_eq!(expected, actual);
 
@@ -395,7 +398,10 @@ users: []
 
         let expected = Some(format!(
             "{} in ",
-            Color::Cyan.bold().paint("☸ test_context (test_namespace)")
+            Style::new()
+                .cyan()
+                .bold()
+                .style("☸ test_context (test_namespace)")
         ));
         assert_eq!(expected, actual);
 
@@ -443,7 +449,10 @@ users: []
 
         let expected = Some(format!(
             "{} in ",
-            Color::Cyan.bold().paint("☸ test_context (test_namespace)")
+            Style::new()
+                .cyan()
+                .bold()
+                .style("☸ test_context (test_namespace)")
         ));
         assert_eq!(expected, actual);
 
@@ -521,7 +530,10 @@ users: []
 
         let expected = Some(format!(
             "{} in ",
-            Color::Cyan.bold().paint("☸ test_context (test_namespace)")
+            Style::new()
+                .cyan()
+                .bold()
+                .style("☸ test_context (test_namespace)")
         ));
         assert_eq!(expected, actual_cc_first);
         assert_eq!(expected, actual_ctx_first);

--- a/src/modules/localip.rs
+++ b/src/modules/localip.rs
@@ -61,7 +61,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 #[cfg(test)]
 mod tests {
     use crate::test::ModuleRenderer;
-    use ansi_term::{Color, Style};
+    use owo_colors::Style;
 
     macro_rules! get_localip {
         () => {
@@ -95,7 +95,7 @@ mod tests {
                 disabled = false
             })
             .collect();
-        let expected = Some(format!("{} ", style().paint(localip)));
+        let expected = Some(format!("{} ", style().style(localip)));
 
         assert_eq!(expected, actual);
     }
@@ -126,7 +126,7 @@ mod tests {
             })
             .env("SSH_CONNECTION", "something")
             .collect();
-        let expected = Some(format!("{} ", style().paint(localip)));
+        let expected = Some(format!("{} ", style().style(localip)));
 
         assert_eq!(expected, actual);
     }
@@ -142,6 +142,6 @@ mod tests {
     }
 
     fn style() -> Style {
-        Color::Yellow.bold()
+        Style::new().yellow().bold()
     }
 }

--- a/src/modules/lua.rs
+++ b/src/modules/lua.rs
@@ -80,7 +80,7 @@ fn parse_lua_version(lua_version: &str) -> Option<String> {
 mod tests {
     use super::*;
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use owo_colors::Style;
     use std::fs::{self, File};
     use std::io;
 
@@ -98,7 +98,10 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("main.lua"))?.sync_all()?;
         let actual = ModuleRenderer::new("lua").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Blue.bold().paint("🌙 v5.4.0 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().blue().bold().style("🌙 v5.4.0 "))
+        );
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -109,7 +112,10 @@ mod tests {
         File::create(dir.path().join(".lua-version"))?.sync_all()?;
 
         let actual = ModuleRenderer::new("lua").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Blue.bold().paint("🌙 v5.4.0 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().blue().bold().style("🌙 v5.4.0 "))
+        );
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -121,7 +127,10 @@ mod tests {
         fs::create_dir_all(&lua_dir)?;
 
         let actual = ModuleRenderer::new("lua").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Blue.bold().paint("🌙 v5.4.0 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().blue().bold().style("🌙 v5.4.0 "))
+        );
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -141,7 +150,10 @@ mod tests {
             .config(config)
             .collect();
 
-        let expected = Some(format!("via {}", Color::Blue.bold().paint("🌙 v2.0.5 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().blue().bold().style("🌙 v2.0.5 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }

--- a/src/modules/lua.rs
+++ b/src/modules/lua.rs
@@ -100,8 +100,8 @@ mod tests {
         let actual = ModuleRenderer::new("lua").path(dir.path()).collect();
         let expected = Some(format!(
             "via {}",
-            Style::new().blue().bold().style("🌙 v5.4.0 "))
-        );
+            Style::new().blue().bold().style("🌙 v5.4.0 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -114,8 +114,8 @@ mod tests {
         let actual = ModuleRenderer::new("lua").path(dir.path()).collect();
         let expected = Some(format!(
             "via {}",
-            Style::new().blue().bold().style("🌙 v5.4.0 "))
-        );
+            Style::new().blue().bold().style("🌙 v5.4.0 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -129,8 +129,8 @@ mod tests {
         let actual = ModuleRenderer::new("lua").path(dir.path()).collect();
         let expected = Some(format!(
             "via {}",
-            Style::new().blue().bold().style("🌙 v5.4.0 "))
-        );
+            Style::new().blue().bold().style("🌙 v5.4.0 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }

--- a/src/modules/nim.rs
+++ b/src/modules/nim.rs
@@ -71,7 +71,7 @@ fn parse_nim_version(version_cmd_output: &str) -> Option<&str> {
 mod tests {
     use super::parse_nim_version;
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use owo_colors::Style;
     use std::fs::File;
     use std::io;
 
@@ -113,7 +113,10 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("main.nimble"))?.sync_all()?;
         let actual = ModuleRenderer::new("nim").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Yellow.bold().paint("👑 v1.2.0 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().yellow().bold().style("👑 v1.2.0 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -123,7 +126,10 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("main.nim"))?.sync_all()?;
         let actual = ModuleRenderer::new("nim").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Yellow.bold().paint("👑 v1.2.0 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().yellow().bold().style("👑 v1.2.0 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -133,7 +139,10 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("main.nims"))?.sync_all()?;
         let actual = ModuleRenderer::new("nim").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Yellow.bold().paint("👑 v1.2.0 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().yellow().bold().style("👑 v1.2.0 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -143,7 +152,10 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("cfg.nim"))?.sync_all()?;
         let actual = ModuleRenderer::new("nim").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Yellow.bold().paint("👑 v1.2.0 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().yellow().bold().style("👑 v1.2.0 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }

--- a/src/modules/nix_shell.rs
+++ b/src/modules/nix_shell.rs
@@ -63,7 +63,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 #[cfg(test)]
 mod tests {
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use owo_colors::Style;
 
     #[test]
     fn no_env_variables() {
@@ -88,7 +88,10 @@ mod tests {
         let actual = ModuleRenderer::new("nix_shell")
             .env("IN_NIX_SHELL", "pure")
             .collect();
-        let expected = Some(format!("via {} ", Color::Blue.bold().paint("❄️  pure")));
+        let expected = Some(format!(
+            "via {} ",
+            Style::new().blue().bold().style("❄️  pure")
+        ));
 
         assert_eq!(expected, actual);
     }
@@ -98,7 +101,10 @@ mod tests {
         let actual = ModuleRenderer::new("nix_shell")
             .env("IN_NIX_SHELL", "impure")
             .collect();
-        let expected = Some(format!("via {} ", Color::Blue.bold().paint("❄️  impure")));
+        let expected = Some(format!(
+            "via {} ",
+            Style::new().blue().bold().style("❄️  impure")
+        ));
 
         assert_eq!(expected, actual);
     }
@@ -111,7 +117,7 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "via {} ",
-            Color::Blue.bold().paint("❄️  pure (starship)")
+            Style::new().blue().bold().style("❄️  pure (starship)")
         ));
 
         assert_eq!(expected, actual);
@@ -125,7 +131,7 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "via {} ",
-            Color::Blue.bold().paint("❄️  impure (starship)")
+            Style::new().blue().bold().style("❄️  impure (starship)")
         ));
 
         assert_eq!(expected, actual);

--- a/src/modules/nodejs.rs
+++ b/src/modules/nodejs.rs
@@ -119,7 +119,7 @@ fn check_engines_version(nodejs_version: &str, engines_version: Option<String>) 
 #[cfg(test)]
 mod tests {
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use owo_colors::Style;
     use std::fs::{self, File};
     use std::io;
     use std::io::Write;
@@ -139,7 +139,10 @@ mod tests {
         File::create(dir.path().join("package.json"))?.sync_all()?;
 
         let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Green.bold().paint(" v12.0.0 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().green().bold().style(" v12.0.0 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -163,7 +166,10 @@ mod tests {
         File::create(dir.path().join(".node-version"))?.sync_all()?;
 
         let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Green.bold().paint(" v12.0.0 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().green().bold().style(" v12.0.0 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -174,7 +180,10 @@ mod tests {
         File::create(dir.path().join(".nvmrc"))?.sync_all()?;
 
         let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Green.bold().paint(" v12.0.0 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().green().bold().style(" v12.0.0 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -185,7 +194,10 @@ mod tests {
         File::create(dir.path().join("index.js"))?.sync_all()?;
 
         let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Green.bold().paint(" v12.0.0 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().green().bold().style(" v12.0.0 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -196,7 +208,10 @@ mod tests {
         File::create(dir.path().join("index.mjs"))?.sync_all()?;
 
         let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Green.bold().paint(" v12.0.0 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().green().bold().style(" v12.0.0 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -207,7 +222,10 @@ mod tests {
         File::create(dir.path().join("index.cjs"))?.sync_all()?;
 
         let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Green.bold().paint(" v12.0.0 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().green().bold().style(" v12.0.0 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -218,7 +236,10 @@ mod tests {
         File::create(dir.path().join("index.ts"))?.sync_all()?;
 
         let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Green.bold().paint(" v12.0.0 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().green().bold().style(" v12.0.0 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -230,7 +251,10 @@ mod tests {
         fs::create_dir_all(&node_modules)?;
 
         let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Green.bold().paint(" v12.0.0 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().green().bold().style(" v12.0.0 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -249,7 +273,10 @@ mod tests {
         file.sync_all()?;
 
         let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Green.bold().paint(" v12.0.0 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().green().bold().style(" v12.0.0 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -268,7 +295,10 @@ mod tests {
         file.sync_all()?;
 
         let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Red.bold().paint(" v12.0.0 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().red().bold().style(" v12.0.0 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }

--- a/src/modules/ocaml.rs
+++ b/src/modules/ocaml.rs
@@ -112,7 +112,7 @@ fn parse_opam_switch(opam_switch: &str) -> Option<OpamSwitch> {
 mod tests {
     use super::{parse_opam_switch, SwitchType};
     use crate::{test::ModuleRenderer, utils::CommandOutput};
-    use ansi_term::Color;
+    use owo_colors::Style;
     use std::fs::{self, File};
     use std::io;
 
@@ -147,7 +147,7 @@ mod tests {
         let actual = ModuleRenderer::new("ocaml").path(dir.path()).collect();
         let expected = Some(format!(
             "via {}",
-            Color::Yellow.bold().paint("🐫 v4.10.0 (default) ")
+            Style::new().yellow().bold().style("🐫 v4.10.0 (default) ")
         ));
         assert_eq!(expected, actual);
         dir.close()
@@ -161,7 +161,7 @@ mod tests {
         let actual = ModuleRenderer::new("ocaml").path(dir.path()).collect();
         let expected = Some(format!(
             "via {}",
-            Color::Yellow.bold().paint("🐫 v4.10.0 (default) ")
+            Style::new().yellow().bold().style("🐫 v4.10.0 (default) ")
         ));
         assert_eq!(expected, actual);
         dir.close()
@@ -179,7 +179,7 @@ mod tests {
         let actual = ModuleRenderer::new("ocaml").path(dir.path()).collect();
         let expected = Some(format!(
             "via {}",
-            Color::Yellow.bold().paint("🐫 v4.08.1 (default) ")
+            Style::new().yellow().bold().style("🐫 v4.08.1 (default) ")
         ));
         assert_eq!(expected, actual);
         dir.close()
@@ -193,7 +193,7 @@ mod tests {
         let actual = ModuleRenderer::new("ocaml").path(dir.path()).collect();
         let expected = Some(format!(
             "via {}",
-            Color::Yellow.bold().paint("🐫 v4.10.0 (default) ")
+            Style::new().yellow().bold().style("🐫 v4.10.0 (default) ")
         ));
         assert_eq!(expected, actual);
         dir.close()
@@ -207,7 +207,7 @@ mod tests {
         let actual = ModuleRenderer::new("ocaml").path(dir.path()).collect();
         let expected = Some(format!(
             "via {}",
-            Color::Yellow.bold().paint("🐫 v4.10.0 (default) ")
+            Style::new().yellow().bold().style("🐫 v4.10.0 (default) ")
         ));
         assert_eq!(expected, actual);
         dir.close()
@@ -221,7 +221,7 @@ mod tests {
         let actual = ModuleRenderer::new("ocaml").path(dir.path()).collect();
         let expected = Some(format!(
             "via {}",
-            Color::Yellow.bold().paint("🐫 v4.10.0 (default) ")
+            Style::new().yellow().bold().style("🐫 v4.10.0 (default) ")
         ));
         assert_eq!(expected, actual);
         dir.close()
@@ -235,7 +235,7 @@ mod tests {
         let actual = ModuleRenderer::new("ocaml").path(dir.path()).collect();
         let expected = Some(format!(
             "via {}",
-            Color::Yellow.bold().paint("🐫 v4.10.0 (default) ")
+            Style::new().yellow().bold().style("🐫 v4.10.0 (default) ")
         ));
         assert_eq!(expected, actual);
         dir.close()
@@ -249,7 +249,7 @@ mod tests {
         let actual = ModuleRenderer::new("ocaml").path(dir.path()).collect();
         let expected = Some(format!(
             "via {}",
-            Color::Yellow.bold().paint("🐫 v4.10.0 (default) ")
+            Style::new().yellow().bold().style("🐫 v4.10.0 (default) ")
         ));
         assert_eq!(expected, actual);
         dir.close()
@@ -263,7 +263,7 @@ mod tests {
         let actual = ModuleRenderer::new("ocaml").path(dir.path()).collect();
         let expected = Some(format!(
             "via {}",
-            Color::Yellow.bold().paint("🐫 v4.10.0 (default) ")
+            Style::new().yellow().bold().style("🐫 v4.10.0 (default) ")
         ));
         assert_eq!(expected, actual);
         dir.close()
@@ -277,7 +277,7 @@ mod tests {
         let actual = ModuleRenderer::new("ocaml").path(dir.path()).collect();
         let expected = Some(format!(
             "via {}",
-            Color::Yellow.bold().paint("🐫 v4.10.0 (default) ")
+            Style::new().yellow().bold().style("🐫 v4.10.0 (default) ")
         ));
         assert_eq!(expected, actual);
         dir.close()
@@ -291,7 +291,7 @@ mod tests {
         let actual = ModuleRenderer::new("ocaml").path(dir.path()).collect();
         let expected = Some(format!(
             "via {}",
-            Color::Yellow.bold().paint("🐫 v4.10.0 (default) ")
+            Style::new().yellow().bold().style("🐫 v4.10.0 (default) ")
         ));
         assert_eq!(expected, actual);
         dir.close()
@@ -305,7 +305,7 @@ mod tests {
         let actual = ModuleRenderer::new("ocaml").path(dir.path()).collect();
         let expected = Some(format!(
             "via {}",
-            Color::Yellow.bold().paint("🐫 v4.10.0 (default) ")
+            Style::new().yellow().bold().style("🐫 v4.10.0 (default) ")
         ));
         assert_eq!(expected, actual);
         dir.close()
@@ -326,7 +326,10 @@ mod tests {
             )
             .path(dir.path())
             .collect();
-        let expected = Some(format!("via {}", Color::Yellow.bold().paint("🐫 v4.10.0 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().yellow().bold().style("🐫 v4.10.0 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -348,9 +351,10 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "via {}",
-            Color::Yellow
+            Style::new()
+                .yellow()
                 .bold()
-                .paint("🐫 v4.10.0 (ocaml-base-compiler.4.10.0) ")
+                .style("🐫 v4.10.0 (ocaml-base-compiler.4.10.0) ")
         ));
         assert_eq!(expected, actual);
         dir.close()
@@ -377,9 +381,10 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "via {}",
-            Color::Yellow
+            Style::new()
+                .yellow()
                 .bold()
-                .paint("🐫 v4.10.0 (g/ocaml-base-compiler.4.10.0) ")
+                .style("🐫 v4.10.0 (g/ocaml-base-compiler.4.10.0) ")
         ));
         assert_eq!(expected, actual);
         dir.close()
@@ -402,7 +407,10 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "via {}",
-            Color::Yellow.bold().paint("🐫 v4.10.0 (*my-project) ")
+            Style::new()
+                .yellow()
+                .bold()
+                .style("🐫 v4.10.0 (*my-project) ")
         ));
         assert_eq!(expected, actual);
         dir.close()
@@ -429,7 +437,10 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "via {}",
-            Color::Yellow.bold().paint("🐫 v4.10.0 (^my-project) ")
+            Style::new()
+                .yellow()
+                .bold()
+                .style("🐫 v4.10.0 (^my-project) ")
         ));
         assert_eq!(expected, actual);
         dir.close()

--- a/src/modules/openstack.rs
+++ b/src/modules/openstack.rs
@@ -86,7 +86,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 #[cfg(test)]
 mod tests {
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use owo_colors::Style;
     use std::fs::File;
     use std::io::{self, Write};
 
@@ -115,7 +115,7 @@ clouds:
             .collect();
         let expected = Some(format!(
             "on {} ",
-            Color::Yellow.bold().paint("☁️  corp(testproject)")
+            Style::new().yellow().bold().style("☁️  corp(testproject)")
         ));
 
         assert_eq!(actual, expected);
@@ -139,7 +139,10 @@ dummy_yaml
                 [openstack]
             })
             .collect();
-        let expected = Some(format!("on {} ", Color::Yellow.bold().paint("☁️  test")));
+        let expected = Some(format!(
+            "on {} ",
+            Style::new().yellow().bold().style("☁️  test")
+        ));
 
         assert_eq!(actual, expected);
         dir.close()
@@ -159,7 +162,10 @@ dummy_yaml
                 [openstack]
             })
             .collect();
-        let expected = Some(format!("on {} ", Color::Yellow.bold().paint("☁️  test")));
+        let expected = Some(format!(
+            "on {} ",
+            Style::new().yellow().bold().style("☁️  test")
+        ));
 
         assert_eq!(actual, expected);
         dir.close()

--- a/src/modules/package.rs
+++ b/src/modules/package.rs
@@ -286,7 +286,7 @@ fn format_version(version: &str, version_format: &str) -> Option<String> {
 mod tests {
     use super::*;
     use crate::{test::ModuleRenderer, utils::CommandOutput};
-    use ansi_term::Color;
+    use owo_colors::{Style, XtermColors};
     use std::fs::File;
     use std::io;
     use std::io::Write;
@@ -390,7 +390,10 @@ license = "MIT"
 
         let expected = Some(format!(
             "is {} ",
-            Color::Fixed(208).bold().paint(format!("📦 {}", "v0.1.0"))
+            Style::new()
+                .color(XtermColors::from(208))
+                .bold()
+                .style(format!("📦 {}", "v0.1.0"))
         ));
 
         assert_eq!(actual, expected);
@@ -1185,7 +1188,10 @@ environment:
         let text = String::from(contains.unwrap_or(""));
         let expected = Some(format!(
             "is {} ",
-            Color::Fixed(208).bold().paint(format!("📦 {}", text))
+            Style::new()
+                .color(XtermColors::from(208))
+                .bold()
+                .style(format!("📦 {}", text))
         ));
 
         if contains.is_some() {

--- a/src/modules/perl.rs
+++ b/src/modules/perl.rs
@@ -60,7 +60,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 #[cfg(test)]
 mod tests {
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use owo_colors::{Style, XtermColors};
     use std::fs::File;
     use std::io;
 
@@ -84,7 +84,7 @@ mod tests {
 
         let expected = Some(format!(
             "via {}",
-            Color::Fixed(149).bold().paint("🐪 v5.26.1 ")
+            Style::new().color(XtermColors::from(149)).bold().style("🐪 v5.26.1 ")
         ));
         assert_eq!(expected, actual);
         dir.close()
@@ -99,7 +99,7 @@ mod tests {
 
         let expected = Some(format!(
             "via {}",
-            Color::Fixed(149).bold().paint("🐪 v5.26.1 ")
+            Style::new().color(XtermColors::from(149)).bold().style("🐪 v5.26.1 ")
         ));
         assert_eq!(expected, actual);
         dir.close()
@@ -114,7 +114,7 @@ mod tests {
 
         let expected = Some(format!(
             "via {}",
-            Color::Fixed(149).bold().paint("🐪 v5.26.1 ")
+            Style::new().color(XtermColors::from(149)).bold().style("🐪 v5.26.1 ")
         ));
         assert_eq!(expected, actual);
         dir.close()
@@ -129,7 +129,7 @@ mod tests {
 
         let expected = Some(format!(
             "via {}",
-            Color::Fixed(149).bold().paint("🐪 v5.26.1 ")
+            Style::new().color(XtermColors::from(149)).bold().style("🐪 v5.26.1 ")
         ));
         assert_eq!(expected, actual);
         dir.close()
@@ -144,7 +144,7 @@ mod tests {
 
         let expected = Some(format!(
             "via {}",
-            Color::Fixed(149).bold().paint("🐪 v5.26.1 ")
+            Style::new().color(XtermColors::from(149)).bold().style("🐪 v5.26.1 ")
         ));
         assert_eq!(expected, actual);
         dir.close()
@@ -159,7 +159,7 @@ mod tests {
 
         let expected = Some(format!(
             "via {}",
-            Color::Fixed(149).bold().paint("🐪 v5.26.1 ")
+            Style::new().color(XtermColors::from(149)).bold().style("🐪 v5.26.1 ")
         ));
         assert_eq!(expected, actual);
         dir.close()
@@ -174,7 +174,7 @@ mod tests {
 
         let expected = Some(format!(
             "via {}",
-            Color::Fixed(149).bold().paint("🐪 v5.26.1 ")
+            Style::new().color(XtermColors::from(149)).bold().style("🐪 v5.26.1 ")
         ));
         assert_eq!(expected, actual);
         dir.close()
@@ -189,7 +189,7 @@ mod tests {
 
         let expected = Some(format!(
             "via {}",
-            Color::Fixed(149).bold().paint("🐪 v5.26.1 ")
+            Style::new().color(XtermColors::from(149)).bold().style("🐪 v5.26.1 ")
         ));
         assert_eq!(expected, actual);
         dir.close()
@@ -204,7 +204,7 @@ mod tests {
 
         let expected = Some(format!(
             "via {}",
-            Color::Fixed(149).bold().paint("🐪 v5.26.1 ")
+            Style::new().color(XtermColors::from(149)).bold().style("🐪 v5.26.1 ")
         ));
         assert_eq!(expected, actual);
         dir.close()
@@ -219,7 +219,7 @@ mod tests {
 
         let expected = Some(format!(
             "via {}",
-            Color::Fixed(149).bold().paint("🐪 v5.26.1 ")
+            Style::new().color(XtermColors::from(149)).bold().style("🐪 v5.26.1 ")
         ));
         assert_eq!(expected, actual);
         dir.close()

--- a/src/modules/perl.rs
+++ b/src/modules/perl.rs
@@ -84,7 +84,10 @@ mod tests {
 
         let expected = Some(format!(
             "via {}",
-            Style::new().color(XtermColors::from(149)).bold().style("🐪 v5.26.1 ")
+            Style::new()
+                .color(XtermColors::from(149))
+                .bold()
+                .style("🐪 v5.26.1 ")
         ));
         assert_eq!(expected, actual);
         dir.close()
@@ -99,7 +102,10 @@ mod tests {
 
         let expected = Some(format!(
             "via {}",
-            Style::new().color(XtermColors::from(149)).bold().style("🐪 v5.26.1 ")
+            Style::new()
+                .color(XtermColors::from(149))
+                .bold()
+                .style("🐪 v5.26.1 ")
         ));
         assert_eq!(expected, actual);
         dir.close()
@@ -114,7 +120,10 @@ mod tests {
 
         let expected = Some(format!(
             "via {}",
-            Style::new().color(XtermColors::from(149)).bold().style("🐪 v5.26.1 ")
+            Style::new()
+                .color(XtermColors::from(149))
+                .bold()
+                .style("🐪 v5.26.1 ")
         ));
         assert_eq!(expected, actual);
         dir.close()
@@ -129,7 +138,10 @@ mod tests {
 
         let expected = Some(format!(
             "via {}",
-            Style::new().color(XtermColors::from(149)).bold().style("🐪 v5.26.1 ")
+            Style::new()
+                .color(XtermColors::from(149))
+                .bold()
+                .style("🐪 v5.26.1 ")
         ));
         assert_eq!(expected, actual);
         dir.close()
@@ -144,7 +156,10 @@ mod tests {
 
         let expected = Some(format!(
             "via {}",
-            Style::new().color(XtermColors::from(149)).bold().style("🐪 v5.26.1 ")
+            Style::new()
+                .color(XtermColors::from(149))
+                .bold()
+                .style("🐪 v5.26.1 ")
         ));
         assert_eq!(expected, actual);
         dir.close()
@@ -159,7 +174,10 @@ mod tests {
 
         let expected = Some(format!(
             "via {}",
-            Style::new().color(XtermColors::from(149)).bold().style("🐪 v5.26.1 ")
+            Style::new()
+                .color(XtermColors::from(149))
+                .bold()
+                .style("🐪 v5.26.1 ")
         ));
         assert_eq!(expected, actual);
         dir.close()
@@ -174,7 +192,10 @@ mod tests {
 
         let expected = Some(format!(
             "via {}",
-            Style::new().color(XtermColors::from(149)).bold().style("🐪 v5.26.1 ")
+            Style::new()
+                .color(XtermColors::from(149))
+                .bold()
+                .style("🐪 v5.26.1 ")
         ));
         assert_eq!(expected, actual);
         dir.close()
@@ -189,7 +210,10 @@ mod tests {
 
         let expected = Some(format!(
             "via {}",
-            Style::new().color(XtermColors::from(149)).bold().style("🐪 v5.26.1 ")
+            Style::new()
+                .color(XtermColors::from(149))
+                .bold()
+                .style("🐪 v5.26.1 ")
         ));
         assert_eq!(expected, actual);
         dir.close()
@@ -204,7 +228,10 @@ mod tests {
 
         let expected = Some(format!(
             "via {}",
-            Style::new().color(XtermColors::from(149)).bold().style("🐪 v5.26.1 ")
+            Style::new()
+                .color(XtermColors::from(149))
+                .bold()
+                .style("🐪 v5.26.1 ")
         ));
         assert_eq!(expected, actual);
         dir.close()
@@ -219,7 +246,10 @@ mod tests {
 
         let expected = Some(format!(
             "via {}",
-            Style::new().color(XtermColors::from(149)).bold().style("🐪 v5.26.1 ")
+            Style::new()
+                .color(XtermColors::from(149))
+                .bold()
+                .style("🐪 v5.26.1 ")
         ));
         assert_eq!(expected, actual);
         dir.close()

--- a/src/modules/php.rs
+++ b/src/modules/php.rs
@@ -59,7 +59,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 #[cfg(test)]
 mod tests {
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use owo_colors::{Style, XtermColors};
     use std::fs::File;
     use std::io;
 
@@ -83,7 +83,7 @@ mod tests {
 
         let expected = Some(format!(
             "via {}",
-            Color::Fixed(147).bold().paint("🐘 v7.3.8 ")
+            Style::new().color(XtermColors::from(147)).bold().style("🐘 v7.3.8 ")
         ));
         assert_eq!(expected, actual);
         dir.close()
@@ -98,7 +98,7 @@ mod tests {
 
         let expected = Some(format!(
             "via {}",
-            Color::Fixed(147).bold().paint("🐘 v7.3.8 ")
+            Style::new().color(XtermColors::from(147)).bold().style("🐘 v7.3.8 ")
         ));
         assert_eq!(expected, actual);
         dir.close()
@@ -113,7 +113,7 @@ mod tests {
 
         let expected = Some(format!(
             "via {}",
-            Color::Fixed(147).bold().paint("🐘 v7.3.8 ")
+            Style::new().color(XtermColors::from(147)).bold().style("🐘 v7.3.8 ")
         ));
         assert_eq!(expected, actual);
         dir.close()

--- a/src/modules/php.rs
+++ b/src/modules/php.rs
@@ -83,7 +83,10 @@ mod tests {
 
         let expected = Some(format!(
             "via {}",
-            Style::new().color(XtermColors::from(147)).bold().style("🐘 v7.3.8 ")
+            Style::new()
+                .color(XtermColors::from(147))
+                .bold()
+                .style("🐘 v7.3.8 ")
         ));
         assert_eq!(expected, actual);
         dir.close()
@@ -98,7 +101,10 @@ mod tests {
 
         let expected = Some(format!(
             "via {}",
-            Style::new().color(XtermColors::from(147)).bold().style("🐘 v7.3.8 ")
+            Style::new()
+                .color(XtermColors::from(147))
+                .bold()
+                .style("🐘 v7.3.8 ")
         ));
         assert_eq!(expected, actual);
         dir.close()
@@ -113,7 +119,10 @@ mod tests {
 
         let expected = Some(format!(
             "via {}",
-            Style::new().color(XtermColors::from(147)).bold().style("🐘 v7.3.8 ")
+            Style::new()
+                .color(XtermColors::from(147))
+                .bold()
+                .style("🐘 v7.3.8 ")
         ));
         assert_eq!(expected, actual);
         dir.close()

--- a/src/modules/pulumi.rs
+++ b/src/modules/pulumi.rs
@@ -199,7 +199,7 @@ mod tests {
     use super::*;
     use crate::context::Target;
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use owo_colors::{Style, XtermColors};
 
     #[test]
     fn pulumi_version_release() {
@@ -257,7 +257,10 @@ mod tests {
             })
             .collect();
         dir.close()?;
-        let expected = format!("with {} ", Color::Fixed(5).bold().paint("v1.2.3-ver"));
+        let expected = format!(
+            "with {} ",
+            Style::new().color(XtermColors::from(5)).bold().style("v1.2.3-ver")
+        );
 
         assert_eq!(expected, rendered.expect("a result"));
         Ok(())
@@ -324,7 +327,7 @@ mod tests {
             .collect();
         let expected = format!(
             "via {} ",
-            Color::Fixed(5).bold().paint(" test-user@launch")
+            Style::new().color(XtermColors::from(5)).bold().style(" test-user@launch")
         );
         assert_eq!(expected, rendered.expect("a result"));
         dir.close()?;
@@ -384,7 +387,7 @@ mod tests {
             })
             .env("HOME", root.to_str().unwrap())
             .collect();
-        let expected = format!("via {} ", Color::Fixed(5).bold().paint(" launch"));
+        let expected = format!("via {} ", Style::new().color(XtermColors::from(5)).bold().style(" launch"));
         assert_eq!(expected, rendered.expect("a result"));
         dir.close()?;
         Ok(())
@@ -404,7 +407,7 @@ mod tests {
                 format = "in [$symbol($stack)]($style) "
             })
             .collect();
-        let expected = format!("in {} ", Color::Fixed(5).bold().paint(" "));
+        let expected = format!("in {} ", Style::new().color(XtermColors::from(5)).bold().style(" "));
         assert_eq!(expected, rendered.expect("a result"));
         dir.close()?;
         Ok(())

--- a/src/modules/pulumi.rs
+++ b/src/modules/pulumi.rs
@@ -259,7 +259,10 @@ mod tests {
         dir.close()?;
         let expected = format!(
             "with {} ",
-            Style::new().color(XtermColors::from(5)).bold().style("v1.2.3-ver")
+            Style::new()
+                .color(XtermColors::from(5))
+                .bold()
+                .style("v1.2.3-ver")
         );
 
         assert_eq!(expected, rendered.expect("a result"));
@@ -327,7 +330,10 @@ mod tests {
             .collect();
         let expected = format!(
             "via {} ",
-            Style::new().color(XtermColors::from(5)).bold().style(" test-user@launch")
+            Style::new()
+                .color(XtermColors::from(5))
+                .bold()
+                .style(" test-user@launch")
         );
         assert_eq!(expected, rendered.expect("a result"));
         dir.close()?;
@@ -387,7 +393,13 @@ mod tests {
             })
             .env("HOME", root.to_str().unwrap())
             .collect();
-        let expected = format!("via {} ", Style::new().color(XtermColors::from(5)).bold().style(" launch"));
+        let expected = format!(
+            "via {} ",
+            Style::new()
+                .color(XtermColors::from(5))
+                .bold()
+                .style(" launch")
+        );
         assert_eq!(expected, rendered.expect("a result"));
         dir.close()?;
         Ok(())
@@ -407,7 +419,10 @@ mod tests {
                 format = "in [$symbol($stack)]($style) "
             })
             .collect();
-        let expected = format!("in {} ", Style::new().color(XtermColors::from(5)).bold().style(" "));
+        let expected = format!(
+            "in {} ",
+            Style::new().color(XtermColors::from(5)).bold().style(" ")
+        );
         assert_eq!(expected, rendered.expect("a result"));
         dir.close()?;
         Ok(())

--- a/src/modules/purescript.rs
+++ b/src/modules/purescript.rs
@@ -58,7 +58,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 #[cfg(test)]
 mod tests {
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use owo_colors::Style;
     use std::fs::File;
     use std::io;
 
@@ -77,7 +77,10 @@ mod tests {
         File::create(dir.path().join("Main.purs"))?.sync_all()?;
 
         let actual = ModuleRenderer::new("purescript").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::White.bold().paint("<=> v0.13.5 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().white().bold().style("<=> v0.13.5 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -88,7 +91,10 @@ mod tests {
         File::create(dir.path().join("spago.dhall"))?.sync_all()?;
 
         let actual = ModuleRenderer::new("purescript").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::White.bold().paint("<=> v0.13.5 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().white().bold().style("<=> v0.13.5 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }

--- a/src/modules/python.rs
+++ b/src/modules/python.rs
@@ -133,7 +133,7 @@ fn get_prompt_from_venv(venv_path: &Path) -> Option<String> {
 mod tests {
     use super::*;
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use owo_colors::Style;
     use std::fs::{create_dir_all, File};
     use std::io;
     use std::io::Write;
@@ -345,7 +345,7 @@ Python 3.7.9 (7e6e2bb30ac5fbdbd443619cae28c51d5c162a02, Nov 24 2020, 10:03:59)
 
         let expected = Some(format!(
             "via {}",
-            Color::Yellow.bold().paint("🐍 v3.8.0 (my_venv) ")
+            Style::new().yellow().bold().style("🐍 v3.8.0 (my_venv) ")
         ));
 
         assert_eq!(actual, expected);
@@ -363,7 +363,7 @@ Python 3.7.9 (7e6e2bb30ac5fbdbd443619cae28c51d5c162a02, Nov 24 2020, 10:03:59)
 
         let expected = Some(format!(
             "via {}",
-            Color::Yellow.bold().paint("🐍 v3.8.0 (my_venv) ")
+            Style::new().yellow().bold().style("🐍 v3.8.0 (my_venv) ")
         ));
 
         assert_eq!(actual, expected);
@@ -390,7 +390,7 @@ prompt = 'foo'
 
         let expected = Some(format!(
             "via {}",
-            Color::Yellow.bold().paint("🐍 v3.8.0 (foo) ")
+            Style::new().yellow().bold().style("🐍 v3.8.0 (foo) ")
         ));
 
         assert_eq!(actual, expected);
@@ -417,7 +417,7 @@ prompt = '(foo)'
 
         let expected = Some(format!(
             "via {}",
-            Color::Yellow.bold().paint("🐍 v3.8.0 (foo) ")
+            Style::new().yellow().bold().style("🐍 v3.8.0 (foo) ")
         ));
 
         assert_eq!(actual, expected);
@@ -435,7 +435,10 @@ prompt = '(foo)'
             .config(config)
             .collect();
 
-        let expected = Some(format!("via {}", Color::Yellow.bold().paint("🐍 v2.7.17 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().yellow().bold().style("🐍 v2.7.17 ")
+        ));
         assert_eq!(expected, actual);
     }
 
@@ -450,7 +453,10 @@ prompt = '(foo)'
             .config(config)
             .collect();
 
-        let expected = Some(format!("via {}", Color::Yellow.bold().paint("🐍 v3.8.0 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().yellow().bold().style("🐍 v3.8.0 ")
+        ));
         assert_eq!(expected, actual);
     }
 
@@ -468,7 +474,10 @@ prompt = '(foo)'
             .config(config)
             .collect();
 
-        let expected = Some(format!("via {}", Color::Yellow.bold().paint("🐍 v3.8.0 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().yellow().bold().style("🐍 v3.8.0 ")
+        ));
         assert_eq!(expected, actual);
     }
 
@@ -486,7 +495,7 @@ prompt = '(foo)'
 
         let expected = Some(format!(
             "via {}",
-            Color::Yellow.bold().paint("🐍 test_pyenv system ")
+            Style::new().yellow().bold().style("🐍 test_pyenv system ")
         ));
         assert_eq!(expected, actual);
     }

--- a/src/modules/red.rs
+++ b/src/modules/red.rs
@@ -58,7 +58,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 #[cfg(test)]
 mod tests {
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use owo_colors::Style;
     use std::fs::File;
     use std::io;
 
@@ -76,7 +76,10 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("hello.red"))?.sync_all()?;
         let actual = ModuleRenderer::new("red").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Red.bold().paint("🔺 v0.6.4 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().red().bold().style("🔺 v0.6.4 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -86,7 +89,10 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("hello.reds"))?.sync_all()?;
         let actual = ModuleRenderer::new("red").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Red.bold().paint("🔺 v0.6.4 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().red().bold().style("🔺 v0.6.4 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -102,7 +108,10 @@ mod tests {
                 version_format = "${raw}"
             })
             .collect();
-        let expected = Some(format!("via {}", Color::Red.bold().paint("🔺 0.6.4 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().red().bold().style("🔺 0.6.4 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }

--- a/src/modules/rlang.rs
+++ b/src/modules/rlang.rs
@@ -73,7 +73,7 @@ fn parse_r_version(r_version: &str) -> Option<String> {
 mod tests {
     use super::parse_r_version;
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use owo_colors::Style;
     use std::fs;
     use std::fs::File;
     use std::io;
@@ -151,7 +151,10 @@ https://www.gnu.org/licenses/."#;
 
     fn check_r_render(dir: &tempfile::TempDir) {
         let actual = ModuleRenderer::new("rlang").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Blue.bold().paint("📐 v4.1.0 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().blue().bold().style("📐 v4.1.0 ")
+        ));
         assert_eq!(expected, actual);
     }
 }

--- a/src/modules/ruby.rs
+++ b/src/modules/ruby.rs
@@ -85,7 +85,7 @@ fn format_ruby_version(ruby_version: &str, version_format: &str) -> Option<Strin
 mod tests {
     use super::*;
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use owo_colors::Style;
     use std::fs::File;
     use std::io;
 
@@ -107,7 +107,10 @@ mod tests {
 
         let actual = ModuleRenderer::new("ruby").path(dir.path()).collect();
 
-        let expected = Some(format!("via {}", Color::Red.bold().paint("💎 v2.5.1 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().red().bold().style("💎 v2.5.1 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -119,7 +122,10 @@ mod tests {
 
         let actual = ModuleRenderer::new("ruby").path(dir.path()).collect();
 
-        let expected = Some(format!("via {}", Color::Red.bold().paint("💎 v2.5.1 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().red().bold().style("💎 v2.5.1 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -131,7 +137,10 @@ mod tests {
 
         let actual = ModuleRenderer::new("ruby").path(dir.path()).collect();
 
-        let expected = Some(format!("via {}", Color::Red.bold().paint("💎 v2.5.1 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().red().bold().style("💎 v2.5.1 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -144,7 +153,10 @@ mod tests {
             .env("RUBY_VERSION", "2.5.1")
             .collect();
 
-        let expected = Some(format!("via {}", Color::Red.bold().paint("💎 v2.5.1 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().red().bold().style("💎 v2.5.1 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -158,7 +170,10 @@ mod tests {
             .collect();
 
         // rbenv variable is only detected; its value is not used
-        let expected = Some(format!("via {}", Color::Red.bold().paint("💎 v2.5.1 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().red().bold().style("💎 v2.5.1 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }

--- a/src/modules/scala.rs
+++ b/src/modules/scala.rs
@@ -77,7 +77,7 @@ fn parse_scala_version(scala_version_string: &str) -> Option<String> {
 mod tests {
     use super::*;
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use owo_colors::Style;
     use std::fs::{self, File};
     use std::io;
 
@@ -111,7 +111,10 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("Test.scala"))?.sync_all()?;
         let actual = ModuleRenderer::new("scala").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Red.bold().paint("🆂 v2.13.5 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().red().bold().style("🆂 v2.13.5 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -124,7 +127,7 @@ mod tests {
             .cmd("scalac -version", None)
             .path(dir.path())
             .collect();
-        let expected = Some(format!("via {}", Color::Red.bold().paint("🆂 ")));
+        let expected = Some(format!("via {}", Style::new().red().bold().style("🆂 ")));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -134,7 +137,10 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("build.sbt"))?.sync_all()?;
         let actual = ModuleRenderer::new("scala").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Red.bold().paint("🆂 v2.13.5 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().red().bold().style("🆂 v2.13.5 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -144,7 +150,10 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join(".scalaenv"))?.sync_all()?;
         let actual = ModuleRenderer::new("scala").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Red.bold().paint("🆂 v2.13.5 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().red().bold().style("🆂 v2.13.5 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -154,7 +163,10 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join(".sbtenv"))?.sync_all()?;
         let actual = ModuleRenderer::new("scala").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Red.bold().paint("🆂 v2.13.5 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().red().bold().style("🆂 v2.13.5 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -164,7 +176,10 @@ mod tests {
         let dir = tempfile::tempdir()?;
         fs::create_dir_all(dir.path().join(".metals"))?;
         let actual = ModuleRenderer::new("scala").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Red.bold().paint("🆂 v2.13.5 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().red().bold().style("🆂 v2.13.5 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }

--- a/src/modules/shell.rs
+++ b/src/modules/shell.rs
@@ -66,7 +66,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 mod tests {
     use crate::context::Shell;
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use owo_colors::Style;
 
     #[test]
     fn test_none_if_disabled() {
@@ -86,7 +86,7 @@ mod tests {
 
     #[test]
     fn test_bash_default_format() {
-        let expected = Some(format!("{} ", Color::White.bold().paint("bsh")));
+        let expected = Some(format!("{} ", Style::new().white().bold().style("bsh")));
         let actual = ModuleRenderer::new("shell")
             .shell(Shell::Bash)
             .config(toml::toml! {
@@ -100,7 +100,7 @@ mod tests {
 
     #[test]
     fn test_bash_custom_format() {
-        let expected = Some(format!("{} ", Color::Cyan.bold().paint("bash")));
+        let expected = Some(format!("{} ", Style::new().cyan().bold().style("bash")));
         let actual = ModuleRenderer::new("shell")
             .shell(Shell::Bash)
             .config(toml::toml! {
@@ -115,7 +115,7 @@ mod tests {
 
     #[test]
     fn test_fish_default_format() {
-        let expected = Some(format!("{} ", Color::White.bold().paint("fsh")));
+        let expected = Some(format!("{} ", Style::new().white().bold().style("fsh")));
         let actual = ModuleRenderer::new("shell")
             .shell(Shell::Fish)
             .config(toml::toml! {
@@ -129,7 +129,7 @@ mod tests {
 
     #[test]
     fn test_fish_custom_format() {
-        let expected = Some(format!("{} ", Color::Cyan.bold().paint("fish")));
+        let expected = Some(format!("{} ", Style::new().cyan().bold().style("fish")));
         let actual = ModuleRenderer::new("shell")
             .shell(Shell::Fish)
             .config(toml::toml! {
@@ -144,7 +144,7 @@ mod tests {
 
     #[test]
     fn test_zsh_default_format() {
-        let expected = Some(format!("{} ", Color::White.bold().paint("zsh")));
+        let expected = Some(format!("{} ", Style::new().white().bold().style("zsh")));
         let actual = ModuleRenderer::new("shell")
             .shell(Shell::Zsh)
             .config(toml::toml! {
@@ -158,7 +158,7 @@ mod tests {
 
     #[test]
     fn test_zsh_custom_format() {
-        let expected = Some(format!("{} ", Color::Cyan.bold().paint("zsh")));
+        let expected = Some(format!("{} ", Style::new().cyan().bold().style("zsh")));
         let actual = ModuleRenderer::new("shell")
             .shell(Shell::Bash)
             .config(toml::toml! {
@@ -173,7 +173,7 @@ mod tests {
 
     #[test]
     fn test_powershell_default_format() {
-        let expected = Some(format!("{} ", Color::White.bold().paint("psh")));
+        let expected = Some(format!("{} ", Style::new().white().bold().style("psh")));
         let actual = ModuleRenderer::new("shell")
             .shell(Shell::PowerShell)
             .config(toml::toml! {
@@ -187,7 +187,10 @@ mod tests {
 
     #[test]
     fn test_powershell_custom_format() {
-        let expected = Some(format!("{} ", Color::Cyan.bold().paint("powershell")));
+        let expected = Some(format!(
+            "{} ",
+            Style::new().cyan().bold().style("powershell")
+        ));
         let actual = ModuleRenderer::new("shell")
             .shell(Shell::PowerShell)
             .config(toml::toml! {
@@ -202,7 +205,7 @@ mod tests {
 
     #[test]
     fn test_ion_default_format() {
-        let expected = Some(format!("{} ", Color::White.bold().paint("ion")));
+        let expected = Some(format!("{} ", Style::new().white().bold().style("ion")));
         let actual = ModuleRenderer::new("shell")
             .shell(Shell::Ion)
             .config(toml::toml! {
@@ -216,7 +219,7 @@ mod tests {
 
     #[test]
     fn test_ion_custom_format() {
-        let expected = Some(format!("{} ", Color::Cyan.bold().paint("ion")));
+        let expected = Some(format!("{} ", Style::new().cyan().bold().style("ion")));
         let actual = ModuleRenderer::new("shell")
             .shell(Shell::Ion)
             .config(toml::toml! {
@@ -231,7 +234,7 @@ mod tests {
 
     #[test]
     fn test_elvish_default_format() {
-        let expected = Some(format!("{} ", Color::White.bold().paint("esh")));
+        let expected = Some(format!("{} ", Style::new().white().bold().style("esh")));
         let actual = ModuleRenderer::new("shell")
             .shell(Shell::Elvish)
             .config(toml::toml! {
@@ -245,7 +248,7 @@ mod tests {
 
     #[test]
     fn test_elvish_custom_format() {
-        let expected = Some(format!("{} ", Color::Cyan.bold().paint("elvish")));
+        let expected = Some(format!("{} ", Style::new().cyan().bold().style("elvish")));
         let actual = ModuleRenderer::new("shell")
             .shell(Shell::Elvish)
             .config(toml::toml! {
@@ -260,7 +263,7 @@ mod tests {
 
     #[test]
     fn test_nu_default_format() {
-        let expected = Some(format!("{} ", Color::White.bold().paint("nu")));
+        let expected = Some(format!("{} ", Style::new().white().bold().style("nu")));
         let actual = ModuleRenderer::new("shell")
             .shell(Shell::Nu)
             .config(toml::toml! {
@@ -274,7 +277,7 @@ mod tests {
 
     #[test]
     fn test_nu_custom_format() {
-        let expected = Some(format!("{} ", Color::Cyan.bold().paint("nu")));
+        let expected = Some(format!("{} ", Style::new().cyan().bold().style("nu")));
         let actual = ModuleRenderer::new("shell")
             .shell(Shell::Nu)
             .config(toml::toml! {
@@ -289,7 +292,7 @@ mod tests {
 
     #[test]
     fn test_xonsh_default_format() {
-        let expected = Some(format!("{} ", Color::White.bold().paint("xsh")));
+        let expected = Some(format!("{} ", Style::new().white().bold().style("xsh")));
         let actual = ModuleRenderer::new("shell")
             .shell(Shell::Xonsh)
             .config(toml::toml! {
@@ -303,7 +306,7 @@ mod tests {
 
     #[test]
     fn test_xonsh_custom_format() {
-        let expected = Some(format!("{} ", Color::Cyan.bold().paint("xonsh")));
+        let expected = Some(format!("{} ", Style::new().cyan().bold().style("xonsh")));
         let actual = ModuleRenderer::new("shell")
             .shell(Shell::Xonsh)
             .config(toml::toml! {
@@ -318,7 +321,7 @@ mod tests {
 
     #[test]
     fn test_cmd_default_format() {
-        let expected = Some(format!("{} ", Color::White.bold().paint("cmd")));
+        let expected = Some(format!("{} ", Style::new().white().bold().style("cmd")));
         let actual = ModuleRenderer::new("shell")
             .shell(Shell::Cmd)
             .config(toml::toml! {
@@ -332,7 +335,7 @@ mod tests {
 
     #[test]
     fn test_cmd_custom_format() {
-        let expected = Some(format!("{} ", Color::Cyan.bold().paint("cmd")));
+        let expected = Some(format!("{} ", Style::new().cyan().bold().style("cmd")));
         let actual = ModuleRenderer::new("shell")
             .shell(Shell::Cmd)
             .config(toml::toml! {
@@ -379,7 +382,7 @@ mod tests {
 
     #[test]
     fn test_default_style() {
-        let expected = Some(format!("{}", Color::White.bold().paint("fish")));
+        let expected = Some(format!("{}", Style::new().white().bold().style("fish")));
         let actual = ModuleRenderer::new("shell")
             .shell(Shell::Fish)
             .config(toml::toml! {
@@ -394,7 +397,7 @@ mod tests {
 
     #[test]
     fn test_custom_style() {
-        let expected = Some(format!("{}", Color::Cyan.bold().paint("fish")));
+        let expected = Some(format!("{}", Style::new().cyan().bold().style("fish")));
         let actual = ModuleRenderer::new("shell")
             .shell(Shell::Fish)
             .config(toml::toml! {

--- a/src/modules/shlvl.rs
+++ b/src/modules/shlvl.rs
@@ -63,7 +63,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
 #[cfg(test)]
 mod tests {
-    use ansi_term::{Color, Style};
+    use owo_colors::Style;
 
     use crate::test::ModuleRenderer;
 
@@ -71,7 +71,7 @@ mod tests {
 
     fn style() -> Style {
         // default style
-        Color::Yellow.bold()
+        Style::new().yellow().bold()
     }
 
     #[test]
@@ -96,7 +96,7 @@ mod tests {
             })
             .env(SHLVL_ENV_VAR, "2")
             .collect();
-        let expected = Some(format!("{} ", style().paint("↕️  2")));
+        let expected = Some(format!("{} ", style().style("↕️  2")));
 
         assert_eq!(expected, actual);
     }
@@ -138,7 +138,7 @@ mod tests {
             })
             .env(SHLVL_ENV_VAR, "1")
             .collect();
-        let expected = Some(format!("{} ", style().paint("↕️  1")));
+        let expected = Some(format!("{} ", style().style("↕️  1")));
 
         assert_eq!(expected, actual);
     }
@@ -168,7 +168,7 @@ mod tests {
             })
             .env(SHLVL_ENV_VAR, "2")
             .collect();
-        let expected = Some(format!("{} ", Color::Red.underline().paint("↕️  2")));
+        let expected = Some(format!("{} ", Style::new().red().underline().style("↕️  2")));
 
         assert_eq!(expected, actual);
     }
@@ -183,7 +183,7 @@ mod tests {
             })
             .env(SHLVL_ENV_VAR, "2")
             .collect();
-        let expected = Some(format!("{} ", style().paint("shlvl is 2")));
+        let expected = Some(format!("{} ", style().style("shlvl is 2")));
 
         assert_eq!(expected, actual);
     }
@@ -198,7 +198,7 @@ mod tests {
             })
             .env(SHLVL_ENV_VAR, "2")
             .collect();
-        let expected = Some(format!("↕️   going down {} GOING UP ", style().paint("2")));
+        let expected = Some(format!("↕️   going down {} GOING UP ", style().style("2")));
 
         assert_eq!(expected, actual);
     }
@@ -215,7 +215,7 @@ mod tests {
             })
             .env(SHLVL_ENV_VAR, "3")
             .collect();
-        let expected = Some(format!("{} ", style().paint("~~~>")));
+        let expected = Some(format!("{} ", style().style("~~~>")));
 
         assert_eq!(expected, actual);
     }

--- a/src/modules/singularity.rs
+++ b/src/modules/singularity.rs
@@ -43,7 +43,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 #[cfg(test)]
 mod tests {
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use owo_colors::Style;
 
     #[test]
     fn no_env_set() {
@@ -60,7 +60,7 @@ mod tests {
 
         let expected = Some(format!(
             "{} ",
-            Color::Blue.bold().dimmed().paint("[centos.img]")
+            Style::new().blue().bold().dimmed().style("[centos.img]")
         ));
 
         assert_eq!(expected, actual);

--- a/src/modules/status.rs
+++ b/src/modules/status.rs
@@ -224,7 +224,7 @@ fn status_signal_name(signal: SignalNumber) -> Option<&'static str> {
 
 #[cfg(test)]
 mod tests {
-    use ansi_term::Color;
+    use owo_colors::Style;
 
     use crate::test::ModuleRenderer;
 
@@ -314,7 +314,7 @@ mod tests {
         for status in &exit_values {
             let expected = Some(format!(
                 "{} ",
-                Color::Red.bold().paint(format!("✖{}", status))
+                Style::new().red().bold().style(format!("✖{}", status))
             ));
             let actual = ModuleRenderer::new("status")
                 .config(toml::toml! {
@@ -336,7 +336,10 @@ mod tests {
         for (exit_value, string_value) in exit_values.iter().zip(string_values) {
             let expected = Some(format!(
                 "{} ",
-                Color::Red.bold().paint(format!("✖{}", string_value))
+                Style::new()
+                    .red()
+                    .bold()
+                    .style(format!("✖{}", string_value))
             ));
             let actual = ModuleRenderer::new("status")
                 .config(toml::toml! {

--- a/src/modules/status.rs
+++ b/src/modules/status.rs
@@ -275,7 +275,7 @@ mod tests {
 
     #[test]
     fn success_status_success_symbol_filled() {
-        let expected = Some(format!("{} ", Color::Red.bold().paint("✔️0")));
+        let expected = Some(format!("{} ", Style::new().red().bold().style("✔️0")));
 
         // Status code 0
         let actual = ModuleRenderer::new("status")

--- a/src/modules/sudo.rs
+++ b/src/modules/sudo.rs
@@ -51,7 +51,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 #[cfg(test)]
 mod tests {
     use crate::{test::ModuleRenderer, utils::CommandOutput};
-    use ansi_term::Color;
+    use owo_colors::Style;
 
     #[test]
     fn test_sudo_not_cached() {
@@ -84,7 +84,7 @@ mod tests {
                 allow_windows = true
             })
             .collect();
-        let expected = Some(format!("{}", Color::Blue.bold().paint("as 🧙 ")));
+        let expected = Some(format!("{}", Style::new().blue().bold().style("as 🧙 ")));
 
         assert_eq!(expected, actual);
     }

--- a/src/modules/swift.rs
+++ b/src/modules/swift.rs
@@ -72,7 +72,7 @@ fn parse_swift_version(swift_version: &str) -> Option<String> {
 mod tests {
     use super::parse_swift_version;
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use owo_colors::{Style, XtermColors};
     use std::fs::File;
     use std::io;
 
@@ -105,7 +105,7 @@ mod tests {
         let actual = ModuleRenderer::new("swift").path(dir.path()).collect();
         let expected = Some(format!(
             "via {}",
-            Color::Fixed(202).bold().paint("🐦 v5.2.2 ")
+            Style::new().color(XtermColors::from(202)).bold().style("🐦 v5.2.2 ")
         ));
         assert_eq!(expected, actual);
         dir.close()
@@ -118,7 +118,7 @@ mod tests {
         let actual = ModuleRenderer::new("swift").path(dir.path()).collect();
         let expected = Some(format!(
             "via {}",
-            Color::Fixed(202).bold().paint("🐦 v5.2.2 ")
+            Style::new().color(XtermColors::from(202)).bold().style("🐦 v5.2.2 ")
         ));
         assert_eq!(expected, actual);
         dir.close()

--- a/src/modules/swift.rs
+++ b/src/modules/swift.rs
@@ -105,7 +105,10 @@ mod tests {
         let actual = ModuleRenderer::new("swift").path(dir.path()).collect();
         let expected = Some(format!(
             "via {}",
-            Style::new().color(XtermColors::from(202)).bold().style("🐦 v5.2.2 ")
+            Style::new()
+                .color(XtermColors::from(202))
+                .bold()
+                .style("🐦 v5.2.2 ")
         ));
         assert_eq!(expected, actual);
         dir.close()
@@ -118,7 +121,10 @@ mod tests {
         let actual = ModuleRenderer::new("swift").path(dir.path()).collect();
         let expected = Some(format!(
             "via {}",
-            Style::new().color(XtermColors::from(202)).bold().style("🐦 v5.2.2 ")
+            Style::new()
+                .color(XtermColors::from(202))
+                .bold()
+                .style("🐦 v5.2.2 ")
         ));
         assert_eq!(expected, actual);
         dir.close()

--- a/src/modules/terraform.rs
+++ b/src/modules/terraform.rs
@@ -156,7 +156,8 @@ is 0.12.14. You can update by downloading from www.terraform.io/downloads.html
 
         let expected = Some(format!(
             "via {} ",
-            Style::new().color(XtermColors::from(105))
+            Style::new()
+                .color(XtermColors::from(105))
                 .bold()
                 .style("💠 v0.12.14 default")
         ));
@@ -183,7 +184,8 @@ is 0.12.14. You can update by downloading from www.terraform.io/downloads.html
 
         let expected = Some(format!(
             "via {} ",
-            Style::new().color(XtermColors::from(105))
+            Style::new()
+                .color(XtermColors::from(105))
                 .bold()
                 .style("💠 v0.12.14 development")
         ));
@@ -210,7 +212,10 @@ is 0.12.14. You can update by downloading from www.terraform.io/downloads.html
         let actual = ModuleRenderer::new("terraform").path(dir.path()).collect();
         let expected = Some(format!(
             "via {} ",
-            Style::new().color(XtermColors::from(105)).bold().style("💠 default")
+            Style::new()
+                .color(XtermColors::from(105))
+                .bold()
+                .style("💠 default")
         ));
 
         assert_eq!(expected, actual);
@@ -228,7 +233,10 @@ is 0.12.14. You can update by downloading from www.terraform.io/downloads.html
             .collect();
         let expected = Some(format!(
             "via {} ",
-            Style::new().color(XtermColors::from(105)).bold().style("💠 development")
+            Style::new()
+                .color(XtermColors::from(105))
+                .bold()
+                .style("💠 development")
         ));
 
         assert_eq!(expected, actual);
@@ -251,7 +259,10 @@ is 0.12.14. You can update by downloading from www.terraform.io/downloads.html
             .collect();
         let expected = Some(format!(
             "via {} ",
-            Style::new().color(XtermColors::from(105)).bold().style("💠 development")
+            Style::new()
+                .color(XtermColors::from(105))
+                .bold()
+                .style("💠 development")
         ));
 
         assert_eq!(expected, actual);
@@ -268,7 +279,10 @@ is 0.12.14. You can update by downloading from www.terraform.io/downloads.html
         let actual = ModuleRenderer::new("terraform").path(dir.path()).collect();
         let expected = Some(format!(
             "via {} ",
-            Style::new().color(XtermColors::from(105)).bold().style("💠 default")
+            Style::new()
+                .color(XtermColors::from(105))
+                .bold()
+                .style("💠 default")
         ));
 
         assert_eq!(expected, actual);
@@ -287,7 +301,10 @@ is 0.12.14. You can update by downloading from www.terraform.io/downloads.html
         let actual = ModuleRenderer::new("terraform").path(dir.path()).collect();
         let expected = Some(format!(
             "via {} ",
-            Style::new().color(XtermColors::from(105)).bold().style("💠 development")
+            Style::new()
+                .color(XtermColors::from(105))
+                .bold()
+                .style("💠 development")
         ));
 
         assert_eq!(expected, actual);

--- a/src/modules/terraform.rs
+++ b/src/modules/terraform.rs
@@ -101,7 +101,7 @@ fn parse_terraform_version(version: &str) -> Option<String> {
 mod tests {
     use super::*;
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use owo_colors::{Style, XtermColors};
     use std::fs::{self, File};
     use std::io::{self, Write};
 
@@ -156,7 +156,9 @@ is 0.12.14. You can update by downloading from www.terraform.io/downloads.html
 
         let expected = Some(format!(
             "via {} ",
-            Color::Fixed(105).bold().paint("💠 v0.12.14 default")
+            Style::new().color(XtermColors::from(105))
+                .bold()
+                .style("💠 v0.12.14 default")
         ));
         assert_eq!(expected, actual);
         dir.close()
@@ -181,7 +183,9 @@ is 0.12.14. You can update by downloading from www.terraform.io/downloads.html
 
         let expected = Some(format!(
             "via {} ",
-            Color::Fixed(105).bold().paint("💠 v0.12.14 development")
+            Style::new().color(XtermColors::from(105))
+                .bold()
+                .style("💠 v0.12.14 development")
         ));
         assert_eq!(expected, actual);
         dir.close()
@@ -206,7 +210,7 @@ is 0.12.14. You can update by downloading from www.terraform.io/downloads.html
         let actual = ModuleRenderer::new("terraform").path(dir.path()).collect();
         let expected = Some(format!(
             "via {} ",
-            Color::Fixed(105).bold().paint("💠 default")
+            Style::new().color(XtermColors::from(105)).bold().style("💠 default")
         ));
 
         assert_eq!(expected, actual);
@@ -224,7 +228,7 @@ is 0.12.14. You can update by downloading from www.terraform.io/downloads.html
             .collect();
         let expected = Some(format!(
             "via {} ",
-            Color::Fixed(105).bold().paint("💠 development")
+            Style::new().color(XtermColors::from(105)).bold().style("💠 development")
         ));
 
         assert_eq!(expected, actual);
@@ -247,7 +251,7 @@ is 0.12.14. You can update by downloading from www.terraform.io/downloads.html
             .collect();
         let expected = Some(format!(
             "via {} ",
-            Color::Fixed(105).bold().paint("💠 development")
+            Style::new().color(XtermColors::from(105)).bold().style("💠 development")
         ));
 
         assert_eq!(expected, actual);
@@ -264,7 +268,7 @@ is 0.12.14. You can update by downloading from www.terraform.io/downloads.html
         let actual = ModuleRenderer::new("terraform").path(dir.path()).collect();
         let expected = Some(format!(
             "via {} ",
-            Color::Fixed(105).bold().paint("💠 default")
+            Style::new().color(XtermColors::from(105)).bold().style("💠 default")
         ));
 
         assert_eq!(expected, actual);
@@ -283,7 +287,7 @@ is 0.12.14. You can update by downloading from www.terraform.io/downloads.html
         let actual = ModuleRenderer::new("terraform").path(dir.path()).collect();
         let expected = Some(format!(
             "via {} ",
-            Color::Fixed(105).bold().paint("💠 development")
+            Style::new().color(XtermColors::from(105)).bold().style("💠 development")
         ));
 
         assert_eq!(expected, actual);

--- a/src/modules/time.rs
+++ b/src/modules/time.rs
@@ -502,7 +502,7 @@ mod tests {
             .unwrap();
 
         // This is the prefix with "at ", the color code, then the prefix char [
-        let col_prefix = format!("at {}{}[", '\u{1b}', "[1;33m");
+        let col_prefix = format!("at {}{}[", '\u{1b}', "[33;1m");
 
         // This is the suffix with suffix char ']', then color codes, then a space
         let col_suffix = format!("]{}{} ", '\u{1b}', "[0m");

--- a/src/modules/vagrant.rs
+++ b/src/modules/vagrant.rs
@@ -74,7 +74,7 @@ fn parse_vagrant_version(vagrant_stdout: &str) -> Option<String> {
 mod tests {
     use super::*;
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use owo_colors::Style;
     use std::fs::File;
     use std::io;
 
@@ -96,7 +96,10 @@ mod tests {
 
         let actual = ModuleRenderer::new("vagrant").path(dir.path()).collect();
 
-        let expected = Some(format!("via {}", Color::Cyan.bold().paint("⍱ v2.2.10 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().cyan().bold().style("⍱ v2.2.10 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }

--- a/src/modules/vcsh.rs
+++ b/src/modules/vcsh.rs
@@ -47,7 +47,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 #[cfg(test)]
 mod tests {
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use owo_colors::Style;
 
     #[test]
     fn not_in_env() {
@@ -66,7 +66,7 @@ mod tests {
 
         let expected = Some(format!(
             "vcsh {} ",
-            Color::Yellow.bold().paint("astronauts")
+            Style::new().yellow().bold().style("astronauts")
         ));
 
         assert_eq!(expected, actual);

--- a/src/modules/vlang.rs
+++ b/src/modules/vlang.rs
@@ -71,7 +71,7 @@ fn parse_v_version(v_version: &str) -> Option<String> {
 mod tests {
     use super::parse_v_version;
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use owo_colors::Style;
     use std::fs::File;
     use std::io;
 
@@ -95,7 +95,10 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("hello.v"))?.sync_all()?;
         let actual = ModuleRenderer::new("vlang").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Blue.bold().paint("V v0.2 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().blue().bold().style("V v0.2 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -105,7 +108,10 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("v.mod"))?.sync_all()?;
         let actual = ModuleRenderer::new("vlang").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Blue.bold().paint("V v0.2 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().blue().bold().style("V v0.2 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -115,7 +121,10 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("vpkg.json"))?.sync_all()?;
         let actual = ModuleRenderer::new("vlang").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Blue.bold().paint("V v0.2 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().blue().bold().style("V v0.2 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -125,7 +134,10 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join(".vpkg-lock.json"))?.sync_all()?;
         let actual = ModuleRenderer::new("vlang").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Blue.bold().paint("V v0.2 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().blue().bold().style("V v0.2 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -141,7 +153,10 @@ mod tests {
                 version_format = "${raw}"
             })
             .collect();
-        let expected = Some(format!("via {}", Color::Blue.bold().paint("V 0.2 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().blue().bold().style("V 0.2 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }

--- a/src/modules/zig.rs
+++ b/src/modules/zig.rs
@@ -59,7 +59,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 #[cfg(test)]
 mod tests {
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use owo_colors::Style;
     use std::fs::File;
     use std::io;
 
@@ -78,7 +78,10 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("main.zig"))?.sync_all()?;
         let actual = ModuleRenderer::new("zig").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Yellow.bold().paint("↯ v0.6.0 ")));
+        let expected = Some(format!(
+            "via {}",
+            Style::new().yellow().bold().style("↯ v0.6.0 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }

--- a/src/print.rs
+++ b/src/print.rs
@@ -1,4 +1,3 @@
-use ansi_term::ANSIStrings;
 use rayon::prelude::*;
 use std::collections::BTreeSet;
 use std::fmt::{self, Debug, Write as FmtWrite};
@@ -51,6 +50,10 @@ fn test_grapheme_aware_width() {
     assert_eq!(2, "👩‍👩‍👦‍👦".width_graphemes());
     assert_eq!(1, "Ü".width_graphemes());
     assert_eq!(11, "normal text".width_graphemes());
+}
+
+fn render_ansi_strings(strings: Vec<String>) -> String {
+    strings.into_iter().collect()
 }
 
 pub fn prompt(args: Properties, target: Target) {
@@ -117,7 +120,8 @@ pub fn get_prompt(context: Context) -> String {
         // continuation prompts normally do not include newlines, but they can
         writeln!(buf).unwrap();
     }
-    write!(buf, "{}", ANSIStrings(&module_strings)).unwrap();
+
+    buf.extend(module_strings);
 
     if context.target == Target::Right {
         // right prompts generally do not allow newlines
@@ -161,9 +165,7 @@ pub fn timings(args: Properties) {
         .map(|module| ModuleTiming {
             name: String::from(module.get_name().as_str()),
             name_len: module.get_name().width_graphemes(),
-            value: ansi_term::ANSIStrings(&module.ansi_strings())
-                .to_string()
-                .replace('\n', "\\n"),
+            value: render_ansi_strings(module.ansi_strings()).replace('\n', "\\n"),
             duration: module.duration,
             duration_len: format_duration(&module.duration).width_graphemes(),
         })
@@ -210,7 +212,7 @@ pub fn explain(args: Properties) {
         .map(|module| {
             let value = module.get_segments().join("");
             ModuleInfo {
-                value: ansi_term::ANSIStrings(&module.ansi_strings()).to_string(),
+                value: render_ansi_strings(module.ansi_strings()),
                 value_len: value.width_graphemes()
                     + format_duration(&module.duration).width_graphemes(),
                 desc: module.get_description().clone(),


### PR DESCRIPTION
#### Description

* Replace ansi_term dependency with owo-colors 3.3.0
* Use strip-ansi-escapes in place of ansi_term's ANSI parser
  * This library is used by cargo and is quite popular, which I believe reflects well on its maintenance status relative to ansi_term's parsing
* Rework Module/Segments to merge TextSegments with identical formatting
  * This is necessary to avoid regressions in the output escape sequences due to the fact that owo-colors avoids the runtime cost of parsing/optimizing ANSI sequences
* Update module UI tests to use owo-colors

#### Motivation and Context

Copying from #3704:

> ansi_term appears to be unmaintained, having merged its last PR 3 years ago, and having had no response to its maintenance inquiry

Closes #3704 

#### How Has This Been Tested?

- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

Primary testing was performed via conformance to existing UI tests present throughout the modules, which were painfully thorough (great work, to be clear). Secondary testing was performed by installation and use on Linux (Ubuntu, Alacritty).

#### Checklist:

- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.

Sidenote/disclaimer: this was intended to be a small PR just for assessment purposes after seeing interest in owo-colors (a crate I am the author/maintainer of). However this turned out to be quite a rabbit hole. If owo-colors is determined to be a poor fit, I will 100% understand and it won't hurt my feelings \:)