### PR TITLE
chore(dprint): fmt & upgrade plugins

### DIFF
--- a/.dprint.json
+++ b/.dprint.json
@@ -1,6 +1,8 @@
 {
   "incremental": true,
-  "typescript": {},
+  "typescript": {
+    "indentWidth": 4
+  },
   "json": {},
   "markdown": {
     "lineWidth": 100
@@ -37,9 +39,9 @@
     "target/"
   ],
   "plugins": [
-    "https://plugins.dprint.dev/typescript-0.62.0.wasm",
-    "https://plugins.dprint.dev/json-0.14.0.wasm",
-    "https://plugins.dprint.dev/markdown-0.12.0.wasm",
-    "https://plugins.dprint.dev/toml-0.5.3.wasm"
+    "https://plugins.dprint.dev/typescript-0.68.2.wasm",
+    "https://plugins.dprint.dev/json-0.15.2.wasm",
+    "https://plugins.dprint.dev/markdown-0.13.2.wasm",
+    "https://plugins.dprint.dev/toml-0.5.4.wasm"
   ]
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -140,9 +140,9 @@ description: Starship is the minimal, blazing fast, and extremely customizable p
 
    This will change in the future.
    Only Nushell v0.61+ is supported.
-   
+
    :::
-   
+
    Add the following to to the end of your Nushell env file (find it by running `$nu.env-path` in Nushell):
    ```sh
    mkdir ~/.cache/starship


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
~It seems like dprint has had a formatter behavior change~ (Or perhaps just the #3908 master-conflict-merge?). Fix the formatting error and also upgrade the dprint plugins (`dprint config update && dprint fmt`). Because the upgrade changes the default typescript indention width to 2, also set it back to 4 to avoid unnecessary changes.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/starship/starship/pull/3968#issuecomment-1119697272

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
