### PR TITLE
feat: Enable transience for Cmd and PowerShell

### DIFF
--- a/docs/advanced-config/README.md
+++ b/docs/advanced-config/README.md
@@ -32,6 +32,44 @@ Invoke-Expression (&starship init powershell)
 Enable-TransientPrompt
 ```
 
+## TransientPrompt and TransientRightPrompt in Cmd
+
+Clink allows you to replace the previous-printed prompt with custom strings. This
+is useful in cases where all the prompt information is not always needed. To enable
+this, run `clink set prompt.transient <value>` where \<value\> can be one of:
+- `always`: always replace the previous prompt
+- `same_dir`: replace the previous prompt only if the working directory is same
+- `off`: do not replace the prompt (i.e. turn off transience)
+
+You need to do this only once. Make the following changes to your `starship.lua`
+to customize what gets displayed on the left and on the right:
+
+- By default, the left side of input gets replaced with `>`. To customize this,
+  define a new function called `starship_transient_prompt_func`. This function
+  receives the current prompt as a string that you can utilize. For example, to
+  display Starship's `character` module here, you would do
+
+```lua
+function starship_transient_prompt_func(prompt)
+  return io.popen("starship module character"
+    .." --keymap="..rl.getvariable('keymap')
+  ):read("*a")
+end
+load(io.popen('starship init cmd'):read("*a"))()
+```
+
+- By default, the right side of input is empty. To customize this, define a new
+  function called `starship_transient_rprompt_func`. This function receives the
+  current prompt as a string that you can utilize. For example, to display
+  the time at which the last command was started here, you would do
+
+```lua
+function starship_transient_rprompt_func(prompt)
+  return io.popen("starship module time"):read("*a")
+end
+load(io.popen('starship init cmd'):read("*a"))()
+```
+
 ## Custom pre-prompt and pre-execution Commands in Cmd
 
 Clink provides extremely flexible APIs to run pre-prompt and pre-exec commands

--- a/docs/advanced-config/README.md
+++ b/docs/advanced-config/README.md
@@ -10,6 +10,28 @@ The configurations in this section are subject to change in future releases of S
 
 :::
 
+## TransientPrompt in PowerShell
+
+It is possible to replace the previous-printed prompt with a custom string. This
+is useful in cases where all the prompt information is not always needed. To enable
+this, run `Enable-TransientPrompt` in the shell session. To make it permanent, put
+this statement in your `$PROFILE`. Transience can be disabled on-the-fly with
+`Disable-TransientPrompt`.
+
+By default, the left side of input gets replaced with `>`. To customize this,
+define a new function called `Invoke-Starship-TransientFunction`. For example, to
+display Starship's `character` module here, you would do
+
+```powershell
+function Invoke-Starship-TransientFunction {
+  &starship module character
+}
+
+Invoke-Expression (&starship init powershell)
+
+Enable-TransientPrompt
+```
+
 ## Custom pre-prompt and pre-execution Commands in Cmd
 
 Clink provides extremely flexible APIs to run pre-prompt and pre-exec commands

--- a/docs/advanced-config/README.md
+++ b/docs/advanced-config/README.md
@@ -37,6 +37,7 @@ Enable-TransientPrompt
 Clink allows you to replace the previous-printed prompt with custom strings. This
 is useful in cases where all the prompt information is not always needed. To enable
 this, run `clink set prompt.transient <value>` where \<value\> can be one of:
+
 - `always`: always replace the previous prompt
 - `same_dir`: replace the previous prompt only if the working directory is same
 - `off`: do not replace the prompt (i.e. turn off transience)

--- a/src/init/starship.lua
+++ b/src/init/starship.lua
@@ -49,6 +49,18 @@ function starship_prompt:rightfilter(prompt)
   ):read("*a")
 end
 
+if starship_transient_prompt_func ~= nil then
+  function starship_prompt:transientfilter(prompt)
+    return starship_transient_prompt_func(prompt)
+  end
+end
+
+if starship_transient_rprompt_func ~= nil then
+  function starship_prompt:transientrightfilter(prompt)
+    return starship_transient_rprompt_func(prompt)
+  end
+end
+
 local characterset = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 local randomkey = ""
 math.randomseed(os.time())

--- a/src/init/starship.ps1
+++ b/src/init/starship.ps1
@@ -64,6 +64,35 @@ $null = New-Module starship {
         $process.StandardOutput.ReadToEnd();
     }
 
+    function Enable-TransientPrompt {
+        Set-PSReadLineKeyHandler -Key Enter -ScriptBlock {
+            $previousOutputEncoding = [Console]::OutputEncoding
+            try {
+                $parseErrors = $null
+                [Microsoft.PowerShell.PSConsoleReadLine]::GetBufferState([ref]$null, [ref]$null, [ref]$parseErrors, [ref]$null)
+                if ($parseErrors.Count -eq 0) {
+                    $script:TransientPrompt = $true
+                    [Console]::OutputEncoding = [Text.Encoding]::UTF8
+                    [Microsoft.PowerShell.PSConsoleReadLine]::InvokePrompt()
+                }
+            } finally {
+                if ($script:DoesUseLists) {
+                    # If PSReadline is set to display suggestion list, this workaround is needed to clear the buffer below
+                    # before accepting the current commandline. The max amount of items in the list is 10, so 12 lines
+                    # are cleared (10 + 1 more for the prompt + 1 more for current commandline).
+                    [Microsoft.PowerShell.PSConsoleReadLine]::Insert("`n" * [math]::Min($Host.UI.RawUI.WindowSize.Height - $Host.UI.RawUI.CursorPosition.Y - 1, 12))
+                    [Microsoft.PowerShell.PSConsoleReadLine]::Undo()
+                }
+                [Microsoft.PowerShell.PSConsoleReadLine]::AcceptLine()
+                [Console]::OutputEncoding = $previousOutputEncoding
+            }
+        }
+    }
+
+    function Disable-TransientPrompt {
+        Set-PSReadLineKeyHandler -Key Enter -Function AcceptLine
+    }
+
     function global:prompt {
         $origDollarQuestion = $global:?
         $origLastExitCode = $global:LASTEXITCODE
@@ -106,7 +135,16 @@ $null = New-Module starship {
         $arguments += "--status=$($lastExitCodeForPrompt)"
 
         # Invoke Starship
-        $promptText = Invoke-Native -Executable ::STARSHIP:: -Arguments $arguments
+        $promptText = if ($script:TransientPrompt) {
+            $script:TransientPrompt = $false
+            if (Test-Path function:Invoke-Starship-TransientFunction) {
+                Invoke-Starship-TransientFunction
+            } else {
+                "> "
+            }
+        } else {
+            Invoke-Native -Executable ::STARSHIP:: -Arguments $arguments
+        }
 
         # Set the number of extra lines in the prompt for PSReadLine prompt redraw.
         Set-PSReadLineOption -ExtraPromptLineCount ($promptText.Split("`n").Length - 1)
@@ -141,6 +179,9 @@ $null = New-Module starship {
     # Disable virtualenv prompt, it breaks starship
     $ENV:VIRTUAL_ENV_DISABLE_PROMPT=1
 
+    $script:TransientPrompt = $false
+    $script:DoesUseLists = (Get-PSReadLineOption).PredictionViewStyle -eq 'ListView'
+
     if ($PSVersionTable.PSVersion.Major -gt 5) {
         $ENV:STARSHIP_SHELL = "pwsh"
     } else {
@@ -158,5 +199,8 @@ $null = New-Module starship {
         )
     )
 
-    Export-ModuleMember
+    Export-ModuleMember -Function @(
+        "Enable-TransientPrompt"
+        "Disable-TransientPrompt"
+    )
 }

--- a/src/init/starship.ps1
+++ b/src/init/starship.ps1
@@ -91,6 +91,7 @@ $null = New-Module starship {
 
     function Disable-TransientPrompt {
         Set-PSReadLineKeyHandler -Key Enter -Function AcceptLine
+        $script:TransientPrompt = $false
     }
 
     function global:prompt {
@@ -140,7 +141,7 @@ $null = New-Module starship {
             if (Test-Path function:Invoke-Starship-TransientFunction) {
                 Invoke-Starship-TransientFunction
             } else {
-                "> "
+                "$([char]0x1B)[1;32m❯$([char]0x1B)[0m "
             }
         } else {
             Invoke-Native -Executable ::STARSHIP:: -Arguments $arguments


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Enables both left and right transience for Cmd.
Enables only left transience for PowerShell.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related to #888

#### Asciinema Recording:
[![asciicast](https://asciinema.org/a/Vl7k1E3IpRFBvpV33Y1h1OyUv.png)](https://asciinema.org/a/Vl7k1E3IpRFBvpV33Y1h1OyUv?autoplay=1)


#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
