### PR TITLE
fix: check that BP_PIPESTATUS is defined

### DIFF
--- a/src/init/starship.bash
+++ b/src/init/starship.bash
@@ -33,9 +33,11 @@ starship_preexec() {
 starship_precmd() {
     # Save the status, because commands in this pipeline will change $?
     STARSHIP_CMD_STATUS=$? STARSHIP_PIPE_STATUS=(${PIPESTATUS[@]})
-    if [[ "${#BP_PIPESTATUS[@]}" -gt "${#STARSHIP_PIPE_STATUS[@]}" ]]; then
-        STARSHIP_PIPE_STATUS=(${BP_PIPESTATUS[@]})
-    fi
+	if [[! -z "${#BP_PIPESTATUS[@]}"]]; then
+		if [["${#BP_PIPESTATUS[@]}" -gt "${#STARSHIP_PIPE_STATUS[@]}" ]]; then
+			STARSHIP_PIPE_STATUS=(${BP_PIPESTATUS[@]})
+		fi
+	fi
 
     local NUM_JOBS=0
     # Evaluate the number of jobs before running the preserved prompt command, so that tools


### PR DESCRIPTION
#### Description
Check that BP_PIPESTATUS is defined before operating on it.

#### Motivation and Context

If `set -u` to treat undefined parameters as error during parameters expansion, you will get an error at every command.

Closes #4567
Closes #4540

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [X] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
