### PR TITLE
feat: add Haxe support

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -651,9 +651,6 @@
           "hxml"
         ],
         "detect_files": [
-          "project.xml",
-          "Project.xml",
-          "application.xml",
           "haxelib.json",
           "hxformat.json",
           ".haxerc"
@@ -3160,9 +3157,6 @@
         },
         "detect_files": {
           "default": [
-            "project.xml",
-            "Project.xml",
-            "application.xml",
             "haxelib.json",
             "hxformat.json",
             ".haxerc"

--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -644,6 +644,36 @@
         }
       ]
     },
+    "haxe": {
+      "default": {
+        "detect_extensions": [
+          "hx",
+          "hxml"
+        ],
+        "detect_files": [
+          "haxelib.json",
+          "hxformat.json",
+          ".haxerc",
+          "project.xml",
+          "Project.xml",
+          "application.xml"
+        ],
+        "detect_folders": [
+          ".haxelib", 
+          "haxe_libraries"
+        ],
+        "disabled": false,
+        "format": "via [$symbol($version )]($style)",
+        "style": "bold fg:202",
+        "symbol": "⌘ ",
+        "version_format": "v${raw}"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/HaxeConfig"
+        }
+      ]
+    },
     "helm": {
       "default": {
         "detect_extensions": [],
@@ -3095,6 +3125,69 @@
       },
       "additionalProperties": false
     },
+
+
+    "HaxeConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "via [$symbol($version )]($style)",
+          "type": "string"
+        },
+        "version_format": {
+          "default": "v${raw}",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "⌘ ",
+          "type": "string"
+        },
+        "style": {
+          "default": "bold fg:202",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "detect_extensions": {
+          "default": [
+            "hx",
+            "hxml"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_files": {
+          "default": [
+            "haxelib.json",
+            "hxformat.json",
+            ".haxerc",
+            "project.xml",
+            "Project.xml",
+            "application.xml"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_folders": {
+          "default": [
+            ".haxelib", 
+            "haxe_libraries"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+
     "HelmConfig": {
       "type": "object",
       "properties": {

--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -651,15 +651,15 @@
           "hxml"
         ],
         "detect_files": [
-          "haxelib.json",
-          "hxformat.json",
-          ".haxerc",
           "project.xml",
           "Project.xml",
-          "application.xml"
+          "application.xml",
+          "haxelib.json",
+          "hxformat.json",
+          ".haxerc"
         ],
         "detect_folders": [
-          ".haxelib", 
+          ".haxelib",
           "haxe_libraries"
         ],
         "disabled": false,
@@ -3125,8 +3125,6 @@
       },
       "additionalProperties": false
     },
-
-
     "HaxeConfig": {
       "type": "object",
       "properties": {
@@ -3162,12 +3160,12 @@
         },
         "detect_files": {
           "default": [
-            "haxelib.json",
-            "hxformat.json",
-            ".haxerc",
             "project.xml",
             "Project.xml",
-            "application.xml"
+            "application.xml",
+            "haxelib.json",
+            "hxformat.json",
+            ".haxerc"
           ],
           "type": "array",
           "items": {
@@ -3176,7 +3174,7 @@
         },
         "detect_folders": {
           "default": [
-            ".haxelib", 
+            ".haxelib",
             "haxe_libraries"
           ],
           "type": "array",
@@ -3187,7 +3185,6 @@
       },
       "additionalProperties": false
     },
-
     "HelmConfig": {
       "type": "object",
       "properties": {

--- a/docs/.vuepress/public/presets/toml/bracketed-segments.toml
+++ b/docs/.vuepress/public/presets/toml/bracketed-segments.toml
@@ -61,6 +61,9 @@ format = '\[[$symbol($version)]($style)\]'
 [haskell]
 format = '\[[$symbol($version)]($style)\]'
 
+[haxe]
+format = '\[[$symbol($version)]($style)\]'
+
 [helm]
 format = '\[[$symbol($version)]($style)\]'
 

--- a/docs/.vuepress/public/presets/toml/nerd-font-symbols.toml
+++ b/docs/.vuepress/public/presets/toml/nerd-font-symbols.toml
@@ -34,6 +34,9 @@ symbol = " "
 [haskell]
 symbol = " "
 
+[haxe]
+symbol = "⌘ "
+
 [hg_branch]
 symbol = " "
 

--- a/docs/.vuepress/public/presets/toml/no-runtime-versions.toml
+++ b/docs/.vuepress/public/presets/toml/no-runtime-versions.toml
@@ -37,6 +37,9 @@ format = 'via [$symbol]($style)'
 [golang]
 format = 'via [$symbol]($style)'
 
+[haxe]
+format = 'via [$symbol]($style)'
+
 [helm]
 format = 'via [$symbol]($style)'
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1900,7 +1900,6 @@ By default the module will be shown if any of the following conditions are met:
 format = "via [⌘ $version](bold fg:202) "
 ```
 
-
 ## Helm
 
 The `helm` module shows the currently installed version of [Helm](https://helm.sh/).

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1870,16 +1870,16 @@ By default the module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Option              | Default                              | Description                                                               |
-| ------------------- | ------------------------------------ | ------------------------------------------------------------------------- |
-| `format`            | `"via [$symbol($version )]($style)"` | The format for the module.                                                |
-| `version_format`    | `"v${raw}"`                          | The version format. Available vars are `raw`, `major`, `minor`, & `patch` |
-| `detect_extensions` | `["hx", "hxml"]`                                 | Which extensions should trigger this module.                              |
-| `detect_files`      | `["project.xml", "Project.xml", "application.xml", "haxelib.json", "hxformat.json", ".haxerc"]`    | Which filenames should trigger this module.                               |
-| `detect_folders`    | `[".haxelib", "haxe_libraries"]`                                 | Which folders should trigger this modules.                                |
-| `symbol`            | `"⌘ "`                               | A format string representing the symbol of Helm.                          |
-| `style`             | `"bold fg:202"`                       | The style for the module.                                                 |
-| `disabled`          | `false`                              | Disables the `haxe` module.                                               |
+| Option              | Default                                                                                         | Description                                                               |
+| ------------------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `format`            | `"via [$symbol($version )]($style)"`                                                            | The format for the module.                                                |
+| `version_format`    | `"v${raw}"`                                                                                     | The version format. Available vars are `raw`, `major`, `minor`, & `patch` |
+| `detect_extensions` | `["hx", "hxml"]`                                                                                | Which extensions should trigger this module.                              |
+| `detect_files`      | `["project.xml", "Project.xml", "application.xml", "haxelib.json", "hxformat.json", ".haxerc"]` | Which filenames should trigger this module.                               |
+| `detect_folders`    | `[".haxelib", "haxe_libraries"]`                                                                | Which folders should trigger this modules.                                |
+| `symbol`            | `"⌘ "`                                                                                          | A format string representing the symbol of Helm.                          |
+| `style`             | `"bold fg:202"`                                                                                 | The style for the module.                                                 |
+| `disabled`          | `false`                                                                                         | Disables the `haxe` module.                                               |
 
 ### Variables
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -239,6 +239,7 @@ $elm\
 $erlang\
 $golang\
 $haskell\
+$haxe\
 $helm\
 $java\
 $julia\
@@ -1857,6 +1858,48 @@ By default the module will be shown if any of the following conditions are met:
 | style\*      |             | Mirrors the value of option `style`                                                     |
 
 *: This variable can only be used as a part of a style string
+
+## Haxe
+
+The `haxe` module shows the currently installed version of [Haxe](https://haxe.org/).
+By default the module will be shown if any of the following conditions are met:
+
+- The current directory contains a `project.xml`, `Project.xml`, `application.xml`, `haxelib.json`, `hxformat.json` or `.haxerc` file
+- The current directory contains a `.haxelib` or a `haxe_libraries` directory
+- The current directory contains a file with the `.hx` or `.hxml` extension
+
+### Options
+
+| Option              | Default                              | Description                                                               |
+| ------------------- | ------------------------------------ | ------------------------------------------------------------------------- |
+| `format`            | `"via [$symbol($version )]($style)"` | The format for the module.                                                |
+| `version_format`    | `"v${raw}"`                          | The version format. Available vars are `raw`, `major`, `minor`, & `patch` |
+| `detect_extensions` | `["hx", "hxml"]`                                 | Which extensions should trigger this module.                              |
+| `detect_files`      | `["project.xml", "Project.xml", "application.xml", "haxelib.json", "hxformat.json", ".haxerc"]`    | Which filenames should trigger this module.                               |
+| `detect_folders`    | `[".haxelib", "haxe_libraries"]`                                 | Which folders should trigger this modules.                                |
+| `symbol`            | `"⌘ "`                               | A format string representing the symbol of Helm.                          |
+| `style`             | `"bold fg:202"`                       | The style for the module.                                                 |
+| `disabled`          | `false`                              | Disables the `haxe` module.                                               |
+
+### Variables
+
+| Variable | Example  | Description                          |
+| -------- | -------- | ------------------------------------ |
+| version  | `v4.2.5` | The version of `haxe`                |
+| symbol   |          | Mirrors the value of option `symbol` |
+| style\*  |          | Mirrors the value of option `style`  |
+
+*: This variable can only be used as a part of a style string
+
+### Example
+
+```toml
+# ~/.config/starship.toml
+
+[haxe]
+format = "via [⌘ $version](bold fg:202) "
+```
+
 
 ## Helm
 

--- a/src/configs/haxe.rs
+++ b/src/configs/haxe.rs
@@ -28,9 +28,6 @@ impl<'a> Default for HaxeConfig<'a> {
             disabled: false,
             detect_extensions: vec!["hx", "hxml"],
             detect_files: vec![
-                "project.xml",
-                "Project.xml",
-                "application.xml",
                 "haxelib.json",
                 "hxformat.json",
                 ".haxerc",

--- a/src/configs/haxe.rs
+++ b/src/configs/haxe.rs
@@ -27,11 +27,7 @@ impl<'a> Default for HaxeConfig<'a> {
             style: "bold fg:202",
             disabled: false,
             detect_extensions: vec!["hx", "hxml"],
-            detect_files: vec![
-                "haxelib.json",
-                "hxformat.json",
-                ".haxerc",
-            ],
+            detect_files: vec!["haxelib.json", "hxformat.json", ".haxerc"],
             detect_folders: vec![".haxelib", "haxe_libraries"],
         }
     }

--- a/src/configs/haxe.rs
+++ b/src/configs/haxe.rs
@@ -27,7 +27,14 @@ impl<'a> Default for HaxeConfig<'a> {
             style: "bold fg:202",
             disabled: false,
             detect_extensions: vec!["hx", "hxml"],
-            detect_files: vec!["project.xml", "Project.xml", "application.xml", "haxelib.json", "hxformat.json", ".haxerc"],
+            detect_files: vec![
+                "project.xml",
+                "Project.xml",
+                "application.xml",
+                "haxelib.json",
+                "hxformat.json",
+                ".haxerc",
+            ],
             detect_folders: vec![".haxelib", "haxe_libraries"],
         }
     }

--- a/src/configs/haxe.rs
+++ b/src/configs/haxe.rs
@@ -1,0 +1,34 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(
+    feature = "config-schema",
+    derive(schemars::JsonSchema),
+    schemars(deny_unknown_fields)
+)]
+#[serde(default)]
+pub struct HaxeConfig<'a> {
+    pub format: &'a str,
+    pub version_format: &'a str,
+    pub symbol: &'a str,
+    pub style: &'a str,
+    pub disabled: bool,
+    pub detect_extensions: Vec<&'a str>,
+    pub detect_files: Vec<&'a str>,
+    pub detect_folders: Vec<&'a str>,
+}
+
+impl<'a> Default for HaxeConfig<'a> {
+    fn default() -> Self {
+        HaxeConfig {
+            format: "via [$symbol($version )]($style)",
+            version_format: "v${raw}",
+            symbol: "⌘ ",
+            style: "bold fg:202",
+            disabled: false,
+            detect_extensions: vec!["hx", "hxml"],
+            detect_files: vec!["project.xml", "Project.xml", "application.xml", "haxelib.json", "hxformat.json", ".haxerc"],
+            detect_folders: vec![".haxelib", "haxe_libraries"],
+        }
+    }
+}

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -34,6 +34,7 @@ pub mod git_state;
 pub mod git_status;
 pub mod go;
 pub mod haskell;
+pub mod haxe;
 pub mod helm;
 pub mod hg_branch;
 pub mod hostname;
@@ -160,6 +161,8 @@ pub struct FullConfig<'a> {
     golang: go::GoConfig<'a>,
     #[serde(borrow)]
     haskell: haskell::HaskellConfig<'a>,
+    #[serde(borrow)]
+    haxe: haxe::HaxeConfig<'a>,
     #[serde(borrow)]
     helm: helm::HelmConfig<'a>,
     #[serde(borrow)]

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -53,6 +53,7 @@ pub const PROMPT_ORDER: &[&str] = &[
     "erlang",
     "golang",
     "haskell",
+    "haxe",
     "helm",
     "java",
     "julia",

--- a/src/module.rs
+++ b/src/module.rs
@@ -42,6 +42,7 @@ pub const ALL_MODULES: &[&str] = &[
     "git_status",
     "golang",
     "haskell",
+    "haxe",
     "helm",
     "hg_branch",
     "hostname",

--- a/src/modules/haxe.rs
+++ b/src/modules/haxe.rs
@@ -78,7 +78,7 @@ fn get_haxerc_version(context: &Context) -> Option<String> {
         if raw_version == "null" {
             return None;
         };
-        if raw_version.contains('/') {
+        if raw_version.contains('/') || raw_version.contains('\\') {
             return None;
         }
 

--- a/src/modules/haxe.rs
+++ b/src/modules/haxe.rs
@@ -68,8 +68,7 @@ fn get_haxe_version(context: &Context) -> Option<String> {
 }
 
 fn get_haxerc_version(context: &Context) -> Option<String> {
-    let file_contents = context.read_file_from_pwd(".haxerc");
-    if let Some(raw_json) = file_contents {
+    let raw_json = context.read_file_from_pwd(".haxerc")?;
         let package_json: json::Value = json::from_str(&raw_json).ok()?;
 
         let raw_version = package_json.get("version")?.as_str()?;

--- a/src/modules/haxe.rs
+++ b/src/modules/haxe.rs
@@ -61,12 +61,10 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 }
 
 fn get_haxe_version(context: &Context) -> Option<String> {
-    if let Some(version) = get_haxerc_version(context) {
-        Some(version)
-    } else {
-        let cmd_output = context.exec_cmd("haxe", &["--version"])?;
+    get_haxerc_version(context).or_else(|| {
+        context.exec_cmd("haxe", &["--version"])?;
         parse_haxe_version(cmd_output.stdout.as_str())
-    }
+    })
 }
 
 fn get_haxerc_version(context: &Context) -> Option<String> {

--- a/src/modules/haxe.rs
+++ b/src/modules/haxe.rs
@@ -80,7 +80,7 @@ fn get_haxerc_version(context: &Context) -> Option<String> {
 
 fn parse_haxe_version(raw_version: &str) -> Option<String> {
     let re = Regex::new(HAXERC_VERSION_PATTERN).ok()?;
-    if !re.is_match(raw_version)  {
+    if !re.is_match(raw_version) {
         return None;
     }
     Some(raw_version.trim().to_string())

--- a/src/modules/haxe.rs
+++ b/src/modules/haxe.rs
@@ -6,8 +6,7 @@ use crate::formatter::VersionFormatter;
 use serde_json as json;
 
 use regex::Regex;
-const HAXERC_VERSION_PATTERN: &str =
-    "(?P<version>[-+0-9.a-zA-Z/ ]+)";
+const HAXERC_VERSION_PATTERN: &str = "(?P<version>[-+0-9.a-zA-Z/ ]+)";
 
 /// Creates a module with the current Haxe version
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
@@ -64,8 +63,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 fn get_haxe_version(context: &Context) -> Option<String> {
     if let Some(version) = get_haxerc_version(context) {
         Some(version)
-    }
-    else {
+    } else {
         let cmd_output = context.exec_cmd("haxe", &["--version"])?;
         parse_haxe_version(cmd_output.stdout.as_str())
     }
@@ -108,7 +106,17 @@ mod tests {
 
     #[test]
     fn haxe_version() {
-        let ok_versions = ["4.2.5", "4.3.0-rc.1+", "3.4.7abcdf", "779b005", "beta", "alpha", "latest", "/git/779b005/bin/haxe"];
+        let ok_versions = [
+            "4.2.5",
+            "4.3.0-rc.1+",
+            "3.4.7abcdf",
+            "779b005",
+            "beta",
+            "alpha",
+            "latest",
+            "/git/779b005/bin/haxe",
+            "git/779b005/bin/haxe",
+        ];
 
         let all_some = ok_versions.iter().all(|&v| parse_haxe_version(v).is_some());
 

--- a/src/modules/haxe.rs
+++ b/src/modules/haxe.rs
@@ -63,11 +63,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
 fn get_haxe_version(context: &Context) -> Option<String> {
     let file_contents = context.read_file_from_pwd(".haxerc");
-    if file_contents.is_some() {
-        let raw_json = match file_contents {
-            Some(val) => val,
-            None => panic!("failed to read contents of .haxerc!"),
-        };
+    if let Some(raw_json) = file_contents {
         let haxerc_json: json::Value = json::from_str(&raw_json).ok()?;
         let raw_version = haxerc_json.get("version")?.as_str()?;
         parse_haxe_version(raw_version)

--- a/src/modules/haxe.rs
+++ b/src/modules/haxe.rs
@@ -78,7 +78,7 @@ fn get_haxerc_version(context: &Context) -> Option<String> {
         if raw_version == "null" {
             return None;
         };
-        if raw_version.contains("/") {
+        if raw_version.contains('/') {
             return None;
         }
 

--- a/src/modules/haxe.rs
+++ b/src/modules/haxe.rs
@@ -64,7 +64,11 @@ fn get_haxe_version(context: &Context) -> Option<String> {
     let file_contents = context.read_file_from_pwd(".haxerc");
     if file_contents.is_some() 
     {
-        let haxerc_json: json::Value = json::from_str(&file_contents.unwrap()).ok()?;
+        let raw_json = match file_contents {
+            Some(val) => val,
+            None => panic!("failed to read contents of .haxerc!"),
+        };
+        let haxerc_json: json::Value = json::from_str(&raw_json).ok()?;
         let raw_version = haxerc_json.get("version")?.as_str()?;
         parse_haxe_version(&raw_version)
     }

--- a/src/modules/haxe.rs
+++ b/src/modules/haxe.rs
@@ -1,0 +1,205 @@
+use super::{Context, Module, ModuleConfig};
+
+use crate::configs::haxe::HaxeConfig;
+use crate::formatter::StringFormatter;
+use crate::formatter::VersionFormatter;
+use serde_json as json;
+
+use regex::Regex;
+const HAXE_VERSION_PATTERN: &str = "(?P<version>(?:\\d+\\.\\d+\\.\\d+(?:-(?:alpha|beta|pre|rc)[\\d\\.+]+)?)|[[:xdigit:]]+)";
+
+/// Creates a module with the current Haxe version
+pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let mut module = context.new_module("haxe");
+    let config = HaxeConfig::try_load(module.config);
+
+    let is_haxe_project = context
+        .try_begin_scan()?
+        .set_files(&config.detect_files)
+        .set_extensions(&config.detect_extensions)
+        .set_folders(&config.detect_folders)
+        .is_match();
+
+    if !is_haxe_project {
+        return None;
+    }
+
+    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
+        formatter
+            .map_meta(|var, _| match var {
+                "symbol" => Some(config.symbol),
+                _ => None,
+            })
+            .map_style(|variable| match variable {
+                "style" => Some(Ok(config.style)),
+                _ => None,
+            })
+            .map(|variable| match variable {
+                "version" => {
+                    let haxe_version = get_haxe_version(context)?;
+                    VersionFormatter::format_module_version(
+                        module.get_name(),
+                        &haxe_version,
+                        config.version_format,
+                    )
+                    .map(Ok)
+                }
+                _ => None,
+            })
+            .parse(None, Some(context))
+    });
+
+    module.set_segments(match parsed {
+        Ok(segments) => segments,
+        Err(error) => {
+            log::warn!("Error in module `haxe`:\n{}", error);
+            return None;
+        }
+    });
+
+    Some(module)
+}
+
+fn get_haxe_version(context: &Context) -> Option<String> {
+    let file_contents = context.read_file_from_pwd(".haxerc");
+    if file_contents.is_some() 
+    {
+        let haxerc_json: json::Value = json::from_str(&file_contents.unwrap()).ok()?;
+        let raw_version = haxerc_json.get("version")?.as_str()?;
+        parse_haxe_version(&raw_version)
+    }
+    else 
+    {
+        let cmd_output = context.exec_cmd("haxe", &["--version"])?;
+        let raw_version = cmd_output.stdout.as_str();
+        parse_haxe_version(&raw_version)
+    }
+}
+
+fn parse_haxe_version(raw_version: &str) -> Option<String> {
+    let re = Regex::new(HAXE_VERSION_PATTERN).ok()?;
+    let captures = re.captures(raw_version)?;
+    let version = &captures["version"];
+
+    Some(version.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_haxe_version;
+    use crate::{test::ModuleRenderer, utils::CommandOutput};
+    use nu_ansi_term::Color;
+    use serde_json as json;
+    use std::fs::File;
+    use std::io;
+    use std::io::Write;
+    use tempfile::TempDir;
+    
+    #[test]
+    fn haxe_version() {
+        let ok_versions = ["4.2.5", "4.3.0-rc.1+", "3.4.7abcdf", "779b005"];
+        let not_ok_versions = ["abc", " \n.", ". ", "abc."];
+
+        let all_some = ok_versions.iter().all(|&v| parse_haxe_version(v).is_some());
+        let all_none = not_ok_versions
+            .iter()
+            .any(|&v| parse_haxe_version(v).is_some());
+
+        assert!(all_some);
+        assert!(all_none);
+
+        let sample_haxe_output = "4.3.0-rc.1+\n";
+
+        assert_eq!(Some("4.3.0-rc.1+".to_string()), parse_haxe_version(sample_haxe_output))
+    }
+
+    #[test]
+    fn folder_without_haxe() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join("haxe.txt"))?.sync_all()?;
+        let actual = ModuleRenderer::new("haxe").cmd("haxe --version", Some(CommandOutput {
+            stdout: "4.3.0-rc.1+\n".to_owned(),
+            stderr: "".to_owned()
+        })).path(dir.path()).collect();
+        let expected = None;
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn folder_with_hxml_file() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join("build.hxml"))?.sync_all()?;
+        let actual = ModuleRenderer::new("haxe").cmd("haxe --version", Some(CommandOutput {
+            stdout: "4.3.0-rc.1+\n".to_owned(),
+            stderr: "".to_owned()
+        })).path(dir.path()).collect();
+        let expected = Some(format!("via {}", Color::Fixed(202).bold().paint("⌘ v4.3.0-rc.1+ ")));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn folder_with_haxe_file() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join("Main.hx"))?.sync_all()?;
+        let actual = ModuleRenderer::new("haxe").cmd("haxe --version", Some(CommandOutput {
+            stdout: "4.3.0-rc.1+\n".to_owned(),
+            stderr: "".to_owned()
+        })).path(dir.path()).collect();
+        let expected = Some(format!("via {}", Color::Fixed(202).bold().paint("⌘ v4.3.0-rc.1+ ")));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn folder_with_haxerc_file() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+
+        let haxerc_name = ".haxerc";
+        let haxerc_content = json::json!({
+            "version": "4.2.5",
+            "resolveLibs": "scoped"
+        })
+        .to_string();
+        fill_config(&dir, haxerc_name, Some(&haxerc_content))?;
+        let actual = ModuleRenderer::new("haxe").cmd("haxe --version", Some(CommandOutput {
+            stdout: "4.3.0-rc.1+\n".to_owned(),
+            stderr: "".to_owned()
+        })).path(dir.path()).collect();
+        let expected = Some(format!("via {}", Color::Fixed(202).bold().paint("⌘ v4.2.5 ")));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn folder_with_haxerc_nightly_file() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+
+        let haxerc_name = ".haxerc";
+        let haxerc_content = json::json!({
+            "version": "779b005",
+            "resolveLibs": "scoped"
+        })
+        .to_string();
+
+        fill_config(&dir, haxerc_name, Some(&haxerc_content))?;
+        let actual = ModuleRenderer::new("haxe").cmd("haxe --version", Some(CommandOutput {
+            stdout: "4.3.0-rc.1+\n".to_owned(),
+            stderr: "".to_owned()
+        })).path(dir.path()).collect();
+        let expected = Some(format!("via {}", Color::Fixed(202).bold().paint("⌘ v779b005 ")));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    fn fill_config(
+        project_dir: &TempDir,
+        file_name: &str,
+        contents: Option<&str>,
+    ) -> io::Result<()> {
+        let mut file = File::create(project_dir.path().join(file_name))?;
+        file.write_all(contents.unwrap_or("").as_bytes())?;
+        file.sync_all()
+    }
+}

--- a/src/modules/haxe.rs
+++ b/src/modules/haxe.rs
@@ -6,7 +6,8 @@ use crate::formatter::VersionFormatter;
 use serde_json as json;
 
 use regex::Regex;
-const HAXE_VERSION_PATTERN: &str = "(?P<version>(?:\\d+\\.\\d+\\.\\d+(?:-(?:alpha|beta|pre|rc)[\\d\\.+]+)?)|[[:xdigit:]]+)";
+const HAXE_VERSION_PATTERN: &str =
+    "(?P<version>(?:\\d+\\.\\d+\\.\\d+(?:-(?:alpha|beta|pre|rc)[\\d\\.+]+)?)|[[:xdigit:]]+)";
 
 /// Creates a module with the current Haxe version
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
@@ -62,21 +63,18 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
 fn get_haxe_version(context: &Context) -> Option<String> {
     let file_contents = context.read_file_from_pwd(".haxerc");
-    if file_contents.is_some() 
-    {
+    if file_contents.is_some() {
         let raw_json = match file_contents {
             Some(val) => val,
             None => panic!("failed to read contents of .haxerc!"),
         };
         let haxerc_json: json::Value = json::from_str(&raw_json).ok()?;
         let raw_version = haxerc_json.get("version")?.as_str()?;
-        parse_haxe_version(&raw_version)
-    }
-    else 
-    {
+        parse_haxe_version(raw_version)
+    } else {
         let cmd_output = context.exec_cmd("haxe", &["--version"])?;
         let raw_version = cmd_output.stdout.as_str();
-        parse_haxe_version(&raw_version)
+        parse_haxe_version(raw_version)
     }
 }
 
@@ -98,7 +96,7 @@ mod tests {
     use std::io;
     use std::io::Write;
     use tempfile::TempDir;
-    
+
     #[test]
     fn haxe_version() {
         let ok_versions = ["4.2.5", "4.3.0-rc.1+", "3.4.7abcdf", "779b005"];
@@ -114,17 +112,26 @@ mod tests {
 
         let sample_haxe_output = "4.3.0-rc.1+\n";
 
-        assert_eq!(Some("4.3.0-rc.1+".to_string()), parse_haxe_version(sample_haxe_output))
+        assert_eq!(
+            Some("4.3.0-rc.1+".to_string()),
+            parse_haxe_version(sample_haxe_output)
+        )
     }
 
     #[test]
     fn folder_without_haxe() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("haxe.txt"))?.sync_all()?;
-        let actual = ModuleRenderer::new("haxe").cmd("haxe --version", Some(CommandOutput {
-            stdout: "4.3.0-rc.1+\n".to_owned(),
-            stderr: "".to_owned()
-        })).path(dir.path()).collect();
+        let actual = ModuleRenderer::new("haxe")
+            .cmd(
+                "haxe --version",
+                Some(CommandOutput {
+                    stdout: "4.3.0-rc.1+\n".to_owned(),
+                    stderr: "".to_owned(),
+                }),
+            )
+            .path(dir.path())
+            .collect();
         let expected = None;
         assert_eq!(expected, actual);
         dir.close()
@@ -134,11 +141,20 @@ mod tests {
     fn folder_with_hxml_file() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("build.hxml"))?.sync_all()?;
-        let actual = ModuleRenderer::new("haxe").cmd("haxe --version", Some(CommandOutput {
-            stdout: "4.3.0-rc.1+\n".to_owned(),
-            stderr: "".to_owned()
-        })).path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Fixed(202).bold().paint("⌘ v4.3.0-rc.1+ ")));
+        let actual = ModuleRenderer::new("haxe")
+            .cmd(
+                "haxe --version",
+                Some(CommandOutput {
+                    stdout: "4.3.0-rc.1+\n".to_owned(),
+                    stderr: "".to_owned(),
+                }),
+            )
+            .path(dir.path())
+            .collect();
+        let expected = Some(format!(
+            "via {}",
+            Color::Fixed(202).bold().paint("⌘ v4.3.0-rc.1+ ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -147,11 +163,20 @@ mod tests {
     fn folder_with_haxe_file() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("Main.hx"))?.sync_all()?;
-        let actual = ModuleRenderer::new("haxe").cmd("haxe --version", Some(CommandOutput {
-            stdout: "4.3.0-rc.1+\n".to_owned(),
-            stderr: "".to_owned()
-        })).path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Fixed(202).bold().paint("⌘ v4.3.0-rc.1+ ")));
+        let actual = ModuleRenderer::new("haxe")
+            .cmd(
+                "haxe --version",
+                Some(CommandOutput {
+                    stdout: "4.3.0-rc.1+\n".to_owned(),
+                    stderr: "".to_owned(),
+                }),
+            )
+            .path(dir.path())
+            .collect();
+        let expected = Some(format!(
+            "via {}",
+            Color::Fixed(202).bold().paint("⌘ v4.3.0-rc.1+ ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -167,11 +192,20 @@ mod tests {
         })
         .to_string();
         fill_config(&dir, haxerc_name, Some(&haxerc_content))?;
-        let actual = ModuleRenderer::new("haxe").cmd("haxe --version", Some(CommandOutput {
-            stdout: "4.3.0-rc.1+\n".to_owned(),
-            stderr: "".to_owned()
-        })).path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Fixed(202).bold().paint("⌘ v4.2.5 ")));
+        let actual = ModuleRenderer::new("haxe")
+            .cmd(
+                "haxe --version",
+                Some(CommandOutput {
+                    stdout: "4.3.0-rc.1+\n".to_owned(),
+                    stderr: "".to_owned(),
+                }),
+            )
+            .path(dir.path())
+            .collect();
+        let expected = Some(format!(
+            "via {}",
+            Color::Fixed(202).bold().paint("⌘ v4.2.5 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -188,11 +222,20 @@ mod tests {
         .to_string();
 
         fill_config(&dir, haxerc_name, Some(&haxerc_content))?;
-        let actual = ModuleRenderer::new("haxe").cmd("haxe --version", Some(CommandOutput {
-            stdout: "4.3.0-rc.1+\n".to_owned(),
-            stderr: "".to_owned()
-        })).path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Fixed(202).bold().paint("⌘ v779b005 ")));
+        let actual = ModuleRenderer::new("haxe")
+            .cmd(
+                "haxe --version",
+                Some(CommandOutput {
+                    stdout: "4.3.0-rc.1+\n".to_owned(),
+                    stderr: "".to_owned(),
+                }),
+            )
+            .path(dir.path())
+            .collect();
+        let expected = Some(format!(
+            "via {}",
+            Color::Fixed(202).bold().paint("⌘ v779b005 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -31,6 +31,7 @@ mod git_state;
 mod git_status;
 mod golang;
 mod haskell;
+mod haxe;
 mod helm;
 mod hg_branch;
 mod hostname;
@@ -125,6 +126,7 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
             "git_status" => git_status::module(context),
             "golang" => golang::module(context),
             "haskell" => haskell::module(context),
+            "haxe" => haxe::module(context),
             "helm" => helm::module(context),
             "hg_branch" => hg_branch::module(context),
             "hostname" => hostname::module(context),
@@ -230,6 +232,7 @@ pub fn description(module: &str) -> &'static str {
         "git_status" => "Symbol representing the state of the repo",
         "golang" => "The currently installed version of Golang",
         "haskell" => "The selected version of the Haskell toolchain",
+        "haxe" => "The currently installed version of Haxe",
         "helm" => "The currently installed version of Helm",
         "hg_branch" => "The active branch of the repo in your current directory",
         "hostname" => "The system hostname",


### PR DESCRIPTION
#### Description
This adds a [Haxe](https://www.haxe.org) module that will display currently installed / active Haxe version when in a directory that contains Haxe related files and folders, e.g. files ending with `.hx` or `.hxml`, or a folder named `.haxelib` or `haxe_libraries` or specific file names used in Haxe development environments.

module detects Haxe version either by looking at contents of `.haxerc` file (which implies use of [lix package manager](https://github.com/lix-pm/lix.client)) or by calling `haxe --version`.

#### Motivation and Context
As a developer working on Haxe projects you might have different Haxe versions installed on your system (like current release version and a nightly build) and you switch between them to e.g. test compatibility.

#### How Has This Been Tested?
This module is similar to e.g. nim module so I took that as a template. I rewrote and added test cases to reflect the differences of Haxe module. then I ran test cases to until all were green. I also ran a debug build during development in my local bash environment.
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
