### PR TITLE
fix(status): replace multiply with cross mark emoji

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -1341,7 +1341,7 @@
         "signal_symbol": "⚡",
         "style": "bold red",
         "success_symbol": "",
-        "symbol": "✖"
+        "symbol": "❌"
       },
       "allOf": [
         {
@@ -4633,7 +4633,7 @@
           "type": "string"
         },
         "symbol": {
-          "default": "✖",
+          "default": "❌",
           "type": "string"
         },
         "success_symbol": {

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -3397,7 +3397,7 @@ To enable it, set `disabled` to `false` in your configuration file.
 | Option                      | Default                                                                       | Description                                                           |
 | --------------------------- | ----------------------------------------------------------------------------- | --------------------------------------------------------------------- |
 | `format`                    | `"[$symbol$status]($style) "`                                                 | The format of the module                                              |
-| `symbol`                    | `"✖"`                                                                         | The symbol displayed on program error                                 |
+| `symbol`                    | `"❌"`                                                                         | The symbol displayed on program error                                 |
 | `success_symbol`            | `""`                                                                          | The symbol displayed on program success                               |
 | `not_executable_symbol`     | `"🚫"`                                                                         | The symbol displayed when file isn't executable                       |
 | `not_found_symbol`          | `"🔍"`                                                                         | The symbol displayed when the command can't be found                  |

--- a/src/configs/status.rs
+++ b/src/configs/status.rs
@@ -30,7 +30,7 @@ impl<'a> Default for StatusConfig<'a> {
     fn default() -> Self {
         StatusConfig {
             format: "[$symbol$status]($style) ",
-            symbol: "✖",
+            symbol: "❌",
             success_symbol: "",
             not_executable_symbol: "🚫",
             not_found_symbol: "🔍",

--- a/src/modules/status.rs
+++ b/src/modules/status.rs
@@ -323,12 +323,12 @@ mod tests {
         for status in &exit_values {
             let expected = Some(format!(
                 "{} ",
-                Color::Red.bold().paint(format!("✖{}", status))
+                Color::Red.bold().paint(format!("❌{}", status))
             ));
             let actual = ModuleRenderer::new("status")
                 .config(toml::toml! {
                     [status]
-                    symbol = "✖"
+                    symbol = "❌"
                     disabled = false
                 })
                 .status(*status)
@@ -345,12 +345,12 @@ mod tests {
         for (exit_value, string_value) in exit_values.iter().zip(string_values) {
             let expected = Some(format!(
                 "{} ",
-                Color::Red.bold().paint(format!("✖{}", string_value))
+                Color::Red.bold().paint(format!("❌{}", string_value))
             ));
             let actual = ModuleRenderer::new("status")
                 .config(toml::toml! {
                     [status]
-                    symbol = "✖"
+                    symbol = "❌"
                     disabled = false
                     format = "[${symbol}${hex_status}]($style) "
                 })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
The symbol of the status module was provided by the multiply-emoji (`✖️`). This PR replaces it with the "cross mark" emoji `❌`. It is a better fit semantically, and the multiplication emoji misrenders as a plus on some versions of Windows 11 (#4345). 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #4345

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
