### PR TITLE
docs(config): fix invalid escape character in string: `(`

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -3150,7 +3150,7 @@ By default the module will be shown if any of the following conditions are met:
 
 | Option               | Default                                                                                                      | Description                                                                            |
 | -------------------- | ------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- |
-| `format`             | `'via [${symbol}${pyenv_prefix}(${version} )(\($virtualenv\) )]($style)'`                                    | The format for the module.                                                             |
+| `format`             | `'via [${symbol}${pyenv_prefix}(${version} )(\\($virtualenv\\) )]($style)'`                                    | The format for the module.                                                             |
 | `version_format`     | `'v${raw}'`                                                                                                  | The version format. Available vars are `raw`, `major`, `minor`, & `patch`              |
 | `symbol`             | `'🐍 '`                                                                                                       | A format string representing the symbol of Python                                      |
 | `style`              | `'yellow bold'`                                                                                              | The style for the module.                                                              |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description

<!--- Describe your changes in detail -->

If I copy the docs format at **[Python]** configuration for the purpose of showing `(.venv)` at prompt, actually I got:

`[ERROR] - (starship::config): Unable to parse the config file: invalid escape character in string: `(`at line xx column xx"`

Therefore, I decide to add another backslash since we must escape the backslash itself, as mentioned at [Configuration](https://starship.rs/config/#special-characters).

So my change:

| Option   | Default                                                                     | Description                |
| -------- | --------------------------------------------------------------------------- | -------------------------- |
| `format` | `'via [${symbol}${pyenv_prefix}(${version} )(\\($virtualenv\\) )]($style)'` | The format for the module. |

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When I followed the configuration to show that I was at Python virtual environment, with `(.venv)` indicator like other prompts, I applied the **[Python]** format guideline at docs, however I saw the above error. It took me a while to recognise I needed another backslash for escaping character at .toml file, now anyone copies that part from docs will not have to see the error again.

Thanks,

Tony

#### Screenshots (if appropriate):

![prompt error][error]

[error]: https://lh3.googleusercontent.com/u/5/drive-viewer/AJc5JmSWozErQxRB6h0uH1A8shZYLhF3Iexug-IH_URwOBV3uoCFS_IsQ-ghi28GBd9NPV_egbrW5WewzRWaTx3MHp-VSDeGPA=w3456-h2000 'Unable to parse the config'

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

Since this is just a little touch for the docs, I only apply changes and run `source ~/.zshrc` as I am using zsh, and the error has gone.

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
