### PR TITLE
feat(localip): use reserved remote address

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1631,12 +1631,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f9f08d8963a6c613f4b1a78f4f4a4dbfadf8e6545b2d72861731e4858b8b47f"
 
 [[package]]
-name = "local_ipaddress"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6a104730949fbc4c78e4fa98ed769ca0faa02e9818936b61032d2d77526afa9"
-
-[[package]]
 name = "lock_api"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2758,7 +2752,6 @@ dependencies = [
  "guess_host_triple",
  "home",
  "indexmap",
- "local_ipaddress",
  "log",
  "mockall",
  "nix 0.25.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,6 @@ git-features = { version = "0.24.1", optional = true }
 # default feature restriction addresses https://github.com/starship/starship/issues/4251
 git-repository = { version = "0.29.0", default-features = false, features = ["max-performance-safe"] }
 indexmap = { version = "1.9.2", features = ["serde"] }
-local_ipaddress = "0.1.3"
 log = { version = "0.4.17", features = ["std"] }
 # nofity-rust is optional (on by default) because the crate doesn't currently build for darwin with nix
 # see: https://github.com/NixOS/nixpkgs/issues/160876


### PR DESCRIPTION
#### Description
Instead of the remote address of 8.8.8.8 (Google DNS) in the crate `local_ipaddress` use a reserved IPv4 address, that should never be assigned.
Also forward the underlying error on failure.

#### Motivation and Context
The current used crate `local_ipaddress` connects an UDP socket to 8.8.8.8 (Google DNS), which might trigger some privacy concerns (although no actual packet should be send). 

Supersedes: #4614

#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [X] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [X] I have updated the documentation accordingly.
- [X] I have updated the tests accordingly.
