### PR TITLE
docs(custom): use single equal sign for 'when' clause of 'custom.foo' example

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -3968,7 +3968,7 @@ with shell details and starship configuration if you hit such scenario.
 [custom.foo]
 command = "echo foo" # shows output of command
 detect_files = ["foo"] # can specify filters but wildcards are not supported
-when = """ test "$HOME" == "$PWD" """
+when = """ test "$HOME" = "$PWD" """
 format = " transcending [$output]($style)"
 
 [custom.time]


### PR DESCRIPTION
#### Description
The custom shell example `custom.foo` does not work. A correct equality check using the shell builtin `test` command is `test "a" = "b"` and not `test "a" == "b"`.

#### Motivation and Context
Fix wrong docs.

#### Screenshots (if appropriate):
None

#### How Has This Been Tested?
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

I tested the `custom.foo` example using `zsh` on MacOS.

#### Checklist:
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
