### PR TITLE
feat(git_status): track staged/unstaged deletes

### DIFF
--- a/src/modules/git_status.rs
+++ b/src/modules/git_status.rs
@@ -264,13 +264,13 @@ struct RepoStatus {
 
 impl RepoStatus {
     fn is_deleted(short_status: &str) -> bool {
-        // is_wt_deleted || is_index_deleted
-        short_status.contains('D')
+        // is_index_deleted
+        short_status.starts_with('D')
     }
 
     fn is_modified(short_status: &str) -> bool {
-        // is_wt_modified || is_wt_added
-        short_status.ends_with('M') || short_status.ends_with('A')
+        // is_wt_modified || is_wt_added || is_wt_deleted
+        short_status.ends_with('M') || short_status.ends_with('A') || short_status.ends_with('D')
     }
 
     fn is_staged(short_status: &str) -> bool {
@@ -975,7 +975,7 @@ mod tests {
         let actual = ModuleRenderer::new("git_status")
             .path(&repo_dir.path())
             .collect();
-        let expected = format_output("✘?");
+        let expected = format_output("!?");
 
         assert_eq!(expected, actual);
         worktree_dir.close()?;
@@ -1176,6 +1176,11 @@ mod tests {
 
     fn create_deleted(repo_dir: &Path) -> io::Result<()> {
         fs::remove_file(repo_dir.join("readme.md"))?;
+
+        create_command("git")?
+            .args(&["add", "-A"])
+            .current_dir(repo_dir)
+            .output()?;
 
         Ok(())
     }


### PR DESCRIPTION
#### Description
This changes counts unstaged file deletions as modifications, and staged deletions as deletions, following the same flow as renamed files, and what the official docs hint at. Without this, there is no way to know if a deleted file has been staged or not from the prompt.

#### Motivation and Context
Closes #3048 

#### How Has This Been Tested?
Ran the entire `cargo test` suite to ensure everything else still behaves as expected.
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.

I'm not sure the docs need updating, since they explicitly say that `deleted` is only applied
> when a file's deletion has been added to the staging area.
Same wording as `renamed` and `staged`, which is why I went the way I did.