### PR TITLE
fix(nu): Use `=` instead of space to pass command line parameters

### DIFF
--- a/src/init/starship.nu
+++ b/src/init/starship.nu
@@ -9,7 +9,7 @@ let-env PROMPT_INDICATOR = ""
 let-env PROMPT_COMMAND = {
     # jobs are not supported
     let width = (term size -c | get columns | into string)
-    ^::STARSHIP:: prompt --cmd-duration $env.CMD_DURATION_MS --status $env.LAST_EXIT_CODE --terminal-width $width
+    ^::STARSHIP:: prompt $"--cmd-duration=($env.CMD_DURATION_MS)" $"--status=($env.LAST_EXIT_CODE)" $"--terminal-width=($width)"
 }
 
 # Not well-suited for `starship prompt --right`.


### PR DESCRIPTION
#### Description

Clap (?) doesn't like to parse negative integers like this: `--status -1`.
Changing it to `--status=-1` fixes that.
With this change the nu script also follows the fish and powershell script more closely. 

#### Motivation and Context

This fixes https://github.com/nushell/nushell/issues/5074

#### Screenshots (if appropriate):

#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**