### PR TITLE
build(snap): Fix broken shell prompt after refreshing snap

### DIFF
--- a/install/snap/fix-snap-broken-after-refresh.patch
+++ b/install/snap/fix-snap-broken-after-refresh.patch
@@ -1,0 +1,21 @@
+This patch fixes broken shell prompt after the Starship snap being
+refreshed as the original init script hardcodes executable paths
+with the snap revision.
+
+Fixes #4576.
+
+Refer-to: Bash prompt breaks after the Starship snap is refreshed · Issue #4576 · starship/starship <https://github.com/starship/starship/issues/4576>
+Signed-off-by: 林博仁(Buo-ren, Lin) <Buo.Ren.Lin@gmail.com>
+diff -ur starship/src/init/mod.rs starship.patched/src/init/mod.rs
+--- "Starship - The minimal, blazing-fast, and infinitely customizable prompt for any shell!/src/init/mod.rs"	2022-11-07 20:18:33.609229620 +0800
++++ starship.patched/src/init/mod.rs	2022-11-07 21:37:24.529387895 +0800
+@@ -228,7 +228,7 @@
+ }
+ 
+-fn print_script(script: &str, path: &str) {
++fn print_script(script: &str, _path: &str) {
+-    let script = script.replace("::STARSHIP::", path);
++    let script = script.replace("::STARSHIP::", "snap run starship");
+     print!("{script}");
+ }
+ 

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -71,6 +71,10 @@ parts:
         cd ../src
         git checkout "${last_committed_tag}"
       fi
+
+      # Fix shell prompt broken after snap refresh
+      patch -p1 < install/snap/fix-snap-broken-after-refresh.patch
+
       snapcraftctl build
       snapcraftctl set-version $(git -C ../src describe --tags  | sed 's/v//')
 


### PR DESCRIPTION
#### Description
<!--- Describe your changes in detail -->
This patch fixes the broken shell prompt after the Starship snap is refreshed as the original init script hardcodes executable paths with the snap revision.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #4576.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] ~~I have tested using **MacOS**~~: Not applicable
- [x] I have tested using **Linux**: Problem not reproducible after snap refresh
- [ ] ~~I have tested using **Windows**~~: Not applicable

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] ~~I have updated the documentation accordingly.~~ No documentation updates required
- [ ] I have updated the tests accordingly.
