### PR TITLE
feat(cmd_duration): make notify feature optional (compat with nix darwin)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,10 @@ The minimal, blazing-fast, and infinitely customizable prompt for any shell! ☄
 """
 
 [features]
-default = ["battery"]
+default = ["battery", "notify"]
 battery = ["starship-battery"]
 config-schema = ["schemars"]
+notify = ["notify-rust"]
 
 [dependencies]
 ansi_term = "0.12.1"
@@ -47,7 +48,9 @@ git2 = { version = "0.14.2", default-features = false }
 indexmap = { version = "1.8.1", features = ["serde"] }
 local_ipaddress = "0.1.3"
 log = { version = "0.4.16", features = ["std"] }
-notify-rust = "4.5.8"
+# nofity-rust is optional (on by default) because the crate doesn't currently build for darwin with nix
+# see: https://github.com/NixOS/nixpkgs/issues/160876
+notify-rust = { version = "4.5.8", optional = true }
 once_cell = "1.10.0"
 open = "2.1.1"
 os_info = "3.2.0"

--- a/src/modules/cmd_duration.rs
+++ b/src/modules/cmd_duration.rs
@@ -51,6 +51,16 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     Some(undistract_me(module, &config, elapsed))
 }
 
+#[cfg(not(feature = "notify"))]
+fn undistract_me<'a, 'b>(
+    module: Module<'a>,
+    _config: &'b CmdDurationConfig,
+    _elapsed: u128,
+) -> Module<'a> {
+    module
+}
+
+#[cfg(feature = "notify")]
 fn undistract_me<'a, 'b>(
     module: Module<'a>,
     config: &'b CmdDurationConfig,


### PR DESCRIPTION
#### Description

the notify-rust has some very cryptic compilation error on nix and darwin. (reference issue https://github.com/NixOS/nixpkgs/issues/160876)

In the meanwhile, version has been moved forward in nix to not penalize linux users.

Hopefully we can find the source of the error, but in the meanwhile, making this dependency optional is very helpful!

Thank you again for your terminal! (going a month without it, feels like going back to the stone age #addicted)

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?

I ran `cargo test`, `cargo test --no-default-features`, `cargo clippy --all-features --all-targets` and couldn't find problems with it, let me know however if you need changes.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [X] I have updated the tests accordingly.
