### PR TITLE
docs(preset): update presets with Scala nerd font.

### DIFF
--- a/docs/.vuepress/public/presets/toml/nerd-font-symbols.toml
+++ b/docs/.vuepress/public/presets/toml/nerd-font-symbols.toml
@@ -73,5 +73,8 @@ symbol = " "
 [rust]
 symbol = " "
 
+[scala]
+symbol = " "
+
 [spack]
 symbol = "🅢 "

--- a/docs/.vuepress/public/presets/toml/pastel-powerline.toml
+++ b/docs/.vuepress/public/presets/toml/pastel-powerline.toml
@@ -119,7 +119,7 @@ style = "bg:#86BBD8"
 format = '[ $symbol ($version) ]($style)'
 
 [scala]
-symbol = ""
+symbol = " "
 style = "bg:#86BBD8"
 format = '[ $symbol ($version) ]($style)'
 

--- a/docs/.vuepress/public/presets/toml/pastel-powerline.toml
+++ b/docs/.vuepress/public/presets/toml/pastel-powerline.toml
@@ -17,6 +17,7 @@ $julia\
 $nodejs\
 $nim\
 $rust\
+$scala\
 [](fg:#86BBD8 bg:#06969A)\
 $docker_context\
 [](fg:#06969A bg:#33658A)\
@@ -114,6 +115,11 @@ format = '[ $symbol ($version) ]($style)'
 
 [rust]
 symbol = ""
+style = "bg:#86BBD8"
+format = '[ $symbol ($version) ]($style)'
+
+[scala]
+symbol = ""
 style = "bg:#86BBD8"
 format = '[ $symbol ($version) ]($style)'
 


### PR DESCRIPTION
#### Description
Update the following presets with the nerd font for Scala:
* nerd-font-symbols.toml
* pastel-powerline.toml

#### Motivation and Context
For completeness Scala is a supported module.

#### How Has This Been Tested?
Tested both presets on a Scala project. 
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
