### PR TITLE
perf(pulumi): allow disabling upwards discovery

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -1026,6 +1026,7 @@
       "default": {
         "disabled": false,
         "format": "via [$symbol($username@)$stack]($style) ",
+        "search_upwards": false,
         "style": "bold 5",
         "symbol": " ",
         "version_format": "v${raw}"
@@ -3829,6 +3830,10 @@
           "type": "string"
         },
         "disabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "search_upwards": {
           "default": false,
           "type": "boolean"
         }

--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -1026,7 +1026,7 @@
       "default": {
         "disabled": false,
         "format": "via [$symbol($username@)$stack]($style) ",
-        "search_upwards": false,
+        "search_upwards": true,
         "style": "bold 5",
         "symbol": " ",
         "version_format": "v${raw}"
@@ -3834,7 +3834,7 @@
           "type": "boolean"
         },
         "search_upwards": {
-          "default": false,
+          "default": true,
           "type": "boolean"
         }
       }

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2700,7 +2700,7 @@ If you still want to enable it, [follow the example shown below](#with-pulumi-ve
 By default the module will be shown if any of the following conditions are met:
 
 - The current directory contains either `Pulumi.yaml` or `Pulumi.yml`
-- A parent directory contains either `Pulumi.yaml` or `Pulumi.yml` if `search_upwards` is set to `true`
+- A parent directory contains either `Pulumi.yaml` or `Pulumi.yml` unless `search_upwards` is set to `false`
 
 ### Options
 
@@ -2710,7 +2710,7 @@ By default the module will be shown if any of the following conditions are met:
 | `version_format` | `"v${raw}"`                                  | The version format. Available vars are `raw`, `major`, `minor`, & `patch` |
 | `symbol`         | `" "`                                       | A format string shown before the Pulumi stack.                            |
 | `style`          | `"bold 5"`                                   | The style for the module.                                                 |
-| `search_upwards` | `false`                                      | Enable discovery of pulumi config files in parent directories.            |
+| `search_upwards` | `true`                                       | Enable discovery of pulumi config files in parent directories.            |
 | `disabled`       | `false`                                      | Disables the `pulumi` module.                                             |
 
 ### Variables

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2700,7 +2700,7 @@ If you still want to enable it, [follow the example shown below](#with-pulumi-ve
 By default the module will be shown if any of the following conditions are met:
 
 - The current directory contains either `Pulumi.yaml` or `Pulumi.yml`
-- A parent directory contains either `Pulumi.yaml` or `Pulumi.yml`
+- A parent directory contains either `Pulumi.yaml` or `Pulumi.yml` if `search_upwards` is set to `true`
 
 ### Options
 
@@ -2710,6 +2710,7 @@ By default the module will be shown if any of the following conditions are met:
 | `version_format` | `"v${raw}"`                                  | The version format. Available vars are `raw`, `major`, `minor`, & `patch` |
 | `symbol`         | `" "`                                       | A format string shown before the Pulumi stack.                            |
 | `style`          | `"bold 5"`                                   | The style for the module.                                                 |
+| `search_upwards` | `false`                                      | Enable discovery of pulumi config files in parent directories.            |
 | `disabled`       | `false`                                      | Disables the `pulumi` module.                                             |
 
 ### Variables

--- a/src/configs/pulumi.rs
+++ b/src/configs/pulumi.rs
@@ -20,7 +20,7 @@ impl<'a> Default for PulumiConfig<'a> {
             symbol: " ",
             style: "bold 5",
             disabled: false,
-            search_upwards: false,
+            search_upwards: true,
         }
     }
 }

--- a/src/configs/pulumi.rs
+++ b/src/configs/pulumi.rs
@@ -9,6 +9,7 @@ pub struct PulumiConfig<'a> {
     pub symbol: &'a str,
     pub style: &'a str,
     pub disabled: bool,
+    pub search_upwards: bool,
 }
 
 impl<'a> Default for PulumiConfig<'a> {
@@ -19,6 +20,7 @@ impl<'a> Default for PulumiConfig<'a> {
             symbol: " ",
             style: "bold 5",
             disabled: false,
+            search_upwards: false,
         }
     }
 }

--- a/src/modules/pulumi.rs
+++ b/src/modules/pulumi.rs
@@ -31,6 +31,15 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let mut module = context.new_module("pulumi");
     let config = PulumiConfig::try_load(module.config);
 
+    let project_file_in_cwd = context
+        .try_begin_scan()?
+        .set_files(&["Pulumi.yaml", "Pulumi.yml"])
+        .is_match();
+
+    if !project_file_in_cwd && !config.search_upwards {
+        return None;
+    }
+
     let project_file = find_package_file(&context.logical_dir)?;
 
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
@@ -408,5 +417,48 @@ mod tests {
         assert_eq!(expected, rendered.expect("a result"));
         dir.close()?;
         Ok(())
+    }
+
+    #[test]
+    fn do_not_search_upwards() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let child_dir = dir.path().join("child");
+        std::fs::create_dir(&child_dir)?;
+        let yaml = File::create(dir.path().join("Pulumi.yaml"))?;
+        yaml.sync_all()?;
+
+        let actual = ModuleRenderer::new("pulumi")
+            .path(&child_dir)
+            .logical_path(&child_dir)
+            .config(toml::toml! {
+                [pulumi]
+                format = "in [$symbol($stack)]($style) "
+            })
+            .collect();
+        let expected = None;
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn search_upwards_with_opt() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let child_dir = dir.path().join("child");
+        std::fs::create_dir(&child_dir)?;
+        let yaml = File::create(dir.path().join("Pulumi.yaml"))?;
+        yaml.sync_all()?;
+
+        let actual = ModuleRenderer::new("pulumi")
+            .path(&child_dir)
+            .logical_path(&child_dir)
+            .config(toml::toml! {
+                [pulumi]
+                format = "in [$symbol($stack)]($style) "
+                search_upwards = true
+            })
+            .collect();
+        let expected = Some(format!("in {} ", Color::Fixed(5).bold().paint(" ")));
+        assert_eq!(expected, actual);
+        dir.close()
     }
 }

--- a/src/modules/pulumi.rs
+++ b/src/modules/pulumi.rs
@@ -433,6 +433,7 @@ mod tests {
             .config(toml::toml! {
                 [pulumi]
                 format = "in [$symbol($stack)]($style) "
+                search_upwards = false
             })
             .collect();
         let expected = None;
@@ -441,7 +442,7 @@ mod tests {
     }
 
     #[test]
-    fn search_upwards_with_opt() -> io::Result<()> {
+    fn search_upwards_default() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         let child_dir = dir.path().join("child");
         std::fs::create_dir(&child_dir)?;
@@ -454,7 +455,6 @@ mod tests {
             .config(toml::toml! {
                 [pulumi]
                 format = "in [$symbol($stack)]($style) "
-                search_upwards = true
             })
             .collect();
         let expected = Some(format!("in {} ", Color::Fixed(5).bold().paint(" ")));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
I noticed the module was slowing down the prompt a bit on a system with networked drives. This PR disables this upwards discovery by default to avoid this and adds an `search_upwards` option to revert to the old behavior. If this is considered a breaking change, I can also change the default value to `true`.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
