### PR TITLE
feat(battery): Display only when discharging

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -46,6 +46,7 @@
           {
             "charging_symbol": null,
             "discharging_symbol": null,
+            "only_on_discharge": false,
             "style": "red bold",
             "threshold": 10
           }
@@ -1574,6 +1575,7 @@
             {
               "charging_symbol": null,
               "discharging_symbol": null,
+              "only_on_discharge": false,
               "style": "red bold",
               "threshold": 10
             }
@@ -1618,6 +1620,10 @@
             "string",
             "null"
           ]
+        },
+        "only_on_discharge": {
+          "default": false,
+          "type": "boolean"
         }
       }
     },

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -446,8 +446,9 @@ The default value for the `charging_symbol` and `discharging_symbol` option is r
 The `display` option is an array of the following table.
 
 | Option               | Default    | Description                                                                                               |
-| -------------------- | ---------- | --------------------------------------------------------------------------------------------------------- |
+|----------------------|------------|-----------------------------------------------------------------------------------------------------------|
 | `threshold`          | `10`       | The upper bound for the display option.                                                                   |
+| `only_on_discharge`  | `false`    | Display only when discharging.                                                                            |
 | `style`              | `bold red` | The style used if the display option is in use.                                                           |
 | `charging_symbol`    | `-`        | Optional symbol displayed if display option is in use, defaults to battery's `charging_symbol` option.    |
 | `discharging_symbol` | `-`        | Optional symbol displayed if display option is in use, defaults to battery's `discharging_symbol` option. |
@@ -459,8 +460,9 @@ The `display` option is an array of the following table.
 threshold = 10
 style = "bold red"
 
-[[battery.display]] # "bold yellow" style and 💦 symbol when capacity is between 10% and 30%
+[[battery.display]] # "bold yellow" style and 💦 symbol when capacity is between 10% and 30% and battery is discharging
 threshold = 30
+only_on_discharge = true
 style = "bold yellow"
 discharging_symbol = "💦"
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -446,7 +446,7 @@ The default value for the `charging_symbol` and `discharging_symbol` option is r
 The `display` option is an array of the following table.
 
 | Option               | Default    | Description                                                                                               |
-|----------------------|------------|-----------------------------------------------------------------------------------------------------------|
+| -------------------- | ---------- | --------------------------------------------------------------------------------------------------------- |
 | `threshold`          | `10`       | The upper bound for the display option.                                                                   |
 | `only_on_discharge`  | `false`    | Display only when discharging.                                                                            |
 | `style`              | `bold red` | The style used if the display option is in use.                                                           |

--- a/src/configs/battery.rs
+++ b/src/configs/battery.rs
@@ -38,6 +38,7 @@ pub struct BatteryDisplayConfig<'a> {
     pub style: &'a str,
     pub charging_symbol: Option<&'a str>,
     pub discharging_symbol: Option<&'a str>,
+    pub only_on_discharge: bool,
 }
 
 impl<'a> Default for BatteryDisplayConfig<'a> {
@@ -47,6 +48,7 @@ impl<'a> Default for BatteryDisplayConfig<'a> {
             style: "red bold",
             charging_symbol: None,
             discharging_symbol: None,
+            only_on_discharge: false,
         }
     }
 }

--- a/src/modules/battery.rs
+++ b/src/modules/battery.rs
@@ -3,7 +3,6 @@ use crate::configs::battery::BatteryConfig;
 #[cfg(test)]
 use mockall::automock;
 use starship_battery as battery;
-use starship_battery::State;
 
 use crate::formatter::StringFormatter;
 
@@ -20,7 +19,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     // if all thresholds are lower do not display battery module.
     let display_style = config.display.iter().find(|display_style| {
         if percentage <= display_style.threshold as f32 {
-            return state == State::Discharging || !display_style.only_on_discharge;
+            return state == battery::State::Discharging || !display_style.only_on_discharge;
         }
         false
     })?;

--- a/src/modules/battery.rs
+++ b/src/modules/battery.rs
@@ -375,6 +375,58 @@ mod tests {
     }
 
     #[test]
+    fn battery_only_on_discharge_charging() {
+        let mut mock = MockBatteryInfoProvider::new();
+
+        mock.expect_get_battery_info().times(1).returning(|| {
+            Some(BatteryInfo {
+                energy: 100.0,
+                energy_full: 1000.0,
+                state: battery::State::Charging,
+            })
+        });
+
+        let actual = ModuleRenderer::new("battery")
+            .config(toml::toml! {
+                [[battery.display]]
+                threshold = 10
+                only_on_discharge = true
+                style = ""
+            })
+            .battery_info_provider(&mock)
+            .collect();
+        let expected = None;
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn battery_only_on_discharge_discharging() {
+        let mut mock = MockBatteryInfoProvider::new();
+
+        mock.expect_get_battery_info().times(1).returning(|| {
+            Some(BatteryInfo {
+                energy: 100.0,
+                energy_full: 1000.0,
+                state: battery::State::Discharging,
+            })
+        });
+
+        let actual = ModuleRenderer::new("battery")
+            .config(toml::toml! {
+                [[battery.display]]
+                threshold = 10
+                only_on_discharge = true
+                style = ""
+            })
+            .battery_info_provider(&mock)
+            .collect();
+        let expected = Some(String::from(" 10% "));
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
     fn battery_uses_style() {
         let mut mock = MockBatteryInfoProvider::new();
 

--- a/src/modules/battery.rs
+++ b/src/modules/battery.rs
@@ -18,15 +18,12 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     // Parse config under `display`.
     // Select the first style that match the threshold,
     // if all thresholds are lower do not display battery module.
-    let display_style = config
-        .display
-        .iter()
-        .find(|display_style| {
-            if percentage <= display_style.threshold as f32 {
-                return state == State::Discharging || !display_style.only_on_discharge
-            }
-            false
-        })?;
+    let display_style = config.display.iter().find(|display_style| {
+        if percentage <= display_style.threshold as f32 {
+            return state == State::Discharging || !display_style.only_on_discharge;
+        }
+        false
+    })?;
 
     // Parse the format string and build the module
     match StringFormatter::new(config.format) {

--- a/src/modules/battery.rs
+++ b/src/modules/battery.rs
@@ -3,6 +3,7 @@ use crate::configs::battery::BatteryConfig;
 #[cfg(test)]
 use mockall::automock;
 use starship_battery as battery;
+use starship_battery::State;
 
 use crate::formatter::StringFormatter;
 
@@ -20,7 +21,12 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let display_style = config
         .display
         .iter()
-        .find(|display_style| percentage <= display_style.threshold as f32)?;
+        .find(|display_style| {
+            if percentage <= display_style.threshold as f32 {
+                return state == State::Discharging || !display_style.only_on_discharge
+            }
+            false
+        })?;
 
     // Parse the format string and build the module
     match StringFormatter::new(config.format) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
Adds option `only_on_discharge` to limit the display of the `battery` module only when the battery is discharging (not plugged in), given that the existing `threshold` option evalutes to `true`.
As this is my first contribution to this project, I'll keep this as a draft for now and would appreciate some feedback. Thanks!

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #3845 

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
