### PR TITLE
feat(bug-report): ask for confirmation before opening issue

### DIFF
--- a/src/bug_report.rs
+++ b/src/bug_report.rs
@@ -27,7 +27,7 @@ pub fn create() {
     println!("Forward the pre-filled report above to GitHub in your browser?");
     println!("{} To avoid any sensitive data from being exposed, please review the included information before proceeding. Data forwarded to GitHub is subject to GitHub's privacy policy.", Style::new().bold().paint("Warning:"));
     println!(
-        "Enter `{}`, or anything else to decline, and `{}` to confirm your choice:\n",
+        "Enter `{}` to accept, or anything else to decline, and `{}` to confirm your choice:\n",
         Style::new().bold().paint("y"),
         Style::new().bold().paint("Enter key")
     );
@@ -35,7 +35,7 @@ pub fn create() {
     let mut input = String::new();
     let _ = std::io::stdin().read_line(&mut input);
 
-    if input.trim() == "y" {
+    if input.trim().to_lowercase() == "y" {
         let link = make_github_issue_link(&issue_body);
         if let Err(e) = open::that(&link) {
             println!("Failed to open issue report in your browser: {}", e);

--- a/src/bug_report.rs
+++ b/src/bug_report.rs
@@ -1,5 +1,6 @@
 use crate::shadow;
 use crate::utils::{self, exec_cmd};
+use nu_ansi_term::Style;
 
 use std::fs;
 use std::path::PathBuf;
@@ -17,16 +18,33 @@ pub fn create() {
         starship_config: get_starship_config(),
     };
 
-    let link = make_github_issue_link(environment);
+    let issue_body = get_github_issue_body(&environment);
 
-    if open::that(&link).is_ok() {
-        println!("Take a look at your browser. A GitHub issue has been populated with your configuration.");
-        println!("If your browser has failed to open, please click this link:\n");
+    println!(
+        "{}\n{issue_body}\n\n",
+        Style::new().bold().paint("Generated bug report:")
+    );
+    println!("Forward the pre-filled report above to GitHub in your browser?");
+    println!("{} To avoid any sensitive data from being exposed, please review the included information before proceeding. Data forwarded to GitHub is subject to GitHub's privacy policy.", Style::new().bold().paint("Warning:"));
+    println!(
+        "Enter `{}`, or anything else to decline, and `{}` to confirm your choice:\n",
+        Style::new().bold().paint("y"),
+        Style::new().bold().paint("Enter key")
+    );
+
+    let mut input = String::new();
+    let _ = std::io::stdin().read_line(&mut input);
+
+    if input.trim() == "y" {
+        let link = make_github_issue_link(&issue_body);
+        if let Err(e) = open::that(&link) {
+            println!("Failed to open issue report in your browser: {}", e);
+            println!("Please copy the above report and open an issue manually, or try opening the following link:\n{link}");
+        }
     } else {
-        println!("Click this link to create a GitHub issue populated with your configuration:\n");
+        println!("Will not open an issue in your browser! Please copy the above report and open an issue manually.");
     }
-
-    println!("{link}");
+    println!("Thanks for using the Starship bug report tool!");
 }
 
 const UNKNOWN_SHELL: &str = "<unknown shell>";
@@ -50,7 +68,7 @@ fn get_pkg_branch_tag() -> &'static str {
     shadow::BRANCH
 }
 
-fn make_github_issue_link(environment: Environment) -> String {
+fn get_github_issue_body(environment: &Environment) -> String {
     let shell_syntax = match environment.shell_info.name.as_ref() {
         "powershell" | "pwsh" => "pwsh",
         "fish" => "fish",
@@ -60,7 +78,7 @@ fn make_github_issue_link(environment: Environment) -> String {
         _ => "bash",
     };
 
-    let body = urlencoding::encode(&format!("#### Current Behavior
+    format!("#### Current Behavior
 <!-- A clear and concise description of the behavior. -->
 
 #### Expected Behavior
@@ -109,13 +127,16 @@ fn make_github_issue_link(environment: Environment) -> String {
         build_rust_channel =  shadow::BUILD_RUST_CHANNEL,
         build_time =  shadow::BUILD_TIME,
         shell_syntax = shell_syntax,
-    ))
-        .replace("%20", "+");
+    )
+}
+
+fn make_github_issue_link(body: &str) -> String {
+    let escaped = urlencoding::encode(body).replace("%20", "+");
 
     format!(
         "https://github.com/starship/starship/issues/new?template={}&body={}",
         urlencoding::encode("Bug_report.md"),
-        body
+        escaped
     )
     .chars()
     .take(GITHUB_CHAR_LIMIT)
@@ -259,7 +280,8 @@ mod tests {
             starship_config: "No Starship config".to_string(),
         };
 
-        let link = make_github_issue_link(environment);
+        let body = get_github_issue_body(&environment);
+        let link = make_github_issue_link(&body);
 
         assert!(link.contains(clap::crate_version!()));
         assert!(link.contains("Linux"));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Privacy concerns have been voiced about the privacy tool (https://github.com/starship/starship/issues/3757). To avoid any data from being exposed unintentionally, ask for confirmation before forwarding issue reports to GitHub.
Unlike https://github.com/starship/starship/issues/3794, this PR avoids complexity by simply asking for confirmation instead of allowing edits of generated reports.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/starship/starship/issues/3757
Closes https://github.com/starship/starship/issues/3794

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
