### PR TITLE
feat(winget): Add support for winget package manager

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -313,15 +313,14 @@ jobs:
     runs-on: windows-latest
     needs: [release_please, github_build, upload_artifacts]
     if: ${{ needs.release_please.outputs.release_created == 'true' }}
+    env:
+      URL_64: https://github.com/starship/starship/releases/download/${{ needs.release_please.outputs.tag_name }}/starship-x86_64-pc-windows-msvc.msi
+      URL_32: https://github.com/starship/starship/releases/download/${{ needs.release_please.outputs.tag_name }}/starship-i686-pc-windows-msvc.msi
     steps:
       - run: |
-          $releaseUrl = ${{ needs.release_please.outputs.html_url }}
-          $urlPrefix = $releaseUrl.Insert($releaseUrl.lastIndexOf('/'), '/download')
-          $url64 = Write-Host $urlPrefix/starship-x86_64-pc-windows-msvc.msi
-          $url32 = Write-Host $urlPrefix/starship-i686-pc-windows-msvc.msi
           $version = ${{ needs.release_please.outputs.tag_name }}.replace('v', '')
           iwr https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
-          ./wingetcreate.exe update Starship.Starship -s -v $version -u $url64 $url32 -t ${{ secrets.GITHUB_TOKEN }}
+          ./wingetcreate.exe update Starship.Starship -s -v $version -u $env:URL_64 $env:URL_32 -t ${{ secrets.GITHUB_TOKEN }}
 
   merge_crowdin_pr:
     name: Merge Crowdin PR

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -308,6 +308,21 @@ jobs:
         env:
           COMMITTER_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
 
+  winget_update:
+    name: Update Winget Manifest
+    runs-on: windows-latest
+    needs: [release_please, github_build, upload_artifacts]
+    if: ${{ needs.release_please.outputs.release_created == 'true' }}
+    steps:
+      - run: |
+          $releaseUrl = ${{ needs.release_please.outputs.html_url }}
+          $urlPrefix = $releaseUrl.Insert($releaseUrl.lastIndexOf('/'), '/download')
+          $url64 = Write-Host $urlPrefix/starship-x86_64-pc-windows-msvc.msi
+          $url32 = Write-Host $urlPrefix/starship-i686-pc-windows-msvc.msi
+          $version = ${{ needs.release_please.outputs.tag_name }}.replace('v', '')
+          iwr https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+          ./wingetcreate.exe update Starship.Starship -s -v $version -u $url64 $url32 -t ${{ secrets.GITHUB_TOKEN }}
+
   merge_crowdin_pr:
     name: Merge Crowdin PR
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -318,7 +318,7 @@ jobs:
       URL_32: https://github.com/starship/starship/releases/download/${{ needs.release_please.outputs.tag_name }}/starship-i686-pc-windows-msvc.msi
     steps:
       - run: |
-          $version = ${{ needs.release_please.outputs.tag_name }}.replace('v', '')
+          $version = '${{ needs.release_please.outputs.tag_name }}'.replace('v', '')
           iwr https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
           ./wingetcreate.exe update Starship.Starship -s -v $version -u $env:URL_64 $env:URL_32 -t ${{ secrets.GITHUB_TOKEN }}
 

--- a/README.md
+++ b/README.md
@@ -251,6 +251,8 @@ Alternatively, install Starship using any of the following package managers:
 <details>
 <summary>Windows</summary>
 
+Install the latest version for your system with the MSI-installers from the [releases section](https://github.com/starship/starship/releases/latest).
+
 Install Starship using any of the following package managers:
 
 | Repository      | Instructions                            |

--- a/README.md
+++ b/README.md
@@ -251,8 +251,6 @@ Alternatively, install Starship using any of the following package managers:
 <details>
 <summary>Windows</summary>
 
-Install the latest version for your system with the MSI-installers from the [releases section](https://github.com/starship/starship/releases/latest).
-
 Install Starship using any of the following package managers:
 
 | Repository      | Instructions                            |
@@ -261,6 +259,7 @@ Install Starship using any of the following package managers:
 | [Chocolatey]    | `choco install starship`                |
 | [conda-forge]   | `conda install -c conda-forge starship` |
 | [Scoop]         | `scoop install starship`                |
+| [winget]        | `winget install --id Starship.Starship` |
 
 </details>
 
@@ -447,3 +446,4 @@ This project is [ISC](https://github.com/starship/starship/blob/master/LICENSE) 
 [snapcraft]: https://snapcraft.io/starship
 [termux]: https://github.com/termux/termux-packages/tree/master/packages/starship
 [void linux packages]: https://github.com/void-linux/void-packages/tree/master/srcpkgs/starship
+[winget]: https://github.com/microsoft/winget-pkgs/tree/master/manifests/s/Starship/Starship


### PR DESCRIPTION
#### Description
Adds a release step for publishing Starship to the [winget](https://github.com/microsoft/winget-cli) package manager for Windows

#### Motivation and Context
Thought I would kick this off now that #4031 is complete. Still requires an initial [`wingetcreate new`](https://github.com/microsoft/winget-create/blob/main/doc/new.md) once #4029 releases so that the `wingetcreate` tool can download and analyze the MSI installers and generate a manifest that this pipeline step can update thereafter. After that, testing this pipeline step will become possible.

Closes #1295 

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
