### PR TITLE
feat(flutter): Add flutter module

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -484,6 +484,31 @@
         }
       ]
     },
+    "flutter": {
+      "default": {
+        "detect_extensions": [],
+        "detect_files": [
+          "pubspec.yaml",
+          "pubspec.yml",
+          "pubspec.lock"
+        ],
+        "detect_folders": [
+          ".dart_tool",
+          "android",
+          "ios"
+        ],
+        "disabled": false,
+        "format": "via [$symbol($version )]($style)",
+        "style": "bold blue",
+        "symbol": "🇫 ",
+        "version_format": "v${raw}"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/FlutterConfig"
+        }
+      ]
+    },
     "gcloud": {
       "default": {
         "disabled": false,
@@ -2823,6 +2848,61 @@
         "disabled": {
           "default": false,
           "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "FlutterConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "via [$symbol($version )]($style)",
+          "type": "string"
+        },
+        "version_format": {
+          "default": "v${raw}",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "🇫 ",
+          "type": "string"
+        },
+        "style": {
+          "default": "bold blue",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "detect_extensions": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_files": {
+          "default": [
+            "pubspec.yaml",
+            "pubspec.yml",
+            "pubspec.lock"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_folders": {
+          "default": [
+            ".dart_tool",
+            "android",
+            "ios"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       },
       "additionalProperties": false

--- a/docs/.vuepress/public/presets/toml/bracketed-segments.toml
+++ b/docs/.vuepress/public/presets/toml/bracketed-segments.toml
@@ -46,6 +46,9 @@ format = '\[[$symbol($version)]($style)\]'
 [erlang]
 format = '\[[$symbol($version)]($style)\]'
 
+[flutter]
+format = '\[[$symbol($version)]($style)\]'
+
 [gcloud]
 format = '\[[$symbol$account(@$domain)(\($region\))]($style)\]'
 

--- a/docs/.vuepress/public/presets/toml/nerd-font-symbols.toml
+++ b/docs/.vuepress/public/presets/toml/nerd-font-symbols.toml
@@ -25,6 +25,9 @@ symbol = " "
 [elm]
 symbol = " "
 
+[dart]
+symbol = "F "
+
 [git_branch]
 symbol = " "
 

--- a/docs/.vuepress/public/presets/toml/nerd-font-symbols.toml
+++ b/docs/.vuepress/public/presets/toml/nerd-font-symbols.toml
@@ -25,7 +25,7 @@ symbol = " "
 [elm]
 symbol = " "
 
-[dart]
+[flutter]
 symbol = "F "
 
 [git_branch]

--- a/docs/.vuepress/public/presets/toml/no-empty-icons.toml
+++ b/docs/.vuepress/public/presets/toml/no-empty-icons.toml
@@ -37,6 +37,9 @@ format = '(via [$symbol($version )]($style))'
 [erlang]
 format = '(via [$symbol($version )]($style))'
 
+[flutter]
+format = '(via [$symbol($version )]($style))'
+
 [golang]
 format = '(via [$symbol($version )]($style))'
 

--- a/docs/.vuepress/public/presets/toml/no-runtime-versions.toml
+++ b/docs/.vuepress/public/presets/toml/no-runtime-versions.toml
@@ -34,6 +34,9 @@ format = 'via [$symbol]($style)'
 [erlang]
 format = 'via [$symbol]($style)'
 
+[flutter]
+format = "via [$symbol]($style)"
+
 [golang]
 format = 'via [$symbol]($style)'
 

--- a/docs/.vuepress/public/presets/toml/plain-text-symbols.toml
+++ b/docs/.vuepress/public/presets/toml/plain-text-symbols.toml
@@ -58,6 +58,9 @@ symbol = "exs "
 [elm]
 symbol = "elm "
 
+[flutter]
+symbol = "flutter "
+
 [git_branch]
 symbol = "git "
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1501,7 +1501,7 @@ By default the module will be shown if any of the following conditions are met:
 ### Options
 
 | Option           | Default                                           | Description                                                               |
-|------------------|---------------------------------------------------|---------------------------------------------------------------------------|
+| ---------------- | ------------------------------------------------- | ------------------------------------------------------------------------- |
 | `format`         | `'via [$symbol($version )]($style)'`              | The format for the module.                                                |
 | `version_format` | `'v${raw}'`                                       | The version format. Available vars are `raw`, `major`, `minor`, & `patch` |
 | `symbol`         | `'🇫 '`                                           | A format string representing the symbol of Dart                           |
@@ -1512,11 +1512,11 @@ By default the module will be shown if any of the following conditions are met:
 
 ### Variables
 
-| Variable | Example  | Description                          |
-|----------|----------|--------------------------------------|
-| version  | `v3.3.8` | The version of `flutter`             |
-| symbol   |          | Mirrors the value of option `symbol` |
-| style\*  |          | Mirrors the value of option `style`  |
+| Variable  | Example  | Description                          |
+| --------- | -------- | ------------------------------------ |
+| version   | `v3.3.8` | The version of `flutter`             |
+| symbol    |          | Mirrors the value of option `symbol` |
+| style\*   |          | Mirrors the value of option `style`  |
 
 *: This variable can only be used as a part of a style string
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1506,7 +1506,7 @@ By default the module will be shown if any of the following conditions are met:
 | `version_format` | `'v${raw}'`                                       | The version format. Available vars are `raw`, `major`, `minor`, & `patch` |
 | `symbol`         | `'🇫 '`                                           | A format string representing the symbol of Dart                           |
 | `detect_files`   | `['pubspec.yaml', 'pubspec.yml', 'pubspec.lock']` | Which filenames should trigger this module.                               |
-| `detect_folders` | `['.dart_tool']`                                  | Which folders should trigger this module (all must exist).                |
+| `detect_folders` | `['.dart_tool', 'ios', 'android']`                | Which folders should trigger this module (all must exist).                |
 | `style`          | `'bold blue'`                                     | The style for the module.                                                 |
 | `disabled`       | `false`                                           | Disables the `dart` module.                                               |
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1500,20 +1500,20 @@ By default the module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Option              | Default                                           | Description                                                               |
-| ------------------- | ------------------------------------------------- |---------------------------------------------------------------------------|
-| `format`            | `'via [$symbol($version )]($style)'`              | The format for the module.                                                |
-| `version_format`    | `'v${raw}'`                                       | The version format. Available vars are `raw`, `major`, `minor`, & `patch` |
-| `symbol`            | `'🇫 '`                                            | A format string representing the symbol of Dart                           |
-| `detect_files`      | `['pubspec.yaml', 'pubspec.yml', 'pubspec.lock']` | Which filenames should trigger this module.                               |
-| `detect_folders`    | `['.dart_tool']`                                  | Which folders should trigger this module (all must exist).                |
-| `style`             | `'bold blue'`                                     | The style for the module.                                                 |
-| `disabled`          | `false`                                           | Disables the `dart` module.                                               |
+| Option           | Default                                           | Description                                                               |
+|------------------|---------------------------------------------------|---------------------------------------------------------------------------|
+| `format`         | `'via [$symbol($version )]($style)'`              | The format for the module.                                                |
+| `version_format` | `'v${raw}'`                                       | The version format. Available vars are `raw`, `major`, `minor`, & `patch` |
+| `symbol`         | `'🇫 '`                                           | A format string representing the symbol of Dart                           |
+| `detect_files`   | `['pubspec.yaml', 'pubspec.yml', 'pubspec.lock']` | Which filenames should trigger this module.                               |
+| `detect_folders` | `['.dart_tool']`                                  | Which folders should trigger this module (all must exist).                |
+| `style`          | `'bold blue'`                                     | The style for the module.                                                 |
+| `disabled`       | `false`                                           | Disables the `dart` module.                                               |
 
 ### Variables
 
 | Variable | Example  | Description                          |
-| -------- |----------|--------------------------------------|
+|----------|----------|--------------------------------------|
 | version  | `v3.3.8` | The version of `flutter`             |
 | symbol   |          | Mirrors the value of option `symbol` |
 | style\*  |          | Mirrors the value of option `style`  |

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1504,7 +1504,7 @@ By default the module will be shown if any of the following conditions are met:
 | ---------------- | ------------------------------------------------- | ------------------------------------------------------------------------- |
 | `format`         | `'via [$symbol($version )]($style)'`              | The format for the module.                                                |
 | `version_format` | `'v${raw}'`                                       | The version format. Available vars are `raw`, `major`, `minor`, & `patch` |
-| `symbol`         | `'🇫 '`                                           | A format string representing the symbol of Dart                           |
+| `symbol`         | `'🇫 '`                                            | A format string representing the symbol of Dart                           |
 | `detect_files`   | `['pubspec.yaml', 'pubspec.yml', 'pubspec.lock']` | Which filenames should trigger this module.                               |
 | `detect_folders` | `['.dart_tool', 'ios', 'android']`                | Which folders should trigger this module (all must exist).                |
 | `style`          | `'bold blue'`                                     | The style for the module.                                                 |
@@ -1512,11 +1512,11 @@ By default the module will be shown if any of the following conditions are met:
 
 ### Variables
 
-| Variable  | Example  | Description                          |
-| --------- | -------- | ------------------------------------ |
-| version   | `v3.3.8` | The version of `flutter`             |
-| symbol    |          | Mirrors the value of option `symbol` |
-| style\*   |          | Mirrors the value of option `style`  |
+| Variable | Example  | Description                          |
+| -------- | -------- | ------------------------------------ |
+| version  | `v3.3.8` | The version of `flutter`             |
+| symbol   |          | Mirrors the value of option `symbol` |
+| style\*  |          | Mirrors the value of option `style`  |
 
 *: This variable can only be used as a part of a style string
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -283,6 +283,7 @@ $dotnet\
 $elixir\
 $elm\
 $erlang\
+$flutter\
 $golang\
 $guix_shell\
 $haskell\
@@ -1487,6 +1488,45 @@ Produces a prompt that looks like:
 
 ```
 AA -------------------------------------------- BB -------------------------------------------- CC
+```
+
+## Flutter
+
+The `flutter` module shows the flutter version of the current project from .dart_tool/version.
+By default the module will be shown if any of the following conditions are met:
+
+- The current directory contains a `.dart_tool`, `ios` and `android` directory
+- The current directory contains a `pubspec.yaml`, `pubspec.yml` or `pubspec.lock` file
+
+### Options
+
+| Option              | Default                                           | Description                                                               |
+| ------------------- | ------------------------------------------------- |---------------------------------------------------------------------------|
+| `format`            | `'via [$symbol($version )]($style)'`              | The format for the module.                                                |
+| `version_format`    | `'v${raw}'`                                       | The version format. Available vars are `raw`, `major`, `minor`, & `patch` |
+| `symbol`            | `'🇫 '`                                            | A format string representing the symbol of Dart                           |
+| `detect_files`      | `['pubspec.yaml', 'pubspec.yml', 'pubspec.lock']` | Which filenames should trigger this module.                               |
+| `detect_folders`    | `['.dart_tool']`                                  | Which folders should trigger this module (all must exist).                |
+| `style`             | `'bold blue'`                                     | The style for the module.                                                 |
+| `disabled`          | `false`                                           | Disables the `dart` module.                                               |
+
+### Variables
+
+| Variable | Example  | Description                          |
+| -------- |----------|--------------------------------------|
+| version  | `v3.3.8` | The version of `flutter`             |
+| symbol   |          | Mirrors the value of option `symbol` |
+| style\*  |          | Mirrors the value of option `style`  |
+
+*: This variable can only be used as a part of a style string
+
+### Example
+
+```toml
+# ~/.config/starship.toml
+
+[flutter]
+format = 'via [🔰 $version](bold red) '
 ```
 
 ## Google Cloud (`gcloud`)

--- a/src/configs/flutter.rs
+++ b/src/configs/flutter.rs
@@ -1,0 +1,34 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(
+    feature = "config-schema",
+    derive(schemars::JsonSchema),
+    schemars(deny_unknown_fields)
+)]
+#[serde(default)]
+pub struct FlutterConfig<'a> {
+    pub format: &'a str,
+    pub version_format: &'a str,
+    pub symbol: &'a str,
+    pub style: &'a str,
+    pub disabled: bool,
+    pub detect_extensions: Vec<&'a str>,
+    pub detect_files: Vec<&'a str>,
+    pub detect_folders: Vec<&'a str>,
+}
+
+impl<'a> Default for FlutterConfig<'a> {
+    fn default() -> Self {
+        FlutterConfig {
+            format: "via [$symbol($version )]($style)",
+            version_format: "v${raw}",
+            symbol: "🇫 ",
+            style: "bold blue",
+            disabled: false,
+            detect_extensions: vec![],
+            detect_files: vec!["pubspec.yaml", "pubspec.yml", "pubspec.lock"],
+            detect_folders: vec![".dart_tool", "android", "ios"],
+        }
+    }
+}

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -26,6 +26,7 @@ pub mod elm;
 pub mod env_var;
 pub mod erlang;
 pub mod fill;
+pub mod flutter;
 pub mod gcloud;
 pub mod git_branch;
 pub mod git_commit;
@@ -148,6 +149,8 @@ pub struct FullConfig<'a> {
     erlang: erlang::ErlangConfig<'a>,
     #[serde(borrow)]
     fill: fill::FillConfig<'a>,
+    #[serde(borrow)]
+    flutter: flutter::FlutterConfig<'a>,
     #[serde(borrow)]
     gcloud: gcloud::GcloudConfig<'a>,
     #[serde(borrow)]

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -57,6 +57,7 @@ pub const PROMPT_ORDER: &[&str] = &[
     "elixir",
     "elm",
     "erlang",
+    "flutter",
     "golang",
     "haskell",
     "helm",

--- a/src/context.rs
+++ b/src/context.rs
@@ -514,7 +514,13 @@ impl DirContents {
             .iter()
             .any(|path| !path.starts_with('!') && self.has_folder(path))
     }
-
+    
+    pub fn has_all_positive_folder(&self, paths: &[&str]) -> bool {
+        paths
+            .iter()
+            .all(|path| !path.starts_with('!') && self.has_folder(path))
+    }
+    
     pub fn has_any_positive_extension(&self, exts: &[&str]) -> bool {
         exts.iter()
             .any(|ext| !ext.starts_with('!') && self.has_extension(ext))

--- a/src/context.rs
+++ b/src/context.rs
@@ -514,13 +514,13 @@ impl DirContents {
             .iter()
             .any(|path| !path.starts_with('!') && self.has_folder(path))
     }
-    
+
     pub fn has_all_positive_folder(&self, paths: &[&str]) -> bool {
         paths
             .iter()
             .all(|path| !path.starts_with('!') && self.has_folder(path))
     }
-    
+
     pub fn has_any_positive_extension(&self, exts: &[&str]) -> bool {
         exts.iter()
             .any(|ext| !ext.starts_with('!') && self.has_extension(ext))

--- a/src/module.rs
+++ b/src/module.rs
@@ -34,6 +34,7 @@ pub const ALL_MODULES: &[&str] = &[
     "env_var",
     "erlang",
     "fill",
+    "flutter",
     "gcloud",
     "git_branch",
     "git_commit",

--- a/src/modules/flutter.rs
+++ b/src/modules/flutter.rs
@@ -1,0 +1,173 @@
+use super::{Context, Module, ModuleConfig};
+
+use crate::configs::flutter::FlutterConfig;
+use crate::formatter::StringFormatter;
+use crate::formatter::VersionFormatter;
+use crate::utils::get_command_string_output;
+
+/// Creates a module with the current Flutter version
+pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let mut module = context.new_module("flutter");
+    let config: FlutterConfig = FlutterConfig::try_load(module.config);
+    
+    let dir_contents = context.dir_contents().ok()?;
+    let is_flutter_project = dir_contents.has_any_positive_file_name(&config.detect_files)
+        && dir_contents.has_all_positive_folder(&config.detect_folders);
+
+    if !is_flutter_project {
+        return None;
+    }
+
+    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
+        formatter
+            .map_meta(|var, _| match var {
+                "symbol" => Some(config.symbol),
+                _ => None,
+            })
+            .map_style(|variable| match variable {
+                "style" => Some(Ok(config.style)),
+                _ => None,
+            })
+            .map(|variable| match variable {
+                "version" => {
+                    let command = context.exec_cmd("cat", &[".dart_tool/version"])?;
+                    let flutter_version = &get_command_string_output(command);
+                    VersionFormatter::format_module_version(
+                        module.get_name(),
+                        &flutter_version,
+                        config.version_format,
+                    )
+                        .map(Ok)
+                }
+                _ => None,
+            })
+            .parse(None, Some(context))
+    });
+
+    module.set_segments(match parsed {
+        Ok(segments) => segments,
+        Err(error) => {
+            log::warn!("Error in module `flutter`:\n{}", error);
+            return None;
+        }
+    });
+
+    Some(module)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::ModuleRenderer;
+    use crate::utils::CommandOutput;
+    use nu_ansi_term::Color;
+    use std::fs::{self, File};
+    use std::io;
+    use std::io::Write;
+
+    #[test]
+    fn folder_without_ios_directory() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        fs::create_dir_all(dir.path().join(".dart_tool"))?;
+        fs::create_dir_all(dir.path().join("android"))?;
+        File::create(dir.path().join("pubspec.yaml"))?.sync_all()?;
+
+        let actual = ModuleRenderer::new("flutter").path(dir.path()).collect();
+        let expected = None;
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+    
+    #[test]
+    fn folder_without_android_directory() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        fs::create_dir_all(dir.path().join(".dart_tool"))?;
+        fs::create_dir_all(dir.path().join("ios"))?;
+        File::create(dir.path().join("pubspec.yaml"))?.sync_all()?;
+        
+        let actual = ModuleRenderer::new("flutter").path(dir.path()).collect();
+        let expected = None;
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+    
+    #[test]
+    fn folder_without_dart_tool_directory() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        fs::create_dir_all(dir.path().join("android"))?;
+        fs::create_dir_all(dir.path().join("ios"))?;
+        File::create(dir.path().join("pubspec.yaml"))?.sync_all()?;
+        
+        let actual = ModuleRenderer::new("flutter").path(dir.path()).collect();
+        let expected = None;
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn folder_with_pubspec_yaml_file() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        fs::create_dir_all(dir.path().join(".dart_tool"))?;
+        fs::create_dir_all(dir.path().join("android"))?;
+        fs::create_dir_all(dir.path().join("ios"))?;
+        File::create(dir.path().join("pubspec.yaml"))?.sync_all()?;
+        File::create(dir.path().join(".dart_tool/version"))?.write_all(b"3.3.8")?;
+
+        let actual = ModuleRenderer::new("flutter").path(dir.path()).collect();
+        let expected = Some(format!("via {}", Color::Blue.bold().paint("🇫 v3.3.8 ")));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn folder_with_pubspec_yml_file() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        fs::create_dir_all(dir.path().join(".dart_tool"))?;
+        fs::create_dir_all(dir.path().join("android"))?;
+        fs::create_dir_all(dir.path().join("ios"))?;
+        File::create(dir.path().join("pubspec.yml"))?.sync_all()?;
+        File::create(dir.path().join(".dart_tool/version"))?.write_all(b"3.3.8")?;
+    
+        let actual = ModuleRenderer::new("flutter").path(dir.path()).collect();
+        let expected = Some(format!("via {}", Color::Blue.bold().paint("🇫 v3.3.8 ")));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn folder_with_pubspec_lock_file() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        fs::create_dir_all(dir.path().join(".dart_tool"))?;
+        fs::create_dir_all(dir.path().join("android"))?;
+        fs::create_dir_all(dir.path().join("ios"))?;
+        File::create(dir.path().join("pubspec.lock"))?.sync_all()?;
+        File::create(dir.path().join(".dart_tool/version"))?.write_all(b"3.3.8")?;
+    
+        let actual = ModuleRenderer::new("flutter").path(dir.path()).collect();
+        let expected = Some(format!("via {}", Color::Blue.bold().paint("🇫 v3.3.8 ")));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn detect_version_output_in_stdout() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        fs::create_dir_all(dir.path().join(".dart_tool"))?;
+        fs::create_dir_all(dir.path().join("android"))?;
+        fs::create_dir_all(dir.path().join("ios"))?;
+        File::create(dir.path().join("pubspec.yaml"))?.sync_all()?;
+    
+        let actual = ModuleRenderer::new("flutter")
+            .cmd(
+                "cat .dart_tool/version",
+                Some(CommandOutput {
+                    stdout: String::from("3.3.8"),
+                    stderr: String::default(),
+                }),
+            )
+            .path(dir.path())
+            .collect();
+        let expected = Some(format!("via {}", Color::Blue.bold().paint("🇫 v3.3.8 ")));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+}

--- a/src/modules/flutter.rs
+++ b/src/modules/flutter.rs
@@ -9,7 +9,7 @@ use crate::utils::get_command_string_output;
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let mut module = context.new_module("flutter");
     let config: FlutterConfig = FlutterConfig::try_load(module.config);
-    
+
     let dir_contents = context.dir_contents().ok()?;
     let is_flutter_project = dir_contents.has_any_positive_file_name(&config.detect_files)
         && dir_contents.has_all_positive_folder(&config.detect_folders);
@@ -34,10 +34,10 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                     let flutter_version = &get_command_string_output(command);
                     VersionFormatter::format_module_version(
                         module.get_name(),
-                        &flutter_version,
+                        flutter_version,
                         config.version_format,
                     )
-                        .map(Ok)
+                    .map(Ok)
                 }
                 _ => None,
             })
@@ -76,27 +76,27 @@ mod tests {
         assert_eq!(expected, actual);
         dir.close()
     }
-    
+
     #[test]
     fn folder_without_android_directory() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         fs::create_dir_all(dir.path().join(".dart_tool"))?;
         fs::create_dir_all(dir.path().join("ios"))?;
         File::create(dir.path().join("pubspec.yaml"))?.sync_all()?;
-        
+
         let actual = ModuleRenderer::new("flutter").path(dir.path()).collect();
         let expected = None;
         assert_eq!(expected, actual);
         dir.close()
     }
-    
+
     #[test]
     fn folder_without_dart_tool_directory() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         fs::create_dir_all(dir.path().join("android"))?;
         fs::create_dir_all(dir.path().join("ios"))?;
         File::create(dir.path().join("pubspec.yaml"))?.sync_all()?;
-        
+
         let actual = ModuleRenderer::new("flutter").path(dir.path()).collect();
         let expected = None;
         assert_eq!(expected, actual);
@@ -126,7 +126,7 @@ mod tests {
         fs::create_dir_all(dir.path().join("ios"))?;
         File::create(dir.path().join("pubspec.yml"))?.sync_all()?;
         File::create(dir.path().join(".dart_tool/version"))?.write_all(b"3.3.8")?;
-    
+
         let actual = ModuleRenderer::new("flutter").path(dir.path()).collect();
         let expected = Some(format!("via {}", Color::Blue.bold().paint("🇫 v3.3.8 ")));
         assert_eq!(expected, actual);
@@ -141,7 +141,7 @@ mod tests {
         fs::create_dir_all(dir.path().join("ios"))?;
         File::create(dir.path().join("pubspec.lock"))?.sync_all()?;
         File::create(dir.path().join(".dart_tool/version"))?.write_all(b"3.3.8")?;
-    
+
         let actual = ModuleRenderer::new("flutter").path(dir.path()).collect();
         let expected = Some(format!("via {}", Color::Blue.bold().paint("🇫 v3.3.8 ")));
         assert_eq!(expected, actual);
@@ -155,7 +155,7 @@ mod tests {
         fs::create_dir_all(dir.path().join("android"))?;
         fs::create_dir_all(dir.path().join("ios"))?;
         File::create(dir.path().join("pubspec.yaml"))?.sync_all()?;
-    
+
         let actual = ModuleRenderer::new("flutter")
             .cmd(
                 "cat .dart_tool/version",

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -23,6 +23,7 @@ mod elm;
 mod env_var;
 mod erlang;
 mod fill;
+mod flutter;
 mod gcloud;
 mod git_branch;
 mod git_commit;
@@ -121,6 +122,7 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
             "erlang" => erlang::module(context),
             "env_var" => env_var::module(context),
             "fill" => fill::module(context),
+            "flutter" => flutter::module(context),
             "gcloud" => gcloud::module(context),
             "git_branch" => git_branch::module(context),
             "git_commit" => git_commit::module(context),
@@ -230,6 +232,7 @@ pub fn description(module: &str) -> &'static str {
         "env_var" => "Displays the current value of a selected environment variable",
         "erlang" => "Current OTP version",
         "fill" => "Fills the remaining space on the line with a pad string",
+        "flutter" => "Displays the current flutter version",
         "gcloud" => "The current GCP client configuration",
         "git_branch" => "The active branch of the repo in your current directory",
         "git_commit" => "The active commit (and tag if any) of the repo in your current directory",


### PR DESCRIPTION
#### Description
Add a module to detect flutter projects and get the version from .dart_tool/version. It is not possible to use "flutter --version" command since it times out.

#### Motivation and Context
Closes #4566

#### Screenshots (if appropriate):

#### How Has This Been Tested?
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
