### PR TITLE
docs(dotnet): fix link to Microsoft’s documentation for Dotnet

### DIFF
--- a/docs/advanced-config/README.md
+++ b/docs/advanced-config/README.md
@@ -163,7 +163,7 @@ in `format` is also supported in `right_format`. The `$all` variable will only c
 not explicitly used in either `format` or `right_format`.
 
 Note: The right prompt is a single line following the input location. To right align modules above
-the input line in a multi-line prompt, see the [fill module](/config/#fill).
+the input line in a multi-line prompt, see the [`fill` module](/config/#fill).
 
 `right_format` is currently supported for the following shells: elvish, fish, zsh, xonsh, cmd.
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1076,7 +1076,7 @@ unusual directory layout. If accuracy is more important than speed, you can disa
 setting `heuristic = false` in the module options.
 
 The module will also show the Target Framework Moniker
-(<https://docs.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-framework-versions>)
+(<https://docs.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks>)
 when there is a csproj file in the current directory.
 
 ### Options

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -302,16 +302,16 @@ date is read from the `AWSUME_EXPIRATION` env var.
 
 ### Options
 
-| Option              | Default                                                          | Description                                                                                               |
-| ------------------- | ---------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| `format`            | `'on [$symbol($profile )(\($region\) )(\[$duration\])]($style)'` | The format for the module.                                                                                |
-| `symbol`            | `"☁️ "`                                                          | The symbol used before displaying the current AWS profile.                                                |
-| `region_aliases`    |                                                                  | Table of region aliases to display in addition to the AWS name.                                           |
-| `profile_aliases`   |                                                                  | Table of profile aliases to display in addition to the AWS name.                                          |
-| `style`             | `"bold yellow"`                                                  | The style for the module.                                                                                 |
-| `expiration_symbol` | `X`                                                              | The symbol displayed when the temporary credentials have expired.                                         |
-| `disabled`          | `false`                                                          | Disables the `AWS` module.                                                                                |
-| `force_display`     | `false`                                                          | If true displays info even if `credentials`, `credential_process` or `sso_start_url` have not been setup. |
+| Option              | Default                                                          | Description                                                                                                 |
+| ------------------- | ---------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `format`            | `'on [$symbol($profile )(\($region\) )(\[$duration\])]($style)'` | The format for the module.                                                                                  |
+| `symbol`            | `"☁️ "`                                                          | The symbol used before displaying the current AWS profile.                                                  |
+| `region_aliases`    |                                                                  | Table of region aliases to display in addition to the AWS name.                                             |
+| `profile_aliases`   |                                                                  | Table of profile aliases to display in addition to the AWS name.                                            |
+| `style`             | `"bold yellow"`                                                  | The style for the module.                                                                                   |
+| `expiration_symbol` | `X`                                                              | The symbol displayed when the temporary credentials have expired.                                           |
+| `disabled`          | `false`                                                          | Disables the `AWS` module.                                                                                  |
+| `force_display`     | `false`                                                          | If `true` displays info even if `credentials`, `credential_process` or `sso_start_url` have not been setup. |
 
 ### Variables
 
@@ -1077,7 +1077,7 @@ setting `heuristic = false` in the module options.
 
 The module will also show the Target Framework Moniker
 (<https://docs.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks>)
-when there is a csproj file in the current directory.
+when there is a `.csproj` file in the current directory.
 
 ### Options
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -275,7 +275,7 @@ format = "$all$directory$character"
 
 The `aws` module shows the current AWS region and profile when
 credentials, a `credential_process` or a `sso_start_url` have been setup. Alternatively, you can force this
-module to show the region and profile event when the credentials have not been setup
+module to show the region and profile even when the credentials have not been setup
 with the `force_display` option. This is based on
 `AWS_REGION`, `AWS_DEFAULT_REGION`, and `AWS_PROFILE` env var with
 `~/.aws/config` file. This module also shows an expiration timer when using temporary


### PR DESCRIPTION
#### Description
Anchor in link was broken, I fixed it.

Edit: change «when there is a csproj file» to «when there is a `.csproj` file», and add backticks forgotten around a `true`.