### PR TITLE
docs(java): Fix typo in file detection list

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1952,21 +1952,21 @@ disabled = false
 The `java` module shows the currently installed version of [Java](https://www.oracle.com/java/).
 By default the module will be shown if any of the following conditions are met:
 
-- The current directory contains a `pom.xml`, `build.gradle.kts`, `build.sbt`, `.java-version`, `.deps.edn`, `project.clj`, or `build.boot` file
+- The current directory contains a `pom.xml`, `build.gradle.kts`, `build.sbt`, `.java-version`, `deps.edn`, `project.clj`, or `build.boot` file
 - The current directory contains a file with the `.java`, `.class`, `.gradle`, `.jar`, `.clj`, or `.cljc` extension
 
 ### Options
 
-| Option              | Default                                                                                                   | Description                                                               |
-| ------------------- | --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| `format`            | `"via [${symbol}(${version} )]($style)"`                                                                  | The format for the module.                                                |
-| `version_format`    | `"v${raw}"`                                                                                               | The version format. Available vars are `raw`, `major`, `minor`, & `patch` |
-| `detect_extensions` | `["java", "class", "gradle", "jar", "cljs", "cljc"]`                                                      | Which extensions should trigger this module.                              |
-| `detect_files`      | `["pom.xml", "build.gradle.kts", "build.sbt", ".java-version", ".deps.edn", "project.clj", "build.boot"]` | Which filenames should trigger this module.                               |
-| `detect_folders`    | `[]`                                                                                                      | Which folders should trigger this modules.                                |
-| `symbol`            | `"☕ "`                                                                                                    | A format string representing the symbol of Java                           |
-| `style`             | `"red dimmed"`                                                                                            | The style for the module.                                                 |
-| `disabled`          | `false`                                                                                                   | Disables the `java` module.                                               |
+| Option              | Default                                                                                                  | Description                                                               |
+| ------------------- | -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `format`            | `"via [${symbol}(${version} )]($style)"`                                                                 | The format for the module.                                                |
+| `version_format`    | `"v${raw}"`                                                                                              | The version format. Available vars are `raw`, `major`, `minor`, & `patch` |
+| `detect_extensions` | `["java", "class", "gradle", "jar", "cljs", "cljc"]`                                                     | Which extensions should trigger this module.                              |
+| `detect_files`      | `["pom.xml", "build.gradle.kts", "build.sbt", ".java-version", "deps.edn", "project.clj", "build.boot"]` | Which filenames should trigger this module.                               |
+| `detect_folders`    | `[]`                                                                                                     | Which folders should trigger this modules.                                |
+| `symbol`            | `"☕ "`                                                                                                   | A format string representing the symbol of Java                           |
+| `style`             | `"red dimmed"`                                                                                           | The style for the module.                                                 |
+| `disabled`          | `false`                                                                                                  | Disables the `java` module.                                               |
 
 ### Variables
 


### PR DESCRIPTION
The Clojure tools.deps build file is called `deps.edn`, not `.deps.edn` (with a dot at the beginning). The Starship code itself looks for the correct file name, the typo is only in the docs.

#### Description
I replaced `.deps.edn` with `deps.edn` in the `docs/config/README.md` file. I did NOT replace it in any of the translated files, since, if I understand https://github.com/starship/starship/blob/d93074d0569db4bafb1788aa3f39136b734b5370/CONTRIBUTING.md#crowdin-translated-pages correctly, that could cause merge problems.

If you need someone to update the Crowdin files after this is merged, I can do that.

#### Motivation and Context
This fixes a minor, but slightly confusing, typo in the Java identification docs.

#### How Has This Been Tested?
This has not been tested, but I'm not sure tests are warranted in this case.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
