### PR TITLE
feat: Add a module for C++ projects

### DIFF
--- a/docs/.vuepress/public/config-schema.json
+++ b/docs/.vuepress/public/config-schema.json
@@ -216,6 +216,44 @@
         }
       ]
     },
+    "cpp": {
+      "default": {
+        "commands": [
+          [
+            "c++",
+            "--version"
+          ],
+          [
+            "cpp",
+            "--version"
+          ],
+          [
+            "g++",
+            "--version"
+          ],
+          [
+            "clang++",
+            "--version"
+          ]
+        ],
+        "detect_extensions": [
+          "cpp",
+          "hpp"
+        ],
+        "detect_files": [],
+        "detect_folders": [],
+        "disabled": false,
+        "format": "via [$symbol($version(-$name) )]($style)",
+        "style": "cyan bold",
+        "symbol": "C++ ",
+        "version_format": "v${raw}"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/CppConfig"
+        }
+      ]
+    },
     "crystal": {
       "default": {
         "detect_extensions": [
@@ -1960,6 +1998,82 @@
         "disabled": {
           "default": false,
           "type": "boolean"
+        }
+      }
+    },
+    "CppConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "via [$symbol($version(-$name) )]($style)",
+          "type": "string"
+        },
+        "version_format": {
+          "default": "v${raw}",
+          "type": "string"
+        },
+        "style": {
+          "default": "cyan bold",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "C++ ",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "detect_extensions": {
+          "default": [
+            "cpp",
+            "hpp"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_files": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_folders": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "commands": {
+          "default": [
+            [
+              "c++",
+              "--version"
+            ],
+            [
+              "cpp",
+              "--version"
+            ],
+            [
+              "g++",
+              "--version"
+            ],
+            [
+              "clang++",
+              "--version"
+            ]
+          ],
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
         }
       }
     },

--- a/docs/.vuepress/public/presets/toml/bracketed-segments.toml
+++ b/docs/.vuepress/public/presets/toml/bracketed-segments.toml
@@ -16,6 +16,9 @@ format = '\[[$symbol($version)]($style)\]'
 [conda]
 format = '\[[$symbol$environment]($style)\]'
 
+[cpp]
+format = '\[[$symbol($version(-$name))]($style)\]'
+
 [crystal]
 format = '\[[$symbol($version)]($style)\]'
 

--- a/docs/.vuepress/public/presets/toml/nerd-font-symbols.toml
+++ b/docs/.vuepress/public/presets/toml/nerd-font-symbols.toml
@@ -10,6 +10,9 @@ symbol = " "
 [conda]
 symbol = " "
 
+[cpp]
+symbol = " "
+
 [dart]
 symbol = " "
 

--- a/docs/.vuepress/public/presets/toml/plain-text-symbols.toml
+++ b/docs/.vuepress/public/presets/toml/plain-text-symbols.toml
@@ -25,6 +25,9 @@ symbol = "cobol "
 [conda]
 symbol = "conda "
 
+[cpp]
+symbol = "C++ "
+
 [crystal]
 symbol = "cr "
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -214,6 +214,7 @@ $c\
 $cmake\
 $cobol\
 $container\
+$cpp\
 $dart\
 $deno\
 $dotnet\
@@ -803,6 +804,54 @@ The `container` module displays a symbol and container name, if inside a contain
 
 [container]
 format = "[$symbol \\[$name\\]]($style) "
+```
+
+## Cpp / C++
+
+The `cpp` module shows some information about your C++ compiler. By default
+the module will be shown if the current directory contains a `.cpp` or `.hpp`
+file.
+
+### Options
+
+| Option              | Default                                                                                                | Description                                                               |
+| ------------------- | ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------- |
+| `format`            | `"via [$symbol($version(-$name) )]($style)"`                                                           | The format string for the module.                                         |
+| `version_format`    | `"v${raw}"`                                                                                            | The version format. Available vars are `raw`, `major`, `minor`, & `patch` |
+| `symbol`            | `"C++ "`                                                                                               | The symbol used before displaying the compiler details                    |
+| `detect_extensions` | `["cpp", "hpp"]`                                                                                       | Which extensions should trigger this module.                              |
+| `detect_files`      | `[]`                                                                                                   | Which filenames should trigger this module.                               |
+| `detect_folders`    | `[]`                                                                                                   | Which folders should trigger this module.                                 |
+| `commands`          | [ [ "c++", "--version" ], [ "cpp", "--version" ], [ "g++", "--version" ], [ "clang++", "--version" ] ] | How to detect what the compiler is                                        |
+| `style`             | `"bold cyan"`                                                                                          | The style for the module.                                                 |
+| `disabled`          | `false`                                                                                                | Disables the `cpp` module.                                                |
+
+### Variables
+
+| Variable | Example | Description                          |
+| -------- | ------- | ------------------------------------ |
+| name     | clang++ | The name of the compiler             |
+| version  | 13.0.0  | The version of the compiler          |
+| symbol   |         | Mirrors the value of option `symbol` |
+| style    |         | Mirrors the value of option `style`  |
+
+NB that `version` is not in the default format.
+
+### Commands
+
+The `commands` option accepts a list of commands to determine the compiler version and name.
+
+Each command is represented as a list of the executable name, followed by its arguments, usually something like `["mycc", "--version"]`. Starship will try executing each command until it gets a result on STDOUT.
+
+If a C++ compiler is not supported by this module, you can request it by [raising an issue on GitHub](https://github.com/starship/starship/).
+
+### Example
+
+```toml
+# ~/.config/starship.toml
+
+[cpp]
+format = "via [$name $version]($style)"
 ```
 
 ## Crystal

--- a/src/configs/cpp.rs
+++ b/src/configs/cpp.rs
@@ -1,0 +1,37 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
+#[serde(default)]
+pub struct CppConfig<'a> {
+    pub format: &'a str,
+    pub version_format: &'a str,
+    pub style: &'a str,
+    pub symbol: &'a str,
+    pub disabled: bool,
+    pub detect_extensions: Vec<&'a str>,
+    pub detect_files: Vec<&'a str>,
+    pub detect_folders: Vec<&'a str>,
+    pub commands: Vec<Vec<&'a str>>,
+}
+
+impl<'a> Default for CppConfig<'a> {
+    fn default() -> Self {
+        CppConfig {
+            format: "via [$symbol($version(-$name) )]($style)",
+            version_format: "v${raw}",
+            style: "cyan bold",
+            symbol: "C++ ",
+            disabled: false,
+            detect_extensions: vec!["cpp", "hpp"],
+            detect_files: vec![],
+            detect_folders: vec![],
+            commands: vec![
+                vec!["c++", "--version"],
+                vec!["cpp", "--version"],
+                vec!["g++", "--version"],
+                vec!["clang++", "--version"],
+            ],
+        }
+    }
+}

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -12,6 +12,7 @@ pub mod cmd_duration;
 pub mod cobol;
 pub mod conda;
 pub mod container;
+pub mod cpp;
 pub mod crystal;
 pub mod custom;
 pub mod dart;
@@ -111,6 +112,8 @@ pub struct FullConfig<'a> {
     conda: conda::CondaConfig<'a>,
     #[serde(borrow)]
     container: container::ContainerConfig<'a>,
+    #[serde(borrow)]
+    cpp: cpp::CppConfig<'a>,
     #[serde(borrow)]
     crystal: crystal::CrystalConfig<'a>,
     #[serde(borrow)]

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -39,6 +39,7 @@ pub const PROMPT_ORDER: &[&str] = &[
     "c",
     "cmake",
     "cobol",
+    "cpp",
     "dart",
     "deno",
     "dotnet",

--- a/src/module.rs
+++ b/src/module.rs
@@ -20,6 +20,7 @@ pub const ALL_MODULES: &[&str] = &[
     "cobol",
     "conda",
     "container",
+    "cpp",
     "crystal",
     "dart",
     "deno",

--- a/src/modules/cpp.rs
+++ b/src/modules/cpp.rs
@@ -167,6 +167,7 @@ warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.",
         // The case when it claims to be clang++ is covered in folder_with_hpp_file,
         // and uses the mock in src/test/mod.rs.
         let actual = ModuleRenderer::new("cpp")
+            .cmd("c++ --version", None)
             .cmd(
                 "cpp --version",
                 Some(CommandOutput {
@@ -190,6 +191,7 @@ warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.",
 
         // What happens when `cpp --version` says it's ancient g++?
         let actual = ModuleRenderer::new("cpp")
+            .cmd("c++ --version", None)
             .cmd(
                 "cpp --version",
                 Some(CommandOutput {
@@ -215,6 +217,22 @@ warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.",
         // not running on a Z80 so we're never going to see this one in reality!
         let actual = ModuleRenderer::new("cpp")
             .cmd(
+                "c++ --version",
+                Some(CommandOutput {
+                    stdout: String::from("HISOFT-C++ Compiler  V1.2\nCopyright © 1984 HISOFT"),
+                    stderr: String::default(),
+                }),
+            )
+            .path(dir.path())
+            .collect();
+        let expected = Some(format!("via {}", Color::Cyan.bold().paint("C++ ")));
+        assert_eq!(expected, actual);
+
+        // What happens with an unknown C++ compiler? Needless to say, we're
+        // not running on a Z80 so we're never going to see this one in reality!
+        let actual = ModuleRenderer::new("cpp")
+            .cmd("c++ --version", None)
+            .cmd(
                 "cpp --version",
                 Some(CommandOutput {
                     stdout: String::from("HISOFT-C++ Compiler  V1.2\nCopyright © 1984 HISOFT"),
@@ -226,8 +244,8 @@ warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.",
         let expected = Some(format!("via {}", Color::Cyan.bold().paint("C++ ")));
         assert_eq!(expected, actual);
 
-        // What happens when 'c++ --version' doesn't work, but 'g++ --version' does?
-        // This stubs out `c++` but we'll fall back to `g++ --version` as defined in
+        // What happens when 'c++ --version' doesn't work, but 'cpp --version' does?
+        // This stubs out `c++` but we'll fall back to `cpp --version` as defined in
         // src/test/mod.rs.
         // Also we don't bother to redefine the config for this one, as we've already
         // proved we can parse its version.
@@ -241,18 +259,19 @@ warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.",
         ));
         assert_eq!(expected, actual);
 
-        // What happens when 'cpp --version' doesn't work, but 'g++ --version' does?
-        // This stubs out `cpp` but we'll fall back to `g++ --version` as defined in
+        // What happens when 'c++/cpp --version' doesn't work, but 'g++ --version' does?
+        // This stubs out `c++/cpp` but we'll fall back to `g++ --version` as defined in
         // src/test/mod.rs.
         // Also we don't bother to redefine the config for this one, as we've already
         // proved we can parse its version.
         let actual = ModuleRenderer::new("cpp")
+            .cmd("c++ --version", None)
             .cmd("cpp --version", None)
             .path(dir.path())
             .collect();
         let expected = Some(format!(
             "via {}",
-            Color::Cyan.bold().paint("C++ v10.2.1-g++ ")
+            Color::Cyan.bold().paint("C++ v10.2.2-g++ ")
         ));
         assert_eq!(expected, actual);
 

--- a/src/modules/cpp.rs
+++ b/src/modules/cpp.rs
@@ -1,0 +1,299 @@
+use super::{Context, Module, ModuleConfig};
+
+use crate::configs::cpp::CppConfig;
+use crate::formatter::StringFormatter;
+use crate::formatter::VersionFormatter;
+
+use once_cell::sync::Lazy;
+use semver::Version;
+use std::borrow::Cow;
+use std::ops::Deref;
+
+/// Creates a module with the current C++ compiler and version
+pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let mut module = context.new_module("cpp");
+    let config: CppConfig = CppConfig::try_load(module.config);
+    let is_cpp_project = context
+        .try_begin_scan()?
+        .set_extensions(&config.detect_extensions)
+        .set_files(&config.detect_files)
+        .set_folders(&config.detect_folders)
+        .is_match();
+
+    if !is_cpp_project {
+        return None;
+    }
+
+    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
+        let cpp_compiler_info = Lazy::new(|| context.exec_cmds_return_first(config.commands));
+
+        formatter
+            .map_meta(|var, _| match var {
+                "symbol" => Some(config.symbol),
+                _ => None,
+            })
+            .map_style(|variable| match variable {
+                "style" => Some(Ok(config.style)),
+                _ => None,
+            })
+            .map(|variable| match variable {
+                "name" => {
+                    let cpp_compiler_info = &cpp_compiler_info.deref().as_ref()?.stdout;
+
+                    let cpp_compiler = if cpp_compiler_info.contains("clang") {
+                        "clang++"
+                    } else if cpp_compiler_info.contains("Free Software Foundation") {
+                        "g++"
+                    } else {
+                        return None;
+                    };
+                    Some(cpp_compiler).map(Cow::Borrowed).map(Ok)
+                }
+                "version" => {
+                    let cpp_compiler_info = &cpp_compiler_info.deref().as_ref()?.stdout;
+
+                    // Clang says ...
+                    //   Apple clang version 13.0.0 ...\n
+                    //   OpenBSD clang version 11.1.0\n...
+                    //   FreeBSD clang version 11.0.1 ...\n
+                    // so we always want the first semver-ish whitespace-
+                    // separated "word".
+                    // c++/cpp/g++ says ...
+                    //   g++ (OmniOS 151036/9.3.0-il-1) 9.3.0\n...
+                    //   g++ (Debian 10.2.1-6) 10.2.1 ...\n
+                    //   cpp (GCC) 3.3.5 (Debian 1:3.3.5-13)\n...
+                    // so again we always want the first semver-ish word.
+                    VersionFormatter::format_module_version(
+                        module.get_name(),
+                        cpp_compiler_info.split_whitespace().find_map(
+                            |word| match Version::parse(word) {
+                                Ok(_v) => Some(word),
+                                Err(_e) => None,
+                            },
+                        )?,
+                        config.version_format,
+                    )
+                    .map(Cow::Owned)
+                    .map(Ok)
+                }
+                _ => None,
+            })
+            .parse(None, Some(context))
+    });
+
+    module.set_segments(match parsed {
+        Ok(segments) => segments,
+        Err(error) => {
+            log::warn!("Error in module `cpp`:\n{}", error);
+            return None;
+        }
+    });
+
+    Some(module)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{test::ModuleRenderer, utils::CommandOutput};
+    use ansi_term::Color;
+    use std::fs::File;
+    use std::io;
+
+    #[test]
+    fn folder_without_cpp_files() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+
+        let actual = ModuleRenderer::new("cpp").path(dir.path()).collect();
+
+        let expected = None;
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn folder_with_cpp_file() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join("any.cpp"))?.sync_all()?;
+
+        // What happens when `c++ --version` says it's modern g++?
+        // The case when it claims to be clang++ is covered in folder_with_hpp_file,
+        // and uses the mock in src/test/mod.rs.
+        let actual = ModuleRenderer::new("cpp")
+            .cmd(
+                "c++ --version",
+                Some(CommandOutput {
+                    stdout: String::from(
+                        "\
+c++ (Debian 10.2.1-6) 10.2.1 20210110
+Copyright (C) 2020 Free Software Foundation, Inc.
+This is free software; see the source for copying conditions.  There is NO
+warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.",
+                    ),
+                    stderr: String::default(),
+                }),
+            )
+            .path(dir.path())
+            .collect();
+        let expected = Some(format!(
+            "via {}",
+            Color::Cyan.bold().paint("C++ v10.2.1-g++ ")
+        ));
+        assert_eq!(expected, actual);
+
+        // What happens when `c++ --version` says it's ancient g++?
+        let actual = ModuleRenderer::new("cpp")
+            .cmd(
+                "c++ --version",
+                Some(CommandOutput {
+                    stdout: String::from(
+                        "\
+c++ (GCC) 3.3.5 (Debian 1:3.3.5-13)
+Copyright (C) 2003 Free Software Foundation, Inc.
+This is free software; see the source for copying conditions.  There is NO
+warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.",
+                    ),
+                    stderr: String::default(),
+                }),
+            )
+            .path(dir.path())
+            .collect();
+        let expected = Some(format!(
+            "via {}",
+            Color::Cyan.bold().paint("C++ v3.3.5-g++ ")
+        ));
+        assert_eq!(expected, actual);
+
+        // What happens when `cpp --version` says it's modern g++?
+        // The case when it claims to be clang++ is covered in folder_with_hpp_file,
+        // and uses the mock in src/test/mod.rs.
+        let actual = ModuleRenderer::new("cpp")
+            .cmd(
+                "cpp --version",
+                Some(CommandOutput {
+                    stdout: String::from(
+                        "\
+cpp (Debian 10.2.1-6) 10.2.1 20210110
+Copyright (C) 2020 Free Software Foundation, Inc.
+This is free software; see the source for copying conditions.  There is NO
+warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.",
+                    ),
+                    stderr: String::default(),
+                }),
+            )
+            .path(dir.path())
+            .collect();
+        let expected = Some(format!(
+            "via {}",
+            Color::Cyan.bold().paint("C++ v10.2.1-g++ ")
+        ));
+        assert_eq!(expected, actual);
+
+        // What happens when `cpp --version` says it's ancient g++?
+        let actual = ModuleRenderer::new("cpp")
+            .cmd(
+                "cpp --version",
+                Some(CommandOutput {
+                    stdout: String::from(
+                        "\
+cpp (GCC) 3.3.5 (Debian 1:3.3.5-13)
+Copyright (C) 2003 Free Software Foundation, Inc.
+This is free software; see the source for copying conditions.  There is NO
+warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.",
+                    ),
+                    stderr: String::default(),
+                }),
+            )
+            .path(dir.path())
+            .collect();
+        let expected = Some(format!(
+            "via {}",
+            Color::Cyan.bold().paint("C++ v3.3.5-g++ ")
+        ));
+        assert_eq!(expected, actual);
+
+        // What happens with an unknown C++ compiler? Needless to say, we're
+        // not running on a Z80 so we're never going to see this one in reality!
+        let actual = ModuleRenderer::new("cpp")
+            .cmd(
+                "cpp --version",
+                Some(CommandOutput {
+                    stdout: String::from("HISOFT-C++ Compiler  V1.2\nCopyright © 1984 HISOFT"),
+                    stderr: String::default(),
+                }),
+            )
+            .path(dir.path())
+            .collect();
+        let expected = Some(format!("via {}", Color::Cyan.bold().paint("C++ ")));
+        assert_eq!(expected, actual);
+
+        // What happens when 'c++ --version' doesn't work, but 'g++ --version' does?
+        // This stubs out `c++` but we'll fall back to `g++ --version` as defined in
+        // src/test/mod.rs.
+        // Also we don't bother to redefine the config for this one, as we've already
+        // proved we can parse its version.
+        let actual = ModuleRenderer::new("cpp")
+            .cmd("c++ --version", None)
+            .path(dir.path())
+            .collect();
+        let expected = Some(format!(
+            "via {}",
+            Color::Cyan.bold().paint("C++ v10.2.1-g++ ")
+        ));
+        assert_eq!(expected, actual);
+
+        // What happens when 'cpp --version' doesn't work, but 'g++ --version' does?
+        // This stubs out `cpp` but we'll fall back to `g++ --version` as defined in
+        // src/test/mod.rs.
+        // Also we don't bother to redefine the config for this one, as we've already
+        // proved we can parse its version.
+        let actual = ModuleRenderer::new("cpp")
+            .cmd("cpp --version", None)
+            .path(dir.path())
+            .collect();
+        let expected = Some(format!(
+            "via {}",
+            Color::Cyan.bold().paint("C++ v10.2.1-g++ ")
+        ));
+        assert_eq!(expected, actual);
+
+        // Now with 'c++', 'cpp' and 'g++' not working, this should fall back to 'clang++ --version'
+        let actual = ModuleRenderer::new("cpp")
+            .cmd("c++ --version", None)
+            .cmd("cpp --version", None)
+            .cmd("g++ --version", None)
+            .path(dir.path())
+            .collect();
+        let expected = Some(format!(
+            "via {}",
+            Color::Cyan.bold().paint("C++ v11.1.0-clang++ ")
+        ));
+        assert_eq!(expected, actual);
+
+        // What happens when we can't find any of c++, cpp, g++ or clang++?
+        let actual = ModuleRenderer::new("cpp")
+            .cmd("c++ --version", None)
+            .cmd("cpp --version", None)
+            .cmd("g++ --version", None)
+            .cmd("clang++ --version", None)
+            .path(dir.path())
+            .collect();
+        let expected = Some(format!("via {}", Color::Cyan.bold().paint("C++ ")));
+        assert_eq!(expected, actual);
+
+        dir.close()
+    }
+
+    #[test]
+    fn folder_with_hpp_file() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join("any.hpp"))?.sync_all()?;
+
+        let actual = ModuleRenderer::new("cpp").path(dir.path()).collect();
+        let expected = Some(format!(
+            "via {}",
+            Color::Cyan.bold().paint("C++ v11.0.1-clang++ ")
+        ));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+}

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -9,6 +9,7 @@ mod cmd_duration;
 mod cobol;
 mod conda;
 mod container;
+mod cpp;
 mod crystal;
 pub(crate) mod custom;
 mod dart;
@@ -102,6 +103,7 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
             "cobol" => cobol::module(context),
             "conda" => conda::module(context),
             "container" => container::module(context),
+            "cpp" => cpp::module(context),
             "dart" => dart::module(context),
             "deno" => deno::module(context),
             "directory" => directory::module(context),
@@ -203,6 +205,7 @@ pub fn description(module: &str) -> &'static str {
         "cobol" => "The currently installed version of COBOL/GNUCOBOL",
         "conda" => "The current conda environment, if $CONDA_DEFAULT_ENV is set",
         "container" => "The container indicator, if inside a container.",
+        "cpp" => "Your C++ compiler type",
         "crystal" => "The currently installed version of Crystal",
         "dart" => "The currently installed version of Dart",
         "deno" => "The currently installed version of Deno",

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -159,10 +159,10 @@ InstalledDir: /usr/bin"),
         }),
         "c++ --version" => Some(CommandOutput {
             stdout: String::from("\
-c++ (Debian 10.2.1-6) 10.2.1 20210110
-Copyright (C) 2020 Free Software Foundation, Inc.
-This is free software; see the source for copying conditions.  There is NO
-warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE."),
+FreeBSD clang version 11.0.1 (git@github.com:llvm/llvm-project.git llvmorg-11.0.1-0-g43ff75f2c3fe)
+Target: x86_64-unknown-freebsd13.0
+Thread model: posix
+InstalledDir: /usr/bin"),
             stderr: String::default(),
         }),
         "cpp --version" => Some(CommandOutput {
@@ -175,7 +175,7 @@ warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE."),
         }),
         "g++ --version" => Some(CommandOutput {
             stdout: String::from("\
-g++ (Debian 10.2.1-6) 10.2.1 20210110
+g++ (Debian 10.2.2-6) 10.2.2 20210110
 Copyright (C) 2020 Free Software Foundation, Inc.
 This is free software; see the source for copying conditions.  There is NO
 warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE."),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -157,6 +157,38 @@ Thread model: posix
 InstalledDir: /usr/bin"),
             stderr: String::default(),
         }),
+        "c++ --version" => Some(CommandOutput {
+            stdout: String::from("\
+c++ (Debian 10.2.1-6) 10.2.1 20210110
+Copyright (C) 2020 Free Software Foundation, Inc.
+This is free software; see the source for copying conditions.  There is NO
+warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE."),
+            stderr: String::default(),
+        }),
+        "cpp --version" => Some(CommandOutput {
+            stdout: String::from("\
+cpp (Debian 10.2.1-6) 10.2.1 20210110
+Copyright (C) 2020 Free Software Foundation, Inc.
+This is free software; see the source for copying conditions.  There is NO
+warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE."),
+            stderr: String::default(),
+        }),
+        "g++ --version" => Some(CommandOutput {
+            stdout: String::from("\
+g++ (Debian 10.2.1-6) 10.2.1 20210110
+Copyright (C) 2020 Free Software Foundation, Inc.
+This is free software; see the source for copying conditions.  There is NO
+warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE."),
+            stderr: String::default(),
+        }),
+        "clang++ --version" => Some(CommandOutput {
+            stdout: String::from("\
+OpenBSD clang version 11.1.0
+Target: amd64-unknown-openbsd7.0
+Thread model: posix
+InstalledDir: /usr/bin"),
+            stderr: String::default(),
+        }),
         "cobc -version" => Some(CommandOutput {
             stdout: String::from("\
 cobc (GnuCOBOL) 3.1.2.0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Adds a module to detect and handle C++ language projects

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
There's no existing module for C++, and one for C was merged recently (#3631).

#### Screenshots (if appropriate):
<img width="533" alt="Screenshot 2022-04-16 at 17 47 59" src="https://user-images.githubusercontent.com/39613949/163681726-5539ba37-5996-49be-aedf-af356bab318b.png">

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
