### PR TITLE
feat(status): Add timeout and choose how success is displayed

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -1694,7 +1694,8 @@
         "signal_symbol": "⚡",
         "style": "bold red",
         "success_symbol": "",
-        "symbol": "❌"
+        "symbol": "❌",
+        "timeout_symbol": "⏲️"
       },
       "allOf": [
         {
@@ -5865,6 +5866,10 @@
           "default": "",
           "type": "string"
         },
+        "timeout_symbol": {
+          "default": "⏲️",
+          "type": "string"
+        },
         "not_executable_symbol": {
           "default": "🚫",
           "type": "string"
@@ -5906,6 +5911,24 @@
           "type": "string"
         },
         "pipestatus_segment_format": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "success_format": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "pipestatus_success_format": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "pipestatus_success_segment_format": {
           "type": [
             "string",
             "null"

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -4214,7 +4214,7 @@ format = '[$symbol$environment](dimmed blue) '
 ## Status
 
 The `status` module displays the exit code of the previous command.
-If $success_symbol is empty (default), the module will be shown only if the exit code is not `0`.
+If $success_format is empty (default), the module will be shown only if the exit code is not `0`.
 The status code will cast to a signed 32-bit integer.
 
 ::: tip
@@ -4226,23 +4226,29 @@ To enable it, set `disabled` to `false` in your configuration file.
 
 ### Options
 
-| Option                      | Default                                                                       | Description                                                           |
-| --------------------------- | ----------------------------------------------------------------------------- | --------------------------------------------------------------------- |
-| `format`                    | `'[$symbol$status]($style) '`                                                 | The format of the module                                              |
-| `symbol`                    | `'❌'`                                                                        | The symbol displayed on program error                                 |
-| `success_symbol`            | `''`                                                                          | The symbol displayed on program success                               |
-| `not_executable_symbol`     | `'🚫'`                                                                        | The symbol displayed when file isn't executable                       |
-| `not_found_symbol`          | `'🔍'`                                                                        | The symbol displayed when the command can't be found                  |
-| `sigint_symbol`             | `'🧱'`                                                                        | The symbol displayed on SIGINT (Ctrl + c)                             |
-| `signal_symbol`             | `'⚡'`                                                                        | The symbol displayed on any signal                                    |
-| `style`                     | `'bold red'`                                                                  | The style for the module.                                             |
-| `recognize_signal_code`     | `true`                                                                        | Enable signal mapping from exit code                                  |
-| `map_symbol`                | `false`                                                                       | Enable symbols mapping from exit code                                 |
-| `pipestatus`                | `false`                                                                       | Enable pipestatus reporting                                           |
-| `pipestatus_separator`      | <code>&vert;</code>                                                           | The symbol used to separate pipestatus segments (supports formatting) |
-| `pipestatus_format`         | `'\[$pipestatus\] => [$symbol$common_meaning$signal_name$maybe_int]($style)'` | The format of the module when the command is a pipeline               |
-| `pipestatus_segment_format` |                                                                               | When specified, replaces `format` when formatting pipestatus segments |
-| `disabled`                  | `true`                                                                        | Disables the `status` module.                                         |
+| Option                              | Default                                                                       | Description                                                                           |
+| ----------------------------------- | ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| `format`                            | `"[$symbol$status]($style) "`                                                 | The format of the module                                                              |
+| `symbol`                            | `"❌"`                                                                         | The symbol displayed on program error                                                 |
+| `success_symbol`                    | `""`                                                                          | The symbol displayed on program success                                               |
+| `timeout_symbol`                    | `"⏲️"`                                                                        | The symbol displayed when command timed out                                           |
+| `not_executable_symbol`             | `"🚫"`                                                                         | The symbol displayed when file isn't executable                                       |
+| `not_found_symbol`                  | `"🔍"`                                                                         | The symbol displayed when the command can't be found                                  |
+| `sigint_symbol`                     | `"🧱"`                                                                         | The symbol displayed on SIGINT (Ctrl + c)                                             |
+| `signal_symbol`                     | `"⚡"`                                                                         | The symbol displayed on any signal                                                    |
+| `style`                             | `"bold red"`                                                                  | The style for the module.                                                             |
+| `display_success`                   | `false`                                                                       | Display on success, true will enable `display_success_pipestatus`                     |
+| `display_success_pipestatus`        | `false`                                                                       | Enable pipestatus reporting even when all commands are successful                     |
+| `recognize_signal_code`             | `true`                                                                        | Enable signal mapping from exit code                                                  |
+| `map_symbol`                        | `false`                                                                       | Enable symbols mapping from exit code                                                 |
+| `pipestatus`                        | `false`                                                                       | Enable pipestatus reporting                                                           |
+| `pipestatus_separator`              | <code>&vert;</code>                                                           | The symbol used to separate pipestatus segments (supports formatting)                 |
+| `pipestatus_format`                 | `\[$pipestatus\] => [$symbol$common_meaning$signal_name$maybe_int]($style)` | The format of the module when the command is a pipeline                               |
+| `pipestatus_segment_format`         |                                                                               | When specified, replaces `format` when formatting pipestatus segments                 |
+| `success_format`                    |                                                                               | The format of success commands                                                        |
+| `pipestatus_success_format`         |                                                                               | When specified and pipeline succeed, replaces `pipestatus_format`                     |
+| `pipestatus_success_segment_format` |                                                                               | When specified, replaces `success_format` when formatting pipestatus success segments |
+| `disabled`                          | `true`                                                                        | Disables the `status` module.                                                         |
 
 ### Variables
 

--- a/src/configs/status.rs
+++ b/src/configs/status.rs
@@ -11,6 +11,7 @@ pub struct StatusConfig<'a> {
     pub format: &'a str,
     pub symbol: &'a str,
     pub success_symbol: &'a str,
+    pub timeout_symbol: &'a str,
     pub not_executable_symbol: &'a str,
     pub not_found_symbol: &'a str,
     pub sigint_symbol: &'a str,
@@ -23,6 +24,12 @@ pub struct StatusConfig<'a> {
     pub pipestatus_format: &'a str,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pipestatus_segment_format: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub success_format: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pipestatus_success_format: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pipestatus_success_segment_format: Option<&'a str>,
     pub disabled: bool,
 }
 
@@ -32,6 +39,7 @@ impl<'a> Default for StatusConfig<'a> {
             format: "[$symbol$status]($style) ",
             symbol: "❌",
             success_symbol: "",
+            timeout_symbol: "⏲️",
             not_executable_symbol: "🚫",
             not_found_symbol: "🔍",
             sigint_symbol: "🧱",
@@ -44,6 +52,9 @@ impl<'a> Default for StatusConfig<'a> {
             pipestatus_format:
                 "\\[$pipestatus\\] => [$symbol$common_meaning$signal_name$maybe_int]($style)",
             pipestatus_segment_format: None,
+            success_format: None,
+            pipestatus_success_format: None,
+            pipestatus_success_segment_format: None,
             disabled: true,
         }
     }


### PR DESCRIPTION
#### Description
Add `timeout_symbol` for exit code 124 which the command `timeout` uses when timeout occurs

Introduce `success_format` and `pipestatus_success_format`
which allow to choose how success is displayed
default to none

`success_format = 'format'` displays success commands and
whole pipeline success

`pipestatus_success_format = 'format'` displays whole pipeline success
only if command is a pipeline, doesn't display simple commands

Both to none (default) keeps the current behavior of displaying
nothing on success

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I want to display success pipeline using available variable, previous code
checks if `symbol_success` is set, but user might want to display $status == 0

#### Screenshots (if appropriate):
Timeout
![Screenshot_20220911_105725](https://user-images.githubusercontent.com/2104672/189519618-dbac30f3-63bb-4571-b7b5-31887a7683b4.png)
with following config
```
[status]
format = "[$symbol$common_meaning$signal_name$maybe_int]($style)"
success_symbol = "✔️"
symbol = "🔴"
pipestatus = true
pipestatus_segment_format = "[$symbol$common_meaning$signal_name$maybe_int]($style)"
pipestatus_success_format = "[\\[$pipestatus\\] $common_meaning](green)"
pipestatus_success_segment_format = "[$symbol](green)"
pipestatus_separator = "|"
map_symbol = true
disabled = false
```
![Screenshot_20221015_140427](https://user-images.githubusercontent.com/2104672/195985446-970a2aae-3494-4ba2-a3d3-9bc9980d2e13.png)

#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
