### PR TITLE
feat(character): Add vimcmd_insert_success_symbol and vimcmd_insert_error_symbol

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -122,6 +122,8 @@
         "error_symbol": "[❯](bold red)",
         "format": "$symbol ",
         "success_symbol": "[❯](bold green)",
+        "vimcmd_insert_error_symbol": null,
+        "vimcmd_insert_success_symbol": null,
         "vimcmd_replace_one_symbol": "[❮](bold purple)",
         "vimcmd_replace_symbol": "[❮](bold purple)",
         "vimcmd_symbol": "[❮](bold green)",
@@ -1798,6 +1800,20 @@
         "vimcmd_replace_one_symbol": {
           "default": "[❮](bold purple)",
           "type": "string"
+        },
+        "vimcmd_insert_success_symbol": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "vimcmd_insert_error_symbol": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "disabled": {
           "default": false,

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -562,23 +562,26 @@ look at [this example](#with-custom-error-shape).
 ::: warning
 
 `vimcmd_symbol` is only supported in cmd, fish and zsh.
-`vimcmd_replace_one_symbol`, `vimcmd_replace_symbol`, and `vimcmd_visual_symbol`
+`vimcmd_replace_one_symbol`, `vimcmd_replace_symbol`, `vimcmd_visual_symbol`, `vimcmd_insert_success_symbol` and `vimcmd_insert_error_symbol`
 are only supported in fish due to [upstream issues with mode detection in zsh](https://github.com/starship/starship/issues/625#issuecomment-732454148).
 
 :::
 
 ### Options
 
-| Option                      | Default              | Description                                                                             |
-| --------------------------- | -------------------- | --------------------------------------------------------------------------------------- |
-| `format`                    | `"$symbol "`         | The format string used before the text input.                                           |
-| `success_symbol`            | `"[❯](bold green)"`  | The format string used before the text input if the previous command succeeded.         |
-| `error_symbol`              | `"[❯](bold red)"`    | The format string used before the text input if the previous command failed.            |
-| `vimcmd_symbol`             | `"[❮](bold green)"`  | The format string used before the text input if the shell is in vim normal mode.        |
-| `vimcmd_replace_one_symbol` | `"[❮](bold purple)"` | The format string used before the text input if the shell is in vim `replace_one` mode. |
-| `vimcmd_replace_symbol`     | `"[❮](bold purple)"` | The format string used before the text input if the shell is in vim replace mode.       |
-| `vimcmd_visual_symbol`      | `"[❮](bold yellow)"` | The format string used before the text input if the shell is in vim replace mode.       |
-| `disabled`                  | `false`              | Disables the `character` module.                                                        |
+| Option                         | Default              | Description                                                                             |
+| ------------------------------ | -------------------- | --------------------------------------------------------------------------------------- |
+| `format`                       | `"$symbol "`         | The format string used before the text input.                                           |
+| `success_symbol`               | `"[❯](bold green)"`  | The format string used before the text input if the previous command succeeded.         |
+| `error_symbol`                 | `"[❯](bold red)"`    | The format string used before the text input if the previous command failed.            |
+| `vimcmd_symbol`                | `"[❮](bold green)"`  | The format string used before the text input if the shell is in vim normal mode.        |
+| `vimcmd_replace_one_symbol`    | `"[❮](bold purple)"` | The format string used before the text input if the shell is in vim `replace_one` mode. |
+| `vimcmd_replace_symbol`        | `"[❮](bold purple)"` | The format string used before the text input if the shell is in vim replace mode.       |
+| `vimcmd_visual_symbol`         | `"[❮](bold yellow)"` | The format string used before the text input if the shell is in vim replace mode.       |
+| `vimcmd_insert_success_symbol` | `None`               | If not `None`, used in vim insert mode instead of `success_symbol`                      |
+| `vimcmd_insert_error_symbol`   | `None`               | If not `None`, used in vim insert mode instead of `error_symbol`                        |
+| `vimcmd_visual_symbol`         | `"[❮](bold yellow)"` | The format string used before the text input if the shell is in vim replace mode.       |
+| `disabled`                     | `false`              | Disables the `character` module.                                                        |
 
 ### Variables
 

--- a/src/configs/character.rs
+++ b/src/configs/character.rs
@@ -12,6 +12,8 @@ pub struct CharacterConfig<'a> {
     pub vimcmd_visual_symbol: &'a str,
     pub vimcmd_replace_symbol: &'a str,
     pub vimcmd_replace_one_symbol: &'a str,
+    pub vimcmd_insert_success_symbol: Option<&'a str>,
+    pub vimcmd_insert_error_symbol: Option<&'a str>,
     pub disabled: bool,
 }
 
@@ -25,6 +27,8 @@ impl<'a> Default for CharacterConfig<'a> {
             vimcmd_visual_symbol: "[❮](bold yellow)",
             vimcmd_replace_symbol: "[❮](bold purple)",
             vimcmd_replace_one_symbol: "[❮](bold purple)",
+            vimcmd_insert_success_symbol: None,
+            vimcmd_insert_error_symbol: None,
             disabled: false,
         }
     }

--- a/src/init/starship.fish
+++ b/src/init/starship.fish
@@ -1,12 +1,15 @@
 function fish_prompt
+    set STARSHIP_CMD_PIPESTATUS $pipestatus
+    set STARSHIP_CMD_STATUS $status
     switch "$fish_key_bindings"
         case fish_hybrid_key_bindings fish_vi_key_bindings
             set STARSHIP_KEYMAP "$fish_bind_mode"
+            if test $STARSHIP_KEYMAP = "insert"
+                set STARSHIP_KEYMAP "vi_insert"
+            end
         case '*'
             set STARSHIP_KEYMAP insert
     end
-    set STARSHIP_CMD_PIPESTATUS $pipestatus
-    set STARSHIP_CMD_STATUS $status
     # Account for changes in variable name between v2.7 and v3.0
     set STARSHIP_DURATION "$CMD_DURATION$cmd_duration"
     set STARSHIP_JOBS (count (jobs -p))
@@ -14,14 +17,17 @@ function fish_prompt
 end
 
 function fish_right_prompt
+    set STARSHIP_CMD_PIPESTATUS $pipestatus
+    set STARSHIP_CMD_STATUS $status
     switch "$fish_key_bindings"
         case fish_hybrid_key_bindings fish_vi_key_bindings
             set STARSHIP_KEYMAP "$fish_bind_mode"
+            if test $STARSHIP_KEYMAP = "insert"
+                set STARSHIP_KEYMAP "vi_insert"
+            end
         case '*'
             set STARSHIP_KEYMAP insert
     end
-    set STARSHIP_CMD_PIPESTATUS $pipestatus
-    set STARSHIP_CMD_STATUS $status
     # Account for changes in variable name between v2.7 and v3.0
     set STARSHIP_DURATION "$CMD_DURATION$cmd_duration"
     set STARSHIP_JOBS (count (jobs -p))


### PR DESCRIPTION
#### Description
Add `vimcmd_insert_success_symbol` and `vimcmd_insert_error_symbol` support for fish shell. If those options are not specified, then `success_symbol` and `error_symbol` are used.

#### Motivation and Context
Closes #4101

#### Screenshots (if appropriate):
Screenshot with the following config:
```toml
[character]
vimcmd_insert_success_symbol = "[I](bold green)"
vimcmd_insert_error_symbol = "[I](bold red)"
```

![изображение](https://user-images.githubusercontent.com/16033061/175356887-ae8a3938-ee4c-4604-8b30-1bd0cce59b05.png)

#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
