### PR TITLE
feat: edit the bug report before submission

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ clap = { version = "3.1.6", features = ["derive", "cargo", "unicode"] }
 clap_complete = "3.1.1"
 dirs-next = "2.0.0"
 dunce = "1.0.2"
+edit = "0.1.3"
 gethostname = "0.2.3"
 git2 = { version = "0.14.2", default-features = false }
 indexmap = { version = "1.8.0", features = ["serde"] }
@@ -68,6 +69,7 @@ starship-battery = { version = "0.7.9", optional = true }
 starship_module_config_derive = { version = "0.2.1", path = "starship_module_config_derive" }
 strsim = "0.10.0"
 sys-info = "0.9.1"
+tempfile = "3.3.0"
 terminal_size = "0.1.17"
 toml = { version = "0.5.8", features = ["preserve_order"] }
 toml_edit = "0.13.4"

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ enum Commands {
     /// Create a pre-populated GitHub issue with information about your configuration
     BugReport {
         #[clap(short, long)]
-        print: bool
+        print: bool,
     },
     /// Generate starship shell completions for your shell to stdout
     Completions {

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,10 @@ struct Cli {
 #[derive(Subcommand, Debug)]
 enum Commands {
     /// Create a pre-populated GitHub issue with information about your configuration
-    BugReport,
+    BugReport {
+        #[clap(short, long)]
+        print: bool
+    },
     /// Generate starship shell completions for your shell to stdout
     Completions {
         #[clap(arg_enum)]
@@ -190,7 +193,7 @@ fn main() {
         }
         Commands::PrintConfig { default, name } => configure::print_configuration(default, &name),
         Commands::Toggle { name, value } => configure::toggle_configuration(&name, &value),
-        Commands::BugReport => bug_report::create(),
+        Commands::BugReport { print } => bug_report::create(print),
         Commands::Time => {
             match SystemTime::now()
                 .duration_since(SystemTime::UNIX_EPOCH)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -105,7 +105,7 @@ impl PartialEq for CommandOutput {
 /// Allow the user to edit the given buffer in the system editor
 pub fn edit_temp(buffer: String) -> Result<String> {
     let mut file = tempfile::NamedTempFile::new()?;
-    file.write(buffer.as_bytes())?;
+    file.write_all(buffer.as_bytes())?;
 
     let file = file.into_temp_path();
     let fp = file.as_os_str().to_os_string();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
This pull request changes the behaviour of `starship bug-report` to drop into the system editor and allow the user to edit the bug report before populating the GitHub post. An empty bug report cancels the post. I've also added a `-p` `--print` flag to dump the report to stdin instead of posting, as requested in the issue.

~Note: This PR adds a crate: [`edit`](https://crates.io/crates/edit).~

#### Motivation and Context
To allow for better privacy and control over data submitted in bug reports.
Closes #3757 

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the tests accordingly.
- [ ] I have updated the documentation accordingly. 
_I can't find any documentation for `starship bug-report`_
