### PR TITLE
build(snap): Drop unused build packages

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -57,7 +57,6 @@ parts:
     source: https://github.com/starship/starship.git
     #source-tag: v$SNAPCRAFT_PROJECT_VERSION
     build-packages:
-      - libssl-dev
       - pkg-config
     override-build: |
       last_committed_tag="$(git describe --tags --abbrev=0)"


### PR DESCRIPTION
Refer-to: David Knaack comment at Snap not buildable in v1.11.0 · Issue #4574 · starship/starship <https://github.com/starship/starship/issues/4574#issuecomment-1305411898>
Signed-off-by: 林博仁(Buo-ren Lin) <Buo.Ren.Lin@gmail.com>

#### Description
<!--- Describe your changes in detail -->

This PR implements a snap recipe fix/cleanup [from the suggestion made by @davidkna at #4574](https://github.com/starship/starship/issues/4574#issuecomment-1305411898).

#### Motivation and Context

The patch drops an unused build dependency in the snap recipe.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] ~~I have tested using **MacOS**~~: Not applicable
- [x] I have tested using **Linux**: Ubuntu 22.04 with Snapcraft 7.2.5 build without issues, built snap can be run without any visible problems
- [ ] ~~I have tested using **Windows**~~: Not applicable

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] ~~I have updated the documentation accordingly.~~: No documentation update is required for this change.
- [ ] ~~I have updated the tests accordingly.~~: No test update is required for this change.
