### PR TITLE
fix(config): unrecognized config properties don't cause config error

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -53,7 +53,7 @@ impl<'a, T: Deserialize<'a> + Default> ModuleConfig<'a, ValueError> for T {
             // deserialize ignoring that error. Otherwise, just return the error
             if err.to_string().contains("Unknown key") {
                 log::warn!("{}", err);
-                let deserializer2 = ValueDeserializer::new(config).with_no_ignored_error();
+                let deserializer2 = ValueDeserializer::new(config).with_allow_unknown_keys();
                 T::deserialize(deserializer2)
             } else {
                 Err(err)

--- a/src/config.rs
+++ b/src/config.rs
@@ -593,6 +593,24 @@ mod tests {
     }
 
     #[test]
+    fn test_load_unknown_key_config() {
+        #[derive(Clone, Default, Deserialize)]
+        #[serde(default)]
+        struct TestConfig<'a> {
+            pub foo: &'a str,
+        }
+
+        let config = toml::toml! {
+            foo = "test"
+            bar = "ignore me"
+        };
+        let rust_config = TestConfig::from_config(&config);
+
+        assert!(rust_config.is_ok());
+        assert_eq!(rust_config.unwrap().foo, "test");
+    }
+
+    #[test]
     fn test_from_string() {
         let config = Value::String(String::from("S"));
         assert_eq!(<&str>::from_config(&config).unwrap(), "S");

--- a/src/serde_utils.rs
+++ b/src/serde_utils.rs
@@ -47,7 +47,7 @@ impl<'de> ValueDeserializer<'de> {
         }
     }
 
-    pub fn with_no_ignored_error(self) -> Self {
+    pub fn with_allow_unknown_keys(self) -> Self {
         ValueDeserializer {
             error_on_ignored: false,
             ..self
@@ -354,7 +354,7 @@ mod test {
             "Error in 'StarshipRoot' at 'unknown_key': Unknown key"
         );
 
-        let deserializer2 = ValueDeserializer::new(&value).with_no_ignored_error();
+        let deserializer2 = ValueDeserializer::new(&value).with_allow_unknown_keys();
         let result = StarshipRootConfig::deserialize(deserializer2);
         assert!(result.is_ok());
     }

--- a/src/serde_utils.rs
+++ b/src/serde_utils.rs
@@ -13,6 +13,7 @@ pub struct ValueDeserializer<'de> {
     value: &'de Value,
     info: Option<StructInfo>,
     current_key: Option<&'de str>,
+    error_on_ignored: bool,
 }
 
 /// When deserializing a struct, this struct stores information about the struct.
@@ -28,14 +29,30 @@ impl<'de> ValueDeserializer<'de> {
             value,
             info: None,
             current_key: None,
+            error_on_ignored: true,
         }
     }
 
-    fn with_info(value: &'de Value, info: Option<StructInfo>, current_key: &'de str) -> Self {
+    fn with_info(
+        value: &'de Value,
+        info: Option<StructInfo>,
+        current_key: &'de str,
+        ignored: bool,
+    ) -> Self {
         ValueDeserializer {
             value,
             info,
             current_key: Some(current_key),
+            error_on_ignored: ignored,
+        }
+    }
+
+    pub fn with_no_ignored_error(self) -> Self {
+        ValueDeserializer {
+            value: self.value,
+            info: self.info,
+            current_key: self.current_key,
+            error_on_ignored: false,
         }
     }
 }
@@ -83,7 +100,12 @@ impl<'de> Deserializer<'de> for ValueDeserializer<'de> {
                 let map = MapDeserializer::new(t.iter().map(|(k, v)| {
                     (
                         k.as_str(),
-                        ValueDeserializer::with_info(v, self.info, k.as_str()),
+                        ValueDeserializer::with_info(
+                            v,
+                            self.info,
+                            k.as_str(),
+                            self.error_on_ignored,
+                        ),
                     )
                 }));
                 map.deserialize_map(visitor)
@@ -128,6 +150,10 @@ impl<'de> Deserializer<'de> for ValueDeserializer<'de> {
                 ALL_MODULES.contains(&key) || key == "custom" || key == "env_var"
             })
         {
+            return visitor.visit_none();
+        }
+
+        if !self.error_on_ignored {
             return visitor.visit_none();
         }
 
@@ -322,13 +348,17 @@ mod test {
         let value = toml::toml! {
             unknown_key = "foo"
         };
-        let deserializer = ValueDeserializer::new(&value);
 
+        let deserializer = ValueDeserializer::new(&value);
         let result = StarshipRootConfig::deserialize(deserializer).unwrap_err();
         assert_eq!(
             format!("{result}"),
             "Error in 'StarshipRoot' at 'unknown_key': Unknown key"
         );
+
+        let deserializer2 = ValueDeserializer::new(&value).with_no_ignored_error();
+        let result = StarshipRootConfig::deserialize(deserializer2);
+        assert!(result.is_ok());
     }
 
     #[test]

--- a/src/serde_utils.rs
+++ b/src/serde_utils.rs
@@ -49,10 +49,8 @@ impl<'de> ValueDeserializer<'de> {
 
     pub fn with_no_ignored_error(self) -> Self {
         ValueDeserializer {
-            value: self.value,
-            info: self.info,
-            current_key: self.current_key,
             error_on_ignored: false,
+            ..self
         }
     }
 }


### PR DESCRIPTION
Fixes an issue where the config was not being loaded when ignored properties are present. This still prints a warning log indicating a possible misconfiguration.
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
~~The deserializer wrapper has been updated such that deserialization of ignored properties does not return an error, and instead returns the `visitor.visit_none()`. This function now includes a warning log statement since the [log statement for reporting the error](https://github.com/starship/starship/blob/master/src/config.rs#L34) as shown in the bug ticket is no longer reached.~~ (this described the initial implementation before PR review)

The `ValueDeserializer` wrapper has been updated so that warnings can be either ignored or cause an `Err` result. At this time, the only warning that gets emitted is the warning from ignored properties during deserialization. This can be used via the new `with_allow_unknown_keys` function.

The configurable warning behavior is used within the generic `from_config` implementation of `ModuleConfig`, wherein the deserializer wrapper is used to load the config. If it reports an "Unknown key" error, then the config is loaded again and deserialized without reporting warnings. This results in the warning be reported without preventing the otherwise valid config being loaded and returned.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #4481 

#### Screenshots (if appropriate):
In this screenshot, I'm showing that as I initialize starship with these changes, we can see I have not set a custom format (the line in the config is commented out), and the unexpected property "go" is detected and a warning is printed. After updating the config to enable the format using `sed`, the shell format is updated with the new prompt without resolving the unexpected config field.

<img width="642" alt="image" src="https://user-images.githubusercontent.com/3588764/198867545-a34cd3a4-f83d-4958-a766-35a4fa66908c.png">


#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

1. set `~/.config/starship.toml` with an unexpected key like the following:
```toml
format = 'Hello! $character'

# This should be "golang".
[go]
disabled = true

[shell]
disabled = false
```
2. re-initialize starship using the build with `eval "$(cargo run init zsh)"` (I'm using `zsh`, but the shell type doesn't matter in this case)
3. Expect to see the prompt "Hello!" rather than the default shell name (in my case `zsh  ❯`

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly. **(n/a)**
- [x] I have updated the tests accordingly.
