### PR TITLE
Double application of style fix in pastel-powerline

### DIFF
--- a/docs/.vuepress/public/presets/toml/pastel-powerline.toml
+++ b/docs/.vuepress/public/presets/toml/pastel-powerline.toml
@@ -56,69 +56,69 @@ truncation_symbol = "…/"
 [c]
 symbol = " "
 style = "bg:#86BBD8"
-format = '[[ $symbol ($version) ](bg:#86BBD8)]($style)'
+format = '[ $symbol ($version) ]($style)'
 
 [docker_context]
 symbol = " "
 style = "bg:#06969A"
-format = '[[ $symbol $context ](bg:#06969A)]($style) $path'
+format = '[ $symbol $context ]($style) $path'
 
 [elixir]
 symbol = " "
 style = "bg:#86BBD8"
-format = '[[ $symbol ($version) ](bg:#86BBD8)]($style)'
+format = '[ $symbol ($version) ]($style)'
 
 [elm]
 symbol = " "
 style = "bg:#86BBD8"
-format = '[[ $symbol ($version) ](bg:#86BBD8)]($style)'
+format = '[ $symbol ($version) ]($style)'
 
 [git_branch]
 symbol = ""
 style = "bg:#FCA17D"
-format = '[[ $symbol $branch ](bg:#FCA17D)]($style)'
+format = '[ $symbol $branch ]($style)'
 
 [git_status]
 style = "bg:#FCA17D"
-format = '[[($all_status$ahead_behind )](bg:#FCA17D)]($style)'
+format = '[$all_status$ahead_behind ]($style)'
 
 [golang]
 symbol = " "
 style = "bg:#86BBD8"
-format = '[[ $symbol ($version) ](bg:#86BBD8)]($style)'
+format = '[ $symbol ($version) ]($style)'
 
 [haskell]
 symbol = " "
 style = "bg:#86BBD8"
-format = '[[ $symbol ($version) ](bg:#86BBD8)]($style)'
+format = '[ $symbol ($version) ]($style)'
 
 [java]
 symbol = " "
 style = "bg:#86BBD8"
-format = '[[ $symbol ($version) ](bg:#86BBD8)]($style)'
+format = '[ $symbol ($version) ]($style)'
 
 [julia]
 symbol = " "
 style = "bg:#86BBD8"
-format = '[[ $symbol ($version) ](bg:#86BBD8)]($style)'
+format = '[ $symbol ($version) ]($style)'
 
 [nodejs]
 symbol = ""
 style = "bg:#86BBD8"
-format = '[[ $symbol ($version) ](bg:#86BBD8)]($style)'
+format = '[ $symbol ($version) ]($style)'
 
 [nim]
 symbol = " "
 style = "bg:#86BBD8"
-format = '[[ $symbol ($version) ](bg:#86BBD8)]($style)'
+format = '[ $symbol ($version) ]($style)'
 
 [rust]
 symbol = ""
 style = "bg:#86BBD8"
-format = '[[ $symbol ($version) ](bg:#86BBD8)]($style)'
+format = '[ $symbol ($version) ]($style)'
 
 [time]
 disabled = false
 time_format = "%R" # Hour:Minute Format
 style = "bg:#33658A"
-format = '[[ ♥ $time ](bg:#33658A)]($style)'
+format = '[ ♥ $time ]($style)'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
```
[blabla]($style)
```
already applies `style` to `blabla` (assuming `$style` exists), so there's no need to add the same style again.

#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

Just fixed the config, and nothing changed, so it seems to be working/

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
