### PR TITLE
docs: Hide Runtime Versions preset made simpler

### DIFF
--- a/docs/.vuepress/public/presets/toml/no-runtime-versions.toml
+++ b/docs/.vuepress/public/presets/toml/no-runtime-versions.toml
@@ -1,92 +1,92 @@
 [buf]
-format = "via [$symbol]($style)"
+version_format = ""
 
 [cmake]
-format = "via [$symbol]($style)"
+version_format = ""
 
 [cobol]
-format = "via [$symbol]($style)"
+version_format = ""
 
 [crystal]
-format = "via [$symbol]($style)"
+version_format = ""
 
 [dart]
-format = "via [$symbol]($style)"
+version_format = ""
 
 [deno]
-format = "via [$symbol]($style)"
+version_format = ""
 
 [dotnet]
-format = "[$symbol(🎯 $tfm )]($style)"
+version_format = ""
 
 [elixir]
-format = 'via [$symbol]($style)'
+version_format = ""
 
 [elm]
-format = 'via [$symbol]($style)'
+version_format = ""
 
 [erlang]
-format = 'via [$symbol]($style)'
+version_format = ""
 
 [golang]
-format = 'via [$symbol]($style)'
+version_format = ""
 
 [helm]
-format = 'via [$symbol]($style)'
+version_format = ""
 
 [julia]
-format = 'via [$symbol]($style)'
+version_format = ""
 
 [kotlin]
-format = 'via [$symbol]($style)'
+version_format = ""
 
 [lua]
-format = 'via [$symbol]($style)'
+version_format = ""
 
 [nim]
-format = 'via [$symbol]($style)'
+version_format = ""
 
 [nodejs]
-format = 'via [$symbol]($style)'
+version_format = ""
 
 [ocaml]
-format = 'via [$symbol(\($switch_indicator$switch_name\) )]($style)'
+version_format = ""
 
 [perl]
-format = 'via [$symbol]($style)'
+version_format = ""
 
 [php]
-format = 'via [$symbol]($style)'
+version_format = ""
 
 [pulumi]
-format = 'via [$symbol$stack]($style)'
+version_format = ""
 
 [purescript]
-format = 'via [$symbol]($style)'
+version_format = ""
 
 [python]
-format = 'via [$symbol]($style)'
+version_format = ""
 
 [red]
-format = 'via [$symbol]($style)'
+version_format = ""
 
 [rlang]
-format = 'via [$symbol]($style)'
+version_format = ""
 
 [ruby]
-format = 'via [$symbol]($style)'
+version_format = ""
 
 [rust]
-format = 'via [$symbol]($style)'
+version_format = ""
 
 [swift]
-format = 'via [$symbol]($style)'
+version_format = ""
 
 [vagrant]
-format = 'via [$symbol]($style)'
+version_format = ""
 
 [vlang]
-format = 'via [$symbol]($style)'
+version_format = ""
 
 [zig]
-format = 'via [$symbol]($style)'
+version_format = ""


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
Made "Hide Runtime Versions" preset hide versions only

#### Motivation and Context
 - To show that beginners can do it instead of writing all the formatting
 - Good starter config for cleaner configuration and better than old one
 - If the formatting is changed this configuration will not override it

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [X] I have tested using **Linux**
- [X] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
