### PR TITLE
feat: add npm module

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -884,6 +884,25 @@
         }
       ]
     },
+    "npm": {
+      "default": {
+        "detect_files": [
+          "package-lock.json",
+          ".npmrc"
+        ],
+        "disabled": true,
+        "format": "via [$symbol($version )]($style)",
+        "not_capable_style": "bold red",
+        "style": "bold 88",
+        "symbol": " ",
+        "version_format": "v${raw}"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/NpmConfig"
+        }
+      ]
+    },
     "ocaml": {
       "default": {
         "detect_extensions": [
@@ -3451,6 +3470,45 @@
         "detect_folders": {
           "default": [
             "node_modules"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "NpmConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "via [$symbol($version )]($style)",
+          "type": "string"
+        },
+        "version_format": {
+          "default": "v${raw}",
+          "type": "string"
+        },
+        "symbol": {
+          "default": " ",
+          "type": "string"
+        },
+        "style": {
+          "default": "bold 88",
+          "type": "string"
+        },
+        "disabled": {
+          "default": true,
+          "type": "boolean"
+        },
+        "not_capable_style": {
+          "default": "bold red",
+          "type": "string"
+        },
+        "detect_files": {
+          "default": [
+            "package-lock.json",
+            ".npmrc"
           ],
           "type": "array",
           "items": {

--- a/docs/.vuepress/public/presets/toml/bracketed-segments.toml
+++ b/docs/.vuepress/public/presets/toml/bracketed-segments.toml
@@ -88,6 +88,9 @@ format = '\[[$symbol$state( \($name\))]($style)\]'
 [nodejs]
 format = '\[[$symbol($version)]($style)\]'
 
+[npm]
+format = '\[[$symbol($version)]($style)\]'
+
 [ocaml]
 format = '\[[$symbol($version)(\($switch_indicator$switch_name\))]($style)\]'
 

--- a/docs/.vuepress/public/presets/toml/nerd-font-symbols.toml
+++ b/docs/.vuepress/public/presets/toml/nerd-font-symbols.toml
@@ -55,6 +55,9 @@ symbol = " "
 [nodejs]
 symbol = " "
 
+[npm]
+symbol = " "
+
 [package]
 symbol = " "
 

--- a/docs/.vuepress/public/presets/toml/no-runtime-versions.toml
+++ b/docs/.vuepress/public/presets/toml/no-runtime-versions.toml
@@ -49,6 +49,9 @@ format = 'via [$symbol]($style)'
 [nodejs]
 format = 'via [$symbol]($style)'
 
+[npm]
+format = 'via [$symbol]($style)'
+
 [ocaml]
 format = 'via [$symbol(\($switch_indicator$switch_name\) )]($style)'
 

--- a/docs/.vuepress/public/presets/toml/pastel-powerline.toml
+++ b/docs/.vuepress/public/presets/toml/pastel-powerline.toml
@@ -57,6 +57,11 @@ symbol = ""
 style = "bg:#86BBD8"
 format = '[[ $symbol ($version) ](bg:#86BBD8)]($style)'
 
+[npm]
+symbol = ""
+style = "bg:#86BBD8"
+format = '[[ $symbol ($version) ](bg:#86BBD8)]($style)'
+
 [rust]
 symbol = ""
 style = "bg:#86BBD8"

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -229,6 +229,7 @@ $kotlin\
 $lua\
 $nim\
 $nodejs\
+$npm\
 $ocaml\
 $perl\
 $php\
@@ -2393,6 +2394,45 @@ By default the module will be shown if any of the following conditions are met:
 | `style`             | `"bold green"`                             | The style for the module.                                                                             |
 | `disabled`          | `false`                                    | Disables the `nodejs` module.                                                                         |
 | `not_capable_style` | `bold red`                                 | The style for the module when an engines property in package.json does not match the Node.js version. |
+
+### Variables
+
+| Variable | Example    | Description                          |
+| -------- | ---------- | ------------------------------------ |
+| version  | `v13.12.0` | The version of `node`                |
+| symbol   |            | Mirrors the value of option `symbol` |
+| style\*  |            | Mirrors the value of option `style`  |
+
+*: This variable can only be used as a part of a style string
+
+### Example
+
+```toml
+# ~/.config/starship.toml
+
+[nodejs]
+format = "via [🤖 $version](bold green) "
+```
+
+## npm
+
+The `npm` module shows the currently installed version of [npm](https://docs.npmjs.com/).
+By default the module will be shown if any of the following conditions are met:
+
+- The current directory contains a `package-lock.json` file
+- The current directory contains a `.npmrc` file
+
+### Options
+
+| Option              | Default                               | Description                                                                                           |
+| ------------------- | ------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `format`            | `"with [$symbol($version )]($style)"` | The format for the module.                                                                            |
+| `version_format`    | `"v${raw}"`                           | The version format. Available vars are `raw`, `major`, `minor`, & `patch`                             |
+| `symbol`            | `"npm "`                              | A format string representing the symbol of Node.js.                                                   |
+| `detect_files`      | `["package-lock.json", ".npmrc"]`     | Which filenames should trigger this module.                                                           |
+| `style`             | `"bold 88"`                           | The style for the module.                                                                             |
+| `disabled`          | `true`                                | Disables the `nodejs` module.                                                                         |
+| `not_capable_style` | `bold red`                            | The style for the module when an engines property in package.json does not match the Node.js version. |
 
 ### Variables
 

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -47,6 +47,7 @@ pub mod memory_usage;
 pub mod nim;
 pub mod nix_shell;
 pub mod nodejs;
+pub mod npm;
 pub mod ocaml;
 pub mod openstack;
 pub mod package;
@@ -178,6 +179,8 @@ pub struct FullConfig<'a> {
     nix_shell: nix_shell::NixShellConfig<'a>,
     #[serde(borrow)]
     nodejs: nodejs::NodejsConfig<'a>,
+    #[serde(borrow)]
+    npm: npm::NpmConfig<'a>,
     #[serde(borrow)]
     ocaml: ocaml::OCamlConfig<'a>,
     #[serde(borrow)]

--- a/src/configs/npm.rs
+++ b/src/configs/npm.rs
@@ -1,0 +1,28 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
+#[serde(default)]
+pub struct NpmConfig<'a> {
+    pub format: &'a str,
+    pub version_format: &'a str,
+    pub symbol: &'a str,
+    pub style: &'a str,
+    pub disabled: bool,
+    pub not_capable_style: &'a str,
+    pub detect_files: Vec<&'a str>,
+}
+
+impl<'a> Default for NpmConfig<'a> {
+    fn default() -> Self {
+        NpmConfig {
+            format: "via [$symbol($version )]($style)",
+            version_format: "v${raw}",
+            symbol: " ",
+            style: "bold 88",
+            disabled: true,
+            not_capable_style: "bold red",
+            detect_files: vec!["package-lock.json", ".npmrc"],
+        }
+    }
+}

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -54,6 +54,7 @@ pub const PROMPT_ORDER: &[&str] = &[
     "lua",
     "nim",
     "nodejs",
+    "npm",
     "ocaml",
     "perl",
     "php",

--- a/src/module.rs
+++ b/src/module.rs
@@ -54,6 +54,7 @@ pub const ALL_MODULES: &[&str] = &[
     "nim",
     "nix_shell",
     "nodejs",
+    "npm",
     "ocaml",
     "openstack",
     "package",

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -44,6 +44,7 @@ mod memory_usage;
 mod nim;
 mod nix_shell;
 mod nodejs;
+mod npm;
 mod ocaml;
 mod openstack;
 mod package;
@@ -135,6 +136,7 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
             "nim" => nim::module(context),
             "nix_shell" => nix_shell::module(context),
             "nodejs" => nodejs::module(context),
+            "npm" => npm::module(context),
             "ocaml" => ocaml::module(context),
             "openstack" => openstack::module(context),
             "package" => package::module(context),
@@ -237,6 +239,7 @@ pub fn description(module: &str) -> &'static str {
         "nim" => "The currently installed version of Nim",
         "nix_shell" => "The nix-shell environment",
         "nodejs" => "The currently installed version of NodeJS",
+        "npm" => "The currently installed version of npm",
         "ocaml" => "The currently installed version of OCaml",
         "openstack" => "The current OpenStack cloud and project",
         "package" => "The package version of the current directory's project",

--- a/src/modules/npm.rs
+++ b/src/modules/npm.rs
@@ -1,0 +1,226 @@
+use super::{Context, Module, ModuleConfig};
+
+use crate::configs::npm::NpmConfig;
+use crate::formatter::{StringFormatter, VersionFormatter};
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+use semver::Version;
+use semver::VersionReq;
+use serde_json as json;
+use std::ops::Deref;
+
+/// Creates a module with the current Node.js version
+pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let mut module = context.new_module("npm");
+    let config = NpmConfig::try_load(module.config);
+    let is_npm_project = context
+        .try_begin_scan()?
+        .set_files(&config.detect_files)
+        .is_match();
+
+    if !is_npm_project {
+        return None;
+    }
+
+    let npm_version = Lazy::new(|| {
+        context
+            .exec_cmd("npm", &["--version"])
+            .map(|cmd| cmd.stdout)
+    });
+    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
+        formatter
+            .map_meta(|var, _| match var {
+                "symbol" => Some(config.symbol),
+                _ => None,
+            })
+            .map_style(|variable| match variable {
+                "style" => {
+                    let engines_version = get_engines_version(context);
+                    let in_engines_range =
+                        check_engines_version(npm_version.deref().as_ref()?, engines_version);
+                    if in_engines_range {
+                        Some(Ok(config.style))
+                    } else {
+                        Some(Ok(config.not_capable_style))
+                    }
+                }
+                _ => None,
+            })
+            .map(|variable| match variable {
+                "version" => {
+                    let version = npm_version.deref().as_ref()?.trim_start_matches('v').trim();
+
+                    VersionFormatter::format_module_version(
+                        module.get_name(),
+                        version,
+                        config.version_format,
+                    )
+                    .map(Ok)
+                }
+                _ => None,
+            })
+            .parse(None, Some(context))
+    });
+
+    module.set_segments(match parsed {
+        Ok(segments) => segments,
+        Err(error) => {
+            log::warn!("Error in module `npm`:\n{}", error);
+            return None;
+        }
+    });
+
+    Some(module)
+}
+
+fn get_engines_version(context: &Context) -> Option<String> {
+    let json_str = context.read_file_from_pwd("package.json")?;
+    let package_json: json::Value = json::from_str(&json_str).ok()?;
+    let raw_version = package_json.get("engines")?.get("npm")?.as_str()?;
+    Some(raw_version.to_string())
+}
+
+fn check_engines_version(npm_version: &str, engines_version: Option<String>) -> bool {
+    if engines_version.is_none() {
+        return true;
+    }
+    let r = match VersionReq::parse(&engines_version.unwrap()) {
+        Ok(r) => r,
+        Err(_e) => return true,
+    };
+    let re = Regex::new(r"\d+\.\d+\.\d+").unwrap();
+    let version = re.captures(npm_version).unwrap().get(0).unwrap().as_str();
+    let v = match Version::parse(version) {
+        Ok(v) => v,
+        Err(_e) => return true,
+    };
+    r.matches(&v)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::ModuleRenderer;
+    use ansi_term::Color;
+    use std::fs::File;
+    use std::io;
+    use std::io::Write;
+
+    #[test]
+    fn config_blank() {
+        let actual = ModuleRenderer::new("npm").collect();
+
+        let expected = None;
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn folder_without_npm_files() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let actual = ModuleRenderer::new("npm")
+            .config(toml::toml! {
+                [npm]
+                disabled = false
+            })
+            .path(dir.path())
+            .collect();
+        let expected = None;
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn folder_with_package_lock() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join("package-lock.json"))?.sync_all()?;
+
+        let actual = ModuleRenderer::new("npm")
+            .config(toml::toml! {
+                [npm]
+                disabled = false
+            })
+            .path(dir.path())
+            .collect();
+        let expected = Some(format!(
+            "via {}",
+            Color::Fixed(88).bold().paint(" v8.1.0 ")
+        ));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn folder_with_npmrc() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join(".npmrc"))?.sync_all()?;
+
+        let actual = ModuleRenderer::new("npm")
+            .config(toml::toml! {
+                [npm]
+                disabled = false
+            })
+            .path(dir.path())
+            .collect();
+        let expected = Some(format!(
+            "via {}",
+            Color::Fixed(88).bold().paint(" v8.1.0 ")
+        ));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn engines_npm_version_match() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join("package-lock.json"))?.sync_all()?;
+        let mut file = File::create(dir.path().join("package.json"))?;
+        file.write_all(
+            b"{
+            \"engines\":{
+                \"npm\":\">=8.1.0\"
+            }
+        }",
+        )?;
+        file.sync_all()?;
+
+        let actual = ModuleRenderer::new("npm")
+            .config(toml::toml! {
+                [npm]
+                disabled = false
+            })
+            .path(dir.path())
+            .collect();
+        let expected = Some(format!(
+            "via {}",
+            Color::Fixed(88).bold().paint(" v8.1.0 ")
+        ));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn engines_npm_version_not_match() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join("package-lock.json"))?.sync_all()?;
+        let mut file = File::create(dir.path().join("package.json"))?;
+        file.write_all(
+            b"{
+            \"engines\":{
+                \"npm\":\"<8.1.0\"
+            }
+        }",
+        )?;
+        file.sync_all()?;
+
+        let actual = ModuleRenderer::new("npm")
+            .config(toml::toml! {
+                [npm]
+                disabled = false
+            })
+            .path(dir.path())
+            .collect();
+        let expected = Some(format!("via {}", Color::Red.bold().paint(" v8.1.0 ")));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -262,6 +262,10 @@ active boot switches: -d:release\n",
             stdout: String::from("v12.0.0\n"),
             stderr: String::default(),
         }),
+        "npm --version" => Some(CommandOutput {
+            stdout: String::from("8.1.0\n"),
+            stderr: String::default(),
+        }),
         "ocaml -vnum" => Some(CommandOutput {
             stdout: String::from("4.10.0\n"),
             stderr: String::default(),


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This adds the npm module so that when in a directory with a
package-lock.json or an .npmrc, you will see the npm version displayed.
Usually this will be after the nodejs module because by default the
nodejs module will display if there is a package.json and where there is
a package-lock.json, there is almost always a package.json.

The npm module is disabled by default because it can add extra unwanted
noise to your prompt. However it can also be very useful to have in your
prompt because npm is known for having different behaviors between major
versions that will subtly break your project.

This also mimics the nodejs module when it comes to checking the
engines field in package.json. The default color is a dark red, and if
the current npm version is incompatible with the engines field in the
local package.json, it will display as the default red, to match the
color of the nodejs module when it is incompatible. Yes, npm's color is
red and when there is an error it is just a lighter red, but I didn't
know what color to make npm by default and still have an error color
that made sense 😅 .

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
As a developer who works in the node ecosystem often, I find it to be very
useful to know what version of npm that I'm on at all times. It is not so much of a problem with
other package managers like yarn and pnpm etc. but npm often breaks things
between major versions and different projects require different versions so
having the npm version available in my prompt would be very useful.
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #557

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
This module is very very similar to the nodejs module so I essentially modified the
tests that that module has to work with the npm module.
I also set up my local zsh to use the debug build so that as I was creating the module,
I could test it visually to see how it looked and make sure it was working correctly.
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
