### PR TITLE
feat: Add the ability to have some file extensions *prevent* a module from triggering

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -152,6 +152,27 @@ format = '''
 \$'''
 ```
 
+### File Extensions
+
+Many modules have a `detect_extensions` variable, which takes a list of file extensions to match or not match.
+"Negative" extensions, those which should not be matched, are indicated with a leading "!" character.
+
+Extensions are matched against both the characters after the last dot in a filename, and the characters after
+the first dot in a filename. For example, consider the filename `foo.bar.tar.gz`. To see if that matches anything
+mentioned in `detect_extensions` we will consider both the characters after the last dot, "gz", and those after
+the first dot, "bar.tar.gz".
+
+We first look for any files matching a negative extension. If there are any, the module is not triggered.
+
+If there were none, we then look for any files matching a positive extension.
+
+To see how this works in practice, and why you might want to use negative extensions, consider how a Node
+programmer who also works with video might configure the Nodejs module. By default its `detect_extensions`
+is `["js", "mjs", "cjs", "ts", "mts", "cts"]`. However, in their video work they also deal with `.video.ts`
+and `.audio.ts` files containing MPEG Transport Stream encoded data. They don't want a directory full of
+video data to trigger the Nodejs module! So they add two negative extensions to the list:
+`["js", "mjs", "cjs", "ts", "mts", "cts", "!audio.ts", "!video.ts"]`.
+
 ## Prompt
 
 This is the list of prompt-wide configuration options.

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -152,26 +152,23 @@ format = '''
 \$'''
 ```
 
-### File Extensions
+### Negative matching
 
-Many modules have a `detect_extensions` variable, which takes a list of file extensions to match or not match.
-"Negative" extensions, those which should not be matched, are indicated with a leading "!" character.
+Many modules have `detect_extensions`, `detect_files`, and `detect_folders` variables. These take
+lists of strings to match or not match. "Negative" options, those which should not be matched, are
+indicated with a leading "!" character. The presence of _any_ negative indicator in the directory
+will result in the module not being matched.
 
-Extensions are matched against both the characters after the last dot in a filename, and the characters after
-the first dot in a filename. For example, consider the filename `foo.bar.tar.gz`. To see if that matches anything
-mentioned in `detect_extensions` we will consider both the characters after the last dot, "gz", and those after
-the first dot, "bar.tar.gz".
+Extensions are matched against both the characters after the last dot in a filename, and the
+characters after the first dot in a filename. For example, `foo.bar.tar.gz` will be matched
+against `bar.tar.gz` and `gz` in the `detect_extensions` variable. Files whose name begins with a
+dot are not considered to have extensions at all.
 
-We first look for any files matching a negative extension. If there are any, the module is not triggered.
+To see how this works in practice, you could match TypeScript but not MPEG Transport Stream files thus:
 
-If there were none, we then look for any files matching a positive extension.
-
-To see how this works in practice, and why you might want to use negative extensions, consider how a Node
-programmer who also works with video might configure the Nodejs module. By default its `detect_extensions`
-is `["js", "mjs", "cjs", "ts", "mts", "cts"]`. However, in their video work they also deal with `.video.ts`
-and `.audio.ts` files containing MPEG Transport Stream encoded data. They don't want a directory full of
-video data to trigger the Nodejs module! So they add two negative extensions to the list:
-`["js", "mjs", "cjs", "ts", "mts", "cts", "!audio.ts", "!video.ts"]`.
+```toml
+detect_extensions = ["ts", "!video.ts", "!audio.ts"]
+```
 
 ## Prompt
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -777,6 +777,28 @@ mod tests {
         .is_match());
         dont_match_ext.close()?;
 
+        let dont_match_file = testdir(&["goodfile", "evilfile"])?;
+        let dont_match_file_dc = DirContents::from_path(dont_match_file.path())?;
+        assert!(!ScanDir {
+            dir_contents: &dont_match_file_dc,
+            files: &["goodfile", "!notfound", "!evilfile"],
+            extensions: &[],
+            folders: &[],
+        }
+        .is_match());
+        dont_match_file.close()?;
+
+        let dont_match_folder = testdir(&["gooddir/somefile", "evildir/somefile"])?;
+        let dont_match_folder_dc = DirContents::from_path(dont_match_folder.path())?;
+        assert!(!ScanDir {
+            dir_contents: &dont_match_folder_dc,
+            files: &[],
+            extensions: &[],
+            folders: &["gooddir", "!notfound", "!evildir"],
+        }
+        .is_match());
+        dont_match_folder.close()?;
+
         Ok(())
     }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -464,17 +464,14 @@ impl DirContents {
     }
 
     pub fn has_any_positive_extension(&self, exts: &[&str]) -> bool {
-        exts.iter().any(|ext| {
-            !ext.starts_with("!") &&
-            self.has_extension(ext)
-        })
+        exts.iter()
+            .any(|ext| !ext.starts_with("!") && self.has_extension(ext))
     }
 
     pub fn has_no_negative_extension(&self, exts: &[&str]) -> bool {
-        !exts.iter().any(|ext| {
-            ext.starts_with("!") &&
-            self.has_extension(&ext[1..])
-        })
+        !exts
+            .iter()
+            .any(|ext| ext.starts_with("!") && self.has_extension(&ext[1..]))
     }
 }
 
@@ -543,12 +540,12 @@ impl<'a> ScanDir<'a> {
     pub fn is_match(&self) -> bool {
         // if there exists a file with an extension we've said we don't want,
         // fail the match straight away
-        self.dir_contents.has_no_negative_extension(self.extensions) &&
-        (
-            self.dir_contents.has_any_positive_extension(self.extensions)
+        self.dir_contents.has_no_negative_extension(self.extensions)
+            && (self
+                .dir_contents
+                .has_any_positive_extension(self.extensions)
                 || self.dir_contents.has_any_folder(self.folders)
-                || self.dir_contents.has_any_file_name(self.files)
-        )
+                || self.dir_contents.has_any_file_name(self.files))
     }
 }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -403,6 +403,8 @@ impl DirContents {
                         // to match both.
 
                         // find the minimal extension on a file. ie, the gz in foo.tar.gz
+                        // NB the .to_string_lossy().to_string() here looks weird but is
+                        // required to convert it from a Cow.
                         path.extension()
                             .map(|ext| extensions.insert(ext.to_string_lossy().to_string()));
 
@@ -410,12 +412,12 @@ impl DirContents {
                         path.file_name().map(|file_name| {
                             file_name
                                 .to_string_lossy()
-                                .to_string()
                                 .split_once('.')
                                 .map(|(_, after)| extensions.insert(after.to_string()))
                         });
                     }
                     if let Some(file_name) = path.file_name() {
+                        // this .to_string_lossy().to_string() is also required
                         file_names.insert(file_name.to_string_lossy().to_string());
                     }
                     files.insert(path);

--- a/src/context.rs
+++ b/src/context.rs
@@ -465,13 +465,13 @@ impl DirContents {
 
     pub fn has_any_positive_extension(&self, exts: &[&str]) -> bool {
         exts.iter()
-            .any(|ext| !ext.starts_with("!") && self.has_extension(ext))
+            .any(|ext| !ext.starts_with('!') && self.has_extension(ext))
     }
 
     pub fn has_no_negative_extension(&self, exts: &[&str]) -> bool {
         !exts
             .iter()
-            .any(|ext| ext.starts_with("!") && self.has_extension(&ext[1..]))
+            .any(|ext| ext.starts_with('!') && self.has_extension(&ext[1..]))
     }
 }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -752,6 +752,17 @@ mod tests {
         .is_match());
         tarballs.close()?;
 
+        let dont_match_ext = testdir(&["foo.js", "foo.ts"])?;
+        let dont_match_ext_dc = DirContents::from_path(dont_match_ext.path())?;
+        assert!(!ScanDir {
+            dir_contents: &dont_match_ext_dc,
+            files: &[],
+            extensions: &["js", "!ts"],
+            folders: &[],
+        }
+        .is_match());
+        dont_match_ext.close()?;
+
         Ok(())
     }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -397,8 +397,23 @@ impl DirContents {
                     folders.insert(path);
                 } else {
                     if !path.to_string_lossy().starts_with('.') {
+                        // Extract the file extensions (yes, that's plural) from a filename.
+                        // Why plural? Consider the case of foo.tar.gz. It's a compressed
+                        // tarball (tar.gz), and it's a gzipped file (gz). We should be able
+                        // to match both.
+
+                        // find the minimal extension on a file. ie, the gz in foo.tar.gz
                         path.extension()
                             .map(|ext| extensions.insert(ext.to_string_lossy().to_string()));
+
+                        // find the full extension on a file. ie, the tar.gz in foo.tar.gz
+                        path.file_name().map(|file_name| {
+                            file_name
+                                .to_string_lossy()
+                                .to_string()
+                                .split_once('.')
+                                .map(|(_, after)| extensions.insert(after.to_string()))
+                        });
                     }
                     if let Some(file_name) = path.file_name() {
                         file_names.insert(file_name.to_string_lossy().to_string());

--- a/src/context.rs
+++ b/src/context.rs
@@ -726,6 +726,17 @@ mod tests {
         .is_match());
         node.close()?;
 
+        let tarballs = testdir(&["foo.tgz", "foo.tar.gz"])?;
+        let tarballs_dc = DirContents::from_path(tarballs.path())?;
+        assert!(ScanDir {
+            dir_contents: &tarballs_dc,
+            files: &[],
+            extensions: &["tar.gz"],
+            folders: &[],
+        }
+        .is_match());
+        tarballs.close()?;
+
         Ok(())
     }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -757,7 +757,7 @@ mod tests {
         assert!(!ScanDir {
             dir_contents: &dont_match_ext_dc,
             files: &[],
-            extensions: &["js", "!ts"],
+            extensions: &["js", "!notfound", "!ts"],
             folders: &[],
         }
         .is_match());

--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -493,6 +493,8 @@ mod tests {
     fn make_known_tempdir(root: &Path) -> io::Result<(TempDir, String)> {
         fs::create_dir_all(root)?;
         let dir = TempDir::new_in(root)?;
+        // the .to_string_lossy().to_string() here looks weird but is required
+        // to convert it from a Cow.
         let path = dir
             .path()
             .file_name()


### PR DESCRIPTION
This adds "negative extensions" to `detect_extensions`. A negative extension, signified by starting with a "!" character, will prevent a module from triggering.

#### Description
You can now add "negative extensions" to any `detect_extensions` variable. If any file is found that matches any negative extension then the module will not be triggered.

I also added support for multi-part extensions like "tar.gz" and "video.ts" because for my particular use case I need to prevent the Node module from triggering on "video.ts" files.

#### Motivation and Context

Closes #4033

#### Screenshots (if appropriate):

#### How Has This Been Tested?

Aside from adding unit tests, I have also tested this for real with `detect_extensions = ["ts", "!video.ts"]` in my config and verified that after adding `"!video.ts"` the directory was no longer showing up as a Node project in my prompt.

- [X] I have tested using **MacOS**

#### Checklist:

- [X] I have updated the documentation accordingly.
- [X] I have updated the tests accordingly.
