### PR TITLE
fix(ci): cache after selecting the toolchain

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -50,9 +50,6 @@ jobs:
       - name: Setup | Checkout
         uses: actions/checkout@v3
 
-      - name: Setup | Cache
-        uses: Swatinem/rust-cache@v2
-
       - name: Setup | Rust
         uses: actions-rs/toolchain@v1.0.7
         with:
@@ -60,6 +57,9 @@ jobs:
           override: true
           profile: minimal
           components: clippy
+
+      - name: Setup | Cache
+        uses: Swatinem/rust-cache@v2
 
       - name: Build | Lint
         uses: actions-rs/cargo@v1.0.3
@@ -75,15 +75,15 @@ jobs:
       - name: Setup | Checkout
         uses: actions/checkout@v3
 
-      - name: Setup | Cache
-        uses: Swatinem/rust-cache@v2
-
       - name: Setup | Rust
         uses: actions-rs/toolchain@v1.0.7
         with:
           toolchain: stable
           profile: minimal
           override: true
+
+      - name: Setup | Cache
+        uses: Swatinem/rust-cache@v2
 
       - name: Build | Check
         run: cargo check --workspace --locked
@@ -97,15 +97,15 @@ jobs:
       - name: Setup | Checkout
         uses: actions/checkout@v3
 
-      - name: Setup | Cache
-        uses: Swatinem/rust-cache@v2
-
       - name: Setup | Rust
         uses: actions-rs/toolchain@v1.0.7
         with:
           toolchain: stable
           profile: minimal
           override: true
+
+      - name: Setup | Cache
+        uses: Swatinem/rust-cache@v2
 
       - name: Build | Check
         run: cargo check --workspace --locked --no-default-features
@@ -119,15 +119,15 @@ jobs:
       - name: Setup | Checkout
         uses: actions/checkout@v3
 
-      - name: Setup | Cache
-        uses: Swatinem/rust-cache@v2
-
       - name: Setup | Rust
         uses: actions-rs/toolchain@v1.0.7
         with:
           toolchain: stable
           profile: minimal
           override: true
+
+      - name: Setup | Cache
+        uses: Swatinem/rust-cache@v2
 
       - name: Build | Check
         run: cargo check --workspace --locked --all-features
@@ -141,15 +141,15 @@ jobs:
       - name: Setup | Checkout
         uses: actions/checkout@v3
 
-      - name: Setup | Cache
-        uses: Swatinem/rust-cache@v2
-
       - name: Setup | Rust
         uses: actions-rs/toolchain@v1.0.7
         with:
           toolchain: stable
           profile: minimal
           override: true
+
+      - name: Setup | Cache
+        uses: Swatinem/rust-cache@v2
 
       - name: Run | Generate Schema
         run: cargo run --locked --features config-schema -- config-schema > .github/config-schema.json
@@ -177,9 +177,6 @@ jobs:
       - name: Setup | Checkout
         uses: actions/checkout@v3
 
-      - name: Setup | Cache
-        uses: Swatinem/rust-cache@v2
-
       # Install all the required dependencies for testing
       - name: Setup | Rust
         uses: actions-rs/toolchain@v1.0.7
@@ -188,6 +185,9 @@ jobs:
           components: llvm-tools-preview
           profile: minimal
           override: true
+
+      - name: Setup | Cache
+        uses: Swatinem/rust-cache@v2
 
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov


### PR DESCRIPTION
I noticed the CI initializes the cache BEFORE installing the toolchain.
However, the documentation of [rust-cache](https://github.com/Swatinem/rust-cache#example-usage) says you should call the rust-cache action AFTER you install the toolchain

