### PR TITLE
fix(bash): ensure `checkwinsize` is enabled for `$COLUMNS`

### DIFF
--- a/src/init/starship.bash
+++ b/src/init/starship.bash
@@ -99,6 +99,9 @@ else
     fi
 fi
 
+# Ensure that $COLUMNS gets set
+shopt -s checkwinsize
+
 # Set up the start time and STARSHIP_SHELL, which controls shell-specific sequences
 STARSHIP_START_TIME=$(::STARSHIP:: time)
 export STARSHIP_SHELL="bash"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Without `checkwinsize` `bash` may not properly set `$COLUMNS`, which is passed along by the bash init for the terminal width.

I can't actually reproduce the bug by disabling `checkwinsize`, but it reportedly fixes #3793, and it doesn't seem to break anything.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #3793

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
