### PR TITLE
feat(kubernetes): Add styling based on current context

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -892,6 +892,7 @@
     "kubernetes": {
       "default": {
         "context_aliases": {},
+        "contexts": [],
         "detect_extensions": [],
         "detect_files": [],
         "detect_folders": [],
@@ -3973,6 +3974,58 @@
           "items": {
             "type": "string"
           }
+        },
+        "contexts": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/KubernetesContextConfig"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "KubernetesContextConfig": {
+      "type": "object",
+      "properties": {
+        "context_pattern": {
+          "default": "",
+          "type": "string"
+        },
+        "user_pattern": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "symbol": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "style": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "context_alias": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "user_alias": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "additionalProperties": false

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2434,7 +2434,8 @@ kotlin_binary = 'kotlinc'
 Displays the current [Kubernetes context](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/#context) name and, if set, the namespace, user and cluster from the kubeconfig file.
 The namespace needs to be set in the kubeconfig file, this can be done via
 `kubectl config set-context starship-context --namespace astronaut`.
-Similarly the user and cluster can be set with `kubectl config set-context starship-context --user starship-user` and `kubectl config set-context starship-context --cluster starship-cluster`.
+Similarly, the user and cluster can be set with `kubectl config set-context starship-context --user starship-user`
+and `kubectl config set-context starship-context --cluster starship-cluster`.
 If the `$KUBECONFIG` env var is set the module will use that if not it will use the `~/.kube/config`.
 
 ::: tip
@@ -2450,17 +2451,39 @@ case the module will only be active in directories that match those conditions.
 
 ### Options
 
+::: warning
+
+The `context_aliases` and `user_aliases` options are deprecated. Use `contexts` and the corresponding `context_alias`
+and `user_alias` options instead.
+
+:::
+
 | Option              | Default                                            | Description                                                           |
 | ------------------- | -------------------------------------------------- | --------------------------------------------------------------------- |
 | `symbol`            | `'☸ '`                                             | A format string representing the symbol displayed before the Cluster. |
 | `format`            | `'[$symbol$context( \($namespace\))]($style) in '` | The format for the module.                                            |
 | `style`             | `'cyan bold'`                                      | The style for the module.                                             |
-| `context_aliases`   | `{}`                                               | Table of context aliases to display.                                  |
-| `user_aliases`      | `{}`                                               | Table of user aliases to display.                                     |
+| `context_aliases`*  | `{}`                                               | Table of context aliases to display.                                  |
+| `user_aliases`*     | `{}`                                               | Table of user aliases to display.                                     |
 | `detect_extensions` | `[]`                                               | Which extensions should trigger this module.                          |
 | `detect_files`      | `[]`                                               | Which filenames should trigger this module.                           |
 | `detect_folders`    | `[]`                                               | Which folders should trigger this modules.                            |
+| `contexts`          | `[]`                                               | Customized styles and symbols for specific contexts.                  |
 | `disabled`          | `true`                                             | Disables the `kubernetes` module.                                     |
+
+*: This option is deprecated, please add `contexts` with the corresponding `context_alias` and `user_alias` options instead.
+
+To customize the style of the module for specific environments, use the following configuration as
+part of the `environments` list:
+
+| Variable          | Description                                                                              |
+| ----------------- | ---------------------------------------------------------------------------------------- |
+| `context_pattern` | **Required** Regular expression to match current Kubernetes context name.                |
+| `user_pattern`    | Regular expression to match current Kubernetes user name.                                |
+| `context_alias`   | Context alias to display instead of the full context name.                               |
+| `user_alias`      | User alias to display instead of the full user name.                                     |
+| `style`           | The style for the module when using this context. If not set, will use module's style.   |
+| `symbol`          | The symbol for the module when using this context. If not set, will use module's symbol. |
 
 ### Variables
 
@@ -2483,13 +2506,9 @@ case the module will only be active in directories that match those conditions.
 [kubernetes]
 format = 'on [⛵ ($user on )($cluster in )$context \($namespace\)](dimmed green) '
 disabled = false
-[kubernetes.context_aliases]
-'dev.local.cluster.k8s' = 'dev'
-'.*/openshift-cluster/.*' = 'openshift'
-'gke_.*_(?P<var_cluster>[\w-]+)' = 'gke-$var_cluster'
-[kubernetes.user_aliases]
-'dev.local.cluster.k8s' = 'dev'
-'root/.*' = 'root'
+contexts = [
+  { context_pattern = "dev.local.cluster.k8s", style = "green", symbol = "💔 " },
+]
 ```
 
 Only show the module in directories that contain a `k8s` file.
@@ -2502,29 +2521,28 @@ disabled = false
 detect_files = ['k8s']
 ```
 
-#### Regex Matching
+#### Kubernetes Context specific config
 
-Additional to simple aliasing, `context_aliases` and `user_aliases` also supports
-extended matching and renaming using regular expressions.
-
-The regular expression must match on the entire kube context,
-capture groups can be referenced using `$name` and `$N` in the replacement.
-This is more explained in the [regex crate](https://docs.rs/regex/1.5.4/regex/struct.Regex.html#method.replace) documentation.
-
-Long and automatically generated cluster names can be identified
-and shortened using regular expressions:
+The `contexts` configuration option is used to customise what the current Kubernetes context name looks
+like (style and symbol) if the name matches defined regular expression.
 
 ```toml
-[kubernetes.context_aliases]
-# OpenShift contexts carry the namespace and user in the kube context: `namespace/name/user`:
-'.*/openshift-cluster/.*' = 'openshift'
-# Or better, to rename every OpenShift cluster at once:
-'.*/(?P<var_cluster>[\w-]+)/.*' = '$var_cluster'
+# ~/.config/starship.toml
 
-# Contexts from GKE, AWS and other cloud providers usually carry additional information, like the region/zone.
-# The following entry matches on the GKE format (`gke_projectname_zone_cluster-name`)
-# and renames every matching kube context into a more readable format (`gke-cluster-name`):
-'gke_.*_(?P<var_cluster>[\w-]+)' = 'gke-$var_cluster'
+[[kubernetes.contexts]]
+# "bold red" style + default symbol when Kubernetes current context name contains "production"
+context_pattern = "production"
+user_pattern = "admin_user"
+style = "bold red"
+context_alias = "prod"
+user_alias = "admin"
+
+[[kubernetes.contexts]]
+# "green" style + a different symbol when Kubernetes current context name contains openshift
+context_pattern = ".*openshift.*"
+style = "green"
+symbol = "💔 "
+context_alias = "openshift"
 ```
 
 ## Line Break

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2474,7 +2474,7 @@ and `user_alias` options instead.
 *: This option is deprecated, please add `contexts` with the corresponding `context_alias` and `user_alias` options instead.
 
 To customize the style of the module for specific environments, use the following configuration as
-part of the `environments` list:
+part of the `contexts` list:
 
 | Variable          | Description                                                                              |
 | ----------------- | ---------------------------------------------------------------------------------------- |
@@ -2484,6 +2484,11 @@ part of the `environments` list:
 | `user_alias`      | User alias to display instead of the full user name.                                     |
 | `style`           | The style for the module when using this context. If not set, will use module's style.   |
 | `symbol`          | The symbol for the module when using this context. If not set, will use module's symbol. |
+
+Note that all regular expression are anchored with `^<pattern>$` and so must match the whole string. The `*_pattern`
+regular expressions may contain capture groups, which can be referenced in the corresponding alias via `$name` and `$N`
+(see example below and the
+[rust Regex::replace() documentation](https://docs.rs/regex/latest/regex/struct.Regex.html#method.replace)).
 
 ### Variables
 
@@ -2524,13 +2529,14 @@ detect_files = ['k8s']
 #### Kubernetes Context specific config
 
 The `contexts` configuration option is used to customise what the current Kubernetes context name looks
-like (style and symbol) if the name matches defined regular expression.
+like (style and symbol) if the name matches the defined regular expression.
 
 ```toml
 # ~/.config/starship.toml
 
 [[kubernetes.contexts]]
-# "bold red" style + default symbol when Kubernetes current context name contains "production"
+# "bold red" style + default symbol when Kubernetes current context name equals "production" *and* the current user
+# equals "admin_user"
 context_pattern = "production"
 user_pattern = "admin_user"
 style = "bold red"
@@ -2543,6 +2549,14 @@ context_pattern = ".*openshift.*"
 style = "green"
 symbol = "💔 "
 context_alias = "openshift"
+
+[[kubernetes.contexts]]
+# Using capture groups
+# Contexts from GKE, AWS and other cloud providers usually carry additional information, like the region/zone.
+# The following entry matches on the GKE format (`gke_projectname_zone_cluster-name`)
+# and renames every matching kube context into a more readable format (`gke-cluster-name`):
+context_pattern = "gke_.*_(?P<cluster>[\\w-]+)"
+context_alias = "gke-$cluster"
 ```
 
 ## Line Break

--- a/src/configs/kubernetes.rs
+++ b/src/configs/kubernetes.rs
@@ -18,6 +18,7 @@ pub struct KubernetesConfig<'a> {
     pub detect_extensions: Vec<&'a str>,
     pub detect_files: Vec<&'a str>,
     pub detect_folders: Vec<&'a str>,
+    pub contexts: Vec<KubernetesContextConfig<'a>>,
 }
 
 impl<'a> Default for KubernetesConfig<'a> {
@@ -32,6 +33,23 @@ impl<'a> Default for KubernetesConfig<'a> {
             detect_extensions: vec![],
             detect_files: vec![],
             detect_folders: vec![],
+            contexts: vec![],
         }
     }
+}
+
+#[derive(Clone, Deserialize, Serialize, Default)]
+#[cfg_attr(
+    feature = "config-schema",
+    derive(schemars::JsonSchema),
+    schemars(deny_unknown_fields)
+)]
+#[serde(default)]
+pub struct KubernetesContextConfig<'a> {
+    pub context_pattern: &'a str,
+    pub user_pattern: Option<&'a str>,
+    pub symbol: Option<&'a str>,
+    pub style: Option<&'a str>,
+    pub context_alias: Option<&'a str>,
+    pub user_alias: Option<&'a str>,
 }

--- a/src/modules/kubernetes.rs
+++ b/src/modules/kubernetes.rs
@@ -144,7 +144,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     // for that reason, we can pick the first context with that name
     let ctx_components: KubeCtxComponents = env::split_paths(&kube_cfg)
         .find_map(|filename| get_kube_ctx_components(filename, &current_kube_ctx_name))
-        .unwrap_or({
+        .unwrap_or_else( || {
             // TODO: figure out if returning is more sensible. But currently we have tests depending on this
             log::warn!(
                 "Invalid KUBECONFIG: identified current-context `{}`, but couldn't find the context in any config file(s): `{}`.\n",

--- a/src/modules/kubernetes.rs
+++ b/src/modules/kubernetes.rs
@@ -173,17 +173,15 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             return false;
         };
 
-        if let Some(user_pattern) = context_config.user_pattern {
-            if let Some(kube_user) = &kube_user {
-                match_user_regex(user_pattern, kube_user)
-            } else {
-                // If a pattern is set, but we have no user, there is no match
-                false
-            }
-        } else {
+        let Some(user_pattern) = context_config.user_pattern else {
             // If user pattern not set, treat it as a match-all pattern
-            true
-        }
+            return true;
+        };
+        let Some(kube_user) = &kube_user else {
+            // If a pattern is set, but we have no user, there is no match
+            return false
+        };
+        match_user_regex(user_pattern, kube_user)
     });
 
     let display_context = match matched_context_config {


### PR DESCRIPTION
#### Description
This PR implements the suggestion from https://github.com/starship/starship/issues/570 to add an ability to customize the configuration of the kubernetes module style, based on the current context.

A new variable is added to the config section, called environments, which is a list of possible customizations. Each such customization is an object with a context_pattern regex, which matches context name, and an optional style and icon that will override the global configuration, if the currently used context matched the context_pattern.

Based on multiple attempts to add per-context styling and symbols to the kubernetes module.

- https://github.com/starship/starship/pull/1568 by @lht  -> base (rebased and adjusted to current HEAD)
- https://github.com/starship/starship/pull/614 by @nomaed -> naming, symbol, some tests

Rebase, combined, and extended by @jankatins

#### Motivation and Context
It is common to work with development, testing, staging and production environments when deploying to kubernetes clusters, especially with continuous deployment. However, it is too easy to be using a production context (for example, for inspecting logs) and forgetting to switch to the personal development context when deploying any changes.

This change helps giving better visibility, by allowing to change the style of the kubernetes module in the prompt to draw attention, or changing the color to red (as an example) if using a context that should be used with care.

Closes: https://github.com/starship/starship/issues/570 (original request)
Closes: https://github.com/starship/starship/pull/1568 (superseded PR)
Closes: https://github.com/starship/starship/pull/614 (superseded PR)

#### Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/890156/198907953-fb9b7c9c-e654-4dce-a2f8-b6fd88b374d6.png)


#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
