### PR TITLE
feat: allow loading configuration values from the environment

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -44,6 +44,29 @@ Or for Cmd (Windows) would be adding this line to your `starship.lua`:
 os.setenv('STARSHIP_CONFIG', 'C:\\Users\\user\\example\\non\\default\\path\\starship.toml')
 ```
 
+### Loading additional configuration from the environment
+
+In addition to the configuration file, starship also allows you to set configuration values by using environment variables. The variables should be formatted like this: `STARSHIP_CONFIG__SECTION_NAME__KEY=value`. The configuration keys in the environment need to start with `STARSHIP_CONFIG__` and table keys need to be separated with `__`.
+
+In most POSIX-like shells, you can set the `disabled` key of the `status` module to `false` with the following:
+
+```sh
+export STARSHIP_CONFIG__STATUS__DISABLED=false
+```
+
+Equivalently in PowerShell (Windows) would be adding this line:
+
+```powershell
+$ENV:STARSHIP_CONFIG__STATUS__DISABLED = "false"
+```
+
+Other shells may use a different syntax to set environment variables.
+Any values set in the environment will be parsed as TOML-values, not as full documents. If the environment values cannot be directly parsed as TOML-values, they are treated as strings.
+
+This means that `true` is parsed as a boolean when it's not quoted, but is parsed as a string when it is quoted. In contrast, when a value that cannot be parsed as a TOML value, such as `starship` is found, it is treated as a string (`"starship"`).
+
+Because the values are TOML-values the `[table]` syntax will not work, but inline tables `{ a = 1 }` or arrays `[ 0, 1 ]`.
+
 ### Logging
 
 By default starship logs warnings and errors into a file named `~/.cache/starship/session_${STARSHIP_SESSION_KEY}.log`, where the session key is corresponding to an instance of your terminal.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR allows overwriting individual config keys with config keys like `STARSHIP_CONFIG__STATUS__DISABLED=false`. The code is very similar to the `starship config` sub-command. This allows making smaller overrides to the configuration without needing to create duplicate config files.
~~`toml_edit` is used for parsing the values, because `toml` does not support this, but it looks like both `toml` and `toml_edit` will use the same value types soon.~~ `toml` is used for parsing values now.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related #4352
Closes #4808

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
