### PR TITLE
feat(git_branch): add always_show_remote_branch option

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -502,6 +502,7 @@
     "git_branch": {
       "default": {
         "always_show_remote": false,
+        "always_show_remote_branch": true,
         "disabled": false,
         "format": "on [$symbol$branch(:$remote_branch)]($style) ",
         "ignore_branches": [],
@@ -2753,6 +2754,10 @@
         },
         "always_show_remote": {
           "default": false,
+          "type": "boolean"
+        },
+        "always_show_remote_branch": {
+          "default": true,
           "type": "boolean"
         },
         "ignore_branches": {

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1516,18 +1516,18 @@ The `git_branch` module shows the active branch of the repo in your current dire
 
 ### Options
 
-| Option               | Default                                           | Description                                                                              |
-| -------------------- | ------------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| `always_show_remote` | `false`                                           | Shows the remote name, even if it is equal to the local branch name.     |
-| `always_show_remote_branch` | `true`                                           | If the remote name is shown, shows the remote tracking branch name, even if it is equal to the local branch name.     |
-| `format`             | `"on [$symbol$branch(:$remote_branch)]($style) "` | The format for the module. Use `"$branch"` to refer to the current branch name.          |
-| `symbol`             | `" "`                                            | A format string representing the symbol of git branch.                                   |
-| `style`              | `"bold purple"`                                   | The style for the module.                                                                |
-| `truncation_length`  | `2^63 - 1`                                        | Truncates a git branch to `N` graphemes.                                                 |
-| `truncation_symbol`  | `"…"`                                             | The symbol used to indicate a branch name was truncated. You can use `""` for no symbol. |
-| `only_attached`      | `false`                                           | Only show the branch name when not in a detached `HEAD` state.                           |
-| `ignore_branches`    | `[]`                                              | A list of names to avoid displaying. Useful for "master" or "main".                      |
-| `disabled`           | `false`                                           | Disables the `git_branch` module.                                                        |
+| Option                      | Default                                           | Description                                                                                                       |
+| --------------------------- | ------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `always_show_remote`        | `false`                                           | Shows the remote name, even if it is equal to the local branch name.                                              |
+| `always_show_remote_branch` | `true`                                            | If the remote name is shown, shows the remote tracking branch name, even if it is equal to the local branch name. |
+| `format`                    | `"on [$symbol$branch(:$remote_branch)]($style) "` | The format for the module. Use `"$branch"` to refer to the current branch name.                                   |
+| `symbol`                    | `" "`                                            | A format string representing the symbol of git branch.                                                            |
+| `style`                     | `"bold purple"`                                   | The style for the module.                                                                                         |
+| `truncation_length`         | `2^63 - 1`                                        | Truncates a git branch to `N` graphemes.                                                                          |
+| `truncation_symbol`         | `"…"`                                             | The symbol used to indicate a branch name was truncated. You can use `""` for no symbol.                          |
+| `only_attached`             | `false`                                           | Only show the branch name when not in a detached `HEAD` state.                                                    |
+| `ignore_branches`           | `[]`                                              | A list of names to avoid displaying. Useful for "master" or "main".                                               |
+| `disabled`                  | `false`                                           | Disables the `git_branch` module.                                                                                 |
 
 ### Variables
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1518,7 +1518,8 @@ The `git_branch` module shows the active branch of the repo in your current dire
 
 | Option               | Default                                           | Description                                                                              |
 | -------------------- | ------------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| `always_show_remote` | `false`                                           | Shows the remote tracking branch name, even if it is equal to the local branch name.     |
+| `always_show_remote` | `false`                                           | Shows the remote name, even if it is equal to the local branch name.     |
+| `always_show_remote_branch` | `true`                                           | If the remote name is shown, shows the remote tracking branch name, even if it is equal to the local branch name.     |
 | `format`             | `"on [$symbol$branch(:$remote_branch)]($style) "` | The format for the module. Use `"$branch"` to refer to the current branch name.          |
 | `symbol`             | `" "`                                            | A format string representing the symbol of git branch.                                   |
 | `style`              | `"bold purple"`                                   | The style for the module.                                                                |

--- a/src/configs/git_branch.rs
+++ b/src/configs/git_branch.rs
@@ -11,6 +11,7 @@ pub struct GitBranchConfig<'a> {
     pub truncation_symbol: &'a str,
     pub only_attached: bool,
     pub always_show_remote: bool,
+    pub always_show_remote_branch: bool,
     pub ignore_branches: Vec<&'a str>,
     pub disabled: bool,
 }
@@ -25,6 +26,7 @@ impl<'a> Default for GitBranchConfig<'a> {
             truncation_symbol: "…",
             only_attached: false,
             always_show_remote: false,
+            always_show_remote_branch: true,
             ignore_branches: vec![],
             disabled: false,
         }

--- a/src/modules/git_branch.rs
+++ b/src/modules/git_branch.rs
@@ -41,10 +41,13 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         return None;
     }
 
+    let mut branches_are_same_name = false;
+
     let mut remote_branch_graphemes: Vec<&str> = Vec::new();
     let mut remote_name_graphemes: Vec<&str> = Vec::new();
     if let Some(remote) = repo.remote.as_ref() {
         if let Some(branch) = &remote.branch {
+            branches_are_same_name = branch.eq(branch_name);
             remote_branch_graphemes = branch.graphemes(true).collect()
         };
         if let Some(name) = &remote.name {
@@ -70,6 +73,8 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let show_remote = config.always_show_remote
         || (!graphemes.eq(&remote_branch_graphemes) && !remote_branch_graphemes.is_empty());
 
+    let show_branch = show_remote && (config.always_show_remote_branch || !branches_are_same_name);
+
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter
             .map_meta(|var, _| match var {
@@ -83,7 +88,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             .map(|variable| match variable {
                 "branch" => Some(Ok(graphemes.concat())),
                 "remote_branch" => {
-                    if show_remote && !remote_branch_graphemes.is_empty() {
+                    if show_remote && !remote_branch_graphemes.is_empty() && show_branch {
                         Some(Ok(remote_branch_graphemes.concat()))
                     } else {
                         None

--- a/src/modules/git_branch.rs
+++ b/src/modules/git_branch.rs
@@ -433,6 +433,42 @@ mod tests {
         remote_dir.close()
     }
 
+    #[test]
+    fn test_remote_branch() -> io::Result<()> {
+        let remote_dir = fixture_repo(FixtureProvider::Git)?;
+        let repo_dir = fixture_repo(FixtureProvider::Git)?;
+
+        create_command("git")?
+            .args(&["checkout", "-b", "master"])
+            .current_dir(repo_dir.path())
+            .output()?;
+
+        create_command("git")?
+            .args(&["remote", "add", "--fetch", "remote_repo"])
+            .arg(remote_dir.path())
+            .current_dir(repo_dir.path())
+            .output()?;
+
+        create_command("git")?
+            .args(&["branch", "--set-upstream-to", "remote_repo/master"])
+            .current_dir(repo_dir.path())
+            .output()?;
+
+        let actual = ModuleRenderer::new("git_branch")
+            .path(&repo_dir.path())
+            .config(toml::toml! {
+                [git_branch]
+                format = "$branch(:$remote_name)(/$remote_branch)"
+            })
+            .collect();
+
+        let expected = Some("test_branch:remote_repo");
+
+        assert_eq!(expected, actual.as_deref());
+        repo_dir.close()?;
+        remote_dir.close()
+    }
+
     // This test is not possible until we switch to `git status --porcelain`
     // where we can mock the env for the specific git process. This is because
     // git2 does not care about our mocking and when we set the real `GIT_DIR`

--- a/src/modules/git_branch.rs
+++ b/src/modules/git_branch.rs
@@ -459,10 +459,12 @@ mod tests {
             .config(toml::toml! {
                 [git_branch]
                 format = "$branch(:$remote_name)(/$remote_branch)"
+                always_show_remote = true
+                always_show_remote_branch = false
             })
             .collect();
 
-        let expected = Some("test_branch:remote_repo");
+        let expected = Some("master:remote_repo");
 
         assert_eq!(expected, actual.as_deref());
         repo_dir.close()?;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This adds an always_show_remote_branch option. It allows the name of the remote branch to always be shown if the remote name is being shown. If set to false, the remote branch name will not be shown even if the remote name is shown, if the local branch and the remote branch have the same names.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change allows for greater customisability of how the git prompt registers.
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #4214 

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
