### PR TITLE
chore(aws): adds space to the duration variable

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -12,7 +12,7 @@
         "disabled": false,
         "expiration_symbol": "X",
         "force_display": false,
-        "format": "on [$symbol($profile )(\\($region\\) )(\\[$duration\\])]($style)",
+        "format": "on [$symbol($profile )(\\($region\\) )(\\[$duration\\] )]($style)",
         "profile_aliases": {},
         "region_aliases": {},
         "style": "bold yellow",
@@ -1479,7 +1479,7 @@
       "properties": {
         "format": {
           "description": "The format for the module.",
-          "default": "on [$symbol($profile )(\\($region\\) )(\\[$duration\\])]($style)",
+          "default": "on [$symbol($profile )(\\($region\\) )(\\[$duration\\] )]($style)",
           "type": "string"
         },
         "symbol": {

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -306,16 +306,16 @@ date is read from the `AWSUME_EXPIRATION` env var.
 
 ### Options
 
-| Option              | Default                                                          | Description                                                                                                 |
-| ------------------- | ---------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| `format`            | `'on [$symbol($profile )(\($region\) )(\[$duration\])]($style)'` | The format for the module.                                                                                  |
-| `symbol`            | `"☁️ "`                                                          | The symbol used before displaying the current AWS profile.                                                  |
-| `region_aliases`    |                                                                  | Table of region aliases to display in addition to the AWS name.                                             |
-| `profile_aliases`   |                                                                  | Table of profile aliases to display in addition to the AWS name.                                            |
-| `style`             | `"bold yellow"`                                                  | The style for the module.                                                                                   |
-| `expiration_symbol` | `X`                                                              | The symbol displayed when the temporary credentials have expired.                                           |
-| `disabled`          | `false`                                                          | Disables the `AWS` module.                                                                                  |
-| `force_display`     | `false`                                                          | If `true` displays info even if `credentials`, `credential_process` or `sso_start_url` have not been setup. |
+| Option              | Default                                                           | Description                                                                                                 |
+| ------------------- | ----------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `format`            | `'on [$symbol($profile )(\($region\) )(\[$duration\] )]($style)'` | The format for the module.                                                                                  |
+| `symbol`            | `"☁️ "`                                                           | The symbol used before displaying the current AWS profile.                                                  |
+| `region_aliases`    |                                                                   | Table of region aliases to display in addition to the AWS name.                                             |
+| `profile_aliases`   |                                                                   | Table of profile aliases to display in addition to the AWS name.                                            |
+| `style`             | `"bold yellow"`                                                   | The style for the module.                                                                                   |
+| `expiration_symbol` | `X`                                                               | The symbol displayed when the temporary credentials have expired.                                           |
+| `disabled`          | `false`                                                           | Disables the `AWS` module.                                                                                  |
+| `force_display`     | `false`                                                           | If `true` displays info even if `credentials`, `credential_process` or `sso_start_url` have not been setup. |
 
 ### Variables
 

--- a/src/configs/aws.rs
+++ b/src/configs/aws.rs
@@ -50,7 +50,7 @@ pub struct AwsConfig<'a> {
 impl<'a> Default for AwsConfig<'a> {
     fn default() -> Self {
         AwsConfig {
-            format: "on [$symbol($profile )(\\($region\\) )(\\[$duration\\])]($style)",
+            format: "on [$symbol($profile )(\\($region\\) )(\\[$duration\\] )]($style)",
             symbol: "☁️  ",
             style: "bold yellow",
             disabled: false,

--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -633,7 +633,7 @@ credential_process = /opt/bin/awscreds-retriever
             "on {}",
             Color::Yellow
                 .bold()
-                .paint("☁️  astronauts (ap-northeast-2) [30m]")
+                .paint("☁️  astronauts (ap-northeast-2) [30m] ")
         ));
 
         assert_eq!(expected, actual);
@@ -679,7 +679,7 @@ expiration={}
         // on shared runners may delay it. Allow for up to 2 seconds of delay.
         let possible_values = ["30m", "29m59s", "29m58s"];
         let possible_values = possible_values.map(|duration| {
-            let segment_colored = format!("☁️  astronauts (ap-northeast-2) [{}]", duration);
+            let segment_colored = format!("☁️  astronauts (ap-northeast-2) [{}] ", duration);
             Some(format!(
                 "on {}",
                 Color::Yellow.bold().paint(segment_colored)
@@ -736,7 +736,7 @@ expiration={}
             "on {}",
             Color::Yellow
                 .bold()
-                .paint(format!("☁️  astronauts (ap-northeast-2) [{}]", symbol))
+                .paint(format!("☁️  astronauts (ap-northeast-2) [{}] ", symbol))
         ));
 
         assert_eq!(expected, actual);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
Adds a missing space to the duration variable in the AWS module.

#### Motivation and Context
Styling

#### Screenshots (if appropriate):
before:
<img width="234" alt="Screenshot 2022-04-14 at 13 53 38" src="https://user-images.githubusercontent.com/2544673/163394550-1d831f40-c6fd-4288-a2f1-a2c1e9cefbfb.png">
after:
<img width="263" alt="Screenshot 2022-04-14 at 13 53 48" src="https://user-images.githubusercontent.com/2544673/163394574-33a55000-4395-467d-8de0-231ee1d25462.png">


#### How Has This Been Tested?
I have manually added the format string to my toml config

```toml
[aws]
format = "on [$symbol($profile )(\\($region\\) )(\\[$duration\\] )]($style)"
```
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.

Hopefully, I have updated everything, documentation and tests.