### PR TITLE
style(shlvl): Remove extra space in `symbol` config

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -1387,7 +1387,7 @@
         "format": "[$symbol$shlvl]($style) ",
         "repeat": false,
         "style": "bold yellow",
-        "symbol": "↕️  ",
+        "symbol": "↕️ ",
         "threshold": 2
       },
       "allOf": [

--- a/src/configs/shlvl.rs
+++ b/src/configs/shlvl.rs
@@ -21,7 +21,7 @@ impl<'a> Default for ShLvlConfig<'a> {
         ShLvlConfig {
             threshold: 2,
             format: "[$symbol$shlvl]($style) ",
-            symbol: "↕️  ", // extra space for emoji
+            symbol: "↕️ ",
             repeat: false,
             style: "bold yellow",
             disabled: true,

--- a/src/modules/shlvl.rs
+++ b/src/modules/shlvl.rs
@@ -96,7 +96,7 @@ mod tests {
             })
             .env(SHLVL_ENV_VAR, "2")
             .collect();
-        let expected = Some(format!("{} ", style().paint("↕️  2")));
+        let expected = Some(format!("{} ", style().paint("↕️ 2")));
 
         assert_eq!(expected, actual);
     }
@@ -138,7 +138,7 @@ mod tests {
             })
             .env(SHLVL_ENV_VAR, "1")
             .collect();
-        let expected = Some(format!("{} ", style().paint("↕️  1")));
+        let expected = Some(format!("{} ", style().paint("↕️ 1")));
 
         assert_eq!(expected, actual);
     }
@@ -168,7 +168,7 @@ mod tests {
             })
             .env(SHLVL_ENV_VAR, "2")
             .collect();
-        let expected = Some(format!("{} ", Color::Red.underline().paint("↕️  2")));
+        let expected = Some(format!("{} ", Color::Red.underline().paint("↕️ 2")));
 
         assert_eq!(expected, actual);
     }
@@ -198,7 +198,7 @@ mod tests {
             })
             .env(SHLVL_ENV_VAR, "2")
             .collect();
-        let expected = Some(format!("↕️   going down {} GOING UP ", style().paint("2")));
+        let expected = Some(format!("↕️  going down {} GOING UP ", style().paint("2")));
 
         assert_eq!(expected, actual);
     }


### PR DESCRIPTION
Extra space adds too much asymmetry on Linux terminals. Normally, `symbol` parameter has "emoji + 1 space" format.

<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It's visual improvement. Discussion: https://github.com/starship/starship/pull/1385#discussion_r1024705647

#### Screenshots
**BEFORE (as it is now):**
![](https://user-images.githubusercontent.com/5967447/202343096-589ae51e-4beb-43d2-87d0-1c23b5917e65.png)
![](https://user-images.githubusercontent.com/5967447/202343191-5289650b-da0a-4671-ba53-01589ae9745a.png)

**AFTER (with this patch):**
![](https://user-images.githubusercontent.com/5967447/202343448-eb477f3f-75c4-405b-827f-7cebf370e561.png)
![](https://user-images.githubusercontent.com/5967447/202343468-8e50d11d-c9c9-48a8-be9f-de0d97cf0de1.png)
![image](https://user-images.githubusercontent.com/5967447/202442821-ab539f19-a1b3-44af-b066-b1ad130c8339.png)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**  👈 need someone to test it
- [x] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
