### PR TITLE
fix(docker_context): ignore the "default" context

### DIFF
--- a/src/modules/docker_context.rs
+++ b/src/modules/docker_context.rs
@@ -57,6 +57,10 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         }
     };
 
+    if ctx == "default" {
+        return None;
+    }
+
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter
             .map_meta(|variable, _| match variable {
@@ -301,6 +305,24 @@ mod tests {
             })
             .collect();
         let expected = Some(format!("via {} ", Color::Blue.bold().paint("🐳 starship")));
+
+        assert_eq!(expected, actual);
+
+        cfg_dir.close()
+    }
+
+    #[test]
+    fn test_docker_context_default() -> io::Result<()> {
+        let cfg_dir = tempfile::tempdir()?;
+
+        let actual = ModuleRenderer::new("docker_context")
+            .env("DOCKER_CONTEXT", "default")
+            .config(toml::toml! {
+                [docker_context]
+                only_with_files = false
+            })
+            .collect();
+        let expected = None;
 
         assert_eq!(expected, actual);
 


### PR DESCRIPTION
The [documentation](https://starship.rs/config/#docker-context) states that

> The docker_context module shows the currently active [Docker context (opens new window)](https://docs.docker.com/engine/context/working-with-contexts/) if it's not set to default [...]

This PR checks for the "default" docker context and only shows the module, if the context is not "default", in agreement with the documentation.

#### Description
The PR checks the docker context, which was discovered earlier, for the word "default".

#### Motivation and Context
Closes #3803

#### How Has This Been Tested?
I have tested the before/after behavior by running `test_docker_context_default`, and also in a directory with a Dockerfile where I ran into the issue before.
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [ ] I have updated the documentation accordingly. _(does not apply, I have fixed the code to match the docs)_
- [x] I have updated the tests accordingly.
