### PR TITLE
fix: command to get terminal width in nushell init script

### DIFF
--- a/src/init/starship.nu
+++ b/src/init/starship.nu
@@ -8,7 +8,7 @@ let-env PROMPT_INDICATOR = ""
 
 let-env PROMPT_COMMAND = {
     # jobs are not supported
-    let width = (term size | get columns | into string)
+    let width = (term size).columns
     ^::STARSHIP:: prompt $"--cmd-duration=($env.CMD_DURATION_MS)" $"--status=($env.LAST_EXIT_CODE)" $"--terminal-width=($width)"
 }
 


### PR DESCRIPTION
Signed-off-by: Christoph Dalski <chdalski.coding@gmail.com>

#### Description
With version 0.70.0 of nushell the previous command (`(term size | get columns | into string)`), to get the terminal width, broke.
The replaced version (`(term size).columns`) works with 0.70.0 and below (tested with 0.69.1).

#### Motivation and Context
The change is required because starship prompt will fail to initialize with version 0.70.0, otherwise.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Changed the command in a term with version 0.70.0 were it breaks. After the change it obviously wasn't breaking anymore.
Tried the same thing on my laptop were still version 0.69.1 is running. Both implementations are working fine.

<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [X] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
I didn't update the tests and the documentation because in this particular case there is no need, i guess?
