### PR TITLE
docs: Fix spacing for translations

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -111,7 +111,9 @@ description: Starship is the minimal, blazing fast, and extremely customizable p
    #### Elvish
 
    ::: warning
+
    Only elvish v0.18 or higher is supported.
+
    :::
 
    Add the following to the end of `~/.elvish/rc.elv`:
@@ -135,9 +137,12 @@ description: Starship is the minimal, blazing fast, and extremely customizable p
    #### Nushell
 
    ::: warning
+
    This will change in the future.
    Only Nushell v0.60+ is supported.
+
    :::
+
    Run the following:
    ```sh
    mkdir ~/.cache/starship

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1211,6 +1211,7 @@ The module will be shown only if any of the following conditions are met:
 - The `variable` configuration option is not defined, but the `default` configuration option is
 
 ::: tip
+
 Multiple environmental variables can be displayed by using a `.`. (see example)
 If the `variable` configuration option is not set, the module will display value of variable under the name of text after the `.` character.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Have added so additional spaces around the vuepress markers, `:::`, to
ensure that the don't get included in the line above and below and cause
formatting errors in the translated versions of the documentation.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #3836

See also https://starship.rs/it-IT/#elvish 

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
