### PR TITLE
feat(guix_shell): Initial implementation

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -625,7 +625,7 @@
         "disabled": false,
         "format": "via [$symbol]($style) ",
         "style": "yellow bold",
-        "symbol": " "
+        "symbol": "🐃 "
       },
       "allOf": [
         {
@@ -3062,7 +3062,7 @@
           "type": "string"
         },
         "symbol": {
-          "default": " ",
+          "default": "🐃 ",
           "type": "string"
         },
         "style": {

--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -620,6 +620,19 @@
         }
       ]
     },
+    "guix_shell": {
+      "default": {
+        "disabled": false,
+        "format": "via [$symbol]($style) ",
+        "style": "yellow bold",
+        "symbol": " "
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/GuixShellConfig"
+        }
+      ]
+    },
     "haskell": {
       "default": {
         "detect_extensions": [
@@ -3037,6 +3050,28 @@
           "items": {
             "type": "string"
           }
+        }
+      },
+      "additionalProperties": false
+    },
+    "GuixShellConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "via [$symbol]($style) ",
+          "type": "string"
+        },
+        "symbol": {
+          "default": " ",
+          "type": "string"
+        },
+        "style": {
+          "default": "yellow bold",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
         }
       },
       "additionalProperties": false

--- a/docs/.vuepress/public/presets/toml/bracketed-segments.toml
+++ b/docs/.vuepress/public/presets/toml/bracketed-segments.toml
@@ -58,6 +58,9 @@ format = '([\[$all_status$ahead_behind\]]($style))'
 [golang]
 format = '\[[$symbol($version)]($style)\]'
 
+[guix_shell]
+format = '\[[$symbol]($style)\]'
+
 [haskell]
 format = '\[[$symbol($version)]($style)\]'
 

--- a/docs/.vuepress/public/presets/toml/nerd-font-symbols.toml
+++ b/docs/.vuepress/public/presets/toml/nerd-font-symbols.toml
@@ -31,6 +31,9 @@ symbol = " "
 [golang]
 symbol = " "
 
+[guix_shell]
+symbol = " "
+
 [haskell]
 symbol = " "
 

--- a/docs/.vuepress/public/presets/toml/plain-text-symbols.toml
+++ b/docs/.vuepress/public/presets/toml/plain-text-symbols.toml
@@ -64,6 +64,9 @@ symbol = "git "
 [golang]
 symbol = "go "
 
+[guix_shell]
+symbol = "guix "
+
 [hg_branch]
 symbol = "hg "
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -264,6 +264,7 @@ $vlang\
 $vagrant\
 $zig\
 $buf\
+$guix_shell\
 $nix_shell\
 $conda\
 $spack\
@@ -2449,6 +2450,39 @@ By default the module will be shown if any of the following conditions are met:
 [nim]
 style = "yellow"
 symbol = "🎣 "
+```
+
+## Guix-shell
+
+The `guix_shell` module shows the [guix-shell](https://guix.gnu.org/manual/devel/en/html_node/Invoking-guix-shell.html) environment.
+The module will be shown when inside a guix-shell environment.
+
+### Options
+
+| Option     | Default                    | Description                                            |
+| ---------- | -------------------------- | ------------------------------------------------------ |
+| `format`   | `'via [$symbol]($style) '` | The format for the module.                             |
+| `symbol`   | `" "`                     | A format string representing the symbol of guix-shell. |
+| `style`    | `"yellow bold"`            | The style for the module.                              |
+| `disabled` | `false`                    | Disables the `guix_shell` module.                      |
+
+### Variables
+
+| Variable | Example | Description                          |
+| -------- | ------- | ------------------------------------ |
+| symbol   |         | Mirrors the value of option `symbol` |
+| style\*  |         | Mirrors the value of option `style`  |
+
+*: This variable can only be used as a part of a style string
+
+### Example
+
+```toml
+# ~/.config/starship.toml
+
+[guix_shell]
+disabled = true
+format = 'via [☃️ ](yellow bold) '
 ```
 
 ## Nix-shell

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -238,6 +238,7 @@ $elixir\
 $elm\
 $erlang\
 $golang\
+$guix_shell\
 $haskell\
 $helm\
 $java\
@@ -264,7 +265,6 @@ $vlang\
 $vagrant\
 $zig\
 $buf\
-$guix_shell\
 $nix_shell\
 $conda\
 $spack\
@@ -1826,6 +1826,39 @@ By default the module will be shown if any of the following conditions are met:
 format = "via [🏎💨 $version](bold cyan) "
 ```
 
+## Guix-shell
+
+The `guix_shell` module shows the [guix-shell](https://guix.gnu.org/manual/devel/en/html_node/Invoking-guix-shell.html) environment.
+The module will be shown when inside a guix-shell environment.
+
+### Options
+
+| Option     | Default                    | Description                                            |
+| ---------- | -------------------------- | ------------------------------------------------------ |
+| `format`   | `'via [$symbol]($style) '` | The format for the module.                             |
+| `symbol`   | `"🐃 "`                     | A format string representing the symbol of guix-shell. |
+| `style`    | `"yellow bold"`            | The style for the module.                              |
+| `disabled` | `false`                    | Disables the `guix_shell` module.                      |
+
+### Variables
+
+| Variable | Example | Description                          |
+| -------- | ------- | ------------------------------------ |
+| symbol   |         | Mirrors the value of option `symbol` |
+| style\*  |         | Mirrors the value of option `style`  |
+
+*: This variable can only be used as a part of a style string
+
+### Example
+
+```toml
+# ~/.config/starship.toml
+
+[guix_shell]
+disabled = true
+format = 'via [🐂](yellow bold) '
+```
+
 ## Haskell
 
 The `haskell` module finds the current selected GHC version and/or the selected Stack snapshot.
@@ -2450,39 +2483,6 @@ By default the module will be shown if any of the following conditions are met:
 [nim]
 style = "yellow"
 symbol = "🎣 "
-```
-
-## Guix-shell
-
-The `guix_shell` module shows the [guix-shell](https://guix.gnu.org/manual/devel/en/html_node/Invoking-guix-shell.html) environment.
-The module will be shown when inside a guix-shell environment.
-
-### Options
-
-| Option     | Default                    | Description                                            |
-| ---------- | -------------------------- | ------------------------------------------------------ |
-| `format`   | `'via [$symbol]($style) '` | The format for the module.                             |
-| `symbol`   | `"🐃 "`                     | A format string representing the symbol of guix-shell. |
-| `style`    | `"yellow bold"`            | The style for the module.                              |
-| `disabled` | `false`                    | Disables the `guix_shell` module.                      |
-
-### Variables
-
-| Variable | Example | Description                          |
-| -------- | ------- | ------------------------------------ |
-| symbol   |         | Mirrors the value of option `symbol` |
-| style\*  |         | Mirrors the value of option `style`  |
-
-*: This variable can only be used as a part of a style string
-
-### Example
-
-```toml
-# ~/.config/starship.toml
-
-[guix_shell]
-disabled = true
-format = 'via [🐂](yellow bold) '
 ```
 
 ## Nix-shell

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2462,7 +2462,7 @@ The module will be shown when inside a guix-shell environment.
 | Option     | Default                    | Description                                            |
 | ---------- | -------------------------- | ------------------------------------------------------ |
 | `format`   | `'via [$symbol]($style) '` | The format for the module.                             |
-| `symbol`   | `" "`                     | A format string representing the symbol of guix-shell. |
+| `symbol`   | `"🐃 "`                     | A format string representing the symbol of guix-shell. |
 | `style`    | `"yellow bold"`            | The style for the module.                              |
 | `disabled` | `false`                    | Disables the `guix_shell` module.                      |
 
@@ -2482,7 +2482,7 @@ The module will be shown when inside a guix-shell environment.
 
 [guix_shell]
 disabled = true
-format = 'via [☃️ ](yellow bold) '
+format = 'via [🐂](yellow bold) '
 ```
 
 ## Nix-shell

--- a/src/configs/guix_shell.rs
+++ b/src/configs/guix_shell.rs
@@ -14,14 +14,11 @@ pub struct GuixShellConfig<'a> {
     pub disabled: bool,
 }
 
-/* The trailing double spaces in `symbol` are needed to work around issues with
-multiwidth emoji support in some shells. Please do not file a PR to change this
-unless you can show that your changes do not affect this workaround.  */
 impl<'a> Default for GuixShellConfig<'a> {
     fn default() -> Self {
         GuixShellConfig {
             format: "via [$symbol]($style) ",
-            symbol: " ",
+            symbol: "🐃 ",
             style: "yellow bold",
             disabled: false,
         }

--- a/src/configs/guix_shell.rs
+++ b/src/configs/guix_shell.rs
@@ -1,0 +1,29 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(
+    feature = "config-schema",
+    derive(schemars::JsonSchema),
+    schemars(deny_unknown_fields)
+)]
+#[serde(default)]
+pub struct GuixShellConfig<'a> {
+    pub format: &'a str,
+    pub symbol: &'a str,
+    pub style: &'a str,
+    pub disabled: bool,
+}
+
+/* The trailing double spaces in `symbol` are needed to work around issues with
+multiwidth emoji support in some shells. Please do not file a PR to change this
+unless you can show that your changes do not affect this workaround.  */
+impl<'a> Default for GuixShellConfig<'a> {
+    fn default() -> Self {
+        GuixShellConfig {
+            format: "via [$symbol]($style) ",
+            symbol: " ",
+            style: "yellow bold",
+            disabled: false,
+        }
+    }
+}

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -33,6 +33,7 @@ pub mod git_metrics;
 pub mod git_state;
 pub mod git_status;
 pub mod go;
+pub mod guix_shell;
 pub mod haskell;
 pub mod helm;
 pub mod hg_branch;
@@ -158,6 +159,8 @@ pub struct FullConfig<'a> {
     git_status: git_status::GitStatusConfig<'a>,
     #[serde(borrow)]
     golang: go::GoConfig<'a>,
+    #[serde(borrow)]
+    guix_shell: guix_shell::GuixShellConfig<'a>,
     #[serde(borrow)]
     haskell: haskell::HaskellConfig<'a>,
     #[serde(borrow)]

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -79,6 +79,7 @@ pub const PROMPT_ORDER: &[&str] = &[
     "zig",
     // ↑ Toolchain version modules ↑
     "buf",
+    "guix_shell",
     "nix_shell",
     "conda",
     "spack",

--- a/src/module.rs
+++ b/src/module.rs
@@ -41,6 +41,7 @@ pub const ALL_MODULES: &[&str] = &[
     "git_state",
     "git_status",
     "golang",
+    "guix_shell",
     "haskell",
     "helm",
     "hg_branch",

--- a/src/modules/guix_shell.rs
+++ b/src/modules/guix_shell.rs
@@ -62,7 +62,7 @@ mod tests {
                 "/gnu/store/7vmfs4khf4fllsh83kqkxssbw3437qsh-profile",
             )
             .collect();
-        let expected = Some(format!("via {} ", Color::Yellow.bold().paint(" ")));
+        let expected = Some(format!("via {} ", Color::Yellow.bold().paint("🐃 ")));
 
         assert_eq!(expected, actual);
     }

--- a/src/modules/guix_shell.rs
+++ b/src/modules/guix_shell.rs
@@ -1,0 +1,69 @@
+use super::{Context, Module, ModuleConfig};
+
+use crate::configs::guix_shell::GuixShellConfig;
+use crate::formatter::StringFormatter;
+
+/// Creates a module showing if inside a guix-shell
+///
+/// The module will use the `$GUIX_ENVIRONMENT` environment variable to determine if it's
+/// inside a guix-shell and the name of it.
+pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let mut module = context.new_module("guix_shell");
+    let config: GuixShellConfig = GuixShellConfig::try_load(module.config);
+
+    let is_guix_shell = context.get_env("GUIX_ENVIRONMENT").is_some();
+
+    if !is_guix_shell {
+        return None;
+    };
+
+    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
+        formatter
+            .map_meta(|variable, _| match variable {
+                "symbol" => Some(config.symbol),
+                _ => None,
+            })
+            .map_style(|variable| match variable {
+                "style" => Some(Ok(config.style)),
+                _ => None,
+            })
+            .parse(None, Some(context))
+    });
+
+    module.set_segments(match parsed {
+        Ok(segments) => segments,
+        Err(error) => {
+            log::warn!("Error in module `guix_shell`:\n{}", error);
+            return None;
+        }
+    });
+
+    Some(module)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::ModuleRenderer;
+    use nu_ansi_term::Color;
+
+    #[test]
+    fn no_env_variables() {
+        let actual = ModuleRenderer::new("guix_shell").collect();
+        let expected = None;
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn env_variables() {
+        let actual = ModuleRenderer::new("guix_shell")
+            .env(
+                "GUIX_ENVIRONMENT",
+                "/gnu/store/7vmfs4khf4fllsh83kqkxssbw3437qsh-profile",
+            )
+            .collect();
+        let expected = Some(format!("via {} ", Color::Yellow.bold().paint(" ")));
+
+        assert_eq!(expected, actual);
+    }
+}

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -30,6 +30,7 @@ mod git_metrics;
 mod git_state;
 mod git_status;
 mod golang;
+mod guix_shell;
 mod haskell;
 mod helm;
 mod hg_branch;
@@ -124,6 +125,7 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
             "git_state" => git_state::module(context),
             "git_status" => git_status::module(context),
             "golang" => golang::module(context),
+            "guix_shell" => guix_shell::module(context),
             "haskell" => haskell::module(context),
             "helm" => helm::module(context),
             "hg_branch" => hg_branch::module(context),
@@ -229,6 +231,7 @@ pub fn description(module: &str) -> &'static str {
         "git_state" => "The current git operation, and it's progress",
         "git_status" => "Symbol representing the state of the repo",
         "golang" => "The currently installed version of Golang",
+        "guix_shell" => "The guix-shell environment",
         "haskell" => "The selected version of the Haskell toolchain",
         "helm" => "The currently installed version of Helm",
         "hg_branch" => "The active branch of the repo in your current directory",


### PR DESCRIPTION
#### Description
Added guix_shell module to display a symbol when a guix shell is active.

#### Motivation and Context
It makes it a lot easier to see if a current guix shell is active. Additionally, the feature is requested in #3999 

Closes #3999

#### Screenshot
![guix_shell](https://user-images.githubusercontent.com/50531499/191858342-48425b16-a56a-40f7-b28d-0482027357bb.png)

#### How Has This Been Tested?
- [x] I have tested with `cargo test guix_shell`
- [x] I have tested with `starship module guix_shell` without an active guix shell environment
- [x] I have tested with `starship module guix_shell` with an active guix shell environment

- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly (only english).
- [x] I have updated the tests accordingly.

#### Additional discussion:
As seen in the screenshot the icon does not represent the Guix logo. However, this is the icon I get when I copy the icon from the [Nerd fonts cheat sheet](https://www.nerdfonts.com/cheat-sheet) (search for guix). The icon does not seem to exist in v2.2.2, at least not in Victor Mono (the font I use).
