### PR TITLE
fix(aws): support official `AWS_SHARED_CREDENTIALS_FILE` variable

### DIFF
--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -19,7 +19,7 @@ type AwsCredsFile = OnceCell<Option<Ini>>;
 
 fn get_credentials_file_path(context: &Context) -> Option<PathBuf> {
     context
-        .get_env("AWS_CREDENTIALS_FILE")
+        .get_env("AWS_SHARED_CREDENTIALS_FILE")
         .and_then(|path| PathBuf::from_str(&path).ok())
         .or_else(|| {
             let mut home = context.get_home()?;
@@ -830,7 +830,7 @@ aws_secret_access_key=dummy
             .env("AWS_PROFILE", "astronauts")
             .env("AWS_REGION", "ap-northeast-2")
             .env(
-                "AWS_CREDENTIALS_FILE",
+                "AWS_SHARED_CREDENTIALS_FILE",
                 credentials_path.to_string_lossy().as_ref(),
             )
             .collect();

--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -20,6 +20,7 @@ type AwsCredsFile = OnceCell<Option<Ini>>;
 fn get_credentials_file_path(context: &Context) -> Option<PathBuf> {
     context
         .get_env("AWS_SHARED_CREDENTIALS_FILE")
+        .or_else(|| context.get_env("AWS_CREDENTIALS_FILE"))
         .and_then(|path| PathBuf::from_str(&path).ok())
         .or_else(|| {
             let mut home = context.get_home()?;
@@ -428,7 +429,7 @@ mod tests {
 
         assert!(ModuleRenderer::new("aws")
             .env(
-                "AWS_CREDENTIALS_FILE",
+                "AWS_SHARED_CREDENTIALS_FILE",
                 config_path.to_string_lossy().as_ref(),
             )
             .collect()
@@ -670,10 +671,24 @@ expiration={}
             .env("AWS_PROFILE", "astronauts")
             .env("AWS_REGION", "ap-northeast-2")
             .env(
+                "AWS_SHARED_CREDENTIALS_FILE",
+                credentials_path.to_string_lossy().as_ref(),
+            )
+            .collect();
+
+        let actual_variant = ModuleRenderer::new("aws")
+            .env("AWS_PROFILE", "astronauts")
+            .env("AWS_REGION", "ap-northeast-2")
+            .env(
                 "AWS_CREDENTIALS_FILE",
                 credentials_path.to_string_lossy().as_ref(),
             )
             .collect();
+
+        assert_eq!(
+            actual, actual_variant,
+            "both AWS_SHARED_CREDENTIALS_FILE and AWS_CREDENTIALS_FILE should work"
+        );
 
         // In principle, "30m" should be correct. However, bad luck in scheduling
         // on shared runners may delay it. Allow for up to 2 seconds of delay.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
> According to [current AWS Documentation](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html), the CLI actually looks for the `AWS_SHARED_CREDENTIALS_FILE` variable and not `AWS_CREDENTIALS_FILE`.

This is #4192, but with fixed tests and support for `AWS_CREDENTIALS_FILE` to avoid the possibility of breaking something.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #4192
Closes https://github.com/starship/starship/issues/4167
Closes https://github.com/starship/starship/issues/4213

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
