### PR TITLE
docs(config): Replace misleading $all reference

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -124,7 +124,7 @@ For example:
 
 - `(@$region)` will show nothing if the variable `region` is `None` or empty string, otherwise `@` followed by the value of region.
 - `(some text)` will always show nothing since there are no variables wrapped in the braces.
-- When `$all` is a shortcut for `\[$a$b\]`, `($all)` will show nothing only if `$a` and `$b` are both `None`.
+- When `$combined` is a shortcut for `\[$a$b\]`, `($combined)` will show nothing only if `$a` and `$b` are both `None`.
   This works the same as `(\[$a$b\] )`.
 
 #### Special characters


### PR DESCRIPTION
In the config `$all` has special meaning, as it is and contains the default value for `format`.

Using `$all` in the example for conditional format strings with multiple variables is potentially misleading and confusing.  
Using a neutral variable `$combined` has no conflict with other meanings and is thus preferable.
