### PR TITLE
build: notify-rust now a mandatory dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,10 +30,9 @@ The minimal, blazing-fast, and infinitely customizable prompt for any shell! ☄
 """
 
 [features]
-default = ["battery", "notify"]
+default = ["battery"]
 battery = ["starship-battery"]
 config-schema = ["schemars"]
-notify = ["notify-rust"]
 
 [dependencies]
 ansi_term = "0.12.1"
@@ -47,9 +46,7 @@ git2 = { version = "0.14.4", default-features = false }
 indexmap = { version = "1.9.1", features = ["serde"] }
 local_ipaddress = "0.1.3"
 log = { version = "0.4.16", features = ["std"] }
-# nofity-rust is optional (on by default) because the crate doesn't currently build for darwin with nix
-# see: https://github.com/NixOS/nixpkgs/issues/160876
-notify-rust = { version = "4.5.8", optional = true }
+notify-rust = { version = "4.5.8" }
 once_cell = "1.13.0"
 open = "3.0.1"
 os_info = "3.4.0"

--- a/src/modules/cmd_duration.rs
+++ b/src/modules/cmd_duration.rs
@@ -51,16 +51,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     Some(undistract_me(module, &config, elapsed))
 }
 
-#[cfg(not(feature = "notify"))]
-fn undistract_me<'a, 'b>(
-    module: Module<'a>,
-    _config: &'b CmdDurationConfig,
-    _elapsed: u128,
-) -> Module<'a> {
-    module
-}
-
-#[cfg(feature = "notify")]
 fn undistract_me<'a, 'b>(
     module: Module<'a>,
     config: &'b CmdDurationConfig,


### PR DESCRIPTION
The reason to keep this an optional dep was a portability issue that was fixed in Feb:

https://github.com/NixOS/nixpkgs/issues/160876

#### Motivation and Context

tbh, as the author of zbus crate, I was happy to see that starship depeneds on it indirectly on Linux. This change would mean a mandatory dep on it (even if indirectly).

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

I've only checked if the build works but given that that `notify-rust` was default, I seriously doubt this can break anything.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.

`git grep notify-rust` didn't reveal any docs or tests to update. I did ensure tests build and run successfully though.