### PR TITLE
feat(username): Adds substitution for usernames

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -1403,7 +1403,8 @@
         "format": "[$user]($style) in ",
         "show_always": false,
         "style_root": "red bold",
-        "style_user": "yellow bold"
+        "style_user": "yellow bold",
+        "substitutions": {}
       },
       "allOf": [
         {
@@ -4678,6 +4679,13 @@
         "show_always": {
           "default": false,
           "type": "boolean"
+        },
+        "substitutions": {
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
         },
         "disabled": {
           "default": false,

--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -4668,6 +4668,10 @@
           "default": "[$user]($style) in ",
           "type": "string"
         },
+        "show_always": {
+          "default": false,
+          "type": "boolean"
+        },
         "style_root": {
           "default": "red bold",
           "type": "string"
@@ -4675,10 +4679,6 @@
         "style_user": {
           "default": "yellow bold",
           "type": "string"
-        },
-        "show_always": {
-          "default": false,
-          "type": "boolean"
         },
         "substitutions": {
           "default": {},

--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -4668,10 +4668,6 @@
           "default": "[$user]($style) in ",
           "type": "string"
         },
-        "show_always": {
-          "default": false,
-          "type": "boolean"
-        },
         "style_root": {
           "default": "red bold",
           "type": "string"
@@ -4686,6 +4682,10 @@
           "additionalProperties": {
             "type": "string"
           }
+        },
+        "show_always": {
+          "default": false,
+          "type": "boolean"
         },
         "disabled": {
           "default": false,

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -3591,9 +3591,9 @@ these variables, one workaround is to set one of them with a dummy value.
 <details>
 <summary>This module has a few advanced configuration options that control how the directory is displayed.</summary>
 
-| Advanced Option             | Default | Description                                                                                                                                                            |
-| --------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `substitutions`             |         | A table of substitutions to be made to the path.                                                                                                                       |
+| Advanced Option | Default | Description                                      |
+| --------------- | ------- | ------------------------------------------------ |
+| `substitutions` |         | A table of substitutions to be made to the path. |
 
 `substitutions` allows you to define arbitrary replacements for literal strings that occur in the username, for example your usual username or the root user.
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -3587,6 +3587,24 @@ these variables, one workaround is to set one of them with a dummy value.
 | `style`  | `"red bold"` | Mirrors the value of option `style_root` when root is logged in and `style_user` otherwise. |
 | `user`   | `"matchai"`  | The currently logged-in user ID.                                                            |
 
+
+<details>
+<summary>This module has a few advanced configuration options that control how the directory is displayed.</summary>
+
+| Advanced Option             | Default | Description                                                                                                                                                            |
+| --------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `substitutions`             |         | A table of substitutions to be made to the path.                                                                                                                       |
+
+`substitutions` allows you to define arbitrary replacements for literal strings that occur in the username, for example your usual username or the root user.
+
+```toml
+[directory.substitutions]
+"astronaut" = "👩‍🚀"
+"root" = "🛡"
+```
+
+</details>
+
 ### Example
 
 ```toml

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -3587,7 +3587,6 @@ these variables, one workaround is to set one of them with a dummy value.
 | `style`  | `"red bold"` | Mirrors the value of option `style_root` when root is logged in and `style_user` otherwise. |
 | `user`   | `"matchai"`  | The currently logged-in user ID.                                                            |
 
-
 <details>
 <summary>This module has a few advanced configuration options that control how the directory is displayed.</summary>
 

--- a/src/configs/username.rs
+++ b/src/configs/username.rs
@@ -1,3 +1,5 @@
+use indexmap::IndexMap;
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
@@ -7,6 +9,7 @@ pub struct UsernameConfig<'a> {
     pub format: &'a str,
     pub style_root: &'a str,
     pub style_user: &'a str,
+    pub substitutions: IndexMap<String, &'a str>,
     pub show_always: bool,
     pub disabled: bool,
 }
@@ -17,6 +20,7 @@ impl<'a> Default for UsernameConfig<'a> {
             format: "[$user]($style) in ",
             style_root: "red bold",
             style_user: "yellow bold",
+            substitutions: IndexMap::new(),
             show_always: false,
             disabled: false,
         }


### PR DESCRIPTION
#### Description
Adds `username.substitutions` to the configuration which can be used to substitute usernames in a similar way to the directory module.

Example configuration:
```toml
[username]
disabled = false
show_always = true
format = '[$user]($style)'

[username.substitutions]
"colings86" = "🤷"
"root" = "🛡"

```

#### Motivation and Context
For common usernames I find it useful to still show an indicator of the user but to have an icon or something short that doesn't take up lots of space.

#### Screenshots (if appropriate):
<img width="838" alt="Screenshot 2022-07-02 at 09 42 04" src="https://user-images.githubusercontent.com/236731/176993450-3b57e748-8337-46d3-95b8-4bbd5500da65.png">

#### How Has This Been Tested?
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

The PR adds tests for the new functionality and I tested on my local shell prompt.

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
