### PR TITLE
fix(module): list option not working

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -55,7 +55,7 @@ enum Commands {
     ///  Prints a specific prompt module
     Module {
         /// The name of the module to be printed
-        #[clap(required = true, required_unless_present = "list")]
+        #[clap(required_unless_present("list"))]
         name: Option<String>,
         /// List out all supported modules
         #[clap(short, long)]


### PR DESCRIPTION
#### Description

The current version of starship will fail to run `starship module --list`, citing that a module name was not given. Here is the code currently on `master`:

```rs
/// The name of the module to be printed
#[clap(required = true, required_unless_present = "list")]
name: Option<String>,
```

`required_unless_present` itself implies `required`, but by additionally providing `required` it is superseded and does nothing. I have fixed that issue as well as changing the syntax to match [clap's documentation](https://docs.rs/clap/3.0.0-beta.2/clap/struct.Arg.html#method.required_unless_present).

For those interested, I also started a [discussion](https://github.com/clap-rs/clap/discussions/3658) on clap's repo about this, as I was surprised this doesn't result in an actual error.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
