### PR TITLE
feat(package): Extract package version from PEP 621 compliant pyproject.toml

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2503,7 +2503,7 @@ symbol = "☁️ "
 
 The `package` module is shown when the current directory is the repository for a
 package, and shows its current version. The module currently supports `npm`, `nimble`, `cargo`,
-`poetry`, `composer`, `gradle`, `julia`, `mix`, `helm`, `shards` and `dart` packages.
+`poetry`, `python`, `composer`, `gradle`, `julia`, `mix`, `helm`, `shards` and `dart` packages.
 
 - [**npm**](https://docs.npmjs.com/cli/commands/npm) – The `npm` package version is extracted from the `package.json` present
   in the current directory
@@ -2511,7 +2511,7 @@ package, and shows its current version. The module currently supports `npm`, `ni
 - [**Nimble**](https://github.com/nim-lang/nimble) - The `nimble` package version is extracted from the `*.nimble` file present in the current directory with the `nimble dump` command
 - [**Poetry**](https://python-poetry.org/) – The `poetry` package version is extracted from the `pyproject.toml` present
   in the current directory
-- [**Python**](https://www.python.org) - The `python` package version is extracted from the `setup.cfg` present in the current directory
+- [**Python**](https://www.python.org) - The `python` package version is extracted from a [PEP 621](https://peps.python.org/pep-0621/) compliant `pyproject.toml` or a `setup.cfg` present in the current directory
 - [**Composer**](https://getcomposer.org/) – The `composer` package version is extracted from the `composer.json` present
   in the current directory
 - [**Gradle**](https://gradle.org/) – The `gradle` package version is extracted from the `build.gradle` present

--- a/src/modules/package.rs
+++ b/src/modules/package.rs
@@ -66,10 +66,8 @@ fn get_node_package_version(context: &Context, config: &PackageConfig) -> Option
     Some(formatted_version)
 }
 
-fn get_poetry_version(context: &Context, config: &PackageConfig) -> Option<String> {
-    let file_contents = context.read_file_from_pwd("pyproject.toml")?;
-    let poetry_toml: toml::Value = toml::from_str(&file_contents).ok()?;
-    let raw_version = poetry_toml
+fn get_poetry_version(pyproject: &toml::Value, config: &PackageConfig) -> Option<String> {
+    let raw_version = pyproject
         .get("tool")?
         .get("poetry")?
         .get("version")?
@@ -78,10 +76,8 @@ fn get_poetry_version(context: &Context, config: &PackageConfig) -> Option<Strin
     format_version(raw_version, config.version_format)
 }
 
-fn get_pep621_version(context: &Context, config: &PackageConfig) -> Option<String> {
-    let file_contents = context.read_file_from_pwd("pyproject.toml")?;
-    let pep621_toml: toml::Value = toml::from_str(&file_contents).ok()?;
-    let version = pep621_toml.get("project")?.get("version")?;
+fn get_pep621_version(pyproject: &toml::Value, config: &PackageConfig) -> Option<String> {
+    let version = pyproject.get("project")?.get("version")?;
 
     if version.is_table() {
         None
@@ -89,6 +85,14 @@ fn get_pep621_version(context: &Context, config: &PackageConfig) -> Option<Strin
         let raw_version = version.as_str()?;
         format_version(raw_version, config.version_format)
     }
+}
+
+fn get_pyproject_version(context: &Context, config: &PackageConfig) -> Option<String> {
+    let file_contents = context.read_file_from_pwd("pyproject.toml")?;
+    let pyproject_toml: toml::Value = toml::from_str(&file_contents).ok()?;
+
+    get_pep621_version(&pyproject_toml, config)
+        .or_else(|| get_poetry_version(&pyproject_toml, config))
 }
 
 fn get_setup_cfg_version(context: &Context, config: &PackageConfig) -> Option<String> {
@@ -265,8 +269,7 @@ fn get_version(context: &Context, config: &PackageConfig) -> Option<String> {
         get_cargo_version,
         get_nimble_version,
         get_node_package_version,
-        get_poetry_version,
-        get_pep621_version,
+        get_pyproject_version,
         get_setup_cfg_version,
         get_composer_version,
         get_gradle_version,

--- a/src/modules/package.rs
+++ b/src/modules/package.rs
@@ -77,14 +77,8 @@ fn get_poetry_version(pyproject: &toml::Value, config: &PackageConfig) -> Option
 }
 
 fn get_pep621_version(pyproject: &toml::Value, config: &PackageConfig) -> Option<String> {
-    let version = pyproject.get("project")?.get("version")?;
-
-    if version.is_table() {
-        None
-    } else {
-        let raw_version = version.as_str()?;
-        format_version(raw_version, config.version_format)
-    }
+    let raw_version = pyproject.get("project")?.get("version")?.as_str()?;
+    format_version(raw_version, config.version_format)
 }
 
 fn get_pyproject_version(context: &Context, config: &PackageConfig) -> Option<String> {

--- a/src/modules/package.rs
+++ b/src/modules/package.rs
@@ -66,27 +66,25 @@ fn get_node_package_version(context: &Context, config: &PackageConfig) -> Option
     Some(formatted_version)
 }
 
-fn get_poetry_version(pyproject: &toml::Value, config: &PackageConfig) -> Option<String> {
-    let raw_version = pyproject
+fn get_poetry_version(pyproject: &toml::Value) -> Option<&str> {
+    pyproject
         .get("tool")?
         .get("poetry")?
         .get("version")?
-        .as_str()?;
-
-    format_version(raw_version, config.version_format)
+        .as_str()
 }
 
-fn get_pep621_version(pyproject: &toml::Value, config: &PackageConfig) -> Option<String> {
-    let raw_version = pyproject.get("project")?.get("version")?.as_str()?;
-    format_version(raw_version, config.version_format)
+fn get_pep621_version(pyproject: &toml::Value) -> Option<&str> {
+    pyproject.get("project")?.get("version")?.as_str()
 }
 
 fn get_pyproject_version(context: &Context, config: &PackageConfig) -> Option<String> {
     let file_contents = context.read_file_from_pwd("pyproject.toml")?;
     let pyproject_toml: toml::Value = toml::from_str(&file_contents).ok()?;
 
-    get_pep621_version(&pyproject_toml, config)
-        .or_else(|| get_poetry_version(&pyproject_toml, config))
+    get_pep621_version(&pyproject_toml)
+        .or_else(|| get_poetry_version(&pyproject_toml))
+        .and_then(|raw_version| format_version(raw_version, config.version_format))
 }
 
 fn get_setup_cfg_version(context: &Context, config: &PackageConfig) -> Option<String> {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR adds a function to the package module to extract the package version from a [PEP 621](https://peps.python.org/pep-0621/) compliant `pyproject.toml`

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #3949 

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

Ran `cargo test`, `cargo clippy --all-targets --all-features` and `cargo fmt`

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
