### PR TITLE
feat(aws): add customizable `expiration_keyname`

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -10,6 +10,7 @@
     "aws": {
       "default": {
         "disabled": false,
+        "expiration_keyname": "expiration",
         "expiration_symbol": "X",
         "force_display": false,
         "format": "on [$symbol($profile )(\\($region\\) )(\\[$duration\\] )]($style)",
@@ -1614,6 +1615,11 @@
           "description": "If true displays info even if `credentials`, `credential_process` or `sso_start_url` have not been setup.",
           "default": false,
           "type": "boolean"
+        },
+        "expiration_keyname": {
+          "description": "Allows customized expiration key name like `x_security_token_expires`",
+          "default": "expiration",
+          "type": "string"
         }
       },
       "additionalProperties": false

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -331,7 +331,7 @@ date is read from the `AWSUME_EXPIRATION` env var.
 | Option               | Default                                                           | Description                                                                                                 |
 | -------------------  | ----------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
 | `format`             | `'on [$symbol($profile )(\($region\) )(\[$duration\] )]($style)'` | The format for the module.                                                                                  |
-| `symbol`             | `"☁️ "`                                                            | The symbol used before displaying the current AWS profile.                                                  |
+| `symbol`             | `"☁️ "`                                                           | The symbol used before displaying the current AWS profile.                                                  |
 | `region_aliases`     |                                                                   | Table of region aliases to display in addition to the AWS name.                                             |
 | `profile_aliases`    |                                                                   | Table of profile aliases to display in addition to the AWS name.                                            |
 | `style`              | `"bold yellow"`                                                   | The style for the module.                                                                                   |

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -328,16 +328,17 @@ date is read from the `AWSUME_EXPIRATION` env var.
 
 ### Options
 
-| Option              | Default                                                           | Description                                                                                                 |
-| ------------------- | ----------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| `format`            | `'on [$symbol($profile )(\($region\) )(\[$duration\] )]($style)'` | The format for the module.                                                                                  |
-| `symbol`            | `"☁️ "`                                                           | The symbol used before displaying the current AWS profile.                                                  |
-| `region_aliases`    |                                                                   | Table of region aliases to display in addition to the AWS name.                                             |
-| `profile_aliases`   |                                                                   | Table of profile aliases to display in addition to the AWS name.                                            |
-| `style`             | `"bold yellow"`                                                   | The style for the module.                                                                                   |
-| `expiration_symbol` | `X`                                                               | The symbol displayed when the temporary credentials have expired.                                           |
-| `disabled`          | `false`                                                           | Disables the `AWS` module.                                                                                  |
-| `force_display`     | `false`                                                           | If `true` displays info even if `credentials`, `credential_process` or `sso_start_url` have not been setup. |
+| Option               | Default                                                           | Description                                                                                                 |
+| -------------------  | ----------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `format`             | `'on [$symbol($profile )(\($region\) )(\[$duration\] )]($style)'` | The format for the module.                                                                                  |
+| `symbol`             | `"☁️ "`                                                            | The symbol used before displaying the current AWS profile.                                                  |
+| `region_aliases`     |                                                                   | Table of region aliases to display in addition to the AWS name.                                             |
+| `profile_aliases`    |                                                                   | Table of profile aliases to display in addition to the AWS name.                                            |
+| `style`              | `"bold yellow"`                                                   | The style for the module.                                                                                   |
+| `expiration_symbol`  | `X`                                                               | The symbol displayed when the temporary credentials have expired.                                           |
+| `disabled`           | `false`                                                           | Disables the `AWS` module.                                                                                  |
+| `force_display`      | `false`                                                           | If `true` displays info even if `credentials`, `credential_process` or `sso_start_url` have not been setup. |
+| `expiration_keyname` | `expiration`                                                      | The expiration key name in `~/.aws/credentials`.                                                            |
 
 ### Variables
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -329,7 +329,7 @@ date is read from the `AWSUME_EXPIRATION` env var.
 ### Options
 
 | Option               | Default                                                           | Description                                                                                                 |
-| -------------------  | ----------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| -------------------- | ----------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
 | `format`             | `'on [$symbol($profile )(\($region\) )(\[$duration\] )]($style)'` | The format for the module.                                                                                  |
 | `symbol`             | `"☁️ "`                                                           | The symbol used before displaying the current AWS profile.                                                  |
 | `region_aliases`     |                                                                   | Table of region aliases to display in addition to the AWS name.                                             |

--- a/src/configs/aws.rs
+++ b/src/configs/aws.rs
@@ -43,6 +43,8 @@ pub struct AwsConfig<'a> {
     pub expiration_symbol: &'a str,
     /// If true displays info even if `credentials`, `credential_process` or `sso_start_url` have not been setup.
     pub force_display: bool,
+    /// Allows customized expiration key name like `x_security_token_expires`
+    pub expiration_keyname: &'a str,
 }
 
 impl<'a> Default for AwsConfig<'a> {
@@ -56,6 +58,7 @@ impl<'a> Default for AwsConfig<'a> {
             profile_aliases: HashMap::new(),
             expiration_symbol: "X",
             force_display: false,
+            expiration_keyname: "expiration",
         }
     }
 }

--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -969,6 +969,7 @@ sso_role_name = <AWS-ROLE-NAME>
         let dir = tempfile::tempdir()?;
         let config_path = dir.path().join("config");
         let mut file = File::create(&config_path)?;
+        let symbol = "!!!";
 
         file.write_all(
             "[default]
@@ -987,12 +988,17 @@ x_security_token_expires = 2022-09-28T15:12:38+08:00
                 [aws]
                 // format = "on [$symbol$region] [$duration] ($style) "
                 format = "on [$symbol$region]($style) ($duration)"
-                expiration_symbol = "❌"
+                expiration_symbol = symbol
                 expiration_keyname = "x_security_token_expires"
-                force_display = true
             })
             .collect();
-        let expected = Some(format!("on {} ❌", Color::Yellow.bold().paint("☁️  ")));
+        // let expected = Some(format!("on {} ", Color::Yellow.bold().paint("☁️  ")));
+        let expected = Some(format!(
+            "on {}",
+            Color::Yellow
+                .bold()
+                .paint(format!("☁️  default (ap-northeast-2) [{}] ", symbol))
+        ));
 
         assert_eq!(expected, actual);
         dir.close()

--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -973,6 +973,8 @@ sso_role_name = <AWS-ROLE-NAME>
         file.write_all(
             "[default]
 region = ap-northeast-2
+aws_access_key_id=dummy
+aws_secret_access_key=dummy
 x_security_token_expires = 2022-09-28T15:12:38+08:00
 "
             .as_bytes(),
@@ -980,6 +982,7 @@ x_security_token_expires = 2022-09-28T15:12:38+08:00
 
         let actual = ModuleRenderer::new("aws")
             .env("AWS_CONFIG_FILE", config_path.to_string_lossy().as_ref())
+            .env("AWS_PROFILE", "default")
             .config(toml::toml! {
                 [aws]
                 // format = "on [$symbol$region] [$duration] ($style) "
@@ -991,7 +994,7 @@ x_security_token_expires = 2022-09-28T15:12:38+08:00
             .collect();
         let expected = Some(format!(
             "on {} ❌",
-            Color::Yellow.bold().paint("☁️  ap-northeast-2")
+            Color::Yellow.bold().paint("☁️  ")
         ));
 
         assert_eq!(expected, actual);

--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -992,10 +992,7 @@ x_security_token_expires = 2022-09-28T15:12:38+08:00
                 force_display = true
             })
             .collect();
-        let expected = Some(format!(
-            "on {} ❌",
-            Color::Yellow.bold().paint("☁️  ")
-        ));
+        let expected = Some(format!("on {} ❌", Color::Yellow.bold().paint("☁️  ")));
 
         assert_eq!(expected, actual);
         dir.close()

--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -997,5 +997,4 @@ x_security_token_expires = 2022-09-28T15:12:38+08:00
         assert_eq!(expected, actual);
         dir.close()
     }
-
 }


### PR DESCRIPTION
#### Description
For third party login solution like [saml2aws](https://github.com/Versent/saml2aws/blob/master/README.md#advanced-configuration-multiple-aws-account-access-but-saml-authenticate-against-a-single-sso-aws-account). It uses `x_security_token_expires` as the key name.

#### Motivation and Context
As description.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
