### PR TITLE
feat(sudo): use new -N option if available

### DIFF
--- a/src/modules/sudo.rs
+++ b/src/modules/sudo.rs
@@ -18,7 +18,15 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         return None;
     }
 
-    let is_sudo_cached = context.exec_cmd("sudo", &["-n", "true"]).is_some();
+    let mut sudo_option = "-nv";
+
+    /* let's check if -N option is supported */
+    let is_sudo_nocreds_update = context.exec_cmd("sudo", &["-NV"]).is_some();
+    if is_sudo_nocreds_update {
+        sudo_option = "-Nnv"
+    }
+
+    let is_sudo_cached = context.exec_cmd("sudo", &[sudo_option]).is_some();
 
     if !is_sudo_cached {
         return None;


### PR DESCRIPTION
This implements the concept described in https://github.com/starship/starship/issues/4538. It improves the sudo module by not updating the cache when sudo is not used.

#### Description

Patch detect if the -N option is available in sudo then update command to avoid cache update.

Closes #4538

#### How Has This Been Tested?

Tested with sudo 1.1.12.

- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:

- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
