### PR TITLE
build(deps): update rust crate chrono to 0.4.23

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,9 +311,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.22"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
+checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
 dependencies = [
  "iana-time-zone",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ git-repository-max-perf = ["git-features/zlib-ng", "git-repository/fast-sha1"]
 git-repository-faster = ["git-features/zlib-stock", "git-repository/fast-sha1"]
 
 [dependencies]
-chrono = { version = "0.4.22", features = ["clock", "std"] }
+chrono = { version = "0.4.23", features = ["clock", "std"] }
 clap = { version = "4.0.23", features = ["derive", "cargo", "unicode"] }
 clap_complete = "4.0.5"
 dirs-next = "2.0.0"

--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -619,7 +619,7 @@ credential_process = /opt/bin/awscreds-retriever
         use chrono::{DateTime, NaiveDateTime, SecondsFormat, Utc};
 
         let now_plus_half_hour: DateTime<Utc> = chrono::DateTime::from_utc(
-            NaiveDateTime::from_timestamp(chrono::Local::now().timestamp() + 1800, 0),
+            NaiveDateTime::from_timestamp_opt(chrono::Local::now().timestamp() + 1800, 0).unwrap(),
             Utc,
         );
 
@@ -651,7 +651,7 @@ credential_process = /opt/bin/awscreds-retriever
         use chrono::{DateTime, NaiveDateTime, Utc};
 
         let now_plus_half_hour: DateTime<Utc> = chrono::DateTime::from_utc(
-            NaiveDateTime::from_timestamp(chrono::Local::now().timestamp() + 1800, 0),
+            NaiveDateTime::from_timestamp_opt(chrono::Local::now().timestamp() + 1800, 0).unwrap(),
             Utc,
         );
 
@@ -739,7 +739,7 @@ aws_secret_access_key=dummy
         use chrono::{DateTime, NaiveDateTime, SecondsFormat, Utc};
 
         let now: DateTime<Utc> = chrono::DateTime::from_utc(
-            NaiveDateTime::from_timestamp(chrono::Local::now().timestamp() - 1800, 0),
+            NaiveDateTime::from_timestamp_opt(chrono::Local::now().timestamp() - 1800, 0).unwrap(),
             Utc,
         );
 

--- a/src/modules/time.rs
+++ b/src/modules/time.rs
@@ -80,7 +80,10 @@ fn create_offset_time_string(
     );
     if utc_time_offset_in_hours < 24_f32 && utc_time_offset_in_hours > -24_f32 {
         let utc_offset_in_seconds: i32 = (utc_time_offset_in_hours * 3600_f32) as i32;
-        let timezone_offset = FixedOffset::east(utc_offset_in_seconds);
+        let timezone_offset = match FixedOffset::east_opt(utc_offset_in_seconds) {
+            Some(offset) => offset,
+            None => return Err("Invalid offset"),
+        };
         log::trace!("Target timezone offset is {}", timezone_offset);
 
         let target_time = utc_time.with_timezone(&timezone_offset);
@@ -161,59 +164,59 @@ mod tests {
 
     #[test]
     fn test_midnight_12hr() {
-        let time = Local.ymd(2014, 7, 8).and_hms(0, 0, 0);
+        let time = Local.with_ymd_and_hms(2014, 7, 8, 0, 0, 0).unwrap();
         let formatted = format_time(FMT_12, time);
         assert_eq!(formatted, "12:00:00 AM");
     }
 
     #[test]
     fn test_midnight_24hr() {
-        let time = Local.ymd(2014, 7, 8).and_hms(0, 0, 0);
+        let time = Local.with_ymd_and_hms(2014, 7, 8, 0, 0, 0).unwrap();
         let formatted = format_time(FMT_24, time);
         assert_eq!(formatted, "00:00:00");
     }
 
     #[test]
     fn test_noon_12hr() {
-        let time = Local.ymd(2014, 7, 8).and_hms(12, 0, 0);
+        let time = Local.with_ymd_and_hms(2014, 7, 8, 12, 0, 0).unwrap();
         let formatted = format_time(FMT_12, time);
         assert_eq!(formatted, "12:00:00 PM");
     }
 
     #[test]
     fn test_noon_24hr() {
-        let time = Local.ymd(2014, 7, 8).and_hms(12, 0, 0);
+        let time = Local.with_ymd_and_hms(2014, 7, 8, 12, 0, 0).unwrap();
         let formatted = format_time(FMT_24, time);
         assert_eq!(formatted, "12:00:00");
     }
 
     #[test]
     fn test_arbtime_12hr() {
-        let time = Local.ymd(2014, 7, 8).and_hms(15, 36, 47);
+        let time = Local.with_ymd_and_hms(2014, 7, 8, 15, 36, 47).unwrap();
         let formatted = format_time(FMT_12, time);
         assert_eq!(formatted, "03:36:47 PM");
     }
 
     #[test]
     fn test_arbtime_24hr() {
-        let time = Local.ymd(2014, 7, 8).and_hms(15, 36, 47);
+        let time = Local.with_ymd_and_hms(2014, 7, 8, 15, 36, 47).unwrap();
         let formatted = format_time(FMT_24, time);
         assert_eq!(formatted, "15:36:47");
     }
 
     #[test]
     fn test_format_with_paren() {
-        let time = Local.ymd(2014, 7, 8).and_hms(15, 36, 47);
+        let time = Local.with_ymd_and_hms(2014, 7, 8, 15, 36, 47).unwrap();
         let formatted = format_time("[%T]", time);
         assert_eq!(formatted, "[15:36:47]");
     }
 
     #[test]
     fn test_midnight_12hr_fixed_offset() {
-        let timezone_offset = FixedOffset::east(0);
+        let timezone_offset = FixedOffset::east_opt(0).unwrap();
         let time = Utc
-            .ymd(2014, 7, 8)
-            .and_hms(0, 0, 0)
+            .with_ymd_and_hms(2014, 7, 8, 0, 0, 0)
+            .unwrap()
             .with_timezone(&timezone_offset);
         let formatted = format_time_fixed_offset(FMT_12, time);
         assert_eq!(formatted, "12:00:00 AM");
@@ -221,10 +224,10 @@ mod tests {
 
     #[test]
     fn test_midnight_24hr_fixed_offset() {
-        let timezone_offset = FixedOffset::east(0);
+        let timezone_offset = FixedOffset::east_opt(0).unwrap();
         let time = Utc
-            .ymd(2014, 7, 8)
-            .and_hms(0, 0, 0)
+            .with_ymd_and_hms(2014, 7, 8, 0, 0, 0)
+            .unwrap()
             .with_timezone(&timezone_offset);
         let formatted = format_time_fixed_offset(FMT_24, time);
         assert_eq!(formatted, "00:00:00");
@@ -232,10 +235,10 @@ mod tests {
 
     #[test]
     fn test_noon_12hr_fixed_offset() {
-        let timezone_offset = FixedOffset::east(0);
+        let timezone_offset = FixedOffset::east_opt(0).unwrap();
         let time = Utc
-            .ymd(2014, 7, 8)
-            .and_hms(12, 0, 0)
+            .with_ymd_and_hms(2014, 7, 8, 12, 0, 0)
+            .unwrap()
             .with_timezone(&timezone_offset);
         let formatted = format_time_fixed_offset(FMT_12, time);
         assert_eq!(formatted, "12:00:00 PM");
@@ -243,10 +246,10 @@ mod tests {
 
     #[test]
     fn test_noon_24hr_fixed_offset() {
-        let timezone_offset = FixedOffset::east(0);
+        let timezone_offset = FixedOffset::east_opt(0).unwrap();
         let time = Utc
-            .ymd(2014, 7, 8)
-            .and_hms(12, 0, 0)
+            .with_ymd_and_hms(2014, 7, 8, 12, 0, 0)
+            .unwrap()
             .with_timezone(&timezone_offset);
         let formatted = format_time_fixed_offset(FMT_24, time);
         assert_eq!(formatted, "12:00:00");
@@ -254,10 +257,10 @@ mod tests {
 
     #[test]
     fn test_arbtime_12hr_fixed_offset() {
-        let timezone_offset = FixedOffset::east(0);
+        let timezone_offset = FixedOffset::east_opt(0).unwrap();
         let time = Utc
-            .ymd(2014, 7, 8)
-            .and_hms(15, 36, 47)
+            .with_ymd_and_hms(2014, 7, 8, 15, 36, 47)
+            .unwrap()
             .with_timezone(&timezone_offset);
         let formatted = format_time_fixed_offset(FMT_12, time);
         assert_eq!(formatted, "03:36:47 PM");
@@ -265,10 +268,10 @@ mod tests {
 
     #[test]
     fn test_arbtime_24hr_fixed_offset() {
-        let timezone_offset = FixedOffset::east(0);
+        let timezone_offset = FixedOffset::east_opt(0).unwrap();
         let time = Utc
-            .ymd(2014, 7, 8)
-            .and_hms(15, 36, 47)
+            .with_ymd_and_hms(2014, 7, 8, 15, 36, 47)
+            .unwrap()
             .with_timezone(&timezone_offset);
         let formatted = format_time_fixed_offset(FMT_24, time);
         assert_eq!(formatted, "15:36:47");
@@ -276,10 +279,10 @@ mod tests {
 
     #[test]
     fn test_format_with_paren_fixed_offset() {
-        let timezone_offset = FixedOffset::east(0);
+        let timezone_offset = FixedOffset::east_opt(0).unwrap();
         let time = Utc
-            .ymd(2014, 7, 8)
-            .and_hms(15, 36, 47)
+            .with_ymd_and_hms(2014, 7, 8, 15, 36, 47)
+            .unwrap()
             .with_timezone(&timezone_offset);
         let formatted = format_time_fixed_offset("[%T]", time);
         assert_eq!(formatted, "[15:36:47]");
@@ -287,7 +290,7 @@ mod tests {
 
     #[test]
     fn test_create_formatted_time_string_with_minus_3() {
-        let utc_time: DateTime<Utc> = Utc.ymd(2014, 7, 8).and_hms(15, 36, 47);
+        let utc_time: DateTime<Utc> = Utc.with_ymd_and_hms(2014, 7, 8, 15, 36, 47).unwrap();
         let utc_time_offset_str = "-3";
 
         let actual = create_offset_time_string(utc_time, utc_time_offset_str, FMT_12).unwrap();
@@ -296,7 +299,7 @@ mod tests {
 
     #[test]
     fn test_create_formatted_time_string_with_plus_5() {
-        let utc_time: DateTime<Utc> = Utc.ymd(2014, 7, 8).and_hms(15, 36, 47);
+        let utc_time: DateTime<Utc> = Utc.with_ymd_and_hms(2014, 7, 8, 15, 36, 47).unwrap();
         let utc_time_offset_str = "+5";
 
         let actual = create_offset_time_string(utc_time, utc_time_offset_str, FMT_12).unwrap();
@@ -305,7 +308,7 @@ mod tests {
 
     #[test]
     fn test_create_formatted_time_string_with_plus_9_30() {
-        let utc_time: DateTime<Utc> = Utc.ymd(2014, 7, 8).and_hms(15, 36, 47);
+        let utc_time: DateTime<Utc> = Utc.with_ymd_and_hms(2014, 7, 8, 15, 36, 47).unwrap();
         let utc_time_offset_str = "+9.5";
 
         let actual = create_offset_time_string(utc_time, utc_time_offset_str, FMT_12).unwrap();
@@ -314,7 +317,7 @@ mod tests {
 
     #[test]
     fn test_create_formatted_time_string_with_plus_5_45() {
-        let utc_time: DateTime<Utc> = Utc.ymd(2014, 7, 8).and_hms(15, 36, 47);
+        let utc_time: DateTime<Utc> = Utc.with_ymd_and_hms(2014, 7, 8, 15, 36, 47).unwrap();
         let utc_time_offset_str = "+5.75";
 
         let actual = create_offset_time_string(utc_time, utc_time_offset_str, FMT_12).unwrap();
@@ -323,7 +326,7 @@ mod tests {
 
     #[test]
     fn test_create_formatted_time_string_with_plus_24() {
-        let utc_time: DateTime<Utc> = Utc.ymd(2014, 7, 8).and_hms(15, 36, 47);
+        let utc_time: DateTime<Utc> = Utc.with_ymd_and_hms(2014, 7, 8, 15, 36, 47).unwrap();
         let utc_time_offset_str = "+24";
 
         create_offset_time_string(utc_time, utc_time_offset_str, FMT_12)
@@ -332,7 +335,7 @@ mod tests {
 
     #[test]
     fn test_create_formatted_time_string_with_minus_24() {
-        let utc_time: DateTime<Utc> = Utc.ymd(2014, 7, 8).and_hms(15, 36, 47);
+        let utc_time: DateTime<Utc> = Utc.with_ymd_and_hms(2014, 7, 8, 15, 36, 47).unwrap();
         let utc_time_offset_str = "-24";
 
         create_offset_time_string(utc_time, utc_time_offset_str, FMT_12)
@@ -341,7 +344,7 @@ mod tests {
 
     #[test]
     fn test_create_formatted_time_string_with_plus_9001() {
-        let utc_time: DateTime<Utc> = Utc.ymd(2014, 7, 8).and_hms(15, 36, 47);
+        let utc_time: DateTime<Utc> = Utc.with_ymd_and_hms(2014, 7, 8, 15, 36, 47).unwrap();
         let utc_time_offset_str = "+9001";
 
         create_offset_time_string(utc_time, utc_time_offset_str, FMT_12)
@@ -350,7 +353,7 @@ mod tests {
 
     #[test]
     fn test_create_formatted_time_string_with_minus_4242() {
-        let utc_time: DateTime<Utc> = Utc.ymd(2014, 7, 8).and_hms(15, 36, 47);
+        let utc_time: DateTime<Utc> = Utc.with_ymd_and_hms(2014, 7, 8, 15, 36, 47).unwrap();
         let utc_time_offset_str = "-4242";
 
         create_offset_time_string(utc_time, utc_time_offset_str, FMT_12)
@@ -359,7 +362,7 @@ mod tests {
 
     #[test]
     fn test_create_formatted_time_string_with_invalid_string() {
-        let utc_time: DateTime<Utc> = Utc.ymd(2014, 7, 8).and_hms(15, 36, 47);
+        let utc_time: DateTime<Utc> = Utc.with_ymd_and_hms(2014, 7, 8, 15, 36, 47).unwrap();
         let utc_time_offset_str = "completely wrong config";
 
         create_offset_time_string(utc_time, utc_time_offset_str, FMT_12)
@@ -381,7 +384,7 @@ mod tests {
 
         assert_eq!(
             parse_time_range(time_range),
-            (Some(NaiveTime::from_hms(10, 00, 00)), None)
+            (Some(NaiveTime::from_hms_opt(10, 00, 00).unwrap()), None)
         );
     }
 
@@ -391,7 +394,7 @@ mod tests {
 
         assert_eq!(
             parse_time_range(time_range),
-            (None, Some(NaiveTime::from_hms(22, 00, 00)))
+            (None, Some(NaiveTime::from_hms_opt(22, 00, 00).unwrap()))
         );
     }
 
@@ -402,8 +405,8 @@ mod tests {
         assert_eq!(
             parse_time_range(time_range),
             (
-                Some(NaiveTime::from_hms(10, 00, 00)),
-                Some(NaiveTime::from_hms(16, 00, 00))
+                Some(NaiveTime::from_hms_opt(10, 00, 00).unwrap()),
+                Some(NaiveTime::from_hms_opt(16, 00, 00).unwrap())
             )
         );
     }
@@ -412,16 +415,16 @@ mod tests {
     fn test_is_inside_time_range_with_no_range() {
         let time_start = None;
         let time_end = None;
-        let time_now = NaiveTime::from_hms(10, 00, 00);
+        let time_now = NaiveTime::from_hms_opt(10, 00, 00).unwrap();
 
         assert!(is_inside_time_range(time_now, time_start, time_end));
     }
 
     #[test]
     fn test_is_inside_time_range_with_start_range() {
-        let time_start = Some(NaiveTime::from_hms(10, 00, 00));
-        let time_now = NaiveTime::from_hms(12, 00, 00);
-        let time_now2 = NaiveTime::from_hms(8, 00, 00);
+        let time_start = Some(NaiveTime::from_hms_opt(10, 00, 00).unwrap());
+        let time_now = NaiveTime::from_hms_opt(12, 00, 00).unwrap();
+        let time_now2 = NaiveTime::from_hms_opt(8, 00, 00).unwrap();
 
         assert!(is_inside_time_range(time_now, time_start, None));
         assert!(!is_inside_time_range(time_now2, time_start, None));
@@ -429,9 +432,9 @@ mod tests {
 
     #[test]
     fn test_is_inside_time_range_with_end_range() {
-        let time_end = Some(NaiveTime::from_hms(16, 00, 00));
-        let time_now = NaiveTime::from_hms(15, 00, 00);
-        let time_now2 = NaiveTime::from_hms(19, 00, 00);
+        let time_end = Some(NaiveTime::from_hms_opt(16, 00, 00).unwrap());
+        let time_now = NaiveTime::from_hms_opt(15, 00, 00).unwrap();
+        let time_now2 = NaiveTime::from_hms_opt(19, 00, 00).unwrap();
 
         assert!(is_inside_time_range(time_now, None, time_end));
         assert!(!is_inside_time_range(time_now2, None, time_end));
@@ -439,11 +442,11 @@ mod tests {
 
     #[test]
     fn test_is_inside_time_range_with_complete_range() {
-        let time_start = Some(NaiveTime::from_hms(9, 00, 00));
-        let time_end = Some(NaiveTime::from_hms(18, 00, 00));
-        let time_now = NaiveTime::from_hms(3, 00, 00);
-        let time_now2 = NaiveTime::from_hms(13, 00, 00);
-        let time_now3 = NaiveTime::from_hms(20, 00, 00);
+        let time_start = Some(NaiveTime::from_hms_opt(9, 00, 00).unwrap());
+        let time_end = Some(NaiveTime::from_hms_opt(18, 00, 00).unwrap());
+        let time_now = NaiveTime::from_hms_opt(3, 00, 00).unwrap();
+        let time_now2 = NaiveTime::from_hms_opt(13, 00, 00).unwrap();
+        let time_now3 = NaiveTime::from_hms_opt(20, 00, 00).unwrap();
 
         assert!(!is_inside_time_range(time_now, time_start, time_end));
         assert!(is_inside_time_range(time_now2, time_start, time_end));
@@ -452,11 +455,11 @@ mod tests {
 
     #[test]
     fn test_is_inside_time_range_with_complete_range_passing_midnight() {
-        let time_start = Some(NaiveTime::from_hms(19, 00, 00));
-        let time_end = Some(NaiveTime::from_hms(12, 00, 00));
-        let time_now = NaiveTime::from_hms(3, 00, 00);
-        let time_now2 = NaiveTime::from_hms(13, 00, 00);
-        let time_now3 = NaiveTime::from_hms(20, 00, 00);
+        let time_start = Some(NaiveTime::from_hms_opt(19, 00, 00).unwrap());
+        let time_end = Some(NaiveTime::from_hms_opt(12, 00, 00).unwrap());
+        let time_now = NaiveTime::from_hms_opt(3, 00, 00).unwrap();
+        let time_now2 = NaiveTime::from_hms_opt(13, 00, 00).unwrap();
+        let time_now3 = NaiveTime::from_hms_opt(20, 00, 00).unwrap();
 
         assert!(is_inside_time_range(time_now, time_start, time_end));
         assert!(!is_inside_time_range(time_now2, time_start, time_end));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR updates chrono to 0.4.23 and fixes the new depreciations, mostly by switching to `_opt` function variants that don't panic.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
