### PR TITLE
docs: Fix typo in custom command docs

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -3719,7 +3719,7 @@ These modules will be shown if any of the following conditions are met:
 - The current directory contains a directory whose name is in `detect_folders`
 - The current directory contains a file whose extension is in `detect_extensions`
 - The `when` command returns 0
-- The current Operating System (std::env::consts::OS) matchs with `os` field if defined.
+- The current Operating System (std::env::consts::OS) matches with `os` field if defined.
 
 ::: tip
 


### PR DESCRIPTION
#### Description
Small typo in docs. Starship is great :+1:

#### Checklist:
- [X] I have updated the documentation accordingly.
