### PR TITLE
test(git): enable `fsync` for git operations

### DIFF
--- a/src/modules/git_status.rs
+++ b/src/modules/git_status.rs
@@ -473,18 +473,6 @@ mod tests {
     use crate::test::{fixture_repo, FixtureProvider, ModuleRenderer};
     use crate::utils::create_command;
 
-    /// Right after the calls to git the filesystem state may not have finished
-    /// updating yet causing some of the tests to fail. These barriers are placed
-    /// after each call to git.
-    /// This barrier is windows-specific though other operating systems may need it
-    /// in the future.
-    #[cfg(not(windows))]
-    fn barrier() {}
-    #[cfg(windows)]
-    fn barrier() {
-        std::thread::sleep(std::time::Duration::from_millis(500));
-    }
-
     #[allow(clippy::unnecessary_wraps)]
     fn format_output(symbols: &str) -> Option<String> {
         Some(format!(
@@ -705,7 +693,6 @@ mod tests {
             .args(&["config", "status.showUntrackedFiles", "no"])
             .current_dir(repo_dir.path())
             .output()?;
-        barrier();
 
         let actual = ModuleRenderer::new("git_status")
             .path(&repo_dir.path())
@@ -719,7 +706,6 @@ mod tests {
     #[test]
     fn shows_stashed() -> io::Result<()> {
         let repo_dir = fixture_repo(FixtureProvider::Git)?;
-        barrier();
 
         create_stash(repo_dir.path())?;
 
@@ -727,7 +713,6 @@ mod tests {
             .args(&["reset", "--hard", "HEAD"])
             .current_dir(repo_dir.path())
             .output()?;
-        barrier();
 
         let actual = ModuleRenderer::new("git_status")
             .path(&repo_dir.path())
@@ -741,16 +726,13 @@ mod tests {
     #[test]
     fn shows_stashed_with_count() -> io::Result<()> {
         let repo_dir = fixture_repo(FixtureProvider::Git)?;
-        barrier();
 
         create_stash(repo_dir.path())?;
-        barrier();
 
         create_command("git")?
             .args(&["reset", "--hard", "HEAD"])
             .current_dir(repo_dir.path())
             .output()?;
-        barrier();
 
         let actual = ModuleRenderer::new("git_status")
             .config(toml::toml! {
@@ -1014,7 +996,6 @@ mod tests {
 
         fs::remove_file(repo_dir.path().join("a"))?;
         fs::rename(repo_dir.path().join("b"), repo_dir.path().join("c"))?;
-        barrier();
 
         let actual = ModuleRenderer::new("git_status")
             .path(&repo_dir.path())
@@ -1040,7 +1021,6 @@ mod tests {
             .args(&["commit", "-am", "Update readme", "--no-gpg-sign"])
             .current_dir(&repo_dir)
             .output()?;
-        barrier();
 
         Ok(())
     }
@@ -1050,7 +1030,6 @@ mod tests {
             .args(&["reset", "--hard", "HEAD^"])
             .current_dir(repo_dir)
             .output()?;
-        barrier();
 
         Ok(())
     }
@@ -1060,7 +1039,6 @@ mod tests {
             .args(&["reset", "--hard", "HEAD^"])
             .current_dir(repo_dir)
             .output()?;
-        barrier();
 
         fs::write(repo_dir.join("Cargo.toml"), " ")?;
 
@@ -1068,7 +1046,6 @@ mod tests {
             .args(&["commit", "-am", "Update readme", "--no-gpg-sign"])
             .current_dir(repo_dir)
             .output()?;
-        barrier();
 
         Ok(())
     }
@@ -1078,7 +1055,6 @@ mod tests {
             .args(&["reset", "--hard", "HEAD^"])
             .current_dir(repo_dir)
             .output()?;
-        barrier();
 
         fs::write(repo_dir.join("readme.md"), "# goodbye")?;
 
@@ -1086,32 +1062,27 @@ mod tests {
             .args(&["add", "."])
             .current_dir(repo_dir)
             .output()?;
-        barrier();
 
         create_command("git")?
             .args(&["commit", "-m", "Change readme", "--no-gpg-sign"])
             .current_dir(repo_dir)
             .output()?;
-        barrier();
 
         create_command("git")?
             .args(&["pull", "--rebase"])
             .current_dir(repo_dir)
             .output()?;
-        barrier();
 
         Ok(())
     }
 
     fn create_stash(repo_dir: &Path) -> io::Result<()> {
         File::create(repo_dir.join("readme.md"))?.sync_all()?;
-        barrier();
 
         create_command("git")?
             .args(&["stash", "--all"])
             .current_dir(repo_dir)
             .output()?;
-        barrier();
 
         Ok(())
     }
@@ -1129,7 +1100,6 @@ mod tests {
             .args(&["add", "-A", "-N"])
             .current_dir(repo_dir)
             .output()?;
-        barrier();
 
         Ok(())
     }
@@ -1147,7 +1117,6 @@ mod tests {
             .args(&["add", "."])
             .current_dir(repo_dir)
             .output()?;
-        barrier();
 
         Ok(())
     }
@@ -1160,7 +1129,6 @@ mod tests {
             .args(&["add", "."])
             .current_dir(repo_dir)
             .output()?;
-        barrier();
 
         writeln!(&mut file, "modified")?;
         file.sync_all()?;
@@ -1173,13 +1141,11 @@ mod tests {
             .args(&["mv", "readme.md", "readme.md.bak"])
             .current_dir(repo_dir)
             .output()?;
-        barrier();
 
         create_command("git")?
             .args(&["add", "-A"])
             .current_dir(repo_dir)
             .output()?;
-        barrier();
 
         Ok(())
     }
@@ -1189,13 +1155,11 @@ mod tests {
             .args(&["mv", "readme.md", "readme.md.bak"])
             .current_dir(repo_dir)
             .output()?;
-        barrier();
 
         create_command("git")?
             .args(&["add", "-A"])
             .current_dir(repo_dir)
             .output()?;
-        barrier();
 
         let mut file = File::create(repo_dir.join("readme.md.bak"))?;
         writeln!(&mut file, "modified")?;
@@ -1219,7 +1183,6 @@ mod tests {
             .args(&["add", ".gitignore"])
             .current_dir(repo_dir)
             .output()?;
-        barrier();
 
         let mut file = File::create(repo_dir.join("ignored.txt"))?;
         writeln!(&mut file, "modified")?;

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -188,11 +188,16 @@ pub fn fixture_repo(provider: FixtureProvider) -> io::Result<TempDir> {
                 .current_dir(&path.path())
                 .output()?;
 
+            // Prevent intermittent test failures and ensure that the result of git commands
+            // are available during I/O-contentious tests, by having git run `fsync`.
+            // This is especially important on Windows.
+            // Newer, more far-reaching git setting for `fsync`, that's not yet widely supported:
             create_command("git")?
                 .args(&["config", "--local", "core.fsync", "all"])
                 .current_dir(&path.path())
                 .output()?;
 
+            // Older git setting for `fsync` for compatibility with older git versions:
             create_command("git")?
                 .args(&["config", "--local", "core.fsyncObjectFiles", "true"])
                 .current_dir(&path.path())

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -189,6 +189,16 @@ pub fn fixture_repo(provider: FixtureProvider) -> io::Result<TempDir> {
                 .output()?;
 
             create_command("git")?
+                .args(&["config", "--local", "core.fsync", "all"])
+                .current_dir(&path.path())
+                .output()?;
+
+            create_command("git")?
+                .args(&["config", "--local", "core.fsyncObjectFiles", "true"])
+                .current_dir(&path.path())
+                .output()?;
+
+            create_command("git")?
                 .args(&["reset", "--hard", "HEAD"])
                 .current_dir(&path.path())
                 .output()?;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR changes the configuration for the fixture git repos to make git issue `fsync`. This enables both the just-released [`core.fsync`](https://github.blog/2022-04-18-highlights-from-git-2-36/) option and the older, now-deprecated `core.fsyncObjectFiles` option. Windows git tests in CI now also seem to work without `barrier` sleep calls. Hopefully, this will reduce intermittent git test failures.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
