### PR TITLE
fix(localip): avoid external network connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1617,10 +1617,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
 
 [[package]]
-name = "local_ipaddress"
-version = "0.1.3"
+name = "local-ip-address"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6a104730949fbc4c78e4fa98ed769ca0faa02e9818936b61032d2d77526afa9"
+checksum = "9eab7f092fb08006040e656c2adce6670e6a516bea831a8b2b3d0fb24d4488f5"
+dependencies = [
+ "libc",
+ "neli",
+ "thiserror",
+ "windows-sys 0.42.0",
+]
 
 [[package]]
 name = "lock_api"
@@ -1748,6 +1754,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "neli"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9053554eb5dcb7e10d9cdab1206965bde870eed5d0d341532ca035e3ba221508"
+dependencies = [
+ "byteorder",
+ "libc",
 ]
 
 [[package]]
@@ -2756,7 +2772,7 @@ dependencies = [
  "guess_host_triple",
  "home",
  "indexmap",
- "local_ipaddress",
+ "local-ip-address",
  "log",
  "mockall",
  "nix 0.25.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ git-features = { version = "0.23.1", optional = true }
 # default feature restriction addresses https://github.com/starship/starship/issues/4251
 git-repository = { version = "0.27.0", default-features = false, features = ["max-performance-safe"] }
 indexmap = { version = "1.9.1", features = ["serde"] }
-local_ipaddress = "0.1.3"
+local-ip-address = "0.4.9"
 log = { version = "0.4.17", features = ["std"] }
 # nofity-rust is optional (on by default) because the crate doesn't currently build for darwin with nix
 # see: https://github.com/NixOS/nixpkgs/issues/160876


### PR DESCRIPTION
#### Description
The currently used crate local_ipaddress opens a network connection to 8.8.8.8 (Google DNS) on each prompt.  This might invade the users privacy.  Use the crate local_ip_address instead, which uses local system APIs.

#### Motivation and Context
Avoid external network connectio to Google on each promt (if the module `localip` is enabled).
See https://github.com/egmkang/local_ipaddress/blob/d64c66b9593537b3d2b1bff11dfac61891a7845a/src/lib.rs#L13

#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
