### PR TITLE
chore(audit): add back `RUSTSEC-2020-0071` & `RUSTSEC-2020-0159` to ignore list

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,11 @@
+[advisories]
+ignore = [
+  # Potential segfault in the time crate
+  # chrono dependency, but vulnerable function is never called
+  # Tacked in #3163
+  "RUSTSEC-2020-0071",
+  # chrono: Potential segfault in localtime_r invocations
+  # starship avoids setting any environment variables to avoid this issue
+  # Tracked in #3166
+  "RUSTSEC-2020-0159",
+]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
One of the warnings has been un-withdrawn, and the other might follow at some point (because they also called `tzset`).

This reverts commit b1ad1c79f53fcc27373cd6128191a867b50fb579.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
