### PR TITLE
docs(directory): add note that fish_style_pwd_dir_length cannot be used with substitutions

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1016,6 +1016,8 @@ the components of the path that would normally be truncated are instead displaye
 `/b/t/c/o/rock/and/roll` with `fish_style_pwd_dir_length = 1`--the path components that would normally be removed are displayed with
 a single character. For `fish_style_pwd_dir_length = 2`, it would be `/bu/th/ci/on/rock/and/roll`.
 
+Do note that `fish_style_pwd_dir_length` will not produce any effect when using `substitutions`.
+
 </details>
 
 ### Variables


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

Add a note to clarify that `fish_style_pwd_dir_length` option of the directory module will not produce any effect when `substitutions` is active.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I was trying to figure out why fish style PWD didn't work in my configuration but could not find any info in the doc.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
