### PR TITLE
feat(install): Update install.sh can use pre-downloaded archive

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -175,7 +175,17 @@ install() {
   fi
   info "$msg"
 
-  archive=$(get_tmpfile "$ext")
+  archive=""
+
+  if [ -e ${STARSHIP_ARCHIVE} ]; then
+    archive=${STARSHIP_ARCHIVE}
+    info "Use local downloaded archive file - ${STARSHIP_ARCHIVE}"
+  else
+    # download to the temp file
+    archive=$(get_tmpfile "$ext")
+    info "Download archive file from ${URL}"
+    download "${archive}" "${URL}"
+  fi
 
   # download to the temp file
   download "${archive}" "${URL}"
@@ -503,7 +513,8 @@ if [ "${PLATFORM}" = "pc-windows-msvc" ]; then
   EXT=zip
 fi
 
-URL="${BASE_URL}/latest/download/starship-${TARGET}.${EXT}"
+STARSHIP_ARCHIVE="starship-${TARGET}.${EXT}"
+URL="${BASE_URL}/latest/download/${STARSHIP_ARCHIVE}"
 info "Tarball URL: ${UNDERLINE}${BLUE}${URL}${NO_COLOR}"
 confirm "Install Starship ${GREEN}latest${NO_COLOR} to ${BOLD}${GREEN}${BIN_DIR}${NO_COLOR}?"
 check_bin_dir "${BIN_DIR}"


### PR DESCRIPTION
Update install.sh can use pre-downloaded archive file to save time.

<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->


#### Description
<!--- Describe your changes in detail -->
Update install.sh can use pre-downloaded archive file to save time.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When using "curl -sS https://starship.rs/install.sh | sh" to install starship, it will download the archive file. In some condition it is slow to down. Then the user can download the archive first and then run the command again.

<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [X] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ N/A] I have updated the documentation accordingly.
- [ N/A] I have updated the tests accordingly.
