### PR TITLE
build(snap): Fix snap package not buildable in v1.11.0

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: starship
-base: core18
+base: core20
 adopt-info: starship
 summary: The minimal, blazing-fast, and infinitely customizable prompt for any shell!
 description: |

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -57,6 +57,7 @@ parts:
     source: https://github.com/starship/starship.git
     #source-tag: v$SNAPCRAFT_PROJECT_VERSION
     build-packages:
+      - cmake
       - libssl-dev
       - pkg-config
     override-build: |

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -58,7 +58,6 @@ parts:
     #source-tag: v$SNAPCRAFT_PROJECT_VERSION
     build-packages:
       - cmake
-      - libssl-dev
       - pkg-config
     override-build: |
       last_committed_tag="$(git describe --tags --abbrev=0)"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

This pull request fixes snap package building using 1.11.0 sources

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #4574.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**: Ubuntu 22.04 LTS
- [ ] I have tested using **Windows**

No code change outside of the packaging recipe, snap with bash integration appears to run without noticeable issues.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] ~~I have updated the documentation accordingly.~~: no documentation update required
- [ ] ~~I have updated the tests accordingly.~~: no test update required
