### PR TITLE
fix(custom): block nu & unknown shells in addition to cmd

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -13,7 +13,7 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::env;
 use std::ffi::{OsStr, OsString};
-use std::fmt::Debug;
+use std::fmt::{self, Debug};
 use std::fs;
 use std::marker::PhantomData;
 use std::num::ParseIntError;
@@ -573,6 +573,24 @@ pub enum Shell {
     Xonsh,
     Cmd,
     Unknown,
+}
+
+impl fmt::Display for Shell {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Shell::Bash => write!(f, "bash"),
+            Shell::Fish => write!(f, "fish"),
+            Shell::Ion => write!(f, "ion"),
+            Shell::PowerShell => write!(f, "powershell"),
+            Shell::Zsh => write!(f, "zsh"),
+            Shell::Elvish => write!(f, "elvish"),
+            Shell::Tcsh => write!(f, "tcsh"),
+            Shell::Nu => write!(f, "nu"),
+            Shell::Xonsh => write!(f, "xonsh"),
+            Shell::Cmd => write!(f, "cmd"),
+            Shell::Unknown => write!(f, "<unknown>"),
+        }
+    }
 }
 
 /// Which kind of prompt target to print (main prompt, rprompt, ...)

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -161,6 +161,12 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
             "vagrant" => vagrant::module(context),
             "vcsh" => vcsh::module(context),
             "zig" => zig::module(context),
+            // Added for tests, avoid potential side effects in production code.
+            #[cfg(test)]
+            custom if custom.starts_with("custom.") => {
+                // SAFETY: We just checked that the module starts with "custom."
+                custom::module(custom.strip_prefix("custom.").unwrap(), context)
+            }
             _ => {
                 eprintln!("Error: Unknown module {}. Use starship module --list to list out all supported modules.", module);
                 None


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
I addition to cmd, also block nu and any unknown shells in custom modules if no explicit `shell` is given.

This PR also adds support for custom modules to `ModuleRenderer`

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #3801

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
