### PR TITLE
fix(pwsh): fix error log display on older versions of pwsh

### DIFF
--- a/src/init/starship.ps1
+++ b/src/init/starship.ps1
@@ -64,7 +64,7 @@ $null = New-Module starship {
         # Manually write it to console
         if ($stderr.Result.Trim() -ne '') {
             # Write-Error doesn't work here
-            $host.ui.WriteErrorLine($stderr)
+            $host.ui.WriteErrorLine($stderr.Result)
         }
 
         $stdout.Result;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Older versions of PowerShell will print `System.Threading.Tasks.Task``1[System.String]` instead of a warning, when the `$stderr`-async object is used without `Result`.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related #4646

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
