### PR TITLE
feat: Add support for Daml

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -237,6 +237,25 @@
         }
       ]
     },
+    "daml": {
+      "default": {
+        "detect_extensions": [],
+        "detect_files": [
+          "daml.yaml"
+        ],
+        "detect_folders": [],
+        "disabled": false,
+        "format": "via [$symbol($version )]($style)",
+        "style": "bold cyan",
+        "symbol": "Λ ",
+        "version_format": "v${raw}"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/DamlConfig"
+        }
+      ]
+    },
     "dart": {
       "default": {
         "detect_extensions": [
@@ -2000,6 +2019,54 @@
         "detect_files": {
           "default": [
             "shard.yml"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_folders": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "DamlConfig": {
+      "type": "object",
+      "properties": {
+        "symbol": {
+          "default": "Λ ",
+          "type": "string"
+        },
+        "format": {
+          "default": "via [$symbol($version )]($style)",
+          "type": "string"
+        },
+        "version_format": {
+          "default": "v${raw}",
+          "type": "string"
+        },
+        "style": {
+          "default": "bold cyan",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "detect_extensions": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_files": {
+          "default": [
+            "daml.yaml"
           ],
           "type": "array",
           "items": {

--- a/docs/.vuepress/public/presets/toml/bracketed-segments.toml
+++ b/docs/.vuepress/public/presets/toml/bracketed-segments.toml
@@ -19,6 +19,9 @@ format = '\[[$symbol$environment]($style)\]'
 [crystal]
 format = '\[[$symbol($version)]($style)\]'
 
+[daml]
+format = '\[[$symbol($version)]($style)\]'
+
 [dart]
 format = '\[[$symbol($version)]($style)\]'
 

--- a/docs/.vuepress/public/presets/toml/no-runtime-versions.toml
+++ b/docs/.vuepress/public/presets/toml/no-runtime-versions.toml
@@ -10,6 +10,9 @@ format = "via [$symbol]($style)"
 [crystal]
 format = "via [$symbol]($style)"
 
+[daml]
+format = "via [$symbol]($style)"
+
 [dart]
 format = "via [$symbol]($style)"
 

--- a/docs/.vuepress/public/presets/toml/plain-text-symbols.toml
+++ b/docs/.vuepress/public/presets/toml/plain-text-symbols.toml
@@ -31,6 +31,9 @@ symbol = "cr "
 [cmake]
 symbol = "cmake "
 
+[daml]
+symbol = "daml "
+
 [dart]
 symbol = "dart "
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -214,6 +214,7 @@ $c\
 $cmake\
 $cobol\
 $container\
+$daml\
 $dart\
 $deno\
 $dotnet\
@@ -843,6 +844,48 @@ By default the module will be shown if any of the following conditions are met:
 
 [crystal]
 format = "via [✨ $version](bold blue) "
+```
+
+## Daml
+
+The `daml` module shows the currently used [Daml](https://www.digitalasset.com/developers)
+SDK version when you are in the root directory of your Daml project. The `sdk-version` in
+the `daml.yaml` file will be used, unless it's overridden by the `DAML_SDK_VERSION`
+environment variable.
+By default the module will be shown if any of the following conditions are met:
+
+- The current directory contains a `daml.yaml` file
+
+### Options
+
+| Option              | Default                            | Description                                                               |
+| ------------------- | ---------------------------------- | ------------------------------------------------------------------------- |
+| `format`            | `via [$symbol($version )]($style)` | The format for the module.                                                |
+| `version_format`    | `v${raw}`                          | The version format. Available vars are `raw`, `major`, `minor`, & `patch` |
+| `symbol`            | `"Λ "`                             | A format string representing the symbol of Daml                           |
+| `style`             | `"bold cyan"`                      | The style for the module.                                                 |
+| `detect_extensions` | `[]`                               | Which extensions should trigger this module.                              |
+| `detect_files`      | `["daml.yaml"]`                    | Which filenames should trigger this module.                               |
+| `detect_folders`    | `[]`                               | Which folders should trigger this module.                                 |
+| `disabled`          | `false`                            | Disables the `daml` module.                                               |
+
+### Variables
+
+| Variable | Example  | Description                          |
+| -------- | -------- | ------------------------------------ |
+| version  | `v2.2.0` | The version of `daml`                |
+| symbol   |          | Mirrors the value of option `symbol` |
+| style\*  |          | Mirrors the value of option `style`  |
+
+*: This variable can only be used as a part of a style string
+
+### Example
+
+```toml
+# ~/.config/starship.toml
+
+[daml]
+format = "via [D $version](bold bright-green) "
 ```
 
 ## Dart
@@ -2506,7 +2549,7 @@ symbol = "☁️ "
 
 The `package` module is shown when the current directory is the repository for a
 package, and shows its current version. The module currently supports `npm`, `nimble`, `cargo`,
-`poetry`, `python`, `composer`, `gradle`, `julia`, `mix`, `helm`, `shards` and `dart` packages.
+`poetry`, `python`, `composer`, `gradle`, `julia`, `mix`, `helm`, `shards`, `daml` and `dart` packages.
 
 - [**npm**](https://docs.npmjs.com/cli/commands/npm) – The `npm` package version is extracted from the `package.json` present
   in the current directory
@@ -2526,6 +2569,7 @@ package, and shows its current version. The module currently supports `npm`, `ni
 - [**Shards**](https://crystal-lang.org/reference/the_shards_command/index.html) - The `shards` package version is extracted from the `shard.yml` present
 - [**V**](https://vlang.io) - The `vlang` package version is extracted from the `v.mod` present
 - [**SBT**](https://scala-sbt.org) - The `sbt` package version is extracted from the `build.sbt` present in the current directory
+- [**Daml**](https://www.digitalasset.com/developers) - The `daml` package version is extracted from the `daml.yaml` present in the current directory
 - [**Dart**](https://pub.dev/) - The `dart` package version is extracted from the `pubspec.yaml` present in the current directory
 
 > ⚠️ The version being shown is that of the package whose source code is in your

--- a/src/configs/daml.rs
+++ b/src/configs/daml.rs
@@ -1,0 +1,30 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "config-schema", derive(schemars::JsonSchema))]
+#[serde(default)]
+pub struct DamlConfig<'a> {
+    pub symbol: &'a str,
+    pub format: &'a str,
+    pub version_format: &'a str,
+    pub style: &'a str,
+    pub disabled: bool,
+    pub detect_extensions: Vec<&'a str>,
+    pub detect_files: Vec<&'a str>,
+    pub detect_folders: Vec<&'a str>,
+}
+
+impl<'a> Default for DamlConfig<'a> {
+    fn default() -> Self {
+        DamlConfig {
+            symbol: "Λ ",
+            format: "via [$symbol($version )]($style)",
+            version_format: "v${raw}",
+            style: "bold cyan",
+            disabled: false,
+            detect_extensions: vec![],
+            detect_files: vec!["daml.yaml"],
+            detect_folders: vec![],
+        }
+    }
+}

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -14,6 +14,7 @@ pub mod conda;
 pub mod container;
 pub mod crystal;
 pub mod custom;
+pub mod daml;
 pub mod dart;
 pub mod deno;
 pub mod directory;
@@ -113,6 +114,8 @@ pub struct FullConfig<'a> {
     container: container::ContainerConfig<'a>,
     #[serde(borrow)]
     crystal: crystal::CrystalConfig<'a>,
+    #[serde(borrow)]
+    daml: daml::DamlConfig<'a>,
     #[serde(borrow)]
     dart: dart::DartConfig<'a>,
     #[serde(borrow)]

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -39,6 +39,7 @@ pub const PROMPT_ORDER: &[&str] = &[
     "c",
     "cmake",
     "cobol",
+    "daml",
     "dart",
     "deno",
     "dotnet",

--- a/src/module.rs
+++ b/src/module.rs
@@ -21,6 +21,7 @@ pub const ALL_MODULES: &[&str] = &[
     "conda",
     "container",
     "crystal",
+    "daml",
     "dart",
     "deno",
     "directory",

--- a/src/modules/daml.rs
+++ b/src/modules/daml.rs
@@ -1,0 +1,135 @@
+use super::{Context, Module, ModuleConfig};
+use crate::configs::daml::DamlConfig;
+use crate::formatter::{StringFormatter, VersionFormatter};
+
+const DAML_SDK_VERSION: &str = "sdk-version";
+const DAML_SDK_VERSION_ENV: &str = "DAML_SDK_VERSION";
+const DAML_YAML: &str = "daml.yaml";
+
+/// Creates a module with the current Daml version
+pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let mut module = context.new_module("daml");
+    let config: DamlConfig = DamlConfig::try_load(module.config);
+
+    let is_daml_project = context
+        .try_begin_scan()?
+        .set_files(&config.detect_files)
+        .set_extensions(&config.detect_extensions)
+        .set_folders(&config.detect_folders)
+        .is_match();
+
+    if !is_daml_project {
+        return None;
+    }
+
+    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
+        formatter
+            .map_meta(|var, _| match var {
+                "symbol" => Some(config.symbol),
+                _ => None,
+            })
+            .map_style(|variable| match variable {
+                "style" => Some(Ok(config.style)),
+                _ => None,
+            })
+            .map(|variable| match variable {
+                "version" => {
+                    let daml_sdk_version = get_daml_sdk_version(context)?;
+                    VersionFormatter::format_module_version(
+                        module.get_name(),
+                        &daml_sdk_version,
+                        config.version_format,
+                    )
+                    .map(Ok)
+                }
+                _ => None,
+            })
+            .parse(None, Some(context))
+    });
+
+    module.set_segments(match parsed {
+        Ok(segments) => segments,
+        Err(error) => {
+            log::warn!("Error in module `daml`:\n{}", error);
+            return None;
+        }
+    });
+
+    Some(module)
+}
+
+fn get_daml_sdk_version(context: &Context) -> Option<String> {
+    context
+        .get_env(DAML_SDK_VERSION_ENV)
+        .or_else(|| read_sdk_version_from_daml_yaml(context))
+}
+
+fn read_sdk_version_from_daml_yaml(context: &Context) -> Option<String> {
+    let file_contents = context.read_file_from_pwd(DAML_YAML)?;
+    let daml_yaml = yaml_rust::YamlLoader::load_from_str(&file_contents).ok()?;
+    let sdk_version = daml_yaml.first()?[DAML_SDK_VERSION].as_str()?;
+    Some(sdk_version.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test::ModuleRenderer;
+    use ansi_term::Color;
+    use std::fs::File;
+    use std::io::{Result, Write};
+
+    #[test]
+    fn folder_without_daml_yaml() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let actual = ModuleRenderer::new("daml").path(dir.path()).collect();
+        let expected = None;
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn folder_with_daml_yaml() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join(DAML_YAML))?.write_all(b"sdk-version: 2.2.0\n")?;
+        let actual = ModuleRenderer::new("daml").path(dir.path()).collect();
+        let expected = Some(format!("via {}", Color::Cyan.bold().paint("Λ v2.2.0 ")));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn folder_with_daml_yaml_without_sdk_version_entry() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join(DAML_YAML))?.write_all(b"version: 1.0.0\n")?;
+        let actual = ModuleRenderer::new("daml").path(dir.path()).collect();
+        let expected = Some(format!("via {}", Color::Cyan.bold().paint("Λ ")));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn folder_with_daml_yaml_and_daml_sdk_version() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join(DAML_YAML))?.write_all(b"sdk-version: 2.2.0\n")?;
+        let actual = ModuleRenderer::new("daml")
+            .env(DAML_SDK_VERSION_ENV, "2.0.0")
+            .path(dir.path())
+            .collect();
+        let expected = Some(format!("via {}", Color::Cyan.bold().paint("Λ v2.0.0 ")));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn folder_without_daml_yaml_with_daml_sdk_version() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let actual = ModuleRenderer::new("daml")
+            .env(DAML_SDK_VERSION_ENV, "2.0.0")
+            .path(dir.path())
+            .collect();
+        let expected = None;
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+}

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -11,6 +11,7 @@ mod conda;
 mod container;
 mod crystal;
 pub(crate) mod custom;
+mod daml;
 mod dart;
 mod deno;
 mod directory;
@@ -102,6 +103,7 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
             "cobol" => cobol::module(context),
             "conda" => conda::module(context),
             "container" => container::module(context),
+            "daml" => daml::module(context),
             "dart" => dart::module(context),
             "deno" => deno::module(context),
             "directory" => directory::module(context),
@@ -204,6 +206,7 @@ pub fn description(module: &str) -> &'static str {
         "conda" => "The current conda environment, if $CONDA_DEFAULT_ENV is set",
         "container" => "The container indicator, if inside a container.",
         "crystal" => "The currently installed version of Crystal",
+        "daml" => "The Daml SDK version of your project",
         "dart" => "The currently installed version of Dart",
         "deno" => "The currently installed version of Deno",
         "directory" => "The current working directory",


### PR DESCRIPTION
#### Description
- Add a `daml` module that reads the currently used SDK version for a project using the one indicated in the `daml.yaml` file or overrides it with `DAML_SDK_VERSION`
- Add Daml support to the `package` module (uses the `version` key in the `daml.yaml` file)

#### Motivation and Context
Closes #3903

#### How Has This Been Tested?
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

Apart from the relevant automated tests, I opened a sample Daml project and touched the `sdk-version` and `version` keys in the `daml.yaml` file, as well as the `DAML_SDK_VERSION` environment variable to see whether the changes were picked up correctly. Also went into a sub-directory to see whether the information disappeared as expected. I further made sure that the example in the documentation works, as well as checking that every option works as expected.

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
