### PR TITLE
perf(directory): Skip repo resolution if unused by directory config

### DIFF
--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -52,7 +52,11 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
     // Attempt repository path contraction (if we are in a git repository)
     // Otherwise use the logical path, automatically contracting
-    let repo = context.get_repo().ok();
+    let repo = if config.truncate_to_repo || config.repo_root_style.is_some() {
+        context.get_repo().ok()
+    } else {
+        None
+    };
     let dir_string = if config.truncate_to_repo {
         repo.and_then(|r| r.workdir.as_ref())
             .filter(|&root| root != &home_dir)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
The `[directory]` config values for either `truncate_to_repo` or `repo_root_style` are evaluated before attempting to get the git repo for a given directory. 

This change solves the performance issues with traversing large directories (particularly NFSs), when you've explicitly opted out of git status based formatting on the path.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change stems from my discussion here https://github.com/starship/starship/discussions/4363 as well as the https://github.com/starship/starship/issues/4352#issuecomment-1245312472 in the feature request for disabling modules for specific directors. #1891 is also similar, WRT performance issues on network drives.

#### Screenshots (if appropriate):
n/a

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
Existing tests and documentation are still valid and should not require a change.
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
