### PR TITLE
feat(azure): add username to azure module config

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -439,7 +439,7 @@ Enterprise_Naming_Scheme-voidstars = 'void**'
 
 ## Azure
 
-The `azure` module shows the current Azure Subscription. This is based on showing the name of the default subscription, as defined in the `~/.azure/azureProfile.json` file.
+The `azure` module shows the current Azure Subscription. This is based on showing the name of the default subscription or the username, as defined in the `~/.azure/azureProfile.json` file.
 
 ### Options
 
@@ -450,7 +450,9 @@ The `azure` module shows the current Azure Subscription. This is based on showin
 | `style`    | `'blue bold'`                            | The style used in the format.              |
 | `disabled` | `true`                                   | Disables the `azure` module.               |
 
-### Example
+### Examples
+
+#### Display Subscription Name
 
 ```toml
 # ~/.config/starship.toml
@@ -460,6 +462,18 @@ disabled = false
 format = 'on [$symbol($subscription)]($style) '
 symbol = 'ﴃ '
 style = 'blue bold'
+```
+
+#### Display Username
+
+```toml
+# ~/.config/starship.toml
+
+[azure]
+disabled = false
+format = "on [$symbol($username)]($style) "
+symbol = "ﴃ "
+style = "blue bold"
 ```
 
 ## Battery

--- a/src/modules/azure.rs
+++ b/src/modules/azure.rs
@@ -1,16 +1,47 @@
-use std::fs::File;
-use std::io::{BufReader, Read};
-use std::path::{Path, PathBuf};
+use std::fs;
+use std::path::{PathBuf};
+use serde::{Serialize, Deserialize};
 
 use super::{Context, Module, ModuleConfig};
-
-type JValue = serde_json::Value;
 
 use crate::configs::azure::AzureConfig;
 use crate::formatter::StringFormatter;
 
-type SubscriptionName = String;
-type UserName = String;
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all="camelCase")]
+struct AzureProfile {
+    installation_id: String,
+    #[serde(default, skip_serializing_if="Vec::is_empty")]
+    subscriptions: Vec<Subscription>
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+struct User {
+    name: String,
+    #[serde(alias="type")]
+    user_type: String,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all="camelCase")]
+struct ManagedByTenant {
+    tenant_id: String,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all="camelCase")]
+struct Subscription {
+    id: String,
+    name: String,
+    state: String,
+    user: User,
+    is_default: bool,
+    tenant_id: String,
+    environment_name: String,
+    home_tenant_id: String,
+    #[serde(default, skip_serializing_if="Vec::is_empty")]
+    managed_by_tenants: Vec<ManagedByTenant>
+}
 
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let mut module = context.new_module("azure");
@@ -19,18 +50,15 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     if config.disabled {
         return None;
     };
+    
+    let subscription: Option<Subscription> = get_azure_profile_info(context);
 
-    let subscription_name: Option<SubscriptionName> = get_azure_subscription_name(context);
-    if subscription_name.is_none() {
-        log::info!("Could not find Azure subscription name");
+    if subscription.is_none() {
+        log::info!("Could not find Subscriptions in azureProfile.json");
         return None;
-    };
+    } 
 
-    let user_name: Option<UserName> = get_azure_user_name(context);
-    if user_name.is_none() {
-        log::info!("Could not find Azure user name");
-        return None;
-    };
+    let subscription = subscription.unwrap();
 
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter
@@ -43,11 +71,8 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 _ => None,
             })
             .map(|variable| match variable {
-                "subscription" => Some(Ok(subscription_name.as_ref().unwrap())),
-                _ => None,
-            })
-            .map(|variable| match variable {
-                "username" => Some(Ok(user_name.as_ref().unwrap())),
+                "subscription" => Some(Ok(&subscription.name)),
+                "username" => Some(Ok(&subscription.user.name)),
                 _ => None,
             })
             .parse(None, Some(context))
@@ -64,48 +89,31 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     Some(module)
 }
 
-fn get_azure_subscription_name(context: &Context) -> Option<SubscriptionName> {
+fn get_azure_profile_info(context: &Context) -> Option<Subscription> {
     let mut config_path = get_config_file_location(context)?;
     config_path.push("azureProfile.json");
 
-    let parsed_json = parse_json(&config_path)?;
-
-    let subscriptions = parsed_json.get("subscriptions")?.as_array()?;
-    let subscription_name = subscriptions.iter().find_map(|s| {
-        if s.get("isDefault")? == true {
-            Some(s.get("name")?.as_str()?.to_string())
-        } else {
-            None
-        }
-    });
-    if subscription_name.is_some() {
-        subscription_name
+    if config_path.exists() {
+        let azure_profile: AzureProfile = load_azure_profile(&config_path);
+        let subscription = azure_profile.subscriptions.iter().find_map(|s| {
+            if s.is_default {
+                Some(s.clone())
+            } else {
+                None
+            }
+        });
+        subscription
     } else {
-        log::info!("Could not find subscription name");
         None
     }
 }
 
-fn get_azure_user_name(context: &Context) -> Option<UserName> {
-    let mut config_path = get_config_file_location(context)?;
-    config_path.push("azureProfile.json");
-
-    let parsed_json = parse_json(&config_path)?;
-
-    let subscriptions = parsed_json.get("subscriptions")?.as_array()?;
-    let user_name = subscriptions.iter().find_map(|s| {
-        if s.get("isDefault")? == true {
-            Some(s.get("user")?.get("name")?.as_str()?.to_string())
-        } else {
-            None
-        }
-    });
-    if user_name.is_some() {
-        user_name
-    } else {
-        log::info!("Could not find user name");
-        None
-    }
+fn load_azure_profile(config_path: &PathBuf) -> AzureProfile {
+    let json_data = fs::read_to_string(&config_path).expect("Unable to open azureProfile.json");
+    let sanitized_json_data = json_data.strip_prefix('\u{feff}').unwrap_or(&json_data);
+    let azure_profile: AzureProfile = serde_json::from_str(sanitized_json_data).expect("Unable to parse json data.");
+    
+    azure_profile 
 }
 
 fn get_config_file_location(context: &Context) -> Option<PathBuf> {
@@ -119,6 +127,7 @@ fn get_config_file_location(context: &Context) -> Option<PathBuf> {
         })
 }
 
+<<<<<<< HEAD
 fn parse_json(json_file_path: &Path) -> Option<JValue> {
     let mut buffer: Vec<u8> = Vec::new();
 
@@ -137,9 +146,11 @@ fn parse_json(json_file_path: &Path) -> Option<JValue> {
     }
 }
 
+=======
+>>>>>>> 7446ed0d (add username to azure module config)
 #[cfg(test)]
 mod tests {
-    use crate::modules::azure::parse_json;
+    use crate::modules::azure::load_azure_profile;
     use crate::test::ModuleRenderer;
     use ini::Ini;
     use nu_ansi_term::Color;
@@ -187,6 +198,7 @@ mod tests {
                   "name": "user@domain.com",
                   "type": "user"
                 },
+                "isDefault": false,
                 "tenantId": "a4e1bb4b-5330-2d50-339d-b9674d3a87bc",
                 "environmentName": "AzureCloud",
                 "homeTenantId": "a4e1bb4b-5330-2d50-339d-b9674d3a87bc",
@@ -256,6 +268,7 @@ mod tests {
                   "name": "user@domain.com",
                   "type": "user"
                 },
+                "isDefault": false,
                 "tenantId": "a4e1bb4b-5330-2d50-339d-b9674d3a87bc",
                 "environmentName": "AzureCloud",
                 "homeTenantId": "a4e1bb4b-5330-2d50-339d-b9674d3a87bc",
@@ -296,6 +309,219 @@ mod tests {
         assert_eq!(actual, expected);
         dir.close()
     }
+    
+    #[test]
+    fn subscription_name_found_username_missing() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+
+        let azure_profile_contents = r#"{
+            "installationId": "3deacd2a-b9db-77e1-aa42-23e2f8dfffc3",
+            "subscriptions": [
+                {
+                "id": "f568c543-d12e-de0b-3d85-69843598b565",
+                "name": "Subscription 2",
+                "state": "Enabled",
+                "user": {
+                  "name": "user@domain.com",
+                  "type": "user"
+                },
+                "isDefault": false,
+                "tenantId": "0e8a15ec-b0f5-d355-7062-8ece54c59aee",
+                "environmentName": "AzureCloud",
+                "homeTenantId": "0e8a15ec-b0f5-d355-7062-8ece54c59aee",
+                "managedByTenants": []
+              },
+              {
+                "id": "d4442d26-ea6d-46c4-07cb-4f70b8ae5465",
+                "name": "Subscription 3",
+                "state": "Enabled",
+                "user": {
+                  "name": "user@domain.com",
+                  "type": "user"
+                },
+                "isDefault": false,
+                "tenantId": "a4e1bb4b-5330-2d50-339d-b9674d3a87bc",
+                "environmentName": "AzureCloud",
+                "homeTenantId": "a4e1bb4b-5330-2d50-339d-b9674d3a87bc",
+                "managedByTenants": []
+              },
+              {
+                "id": "f3935dc9-92b5-9a93-da7b-42c325d86939",
+                "name": "Subscription 1",
+                "state": "Enabled",
+                "user": {
+                  "name": "",
+                  "type": "user"
+                },
+                "isDefault": true,
+                "tenantId": "f0273a19-7779-e40a-00a1-53b8331b3bb6",
+                "environmentName": "AzureCloud",
+                "homeTenantId": "f0273a19-7779-e40a-00a1-53b8331b3bb6",
+                "managedByTenants": []
+              }
+            ]
+          }
+        "#;
+
+        generate_test_config(&dir, azure_profile_contents)?;
+        let dir_path = &dir.path().to_string_lossy();
+        let actual = ModuleRenderer::new("azure")
+            .config(toml::toml! {
+            [azure]
+            format = "on [$symbol($subscription:$username)]($style)"
+            disabled = false
+            })
+            .env("AZURE_CONFIG_DIR", dir_path.as_ref())
+            .collect();
+        let expected = Some(format!(
+            "on {}",
+            Color::Blue.bold().paint("ﴃ Subscription 1:")
+        ));
+        assert_eq!(actual, expected);
+        dir.close()
+    }
+
+    #[test]
+    fn subscription_name_missing_username_found() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+
+        let azure_profile_contents = r#"{
+            "installationId": "3deacd2a-b9db-77e1-aa42-23e2f8dfffc3",
+            "subscriptions": [
+                {
+                "id": "f568c543-d12e-de0b-3d85-69843598b565",
+                "name": "Subscription 2",
+                "state": "Enabled",
+                "user": {
+                  "name": "user@domain.com",
+                  "type": "user"
+                },
+                "isDefault": false,
+                "tenantId": "0e8a15ec-b0f5-d355-7062-8ece54c59aee",
+                "environmentName": "AzureCloud",
+                "homeTenantId": "0e8a15ec-b0f5-d355-7062-8ece54c59aee",
+                "managedByTenants": []
+              },
+              {
+                "id": "d4442d26-ea6d-46c4-07cb-4f70b8ae5465",
+                "name": "Subscription 3",
+                "state": "Enabled",
+                "user": {
+                  "name": "user@domain.com",
+                  "type": "user"
+                },
+                "isDefault": false,
+                "tenantId": "a4e1bb4b-5330-2d50-339d-b9674d3a87bc",
+                "environmentName": "AzureCloud",
+                "homeTenantId": "a4e1bb4b-5330-2d50-339d-b9674d3a87bc",
+                "managedByTenants": []
+              },
+              {
+                "id": "f3935dc9-92b5-9a93-da7b-42c325d86939",
+                "name": "",
+                "state": "Enabled",
+                "user": {
+                  "name": "user@domain.com",
+                  "type": "user"
+                },
+                "isDefault": true,
+                "tenantId": "f0273a19-7779-e40a-00a1-53b8331b3bb6",
+                "environmentName": "AzureCloud",
+                "homeTenantId": "f0273a19-7779-e40a-00a1-53b8331b3bb6",
+                "managedByTenants": []
+              }
+            ]
+          }
+        "#;
+
+        generate_test_config(&dir, azure_profile_contents)?;
+        let dir_path = &dir.path().to_string_lossy();
+        let actual = ModuleRenderer::new("azure")
+            .config(toml::toml! {
+            [azure]
+            format = "on [$symbol($subscription:$username)]($style)"
+            disabled = false
+            })
+            .env("AZURE_CONFIG_DIR", dir_path.as_ref())
+            .collect();
+        let expected = Some(format!(
+            "on {}",
+            Color::Blue.bold().paint("ﴃ :user@domain.com")
+        ));
+        assert_eq!(actual, expected);
+        dir.close()
+    }
+
+    #[test]
+    fn subscription_name_and_username_found() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+
+        let azure_profile_contents = r#"{
+            "installationId": "3deacd2a-b9db-77e1-aa42-23e2f8dfffc3",
+            "subscriptions": [
+                {
+                "id": "f568c543-d12e-de0b-3d85-69843598b565",
+                "name": "Subscription 2",
+                "state": "Enabled",
+                "user": {
+                  "name": "user@domain.com",
+                  "type": "user"
+                },
+                "isDefault": false,
+                "tenantId": "0e8a15ec-b0f5-d355-7062-8ece54c59aee",
+                "environmentName": "AzureCloud",
+                "homeTenantId": "0e8a15ec-b0f5-d355-7062-8ece54c59aee",
+                "managedByTenants": []
+              },
+              {
+                "id": "d4442d26-ea6d-46c4-07cb-4f70b8ae5465",
+                "name": "Subscription 3",
+                "state": "Enabled",
+                "user": {
+                  "name": "user@domain.com",
+                  "type": "user"
+                },
+                "isDefault": false, 
+                "tenantId": "a4e1bb4b-5330-2d50-339d-b9674d3a87bc",
+                "environmentName": "AzureCloud",
+                "homeTenantId": "a4e1bb4b-5330-2d50-339d-b9674d3a87bc",
+                "managedByTenants": []
+              },
+              {
+                "id": "f3935dc9-92b5-9a93-da7b-42c325d86939",
+                "name": "Subscription 1",
+                "state": "Enabled",
+                "user": {
+                  "name": "user@domain.com",
+                  "type": "user"
+                },
+                "isDefault": true,
+                "tenantId": "f0273a19-7779-e40a-00a1-53b8331b3bb6",
+                "environmentName": "AzureCloud",
+                "homeTenantId": "f0273a19-7779-e40a-00a1-53b8331b3bb6",
+                "managedByTenants": []
+              }
+            ]
+          }
+        "#;
+
+        generate_test_config(&dir, azure_profile_contents)?;
+        let dir_path = &dir.path().to_string_lossy();
+        let actual = ModuleRenderer::new("azure")
+            .config(toml::toml! {
+            [azure]
+            format = "on [$symbol($subscription:$username)]($style)"
+            disabled = false
+            })
+            .env("AZURE_CONFIG_DIR", dir_path.as_ref())
+            .collect();
+        let expected = Some(format!(
+            "on {}",
+            Color::Blue.bold().paint("ﴃ Subscription 1:user@domain.com")
+        ));
+        assert_eq!(actual, expected);
+        dir.close()
+    }
 
     #[test]
     fn subscription_azure_profile_empty() -> io::Result<()> {
@@ -306,6 +532,7 @@ mod tests {
             .with_section(Some("AzureCloud"))
             .set("subscription", "f3935dc9-92b5-9a93-da7b-42c325d86939");
 
+        //let azure_profile_contents = "\u{feff}{\"installationId\": \"2652263e-40f8-11ed-ae3b-367ddada549c\", \"subscriptions\": []}";
         let azure_profile_contents = r#"{
             "installationId": "3deacd2a-b9db-77e1-aa42-23e2f8dfffc3",
             "subscriptions": []
@@ -327,6 +554,39 @@ mod tests {
     }
 
     #[test]
+    fn azure_profile_with_leading_char() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+
+        let bom = vec![239, 187, 191];
+        let mut bom_str = String::from_utf8(bom).unwrap();
+        
+        let json_str = r#"{"installationId": "3deacd2a-b9db-77e1-aa42-23e2f8dfffc3", "subscriptions": []}"#;
+
+        bom_str.push_str(json_str);
+
+        let dir_path_no_bom = save_string_to_file(&dir, bom_str, String::from("bom.json"))?;
+        let sanitized_json = load_azure_profile(&dir_path_no_bom);
+
+        assert_eq!(sanitized_json.installation_id, "3deacd2a-b9db-77e1-aa42-23e2f8dfffc3");
+        assert!(sanitized_json.subscriptions.is_empty());
+        dir.close()
+    }
+
+    #[test]
+    fn azure_profile_without_leading_char() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+
+        let json_str = r#"{"installationId": "3deacd2a-b9db-77e1-aa42-23e2f8dfffc3", "subscriptions": []}"#;
+
+        let dir_path_no_bom = save_string_to_file(&dir, json_str.to_string(), String::from("bom.json"))?;
+        let sanitized_json = load_azure_profile(&dir_path_no_bom);
+
+        assert_eq!(sanitized_json.installation_id, "3deacd2a-b9db-77e1-aa42-23e2f8dfffc3");
+        assert!(sanitized_json.subscriptions.is_empty());
+        dir.close()
+    }
+
+    #[test]
     fn files_missing() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
 
@@ -337,22 +597,6 @@ mod tests {
             .collect();
         let expected = None;
         assert_eq!(actual, expected);
-        dir.close()
-    }
-
-    #[test]
-    fn json_parsing() -> io::Result<()> {
-        let dir = tempfile::tempdir()?;
-
-        let bom = vec![239, 187, 191];
-        let mut bom_str = String::from_utf8(bom).unwrap();
-        let json_str = r#"{"testKey": "testValue"}"#;
-        bom_str.push_str(json_str);
-
-        let dir_path_no_bom = save_string_to_file(&dir, bom_str, String::from("bom.json"))?;
-        let parsed_json = parse_json(&dir_path_no_bom).unwrap();
-
-        assert_eq!(parsed_json.get("testKey").unwrap(), "testValue");
         dir.close()
     }
 

--- a/src/modules/azure.rs
+++ b/src/modules/azure.rs
@@ -1,6 +1,6 @@
+use serde::{Deserialize, Serialize};
 use std::fs;
-use std::path::{PathBuf};
-use serde::{Serialize, Deserialize};
+use std::path::PathBuf;
 
 use super::{Context, Module, ModuleConfig};
 
@@ -8,28 +8,28 @@ use crate::configs::azure::AzureConfig;
 use crate::formatter::StringFormatter;
 
 #[derive(Serialize, Deserialize, Clone)]
-#[serde(rename_all="camelCase")]
+#[serde(rename_all = "camelCase")]
 struct AzureProfile {
     installation_id: String,
-    #[serde(default, skip_serializing_if="Vec::is_empty")]
-    subscriptions: Vec<Subscription>
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    subscriptions: Vec<Subscription>,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
 struct User {
     name: String,
-    #[serde(alias="type")]
+    #[serde(alias = "type")]
     user_type: String,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
-#[serde(rename_all="camelCase")]
+#[serde(rename_all = "camelCase")]
 struct ManagedByTenant {
     tenant_id: String,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
-#[serde(rename_all="camelCase")]
+#[serde(rename_all = "camelCase")]
 struct Subscription {
     id: String,
     name: String,
@@ -39,8 +39,8 @@ struct Subscription {
     tenant_id: String,
     environment_name: String,
     home_tenant_id: String,
-    #[serde(default, skip_serializing_if="Vec::is_empty")]
-    managed_by_tenants: Vec<ManagedByTenant>
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    managed_by_tenants: Vec<ManagedByTenant>,
 }
 
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
@@ -50,13 +50,13 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     if config.disabled {
         return None;
     };
-    
+
     let subscription: Option<Subscription> = get_azure_profile_info(context);
 
     if subscription.is_none() {
         log::info!("Could not find Subscriptions in azureProfile.json");
         return None;
-    } 
+    }
 
     let subscription = subscription.unwrap();
 
@@ -111,9 +111,10 @@ fn get_azure_profile_info(context: &Context) -> Option<Subscription> {
 fn load_azure_profile(config_path: &PathBuf) -> AzureProfile {
     let json_data = fs::read_to_string(&config_path).expect("Unable to open azureProfile.json");
     let sanitized_json_data = json_data.strip_prefix('\u{feff}').unwrap_or(&json_data);
-    let azure_profile: AzureProfile = serde_json::from_str(sanitized_json_data).expect("Unable to parse json data.");
-    
-    azure_profile 
+    let azure_profile: AzureProfile =
+        serde_json::from_str(sanitized_json_data).expect("Unable to parse json data.");
+
+    azure_profile
 }
 
 fn get_config_file_location(context: &Context) -> Option<PathBuf> {
@@ -309,7 +310,7 @@ mod tests {
         assert_eq!(actual, expected);
         dir.close()
     }
-    
+
     #[test]
     fn subscription_name_found_username_missing() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
@@ -559,15 +560,19 @@ mod tests {
 
         let bom = vec![239, 187, 191];
         let mut bom_str = String::from_utf8(bom).unwrap();
-        
-        let json_str = r#"{"installationId": "3deacd2a-b9db-77e1-aa42-23e2f8dfffc3", "subscriptions": []}"#;
+
+        let json_str =
+            r#"{"installationId": "3deacd2a-b9db-77e1-aa42-23e2f8dfffc3", "subscriptions": []}"#;
 
         bom_str.push_str(json_str);
 
         let dir_path_no_bom = save_string_to_file(&dir, bom_str, String::from("bom.json"))?;
         let sanitized_json = load_azure_profile(&dir_path_no_bom);
 
-        assert_eq!(sanitized_json.installation_id, "3deacd2a-b9db-77e1-aa42-23e2f8dfffc3");
+        assert_eq!(
+            sanitized_json.installation_id,
+            "3deacd2a-b9db-77e1-aa42-23e2f8dfffc3"
+        );
         assert!(sanitized_json.subscriptions.is_empty());
         dir.close()
     }
@@ -576,12 +581,17 @@ mod tests {
     fn azure_profile_without_leading_char() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
 
-        let json_str = r#"{"installationId": "3deacd2a-b9db-77e1-aa42-23e2f8dfffc3", "subscriptions": []}"#;
+        let json_str =
+            r#"{"installationId": "3deacd2a-b9db-77e1-aa42-23e2f8dfffc3", "subscriptions": []}"#;
 
-        let dir_path_no_bom = save_string_to_file(&dir, json_str.to_string(), String::from("bom.json"))?;
+        let dir_path_no_bom =
+            save_string_to_file(&dir, json_str.to_string(), String::from("bom.json"))?;
         let sanitized_json = load_azure_profile(&dir_path_no_bom);
 
-        assert_eq!(sanitized_json.installation_id, "3deacd2a-b9db-77e1-aa42-23e2f8dfffc3");
+        assert_eq!(
+            sanitized_json.installation_id,
+            "3deacd2a-b9db-77e1-aa42-23e2f8dfffc3"
+        );
         assert!(sanitized_json.subscriptions.is_empty());
         dir.close()
     }


### PR DESCRIPTION
#### Description
Allows a user to show the currently logged in account to azure cli by adding $username as an available variable for the Azure Module configuration. 

#### Motivation and Context
Some companies/users work across many Azure tenants or leverage several accounts for separation of environment access, these changes help provide additional visibility to the context of the user you are currently working as.

#### How Has This Been Tested?
- [X] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
