### PR TITLE
feat(nu): enable right prompt

### DIFF
--- a/docs/advanced-config/README.md
+++ b/docs/advanced-config/README.md
@@ -261,7 +261,9 @@ not explicitly used in either `format` or `right_format`.
 Note: The right prompt is a single line following the input location. To right align modules above
 the input line in a multi-line prompt, see the [`fill` module](/config/#fill).
 
-`right_format` is currently supported for the following shells: elvish, fish, zsh, xonsh, cmd.
+`right_format` is currently supported for the following shells: elvish, fish, zsh, xonsh, cmd, nushell.
+
+Note: Nushell 0.71.0 or later is required
 
 ### Example
 

--- a/src/init/starship.nu
+++ b/src/init/starship.nu
@@ -12,7 +12,28 @@ let-env PROMPT_COMMAND = {
     ^::STARSHIP:: prompt $"--cmd-duration=($env.CMD_DURATION_MS)" $"--status=($env.LAST_EXIT_CODE)" $"--terminal-width=($width)"
 }
 
-# Not well-suited for `starship prompt --right`.
-# Built-in right prompt is equivalent to $fill$right_format in the first prompt line.
-# Thus does not play well with default `add_newline = True`.
-let-env PROMPT_COMMAND_RIGHT = {''}
+# Whether we can show right prompt on the last line
+let has_rprompt_last_line_support = (version).version >= 0.71.0
+
+# Whether we have config items
+let has_config_items = (not ($env | get -i config | is-empty))
+
+if $has_rprompt_last_line_support {
+    let config = if $has_config_items {
+        $env.config | upsert render_right_prompt_on_last_line true
+    } else {
+        {render_right_prompt_on_last_line: true}
+    }
+    {config: $config}
+} else {
+    { }
+} | load-env
+
+let-env PROMPT_COMMAND_RIGHT = {
+    if $has_rprompt_last_line_support {
+        let width = (term size).columns
+        ^::STARSHIP:: prompt --right $"--cmd-duration=($env.CMD_DURATION_MS)" $"--status=($env.LAST_EXIT_CODE)" $"--terminal-width=($width)"
+    } else {
+        ''
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
This PR enables right prompt of nushell. It depends on nushell/reedline#492 and nushell/nushell#6781.

I think it's ready for review since both nushell/reedline#492 and nushell/nushell#6781 have been merged by upstream. @davidkna 

#### Motivation and Context
Closes #3982 

#### Screenshots (if appropriate):
* `new_line` `line_break`
![Screenshot from 2022-10-18 15-56-15](https://user-images.githubusercontent.com/15247421/197098534-0f454d98-74d6-4639-a772-790f3e66a527.png)

* `new_line`  ~~`line_break`~~
![Screenshot from 2022-10-18 16-00-28](https://user-images.githubusercontent.com/15247421/197098530-4b574ffe-c4d6-42f5-a4d3-537a7dd0c866.png)

* ~~`new_line`~~  `line_break`
![Screenshot from 2022-10-18 15-55-51](https://user-images.githubusercontent.com/15247421/197098539-48071c59-9e1e-48b1-8d14-f117ed99413a.png)

* ~~`new_line`~~ ~~`line_break`~~
![Screenshot from 2022-10-18 15-55-27](https://user-images.githubusercontent.com/15247421/197098541-1825dff6-ca90-41de-9e0f-c79c80ed2fda.png)


#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
