### PR TITLE
feat: Add support for blink, hidden, and strikethrough styles.

### DIFF
--- a/docs/advanced-config/README.md
+++ b/docs/advanced-config/README.md
@@ -278,6 +278,9 @@ Style strings are a list of words, separated by whitespace. The words are not ca
 - `underline`
 - `dimmed`
 - `inverted`
+- `blink`
+- `hidden`
+- `strikethrough`
 - `bg:<color>`
 - `fg:<color>`
 - `<color>`
@@ -297,3 +300,9 @@ A color specifier can be one of the following:
 - A number between 0-255. This specifies an [8-bit ANSI Color Code](https://i.stack.imgur.com/KTSQa.png).
 
 If multiple colors are specified for foreground/background, the last one in the string will take priority.
+
+Not every style string will be displayed correctly by every terminal. In particular, the following known quirks exist:
+
+- Many terminals disable support for `blink` by default
+- `hidden` is not supported on iTerm (https://gitlab.com/gnachman/iterm2/-/issues/4564).
+- `strikethrough` is not supported by the default macOS Terminal.app

--- a/src/config.rs
+++ b/src/config.rs
@@ -268,6 +268,7 @@ where
  - 'bold'
  - 'italic'
  - 'inverted'
+ - 'blink'
  - '<color>'       (see the `parse_color_string` doc for valid color strings)
 */
 pub fn parse_style_string(style_string: &str) -> Option<ansi_term::Style> {
@@ -293,6 +294,9 @@ pub fn parse_style_string(style_string: &str) -> Option<ansi_term::Style> {
                     "italic" => Some(style.italic()),
                     "dimmed" => Some(style.dimmed()),
                     "inverted" => Some(style.reverse()),
+                    "blink" => Some(style.blink()),
+                    "hidden" => Some(style.hidden()),
+                    "strikethrough" => Some(style.strikethrough()),
                     // When the string is supposed to be a color:
                     // Decide if we yield none, reset background or set color.
                     color_string => {
@@ -622,6 +626,69 @@ mod tests {
                 .underline()
                 .dimmed()
                 .reverse()
+                .fg(Color::Green)
+        );
+    }
+
+    #[test]
+    fn table_get_styles_bold_italic_underline_green_dimmed_blink_silly_caps() {
+        let config = Value::from("bOlD ItAlIc uNdErLiNe GrEeN diMMeD bLiNk");
+        let mystyle = <StyleWrapper>::from_config(&config).unwrap().0;
+        assert!(mystyle.is_bold);
+        assert!(mystyle.is_italic);
+        assert!(mystyle.is_underline);
+        assert!(mystyle.is_dimmed);
+        assert!(mystyle.is_blink);
+        assert_eq!(
+            mystyle,
+            ansi_term::Style::new()
+                .bold()
+                .italic()
+                .underline()
+                .dimmed()
+                .blink()
+                .fg(Color::Green)
+        );
+    }
+
+    #[test]
+    fn table_get_styles_bold_italic_underline_green_dimmed_hidden_silly_caps() {
+        let config = Value::from("bOlD ItAlIc uNdErLiNe GrEeN diMMeD hIDDen");
+        let mystyle = <StyleWrapper>::from_config(&config).unwrap().0;
+        assert!(mystyle.is_bold);
+        assert!(mystyle.is_italic);
+        assert!(mystyle.is_underline);
+        assert!(mystyle.is_dimmed);
+        assert!(mystyle.is_hidden);
+        assert_eq!(
+            mystyle,
+            ansi_term::Style::new()
+                .bold()
+                .italic()
+                .underline()
+                .dimmed()
+                .hidden()
+                .fg(Color::Green)
+        );
+    }
+
+    #[test]
+    fn table_get_styles_bold_italic_underline_green_dimmed_strikethrough_silly_caps() {
+        let config = Value::from("bOlD ItAlIc uNdErLiNe GrEeN diMMeD StRiKEthROUgh");
+        let mystyle = <StyleWrapper>::from_config(&config).unwrap().0;
+        assert!(mystyle.is_bold);
+        assert!(mystyle.is_italic);
+        assert!(mystyle.is_underline);
+        assert!(mystyle.is_dimmed);
+        assert!(mystyle.is_strikethrough);
+        assert_eq!(
+            mystyle,
+            ansi_term::Style::new()
+                .bold()
+                .italic()
+                .underline()
+                .dimmed()
+                .strikethrough()
                 .fg(Color::Green)
         );
     }


### PR DESCRIPTION
#### Description

Add support for `blink`, `hidden`, and `strikethrough` format strings. The underlying `ansi_term` library supports them on supported terminals; this PR merely exposes those options.

#### Motivation and Context

I find it useful to occasionally use blinking text in my prompts to _really_ get me to pay attention, so it would be nice to be able to style things using blinking text. I noticed strikethrough and hidden could be added trivially, so I threw them into the mix too.

#### How Has This Been Tested?

- [x] I have tested using **MacOS**
  * I noticed that iTerm supports blinking and strikethrough, but does _not_ support hidden text (https://gitlab.com/gnachman/iterm2/-/issues/4564).
  * Terminal.app _does_ support hidden text, but does not appear to support strikethrough text.
- [x] I have tested using **Linux**
  * Tested with Gnome Terminal; supports all three of `blink`, `hidden`, and `strikethrough`
- [x] I have tested using **Windows**
  * Tested both in the traditional terminal (Windows Console Host) and the new one (Windows Terminal); both support all three of `blink`, `hidden`, and `strikethrough`

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
