### PR TITLE
Fix indent and use println instead of print (`starship init {shellname}`)

### DIFF
--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -101,7 +101,7 @@ pub fn init_stub(shell_name: &str) -> io::Result<()> {
     let starship = StarshipPath::init()?;
 
     match shell_basename {
-        "bash" => println!(
+        "bash" => print!(
             /*
              * The standard bash bootstrap is:
              *      `source <(starship init bash --print-full-init)`

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -149,36 +149,36 @@ unset -f __main
             "#,
             starship.sprint_posix()?
         ),
-        "zsh" => println!(
+        "zsh" => print!(
             r#"source <({} init zsh --print-full-init)"#,
             starship.sprint_posix()?
         ),
-        "fish" => println!(
+        "fish" => print!(
             // Fish does process substitution with pipes and psub instead of bash syntax
             r#"source ({} init fish --print-full-init | psub)"#,
             starship.sprint_posix()?
         ),
-        "powershell" => println!(
+        "powershell" => print!(
             r#"Invoke-Expression (& {} init powershell --print-full-init | Out-String)"#,
             starship.sprint_pwsh()?
         ),
-        "ion" => println!("eval $({} init ion --print-full-init)", starship.sprint()?),
+        "ion" => print!("eval $({} init ion --print-full-init)", starship.sprint()?),
         "elvish" => print!(
             r#"eval ({} init elvish --print-full-init | slurp)"#,
             starship.sprint_posix()?
         ),
-        "tcsh" => println!(
+        "tcsh" => print!(
             r#"eval `({} init tcsh --print-full-init)`"#,
             starship.sprint_posix()?
         ),
         "nu" => print_script(NU_INIT, &StarshipPath::init()?.sprint()?),
-        "xonsh" => println!(
+        "xonsh" => print!(
             r#"execx($({} init xonsh --print-full-init))"#,
             starship.sprint_posix()?
         ),
         "cmd" => print_script(CMDEXE_INIT, &StarshipPath::init()?.sprint_cmdexe()?),
         _ => {
-            eprintln!(
+            eprint!(
                 "{0} is not yet supported by starship.\n\
                  For the time being, we support the following shells:\n\
                  * bash\n\

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -178,7 +178,7 @@ unset -f __main
         ),
         "cmd" => print_script(CMDEXE_INIT, &StarshipPath::init()?.sprint_cmdexe()?),
         _ => {
-            eprint!(
+            eprintln!(
                 "{0} is not yet supported by starship.\n\
                  For the time being, we support the following shells:\n\
                  * bash\n\

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -229,7 +229,7 @@ pub fn init_main(shell_name: &str) -> io::Result<()> {
 
 fn print_script(script: &str, path: &str) {
     let script = script.replace("::STARSHIP::", path);
-    println!("{}", script);
+    print!("{}", script);
 }
 
 /* GENERAL INIT SCRIPT NOTES

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -101,7 +101,7 @@ pub fn init_stub(shell_name: &str) -> io::Result<()> {
     let starship = StarshipPath::init()?;
 
     match shell_basename {
-        "bash" => print!(
+        "bash" => println!(
             /*
              * The standard bash bootstrap is:
              *      `source <(starship init bash --print-full-init)`
@@ -134,45 +134,45 @@ pub fn init_stub(shell_name: &str) -> io::Result<()> {
              * https://github.com/starship/starship/pull/278
              */
             r#"
-            __main() {{
-                local major="${{BASH_VERSINFO[0]}}"
-                local minor="${{BASH_VERSINFO[1]}}"
+__main() {{
+    local major="${{BASH_VERSINFO[0]}}"
+    local minor="${{BASH_VERSINFO[1]}}"
 
-                if ((major > 4)) || {{ ((major == 4)) && ((minor >= 1)); }}; then
-                    source <({0} init bash --print-full-init)
-                else
-                    source /dev/stdin <<<"$({0} init bash --print-full-init)"
-                fi
-            }}
-            __main
-            unset -f __main
+    if ((major > 4)) || {{ ((major == 4)) && ((minor >= 1)); }}; then
+        source <({0} init bash --print-full-init)
+    else
+        source /dev/stdin <<<"$({0} init bash --print-full-init)"
+    fi
+}}
+__main
+unset -f __main
             "#,
             starship.sprint_posix()?
         ),
-        "zsh" => print!(
+        "zsh" => println!(
             r#"source <({} init zsh --print-full-init)"#,
             starship.sprint_posix()?
         ),
-        "fish" => print!(
+        "fish" => println!(
             // Fish does process substitution with pipes and psub instead of bash syntax
             r#"source ({} init fish --print-full-init | psub)"#,
             starship.sprint_posix()?
         ),
-        "powershell" => print!(
+        "powershell" => println!(
             r#"Invoke-Expression (& {} init powershell --print-full-init | Out-String)"#,
             starship.sprint_pwsh()?
         ),
-        "ion" => print!("eval $({} init ion --print-full-init)", starship.sprint()?),
+        "ion" => println!("eval $({} init ion --print-full-init)", starship.sprint()?),
         "elvish" => print!(
             r#"eval ({} init elvish --print-full-init | slurp)"#,
             starship.sprint_posix()?
         ),
-        "tcsh" => print!(
+        "tcsh" => println!(
             r#"eval `({} init tcsh --print-full-init)`"#,
             starship.sprint_posix()?
         ),
         "nu" => print_script(NU_INIT, &StarshipPath::init()?.sprint()?),
-        "xonsh" => print!(
+        "xonsh" => println!(
             r#"execx($({} init xonsh --print-full-init))"#,
             starship.sprint_posix()?
         ),
@@ -229,7 +229,7 @@ pub fn init_main(shell_name: &str) -> io::Result<()> {
 
 fn print_script(script: &str, path: &str) {
     let script = script.replace("::STARSHIP::", path);
-    print!("{}", script);
+    println!("{}", script);
 }
 
 /* GENERAL INIT SCRIPT NOTES


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
- Use `println!` instead of  `print!` in `src/init/mod.rs` to add a line break properly.
- Remove indents of bash script to show the code properly. (indoc crate seems great to use in this case though)

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

1. First, the script printed by `starship init bash` is indented, which is not necessary.

![2022-10-02_05-27_1](https://user-images.githubusercontent.com/61998590/193427257-43566a58-2310-41d5-89d0-55bfbdde854a.png)

2. Second, every script printed by `starship init {shellname}` does not have new line character at the end of it, which makes the next shell prompt appear without a line break.

![2022-10-02_05-27](https://user-images.githubusercontent.com/61998590/193427282-a1cd5984-dcf3-4908-95f4-d5a6dc92aeae.png)

Note that the line break issue appears differently according to the terminal emulator we use: For example, alacritty shows this issue, while wezterm does not.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
