### PR TITLE
build: expose features for easier-to-build `git-repository` features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1036,7 +1036,7 @@ dependencies = [
  "parking_lot",
  "prodash",
  "quick-error",
- "sha1 0.10.1",
+ "sha1 0.10.2",
  "sha1_smol",
  "walkdir",
 ]
@@ -2532,9 +2532,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c77f4e7f65455545c2153c1253d25056825e77ee2533f0e41deb65a93a34852f"
+checksum = "5cf2781a4ca844dd4f9b608a1791eea19830df0ad3cdd9988cd05f1c66ccb63a"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,11 @@ The minimal, blazing-fast, and infinitely customizable prompt for any shell! ☄
 """
 
 [features]
-default = ["battery", "notify"]
+# git-repository/max-performance will improve performance, but can be more difficult to build
+default = ["battery", "notify", "git-repository/max-performance"]
+# Can be used instead of `git-repository/max-performance` without stepping down to `git-repository/max-performance-safe`
+# It's slower (avoiding zlibng feature), but avoids cmake dependency and allows linking zlib dynamically
+git-repository-faster = ["git-features/zlib-stock", "git-repository/fast-sha1"]
 battery = ["starship-battery"]
 config-schema = ["schemars"]
 notify = ["notify-rust"]
@@ -44,7 +48,7 @@ dunce = "1.0.2"
 gethostname = "0.2.3"
 # Addresses https://github.com/starship/starship/issues/4251
 git-features = { version = "0.22.3", features = ["fs-walkdir-single-threaded"] }
-git-repository = "0.23.1"
+git-repository = { version = "0.23.1", features = ["max-performance-safe"], default-features = false }
 indexmap = { version = "1.9.1", features = ["serde"] }
 local_ipaddress = "0.1.3"
 log = { version = "0.4.16", features = ["std"] }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR changes `git-repository` to only default to `max-performance-safe` which should be non-problematic to build in all environments. But by default, re-enable the current level of optimizations in the default feature.

In addition, add a new feature `git-repository-faster` specifically to opt into `zlib-stock` instead of `zlib-ng` from `max-performance-safe`, because it's easier to build (no cmake) and can link to zlib dynamically.

I also bumped `sha1` in `Cargo.lock` to v0.10.2, because it fixes a potential build issue.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
