### PR TITLE
feat: add support for non-native rprompt

### DIFF
--- a/docs/advanced-config/README.md
+++ b/docs/advanced-config/README.md
@@ -261,7 +261,11 @@ not explicitly used in either `format` or `right_format`.
 Note: The right prompt is a single line following the input location. To right align modules above
 the input line in a multi-line prompt, see the [`fill` module](/config/#fill).
 
-`right_format` is currently supported for the following shells: elvish, fish, zsh, xonsh, cmd, nushell.
+`right_format` is currently supported for the following shells: pwsh, elvish, fish, zsh, xonsh, cmd, nushell.
+For pwsh, it is not implemented natively, and hence can result in two side-effects:
+
+- the right prompt won't be cleared once the input starts overlapping with the right prompt
+- the right prompt won't be reprinted if the input is cleared from the overlap region
 
 ### Example
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -697,6 +697,24 @@ pub enum Shell {
     Unknown,
 }
 
+impl Shell {
+    /// Returns `true` if starship should use the universal rprompt fallback.
+    /// If the shell natively supports rprompt or if the universal fallback is
+    /// not supported by the shell, returns `false`.
+    pub fn use_universal_prompt(&self) -> bool {
+        match self {
+            // Supported via universal fallback
+            Shell::PowerShell => true,
+            // Broken with universal fallback
+            Shell::Bash | Shell::Tcsh | Shell::Ion | Shell::Unknown => false,
+            // Supported natively
+            Shell::Elvish | Shell::Fish | Shell::Zsh | Shell::Xonsh | Shell::Cmd | Shell::Nu => {
+                false
+            }
+        }
+    }
+}
+
 /// Which kind of prompt target to print (main prompt, rprompt, ...)
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Target {

--- a/src/module.rs
+++ b/src/module.rs
@@ -174,6 +174,11 @@ impl<'a> Module<'a> {
             _ => ansi_strings,
         }
     }
+
+    /// Add a segment to the module
+    pub fn push_segment(&mut self, segment: Segment) {
+        self.segments.push(segment);
+    }
 }
 
 impl<'a> fmt::Display for Module<'a> {

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -93,6 +93,7 @@ mod fill_seg_tests {
 pub enum Segment {
     Text(TextSegment),
     Fill(FillSegment),
+    Control(&'static str),
     LineTerm,
 }
 
@@ -126,11 +127,18 @@ impl Segment {
         })
     }
 
+    /// Creates a new control segment
+    /// Control segments are used to output ANSI control sequences.
+    /// The width of a control segment is always 0.
+    pub fn control(value: &'static str) -> Self {
+        Self::Control(value)
+    }
+
     pub fn style(&self) -> Option<Style> {
         match self {
             Self::Fill(fs) => fs.style,
             Self::Text(ts) => ts.style,
-            Self::LineTerm => None,
+            Self::LineTerm | Self::Control(_) => None,
         }
     }
 
@@ -146,7 +154,7 @@ impl Segment {
                     ts.style = style
                 }
             }
-            Self::LineTerm => {}
+            Self::LineTerm | Self::Control(_) => {}
         }
     }
 
@@ -155,6 +163,7 @@ impl Segment {
             Self::Fill(fs) => &fs.value,
             Self::Text(ts) => &ts.value,
             Self::LineTerm => LINE_TERMINATOR_STRING,
+            Self::Control(c) => c,
         }
     }
 
@@ -164,6 +173,7 @@ impl Segment {
             Self::Fill(fs) => fs.ansi_string(None),
             Self::Text(ts) => ts.ansi_string(),
             Self::LineTerm => AnsiString::from(LINE_TERMINATOR_STRING),
+            Self::Control(c) => AnsiString::from(*c),
         }
     }
 
@@ -171,7 +181,7 @@ impl Segment {
         match self {
             Self::Fill(fs) => fs.value.width_graphemes(),
             Self::Text(ts) => ts.value.width_graphemes(),
-            Self::LineTerm => 0,
+            Self::LineTerm | Self::Control(_) => 0,
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
On shells that don't have native rprompt support enabled, use a fallback mechanism in the starship binary that print the rprompt after the main prompt via fill segments and ANSI sequences to save and restore the cursor positioning. The rprompt won't be printed if it would cause the line to overflow.

I've moved that code handles modules and `$all` in `get_prompt` for the active top-level format string into `StringFormatter::map_to_modules` to allow its use by both the main prompt and the rprompt. I also added a new `Segment`-type `Control` which holds a static string that gets ignored in width-calculations.

Compared to native rprompt this approach has some disadvantages:
> The right prompt will be printed in other shells as well, but it can behave differently. For instance, the right prompt won't be cleared once the input starts overlapping with the right prompt, and it might not line up correctly.


#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Mostly supersedes #4160
Closes #3177
Closes #3982
Related #4156

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS** (bash, ion, pwsh and tcsh)
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows** (pwsh and nu)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
