### PR TITLE
fix(nu): use the most recent starship init

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ eval $(starship init ion)
 <details>
 <summary>Nushell</summary>
 
-Run the following:
+Add the following to the end of your Nushell env file (find it by running `$nu.env-path` in Nushell):
 
 ```sh
 mkdir ~/.cache/starship
@@ -337,11 +337,10 @@ starship init nu | save ~/.cache/starship/init.nu
 And add the following to the end of your Nushell configuration (find it by running `$nu.config-path`):
 
 ```sh
-starship init nu | save ~/.cache/starship/init.nu
 source ~/.cache/starship/init.nu
 ```
 
-Note: Only Nushell v0.60+ is supported
+Note: Only Nushell v0.61+ is supported
 
 </details>
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -136,9 +136,9 @@ description: Starship is the minimal, blazing fast, and extremely customizable p
 
    ::: warning
    This will change in the future.
-   Only Nushell v0.60+ is supported.
+   Only Nushell v0.61+ is supported.
    :::
-   Run the following:
+   Add the following to to the end of your Nushell env file (find it by running `$nu.env-path` in Nushell):
    ```sh
    mkdir ~/.cache/starship
    starship init nu | save ~/.cache/starship/init.nu
@@ -147,8 +147,6 @@ description: Starship is the minimal, blazing fast, and extremely customizable p
    And add the following to the end of your Nushell configuration (find it by running `$nu.config-path`):
 
    ```sh
-   mkdir ~/.cache/starship
-   starship init nu | save ~/.cache/starship/init.nu
    source ~/.cache/starship/init.nu
    ```
    #### Xonsh

--- a/install/install.sh
+++ b/install/install.sh
@@ -336,20 +336,19 @@ print_install() {
         ;;
       nushell )
         # shellcheck disable=SC2088
-        config_file="your nu config file"
+        config_file="${BOLD}your nu config file${NO_COLOR} (find it by running ${BOLD}\$nu.config-path${NO_COLOR} in Nushell)"
         config_cmd="mkdir ~/.cache/starship
         starship init nu | save ~/.cache/starship/init.nu
         source ~/.cache/starship/init.nu"
         warning="${warning} This will change in the future.
-  Only Nushell v0.60 or higher is supported.
-  You can check the location of this your config file by running \$nu.config-path in nu.
-  ${BOLD}First run${NO_COLOR} \"mkdir ~/.cache/starship; starship init nu | save ~/.cache/starship/init.nu\""
+  Only Nushell v0.61 or higher is supported.
+  Add the following to the end of ${BOLD}your Nushell env file${NO_COLOR} (find it by running ${BOLD}\$nu.env-path${NO_COLOR} in Nushell): \"mkdir ~/.cache/starship; starship init nu | save ~/.cache/starship/init.nu\""
         ;;
     esac
-    printf "  %s\n  %s\n  Add the following to the end of %s:\n\n\t%s\n\n" \
+    printf "  %s\n  %s\n  And add the following to the end of %s:\n\n\t%s\n\n" \
       "${BOLD}${UNDERLINE}${s}${NO_COLOR}" \
       "${warning}" \
-      "${BOLD}${config_file}${NO_COLOR}" \
+      "${config_file}" \
       "${config_cmd}"
   done
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
The old nushell init approach caused the init only to update if the shell was opened a second time due to how nu handles sourcing (https://github.com/starship/starship/pull/3773#issuecomment-1076625914).

Thanks to @ajeetdsouza (thanks for notifying me!), there's a different approach that doesn't have this issue, by utilizing the nushell env file: https://github.com/nushell/nushell/issues/4773#issuecomment-1106114104

The default env file also contains some prompt-related configuration, so using it for this seems reasonable. The supported nushell version needed to be raised to 0.61, because that version introduced the env file feature.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
