### PR TITLE
fix(pwsh): avoid potential deadlock in init

### DIFF
--- a/src/init/starship.ps1
+++ b/src/init/starship.ps1
@@ -53,15 +53,21 @@ $null = New-Module starship {
         }
         $process = [System.Diagnostics.Process]::Start($startInfo)
 
+        # Read the output and error streams asynchronously
+        # Avoids potential deadlocks when the child process fills one of the buffers
+        # https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.process.standardoutput?view=net-6.0#remarks
+        $stdout = $process.StandardOutput.ReadToEndAsync()
+        $stderr = $process.StandardError.ReadToEndAsync()
+        [System.Threading.Tasks.Task]::WaitAll(@($stdout, $stderr))
+
         # stderr isn't displayed with this style of invocation
         # Manually write it to console
-        $stderr = $process.StandardError.ReadToEnd().Trim()
-        if ($stderr -ne '') {
+        if ($stderr.Result.Trim() -ne '') {
             # Write-Error doesn't work here
             $host.ui.WriteErrorLine($stderr)
         }
 
-        $process.StandardOutput.ReadToEnd();
+        $stdout.Result;
     }
 
     function Enable-TransientPrompt {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
If the stdout buffer was completely filled while `StandardError.ReadToEnd()` was running, a deadlock could have occurred. Use asynchronous methods instead which don't have this issue: https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.process.standardoutput?view=net-6.0#remarks

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
