### PR TITLE
ci: fix release hiccups caused by draft release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -265,12 +265,16 @@ jobs:
       - name: Setup | Checksums
         run: for file in starship-*/starship-*; do openssl dgst -sha256 -r "$file" | awk '{print $1}' > "${file}.sha256"; done
 
+      - name: Setup | Publish Release
+        run: gh release edit ${{ needs.release_please.outputs.tag_name }} --draft=false --repo=starship/starship
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build | Add Artifacts to Release
         uses: softprops/action-gh-release@v1
         with:
           files: starship-*/starship-*
           tag_name: ${{ needs.release_please.outputs.tag_name }}
-          draft: false
 
   # Publish starship to Crates.io
   cargo_publish:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -303,7 +303,10 @@ jobs:
           formula-name: starship
           tag-name: ${{ needs.release_please.outputs.tag_name }}
         env:
+          # Used for creating the formula update PR
           COMMITTER_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
+          # Used for verifying the SHA256 sum of the draft release
+          GITHUB_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
 
   winget_update:
     name: Update Winget Manifest


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

Fix issues encountered during the release of v1.9.1:
- Draft release couldn't be found by `mislav/bump-homebrew-formula-action`
  Fixed by providing a GitHub token with permissions to view draft release
- Draft release was not updated by `softprops/action-gh-release`
  Fixed by publishing the draft release before adding artifacts
