### PR TITLE
fix(install): ignore tarfile ownership values when installing as root

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -111,32 +111,8 @@ unpack() {
 
   case "$archive" in
     *.tar.gz)
-      flags=$(test -n "${VERBOSE-}" && echo "-xzvf" || echo "-xzf")
+      flags=$(test -n "${VERBOSE-}" && echo "-xzvof" || echo "-xzof")
       ${sudo} tar "${flags}" "${archive}" -C "${bin_dir}"
-      if [ "$sudo" != "" ]; then
-        # set the owner to root instead of whatever was in the tarball
-        "${sudo}" chown root "${bin_dir}/starship"
-        # group ownership of root's binaries varies by platform. It's not
-        # even always groupid 0! This copies the group_id from /bin/sh.
-        # This list includes some platforms that aren't (yet) supported as
-        # future-proofing. NB that GNU stat and BSD stat are annoyingly
-        # different.
-        platform=`uname`
-      # script tested on these platforms
-        if [ "$platform" = "Linux" ]; then
-          "${sudo}" chgrp `stat -c %g /bin/sh` "${bin_dir}/starship"
-        elif [ "$platform" = "Darwin" ]; then # MacOS
-          "${sudo}" chgrp `stat -f %g /bin/sh` "${bin_dir}/starship"
-      # chgrp/stat trick tested on these platforms but not as part of this script
-      # as the rest of the install script / starship / rust aren't fully supported
-        elif [ "$platform" = "FreeBSD" ]; then
-          "${sudo}" chgrp `stat -f %g /bin/sh` "${bin_dir}/starship"
-        elif [ "$platform" = "OpenBSD" ]; then
-          "${sudo}" chgrp `stat -f %g /bin/sh` "${bin_dir}/starship"
-        elif [ "$platform" = "SunOS" ]; then  # tested on IllumOS, but not real Solaris
-          "${sudo}" chgrp `stat -c %g /bin/sh` "${bin_dir}/starship"
-        fi
-      fi
       return 0
       ;;
     *.zip)


### PR DESCRIPTION
If the install script used `sudo` to install Starship from a tarball, it left the file with what the userid/groupid was in the tarball. That user/group might or might not actually exist. This change fixes that.

#### Description
We now use the `-o` flag when untarring, to force tar to use the current user's userid/groupid instead of whatever is in the tarball. That is on by default for non-root users, but not for root.

#### Motivation and Context
Closes #4039

#### Screenshots (if appropriate):

#### How Has This Been Tested?
- [X] I have tested the install script on **MacOS**
- [X] I have tested the install script on **Linux**

The script claims to support FreeBSD but doesn't - it can't find a binary to download.