### PR TITLE
feat(go): check for go.work file to show Go module in prompt

### DIFF
--- a/.dprint.json
+++ b/.dprint.json
@@ -1,6 +1,8 @@
 {
   "incremental": true,
-  "typescript": {},
+  "typescript": {
+    "indentWidth": 4
+  },
   "json": {},
   "markdown": {
     "lineWidth": 100
@@ -37,9 +39,9 @@
     "target/"
   ],
   "plugins": [
-    "https://plugins.dprint.dev/typescript-0.62.0.wasm",
-    "https://plugins.dprint.dev/json-0.14.0.wasm",
-    "https://plugins.dprint.dev/markdown-0.12.0.wasm",
-    "https://plugins.dprint.dev/toml-0.5.3.wasm"
+    "https://plugins.dprint.dev/typescript-0.68.2.wasm",
+    "https://plugins.dprint.dev/json-0.15.2.wasm",
+    "https://plugins.dprint.dev/markdown-0.13.2.wasm",
+    "https://plugins.dprint.dev/toml-0.5.4.wasm"
   ]
 }

--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -556,6 +556,7 @@
         "detect_files": [
           "go.mod",
           "go.sum",
+          "go.work",
           "glide.yaml",
           "Gopkg.yml",
           "Gopkg.lock",
@@ -2797,6 +2798,7 @@
           "default": [
             "go.mod",
             "go.sum",
+            "go.work",
             "glide.yaml",
             "Gopkg.yml",
             "Gopkg.lock",

--- a/docs/README.md
+++ b/docs/README.md
@@ -140,9 +140,9 @@ description: Starship is the minimal, blazing fast, and extremely customizable p
 
    This will change in the future.
    Only Nushell v0.61+ is supported.
-   
+
    :::
-   
+
    Add the following to to the end of your Nushell env file (find it by running `$nu.env-path` in Nushell):
    ```sh
    mkdir ~/.cache/starship

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1687,6 +1687,7 @@ By default the module will be shown if any of the following conditions are met:
 
 - The current directory contains a `go.mod` file
 - The current directory contains a `go.sum` file
+- The current directory contains a `go.work` file
 - The current directory contains a `glide.yaml` file
 - The current directory contains a `Gopkg.yml` file
 - The current directory contains a `Gopkg.lock` file
@@ -1696,16 +1697,16 @@ By default the module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Option              | Default                                                                        | Description                                                               |
-| ------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------- |
-| `format`            | `"via [$symbol($version )]($style)"`                                           | The format for the module.                                                |
-| `version_format`    | `"v${raw}"`                                                                    | The version format. Available vars are `raw`, `major`, `minor`, & `patch` |
-| `symbol`            | `"🐹 "`                                                                         | A format string representing the symbol of Go.                            |
-| `detect_extensions` | `["go"]`                                                                       | Which extensions should trigger this module.                              |
-| `detect_files`      | `["go.mod", "go.sum", "glide.yaml", "Gopkg.yml", "Gopkg.lock", ".go-version"]` | Which filenames should trigger this module.                               |
-| `detect_folders`    | `["Godeps"]`                                                                   | Which folders should trigger this module.                                 |
-| `style`             | `"bold cyan"`                                                                  | The style for the module.                                                 |
-| `disabled`          | `false`                                                                        | Disables the `golang` module.                                             |
+| Option              | Default                                                                                   | Description                                                               |
+| ------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `format`            | `"via [$symbol($version )]($style)"`                                                      | The format for the module.                                                |
+| `version_format`    | `"v${raw}"`                                                                               | The version format. Available vars are `raw`, `major`, `minor`, & `patch` |
+| `symbol`            | `"🐹 "`                                                                                    | A format string representing the symbol of Go.                            |
+| `detect_extensions` | `["go"]`                                                                                  | Which extensions should trigger this module.                              |
+| `detect_files`      | `["go.mod", "go.sum", "go.work", "glide.yaml", "Gopkg.yml", "Gopkg.lock", ".go-version"]` | Which filenames should trigger this module.                               |
+| `detect_folders`    | `["Godeps"]`                                                                              | Which folders should trigger this module.                                 |
+| `style`             | `"bold cyan"`                                                                             | The style for the module.                                                 |
+| `disabled`          | `false`                                                                                   | Disables the `golang` module.                                             |
 
 ### Variables
 

--- a/src/configs/go.rs
+++ b/src/configs/go.rs
@@ -26,6 +26,7 @@ impl<'a> Default for GoConfig<'a> {
             detect_files: vec![
                 "go.mod",
                 "go.sum",
+                "go.work",
                 "glide.yaml",
                 "Gopkg.yml",
                 "Gopkg.lock",

--- a/src/modules/golang.rs
+++ b/src/modules/golang.rs
@@ -130,6 +130,18 @@ mod tests {
     }
 
     #[test]
+    fn folder_with_go_work() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join("go.work"))?.sync_all()?;
+
+        let actual = ModuleRenderer::new("golang").path(dir.path()).collect();
+
+        let expected = Some(format!("via {}", Color::Cyan.bold().paint("🐹 v1.12.1 ")));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
     fn folder_with_godeps() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         let godeps = dir.path().join("Godeps");


### PR DESCRIPTION

#### Description
- Show Go module if `go.work` file is found in the project's root directory
- Earlier only these files were being checked: `"go.mod", "go.sum", "glide.yaml", "Gopkg.yml", "Gopkg.lock", ".go-version"`. With this change, starship also checks for `go.work` file

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- Golang has introduced the concept of [workspaces](https://go.dev/ref/mod#workspaces) since [v1.18](https://go.dev/blog/get-familiar-with-workspaces) to let users work on multiple modules simultaneously.
- It works by creating a `go.work` file in the project root directory. There is no `go.mod` file in project root directory; they are only present in respective module directories.
- This change effectively adds `Go v1.18` support to starship

#### Screenshots (if appropriate):

#### How Has This Been Tested?
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
