### PR TITLE
feat: Open Policy Agent module (#1740)

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -967,6 +967,25 @@
         }
       ]
     },
+    "opa": {
+      "default": {
+        "detect_extensions": [
+          "rego"
+        ],
+        "detect_files": [],
+        "detect_folders": [],
+        "disabled": false,
+        "format": "via [$symbol($version )]($style)",
+        "style": "bold blue",
+        "symbol": "🪖 ",
+        "version_format": "v${raw}"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/OpaConfig"
+        }
+      ]
+    },
     "openstack": {
       "default": {
         "disabled": false,
@@ -3809,6 +3828,55 @@
             "_opam",
             "esy.lock"
           ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "OpaConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "via [$symbol($version )]($style)",
+          "type": "string"
+        },
+        "version_format": {
+          "default": "v${raw}",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "🪖 ",
+          "type": "string"
+        },
+        "style": {
+          "default": "bold blue",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "detect_extensions": {
+          "default": [
+            "rego"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_files": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_folders": {
+          "default": [],
           "type": "array",
           "items": {
             "type": "string"

--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -977,7 +977,7 @@
         "disabled": false,
         "format": "via [$symbol($version )]($style)",
         "style": "bold blue",
-        "symbol": "🪖 ",
+        "symbol": "🪖  ",
         "version_format": "v${raw}"
       },
       "allOf": [
@@ -3848,7 +3848,7 @@
           "type": "string"
         },
         "symbol": {
-          "default": "🪖 ",
+          "default": "🪖  ",
           "type": "string"
         },
         "style": {

--- a/docs/.vuepress/public/presets/toml/bracketed-segments.toml
+++ b/docs/.vuepress/public/presets/toml/bracketed-segments.toml
@@ -97,6 +97,9 @@ format = '\[[$symbol($version)]($style)\]'
 [ocaml]
 format = '\[[$symbol($version)(\($switch_indicator$switch_name\))]($style)\]'
 
+[opa]
+format = '\[[$symbol($version)]($style)\]'
+
 [openstack]
 format = '\[[$symbol$cloud(\($project\))]($style)\]'
 

--- a/docs/.vuepress/public/presets/toml/no-runtime-versions.toml
+++ b/docs/.vuepress/public/presets/toml/no-runtime-versions.toml
@@ -58,6 +58,9 @@ format = 'via [$symbol]($style)'
 [ocaml]
 format = 'via [$symbol(\($switch_indicator$switch_name\) )]($style)'
 
+[opa]
+format = 'via [$symbol]($style)'
+
 [perl]
 format = 'via [$symbol]($style)'
 

--- a/docs/.vuepress/public/presets/toml/plain-text-symbols.toml
+++ b/docs/.vuepress/public/presets/toml/plain-text-symbols.toml
@@ -94,6 +94,9 @@ symbol = "nix "
 [ocaml]
 symbol = "ml "
 
+[opa]
+symbol = "opa "
+
 [package]
 symbol = "pkg "
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -259,6 +259,7 @@ $lua\
 $nim\
 $nodejs\
 $ocaml\
+$opa\
 $perl\
 $php\
 $pulumi\
@@ -2594,6 +2595,44 @@ By default the module will be shown if any of the following conditions are met:
 [ocaml]
 format = "via [🐪 $version]($style) "
 ```
+
+## Open Policy Agent
+
+The `opa` module shows the currently installed version of the OPA tool.
+By default the module will be shown if the current directory contains a `.rego` file.
+
+### Options
+
+| Option              | Default                              | Description                                                               |
+| ------------------- | ------------------------------------ | ------------------------------------------------------------------------- |
+| `format`            | `"via [$symbol($version )]($style)"` | The format for the module.                                                |
+| `version_format`    | `"v${raw}"`                          | The version format. Available vars are `raw`, `major`, `minor`, & `patch` |
+| `symbol`            | `"🪖 "`                               | A format string representing the symbol of OPA.                       |
+| `detect_extensions` | `["ropa"]`                                 | Which extensions should trigger this module.                              |
+| `detect_files`      | `[]`       | Which filenames should trigger this module.                               |
+| `detect_folders`    | `[]`                                 | Which folders should trigger this module.                                 |
+| `style`             | `"bold blue"`                         | The style for the module.                                                 |
+| `disabled`          | `false`                              | Disables the `opa` module.                                                |
+
+### Variables
+
+| Variable | Example  | Description                          |
+| -------- | -------- | ------------------------------------ |
+| version  | `v0.44.0` | The version of `opa`                 |
+| symbol   |          | Mirrors the value of option `symbol` |
+| style\*  |          | Mirrors the value of option `style`  |
+
+*: This variable can only be used as a part of a style string
+
+### Example
+
+```toml
+# ~/.config/starship.toml
+
+[bun]
+format = "via [⛑️ $version](bold red) "
+```
+
 
 ## OpenStack
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2608,7 +2608,7 @@ By default the module will be shown if the current directory contains a `.rego` 
 | `format`            | `"via [$symbol($version )]($style)"` | The format for the module.                                                |
 | `version_format`    | `"v${raw}"`                          | The version format. Available vars are `raw`, `major`, `minor`, & `patch` |
 | `symbol`            | `"🪖 "`                               | A format string representing the symbol of OPA.                           |
-| `detect_extensions` | `["ropa"]`                           | Which extensions should trigger this module.                              |
+| `detect_extensions` | `["rego"]`                           | Which extensions should trigger this module.                              |
 | `detect_files`      | `[]`                                 | Which filenames should trigger this module.                               |
 | `detect_folders`    | `[]`                                 | Which folders should trigger this module.                                 |
 | `style`             | `"bold blue"`                        | The style for the module.                                                 |

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2607,7 +2607,7 @@ By default the module will be shown if the current directory contains a `.rego` 
 | ------------------- | ------------------------------------ | ------------------------------------------------------------------------- |
 | `format`            | `"via [$symbol($version )]($style)"` | The format for the module.                                                |
 | `version_format`    | `"v${raw}"`                          | The version format. Available vars are `raw`, `major`, `minor`, & `patch` |
-| `symbol`            | `"🪖 "`                               | A format string representing the symbol of OPA.                           |
+| `symbol`            | `"🪖  "`                              | A format string representing the symbol of OPA.                           |
 | `detect_extensions` | `["rego"]`                           | Which extensions should trigger this module.                              |
 | `detect_files`      | `[]`                                 | Which filenames should trigger this module.                               |
 | `detect_folders`    | `[]`                                 | Which folders should trigger this module.                                 |
@@ -2629,8 +2629,8 @@ By default the module will be shown if the current directory contains a `.rego` 
 ```toml
 # ~/.config/starship.toml
 
-[bun]
-format = "via [⛑️ $version](bold red) "
+[opa]
+format = "via [⛑️  $version](bold red) "
 ```
 
 ## OpenStack

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2607,20 +2607,20 @@ By default the module will be shown if the current directory contains a `.rego` 
 | ------------------- | ------------------------------------ | ------------------------------------------------------------------------- |
 | `format`            | `"via [$symbol($version )]($style)"` | The format for the module.                                                |
 | `version_format`    | `"v${raw}"`                          | The version format. Available vars are `raw`, `major`, `minor`, & `patch` |
-| `symbol`            | `"🪖 "`                               | A format string representing the symbol of OPA.                       |
-| `detect_extensions` | `["ropa"]`                                 | Which extensions should trigger this module.                              |
-| `detect_files`      | `[]`       | Which filenames should trigger this module.                               |
+| `symbol`            | `"🪖 "`                               | A format string representing the symbol of OPA.                           |
+| `detect_extensions` | `["ropa"]`                           | Which extensions should trigger this module.                              |
+| `detect_files`      | `[]`                                 | Which filenames should trigger this module.                               |
 | `detect_folders`    | `[]`                                 | Which folders should trigger this module.                                 |
-| `style`             | `"bold blue"`                         | The style for the module.                                                 |
+| `style`             | `"bold blue"`                        | The style for the module.                                                 |
 | `disabled`          | `false`                              | Disables the `opa` module.                                                |
 
 ### Variables
 
-| Variable | Example  | Description                          |
-| -------- | -------- | ------------------------------------ |
+| Variable | Example   | Description                          |
+| -------- | --------- | ------------------------------------ |
 | version  | `v0.44.0` | The version of `opa`                 |
-| symbol   |          | Mirrors the value of option `symbol` |
-| style\*  |          | Mirrors the value of option `style`  |
+| symbol   |           | Mirrors the value of option `symbol` |
+| style\*  |           | Mirrors the value of option `style`  |
 
 *: This variable can only be used as a part of a style string
 
@@ -2632,7 +2632,6 @@ By default the module will be shown if the current directory contains a `.rego` 
 [bun]
 format = "via [⛑️ $version](bold red) "
 ```
-
 
 ## OpenStack
 

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -50,6 +50,7 @@ pub mod nim;
 pub mod nix_shell;
 pub mod nodejs;
 pub mod ocaml;
+pub mod opa;
 pub mod openstack;
 pub mod package;
 pub mod perl;
@@ -191,6 +192,8 @@ pub struct FullConfig<'a> {
     nodejs: nodejs::NodejsConfig<'a>,
     #[serde(borrow)]
     ocaml: ocaml::OCamlConfig<'a>,
+    #[serde(borrow)]
+    opa: opa::OpaConfig<'a>,
     #[serde(borrow)]
     openstack: openstack::OspConfig<'a>,
     #[serde(borrow)]

--- a/src/configs/opa.rs
+++ b/src/configs/opa.rs
@@ -23,7 +23,7 @@ impl<'a> Default for OpaConfig<'a> {
         OpaConfig {
             format: "via [$symbol($version )]($style)",
             version_format: "v${raw}",
-            symbol: "🪖 ",
+            symbol: "🪖  ",
             style: "bold blue",
             disabled: false,
             detect_extensions: vec!["rego"],

--- a/src/configs/opa.rs
+++ b/src/configs/opa.rs
@@ -1,0 +1,34 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(
+    feature = "config-schema",
+    derive(schemars::JsonSchema),
+    schemars(deny_unknown_fields)
+)]
+#[serde(default)]
+pub struct OpaConfig<'a> {
+    pub format: &'a str,
+    pub version_format: &'a str,
+    pub symbol: &'a str,
+    pub style: &'a str,
+    pub disabled: bool,
+    pub detect_extensions: Vec<&'a str>,
+    pub detect_files: Vec<&'a str>,
+    pub detect_folders: Vec<&'a str>,
+}
+
+impl<'a> Default for OpaConfig<'a> {
+    fn default() -> Self {
+        OpaConfig {
+            format: "via [$symbol($version )]($style)",
+            version_format: "v${raw}",
+            symbol: "🪖 ",
+            style: "bold blue",
+            disabled: false,
+            detect_extensions: vec!["rego"],
+            detect_files: vec![],
+            detect_folders: vec![],
+        }
+    }
+}

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -67,6 +67,7 @@ pub const PROMPT_ORDER: &[&str] = &[
     "nim",
     "nodejs",
     "ocaml",
+    "opa",
     "perl",
     "php",
     "pulumi",

--- a/src/module.rs
+++ b/src/module.rs
@@ -58,6 +58,7 @@ pub const ALL_MODULES: &[&str] = &[
     "nix_shell",
     "nodejs",
     "ocaml",
+    "opa",
     "openstack",
     "package",
     "perl",

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -47,6 +47,7 @@ mod nim;
 mod nix_shell;
 mod nodejs;
 mod ocaml;
+mod opa;
 mod openstack;
 mod package;
 mod perl;
@@ -141,6 +142,7 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
             "nix_shell" => nix_shell::module(context),
             "nodejs" => nodejs::module(context),
             "ocaml" => ocaml::module(context),
+            "opa" => opa::module(context),
             "openstack" => openstack::module(context),
             "package" => package::module(context),
             "perl" => perl::module(context),
@@ -246,6 +248,7 @@ pub fn description(module: &str) -> &'static str {
         "nix_shell" => "The nix-shell environment",
         "nodejs" => "The currently installed version of NodeJS",
         "ocaml" => "The currently installed version of OCaml",
+        "opa" => "The currently installed version of Open Platform Agent",
         "openstack" => "The current OpenStack cloud and project",
         "package" => "The package version of the current directory's project",
         "perl" => "The currently installed version of Perl",

--- a/src/modules/opa.rs
+++ b/src/modules/opa.rs
@@ -90,7 +90,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("test.rego"))?.sync_all()?;
         let actual = ModuleRenderer::new("opa").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Blue.bold().paint("🪖 v0.44.0 ")));
+        let expected = Some(format!("via {}", Color::Blue.bold().paint("🪖  v0.44.0 ")));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -103,7 +103,7 @@ mod tests {
             .path(dir.path())
             .cmd("opa version", None)
             .collect();
-        let expected = Some(format!("via {}", Color::Blue.bold().paint("🪖 ")));
+        let expected = Some(format!("via {}", Color::Blue.bold().paint("🪖  ")));
         assert_eq!(expected, actual);
         dir.close()
     }

--- a/src/modules/opa.rs
+++ b/src/modules/opa.rs
@@ -1,0 +1,110 @@
+/// Creates a module with the current Open Policy Agent version
+use super::{Context, Module, ModuleConfig};
+
+use crate::configs::opa::OpaConfig;
+use crate::formatter::StringFormatter;
+use crate::formatter::VersionFormatter;
+use crate::utils::get_command_string_output;
+
+/// Creates a module with the current Open Policy Agent version
+pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let mut module = context.new_module("opa");
+    let config = OpaConfig::try_load(module.config);
+
+    let is_opa_project = context
+        .try_begin_scan()?
+        .set_files(&config.detect_files)
+        .set_extensions(&config.detect_extensions)
+        .set_folders(&config.detect_folders)
+        .is_match();
+
+    if !is_opa_project {
+        return None;
+    }
+
+    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
+        formatter
+            .map_meta(|var, _| match var {
+                "symbol" => Some(config.symbol),
+                _ => None,
+            })
+            .map_style(|variable| match variable {
+                "style" => Some(Ok(config.style)),
+                _ => None,
+            })
+            .map(|variable| match variable {
+                "version" => {
+                    let opa_version = get_opa_version(context)?;
+                    VersionFormatter::format_module_version(
+                        module.get_name(),
+                        &opa_version,
+                        config.version_format,
+                    )
+                    .map(Ok)
+                }
+                _ => None,
+            })
+            .parse(None, Some(context))
+    });
+
+    module.set_segments(match parsed {
+        Ok(segments) => segments,
+        Err(error) => {
+            log::warn!("Error in module `opa`:\n{}", error);
+            return None;
+        }
+    });
+
+    Some(module)
+}
+
+fn get_opa_version(context: &Context) -> Option<String> {
+    let version_output: String = context
+        .exec_cmd("opa", &["version"])
+        .map(get_command_string_output)?;
+    parse_opa_version(version_output)
+}
+
+fn parse_opa_version(version_output: String) -> Option<String> {
+    Some(version_output.split_whitespace().nth(1)?.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::ModuleRenderer;
+    use nu_ansi_term::Color;
+    use std::fs::File;
+    use std::io;
+
+    #[test]
+    fn folder_without_opa_files() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let actual = ModuleRenderer::new("opa").path(dir.path()).collect();
+        let expected = None;
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn folder_with_opa_file() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join("test.rego"))?.sync_all()?;
+        let actual = ModuleRenderer::new("opa").path(dir.path()).collect();
+        let expected = Some(format!("via {}", Color::Blue.bold().paint("🪖 v0.44.0 ")));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn no_opa_installed() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join("test.rego"))?.sync_all()?;
+        let actual = ModuleRenderer::new("opa")
+            .path(dir.path())
+            .cmd("opa version", None)
+            .collect();
+        let expected = Some(format!("via {}", Color::Blue.bold().paint("🪖 ")));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -270,6 +270,17 @@ active boot switches: -d:release\n",
             stdout: String::from("4.10.0\n"),
             stderr: String::default(),
         }),
+        "opa version" => Some(CommandOutput {
+            stdout: String::from("Version: 0.44.0
+Build Commit: e8d488f
+Build Timestamp: 2022-09-07T23:50:25Z
+Build Hostname: 119428673f4c
+Go Version: go1.19.1
+Platform: linux/amd64
+WebAssembly: unavailable
+"),
+            stderr: String::default(),
+        }),
         "opam switch show --safe" => Some(CommandOutput {
             stdout: String::from("default\n"),
             stderr: String::default(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Adds a module for the [Open Policy Agent](https://www.openpolicyagent.org/) tool, `opa`.
This assumes that people put the opa binary on $PATH, as it seems to not really be packaged apart from Docker Hub.

Emoji was picked because it's the closest to the official logo, which is a horned hat.

Largely based on the bun module and other modules that just run a command and parse it.

Upstream will likely not change the output of `opa version`, as they're conscious of it potentially being parsed; see https://github.com/open-policy-agent/opa/blob/15b9a884cd5f5fd403cec9929fa58d86b0a9046f/cmd/version.go

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1740

#### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/20385973/193651122-63343192-c983-43a9-b223-a24eb67fa2f2.png)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
