### PR TITLE
feat(container): Allow use of podman container name instead of image name

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -231,7 +231,8 @@
         "disabled": false,
         "format": "[$symbol \\[$name\\]]($style) ",
         "style": "red bold dimmed",
-        "symbol": "⬢"
+        "symbol": "⬢",
+        "use_container_name": false
       },
       "allOf": [
         {
@@ -2093,6 +2094,10 @@
           "type": "string"
         },
         "disabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "use_container_name": {
           "default": false,
           "type": "boolean"
         }

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -834,22 +834,25 @@ The `container` module displays a symbol and container name, if inside a contain
 
 ### Options
 
-| Option     | Default                            | Description                               |
-| ---------- | ---------------------------------- | ----------------------------------------- |
-| `symbol`   | `"⬢"`                              | The symbol shown, when inside a container |
-| `style`    | `"bold red dimmed"`                | The style for the module.                 |
-| `format`   | `"[$symbol \\[$name\\]]($style) "` | The format for the module.                |
-| `disabled` | `false`                            | Disables the `container` module.          |
+| Option                 | Default                            | Description                                          |
+| ---------------------- | ---------------------------------- | ---------------------------------------------------- |
+| `symbol`               | `"⬢"`                              | The symbol shown, when inside a container            |
+| `style`                | `"bold red dimmed"`                | The style for the module.                            |
+| `format`               | `"[$symbol \\[$name\\]]($style) "` | The format for the module.                           |
+| `disabled`             | `false`                            | Disables the `container` module.                     |
+| `use_container_name`\* | `false`                            | Display the container name instead of the image name |
 
 ### Variables
 
-| Variable | Example             | Description                          |
-| -------- | ------------------- | ------------------------------------ |
-| name     | `fedora-toolbox:35` | The name of the container            |
-| symbol   |                     | Mirrors the value of option `symbol` |
-| style\*  |                     | Mirrors the value of option `style`  |
+| Variable  | Example                                 | Description                                                                                                  |
+| --------- | --------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| name      | `fedora-toolbox:35`, `my-dev-container` | The name of the container image. If `use_container_name` is set, then the name of the container will be used |
+| symbol    |                                         | Mirrors the value of option `symbol`                                                                         |
+| style\*\* |                                         | Mirrors the value of option `style`                                                                          |
 
-*: This variable can only be used as a part of a style string
+*: Only supported with Podman
+
+**: This variable can only be used as a part of a style string
 
 ### Example
 

--- a/src/configs/container.rs
+++ b/src/configs/container.rs
@@ -8,6 +8,7 @@ pub struct ContainerConfig<'a> {
     pub symbol: &'a str,
     pub style: &'a str,
     pub disabled: bool,
+    pub use_container_name: bool,
 }
 
 impl<'a> Default for ContainerConfig<'a> {
@@ -17,6 +18,7 @@ impl<'a> Default for ContainerConfig<'a> {
             symbol: "⬢",
             style: "red bold dimmed",
             disabled: false,
+            use_container_name: false,
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR adds configuration in the container module to allow displaying the container name instead of the container image. This is useful for when many containers share the same image (ie. toolbox containers). To enable, add the following to starship.toml
```
[container]
use_container_name = true
```

Closes #3592

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [X] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have updated the documentation accordingly.
- [X] I have updated the tests accordingly.
