### PR TITLE
refactor(nu): simplify getting term width

### DIFF
--- a/src/init/starship.nu
+++ b/src/init/starship.nu
@@ -8,7 +8,7 @@ let-env PROMPT_INDICATOR = ""
 
 let-env PROMPT_COMMAND = {
     # jobs are not supported
-    let width = (term size | get columns | into string)
+    let width = (term size).columns
     ^::STARSHIP:: prompt $"--cmd-duration=($env.CMD_DURATION_MS)" $"--status=($env.LAST_EXIT_CODE)" $"--terminal-width=($width)"
 }
 


### PR DESCRIPTION
#### Description
<!--- Describe your changes in detail -->
[starship.nu L11](https://github.com/starship/starship/blob/0b173c263e510be572db3ac88f3df7ca01aa486a/src/init/starship.nu#L11) uses multiple piping commands to pull the terminal width from `term size` and convert the result into a string. These actions can be condensed and combined into one of nushell's subexpressions, which makes the code cleaner and easier to read. The proposal is shown below.

Before:
```nu
let width = (term size | get columns | into string)
```
After:
```nu
let width = (term size).columns
```

#### Motivation and Context

Remove piping chain and reduce points of failure to only `term size` and the requested value `columns`.

#### How Has This Been Tested?

- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
