### PR TITLE
feat(module): Add dbt module to display version and project name

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -304,6 +304,32 @@
         }
       ]
     },
+    "dbt": {
+      "default": {
+        "detect_extensions": [
+          "sql"
+        ],
+        "detect_files": [
+          "dbt_project.yml"
+        ],
+        "detect_folders": [],
+        "disabled": false,
+        "format": "via [$symbol($version )(\\($project\\) )]($style)",
+        "project_dirs": [],
+        "python_binary": [
+          "python",
+          "python3"
+        ],
+        "style": "fg:#FF694A bold",
+        "symbol": "📊 ",
+        "version_format": "v${raw}"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/DbtConfig"
+        }
+      ]
+    },
     "deno": {
       "default": {
         "detect_extensions": [],
@@ -2284,6 +2310,88 @@
       },
       "additionalProperties": false
     },
+    "DbtConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "via [$symbol($version )(\\($project\\) )]($style)",
+          "type": "string"
+        },
+        "python_binary": {
+          "default": [
+            "python",
+            "python3"
+          ],
+          "allOf": [
+            {
+              "$ref": "#/definitions/Either_for_String_and_Array_of_String"
+            }
+          ]
+        },
+        "project_dirs": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "version_format": {
+          "default": "v${raw}",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "📊 ",
+          "type": "string"
+        },
+        "style": {
+          "default": "fg:#FF694A bold",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "detect_extensions": {
+          "default": [
+            "sql"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_files": {
+          "default": [
+            "dbt_project.yml"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_folders": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "Either_for_String_and_Array_of_String": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
+    },
     "DenoConfig": {
       "type": "object",
       "properties": {
@@ -4137,19 +4245,6 @@
         }
       },
       "additionalProperties": false
-    },
-    "Either_for_String_and_Array_of_String": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      ]
     },
     "RakuConfig": {
       "type": "object",

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -995,6 +995,87 @@ By default the module will be shown if any of the following conditions are met:
 format = "via [🔰 $version](bold red) "
 ```
 
+## Dbt
+
+The `dbt` module shows the currently installed version of [dbt](https://docs.getdbt.com/) and the working dbt project.
+By default the module will be shown if any of the following conditions are met:
+
+- The current directory contains a `dbt_project.yml` file
+- The current directory contains a file with `.sql` extension
+
+### Options
+
+| Option              | Default                                             | Description                                                                                           |
+| ------------------- | --------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `format`            | `"via [$symbol($version )(\($project\) )]($style)"` | The format for the module.                                                                            |
+| `version_format`    | `"v${raw}"`                                         | The version format. Available vars are `raw`, `major`, `minor`, & `patch`                             |
+| `symbol`            | `"📊 "`                                              | A format string representing the symbol of dbt                                                        |
+| `detect_extensions` | `["sql"]`                                           | Which extensions should trigger this module.                                                          |
+| `detect_files`      | `["dbt_project.yml"]`                               | Which filenames should trigger this module.                                                           |
+| `detect_folders`    | `[]`                                                | Which folders should trigger this module.                                                             |
+| `style`             | `"fg:#FF694A bold"`                                 | The style for the module.                                                                             |
+| `disabled`          | `false`                                             | Disables the `dbt` module.                                                                            |
+| `python_binary`     | `["python", "python3"]`                             | Configures the python binaries that Starship should execute when getting the version.                 |
+| `project_dirs`      | `[]`                                                | A list of directories containing a `dbt_project.yml` file where the project name can be fetched from. |
+
+::: tip
+
+The `python_binary` variable works as the equally named variable from the
+[Python][#Python] module. However, we use it here to identify the binary to run
+`importlib.resources.files('dbt')` in an attempt to find where dbt was
+installed.
+
+The `importlib.resources` module was added in Python 3.7, and `dbt` depends
+on Python 3.7 or newer versions, so we shouldn't have conflicts.
+
+:::
+
+### Variables
+
+| Variable | Example             | Description                                                                    |
+| -------- | ------------------- | ------------------------------------------------------------------------------ |
+| project  | `"jaffle_shop"`     | The name of the `dbt` project                                                  |
+| version  | `"v1.2.2"`          | The version of `dbt`                                                           |
+| symbol   | `"📊 "`              | Mirrors the value of option `symbol`                                           |
+| style\*  | `"fg:#FF694A bold"` | Mirrors the value of option `style`. `fg:#FF694A` is the `dbt` "orange" color. |
+
+*: This variable can only be used as a part of a style string
+
+### Example
+
+```toml
+# ~/.config/starship.toml
+
+[dbt]
+# Use a different symbol
+symbol = "👩‍🔬 "
+```
+
+```toml
+# ~/.config/starship.toml
+
+[dbt]
+# Don't trigger for files with the sql extension
+detect_extensions = []
+```
+
+::: tip
+
+The project name will only be showed in the prompt if we are currently in a
+directory which contains a `dbt_project.yml` file or if we let Starship know
+where to find a `dbt_project.yml` file by configuring `project_dirs`. Once
+configured, all subdirectories in our project will show the project name.
+
+```toml
+# ~/.config/starship.toml
+
+[dbt]
+# Set my dbt project directory to show the project name on the prompt
+project_dirs = ["~/path/to/my/dbt/project/"]
+```
+
+:::
+
 ## Deno
 
 The `deno` module shows you your currently installed version of [Deno](https://deno.land/).

--- a/src/configs/dbt.rs
+++ b/src/configs/dbt.rs
@@ -1,0 +1,40 @@
+use crate::config::VecOr;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(
+    feature = "config-schema",
+    derive(schemars::JsonSchema),
+    schemars(deny_unknown_fields)
+)]
+#[serde(default)]
+pub struct DbtConfig<'a> {
+    pub format: &'a str,
+    pub python_binary: VecOr<&'a str>,
+    pub project_dirs: Vec<&'a str>,
+    pub version_format: &'a str,
+    pub symbol: &'a str,
+    pub style: &'a str,
+    pub disabled: bool,
+    pub detect_extensions: Vec<&'a str>,
+    pub detect_files: Vec<&'a str>,
+    pub detect_folders: Vec<&'a str>,
+}
+
+impl<'a> Default for DbtConfig<'a> {
+    fn default() -> Self {
+        DbtConfig {
+            python_binary: VecOr(vec!["python", "python3"]),
+            project_dirs: vec![],
+            format: "via [$symbol($version )(\\($project\\) )]($style)",
+            version_format: "v${raw}",
+            symbol: "📊 ",
+            style: "fg:#FF694A bold",
+            disabled: false,
+            detect_extensions: vec!["sql"],
+            detect_files: vec!["dbt_project.yml"],
+            detect_folders: vec![],
+        }
+    }
+}

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -17,6 +17,7 @@ pub mod crystal;
 pub mod custom;
 pub mod daml;
 pub mod dart;
+pub mod dbt;
 pub mod deno;
 pub mod directory;
 pub mod docker_context;
@@ -126,6 +127,8 @@ pub struct FullConfig<'a> {
     daml: daml::DamlConfig<'a>,
     #[serde(borrow)]
     dart: dart::DartConfig<'a>,
+    #[serde(borrow)]
+    dbt: dbt::DbtConfig<'a>,
     #[serde(borrow)]
     deno: deno::DenoConfig<'a>,
     #[serde(borrow)]

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -52,6 +52,7 @@ pub const PROMPT_ORDER: &[&str] = &[
     "cobol",
     "daml",
     "dart",
+    "dbt",
     "deno",
     "dotnet",
     "elixir",

--- a/src/module.rs
+++ b/src/module.rs
@@ -25,6 +25,7 @@ pub const ALL_MODULES: &[&str] = &[
     "crystal",
     "daml",
     "dart",
+    "dbt",
     "deno",
     "directory",
     "docker_context",

--- a/src/modules/dbt.rs
+++ b/src/modules/dbt.rs
@@ -1,0 +1,286 @@
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+
+use super::{Context, Module, ModuleConfig};
+use crate::configs::dbt::DbtConfig;
+use crate::formatter::StringFormatter;
+use crate::formatter::VersionFormatter;
+use crate::utils::{context_path, get_command_string_output, read_file, CommandOutput};
+
+const DBT_PROJECT_YML: &str = "dbt_project.yml";
+
+/// Creates a module with the current dbt version and dbt project
+pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let mut module = context.new_module("dbt");
+    let config: DbtConfig = DbtConfig::try_load(module.config);
+
+    let is_dbt_project = context
+        .try_begin_scan()?
+        .set_files(&config.detect_files)
+        .set_folders(&config.detect_folders)
+        .set_extensions(&config.detect_extensions)
+        .is_match();
+
+    if !is_dbt_project {
+        return None;
+    }
+
+    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
+        formatter
+            .map_meta(|variable, _| match variable {
+                "symbol" => Some(config.symbol),
+                _ => None,
+            })
+            .map_style(|variable| match variable {
+                "style" => Some(Ok(config.style)),
+                _ => None,
+            })
+            .map(|variable| match variable {
+                "version" => {
+                    let dbt_version = get_dbt_version(context, &config)?;
+
+                    VersionFormatter::format_module_version(
+                        module.get_name(),
+                        &dbt_version,
+                        config.version_format,
+                    )
+                    .map(Ok)
+                }
+                "project" => read_project_name_from_dbt_project_yml(context, &config).map(Ok),
+                _ => None,
+            })
+            .parse(None, Some(context))
+    });
+
+    module.set_segments(match parsed {
+        Ok(segments) => segments,
+        Err(error) => {
+            log::warn!("Error in module `dbt`:\n{}", error);
+            return None;
+        }
+    });
+
+    Some(module)
+}
+
+/// Try to read a dbt project's name from a YAML file in the current directory or in config.project_dirs
+fn read_project_name_from_dbt_project_yml(context: &Context, config: &DbtConfig) -> Option<String> {
+    let file_contents = context
+        .read_file_from_pwd(DBT_PROJECT_YML)
+        .or_else(|| try_find_dbt_project_yaml(context, config))?;
+
+    let dbt_project_yaml = yaml_rust::YamlLoader::load_from_str(&file_contents).ok()?;
+    let dbt_project_name = dbt_project_yaml.first()?["name"].as_str()?;
+
+    Some(dbt_project_name.to_string())
+}
+
+/// Try to find a dbt_project.yml file in one of the directories specified in config.project_dirs
+/// We only consider directories that are also prefixes of our current directory
+fn try_find_dbt_project_yaml(context: &Context, config: &DbtConfig) -> Option<String> {
+    for project_dir in config.project_dirs.iter() {
+        let dir = Context::expand_tilde(PathBuf::from_str(project_dir).ok()?);
+        if !context.current_dir.starts_with(&dir) {
+            continue;
+        }
+
+        let dbt_project_yaml_path = dir.join(DBT_PROJECT_YML);
+        return read_file(dbt_project_yaml_path).ok();
+    }
+
+    None
+}
+
+/// Attempt to get the installed version of dbt-core by finding where dbt is installed
+fn get_dbt_version(context: &Context, config: &DbtConfig) -> Option<String> {
+    // Python requires a directory that specifies the version to be created where the package is installed
+    // See: https://packaging.python.org/en/latest/specifications/recording-installed-packages/#the-dist-info-directory
+    // We will rely on this directory existing to extract the version number
+    // This is significantly faster (50ms) than using dbt --version (>500ms), pip freeze (450ms), or importing dbt
+    let dbt_package_dir = config
+        .python_binary
+        .0
+        .iter()
+        .find_map(|binary| {
+            context.exec_cmd(
+                binary,
+                &[
+                    "-c",
+                    "from importlib.resources import files;print(files('dbt') / '');",
+                ],
+            )
+        })
+        .map(get_pathbuf_from_string_output)??;
+    // Example output: /home/username/.pyenv/versions/3.10.5/lib/python3.10/site-packages/dbt
+    let python_packages_dir = context_path(context, dbt_package_dir.parent()?);
+
+    try_find_dbt_package_version_python_packages_dir(&python_packages_dir)
+}
+
+fn get_pathbuf_from_string_output(command: CommandOutput) -> Option<PathBuf> {
+    if command.stdout.is_empty() {
+        None
+    } else {
+        PathBuf::from_str(get_command_string_output(command).trim()).ok()
+    }
+}
+
+/// Try to find a dist-info directory where dbt was installed
+/// If found, we parse it to quickly extract the version number
+fn try_find_dbt_package_version_python_packages_dir(python_packages_dir: &Path) -> Option<String> {
+    for entry in python_packages_dir.read_dir().ok()? {
+        let path = entry.ok()?.path();
+        let dir_name = path.file_name()?.to_str()?;
+
+        if let Some(version) = parse_dbt_version(dir_name) {
+            return Some(version);
+        }
+    }
+
+    None
+}
+
+/// Parse a dbt version from a dbt dist-info directory
+fn parse_dbt_version(dbt_dist_info: &str) -> Option<String> {
+    // This directory has the following format: dbt_core-{version}.dist-info
+    let version = dbt_dist_info
+        .split_once("dbt_core-")?
+        // ("", "{version}.dist_info")
+        .1
+        .split_once(".dist-info")?
+        // ("{version}", "")
+        .0;
+
+    Some(version.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test::ModuleRenderer;
+    use nu_ansi_term::Color;
+    use std::fs::{create_dir_all, File};
+    use std::io;
+    use std::io::Write;
+
+    fn create_dbt_dist_info_dir(renderer: &ModuleRenderer) -> io::Result<()> {
+        // We rely on a dist-info directory to read the version, and we use
+        // context_path to create a path to the directory. During testing,
+        // context_path will prefix the path return by the python command with
+        // context.root_dir. As ModuleRenderer uses a default context which
+        // creates it's own temporary directory as root_dir, we need to use that here.
+        let site_packages_dir = if cfg!(target_os = "windows") {
+            "site-packages\\dbt_core-1.2.2.dist-info"
+        } else {
+            "site-packages/dbt_core-1.2.2.dist-info"
+        };
+        let dbt_version_dir = renderer.root_path().join(site_packages_dir);
+        create_dir_all(dbt_version_dir)
+    }
+
+    #[test]
+    fn test_get_pathbuf_from_string_output() {
+        let output = CommandOutput {
+            stdout: "/home/username/lib".to_string(),
+            stderr: "".to_string(),
+        };
+        assert_eq!(
+            get_pathbuf_from_string_output(output),
+            Some(PathBuf::from_str("/home/username/lib").unwrap())
+        );
+
+        let output = CommandOutput {
+            stdout: "".to_string(),
+            stderr: "ERROR".to_string(),
+        };
+        assert_eq!(get_pathbuf_from_string_output(output), None);
+    }
+
+    #[test]
+    fn test_parse_dbt_version() {
+        let dir_name = "dbt_core-1.2.2.dist-info";
+        assert_eq!(parse_dbt_version(dir_name), Some("1.2.2".to_string()));
+    }
+
+    #[test]
+    fn folder_with_sql_file() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join("model.sql"))?.sync_all()?;
+
+        let renderer = ModuleRenderer::new("dbt");
+        create_dbt_dist_info_dir(&renderer)?;
+
+        let actual = renderer.path(dir.path()).collect();
+
+        let expected = Some(format!(
+            "via {}",
+            Color::Rgb(255, 105, 74).bold().paint("📊 v1.2.2 ")
+        ));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn folder_with_sql_file_and_dbt_project_file() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join("dbt_project.yml"))?.write_all(b"name: my-test-project\n")?;
+
+        let model_path = dir.path().join("models/model.sql");
+        create_dir_all(model_path.parent().unwrap())?;
+        File::create(model_path)?.sync_all()?;
+
+        let config: toml::Value = toml::from_str(&format!(
+            r#"
+            [dbt]
+            project_dirs = ["{}"]
+        "#,
+            dir.path().to_str().unwrap().replace('\\', r"\\"),
+        ))?;
+
+        let renderer = ModuleRenderer::new("dbt");
+        create_dbt_dist_info_dir(&renderer)?;
+
+        let actual = renderer
+            .path(dir.path().join("models"))
+            .config(config)
+            .collect();
+
+        let expected = Some(format!(
+            "via {}",
+            Color::Rgb(255, 105, 74)
+                .bold()
+                .paint("📊 v1.2.2 (my-test-project) ")
+        ));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn folder_with_dbt_project_file() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join("dbt_project.yml"))?.write_all(b"name: my-test-project\n")?;
+
+        let renderer = ModuleRenderer::new("dbt");
+        create_dbt_dist_info_dir(&renderer)?;
+        let actual = renderer.path(dir.path()).collect();
+
+        let expected = Some(format!(
+            "via {}",
+            Color::Rgb(255, 105, 74)
+                .bold()
+                .paint("📊 v1.2.2 (my-test-project) ")
+        ));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn folder_without_anything() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let actual = ModuleRenderer::new("dbt").path(dir.path()).collect();
+        let expected = None;
+        assert_eq!(expected, actual);
+
+        dir.close()
+    }
+}

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -14,6 +14,7 @@ mod crystal;
 pub(crate) mod custom;
 mod daml;
 mod dart;
+mod dbt;
 mod deno;
 mod directory;
 mod docker_context;
@@ -108,6 +109,7 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
             "container" => container::module(context),
             "daml" => daml::module(context),
             "dart" => dart::module(context),
+            "dbt" => dbt::module(context),
             "deno" => deno::module(context),
             "directory" => directory::module(context),
             "docker_context" => docker_context::module(context),
@@ -213,6 +215,7 @@ pub fn description(module: &str) -> &'static str {
         "crystal" => "The currently installed version of Crystal",
         "daml" => "The Daml SDK version of your project",
         "dart" => "The currently installed version of Dart",
+        "dbt" => "The currently installed version of dbt and current dbt project",
         "deno" => "The currently installed version of Deno",
         "directory" => "The current working directory",
         "docker_context" => "The current docker context",

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -190,6 +190,24 @@ Default target: x86_64-apple-macosx\n",
                 "Dart VM version: 2.8.4 (stable) (Wed Jun 3 12:26:04 2020 +0200) on \"macos_x64\"",
             ),
         }),
+        "python -c from importlib.resources import files;print(files('dbt') / '');" => Some(CommandOutput {
+            stdout: if cfg!(target_os = "windows") {
+                String::from("\\site-packages\\dbt\n")
+            }
+            else {
+                String::from("/site-packages/dbt\n")
+            },
+            stderr: String::default(),
+        }),
+        "python3 -c from importlib.resources import files;print(files('dbt') / '');" => Some(CommandOutput {
+            stdout: if cfg!(target_os = "windows") {
+                String::from("\\site-packages\\dbt\n")
+            }
+            else {
+                String::from("/site-packages/dbt\n")
+            },
+            stderr: String::default(),
+        }),
         "deno -V" => Some(CommandOutput {
             stdout: String::from("deno 1.8.3\n"),
             stderr: String::default()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Adds a module for [dbt](https://github.com/dbt-labs/dbt-core) which displays the current dbt version and the current dbt project.

Fetching the dbt version was not as trivial as I originally imagined: Python requires all installed packages to include a [.dist-info directory](https://packaging.python.org/en/latest/specifications/recording-installed-packages/#the-dist-info-directory). This directory contains the version of a package in its name, and it's what I rely on to obtain the currently installed dbt version. We use [`importlib.resources.files`](https://docs.python.org/3.10/library/importlib.html?highlight=importlib%20resources%20files#importlib.resources.files) to fetch where dbt was installed, and then look for the corresponding `.dist-info` directory.

I felt this was required as the alternatives I considered are painfully slow:
* `dbt --version` does a network request which easily goes over the 500ms limit (and could be worse with slow/no internet connection).
* `pip freeze` is faster, but noticeably slow (450ms).
* `pip show` is slower than `pip freeze`.
* Running a Python script like `from dbt.version import __version__;print(__version__);` is slow due to the size of dbt.

All in all, I'm timing the dbt module at 50ms. This is still quite slow compared to other modules, so perhaps we should remove the `sql` extension from `detect_extensions` and let users configure this one themselves (as `sql` files are what it's most likely to trigger this module).

The dbt project name is fetched from a `dbt_project.yml` configuration file which resides in the root of every dbt project. I wanted to display the project name also when navigating sub-directories of the project. So I implemented a configuration variable `project_dirs` for users to specify directories that may contain a `dbt_project.yml` file. If we are in a directory that `starts_with` any of the directories in `project_dirs`, we use it to look for `dbt_project.yml`. I believed this was easier to implement than a solution that searches in all possible parent directories.

As dbt recommends using an organization name as project name, you could assume that they expect people to have a single project per organization, which means the list of `project_dirs` shouldn't be too large.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
From a personal side, I work with a data team that uses dbt and during their onboarding process we instruct them how to setup their terminal. I love starship and having it support dbt would allow me to recommend it for all team members to install. dbt updates are frequent and folks have sometimes not realized which version they are on.

Moreover, more features can be added to this module in the future to be even more useful (from the top of my head):
* The display of the default profile/target.
* Display results of latest dbt execution.

From a more broader perspective, [dbt](https://github.com/dbt-labs/dbt-core) has around 5.8k stars on GitHub currently, and is well integrated into the data ecosystem: Data Warehouse companies like Snowflake and AWS (Redshift) have hosted articles/labs on working with dbt, and other tools in the ecosystem have integrations to work with it, like [materialize](https://materialize.com/blog/introducing-dbt-materialize/) or [Apache Airflow ](https://github.com/apache/airflow/tree/main/airflow/providers/dbt).

#### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/18740659/194771822-0407ec8c-d3d3-4939-b831-0e2f68b7d849.png)

![image](https://user-images.githubusercontent.com/18740659/194771835-f93c0a46-8805-4331-b5f8-194bd246c7b1.png)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
