### PR TITLE
feat(gcloud): disable if active config is NONE

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1380,7 +1380,7 @@ AA -------------------------------------------- BB -----------------------------
 ## Google Cloud (`gcloud`)
 
 The `gcloud` module shows the current configuration for [`gcloud`](https://cloud.google.com/sdk/gcloud) CLI.
-This is based on the `~/.config/gcloud/active_config` file and the `~/.config/gcloud/configurations/config_{CONFIG NAME}` file and the `CLOUDSDK_CONFIG` env var.
+This is based on the `~/.config/gcloud/active_config` file and the `~/.config/gcloud/configurations/config_{CONFIG NAME}` file and the `CLOUDSDK_CONFIG` env var. Setting `active` to `"NONE"` will disable the module.
 
 ### Options
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1380,7 +1380,7 @@ AA -------------------------------------------- BB -----------------------------
 ## Google Cloud (`gcloud`)
 
 The `gcloud` module shows the current configuration for [`gcloud`](https://cloud.google.com/sdk/gcloud) CLI.
-This is based on the `~/.config/gcloud/active_config` file and the `~/.config/gcloud/configurations/config_{CONFIG NAME}` file and the `CLOUDSDK_CONFIG` env var. Setting `active` to `"NONE"` will disable the module.
+This is based on the `~/.config/gcloud/active_config` file and the `~/.config/gcloud/configurations/config_{CONFIG NAME}` file and the `CLOUDSDK_CONFIG` env var. Setting active name to `"NONE"` will disable the module.
 
 ### Options
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adds additional match condition to return None for active config if set to "NONE".

#### Motivation and Context
Closes #3658
Closes #3692

#### How Has This Been Tested?
(See [comment](https://github.com/starship/starship/pull/4092#issuecomment-1159818107))

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#- [ ] I have tested using **MacOS**
#- [ ] I have tested using **Linux**
#- [ ] I have tested using **Windows**


#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
