### PR TITLE
build(deps): update gitoxide crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "464b3811b747f8f7ebc8849c9c728c39f6ac98a055edad93baf9eb330e3f8f9d"
+dependencies = [
+ "cfg-if 1.0.0",
+ "getrandom 0.2.7",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -208,15 +220,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "bstr"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -886,8 +889,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if 1.0.0",
+ "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -896,7 +901,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18d4ce09c0a6c71c044700e5932877667f427f007b77e6c39ab49aebc4719e25"
 dependencies = [
- "bstr 1.0.1",
+ "bstr",
  "btoi",
  "git-date",
  "itoa",
@@ -910,7 +915,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c62e66a042c6b39c6dbfa3be37d134900d99ff9c54bbe489ed560a573895d5d"
 dependencies = [
- "bstr 1.0.1",
+ "bstr",
  "compact_str",
  "git-features",
  "git-glob",
@@ -944,16 +949,16 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e4b01997b6551554fdac6f02277d0d04c3e869daa649bedd06d38c86f11dc42"
 dependencies = [
- "bstr 1.0.1",
+ "bstr",
 ]
 
 [[package]]
 name = "git-config"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d537c28b924ef1e1610420928e9fad125dec914c50755cb7a523aa3bfcdcdc3"
+checksum = "bd8603e953bd4c9bf310e74e43697400f5542f1cc75fad46fbd7427135a9534f"
 dependencies = [
- "bstr 1.0.1",
+ "bstr",
  "git-config-value",
  "git-features",
  "git-glob",
@@ -970,12 +975,12 @@ dependencies = [
 
 [[package]]
 name = "git-config-value"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ba59463a4f28fda13715a006323f053f95cdce49ca0b38ec58debf275bc5f6"
+checksum = "805f2a8e0f576586bed3de3f1cb26700dfd73cf2197bd95306eb6a77ffb5034d"
 dependencies = [
  "bitflags",
- "bstr 1.0.1",
+ "bstr",
  "git-path",
  "libc",
  "thiserror",
@@ -983,11 +988,11 @@ dependencies = [
 
 [[package]]
 name = "git-credentials"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45e5d9d2fd50e1ad732a9fe795dcad8545c669a11e1b998a8a24aa4d05fe43bb"
+checksum = "3f540186ea56fd075ba2b923180ebf4318e66ceaeac0a2a518e75dab8517d339"
 dependencies = [
- "bstr 1.0.1",
+ "bstr",
  "git-command",
  "git-config-value",
  "git-path",
@@ -1003,7 +1008,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37881e9725df41e15d16216d3a0cee251fd8a39d425f75b389112df5c7f20f3d"
 dependencies = [
- "bstr 1.0.1",
+ "bstr",
  "itoa",
  "thiserror",
  "time 0.3.14",
@@ -1011,23 +1016,23 @@ dependencies = [
 
 [[package]]
 name = "git-diff"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cdc725268f43f7e46aa697c7d163971643aad2e99d9c62f5cf92346f0847199"
+checksum = "0a88666a0ae4365b55a0cbf2efde68d2a4cff0747894ad229403bd60b0b2abc5"
 dependencies = [
  "git-hash",
  "git-object",
- "similar",
+ "imara-diff",
  "thiserror",
 ]
 
 [[package]]
 name = "git-discover"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec56d002fcbe59dd7b52ce5b442045b86cf2972ea28223b78936c4b231e19b15"
+checksum = "881e4136d5599cfdb79d8ef60d650823d1a563589fa493d8e4961e64d78a79f2"
 dependencies = [
- "bstr 1.0.1",
+ "bstr",
  "git-hash",
  "git-path",
  "git-ref",
@@ -1037,9 +1042,9 @@ dependencies = [
 
 [[package]]
 name = "git-features"
-version = "0.23.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84ef58587a0770e9df406ec0ee14bb0155d723750732f4d643cb631710632f9f"
+checksum = "4be88ae837674c71b30c6517c6f5f1335f8135bb8a9ffef20000d211933bed08"
 dependencies = [
  "crc32fast",
  "crossbeam-channel",
@@ -1059,12 +1064,12 @@ dependencies = [
 
 [[package]]
 name = "git-glob"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8243c0d7ceefd49353ee54a836b09c402ca7ab95342a7ab312b4a726d7d94b15"
+checksum = "14d17fc8ae791cd6ee271b283835a3ce6f0e970a9a23f67e332b179055bd260f"
 dependencies = [
  "bitflags",
- "bstr 1.0.1",
+ "bstr",
 ]
 
 [[package]]
@@ -1079,17 +1084,18 @@ dependencies = [
 
 [[package]]
 name = "git-index"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d316820e0a3145d237fbcd40f115f5a425f39a789ad48970411e16548e38ec2"
+checksum = "7639093731ba90b72dd63c73e2a493df847b6227681058339e7b302d445544f1"
 dependencies = [
  "atoi",
  "bitflags",
- "bstr 1.0.1",
+ "bstr",
  "filetime",
  "git-bitmap",
  "git-features",
  "git-hash",
+ "git-lock",
  "git-object",
  "git-traverse",
  "itoa",
@@ -1115,18 +1121,18 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb3f85ce84b2328aeb3124a809f7b3a63e59c4d63c227dba7a9cdf6fca6c0987"
 dependencies = [
- "bstr 1.0.1",
+ "bstr",
  "git-actor",
  "quick-error",
 ]
 
 [[package]]
 name = "git-object"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10afcf37953556c744dba40ced5d4b558df5d24a1f49dc6c19205eb2888bd121"
+checksum = "9469a8c00d8bb500ee76a12e455bb174b4ddf71674713335dd1a84313723f7b3"
 dependencies = [
- "bstr 1.0.1",
+ "bstr",
  "btoi",
  "git-actor",
  "git-features",
@@ -1141,9 +1147,9 @@ dependencies = [
 
 [[package]]
 name = "git-odb"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43bbaf44ad02f2612e7756373ebf9a4398bf320875413d2cdab234839c59f63c"
+checksum = "aaaea7031ac7d8dfee232a16d7114395d118226214fb03fe4e15d1f4d62a88a6"
 dependencies = [
  "arc-swap",
  "git-features",
@@ -1159,9 +1165,9 @@ dependencies = [
 
 [[package]]
 name = "git-pack"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b2f8d8d5a61554ea34db45d7f47c0091d7810f783524b9e9c3bebed555d091f"
+checksum = "bc4386dff835ffdc3697c3558111f708fd7b7695c42a4347f2d211cf3246c8e1"
 dependencies = [
  "bytesize",
  "clru",
@@ -1188,15 +1194,15 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "425dc1022690be13e6c5bde4b7e04d9504d323605ec314cd367cebf38a812572"
 dependencies = [
- "bstr 1.0.1",
+ "bstr",
  "thiserror",
 ]
 
 [[package]]
 name = "git-prompt"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42c59a65ada49836d7b1ace9903dfd7e1db563b15064608238dbd2fa75e5b23f"
+checksum = "fa6947935c0671342277bc883ff0687978477b570c1ffe2200b9ba5ac8afdd9f"
 dependencies = [
  "git-command",
  "git-config-value",
@@ -1211,16 +1217,16 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ea17931d07cbe447f371bbdf45ff03c30ea86db43788166655a5302df87ecfc"
 dependencies = [
- "bstr 1.0.1",
+ "bstr",
  "btoi",
  "quick-error",
 ]
 
 [[package]]
 name = "git-ref"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8224284dc4e3b7df8291fd37cda501e4fcb682c492aa06e8b5ad990c2b90fcc4"
+checksum = "638c9e454bacb2965a43f05b4a383c8f66dc64f3a770bd0324b221c2a20e121d"
 dependencies = [
  "git-actor",
  "git-features",
@@ -1237,11 +1243,11 @@ dependencies = [
 
 [[package]]
 name = "git-refspec"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04409261668d071b4674628dce97fc79a6b9a303968ec8fe763151a3d26c7025"
+checksum = "9497af773538ae8cfda053ff7dd0a9e6c28d333ba653040f54b8b4ee32f14187"
 dependencies = [
- "bstr 1.0.1",
+ "bstr",
  "git-hash",
  "git-revision",
  "git-validate",
@@ -1251,9 +1257,9 @@ dependencies = [
 
 [[package]]
 name = "git-repository"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4041c54eb2bb9b8b7695ef2596545c4a7c1ad251028d4527466f37d93e6c6345"
+checksum = "eeb43e59612e493af6a433bf0a960de0042c8aa6f4e4c4cb414f03b97e296b82"
 dependencies = [
  "byte-unit",
  "clru",
@@ -1298,7 +1304,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efd31c63c3745b5dba5ec7109eec41a9c717f4e1e797fe0ef93098f33f31b25"
 dependencies = [
- "bstr 1.0.1",
+ "bstr",
  "git-date",
  "git-hash",
  "git-object",
@@ -1308,9 +1314,9 @@ dependencies = [
 
 [[package]]
 name = "git-sec"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e2bae52bb50ab0d616470a5c914de62790a6d422c080fc5a616794b747db91"
+checksum = "8c79769f6546814d0774db7295c768441016b7e40bdd414fa8dfae2c616a1892"
 dependencies = [
  "bitflags",
  "dirs 4.0.0",
@@ -1347,11 +1353,11 @@ dependencies = [
 
 [[package]]
 name = "git-url"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5db387299d5c2f02ac90b633db5cb4c2b8c7b461a9b6542a16f19cedf901a007"
+checksum = "21b7f8323196840e7932f5b60e1d9c1d6c140fd806bc512f8beedc3f990a1f81"
 dependencies = [
- "bstr 1.0.1",
+ "bstr",
  "git-features",
  "git-path",
  "home",
@@ -1365,17 +1371,17 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5439d6aa0de838dfadd74a71e97a9e23ebc719fd11a9ab6788b835b112c8c3d"
 dependencies = [
- "bstr 1.0.1",
+ "bstr",
  "thiserror",
 ]
 
 [[package]]
 name = "git-worktree"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a963d00309a948a6f9238bd902ca54a6624a516f75b691cd59439378e430144"
+checksum = "45bcc69c36a29cfa283710b7901877ab251d658935f5a41ed824416af500e0ed"
 dependencies = [
- "bstr 1.0.1",
+ "bstr",
  "git-attributes",
  "git-features",
  "git-glob",
@@ -1411,7 +1417,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.6",
 ]
 
 [[package]]
@@ -1481,6 +1487,16 @@ dependencies = [
  "matches",
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "imara-diff"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e98c1d0ad70fc91b8b9654b1f33db55e59579d3b3de2bffdced0fdb810570cb8"
+dependencies = [
+ "ahash 0.8.1",
+ "hashbrown",
 ]
 
 [[package]]
@@ -2226,9 +2242,9 @@ dependencies = [
 
 [[package]]
 name = "prodash"
-version = "20.2.0"
+version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd4e8b029f29b4eb8f95315957fb7ac8a8fd1924405fadf885b0e208fe34ba39"
+checksum = "d27f6a3ef883aaea624a6ad91c88452e5df05430a79fd880c12673a7bc1648d6"
 dependencies = [
  "bytesize",
  "human_format",
@@ -2691,15 +2707,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "similar"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62ac7f900db32bf3fd12e0117dd3dc4da74bc52ebaac97f39668446d89694803"
-dependencies = [
- "bstr 0.2.17",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,9 +48,9 @@ clap_complete = "4.0.3"
 dirs-next = "2.0.0"
 dunce = "1.0.3"
 gethostname = "0.4.0"
-git-features = { version = "0.23.0", optional = true }
+git-features = { version = "0.23.1", optional = true }
 # default feature restriction addresses https://github.com/starship/starship/issues/4251
-git-repository = { version = "0.25.0", default-features = false, features = ["max-performance-safe"] }
+git-repository = { version = "0.26.0", default-features = false, features = ["max-performance-safe"] }
 indexmap = { version = "1.9.1", features = ["serde"] }
 local_ipaddress = "0.1.3"
 log = { version = "0.4.17", features = ["std"] }

--- a/src/configs/os.rs
+++ b/src/configs/os.rs
@@ -18,7 +18,7 @@ pub struct OSConfig<'a> {
 
 impl<'a> OSConfig<'a> {
     pub fn get_symbol(&self, key: &Type) -> Option<&'a str> {
-        self.symbols.get(key).cloned()
+        self.symbols.get(key).copied()
     }
 }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -635,8 +635,7 @@ fn get_remote_repository_info(
         .map(|r| r.shorten().to_string());
     let name = repository
         .branch_remote_name(branch_name)
-        .map(|n| n.to_string());
-
+        .and_then(|n| n.as_symbol().map(str::to_string));
     Some(Remote { branch, name })
 }
 

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -133,6 +133,6 @@ impl log::Log for StarshipLogger {
 }
 
 pub fn init() {
-    log::set_boxed_logger(Box::new(StarshipLogger::default())).unwrap();
+    log::set_boxed_logger(Box::<StarshipLogger>::default()).unwrap();
     log::set_max_level(LevelFilter::Trace);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -184,7 +184,7 @@ fn main() {
                 println!("Supported modules list");
                 println!("----------------------");
                 for modules in ALL_MODULES {
-                    println!("{}", modules);
+                    println!("{modules}");
                 }
             }
             if let Some(module_name) = name {
@@ -198,7 +198,7 @@ fn main() {
                     configure::update_configuration(&name, &value)
                 }
             } else if let Err(reason) = configure::edit_configuration(None) {
-                eprintln!("Could not edit configuration: {}", reason);
+                eprintln!("Could not edit configuration: {reason}");
                 std::process::exit(1);
             }
         }

--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -658,7 +658,7 @@ credential_process = /opt/bin/awscreds-retriever
         let expiration_date = now_plus_half_hour.to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
 
         let expiration_keys = ["expiration", "x_security_token_expires"];
-        expiration_keys.iter().for_each(|key| {
+        for key in expiration_keys.iter() {
             file.write_all(
                 format!(
                     "[astronauts]
@@ -712,7 +712,7 @@ aws_secret_access_key=dummy
                 possible_values.contains(&actual),
                 "time is not in range: {actual:?}"
             );
-        });
+        }
 
         dir.close()
     }

--- a/src/modules/git_commit.rs
+++ b/src/modules/git_commit.rs
@@ -206,13 +206,13 @@ mod tests {
         let repo_dir = fixture_repo(FixtureProvider::Git)?;
 
         create_command("git")?
-            .args(&["tag", "v1", "-m", "Testing tags"])
-            .current_dir(&repo_dir.path())
+            .args(["tag", "v1", "-m", "Testing tags"])
+            .current_dir(repo_dir.path())
             .output()?;
 
         let mut git_commit = create_command("git")?
-            .args(&["rev-parse", "HEAD"])
-            .current_dir(&repo_dir.path())
+            .args(["rev-parse", "HEAD"])
+            .current_dir(repo_dir.path())
             .output()?
             .stdout;
         git_commit.truncate(7);
@@ -223,7 +223,7 @@ mod tests {
                 [git_commit]
                     only_detached = false
             })
-            .path(&repo_dir.path())
+            .path(repo_dir.path())
             .collect();
 
         let expected = Some(format!(
@@ -242,8 +242,8 @@ mod tests {
         let repo_dir = fixture_repo(FixtureProvider::Git)?;
 
         create_command("git")?
-            .args(&["tag", "v1", "-m", "Testing tags"])
-            .current_dir(&repo_dir.path())
+            .args(["tag", "v1", "-m", "Testing tags"])
+            .current_dir(repo_dir.path())
             .output()?;
 
         let mut git_commit = create_command("git")?

--- a/src/modules/os.rs
+++ b/src/modules/os.rs
@@ -77,7 +77,7 @@ fn get_type(os: &os_info::Info) -> Option<String> {
 fn get_version(os: &os_info::Info) -> Option<String> {
     Some(os.version())
         .filter(|&x| x != &os_info::Version::Unknown)
-        .map(|x| x.to_string())
+        .map(os_info::Version::to_string)
 }
 
 #[cfg(test)]

--- a/src/modules/rust.rs
+++ b/src/modules/rust.rs
@@ -394,7 +394,7 @@ fn format_rustc_version(rustc_version: &str, version_format: &str) -> Option<Str
         Ok(formatted) => Some(formatted),
         Err(error) => {
             log::warn!("Error formatting `rust` version:\n{}", error);
-            Some(format!("v{}", version))
+            Some(format!("v{version}"))
         }
     }
 }
@@ -402,7 +402,7 @@ fn format_rustc_version(rustc_version: &str, version_format: &str) -> Option<Str
 fn format_toolchain(toolchain: &str, default_host_triple: Option<&str>) -> String {
     default_host_triple
         .map_or(toolchain, |triple| {
-            toolchain.trim_end_matches(&format!("-{}", triple))
+            toolchain.trim_end_matches(&format!("-{triple}"))
         })
         .to_owned()
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR updates the gitoxide crates (#4572). The API change leads to starship no longer displaying URLs for remote names.

In addition, I added a commit with `cargo +nightly clippy --fix` to fix the new clippy warnings in the master branch.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
