### PR TITLE
feat: add global plugin disable

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -1523,6 +1523,10 @@
     "add_newline": {
       "default": true,
       "type": "boolean"
+    },
+    "disable_all": {
+      "default": false,
+      "type": "boolean"
     }
   },
   "definitions": {

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -15,6 +15,10 @@ All configuration for starship is done in this [TOML](https://github.com/toml-la
 # Inserts a blank line between shell prompts
 add_newline = true
 
+# disables all modules by default unless defined in this file overriden by individual disabled states
+# this would cause only the charater symbol below to be enabled
+disable_all = true
+
 # Replace the "❯" symbol in the prompt with "➜"
 [character] # The name of the module we are configuring is "character"
 success_symbol = "[➜](bold green)" # The "success_symbol" segment is being set to "➜" with the color "bold green"

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -12,6 +12,7 @@ pub struct StarshipRootConfig {
     pub scan_timeout: u64,
     pub command_timeout: u64,
     pub add_newline: bool,
+    pub disable_all: bool,
 }
 
 // List of default prompt order
@@ -109,6 +110,7 @@ impl Default for StarshipRootConfig {
             scan_timeout: 30,
             command_timeout: 500,
             add_newline: true,
+            disable_all: false,
         }
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -227,9 +227,15 @@ impl<'a> Context<'a> {
     /// Check if `disabled` option of the module is true in configuration file.
     pub fn is_module_disabled_in_config(&self, name: &str) -> bool {
         let config = self.config.get_module_config(name);
+        let all_disable = self.root_config.disable_all;
 
         // If the segment has "disabled" set to "true", don't show it
-        let disabled = config.and_then(|table| table.as_table()?.get("disabled")?.as_bool());
+        let mut disabled = config.and_then(|table| table.as_table()?.get("disabled")?.as_bool());
+
+        if all_disable && disabled != Some(false) && config.is_none() {
+            disabled = Some(true)
+        }
+        log::trace!("{} disabled:\"{}\"", name, disabled == Some(true));
 
         disabled == Some(true)
     }


### PR DESCRIPTION
#### Description
add an option to disable all the plugins by default and selectively opt-in to enabling them.

#### Motivation and Context
Options are always a good thing in my opinion.

#### How Has This Been Tested?
- [x] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
