### PR TITLE
test(custom): increase timeout in timeout test

### DIFF
--- a/src/modules/custom.rs
+++ b/src/modules/custom.rs
@@ -593,7 +593,7 @@ mod tests {
         let actual = ModuleRenderer::new("custom.test")
             .path(dir.path())
             .config(toml::toml! {
-                command_timeout = 10000
+                command_timeout = 100000
                 [custom.test]
                 format = "test"
                 when = when


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
As the test that ensures custom commands are still run if a timeout is set have been timing out on Windows CI, increase the timeout duration to avoid intermittent test failures.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
