### PR TITLE
fix(buf): fix spacing & harmonize docs with actual configuration

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -73,7 +73,7 @@
         "disabled": false,
         "format": "with [$symbol($version )]($style)",
         "style": "bold blue",
-        "symbol": " ",
+        "symbol": "🦬 ",
         "version_format": "v${raw}"
       },
       "allOf": [
@@ -1729,7 +1729,7 @@
           "type": "string"
         },
         "symbol": {
-          "default": " ",
+          "default": "🦬 ",
           "type": "string"
         },
         "style": {

--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -71,9 +71,9 @@
         ],
         "detect_folders": [],
         "disabled": false,
-        "format": "with [$symbol ($version)]($style)",
+        "format": "with [$symbol($version )]($style)",
         "style": "bold blue",
-        "symbol": "",
+        "symbol": " ",
         "version_format": "v${raw}"
       },
       "allOf": [
@@ -1721,7 +1721,7 @@
       "type": "object",
       "properties": {
         "format": {
-          "default": "with [$symbol ($version)]($style)",
+          "default": "with [$symbol($version )]($style)",
           "type": "string"
         },
         "version_format": {
@@ -1729,7 +1729,7 @@
           "type": "string"
         },
         "symbol": {
-          "default": "",
+          "default": " ",
           "type": "string"
         },
         "style": {

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -502,7 +502,7 @@ The `buf` module shows the currently installed version of [Buf](https://buf.buil
 | ------------------- | ---------------------------------------------------------- | ----------------------------------------------------- |
 | `format`            | `'with [$symbol($version \(Buf $buf_version\) )]($style)'` | The format for the `buf` module.                      |
 | `version_format`    | `"v${raw}"`                                                | The version format.                                   |
-| `symbol`            | `"🦬 "`                                                     | The symbol used before displaying the version of Buf. |
+| `symbol`            | `"🦬 "`                                                    | The symbol used before displaying the version of Buf. |
 | `detect_extensions` | `[]`                                                       | Which extensions should trigger this module.          |
 | `detect_files`      | `["buf.yaml", "buf.gen.yaml", "buf.work.yaml"]`            | Which filenames should trigger this module.           |
 | `detect_folders`    | `[]`                                                       | Which folders should trigger this modules.            |
@@ -513,7 +513,7 @@ The `buf` module shows the currently installed version of [Buf](https://buf.buil
 
 | Variable      | Example  | Description                          |
 | ------------- | -------- | ------------------------------------ |
-| `buf_version` | `v1.0.0` | The version of `buf`                 |
+| `version`     | `v1.0.0` | The version of `buf`                 |
 | `symbol`      |          | Mirrors the value of option `symbol` |
 | `style`*      |          | Mirrors the value of option `style`  |
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -498,24 +498,24 @@ The `buf` module shows the currently installed version of [Buf](https://buf.buil
 
 ### Options
 
-| Option              | Default                                                    | Description                                           |
-| ------------------- | ---------------------------------------------------------- | ----------------------------------------------------- |
-| `format`            | `"with [$symbol($version )]($style)"`                      | The format for the `buf` module.                      |
-| `version_format`    | `"v${raw}"`                                                | The version format.                                   |
-| `symbol`            | `"🦬 "`                                                    | The symbol used before displaying the version of Buf. |
-| `detect_extensions` | `[]`                                                       | Which extensions should trigger this module.          |
-| `detect_files`      | `["buf.yaml", "buf.gen.yaml", "buf.work.yaml"]`            | Which filenames should trigger this module.           |
-| `detect_folders`    | `[]`                                                       | Which folders should trigger this modules.            |
-| `style`             | `"bold blue"`                                              | The style for the module.                             |
-| `disabled`          | `false`                                                    | Disables the `elixir` module.                         |
+| Option              | Default                                         | Description                                           |
+| ------------------- | ----------------------------------------------- | ----------------------------------------------------- |
+| `format`            | `"with [$symbol($version )]($style)"`           | The format for the `buf` module.                      |
+| `version_format`    | `"v${raw}"`                                     | The version format.                                   |
+| `symbol`            | `"🦬 "`                                          | The symbol used before displaying the version of Buf. |
+| `detect_extensions` | `[]`                                            | Which extensions should trigger this module.          |
+| `detect_files`      | `["buf.yaml", "buf.gen.yaml", "buf.work.yaml"]` | Which filenames should trigger this module.           |
+| `detect_folders`    | `[]`                                            | Which folders should trigger this modules.            |
+| `style`             | `"bold blue"`                                   | The style for the module.                             |
+| `disabled`          | `false`                                         | Disables the `elixir` module.                         |
 
 ### Variables
 
-| Variable      | Example  | Description                          |
-| ------------- | -------- | ------------------------------------ |
-| `version`     | `v1.0.0` | The version of `buf`                 |
-| `symbol`      |          | Mirrors the value of option `symbol` |
-| `style`*      |          | Mirrors the value of option `style`  |
+| Variable  | Example  | Description                          |
+| --------- | -------- | ------------------------------------ |
+| `version` | `v1.0.0` | The version of `buf`                 |
+| `symbol`  |          | Mirrors the value of option `symbol` |
+| `style`*  |          | Mirrors the value of option `style`  |
 
 *: This variable can only be used as a part of a style string
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -500,7 +500,7 @@ The `buf` module shows the currently installed version of [Buf](https://buf.buil
 
 | Option              | Default                                                    | Description                                           |
 | ------------------- | ---------------------------------------------------------- | ----------------------------------------------------- |
-| `format`            | `'with [$symbol($version \(Buf $buf_version\) )]($style)'` | The format for the `buf` module.                      |
+| `format`            | `"with [$symbol($version )]($style)"`                      | The format for the `buf` module.                      |
 | `version_format`    | `"v${raw}"`                                                | The version format.                                   |
 | `symbol`            | `"🦬 "`                                                    | The symbol used before displaying the version of Buf. |
 | `detect_extensions` | `[]`                                                       | Which extensions should trigger this module.          |

--- a/src/configs/buf.rs
+++ b/src/configs/buf.rs
@@ -23,7 +23,7 @@ impl<'a> Default for BufConfig<'a> {
         BufConfig {
             format: "with [$symbol($version )]($style)",
             version_format: "v${raw}",
-            symbol: " ",
+            symbol: "🦬 ",
             style: "bold blue",
             disabled: false,
             detect_extensions: vec![],

--- a/src/configs/buf.rs
+++ b/src/configs/buf.rs
@@ -21,9 +21,9 @@ pub struct BufConfig<'a> {
 impl<'a> Default for BufConfig<'a> {
     fn default() -> Self {
         BufConfig {
-            format: "with [$symbol ($version)]($style)",
+            format: "with [$symbol($version )]($style)",
             version_format: "v${raw}",
-            symbol: "",
+            symbol: " ",
             style: "bold blue",
             disabled: false,
             detect_extensions: vec![],

--- a/src/modules/buf.rs
+++ b/src/modules/buf.rs
@@ -103,7 +103,7 @@ mod tests {
                 .sync_all()
                 .unwrap();
             let actual = ModuleRenderer::new("buf").path(dir.path()).collect();
-            let expected = Some(format!("with {}", Color::Blue.bold().paint(" v1.0.0 ")));
+            let expected = Some(format!("with {}", Color::Blue.bold().paint("🦬 v1.0.0 ")));
             assert_eq!(expected, actual);
             dir.close().unwrap();
         }

--- a/src/modules/buf.rs
+++ b/src/modules/buf.rs
@@ -103,7 +103,7 @@ mod tests {
                 .sync_all()
                 .unwrap();
             let actual = ModuleRenderer::new("buf").path(dir.path()).collect();
-            let expected = Some(format!("with {}", Color::Blue.bold().paint(" v1.0.0")));
+            let expected = Some(format!("with {}", Color::Blue.bold().paint(" v1.0.0 ")));
             assert_eq!(expected, actual);
             dir.close().unwrap();
         }


### PR DESCRIPTION
#### Description

This change adds a trailing whitespace character after the printed version to align with behaviour of other modules. I've used the configuration for the `node` and `bun` modules as reference points.

Additionally:

- Updated documentation to specify `version` instead of incorrect `buf_version`
- Use bison emoji in-line with documentation.

#### Motivation and Context

The lack of trailing whitespace leads to rendering error when used with other modules.

#### Screenshots (if appropriate):

Currently `buf` version is printed as:

<img width="451" alt="image" src="https://user-images.githubusercontent.com/609452/194177266-5f40eb5a-b156-4c7a-bee0-911d07653e52.png">

#### How Has This Been Tested?

- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:

- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
