### PR TITLE
fix(ci): Version bump and fix Crowdin Pretranslate

### DIFF
--- a/.github/workflows/crowdin-pretranslate.yml
+++ b/.github/workflows/crowdin-pretranslate.yml
@@ -9,7 +9,7 @@ jobs:
     name: Crowdin Translation Memory Trigger
     runs-on: ubuntu-latest
     steps:
-      - uses: starship/crowdin-pretranslate-action@v0.1.0
+      - uses: starship/crowdin-pretranslate-action@v0.1.1
         with:
           project_id: 372655
-          api_key: ${{ secrets.CROWDIN_API_KEY }}
+          api_key: ${{ secrets.CROWDIN_API_TOKEN }}


### PR DESCRIPTION
#### Description
Turns out you need to name the `api_key` the right thing in order for the CI to work, otherwise it just fails :(

Also update the Action from v0.1.0 to v0.1.1, which will correctly call `setFailed` if the GitHub action fails, instead of printing error messages but then pretending everything worked fine.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
