### PR TITLE
build: bump chrono from 0.4.19 to 0.4.20

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -4,8 +4,4 @@ ignore = [
   # chrono dependency, but vulnerable function is never called
   # Tacked in #3163
   "RUSTSEC-2020-0071",
-  # chrono: Potential segfault in localtime_r invocations
-  # starship avoids setting any environment variables to avoid this issue
-  # Tracked in #3166
-  "RUSTSEC-2020-0159",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,14 +242,15 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+checksum = "6127248204b9aba09a362f6c930ef6a78f2c1b2215f8a7b398c06e1083f17af0"
 dependencies = [
- "libc",
+ "js-sys",
  "num-integer",
  "num-traits",
  "time 0.1.44",
+ "wasm-bindgen",
  "winapi",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ notify = ["notify-rust"]
 
 [dependencies]
 ansi_term = "0.12.1"
-chrono = "0.4.19"
+chrono = { version = "0.4.20", features = ["clock", "std"] }
 clap = { version = "=3.2.16", features = ["derive", "cargo", "unicode", "unstable-v4"] }
 clap_complete = "3.2.3"
 dirs-next = "2.0.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR bumps chrono to [v0.4.20](https://github.com/chronotope/chrono/releases/tag/v0.4.20), which fixes RUSTSEC-2020-0159. In addition, restrict the default feature set to remove the "oldtime" feature. This would also remove the dependency on time v0.1 (solving #3163), if the (default) feature wasn't getting enabled via systemstat. But their next release is going to replace chrono with time v0.3, so this ensures its update will get rid of that.


#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #3166
Closes #4234

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
