### PR TITLE
fix(git): prevent `core.fsmonitor` from executing external commands

### DIFF
--- a/src/modules/git_metrics.rs
+++ b/src/modules/git_metrics.rs
@@ -1,5 +1,4 @@
 use regex::Regex;
-use std::ffi::OsStr;
 
 use crate::{
     config::ModuleConfig, configs::git_metrics::GitMetricsConfig,
@@ -21,23 +20,12 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     };
 
     let repo = context.get_repo().ok()?;
-    let repo_root = repo.workdir.as_ref()?;
-
-    let mut args = vec![
-        OsStr::new("--git-dir"),
-        repo.path.as_os_str(),
-        OsStr::new("--work-tree"),
-        repo_root.as_os_str(),
-        OsStr::new("--no-optional-locks"),
-        OsStr::new("diff"),
-        OsStr::new("--shortstat"),
-    ];
-
+    let mut git_args = vec!["diff", "--shortstat"];
     if config.ignore_submodules {
-        args.push(OsStr::new("--ignore-submodules"));
+        git_args.push("--ignore-submodules");
     }
 
-    let diff = context.exec_cmd("git", &args)?.stdout;
+    let diff = repo.exec_git(context, &git_args)?.stdout;
 
     let stats = GitDiff::parse(&diff);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR ensures `core.fsmonitor` is unset unless it is set to `true`.

I created a `exec_git` wrapper in `Context::Repo` in order to allow controlling all instances of external git commands centrally. In that function, `core.fsmonitor` is unset as required.
`exec_git` also handles all extra flags previously shared by all external git commands (`--no-optional-locks`, `-C`). Some external git commands used `-C` and some used `--git-dir` and `--work-tree` to set the active repo. I've opted to use both since `--work-tree` isn't always available.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Partial fix for #3974
Closes? #4263
Closes #4712

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
