### PR TITLE
feat(k8s): Add folder detection to the k8s module.

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -767,6 +767,9 @@
     "kubernetes": {
       "default": {
         "context_aliases": {},
+        "detect_extensions": [],
+        "detect_files": [],
+        "detect_folders": [],
         "disabled": true,
         "format": "[$symbol$context( \\($namespace\\))]($style) in ",
         "style": "cyan bold",
@@ -3320,6 +3323,27 @@
           "default": {},
           "type": "object",
           "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "detect_extensions": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_files": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_folders": {
+          "default": [],
+          "type": "array",
+          "items": {
             "type": "string"
           }
         }

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2084,18 +2084,25 @@ If the `$KUBECONFIG` env var is set the module will use that if not it will use 
 This module is disabled by default.
 To enable it, set `disabled` to `false` in your configuration file.
 
+When the module is enabled it will always be active, unless any of
+`detect_extensions`, `detect_files` or `detect_folders` have been st in which
+case the module will only be active in directories that match those conditions.
+
 :::
 
 ### Options
 
-| Option            | Default                                            | Description                                                           |
-| ----------------- | -------------------------------------------------- | --------------------------------------------------------------------- |
-| `symbol`          | `"☸ "`                                             | A format string representing the symbol displayed before the Cluster. |
-| `format`          | `'[$symbol$context( \($namespace\))]($style) in '` | The format for the module.                                            |
-| `style`           | `"cyan bold"`                                      | The style for the module.                                             |
-| `context_aliases` |                                                    | Table of context aliases to display.                                  |
-| `user_aliases`    |                                                    | Table of user aliases to display.                                     |
-| `disabled`        | `true`                                             | Disables the `kubernetes` module.                                     |
+| Option              | Default                                            | Description                                                           |
+| ------------------- | -------------------------------------------------- | --------------------------------------------------------------------- |
+| `symbol`            | `"☸ "`                                             | A format string representing the symbol displayed before the Cluster. |
+| `format`            | `'[$symbol$context( \($namespace\))]($style) in '` | The format for the module.                                            |
+| `style`             | `"cyan bold"`                                      | The style for the module.                                             |
+| `context_aliases`   |                                                    | Table of context aliases to display.                                  |
+| `user_aliases`      |                                                    | Table of user aliases to display.                                     |
+| `detect_extensions` | `[]`                                               | Which extensions should trigger this module.                          |
+| `detect_files`      | `[]`                                               | Which filenames should trigger this module.                           |
+| `detect_folders`    | `[]`                                               | Which folders should trigger this modules.                            |
+| `disabled`          | `true`                                             | Disables the `kubernetes` module.                                     |
 
 ### Variables
 
@@ -2125,6 +2132,16 @@ disabled = false
 [kubernetes.user_aliases]
 "dev.local.cluster.k8s" = "dev"
 "root/.*" = "root"
+```
+
+Only show the module in directories that contain a `k8s` file.
+
+```toml
+# ~/.config/starship.toml
+
+[kubernetes]
+disabled = false
+detect_files = ['k8s']
 ```
 
 #### Regex Matching

--- a/src/configs/kubernetes.rs
+++ b/src/configs/kubernetes.rs
@@ -11,6 +11,9 @@ pub struct KubernetesConfig<'a> {
     pub disabled: bool,
     pub context_aliases: HashMap<String, &'a str>,
     pub user_aliases: HashMap<String, &'a str>,
+    pub detect_extensions: Vec<&'a str>,
+    pub detect_files: Vec<&'a str>,
+    pub detect_folders: Vec<&'a str>,
 }
 
 impl<'a> Default for KubernetesConfig<'a> {
@@ -22,6 +25,9 @@ impl<'a> Default for KubernetesConfig<'a> {
             disabled: true,
             context_aliases: HashMap::new(),
             user_aliases: HashMap::new(),
+            detect_extensions: vec![],
+            detect_files: vec![],
+            detect_folders: vec![],
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Have added configuration options to the k8s module to allow activating
the module only in directories that contains certain files or folders.
To ensure this is backwards compatible and because there are not really
any standard files or folders for Kubernetes I have set the defaults to
empty and will activate the module for all directories.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #4126

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
