### PR TITLE
feat(status): Support formatting of pipestatus separator

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -3407,7 +3407,7 @@ To enable it, set `disabled` to `false` in your configuration file.
 | `recognize_signal_code`     | `true`                                                                        | Enable signal mapping from exit code                                  |
 | `map_symbol`                | `false`                                                                       | Enable symbols mapping from exit code                                 |
 | `pipestatus`                | `false`                                                                       | Enable pipestatus reporting                                           |
-| `pipestatus_separator`      | <code>&vert;</code>                                                           | The symbol used to separate pipestatus segments                       |
+| `pipestatus_separator`      | <code>&vert;</code>                                                           | The symbol used to separate pipestatus segments (supports formatting) |
 | `pipestatus_format`         | `'\[$pipestatus\] => [$symbol$common_meaning$signal_name$maybe_int]($style)'` | The format of the module when the command is a pipeline               |
 | `pipestatus_segment_format` |                                                                               | When specified, replaces `format` when formatting pipestatus segments |
 | `disabled`                  | `true`                                                                        | Disables the `status` module.                                         |

--- a/src/modules/status.rs
+++ b/src/modules/status.rs
@@ -722,17 +722,19 @@ mod tests {
 
     #[test]
     fn pipestatus_separator_format() {
-        let pipe_exit_code = &[0, 1];
-        let main_exit_code = 1;
+        let pipe_exit_code = &[0, 1, 2];
+        let main_exit_code = 2;
 
         let expected_style = Style::new().on(Color::Red).fg(Color::White).bold();
         let expected = Some(format!(
-            "{}{}{}{}{}",
+            "{}{}{}{}{}{}{}",
             expected_style.paint("["),
             expected_style.paint("0"),
             expected_style.paint("|"),
             expected_style.paint("1"),
-            expected_style.paint("] => <1>"),
+            expected_style.paint("|"),
+            expected_style.paint("2"),
+            expected_style.paint("] => <2>"),
         ));
         let actual = ModuleRenderer::new("status")
             .config(toml::toml! {

--- a/src/modules/status.rs
+++ b/src/modules/status.rs
@@ -61,8 +61,8 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         PipeStatusStatus::Pipe(pipestatus) => pipestatus
             .iter()
             .enumerate()
-            .map(|(i, ec)| {
-                match format_exit_code(
+            .filter_map(|(i, ec)| {
+                format_exit_code(
                     ec.as_str(),
                     if i == pipestatus.len() - 1 {
                         segment_format
@@ -72,16 +72,12 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                     None,
                     &config,
                     context,
-                ) {
-                    Ok(segments) => segments
-                        .into_iter()
-                        .map(|s| s.to_string())
-                        .collect::<String>(),
-                    Err(_) => "".to_string(),
-                }
+                )
+                .ok()
+                .map(|segments| segments.into_iter().map(|s| s.to_string()))
             })
-            .collect::<Vec<String>>()
-            .join(""),
+            .flatten()
+            .collect::<String>(),
         _ => "".to_string(),
     };
 

--- a/src/modules/status.rs
+++ b/src/modules/status.rs
@@ -57,6 +57,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let segment_format = config.pipestatus_segment_format.unwrap_or(config.format);
     let segment_format_with_separator = [segment_format, config.pipestatus_separator].join("");
 
+    // Create pipestatus string
     let pipestatus = match pipestatus_status {
         PipeStatusStatus::Pipe(pipestatus) => pipestatus
             .iter()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR adds formatting of the `pipestatus_separator` string in the "status" module before `pipestatus_separator` is used to join the pipestatus segments.

The `$style` variable can also be used in the format string, though I did not include the other variables as they seem irrelevant for formatting the pipestatus separator.

#### Motivation and Context
I could not find a way to format the pipestatus separator, so it sticks out from the rest of the status segments when they have a background color.

#### Screenshots:
before:
<img width="522" alt="Screen Shot 2022-08-15 at 18 48 56" src="https://user-images.githubusercontent.com/7785912/184733818-9f70517d-6a99-42b8-99ed-23b41eb8fb13.png">

with status config:
```toml
[status]
style = "bg:57 fg:255 bold"
format = '[ $symbol $common_meaning$signal_name$maybe_int ]($style)'
disabled = false
pipestatus = true
pipestatus_format = '[ \[]($style)$pipestatus[\] => $symbol $common_meaning$signal_name$maybe_int ]($style)'
```
and after:
<img width="532" alt="Screen Shot 2022-08-15 at 18 47 48" src="https://user-images.githubusercontent.com/7785912/184733840-a3f906ae-79dc-4ecd-a8c8-00fbe7f085db.png">

with the added status config line:
```toml
pipestatus_separator = '[|]($style)'
```

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.