### PR TITLE
build: use cargo for stripping release binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,7 +127,6 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: |
           cd target/${{ matrix.target }}/release
-          strip starship.exe
           7z a ../../../${{ matrix.name }} starship.exe
           cd -
 
@@ -135,8 +134,6 @@ jobs:
         if: matrix.os != 'windows-latest'
         run: |
           cd target/${{ matrix.target }}/release
-          # TODO: investigate better cross platform stripping
-          strip starship || true
           tar czvf ../../../${{ matrix.name }} starship
           cd -
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,6 +121,7 @@ tempfile = "3.2.0"
 [profile.release]
 codegen-units = 1
 lto = true
+strip = true
 
 [[bin]]
 name = "starship"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Use `strip = true` in `Cargo.toml` to strip the release binaries instead of manually calling `strip` manually in CI.
In the past, this printed some warnings on macOS, but I've fixed the issue in rust 1.63 (which already seems to be public in rustup).

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
