### PR TITLE
fix: Disable multithreading in `jwalk` (via `gitoxide`) as workaround for #4251

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1032,9 +1032,9 @@ dependencies = [
 
 [[package]]
 name = "git-features"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57bfebf2c0a0d28414aa7c3baa058d5c1c2969e553806904343a2c11483f425a"
+checksum = "48289da362ef7ee1412a9a80bb459406d3045ad604484526210d594d10aa5268"
 dependencies = [
  "crc32fast",
  "crossbeam-channel",
@@ -1064,9 +1064,9 @@ dependencies = [
 
 [[package]]
 name = "git-hash"
-version = "0.9.6"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f82a0c09fdddeb738ed8338d214652c6d60ebf814a30d9ae1ecae7c91e0bbe81"
+checksum = "898628aaedf437563872461736f861acc1503e23ee4a59857513b0261c014460"
 dependencies = [
  "hex",
  "quick-error",
@@ -2677,6 +2677,7 @@ dependencies = [
  "dirs-next",
  "dunce",
  "gethostname",
+ "git-features",
  "git-repository",
  "guess_host_triple",
  "home",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,8 @@ clap_complete = "3.2.4"
 dirs-next = "2.0.0"
 dunce = "1.0.2"
 gethostname = "0.2.3"
+# Addresses https://github.com/starship/starship/issues/4251
+git-features = { version = "0.22.1", features = ["fs-walkdir-single-threaded"] }
 git-repository = "0.20.0"
 indexmap = { version = "1.9.1", features = ["serde"] }
 local_ipaddress = "0.1.3"


### PR DESCRIPTION
#### Description

Even though that theoretically makes some filesystem iterations slower,
I don't think it matters much for typical repositories, so this fix
could be permanent.

One can explore to have this issue fixed upstream in `jwalk` as well
and I will bring it up there provided I can make a minimal reproducible
example.

With this fix, `STARSHIP_NUM_THREAD=1 starship prompt` won't hang anymore, 
which resolves #4251.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
