### PR TITLE
refactor: replace `ansi_term` with `nu_ansi_term`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,7 +180,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 mod tests {
    use super::*;
    use crate::test::ModuleRenderer;
-   use ansi_term::Color;
+   use nu_ansi_term::Color;
    use std::fs::File;
    use std::io;
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,15 +38,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1758,6 +1749,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num-derive"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1902,6 +1903,12 @@ name = "os_str_bytes"
 version = "6.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking"
@@ -2661,7 +2668,6 @@ dependencies = [
 name = "starship"
 version = "1.10.2"
 dependencies = [
- "ansi_term",
  "chrono",
  "clap",
  "clap_complete",
@@ -2679,6 +2685,7 @@ dependencies = [
  "mockall",
  "nix 0.25.0",
  "notify-rust",
+ "nu-ansi-term",
  "once_cell",
  "open",
  "os_info",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ config-schema = ["schemars"]
 notify = ["notify-rust"]
 
 [dependencies]
-ansi_term = "0.12.1"
 chrono = { version = "0.4.22", features = ["clock", "std"] }
 clap = { version = "=3.2.20", features = ["derive", "cargo", "unicode", "unstable-v4"] }
 clap_complete = "3.2.4"
@@ -51,6 +50,7 @@ log = { version = "0.4.16", features = ["std"] }
 # nofity-rust is optional (on by default) because the crate doesn't currently build for darwin with nix
 # see: https://github.com/NixOS/nixpkgs/issues/160876
 notify-rust = { version = "4.5.8", optional = true }
+nu-ansi-term = "0.46.0"
 once_cell = "1.13.1"
 open = "3.0.2"
 os_info = "3.5.0"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 use crate::serde_utils::ValueDeserializer;
 use crate::utils;
-use ansi_term::Color;
+use nu_ansi_term::Color;
 use serde::{
     de::value::Error as ValueError, de::Error as SerdeError, Deserialize, Deserializer, Serialize,
 };
@@ -251,7 +251,7 @@ impl StarshipConfig {
 }
 
 /// Deserialize a style string in the starship format with serde
-pub fn deserialize_style<'de, D>(de: D) -> Result<ansi_term::Style, D::Error>
+pub fn deserialize_style<'de, D>(de: D) -> Result<nu_ansi_term::Style, D::Error>
 where
     D: Deserializer<'de>,
 {
@@ -271,10 +271,10 @@ where
  - 'blink'
  - '<color>'       (see the `parse_color_string` doc for valid color strings)
 */
-pub fn parse_style_string(style_string: &str) -> Option<ansi_term::Style> {
+pub fn parse_style_string(style_string: &str) -> Option<nu_ansi_term::Style> {
     style_string
         .split_whitespace()
-        .fold(Some(ansi_term::Style::new()), |maybe_style, token| {
+        .fold(Some(nu_ansi_term::Style::new()), |maybe_style, token| {
             maybe_style.and_then(|style| {
                 let token = token.to_lowercase();
 
@@ -333,7 +333,7 @@ pub fn parse_style_string(style_string: &str) -> Option<ansi_term::Style> {
   - u8           (a number from 0-255, representing an ANSI color)
   - colstring    (one of the 16 predefined color strings)
 */
-fn parse_color_string(color_string: &str) -> Option<ansi_term::Color> {
+fn parse_color_string(color_string: &str) -> Option<nu_ansi_term::Color> {
     // Parse RGB hex values
     log::trace!("Parsing color_string: {}", color_string);
     if color_string.starts_with('#') {
@@ -349,7 +349,7 @@ fn parse_color_string(color_string: &str) -> Option<ansi_term::Color> {
         let g: u8 = u8::from_str_radix(&color_string[3..5], 16).ok()?;
         let b: u8 = u8::from_str_radix(&color_string[5..7], 16).ok()?;
         log::trace!("Read RGB color string: {},{},{}", r, g, b);
-        return Some(Color::RGB(r, g, b));
+        return Some(Color::Rgb(r, g, b));
     }
 
     // Parse a u8 (ansi color)
@@ -369,14 +369,14 @@ fn parse_color_string(color_string: &str) -> Option<ansi_term::Color> {
         "purple" => Some(Color::Purple),
         "cyan" => Some(Color::Cyan),
         "white" => Some(Color::White),
-        "bright-black" => Some(Color::Fixed(8)), // "bright-black" is dark grey
-        "bright-red" => Some(Color::Fixed(9)),
-        "bright-green" => Some(Color::Fixed(10)),
-        "bright-yellow" => Some(Color::Fixed(11)),
-        "bright-blue" => Some(Color::Fixed(12)),
-        "bright-purple" => Some(Color::Fixed(13)),
-        "bright-cyan" => Some(Color::Fixed(14)),
-        "bright-white" => Some(Color::Fixed(15)),
+        "bright-black" => Some(Color::DarkGray), // "bright-black" is dark grey
+        "bright-red" => Some(Color::LightRed),
+        "bright-green" => Some(Color::LightGreen),
+        "bright-yellow" => Some(Color::LightYellow),
+        "bright-blue" => Some(Color::LightBlue),
+        "bright-purple" => Some(Color::LightPurple),
+        "bright-cyan" => Some(Color::LightCyan),
+        "bright-white" => Some(Color::LightGray),
         _ => None,
     };
 
@@ -391,7 +391,7 @@ fn parse_color_string(color_string: &str) -> Option<ansi_term::Color> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ansi_term::Style;
+    use nu_ansi_term::Style;
 
     // Small wrapper to allow deserializing Style without a struct with #[serde(deserialize_with=)]
     #[derive(Default, Clone, Debug, PartialEq)]
@@ -574,7 +574,7 @@ mod tests {
         let config = Value::from("#a12BcD");
         assert_eq!(
             <StyleWrapper>::from_config(&config).unwrap().0,
-            Color::RGB(0xA1, 0x2B, 0xCD).into()
+            Color::Rgb(0xA1, 0x2B, 0xCD).into()
         );
     }
 
@@ -600,7 +600,7 @@ mod tests {
         assert!(mystyle.is_dimmed);
         assert_eq!(
             mystyle,
-            ansi_term::Style::new()
+            nu_ansi_term::Style::new()
                 .bold()
                 .italic()
                 .underline()
@@ -620,7 +620,7 @@ mod tests {
         assert!(mystyle.is_reverse);
         assert_eq!(
             mystyle,
-            ansi_term::Style::new()
+            nu_ansi_term::Style::new()
                 .bold()
                 .italic()
                 .underline()
@@ -641,7 +641,7 @@ mod tests {
         assert!(mystyle.is_blink);
         assert_eq!(
             mystyle,
-            ansi_term::Style::new()
+            nu_ansi_term::Style::new()
                 .bold()
                 .italic()
                 .underline()
@@ -662,7 +662,7 @@ mod tests {
         assert!(mystyle.is_hidden);
         assert_eq!(
             mystyle,
-            ansi_term::Style::new()
+            nu_ansi_term::Style::new()
                 .bold()
                 .italic()
                 .underline()
@@ -683,7 +683,7 @@ mod tests {
         assert!(mystyle.is_strikethrough);
         assert_eq!(
             mystyle,
-            ansi_term::Style::new()
+            nu_ansi_term::Style::new()
                 .bold()
                 .italic()
                 .underline()
@@ -698,7 +698,7 @@ mod tests {
         // Test a "plain" style with no formatting
         let config = Value::from("");
         let plain_style = <StyleWrapper>::from_config(&config).unwrap().0;
-        assert_eq!(plain_style, ansi_term::Style::new());
+        assert_eq!(plain_style, nu_ansi_term::Style::new());
 
         // Test a string that's clearly broken
         let config = Value::from("djklgfhjkldhlhk;j");
@@ -763,7 +763,7 @@ mod tests {
             Style::new()
                 .underline()
                 .fg(Color::Fixed(120))
-                .on(Color::RGB(5, 5, 5))
+                .on(Color::Rgb(5, 5, 5))
         );
 
         // Test that the last color style is always the one used

--- a/src/formatter/string_formatter.rs
+++ b/src/formatter/string_formatter.rs
@@ -1,4 +1,4 @@
-use ansi_term::Style;
+use nu_ansi_term::Style;
 use pest::error::Error as PestError;
 use rayon::prelude::*;
 use std::borrow::Cow;
@@ -465,7 +465,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
 
     // match_next(result: IterMut<Segment>, value, style)
     macro_rules! match_next {

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,6 +1,6 @@
 use crate::utils;
-use ansi_term::Color;
 use log::{Level, LevelFilter, Metadata, Record};
+use nu_ansi_term::Color;
 use once_cell::sync::OnceCell;
 use std::{
     collections::HashSet,

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,7 +114,7 @@ enum Commands {
 fn main() {
     // Configure the current terminal on windows to support ANSI escape sequences.
     #[cfg(windows)]
-    let _ = ansi_term::enable_ansi_support();
+    let _ = nu_ansi_term::enable_ansi_support();
     logger::init();
     init_global_threadpool();
 

--- a/src/module.rs
+++ b/src/module.rs
@@ -2,7 +2,7 @@ use crate::context::Shell;
 use crate::segment;
 use crate::segment::{FillSegment, Segment};
 use crate::utils::wrap_colorseq_for_shell;
-use ansi_term::{ANSIString, ANSIStrings};
+use nu_ansi_term::{AnsiString, AnsiStrings};
 use std::fmt;
 use std::time::Duration;
 
@@ -146,15 +146,15 @@ impl<'a> Module<'a> {
         self.segments.iter().map(segment::Segment::value).collect()
     }
 
-    /// Returns a vector of colored `ANSIString` elements to be later used with
-    /// `ANSIStrings()` to optimize ANSI codes
-    pub fn ansi_strings(&self) -> Vec<ANSIString> {
+    /// Returns a vector of colored `AnsiString` elements to be later used with
+    /// `AnsiStrings()` to optimize ANSI codes
+    pub fn ansi_strings(&self) -> Vec<AnsiString> {
         self.ansi_strings_for_shell(Shell::Unknown, None)
     }
 
-    pub fn ansi_strings_for_shell(&self, shell: Shell, width: Option<usize>) -> Vec<ANSIString> {
+    pub fn ansi_strings_for_shell(&self, shell: Shell, width: Option<usize>) -> Vec<AnsiString> {
         let mut iter = self.segments.iter().peekable();
-        let mut ansi_strings: Vec<ANSIString> = Vec::new();
+        let mut ansi_strings: Vec<AnsiString> = Vec::new();
         while iter.peek().is_some() {
             ansi_strings.extend(ansi_line(&mut iter, width));
         }
@@ -171,27 +171,27 @@ impl<'a> Module<'a> {
 impl<'a> fmt::Display for Module<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let ansi_strings = self.ansi_strings();
-        write!(f, "{}", ANSIStrings(&ansi_strings))
+        write!(f, "{}", AnsiStrings(&ansi_strings))
     }
 }
 
-fn ansi_strings_modified(ansi_strings: Vec<ANSIString>, shell: Shell) -> Vec<ANSIString> {
+fn ansi_strings_modified(ansi_strings: Vec<AnsiString>, shell: Shell) -> Vec<AnsiString> {
     ansi_strings
         .into_iter()
         .map(|ansi| {
             let wrapped = wrap_colorseq_for_shell(ansi.to_string(), shell);
-            ANSIString::from(wrapped)
+            AnsiString::from(wrapped)
         })
-        .collect::<Vec<ANSIString>>()
+        .collect::<Vec<AnsiString>>()
 }
 
-fn ansi_line<'a, I>(segments: &mut I, term_width: Option<usize>) -> Vec<ANSIString<'a>>
+fn ansi_line<'a, I>(segments: &mut I, term_width: Option<usize>) -> Vec<AnsiString<'a>>
 where
     I: Iterator<Item = &'a Segment>,
 {
     let mut used = 0usize;
-    let mut current: Vec<ANSIString> = Vec::new();
-    let mut chunks: Vec<(Vec<ANSIString>, &FillSegment)> = Vec::new();
+    let mut current: Vec<AnsiString> = Vec::new();
+    let mut chunks: Vec<(Vec<AnsiString>, &FillSegment)> = Vec::new();
 
     for segment in segments {
         match segment {
@@ -223,7 +223,7 @@ where
                     .chain(std::iter::once(fill.ansi_string(fill_size)))
             })
             .chain(current.into_iter())
-            .collect::<Vec<ANSIString>>()
+            .collect::<Vec<AnsiString>>()
     }
 }
 

--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -248,7 +248,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 #[cfg(test)]
 mod tests {
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
     use std::fs::{create_dir, File};
     use std::io::{self, Write};
 

--- a/src/modules/azure.rs
+++ b/src/modules/azure.rs
@@ -108,8 +108,8 @@ fn parse_json(json_file_path: &Path) -> Option<JValue> {
 mod tests {
     use crate::modules::azure::parse_json;
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
     use ini::Ini;
+    use nu_ansi_term::Color;
     use std::fs::File;
     use std::io::{self, Write};
     use std::path::PathBuf;

--- a/src/modules/battery.rs
+++ b/src/modules/battery.rs
@@ -172,7 +172,7 @@ impl BatteryInfoProvider for BatteryInfoProviderImpl {
 mod tests {
     use super::*;
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
 
     #[test]
     fn no_battery_status() {

--- a/src/modules/buf.rs
+++ b/src/modules/buf.rs
@@ -64,7 +64,7 @@ fn parse_buf_version(buf_version: &str) -> Option<String> {
 mod tests {
     use super::parse_buf_version;
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
     use std::fs::File;
     use std::io;
 

--- a/src/modules/bun.rs
+++ b/src/modules/bun.rs
@@ -71,7 +71,7 @@ fn parse_bun_version(bun_version: String) -> String {
 #[cfg(test)]
 mod tests {
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
     use std::fs::File;
     use std::io;
 

--- a/src/modules/c.rs
+++ b/src/modules/c.rs
@@ -92,7 +92,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 #[cfg(test)]
 mod tests {
     use crate::{test::ModuleRenderer, utils::CommandOutput};
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
     use std::fs::File;
     use std::io;
 

--- a/src/modules/character.rs
+++ b/src/modules/character.rs
@@ -82,7 +82,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 mod test {
     use crate::context::Shell;
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
 
     #[test]
     fn success_status() {

--- a/src/modules/cmake.rs
+++ b/src/modules/cmake.rs
@@ -71,7 +71,7 @@ fn parse_cmake_version(cmake_version: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
     use std::fs::File;
     use std::io;
 

--- a/src/modules/cmd_duration.rs
+++ b/src/modules/cmd_duration.rs
@@ -66,13 +66,13 @@ fn undistract_me<'a, 'b>(
     config: &'b CmdDurationConfig,
     elapsed: u128,
 ) -> Module<'a> {
-    use ansi_term::{unstyle, ANSIStrings};
     use notify_rust::{Notification, Timeout};
+    use nu_ansi_term::{unstyle, AnsiStrings};
 
     if config.show_notifications && config.min_time_to_notify as u128 <= elapsed {
         let body = format!(
             "Command execution {}",
-            unstyle(&ANSIStrings(&module.ansi_strings()))
+            unstyle(&AnsiStrings(&module.ansi_strings()))
         );
 
         let timeout = match config.notification_timeout {
@@ -98,7 +98,7 @@ fn undistract_me<'a, 'b>(
 #[cfg(test)]
 mod tests {
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
 
     #[test]
     fn config_blank_duration_1s() {

--- a/src/modules/cobol.rs
+++ b/src/modules/cobol.rs
@@ -75,7 +75,7 @@ fn get_cobol_version(cobol_stdout: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
     use std::fs::File;
     use std::io;
 

--- a/src/modules/conda.rs
+++ b/src/modules/conda.rs
@@ -54,7 +54,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 #[cfg(test)]
 mod tests {
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
 
     #[test]
     fn not_in_env() {

--- a/src/modules/container.rs
+++ b/src/modules/container.rs
@@ -101,7 +101,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 #[cfg(test)]
 mod tests {
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
     use std::path::PathBuf;
 
     #[test]

--- a/src/modules/crystal.rs
+++ b/src/modules/crystal.rs
@@ -72,7 +72,7 @@ fn parse_crystal_version(crystal_version: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
     use std::fs::File;
     use std::io;
 

--- a/src/modules/custom.rs
+++ b/src/modules/custom.rs
@@ -268,7 +268,7 @@ mod tests {
     use super::*;
 
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
     use std::fs::File;
     use std::io;
 

--- a/src/modules/daml.rs
+++ b/src/modules/daml.rs
@@ -75,7 +75,7 @@ fn read_sdk_version_from_daml_yaml(context: &Context) -> Option<String> {
 mod tests {
     use super::*;
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
     use std::fs::File;
     use std::io::{Result, Write};
 

--- a/src/modules/dart.rs
+++ b/src/modules/dart.rs
@@ -73,7 +73,7 @@ fn parse_dart_version(dart_version: &str) -> Option<String> {
 mod tests {
     use crate::test::ModuleRenderer;
     use crate::utils::CommandOutput;
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
     use std::fs::{self, File};
     use std::io;
 

--- a/src/modules/deno.rs
+++ b/src/modules/deno.rs
@@ -70,7 +70,7 @@ fn parse_deno_version(deno_version: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
     use std::fs::File;
     use std::io;
 

--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -345,7 +345,7 @@ mod tests {
     use crate::test::ModuleRenderer;
     use crate::utils::create_command;
     use crate::utils::home_dir;
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
     #[cfg(not(target_os = "windows"))]
     use std::os::unix::fs::symlink;
     #[cfg(target_os = "windows")]

--- a/src/modules/docker_context.rs
+++ b/src/modules/docker_context.rs
@@ -91,7 +91,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 #[cfg(test)]
 mod tests {
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
     use std::fs::File;
     use std::io::{self, Write};
 

--- a/src/modules/dotnet.rs
+++ b/src/modules/dotnet.rs
@@ -352,7 +352,7 @@ mod tests {
     use super::*;
     use crate::test::ModuleRenderer;
     use crate::utils::create_command;
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
     use std::fs::{self, OpenOptions};
     use std::io::{self, Write};
     use tempfile::{self, TempDir};

--- a/src/modules/elixir.rs
+++ b/src/modules/elixir.rs
@@ -91,7 +91,7 @@ fn parse_elixir_version(version: &str) -> Option<(String, String)> {
 mod tests {
     use super::*;
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
     use std::fs::File;
     use std::io;
 

--- a/src/modules/elm.rs
+++ b/src/modules/elm.rs
@@ -59,7 +59,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 #[cfg(test)]
 mod tests {
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
     use std::fs::{self, File};
     use std::io;
 

--- a/src/modules/env_var.rs
+++ b/src/modules/env_var.rs
@@ -105,7 +105,7 @@ fn get_env_value(context: &Context, name: &str, default: Option<&str>) -> Option
 #[cfg(test)]
 mod test {
     use crate::test::ModuleRenderer;
-    use ansi_term::{Color, Style};
+    use nu_ansi_term::{Color, Style};
 
     const TEST_VAR_VALUE: &str = "astronauts";
 

--- a/src/modules/erlang.rs
+++ b/src/modules/erlang.rs
@@ -73,7 +73,7 @@ fn get_erlang_version(context: &Context) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
     use std::fs::File;
     use std::io;
 

--- a/src/modules/fill.rs
+++ b/src/modules/fill.rs
@@ -24,7 +24,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 #[cfg(test)]
 mod tests {
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
 
     #[test]
     fn basic() {

--- a/src/modules/gcloud.rs
+++ b/src/modules/gcloud.rs
@@ -146,7 +146,7 @@ mod tests {
     use std::fs::{create_dir, File};
     use std::io::{self, Write};
 
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
 
     use crate::test::ModuleRenderer;
 

--- a/src/modules/git_branch.rs
+++ b/src/modules/git_branch.rs
@@ -120,7 +120,7 @@ fn get_first_grapheme(text: &str) -> &str {
 
 #[cfg(test)]
 mod tests {
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
     use std::io;
 
     use crate::test::{fixture_repo, FixtureProvider, ModuleRenderer};

--- a/src/modules/git_commit.rs
+++ b/src/modules/git_commit.rs
@@ -78,7 +78,7 @@ fn git_hash(repo: &Repo, config: &GitCommitConfig) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
     use std::{io, str};
 
     use crate::test::{fixture_repo, FixtureProvider, ModuleRenderer};

--- a/src/modules/git_metrics.rs
+++ b/src/modules/git_metrics.rs
@@ -116,7 +116,7 @@ mod tests {
     use std::path::{Path, PathBuf};
     use std::process::Stdio;
 
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
 
     use crate::test::ModuleRenderer;
 

--- a/src/modules/git_state.rs
+++ b/src/modules/git_state.rs
@@ -157,7 +157,7 @@ struct StateDescription<'a> {
 
 #[cfg(test)]
 mod tests {
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
     use std::ffi::OsStr;
     use std::fs::OpenOptions;
     use std::io::{self, Error, ErrorKind, Write};

--- a/src/modules/git_status.rs
+++ b/src/modules/git_status.rs
@@ -470,7 +470,7 @@ fn git_status_wsl(_context: &Context, _conf: &GitStatusConfig) -> Option<String>
 
 #[cfg(test)]
 mod tests {
-    use ansi_term::{ANSIStrings, Color};
+    use nu_ansi_term::{AnsiStrings, Color};
     use std::ffi::OsStr;
     use std::fs::{self, File};
     use std::io::{self, prelude::*};
@@ -832,7 +832,7 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "{} ",
-            ANSIStrings(&[
+            AnsiStrings(&[
                 Color::Red.bold().paint("[+"),
                 Color::Green.paint("1"),
                 Color::Red.bold().paint("]"),

--- a/src/modules/golang.rs
+++ b/src/modules/golang.rs
@@ -78,7 +78,7 @@ fn parse_go_version(go_stdout: &str) -> Option<String> {
 mod tests {
     use super::*;
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
     use std::fs::{self, File};
     use std::io;
 

--- a/src/modules/haskell.rs
+++ b/src/modules/haskell.rs
@@ -87,7 +87,7 @@ fn is_stack_project(context: &Context) -> bool {
 #[cfg(test)]
 mod tests {
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
     use std::fs::File;
     use std::io;
     use std::io::Write;

--- a/src/modules/helm.rs
+++ b/src/modules/helm.rs
@@ -83,7 +83,7 @@ fn parse_helm_version(helm_stdout: &str) -> Option<String> {
 mod tests {
     use super::*;
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
     use std::fs::File;
     use std::io;
 

--- a/src/modules/hg_branch.rs
+++ b/src/modules/hg_branch.rs
@@ -98,7 +98,7 @@ fn graphemes_len(text: &str) -> usize {
 
 #[cfg(test)]
 mod tests {
-    use ansi_term::{Color, Style};
+    use nu_ansi_term::{Color, Style};
     use std::fs;
     use std::io;
     use std::path::Path;

--- a/src/modules/hostname.rs
+++ b/src/modules/hostname.rs
@@ -78,7 +78,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 #[cfg(test)]
 mod tests {
     use crate::test::ModuleRenderer;
-    use ansi_term::{Color, Style};
+    use nu_ansi_term::{Color, Style};
     use unicode_segmentation::UnicodeSegmentation;
 
     macro_rules! get_hostname {

--- a/src/modules/java.rs
+++ b/src/modules/java.rs
@@ -90,7 +90,7 @@ fn parse_java_version(java_version_string: &str) -> Option<String> {
 mod tests {
     use super::*;
     use crate::{test::ModuleRenderer, utils::CommandOutput};
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
     use std::fs::File;
     use std::io;
 

--- a/src/modules/jobs.rs
+++ b/src/modules/jobs.rs
@@ -100,7 +100,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 #[cfg(test)]
 mod test {
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
 
     #[test]
     fn config_blank_job_0() {

--- a/src/modules/julia.rs
+++ b/src/modules/julia.rs
@@ -76,7 +76,7 @@ fn parse_julia_version(julia_stdout: &str) -> Option<String> {
 mod tests {
     use super::*;
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
     use std::fs::File;
     use std::io;
 

--- a/src/modules/kotlin.rs
+++ b/src/modules/kotlin.rs
@@ -82,7 +82,7 @@ fn parse_kotlin_version(kotlin_stdout: &str) -> Option<String> {
 mod tests {
     use super::*;
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
     use std::fs::File;
     use std::io;
 

--- a/src/modules/kubernetes.rs
+++ b/src/modules/kubernetes.rs
@@ -212,7 +212,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 #[cfg(test)]
 mod tests {
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
     use std::env;
     use std::fs::{create_dir, File};
     use std::io::{self, Write};

--- a/src/modules/localip.rs
+++ b/src/modules/localip.rs
@@ -61,7 +61,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 #[cfg(test)]
 mod tests {
     use crate::test::ModuleRenderer;
-    use ansi_term::{Color, Style};
+    use nu_ansi_term::{Color, Style};
 
     macro_rules! get_localip {
         () => {

--- a/src/modules/lua.rs
+++ b/src/modules/lua.rs
@@ -80,7 +80,7 @@ fn parse_lua_version(lua_version: &str) -> Option<String> {
 mod tests {
     use super::*;
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
     use std::fs::{self, File};
     use std::io;
 

--- a/src/modules/nim.rs
+++ b/src/modules/nim.rs
@@ -71,7 +71,7 @@ fn parse_nim_version(version_cmd_output: &str) -> Option<&str> {
 mod tests {
     use super::parse_nim_version;
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
     use std::fs::File;
     use std::io;
 

--- a/src/modules/nix_shell.rs
+++ b/src/modules/nix_shell.rs
@@ -63,7 +63,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 #[cfg(test)]
 mod tests {
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
 
     #[test]
     fn no_env_variables() {

--- a/src/modules/nodejs.rs
+++ b/src/modules/nodejs.rs
@@ -117,7 +117,7 @@ fn check_engines_version(nodejs_version: &str, engines_version: Option<String>) 
 #[cfg(test)]
 mod tests {
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
     use std::fs::{self, File};
     use std::io;
     use std::io::Write;

--- a/src/modules/ocaml.rs
+++ b/src/modules/ocaml.rs
@@ -112,7 +112,7 @@ fn parse_opam_switch(opam_switch: &str) -> Option<OpamSwitch> {
 mod tests {
     use super::{parse_opam_switch, SwitchType};
     use crate::{test::ModuleRenderer, utils::CommandOutput};
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
     use std::fs::{self, File};
     use std::io;
 

--- a/src/modules/openstack.rs
+++ b/src/modules/openstack.rs
@@ -86,7 +86,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 #[cfg(test)]
 mod tests {
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
     use std::fs::File;
     use std::io::{self, Write};
 

--- a/src/modules/package.rs
+++ b/src/modules/package.rs
@@ -341,7 +341,7 @@ fn format_version(version: &str, version_format: &str) -> Option<String> {
 mod tests {
     use super::*;
     use crate::{test::ModuleRenderer, utils::CommandOutput};
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
     use std::fs::File;
     use std::io;
     use std::io::Write;

--- a/src/modules/perl.rs
+++ b/src/modules/perl.rs
@@ -60,7 +60,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 #[cfg(test)]
 mod tests {
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
     use std::fs::File;
     use std::io;
 

--- a/src/modules/php.rs
+++ b/src/modules/php.rs
@@ -59,7 +59,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 #[cfg(test)]
 mod tests {
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
     use std::fs::File;
     use std::io;
 

--- a/src/modules/pulumi.rs
+++ b/src/modules/pulumi.rs
@@ -208,7 +208,7 @@ mod tests {
     use super::*;
     use crate::context::Target;
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
 
     #[test]
     fn pulumi_version_release() {

--- a/src/modules/purescript.rs
+++ b/src/modules/purescript.rs
@@ -58,7 +58,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 #[cfg(test)]
 mod tests {
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
     use std::fs::File;
     use std::io;
 

--- a/src/modules/python.rs
+++ b/src/modules/python.rs
@@ -133,7 +133,7 @@ fn get_prompt_from_venv(venv_path: &Path) -> Option<String> {
 mod tests {
     use super::*;
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
     use std::fs::{create_dir_all, File};
     use std::io;
     use std::io::Write;

--- a/src/modules/raku.rs
+++ b/src/modules/raku.rs
@@ -101,7 +101,7 @@ fn parse_raku_version(version: &str) -> Option<(String, String)> {
 mod tests {
     use super::*;
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
     use std::fs::File;
     use std::io;
 

--- a/src/modules/red.rs
+++ b/src/modules/red.rs
@@ -58,7 +58,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 #[cfg(test)]
 mod tests {
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
     use std::fs::File;
     use std::io;
 

--- a/src/modules/rlang.rs
+++ b/src/modules/rlang.rs
@@ -73,7 +73,7 @@ fn parse_r_version(r_version: &str) -> Option<String> {
 mod tests {
     use super::parse_r_version;
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
     use std::fs;
     use std::fs::File;
     use std::io;

--- a/src/modules/ruby.rs
+++ b/src/modules/ruby.rs
@@ -85,7 +85,7 @@ fn format_ruby_version(ruby_version: &str, version_format: &str) -> Option<Strin
 mod tests {
     use super::*;
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
     use std::fs::File;
     use std::io;
 

--- a/src/modules/scala.rs
+++ b/src/modules/scala.rs
@@ -77,7 +77,7 @@ fn parse_scala_version(scala_version_string: &str) -> Option<String> {
 mod tests {
     use super::*;
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
     use std::fs::{self, File};
     use std::io;
 

--- a/src/modules/shell.rs
+++ b/src/modules/shell.rs
@@ -66,7 +66,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 mod tests {
     use crate::context::Shell;
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
 
     #[test]
     fn test_none_if_disabled() {

--- a/src/modules/shlvl.rs
+++ b/src/modules/shlvl.rs
@@ -63,7 +63,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
 #[cfg(test)]
 mod tests {
-    use ansi_term::{Color, Style};
+    use nu_ansi_term::{Color, Style};
 
     use crate::test::ModuleRenderer;
 

--- a/src/modules/singularity.rs
+++ b/src/modules/singularity.rs
@@ -43,7 +43,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 #[cfg(test)]
 mod tests {
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
 
     #[test]
     fn no_env_set() {

--- a/src/modules/spack.rs
+++ b/src/modules/spack.rs
@@ -49,7 +49,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 #[cfg(test)]
 mod tests {
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
 
     #[test]
     fn not_in_env() {

--- a/src/modules/status.rs
+++ b/src/modules/status.rs
@@ -225,7 +225,7 @@ fn status_signal_name(signal: SignalNumber) -> Option<&'static str> {
 
 #[cfg(test)]
 mod tests {
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
 
     use crate::test::ModuleRenderer;
 

--- a/src/modules/sudo.rs
+++ b/src/modules/sudo.rs
@@ -51,7 +51,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 #[cfg(test)]
 mod tests {
     use crate::{test::ModuleRenderer, utils::CommandOutput};
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
 
     #[test]
     fn test_sudo_not_cached() {

--- a/src/modules/swift.rs
+++ b/src/modules/swift.rs
@@ -72,7 +72,7 @@ fn parse_swift_version(swift_version: &str) -> Option<String> {
 mod tests {
     use super::parse_swift_version;
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
     use std::fs::File;
     use std::io;
 

--- a/src/modules/terraform.rs
+++ b/src/modules/terraform.rs
@@ -101,7 +101,7 @@ fn parse_terraform_version(version: &str) -> Option<String> {
 mod tests {
     use super::*;
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
     use std::fs::{self, File};
     use std::io::{self, Write};
 

--- a/src/modules/vagrant.rs
+++ b/src/modules/vagrant.rs
@@ -74,7 +74,7 @@ fn parse_vagrant_version(vagrant_stdout: &str) -> Option<String> {
 mod tests {
     use super::*;
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
     use std::fs::File;
     use std::io;
 

--- a/src/modules/vcsh.rs
+++ b/src/modules/vcsh.rs
@@ -47,7 +47,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 #[cfg(test)]
 mod tests {
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
 
     #[test]
     fn not_in_env() {

--- a/src/modules/vlang.rs
+++ b/src/modules/vlang.rs
@@ -70,7 +70,7 @@ fn parse_v_version(v_version: &str) -> Option<String> {
 mod tests {
     use super::parse_v_version;
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
     use std::fs::File;
     use std::io;
 

--- a/src/modules/zig.rs
+++ b/src/modules/zig.rs
@@ -59,7 +59,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 #[cfg(test)]
 mod tests {
     use crate::test::ModuleRenderer;
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
     use std::fs::File;
     use std::io;
 

--- a/src/print.rs
+++ b/src/print.rs
@@ -1,5 +1,5 @@
-use ansi_term::ANSIStrings;
 use clap::{PossibleValue, ValueEnum};
+use nu_ansi_term::AnsiStrings;
 use rayon::prelude::*;
 use std::collections::BTreeSet;
 use std::fmt::{self, Debug, Write as FmtWrite};
@@ -119,7 +119,7 @@ pub fn get_prompt(context: Context) -> String {
         // continuation prompts normally do not include newlines, but they can
         writeln!(buf).unwrap();
     }
-    write!(buf, "{}", ANSIStrings(&module_strings)).unwrap();
+    write!(buf, "{}", AnsiStrings(&module_strings)).unwrap();
 
     if context.target == Target::Right {
         // right prompts generally do not allow newlines
@@ -163,7 +163,7 @@ pub fn timings(args: Properties) {
         .map(|module| ModuleTiming {
             name: String::from(module.get_name().as_str()),
             name_len: module.get_name().width_graphemes(),
-            value: ansi_term::ANSIStrings(&module.ansi_strings())
+            value: nu_ansi_term::AnsiStrings(&module.ansi_strings())
                 .to_string()
                 .replace('\n', "\\n"),
             duration: module.duration,
@@ -212,7 +212,7 @@ pub fn explain(args: Properties) {
         .map(|module| {
             let value = module.get_segments().join("");
             ModuleInfo {
-                value: ansi_term::ANSIStrings(&module.ansi_strings()).to_string(),
+                value: nu_ansi_term::AnsiStrings(&module.ansi_strings()).to_string(),
                 value_len: value.width_graphemes()
                     + format_duration(&module.duration).width_graphemes(),
                 desc: module.get_description().clone(),

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -1,5 +1,5 @@
 use crate::print::{Grapheme, UnicodeWidthGraphemes};
-use ansi_term::{ANSIString, Style};
+use nu_ansi_term::{AnsiString, Style};
 use std::fmt;
 use unicode_segmentation::UnicodeSegmentation;
 
@@ -14,11 +14,11 @@ pub struct TextSegment {
 }
 
 impl TextSegment {
-    // Returns the ANSIString of the segment value
-    fn ansi_string(&self) -> ANSIString {
+    // Returns the AnsiString of the segment value
+    fn ansi_string(&self) -> AnsiString {
         match self.style {
             Some(style) => style.paint(&self.value),
-            None => ANSIString::from(&self.value),
+            None => AnsiString::from(&self.value),
         }
     }
 }
@@ -34,8 +34,8 @@ pub struct FillSegment {
 }
 
 impl FillSegment {
-    // Returns the ANSIString of the segment value, not including its prefix and suffix
-    pub fn ansi_string(&self, width: Option<usize>) -> ANSIString {
+    // Returns the AnsiString of the segment value, not including its prefix and suffix
+    pub fn ansi_string(&self, width: Option<usize>) -> AnsiString {
         let s = match width {
             Some(w) => self
                 .value
@@ -54,7 +54,7 @@ impl FillSegment {
         };
         match self.style {
             Some(style) => style.paint(s),
-            None => ANSIString::from(s),
+            None => AnsiString::from(s),
         }
     }
 }
@@ -62,7 +62,7 @@ impl FillSegment {
 #[cfg(test)]
 mod fill_seg_tests {
     use super::FillSegment;
-    use ansi_term::Color;
+    use nu_ansi_term::Color;
 
     #[test]
     fn ansi_string_width() {
@@ -158,12 +158,12 @@ impl Segment {
         }
     }
 
-    // Returns the ANSIString of the segment value, not including its prefix and suffix
-    pub fn ansi_string(&self) -> ANSIString {
+    // Returns the AnsiString of the segment value, not including its prefix and suffix
+    pub fn ansi_string(&self) -> AnsiString {
         match self {
             Self::Fill(fs) => fs.ansi_string(None),
             Self::Text(ts) => ts.ansi_string(),
-            Self::LineTerm => ANSIString::from(LINE_TERMINATOR_STRING),
+            Self::LineTerm => AnsiString::from(LINE_TERMINATOR_STRING),
         }
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Replaced `ansi_term` with the maintained nushell fork `nu_ansi_term`.
Bringing the owo-colors PR up to date was turning out to be difficult. Since `nu-ansi-term` has started to mature a bit, I think it will do as a replacement, at least until we consider brining color code escaping and printing ANSI codes more in sync.

The update is a simple search-and-replace, apart from using the bright colors defined in nu_ansi_term instead of using color numbers, which should require fewer characters to print.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/starship/starship/issues/3770
Closes https://github.com/starship/starship/issues/3704

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
