### PR TITLE
feat(k8s): Add detect env vars option

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -931,6 +931,7 @@
       "default": {
         "context_aliases": {},
         "contexts": [],
+        "detect_env_vars": [],
         "detect_extensions": [],
         "detect_files": [],
         "detect_folders": [],
@@ -4158,6 +4159,13 @@
           }
         },
         "detect_folders": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_env_vars": {
           "default": [],
           "type": "array",
           "items": {

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2561,8 +2561,9 @@ This module is disabled by default.
 To enable it, set `disabled` to `false` in your configuration file.
 
 When the module is enabled it will always be active, unless any of
-`detect_extensions`, `detect_files` or `detect_folders` have been set in which
-case the module will only be active in directories that match those conditions.
+`detect_env_vars`, `detect_extensions`, `detect_files` or `detect_folders` have
+been set in which case the module will only be active in directories that match
+those conditions or one of the environmatal variable has been set.
 
 :::
 
@@ -2585,6 +2586,7 @@ and `user_alias` options instead.
 | `detect_extensions` | `[]`                                               | Which extensions should trigger this module.                          |
 | `detect_files`      | `[]`                                               | Which filenames should trigger this module.                           |
 | `detect_folders`    | `[]`                                               | Which folders should trigger this modules.                            |
+| `detect_env_vars`   | `[]`                                               | Which environmental variables should trigger this module              |
 | `contexts`          | `[]`                                               | Customized styles and symbols for specific contexts.                  |
 | `disabled`          | `true`                                             | Disables the `kubernetes` module.                                     |
 

--- a/src/configs/kubernetes.rs
+++ b/src/configs/kubernetes.rs
@@ -18,6 +18,7 @@ pub struct KubernetesConfig<'a> {
     pub detect_extensions: Vec<&'a str>,
     pub detect_files: Vec<&'a str>,
     pub detect_folders: Vec<&'a str>,
+    pub detect_env_vars: Vec<&'a str>,
     pub contexts: Vec<KubernetesContextConfig<'a>>,
 }
 
@@ -33,6 +34,7 @@ impl<'a> Default for KubernetesConfig<'a> {
             detect_extensions: vec![],
             detect_files: vec![],
             detect_folders: vec![],
+            detect_env_vars: vec![],
             contexts: vec![],
         }
     }

--- a/src/modules/kubernetes.rs
+++ b/src/modules/kubernetes.rs
@@ -107,9 +107,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         return None;
     };
 
-    // We check that detect_env_vars is not empty here first since calling any on an amptry
-    // iternator returns false, since we want to preserve backwards compatibiliTy we default to
-    // being enabled.
     let have_env_vars = context.detect_env_vars(&config.detect_env_vars);
 
     // If we have some config for doing the directory scan then we use it but if we don't then we

--- a/src/modules/kubernetes.rs
+++ b/src/modules/kubernetes.rs
@@ -110,11 +110,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     // We check that detect_env_vars is not empty here first since calling any on an amptry
     // iternator returns false, since we want to preserve backwards compatibiliTy we default to
     // being enabled.
-    let have_env_vars = !config.detect_env_vars.is_empty()
-        && config
-            .detect_env_vars
-            .iter()
-            .any(|e| context.get_env(e).is_some());
+    let have_env_vars = context.detect_env_vars(&config.detect_env_vars);
 
     // If we have some config for doing the directory scan then we use it but if we don't then we
     // assume we should treat it like the module is enabled to preserve backward compatibility.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Have added the option to trigger the k8s module based on what env vars are set, this has been done in a backwards compatible way so if nothing is changed from the defaults the module will still behave the same way as before. This is similar to what I did in #4486 for the python module and if goes well I'd like to rollout to other modules.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #4238
Closes #4898

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
