### PR TITLE
docs(preset): Add more icons to nerd font preset

### DIFF
--- a/docs/.vuepress/public/presets/toml/nerd-font-symbols.toml
+++ b/docs/.vuepress/public/presets/toml/nerd-font-symbols.toml
@@ -43,6 +43,9 @@ symbol = " "
 [julia]
 symbol = " "
 
+[lua]
+symbol = " "
+
 [memory_usage]
 symbol = " "
 

--- a/docs/.vuepress/public/presets/toml/nerd-font-symbols.toml
+++ b/docs/.vuepress/public/presets/toml/nerd-font-symbols.toml
@@ -61,6 +61,9 @@ symbol = " "
 [python]
 symbol = " "
 
+[rlang]
+symbol = "ﳒ "
+
 [spack]
 symbol = "🅢 "
 

--- a/docs/.vuepress/public/presets/toml/nerd-font-symbols.toml
+++ b/docs/.vuepress/public/presets/toml/nerd-font-symbols.toml
@@ -67,8 +67,11 @@ symbol = " "
 [rlang]
 symbol = "ﳒ "
 
-[spack]
-symbol = "🅢 "
+[ruby]
+symbol = " "
 
 [rust]
 symbol = " "
+
+[spack]
+symbol = "🅢 "


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Adding icons for the nerd font preset for `lua`, `rlang`, and `ruby` modules. Also moved the `spack` module to the end to keep it alphabetized.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
