### PR TITLE
docs: Added a new FAQ session addressing the delay for starship on powershell with windows defender real-time protection active

### DIFF
--- a/docs/faq/README.md
+++ b/docs/faq/README.md
@@ -144,3 +144,18 @@ If Starship was installed using the install script, the following command will d
 # Locate and delete the starship binary
 sh -c 'rm "$(command -v 'starship')"'
 ```
+
+## Why am I getting slow response times on PowerShell with Windows Defender real-time protection active?
+When Windows Defender is active, there is a high tendency for the starship prompt on Powershell to have a noticable delay. This is a known issue within other
+custom prompts such as [oh-my-posh](https://github.com/JanDeDobbeleer/oh-my-posh/issues/1904). 
+
+In order to fix this you must add an exclusion for the starship binary within Windows Defender. Within powershell you can find the location of your starship binary
+with the `Get-Command` cmdlet. Assuming that starship has already been installed and is visible on your PATH
+
+```powershell
+# Display the full path of the starship binary
+Get-Command starship
+```
+
+Copy the path displayed under `Source` in the table displayed from the Get-Command cmdlet and [add an exclusion](https://support.microsoft.com/en-us/windows/add-an-exclusion-to-windows-security-811816c0-4dfd-af4a-47e4-c301afe13b26#:~:text=Go%20to%20Start%20%3E%20Settings%20%3E%20Update,%2C%20file%20types%2C%20or%20process.) for this path to Windows Defender
+Upon reloading your shell, the delay should be noticably lessened

--- a/docs/faq/README.md
+++ b/docs/faq/README.md
@@ -146,6 +146,7 @@ sh -c 'rm "$(command -v 'starship')"'
 ```
 
 ## Why am I getting slow response times on PowerShell with Windows Defender real-time protection active?
+
 When Windows Defender is active, there is a high tendency for the starship prompt on Powershell to have a noticable delay. This is a known issue within other
 custom prompts such as [oh-my-posh](https://github.com/JanDeDobbeleer/oh-my-posh/issues/1904). 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Added a new FAQ session addressing the delay for starship on powershell with windows defender real-time protection active. Adding the exclusion provides a significant increase in speed when using the starship prompt.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The starship prompt experiences noticeable delay on windows powershell with windows defender real-time protection active. This can be demonstrated by holding down the enter key within the powershell starship prompt upon which the delay becomes quite obvious for the prompt (there is a time delay between the prompt receiving the newline and proceeding to the next prompt). For some reason, this issue is not mentioned anywhere within the FAQ documentation despite it being somewhat important or significant. Without the exclusion starship was nearly unusable for me, it had a roughly 2 second delay between each prompt and this was outside of git repos (which starship is already noted to struggle in). Since this wasnt mentioned anywhere I had to dig around for a while before stumbling by chance onto [this issue](https://github.com/JanDeDobbeleer/oh-my-posh/issues/1904) from oh-my-posh detailing the exact same phenomena. Therefore because this issue seems like it would be relatively common it should be added in the FAQ
Closes # 

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
No code was affected but this is easily demonstrated within a windows environment on windows terminal/powershell. You can just hold down the enter key within the prompt, there is a noticable delay without the exclusion active. Specifically I tested this within the latest version of Windows 10 on the latest version of Windows terminal using powershell.
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
