### PR TITLE
feat(git): replace `git2` with `git-repository`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "ahash"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -38,6 +44,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
 
 [[package]]
+name = "arc-swap"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "983cd8b9d4b02a6dc6ffa557262eb5858a27a0038ffffe21a0f133eaa819a164"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+
+[[package]]
 name = "async-broadcast"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -46,7 +64,7 @@ dependencies = [
  "easy-parallel",
  "event-listener",
  "futures-core",
- "parking_lot",
+ "parking_lot 0.11.2",
 ]
 
 [[package]]
@@ -131,6 +149,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c57d12312ff59c811c0643f4d80830505833c9ffaebd193d819392b265be8e"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,6 +211,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+]
+
+[[package]]
+name = "btoi"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97c0869a9faa81f8bbf8102371105d6d0a7b79167a04c340b04ab16892246a11"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -194,6 +241,15 @@ name = "byte-slice-cast"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87c5fdd0166095e1d463fc6cc01aa8ce547ad77a4e84d42eb6762b084e28067e"
+
+[[package]]
+name = "byte-unit"
+version = "4.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95ebf10dda65f19ff0f42ea15572a359ed60d7fc74fdc984d90310937be0014b"
+dependencies = [
+ "utf8-width",
+]
 
 [[package]]
 name = "byteorder"
@@ -220,13 +276,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
 
 [[package]]
+name = "castaway"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a17ed5635fc8536268e5d4de1e22e81ac34419e5f052d4d51f4e01dcc263fcc"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
-dependencies = [
- "jobserver",
-]
 
 [[package]]
 name = "cfg-if"
@@ -303,6 +365,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "clru"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "218d6bd3dde8e442a975fa1cd233c0e5fded7596bccfe39f58eca98d22421e0a"
+
+[[package]]
+name = "cmake"
+version = "0.1.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8ad8cef104ac57b68b89df3208164d228503abbdce70f6880ffa3d970e7443a"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "combine"
 version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,6 +387,17 @@ checksum = "2a604e93b79d1808327a6fca85a6f2d69de66461e7620f5a4cbf5fb4d1d7c948"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e33b5c3ee2b4ffa00ac2b00d1645cd9229ade668139bccf95f15fadcf374127b"
+dependencies = [
+ "castaway",
+ "itoa",
+ "ryu",
 ]
 
 [[package]]
@@ -389,6 +477,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "crossbeam"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -424,6 +535,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd42583b04998a5363558e5f9291ee5a5ff6b49944332103f251e7479a82aa7"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -441,6 +562,18 @@ checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "dashmap"
+version = "5.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3495912c9c1ccf2e18976439f4443f3fee0fd61f424ff99fde6a66b15ecb448f"
+dependencies = [
+ "cfg-if 1.0.0",
+ "hashbrown",
+ "lock_api",
+ "parking_lot_core 0.9.3",
 ]
 
 [[package]]
@@ -649,6 +782,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e94a7bbaa59354bc20dd75b67f23e2797b4490e9d6928203fb105c79e448c86c"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "redox_syscall",
+ "windows-sys",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
+dependencies = [
+ "crc32fast",
+ "libz-sys",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "float-cmp"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -775,16 +931,412 @@ dependencies = [
 ]
 
 [[package]]
-name = "git2"
-version = "0.14.4"
+name = "git-actor"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0155506aab710a86160ddb504a480d2964d7ab5b9e62419be69e0032bc5931c"
+checksum = "2a5d2a77331398a96dc6464f1602358f80831f8c1d482d9b36b8589b89727b46"
+dependencies = [
+ "bstr",
+ "btoi",
+ "git-date",
+ "itoa",
+ "nom 7.1.1",
+ "quick-error",
+]
+
+[[package]]
+name = "git-attributes"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76d0551e2d2931a8af08fe587d1d109a621a521fb3f250bd8745653f70fda27f"
+dependencies = [
+ "bstr",
+ "compact_str",
+ "git-features",
+ "git-glob",
+ "git-path",
+ "git-quote",
+ "quick-error",
+ "unicode-bom",
+]
+
+[[package]]
+name = "git-bitmap"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7715cc94cd761fe92bb5626a332e4886292c7af88984abfdafad82dd56002475"
+dependencies = [
+ "quick-error",
+]
+
+[[package]]
+name = "git-chunk"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c915097c009d7870a27ee62dcadbf1410f07cdc6c510efcfb8c1011917bd4f22"
+dependencies = [
+ "quick-error",
+]
+
+[[package]]
+name = "git-config"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2517e4a1f8c82266debd70d43aac472ebc6cc403d4b4213e222d2c4d2c67aa97"
 dependencies = [
  "bitflags",
+ "bstr",
+ "git-features",
+ "git-glob",
+ "git-path",
+ "git-ref",
+ "git-sec",
  "libc",
- "libgit2-sys",
+ "memchr",
+ "nom 7.1.1",
+ "smallvec",
+ "thiserror",
+ "unicode-bom",
+]
+
+[[package]]
+name = "git-date"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de28bca8c01f1ed4e776bed75802c7f7e671da112496445dfcf885bc1a357250"
+dependencies = [
+ "bstr",
+ "itoa",
+ "time 0.3.11",
+]
+
+[[package]]
+name = "git-diff"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca9907f146e0ea61fabca745e45296a4da11cf4d6fd4d7aaa544ccc00f211419"
+dependencies = [
+ "git-hash",
+ "git-object",
+ "quick-error",
+]
+
+[[package]]
+name = "git-discover"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9db794b6e98c7fb9667c371d64a35534a4bfe088868a80efe4cfe38a71379bab"
+dependencies = [
+ "bstr",
+ "git-hash",
+ "git-path",
+ "git-ref",
+ "git-sec",
+ "thiserror",
+]
+
+[[package]]
+name = "git-features"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57bfebf2c0a0d28414aa7c3baa058d5c1c2969e553806904343a2c11483f425a"
+dependencies = [
+ "crc32fast",
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "flate2",
+ "git-hash",
+ "jwalk",
+ "libc",
+ "num_cpus",
+ "once_cell",
+ "parking_lot 0.12.1",
+ "prodash",
+ "quick-error",
+ "sha1_smol",
+ "walkdir",
+]
+
+[[package]]
+name = "git-glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a226a7037e481a312ddba5cc55f6d7aa3eb5043d61e95c289af3632be942f0e"
+dependencies = [
+ "bitflags",
+ "bstr",
+]
+
+[[package]]
+name = "git-hash"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f82a0c09fdddeb738ed8338d214652c6d60ebf814a30d9ae1ecae7c91e0bbe81"
+dependencies = [
+ "hex",
+ "quick-error",
+]
+
+[[package]]
+name = "git-index"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b6795e3808f9ddc823c9864bec0ddb5c1e44479ac5aea0d6ff25ae0f0d657c1"
+dependencies = [
+ "atoi",
+ "bitflags",
+ "bstr",
+ "filetime",
+ "git-bitmap",
+ "git-features",
+ "git-hash",
+ "git-object",
+ "memmap2",
+ "quick-error",
+ "smallvec",
+]
+
+[[package]]
+name = "git-lock"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee44915b070cde930ecc0e251d53f40d2ad66354546edcfd04720b12e1936e91"
+dependencies = [
+ "fastrand",
+ "git-tempfile",
+ "quick-error",
+]
+
+[[package]]
+name = "git-object"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78bbda5da28d4bb564100373816dd21ba94709c39df12c114764967356430a8e"
+dependencies = [
+ "bstr",
+ "btoi",
+ "git-actor",
+ "git-features",
+ "git-hash",
+ "git-validate",
+ "hex",
+ "itoa",
+ "nom 7.1.1",
+ "quick-error",
+ "smallvec",
+]
+
+[[package]]
+name = "git-odb"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff0f045f8ef21a99fcd9ca540b5a3a7d9f50805316fc183da1e580978c9c561"
+dependencies = [
+ "arc-swap",
+ "git-features",
+ "git-hash",
+ "git-object",
+ "git-pack",
+ "git-path",
+ "git-quote",
+ "parking_lot 0.12.1",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
+name = "git-pack"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02268bfe5fe46a6b8dfa5d14357cc1086eba134e254ca7703261ed00f142eb62"
+dependencies = [
+ "bytesize",
+ "clru",
+ "dashmap",
+ "git-chunk",
+ "git-diff",
+ "git-features",
+ "git-hash",
+ "git-object",
+ "git-path",
+ "git-tempfile",
+ "git-traverse",
+ "hash_hasher",
+ "memmap2",
+ "parking_lot 0.12.1",
+ "smallvec",
+ "thiserror",
+ "uluru",
+]
+
+[[package]]
+name = "git-path"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f054752f9f73d557f4ef0a4e48f2f7e01454abd7accdef9f85f0ef4fa2c6e8f"
+dependencies = [
+ "bstr",
+ "thiserror",
+]
+
+[[package]]
+name = "git-quote"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ec1960fa4f68a1637ce03d8c151ae2f8565d1de119a3eee8b5b9a364a08aacb"
+dependencies = [
+ "bstr",
+ "btoi",
+ "quick-error",
+]
+
+[[package]]
+name = "git-ref"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e365e9a3ee19ca10c9cd8f6f7ea4d464b6dfc73b5ef0f0cbc5747e29dfc14e93"
+dependencies = [
+ "git-actor",
+ "git-features",
+ "git-hash",
+ "git-lock",
+ "git-object",
+ "git-path",
+ "git-tempfile",
+ "git-validate",
+ "memmap2",
+ "nom 7.1.1",
+ "quick-error",
+]
+
+[[package]]
+name = "git-repository"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9636655207e546b2885248ead6252b54c319cca182914fd7a6cb1d499ab84dc3"
+dependencies = [
+ "byte-unit",
+ "clru",
+ "git-actor",
+ "git-config",
+ "git-date",
+ "git-diff",
+ "git-discover",
+ "git-features",
+ "git-hash",
+ "git-lock",
+ "git-object",
+ "git-odb",
+ "git-pack",
+ "git-path",
+ "git-ref",
+ "git-revision",
+ "git-sec",
+ "git-tempfile",
+ "git-traverse",
+ "git-url",
+ "git-validate",
+ "git-worktree",
  "log",
+ "signal-hook 0.3.14",
+ "thiserror",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "git-revision"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "681181c8e87d96d6a47bafe1e4d8c9c7b0091c69573e69bd01422fc1a828f43d"
+dependencies = [
+ "bstr",
+ "git-date",
+ "git-hash",
+ "git-object",
+ "hash_hasher",
+ "thiserror",
+]
+
+[[package]]
+name = "git-sec"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffcecb38973b7c8fb3be5ae855a366a1e615fe1b7cf38d217f3e1adeb3608170"
+dependencies = [
+ "bitflags",
+ "dirs 4.0.0",
+ "git-path",
+ "libc",
+ "thiserror",
+ "windows 0.37.0",
+]
+
+[[package]]
+name = "git-tempfile"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c1d7753a96a332e404d6f985caa41bcbd6f08a8e40b4f452dd5e3985d4c4e8e"
+dependencies = [
+ "dashmap",
+ "libc",
+ "once_cell",
+ "signal-hook 0.3.14",
+ "signal-hook-registry",
+ "tempfile",
+]
+
+[[package]]
+name = "git-traverse"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fff51d777e90a9a46b6d556ff4715eace4a42d7fde546ef21a315a80d4121827"
+dependencies = [
+ "git-hash",
+ "git-object",
+ "hash_hasher",
+ "quick-error",
+]
+
+[[package]]
+name = "git-url"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650aa16382e135904f7303cd4156778df3979fc4f3589ea07d870444272486a3"
+dependencies = [
+ "bstr",
+ "git-features",
+ "git-path",
+ "home",
+ "quick-error",
  "url",
+]
+
+[[package]]
+name = "git-validate"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c2c1eaaa942eb3c49ab20f27c0715e79e26e6b156a0f77d7ed7bbb26126a8fa"
+dependencies = [
+ "bstr",
+ "quick-error",
+]
+
+[[package]]
+name = "git-worktree"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a7e0c10fb0543096aa759e4f082866399e375ffb5e95a4f9e3dcdb3cd6ec488"
+dependencies = [
+ "bstr",
+ "git-attributes",
+ "git-features",
+ "git-glob",
+ "git-hash",
+ "git-index",
+ "git-object",
+ "git-path",
+ "io-close",
+ "thiserror",
 ]
 
 [[package]]
@@ -798,6 +1350,12 @@ dependencies = [
  "log",
  "winapi",
 ]
+
+[[package]]
+name = "hash_hasher"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74721d007512d0cb3338cd20f0654ac913920061a4c4d0d8708edb3f2a698c0c"
 
 [[package]]
 name = "hashbrown"
@@ -848,6 +1406,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "human_format"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86cce260d758a9aa3d7c4b99d55c815a540f8a37514ba6046ab6be402a157cb0"
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -891,6 +1455,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-close"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cadcf447f06744f8ce713d2d6239bb5bde2c357a452397a9ed90c625da390bc"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "io-lifetimes"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -918,21 +1492,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
 
 [[package]]
-name = "jobserver"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3fac17f7123a73ca62df411b1bf727ccc805daa070338fda671c86dac1bdc27"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jwalk"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "172752e853a067cbce46427de8470ddf308af7fd8ceaf9b682ef31a5021b6bb9"
+dependencies = [
+ "crossbeam",
+ "rayon",
 ]
 
 [[package]]
@@ -954,24 +1529,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
-name = "libgit2-sys"
-version = "0.13.4+1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0fa6563431ede25f5cc7f6d803c6afbc1c5d3ad3d4925d12c882bf2b526f5d1"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "pkg-config",
-]
-
-[[package]]
 name = "libz-sys"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9702761c3935f8cc2f101793272e202c72b99da8f4224a19ddcf1279a6450bbf"
 dependencies = [
  "cc",
+ "cmake",
  "libc",
  "pkg-config",
  "vcpkg",
@@ -1058,6 +1622,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "memmap2"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a79b39c93a7a5a27eeaf9a23b5ff43f1b9e0ad6b1cdd441140ae53c35613fc7"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memmem"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1077,6 +1650,15 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f5c75688da582b8ffc1f1799e9db273f32133c49e048f614d22ec3256773ccc"
+dependencies = [
+ "adler",
+]
 
 [[package]]
 name = "mockall"
@@ -1329,7 +1911,17 @@ checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.8.5",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core 0.9.3",
 ]
 
 [[package]]
@@ -1344,6 +1936,19 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "winapi",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1597,6 +2202,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "prodash"
+version = "19.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa75e7b3c1591d852ba49539ccac278cb2086e3f5cbbef0d9f5984b0fbcb4fcb"
+dependencies = [
+ "bytesize",
+ "human_format",
+]
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
 name = "quick-xml"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1751,6 +2372,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1790,10 +2417,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24c8ad4f0c00e1eb5bc7614d236a7f1300e3dbd76b68cac8e06fb00b015ad8d8"
+
+[[package]]
 name = "ryu"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schemars"
@@ -1949,7 +2591,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2d399ad15b5c90d8e6461da75c751c77501598dd915d81a108401b252aaa99f"
 dependencies = [
  "const_format",
- "git2",
  "is_debug",
  "time 0.3.11",
  "tzdb",
@@ -2014,9 +2655,9 @@ checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
 
 [[package]]
 name = "smallvec"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc88c725d61fc6c3132893370cac4a0200e3fedf5da8331c570664b1987f5ca2"
+checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
 
 [[package]]
 name = "socket2"
@@ -2040,7 +2681,7 @@ dependencies = [
  "dirs-next",
  "dunce",
  "gethostname",
- "git2",
+ "git-repository",
  "guess_host_triple",
  "home",
  "indexmap",
@@ -2417,6 +3058,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "uluru"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "794a32261a1f5eb6a4462c81b59cec87b5c27d5deea7dd1ac8fc781c41d226db"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "unicase"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2430,6 +3080,12 @@ name = "unicode-bidi"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+
+[[package]]
+name = "unicode-bom"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63ec69f541d875b783ca40184d655f2927c95f0bffd486faa83cd3ac3529ec32"
 
 [[package]]
 name = "unicode-ident"
@@ -2493,6 +3149,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68b90931029ab9b034b300b797048cf23723400aa757e8a2bfb9d748102f9821"
 
 [[package]]
+name = "utf8-width"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5190c9442dcdaf0ddd50f37420417d219ae5261bbf5db120d0f9bab996c9cba1"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2534,6 +3196,17 @@ name = "waker-fn"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
+
+[[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasi"
@@ -2672,6 +3345,19 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57b543186b344cc61c85b5aab0d2e3adf4e0f99bc076eff9aa5927bcc0b8a647"
+dependencies = [
+ "windows_aarch64_msvc 0.37.0",
+ "windows_i686_gnu 0.37.0",
+ "windows_i686_msvc 0.37.0",
+ "windows_x86_64_gnu 0.37.0",
+ "windows_x86_64_msvc 0.37.0",
+]
+
+[[package]]
+name = "windows"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1c4bd0a50ac6020f65184721f758dba47bb9fbc2133df715ec74a237b26794a"
@@ -2704,6 +3390,12 @@ checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2623277cb2d1c216ba3b578c0f3cf9cdebeddb6e66b1b218bb33596ea7769c3a"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec7711666096bd4096ffa835238905bb33fb87267910e154b18b44eaabb340f2"
@@ -2719,6 +3411,12 @@ name = "windows_i686_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3925fd0b0b804730d44d4b6278c50f9699703ec49bcd628020f46f4ba07d9e1"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2740,6 +3438,12 @@ checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce907ac74fe331b524c1298683efbf598bb031bc84d5e274db2083696d07c57c"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bc7cbfe58828921e10a9f446fcaaf649204dcfe6c1ddd712c5eebae6bda1106"
@@ -2758,6 +3462,12 @@ checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
 name = "windows_x86_64_gnu"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2babfba0828f2e6b32457d5341427dcbb577ceef556273229959ac23a10af33d"
+
+[[package]]
+name = "windows_x86_64_gnu"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6868c165637d653ae1e8dc4d82c25d4f97dd6605eaa8d784b5c6e0ab2a252b65"
@@ -2773,6 +3483,12 @@ name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4dd6dc7df2d84cf7b33822ed5b86318fb1781948e9663bacd047fc9dd52259d"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,8 @@ keywords = ["prompt", "shell", "bash", "fish", "zsh"]
 license = "ISC"
 readme = "README.md"
 repository = "https://github.com/starship/starship"
-# MSRV is specified due to our dependency in git2
 # Note: MSRV is only intended as a hint, and only the latest version is officially supported in starship.
-rust-version = "1.60"
+rust-version = "1.59"
 description = """
 The minimal, blazing-fast, and infinitely customizable prompt for any shell! ☄🌌️
 """
@@ -43,7 +42,7 @@ clap_complete = "3.2.3"
 dirs-next = "2.0.0"
 dunce = "1.0.2"
 gethostname = "0.2.3"
-git2 = { version = "0.14.4", default-features = false }
+git-repository = "0.20.0"
 indexmap = { version = "1.9.1", features = ["serde"] }
 local_ipaddress = "0.1.3"
 log = { version = "0.4.16", features = ["std"] }
@@ -65,7 +64,7 @@ semver = "1.0.12"
 serde = { version = "1.0.141", features = ["derive"] }
 serde_json = "1.0.82"
 sha-1 = "0.10.0"
-shadow-rs = "0.16.1"
+shadow-rs = { version = "0.16.1", default-features = false }
 # battery is optional (on by default) because the crate doesn't currently build for Termux
 # see: https://github.com/svartalf/rust-battery/issues/33
 starship-battery = { version = "0.7.9", optional = true }
@@ -109,7 +108,7 @@ features = [
 nix = { version = "0.24.2", default-features = false, features = ["feature", "fs", "user"] }
 
 [build-dependencies]
-shadow-rs = "0.16.1"
+shadow-rs = { version = "0.16.1", default-features = false }
 dunce = "1.0.2"
 
 [target.'cfg(windows)'.build-dependencies]

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1530,13 +1530,13 @@ The `git_branch` module shows the active branch of the repo in your current dire
 
 ### Variables
 
-| Variable      | Example  | Description                                                                                                                   |
-| ------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| branch        | `master` | The current branch name, or else the name of the checked-out reference (`origin/main`), or `HEAD` (e.g. git detached `HEAD`). |
-| remote_name   | `origin` | The remote name.                                                                                                              |
-| remote_branch | `master` | The name of the branch tracked on `remote_name`.                                                                              |
-| symbol        |          | Mirrors the value of option `symbol`                                                                                          |
-| style\*       |          | Mirrors the value of option `style`                                                                                           |
+| Variable      | Example  | Description                                                                                            |
+| ------------- | -------- | ------------------------------------------------------------------------------------------------------ |
+| branch        | `master` | The current branch name, falls back to `HEAD` if there's no current branch (e.g. git detached `HEAD`). |
+| remote_name   | `origin` | The remote name.                                                                                       |
+| remote_branch | `master` | The name of the branch tracked on `remote_name`.                                                       |
+| symbol        |          | Mirrors the value of option `symbol`                                                                   |
+| style\*       |          | Mirrors the value of option `style`                                                                    |
 
 *: This variable can only be used as a part of a style string
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1530,13 +1530,13 @@ The `git_branch` module shows the active branch of the repo in your current dire
 
 ### Variables
 
-| Variable      | Example  | Description                                                                                            |
-| ------------- | -------- | ------------------------------------------------------------------------------------------------------ |
-| branch        | `master` | The current branch name, falls back to `HEAD` if there's no current branch (e.g. git detached `HEAD`). |
-| remote_name   | `origin` | The remote name.                                                                                       |
-| remote_branch | `master` | The name of the branch tracked on `remote_name`.                                                       |
-| symbol        |          | Mirrors the value of option `symbol`                                                                   |
-| style\*       |          | Mirrors the value of option `style`                                                                    |
+| Variable      | Example  | Description                                                                                                                   |
+| ------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| branch        | `master` | The current branch name, or else the name of the checked-out reference (`origin/main`), or `HEAD` (e.g. git detached `HEAD`). |
+| remote_name   | `origin` | The remote name.                                                                                                              |
+| remote_branch | `master` | The name of the branch tracked on `remote_name`.                                                                              |
+| symbol        |          | Mirrors the value of option `symbol`                                                                                          |
+| style\*       |          | Mirrors the value of option `style`                                                                                           |
 
 *: This variable can only be used as a part of a style string
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -6,7 +6,7 @@ use crate::utils::{create_command, exec_timeout, read_file, CommandOutput};
 use crate::modules;
 use crate::utils::{self, home_dir};
 use clap::Parser;
-use git2::{ErrorCode::UnbornBranch, Repository, RepositoryState};
+use git_repository::{state as git_state, Repository, ThreadSafeRepository};
 use once_cell::sync::OnceCell;
 #[cfg(test)]
 use std::collections::HashMap;
@@ -255,22 +255,25 @@ impl<'a> Context<'a> {
     }
 
     /// Will lazily get repo root and branch when a module requests it.
-    pub fn get_repo(&self) -> Result<&Repo, git2::Error> {
-        self.repo.get_or_try_init(|| -> Result<Repo, git2::Error> {
-            let repository = if env::var("GIT_DIR").is_ok() {
-                Repository::open_from_env()
-            } else {
-                let dirs: [PathBuf; 0] = [];
-                Repository::open_ext(&self.current_dir, git2::RepositoryOpenFlags::FROM_ENV, dirs)
-            }?;
-            Ok(Repo {
-                branch: get_current_branch(&repository),
-                workdir: repository.workdir().map(Path::to_path_buf),
-                path: Path::to_path_buf(repository.path()),
-                state: repository.state(),
-                remote: get_remote_repository_info(&repository),
+    pub fn get_repo(&self) -> Result<&Repo, git_repository::discover::Error> {
+        self.repo
+            .get_or_try_init(|| -> Result<Repo, git_repository::discover::Error> {
+                let shared_repo =
+                    ThreadSafeRepository::discover_with_environment_overrides(&self.current_dir)?;
+
+                let repository = shared_repo.to_thread_local();
+                let branch = get_current_branch(&repository);
+                let remote = get_remote_repository_info(&repository, branch.as_deref());
+                let path = repository.path().to_path_buf();
+                Ok(Repo {
+                    repo: shared_repo,
+                    branch,
+                    workdir: repository.work_dir().map(PathBuf::from),
+                    path,
+                    state: repository.state(),
+                    remote,
+                })
             })
-        })
     }
 
     pub fn dir_contents(&self) -> Result<&DirContents, std::io::Error> {
@@ -494,6 +497,8 @@ impl DirContents {
 }
 
 pub struct Repo {
+    pub repo: ThreadSafeRepository,
+
     /// If `current_dir` is a git repository or is contained within one,
     /// this is the current branch name of that repo.
     pub branch: Option<String>,
@@ -506,7 +511,7 @@ pub struct Repo {
     pub path: PathBuf,
 
     /// State
-    pub state: RepositoryState,
+    pub state: Option<git_state::InProgress>,
 
     /// Remote repository
     pub remote: Option<Remote>,
@@ -514,8 +519,8 @@ pub struct Repo {
 
 impl Repo {
     /// Opens the associated git repository.
-    pub fn open(&self) -> Result<Repository, git2::Error> {
-        Repository::open(&self.path)
+    pub fn open(&self) -> Repository {
+        self.repo.to_thread_local()
     }
 }
 
@@ -570,54 +575,26 @@ impl<'a> ScanDir<'a> {
 }
 
 fn get_current_branch(repository: &Repository) -> Option<String> {
-    let head = match repository.head() {
-        Ok(reference) => reference,
-        Err(e) => {
-            return if e.code() == UnbornBranch {
-                // HEAD should only be an unborn branch if the repository is fresh,
-                // in that case read directly from `.git/HEAD`
-                let mut head_path = repository.path().to_path_buf();
-                head_path.push("HEAD");
+    let name = repository.head_name().ok()??;
+    let shorthand = name.shorten();
 
-                // get first line, then last path segment
-                fs::read_to_string(&head_path)
-                    .ok()?
-                    .lines()
-                    .next()?
-                    .trim()
-                    .split('/')
-                    .last()
-                    .map(std::borrow::ToOwned::to_owned)
-            } else {
-                None
-            };
-        }
-    };
-
-    let shorthand = head.shorthand();
-
-    shorthand.map(std::string::ToString::to_string)
+    Some(shorthand.to_string())
 }
 
-fn get_remote_repository_info(repository: &Repository) -> Option<Remote> {
-    if let Ok(head) = repository.head() {
-        if let Some(local_branch_ref) = head.name() {
-            let remote_ref = match repository.branch_upstream_name(local_branch_ref) {
-                Ok(remote_ref) => remote_ref.as_str()?.to_owned(),
-                Err(_) => return None,
-            };
+fn get_remote_repository_info(
+    repository: &Repository,
+    branch_name: Option<&str>,
+) -> Option<Remote> {
+    let branch_name = branch_name?;
+    let branch = repository
+        .remote_ref(branch_name)
+        .and_then(|r| r.ok())
+        .map(|r| r.shorten().to_string());
+    let name = repository
+        .branch_remote_name(branch_name)
+        .map(|n| n.to_string());
 
-            let mut v = remote_ref.splitn(4, '/');
-            let remote_name = v.nth(2)?.to_owned();
-            let remote_branch = v.last()?.to_owned();
-
-            return Some(Remote {
-                branch: Some(remote_branch),
-                name: Some(remote_name),
-            });
-        }
-    }
-    None
+    Some(Remote { branch, name })
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/context.rs
+++ b/src/context.rs
@@ -6,7 +6,9 @@ use crate::utils::{create_command, exec_timeout, read_file, CommandOutput};
 use crate::modules;
 use crate::utils::{self, home_dir};
 use clap::Parser;
-use git_repository::{state as git_state, Repository, ThreadSafeRepository};
+use git_repository::{
+    commit::describe::SelectRef::AllRefs, state as git_state, Repository, ThreadSafeRepository,
+};
 use once_cell::sync::OnceCell;
 #[cfg(test)]
 use std::collections::HashMap;
@@ -17,6 +19,7 @@ use std::fmt::Debug;
 use std::fs;
 use std::marker::PhantomData;
 use std::num::ParseIntError;
+use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::string::String;
@@ -263,7 +266,14 @@ impl<'a> Context<'a> {
 
                 let repository = shared_repo.to_thread_local();
                 let branch = get_current_branch(&repository);
-                let remote = get_remote_repository_info(&repository, branch.as_deref());
+                // Only valid if we have a real branch
+                let remote = match branch {
+                    Some(Branch::HeadName(ref b)) => {
+                        get_remote_repository_info(&repository, b.as_str())
+                    }
+                    _ => None,
+                };
+
                 let path = repository.path().to_path_buf();
                 Ok(Repo {
                     repo: shared_repo,
@@ -501,7 +511,7 @@ pub struct Repo {
 
     /// If `current_dir` is a git repository or is contained within one,
     /// this is the current branch name of that repo.
-    pub branch: Option<String>,
+    pub branch: Option<Branch>,
 
     /// If `current_dir` is a git repository or is contained within one,
     /// this is the path to the root of that repo.
@@ -528,6 +538,24 @@ impl Repo {
 pub struct Remote {
     pub branch: Option<String>,
     pub name: Option<String>,
+}
+
+#[derive(Clone)]
+pub enum Branch {
+    HeadName(String),
+    Ref(String),
+    Head,
+}
+
+impl Deref for Branch {
+    type Target = str;
+    fn deref(&self) -> &str {
+        match self {
+            Branch::HeadName(name) => name.as_str(),
+            Branch::Ref(name) => name.as_str(),
+            Branch::Head => "HEAD",
+        }
+    }
 }
 
 // A struct of Criteria which will be used to verify current PathBuf is
@@ -574,18 +602,31 @@ impl<'a> ScanDir<'a> {
     }
 }
 
-fn get_current_branch(repository: &Repository) -> Option<String> {
+fn get_current_branch(repository: &Repository) -> Option<Branch> {
+    get_current_head_name(repository)
+        .or_else(|| describe_head_ref(repository))
+        .or_else(|| repository.head().is_ok().then(|| Branch::Head))
+}
+
+// Get the conanical name of the current HEAD
+fn get_current_head_name(repository: &Repository) -> Option<Branch> {
     let name = repository.head_name().ok()??;
     let shorthand = name.shorten();
 
-    Some(shorthand.to_string())
+    Some(shorthand.to_string()).map(Branch::HeadName)
 }
 
-fn get_remote_repository_info(
-    repository: &Repository,
-    branch_name: Option<&str>,
-) -> Option<Remote> {
-    let branch_name = branch_name?;
+// Try to get the reference name that the head commit is pointing to. (`origin/main`)
+fn describe_head_ref(repository: &Repository) -> Option<Branch> {
+    let head_commit = repository.head_commit().ok()?;
+
+    let describe_platform = head_commit.describe().names(AllRefs);
+    let formatter = describe_platform.try_format().ok()??;
+
+    Some(formatter.name?.to_string()).map(Branch::Ref)
+}
+
+fn get_remote_repository_info(repository: &Repository, branch_name: &str) -> Option<Remote> {
     let branch = repository
         .remote_ref(branch_name)
         .and_then(|r| r.ok())

--- a/src/context.rs
+++ b/src/context.rs
@@ -264,8 +264,6 @@ impl<'a> Context<'a> {
             .get_or_try_init(|| -> Result<Repo, git::discover::Error> {
                 // custom open options
                 let git_open_opts = GitOpenOptions::default()
-                    // trust the git repo and avoid additional checks
-                    .with(git_sec::Trust::Full)
                     // don't use the global git config
                     .permissions(git::Permissions {
                         config: git::permissions::Config {

--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -112,12 +112,12 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             {
                 let root = repo_path_vec[0];
                 let before = dir_string.replace(&contracted_path, "");
-                [prefix + &before, root.to_string(), after_repo_root]
+                [prefix + before.as_str(), root.to_string(), after_repo_root]
             } else {
-                ["".to_string(), "".to_string(), prefix + &dir_string]
+                ["".to_string(), "".to_string(), prefix + dir_string.as_str()]
             }
         }
-        _ => ["".to_string(), "".to_string(), prefix + &dir_string],
+        _ => ["".to_string(), "".to_string(), prefix + dir_string.as_str()],
     };
 
     let path_vec = if config.use_os_path_sep {

--- a/src/modules/git_branch.rs
+++ b/src/modules/git_branch.rs
@@ -26,12 +26,8 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
     let repo = context.get_repo().ok()?;
 
-    if config.only_attached {
-        if let Ok(git_repo) = repo.open() {
-            if git_repo.head_detached().ok()? {
-                return None;
-            }
-        }
+    if config.only_attached && repo.open().head().ok()?.is_detached() {
+        return None;
     }
 
     let branch_name = repo.branch.as_ref()?;

--- a/src/modules/git_branch.rs
+++ b/src/modules/git_branch.rs
@@ -30,13 +30,13 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         return None;
     }
 
-    let branch_name = repo.branch.as_deref()?;
+    let branch_name = repo.branch.as_ref()?;
     let mut graphemes: Vec<&str> = branch_name.graphemes(true).collect();
 
     if config
         .ignore_branches
         .iter()
-        .any(|ignored| ignored.eq(&branch_name))
+        .any(|ignored| branch_name.eq(ignored))
     {
         return None;
     }
@@ -426,29 +426,6 @@ mod tests {
         assert_eq!(expected, actual.as_deref());
         repo_dir.close()?;
         remote_dir.close()
-    }
-
-    #[test]
-    fn test_detached_head() -> io::Result<()> {
-        let repo_dir = fixture_repo(FixtureProvider::Git)?;
-
-        create_command("git")?
-            .args(&["checkout", "--detach", "HEAD"])
-            .current_dir(repo_dir.path())
-            .output()?;
-
-        let actual = ModuleRenderer::new("git_branch")
-            .path(&repo_dir.path())
-            .config(toml::toml! {
-                [git_branch]
-                format = "$branch(:$remote_name/$remote_branch)"
-            })
-            .collect();
-
-        let expected = Some("origin/master");
-
-        assert_eq!(expected, actual.as_deref());
-        repo_dir.close()
     }
 
     // This test is not possible until we switch to `git status --porcelain`

--- a/src/modules/git_branch.rs
+++ b/src/modules/git_branch.rs
@@ -30,13 +30,13 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         return None;
     }
 
-    let branch_name = repo.branch.as_ref()?;
+    let branch_name = repo.branch.as_deref()?;
     let mut graphemes: Vec<&str> = branch_name.graphemes(true).collect();
 
     if config
         .ignore_branches
         .iter()
-        .any(|ignored| branch_name.eq(ignored))
+        .any(|ignored| ignored.eq(&branch_name))
     {
         return None;
     }
@@ -426,6 +426,29 @@ mod tests {
         assert_eq!(expected, actual.as_deref());
         repo_dir.close()?;
         remote_dir.close()
+    }
+
+    #[test]
+    fn test_detached_head() -> io::Result<()> {
+        let repo_dir = fixture_repo(FixtureProvider::Git)?;
+
+        create_command("git")?
+            .args(&["checkout", "--detach", "HEAD"])
+            .current_dir(repo_dir.path())
+            .output()?;
+
+        let actual = ModuleRenderer::new("git_branch")
+            .path(&repo_dir.path())
+            .config(toml::toml! {
+                [git_branch]
+                format = "$branch(:$remote_name/$remote_branch)"
+            })
+            .collect();
+
+        let expected = Some("origin/master");
+
+        assert_eq!(expected, actual.as_deref());
+        repo_dir.close()
     }
 
     // This test is not possible until we switch to `git status --porcelain`

--- a/src/modules/git_state.rs
+++ b/src/modules/git_state.rs
@@ -1,4 +1,4 @@
-use git2::RepositoryState;
+use git_repository::state::InProgress;
 use std::path::PathBuf;
 
 use super::{Context, Module, ModuleConfig};
@@ -54,54 +54,53 @@ fn get_state_description<'a>(
     repo: &'a Repo,
     config: &GitStateConfig<'a>,
 ) -> Option<StateDescription<'a>> {
-    match repo.state {
-        RepositoryState::Clean => None,
-        RepositoryState::Merge => Some(StateDescription {
+    match repo.state.as_ref()? {
+        InProgress::Merge => Some(StateDescription {
             label: config.merge,
             current: None,
             total: None,
         }),
-        RepositoryState::Revert => Some(StateDescription {
+        InProgress::Revert => Some(StateDescription {
             label: config.revert,
             current: None,
             total: None,
         }),
-        RepositoryState::RevertSequence => Some(StateDescription {
+        InProgress::RevertSequence => Some(StateDescription {
             label: config.revert,
             current: None,
             total: None,
         }),
-        RepositoryState::CherryPick => Some(StateDescription {
+        InProgress::CherryPick => Some(StateDescription {
             label: config.cherry_pick,
             current: None,
             total: None,
         }),
-        RepositoryState::CherryPickSequence => Some(StateDescription {
+        InProgress::CherryPickSequence => Some(StateDescription {
             label: config.cherry_pick,
             current: None,
             total: None,
         }),
-        RepositoryState::Bisect => Some(StateDescription {
+        InProgress::Bisect => Some(StateDescription {
             label: config.bisect,
             current: None,
             total: None,
         }),
-        RepositoryState::ApplyMailbox => Some(StateDescription {
+        InProgress::ApplyMailbox => Some(StateDescription {
             label: config.am,
             current: None,
             total: None,
         }),
-        RepositoryState::ApplyMailboxOrRebase => Some(StateDescription {
+        InProgress::ApplyMailboxRebase => Some(StateDescription {
             label: config.am_or_rebase,
             current: None,
             total: None,
         }),
-        RepositoryState::Rebase => Some(describe_rebase(repo, config.rebase)),
-        RepositoryState::RebaseInteractive => Some(describe_rebase(repo, config.rebase)),
-        RepositoryState::RebaseMerge => Some(describe_rebase(repo, config.rebase)),
+        InProgress::Rebase => Some(describe_rebase(repo, config.rebase)),
+        InProgress::RebaseInteractive => Some(describe_rebase(repo, config.rebase)),
     }
 }
 
+// TODO: Use future gitoxide API to get the state of the rebase
 fn describe_rebase<'a>(repo: &'a Repo, rebase_config: &'a str) -> StateDescription<'a> {
     /*
      *  Sadly, libgit2 seems to have some issues with reading the state of

--- a/src/modules/git_status.rs
+++ b/src/modules/git_status.rs
@@ -34,6 +34,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
     //Return None if not in git repository
     context.get_repo().ok()?;
+
     if let Some(git_status) = git_status_wsl(context, &config) {
         if git_status.is_empty() {
             return None;

--- a/src/modules/hg_branch.rs
+++ b/src/modules/hg_branch.rs
@@ -41,7 +41,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     // The truncation symbol should only be added if we truncated
     let truncated_and_symbol = if len < graphemes_len(&branch_name) {
         let truncation_symbol = get_graphemes(config.truncation_symbol, 1);
-        truncated_graphemes + &truncation_symbol
+        truncated_graphemes + truncation_symbol.as_str()
     } else {
         truncated_graphemes
     };

--- a/src/modules/hostname.rs
+++ b/src/modules/hostname.rs
@@ -150,7 +150,7 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "{} in ",
-            style().paint("🌐 ".to_owned() + &hostname)
+            style().paint("🌐 ".to_owned() + hostname.as_str())
         ));
 
         assert_eq!(expected, actual);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR replaces the `libgit2`-based `git2` crate with the `gitoxide` `git-repository` crate.

~~In addition, add some ownership-based trust handling to the `git_status` and `git_metrics` modules with `git-sec`.~~

In addition, improve the `git_branch` output by preferring the reference name over plain `HEAD`.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #4022
Closes #3482
Closes #4131

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
