### PR TITLE
build: upgrade open for non-blocking 'open::that()' on linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1260,9 +1260,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "open"
-version = "2.1.3"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2423ffbf445b82e58c3b1543655968923dd06f85432f10be2bb4f1b7122f98c"
+checksum = "360bcc8316bf6363aa3954c3ccc4de8add167b087e0259190a043c9514f910fe"
 dependencies = [
  "pathdiff",
  "windows-sys 0.36.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ log = { version = "0.4.16", features = ["std"] }
 # see: https://github.com/NixOS/nixpkgs/issues/160876
 notify-rust = { version = "4.5.8", optional = true }
 once_cell = "1.12.0"
-open = "2.1.3"
+open = "3.0.1"
 os_info = "3.4.0"
 path-slash = "0.1.4"
 pest = "2.1.3"


### PR DESCRIPTION
#### Description
A dependency upgrade, no breaking changes.

