### PR TITLE
fix(nu): remove -c parameter from `term size`

### DIFF
--- a/src/init/starship.nu
+++ b/src/init/starship.nu
@@ -8,7 +8,7 @@ let-env PROMPT_INDICATOR = ""
 
 let-env PROMPT_COMMAND = {
     # jobs are not supported
-    let width = (term size -c | get columns | into string)
+    let width = (term size | get columns | into string)
     ^::STARSHIP:: prompt $"--cmd-duration=($env.CMD_DURATION_MS)" $"--status=($env.LAST_EXIT_CODE)" $"--terminal-width=($width)"
 }
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
The -c parameter has been removed through nushell/nushell#6651

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**
