### PR TITLE
chore: bump msrv to 1.64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ license = "ISC"
 readme = "README.md"
 repository = "https://github.com/starship/starship"
 # Note: MSRV is only intended as a hint, and only the latest version is officially supported in starship.
-rust-version = "1.60"
+rust-version = "1.64"
 description = """
 The minimal, blazing-fast, and infinitely customizable prompt for any shell! ☄🌌️
 """

--- a/src/serde_utils.rs
+++ b/src/serde_utils.rs
@@ -136,7 +136,7 @@ impl<'de> Deserializer<'de> for ValueDeserializer<'de> {
                 .iter()
                 .filter_map(|field| {
                     let score = strsim::jaro_winkler(key, field);
-                    (score > 0.8).then(|| (score, field))
+                    (score > 0.8).then_some((score, field))
                 })
                 .max_by(|(score_a, _field_a), (score_b, _field_b)| {
                     score_a.partial_cmp(score_b).unwrap_or(Ordering::Equal)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR bumps the MSRV to rust 1.64 (the latest rust release), because #4541 already increased it indirectly.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
