### PR TITLE
ci: Set MacOS deployment target at 10.7 in CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,7 @@ env:
   CARGO_NET_RETRY: 10
   RUST_BACKTRACE: short
   RUSTUP_MAX_RETRIES: 10
+  MACOSX_DEPLOYMENT_TARGET: 10.7
 
 jobs:
   # Update release PR

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -15,6 +15,7 @@ env:
   RUST_BACKTRACE: short
   RUSTFLAGS: "-D warnings"
   RUSTUP_MAX_RETRIES: 10
+  MACOSX_DEPLOYMENT_TARGET: 10.7
 
 jobs:
   # Run the `rustfmt` code formatter


### PR DESCRIPTION
#### Description
Sets MACOSX_DEPLOYMENT_TARGET to 10.7 to force backwards compatibility for x64 MacOS builds.

I have tested this on #3945 and it does resolve the error. I've also tested it for aarch64 builds and it doesn't screw up cargo at all (a binary is generated which correctly targets MacOS 11.0 even though the deployment target is set lower). I'm assuming that non-MacOS builds won't look at this variable, so it shouldn't affect them.

In the absence of this variable, [rust is supposed to target 10.7 as a minimum version on x64 anyways](https://github.com/rust-lang/rust/blob/6af09d2505f38e4f1df291df56d497fb2ad935ed/compiler/rustc_target/src/spec/apple_base.rs#L68), and it's not doing so right now. ~I was unable to find anything in [the documentation on the MacOS runners](https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md) as to why this might not be working. In short, I don't know if this is masking a deeper issue.~

EDIT: Discussion on the Rust Discourse [suggests that -sys crates may cause this issue when they invoke a native compiler](https://users.rust-lang.org/t/compile-rust-binary-for-older-versions-of-mac-osx/38695). We have a few of these crates in our dependency tree (notably, git2 and notifications) so that's probably the cause.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #3945

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
