### PR TITLE
fix(init): Change Nushell init for nu 0.60

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -49,7 +49,7 @@ assignees: ''
     Fish: ~/.config/fish/config.fish
     Xonsh: ~/.config/xonsh/rc.xsh
     Elvish: ~/.config/elvish/rc.elv
-    Nushell: ~/.config/nushell/config.nu
+    Nushell: $nu.config-path
     Ion: ~/.config/ion/initrc
 -->
 

--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -41,7 +41,7 @@ assignees: ''
 - Operating system: [e.g. macOS 10.13.4, Windows 10]
 
 #### Relevant Shell Configuration
-<!-- 
+<!--
   Based on the shell you use, please paste the appropriate configuration.
   The default location for your shell is:
     Bash: ~/.bashrc
@@ -49,7 +49,7 @@ assignees: ''
     Fish: ~/.config/fish/config.fish
     Xonsh: ~/.config/xonsh/rc.xsh
     Elvish: ~/.config/elvish/rc.elv
-    Nushell: ~/.config/nu/config.toml
+    Nushell: ~/.config/nushell/config.nu
     Ion: ~/.config/ion/initrc
 -->
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,16 +438,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "directories-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "339ee130d97a610ea5a5872d2bbb130fdf68884ff09d3028b81bec8a1ac23bbc"
-dependencies = [
- "cfg-if",
- "dirs-sys-next",
-]
-
-[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1564,7 +1554,7 @@ dependencies = [
  "chrono",
  "clap",
  "clap_complete",
- "directories-next",
+ "dirs-next",
  "dunce",
  "gethostname",
  "git2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ byte-unit = "4.0.14"
 chrono = "0.4.19"
 clap = { version = "3.1.6", features = ["derive", "cargo", "unicode"] }
 clap_complete = "3.1.1"
-directories-next = "2.0.0"
+dirs-next = "2.0.0"
 dunce = "1.0.2"
 gethostname = "0.2.3"
 git2 = { version = "0.14.2", default-features = false }

--- a/README.md
+++ b/README.md
@@ -327,16 +327,15 @@ eval $(starship init ion)
 <details>
 <summary>Nushell</summary>
 
-Add the following to the end of your Nushell configuration (find it by running `config path`):
+Add the following to the end of your Nushell configuration (find it by running `$nu.config-path`):
 
-```toml
-startup = [
-  "mkdir ~/.cache/starship",
-  "starship init nu | save ~/.cache/starship/init.nu",
-  "source ~/.cache/starship/init.nu",
-]
-prompt = "starship_prompt"
+```sh
+mkdir ~/.cache/starship
+starship init nu | save ~/.cache/starship/init.nu
+source ~/.cache/starship/init.nu
 ```
+
+Note: Only Nushell v0.60+ is supported
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -327,10 +327,16 @@ eval $(starship init ion)
 <details>
 <summary>Nushell</summary>
 
-Add the following to the end of your Nushell configuration (find it by running `$nu.config-path`):
+Run the following:
 
 ```sh
 mkdir ~/.cache/starship
+starship init nu | save ~/.cache/starship/init.nu
+```
+
+And add the following to the end of your Nushell configuration (find it by running `$nu.config-path`):
+
+```sh
 starship init nu | save ~/.cache/starship/init.nu
 source ~/.cache/starship/init.nu
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -136,20 +136,15 @@ description: Starship is the minimal, blazing fast, and extremely customizable p
 
    ::: warning
    This will change in the future.
-   Only nu version v0.33 or higher is supported.
+   Only Nushell v0.60+ is supported.
    :::
-   Add the following to your nu config file. You can check the location of this
-   file by running `config path` in nu.
+   Add the following to the end of your Nushell configuration (find it by running `$nu.config-path`):
 
-   ```toml
-   startup = [
-     "mkdir ~/.cache/starship",
-     "starship init nu | save ~/.cache/starship/init.nu",
-     "source ~/.cache/starship/init.nu",
-   ]
-   prompt = "starship_prompt"
+   ```sh
+   mkdir ~/.cache/starship
+   starship init nu | save ~/.cache/starship/init.nu
+   source ~/.cache/starship/init.nu
    ```
-
    #### Xonsh
 
    Add the following to the end of `~/.xonshrc`:

--- a/docs/README.md
+++ b/docs/README.md
@@ -138,7 +138,13 @@ description: Starship is the minimal, blazing fast, and extremely customizable p
    This will change in the future.
    Only Nushell v0.60+ is supported.
    :::
-   Add the following to the end of your Nushell configuration (find it by running `$nu.config-path`):
+   Run the following:
+   ```sh
+   mkdir ~/.cache/starship
+   starship init nu | save ~/.cache/starship/init.nu
+   ```
+
+   And add the following to the end of your Nushell configuration (find it by running `$nu.config-path`):
 
    ```sh
    mkdir ~/.cache/starship

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -512,12 +512,6 @@ look at [this example](#with-custom-error-shape).
 
 ::: warning
 
-`error_symbol` is not supported on nu shell.
-
-:::
-
-::: warning
-
 `vicmd_symbol` is only supported in cmd, fish and zsh.
 
 :::
@@ -3127,10 +3121,6 @@ The status code will cast to a signed 32-bit integer.
 This module is disabled by default.
 To enable it, set `disabled` to `false` in your configuration file.
 
-:::
-
-::: warning
-This module is not supported on nu shell.
 :::
 
 ### Options

--- a/install/install.sh
+++ b/install/install.sh
@@ -297,7 +297,7 @@ print_install() {
     # we don't want these '~' expanding
     config_file="~/.${s}rc"
     config_cmd="eval \"\$(starship init ${s})\""
- 
+
     case ${s} in
       ion )
         # shellcheck disable=SC2088
@@ -336,16 +336,13 @@ print_install() {
         ;;
       nushell )
         # shellcheck disable=SC2088
-        config_file="your nu config file."
-        config_cmd="startup = [
-          \"mkdir ~/.cache/starship\",
-          \"starship init nu | save ~/.cache/starship/init.nu\",
-          \"source ~/.cache/starship/init.nu\"
-        ]
-        prompt = \"starship_prompt\""
+        config_file="your nu config file"
+        config_cmd="mkdir ~/.cache/starship
+        starship init nu | save ~/.cache/starship/init.nu
+        source ~/.cache/starship/init.nu"
         warning="${warning} This will change in the future.
-  Only nu version v0.33 or higher is supported.
-  You can check the location of this your config file by running config path in nu"
+  Only Nushell v0.60 or higher is supported.
+  You can check the location of this your config file by running \$nu.config-path in nu."
         ;;
     esac
     printf "  %s\n  %s\n  Add the following to the end of %s:\n\n\t%s\n\n" \

--- a/install/install.sh
+++ b/install/install.sh
@@ -342,7 +342,8 @@ print_install() {
         source ~/.cache/starship/init.nu"
         warning="${warning} This will change in the future.
   Only Nushell v0.60 or higher is supported.
-  You can check the location of this your config file by running \$nu.config-path in nu."
+  You can check the location of this your config file by running \$nu.config-path in nu.
+  ${BOLD}First run${NO_COLOR} \"mkdir ~/.cache/starship; starship init nu | save ~/.cache/starship/init.nu\""
         ;;
     esac
     printf "  %s\n  %s\n  Add the following to the end of %s:\n\n\t%s\n\n" \

--- a/src/bug_report.rs
+++ b/src/bug_report.rs
@@ -1,7 +1,6 @@
 use crate::shadow;
 use crate::utils::{self, exec_cmd};
 
-use directories_next::ProjectDirs;
 use std::fs;
 use std::path::PathBuf;
 use std::time::Duration;
@@ -181,8 +180,8 @@ fn get_terminal_info() -> TerminalInfo {
 
 fn get_config_path(shell: &str) -> Option<PathBuf> {
     if shell == "nu" {
-        return ProjectDirs::from("org", "nushell", "nu")
-            .map(|project_dirs| project_dirs.config_dir().join("config.toml"));
+        return dirs_next::config_dir()
+            .map(|config_dir| config_dir.join("nushell").join("config.nu"));
     }
 
     utils::home_dir().and_then(|home_dir| {

--- a/src/init/starship.nu
+++ b/src/init/starship.nu
@@ -1,8 +1,17 @@
 let-env STARSHIP_SHELL = "nu"
 let-env STARSHIP_SESSION_KEY = (random chars -l 16)
+let-env PROMPT_MULTILINE_INDICATOR = (^::STARSHIP:: prompt --continuation)
 
-def starship_prompt [] {
+# Does not play well with default character module.
+# TODO: Also Use starship vi mode indicators?
+let-env PROMPT_INDICATOR = ""
+
+let-env PROMPT_COMMAND = {
     # jobs are not supported
-    # status is not supported
-    ^::STARSHIP:: prompt --cmd-duration $nu.env.CMD_DURATION_MS
+    ^::STARSHIP:: prompt --cmd-duration $env.CMD_DURATION_MS --status $env.LAST_EXIT_CODE
 }
+
+# Not well-suited for `starship prompt --right`.
+# Built-in right prompt is equivalent to $fill$right_format in the first prompt line.
+# Thus does not play well with default `add_newline = True`.
+let-env PROMPT_COMMAND_RIGHT = {''}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -516,7 +516,7 @@ fn render_time_component((component, suffix): (&u128, &&str)) -> String {
 }
 
 pub fn home_dir() -> Option<PathBuf> {
-    directories_next::BaseDirs::new().map(|base_dirs| base_dirs.home_dir().to_owned())
+    dirs_next::home_dir()
 }
 
 const HEXTABLE: &[char] = &[


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR updates the nu init for the upcoming v0.60 release. `directories-next` is also replaced by `dirs-next` again to match nushell behavior.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1716
Closes #3526

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
