### PR TITLE
perf(git_commit): only use exact match for tag by default

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -525,6 +525,7 @@
         "only_detached": true,
         "style": "green bold",
         "tag_disabled": true,
+        "tag_max_candidates": 0,
         "tag_symbol": " 🏷  "
       },
       "allOf": [
@@ -2799,6 +2800,12 @@
         "tag_disabled": {
           "default": true,
           "type": "boolean"
+        },
+        "tag_max_candidates": {
+          "default": 0,
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
         }
       }
     },

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1558,15 +1558,16 @@ The `git_commit` module shows the current commit hash and also the tag (if any) 
 
 ### Options
 
-| Option               | Default                        | Description                                             |
-| -------------------- | ------------------------------ | ------------------------------------------------------- |
-| `commit_hash_length` | `7`                            | The length of the displayed git commit hash.            |
-| `format`             | `"[\\($hash$tag\\)]($style) "` | The format for the module.                              |
-| `style`              | `"bold green"`                 | The style for the module.                               |
-| `only_detached`      | `true`                         | Only show git commit hash when in detached `HEAD` state |
-| `tag_disabled`       | `true`                         | Disables showing tag info in `git_commit` module.       |
-| `tag_symbol`         | `" 🏷 "`                        | Tag symbol prefixing the info shown                     |
-| `disabled`           | `false`                        | Disables the `git_commit` module.                       |
+| Option               | Default                        | Description                                                                          |
+| -------------------- | ------------------------------ | ------------------------------------------------------------------------------------ |
+| `commit_hash_length` | `7`                            | The length of the displayed git commit hash.                                         |
+| `format`             | `"[\\($hash$tag\\)]($style) "` | The format for the module.                                                           |
+| `style`              | `"bold green"`                 | The style for the module.                                                            |
+| `only_detached`      | `true`                         | Only show git commit hash when in detached `HEAD` state                              |
+| `tag_disabled`       | `true`                         | Disables showing tag info in `git_commit` module.                                    |
+| `tag_max_candidates` | `0`                            | How many commits to consider for tag display. The default only allows exact matches. |
+| `tag_symbol`         | `" 🏷 "`                        | Tag symbol prefixing the info shown                                                  |
+| `disabled`           | `false`                        | Disables the `git_commit` module.                                                    |
 
 ### Variables
 

--- a/src/configs/git_commit.rs
+++ b/src/configs/git_commit.rs
@@ -11,6 +11,7 @@ pub struct GitCommitConfig<'a> {
     pub disabled: bool,
     pub tag_symbol: &'a str,
     pub tag_disabled: bool,
+    pub tag_max_candidates: usize,
 }
 
 impl<'a> Default for GitCommitConfig<'a> {
@@ -24,6 +25,7 @@ impl<'a> Default for GitCommitConfig<'a> {
             disabled: false,
             tag_symbol: " 🏷  ",
             tag_disabled: true,
+            tag_max_candidates: 0,
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
I noticed another major difference with the old git tag implementation is that only exact matches were considered, whereas this new one was looking at up to 10 commits. This restores performance to previous levels.

I also added an option `tag_max_candidates` to restore the previous behavior.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #4275

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
