### PR TITLE
fix(character): Standadise Vim config names

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -122,9 +122,9 @@
         "error_symbol": "[❯](bold red)",
         "format": "$symbol ",
         "success_symbol": "[❯](bold green)",
-        "vicmd_symbol": "[❮](bold green)",
         "vimcmd_replace_one_symbol": "[❮](bold purple)",
         "vimcmd_replace_symbol": "[❮](bold purple)",
+        "vimcmd_symbol": "[❮](bold green)",
         "vimcmd_visual_symbol": "[❮](bold yellow)"
       },
       "allOf": [
@@ -1783,7 +1783,7 @@
           "default": "[❯](bold red)",
           "type": "string"
         },
-        "vicmd_symbol": {
+        "vimcmd_symbol": {
           "default": "[❮](bold green)",
           "type": "string"
         },

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -561,7 +561,7 @@ look at [this example](#with-custom-error-shape).
 
 ::: warning
 
-`vicmd_symbol` is only supported in cmd, fish and zsh.
+`vimcmd_symbol` is only supported in cmd, fish and zsh.
 `vimcmd_replace_one_symbol`, `vimcmd_replace_symbol`, and `vimcmd_visual_symbol`
 are only supported in fish due to [upstream issues with mode detection in zsh](https://github.com/starship/starship/issues/625#issuecomment-732454148).
 
@@ -569,16 +569,16 @@ are only supported in fish due to [upstream issues with mode detection in zsh](h
 
 ### Options
 
-| Option                     | Default              | Description                                                                             |
-| -------------------------- | -------------------- | --------------------------------------------------------------------------------------- |
-| `format`                   | `"$symbol "`         | The format string used before the text input.                                           |
-| `success_symbol`           | `"[❯](bold green)"`  | The format string used before the text input if the previous command succeeded.         |
-| `error_symbol`             | `"[❯](bold red)"`    | The format string used before the text input if the previous command failed.            |
-| `vicmd_symbol`             | `"[❮](bold green)"`  | The format string used before the text input if the shell is in vim normal mode.        |
-| `vicmd_replace_one_symbol` | `"[❮](bold purple)"` | The format string used before the text input if the shell is in vim `replace_one` mode. |
-| `vimcmd_replace_symbol`    | `"[❮](bold purple)"` | The format string used before the text input if the shell is in vim replace mode.       |
-| `vimcmd_visual_symbol`     | `"[❮](bold yellow)"` | The format string used before the text input if the shell is in vim replace mode.       |
-| `disabled`                 | `false`              | Disables the `character` module.                                                        |
+| Option                      | Default              | Description                                                                             |
+| --------------------------- | -------------------- | --------------------------------------------------------------------------------------- |
+| `format`                    | `"$symbol "`         | The format string used before the text input.                                           |
+| `success_symbol`            | `"[❯](bold green)"`  | The format string used before the text input if the previous command succeeded.         |
+| `error_symbol`              | `"[❯](bold red)"`    | The format string used before the text input if the previous command failed.            |
+| `vimcmd_symbol`             | `"[❮](bold green)"`  | The format string used before the text input if the shell is in vim normal mode.        |
+| `vimcmd_replace_one_symbol` | `"[❮](bold purple)"` | The format string used before the text input if the shell is in vim `replace_one` mode. |
+| `vimcmd_replace_symbol`     | `"[❮](bold purple)"` | The format string used before the text input if the shell is in vim replace mode.       |
+| `vimcmd_visual_symbol`      | `"[❮](bold yellow)"` | The format string used before the text input if the shell is in vim replace mode.       |
+| `disabled`                  | `false`              | Disables the `character` module.                                                        |
 
 ### Variables
 

--- a/src/configs/character.rs
+++ b/src/configs/character.rs
@@ -7,7 +7,8 @@ pub struct CharacterConfig<'a> {
     pub format: &'a str,
     pub success_symbol: &'a str,
     pub error_symbol: &'a str,
-    pub vicmd_symbol: &'a str,
+    #[serde(alias = "vicmd_symbol")]
+    pub vimcmd_symbol: &'a str,
     pub vimcmd_visual_symbol: &'a str,
     pub vimcmd_replace_symbol: &'a str,
     pub vimcmd_replace_one_symbol: &'a str,
@@ -20,7 +21,7 @@ impl<'a> Default for CharacterConfig<'a> {
             format: "$symbol ",
             success_symbol: "[❯](bold green)",
             error_symbol: "[❯](bold red)",
-            vicmd_symbol: "[❮](bold green)",
+            vimcmd_symbol: "[❮](bold green)",
             vimcmd_visual_symbol: "[❮](bold yellow)",
             vimcmd_replace_symbol: "[❮](bold purple)",
             vimcmd_replace_one_symbol: "[❮](bold purple)",

--- a/src/modules/character.rs
+++ b/src/modules/character.rs
@@ -45,7 +45,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     };
 
     let symbol = match mode {
-        ShellEditMode::Normal => config.vicmd_symbol,
+        ShellEditMode::Normal => config.vimcmd_symbol,
         ShellEditMode::Visual => config.vimcmd_visual_symbol,
         ShellEditMode::Replace => config.vimcmd_replace_symbol,
         ShellEditMode::ReplaceOne => config.vimcmd_replace_one_symbol,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Have switched all vi/vim symbols to have the same prefix 'vim'. To
preserve backwards compatibility with existing configs I have added an
alias for the previous config name, I left the existing test to check this.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #4074

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
