### PR TITLE
c and java(+nerd icon) term colors

### DIFF
--- a/src/configs/c.rs
+++ b/src/configs/c.rs
@@ -25,7 +25,7 @@ impl<'a> Default for CConfig<'a> {
             format: "via [$symbol($version(-$name) )]($style)",
             version_format: "v${raw}",
             style: "bold green",
-            symbol: "C ",
+            symbol: " ",
             disabled: false,
             detect_extensions: vec!["c", "h"],
             detect_files: vec![],

--- a/src/configs/c.rs
+++ b/src/configs/c.rs
@@ -24,7 +24,7 @@ impl<'a> Default for CConfig<'a> {
         CConfig {
             format: "via [$symbol($version(-$name) )]($style)",
             version_format: "v${raw}",
-            style: "149 bold",
+            style: "bold green",
             symbol: "C ",
             disabled: false,
             detect_extensions: vec!["c", "h"],

--- a/src/configs/java.rs
+++ b/src/configs/java.rs
@@ -24,8 +24,8 @@ impl<'a> Default for JavaConfig<'a> {
             format: "via [$symbol($version )]($style)",
             version_format: "v${raw}",
             disabled: false,
-            style: "red dimmed",
-            symbol: "☕ ",
+            style: "bold green",
+            symbol: " ",
             detect_extensions: vec!["java", "class", "jar", "gradle", "clj", "cljc"],
             detect_files: vec![
                 "pom.xml",


### PR DESCRIPTION
Colors of module C and Java are fixed colors and didn't support term colors.
Also using bold green for common color for to represent main language.

Colorscheme :
![pywal-colorscheme](https://user-images.githubusercontent.com/71015415/204449440-bdc6d1af-09a8-4ca2-b3b6-9ff0f580f132.png)

Before :
![before](https://user-images.githubusercontent.com/71015415/204449511-5cc02a71-69fa-4a19-82f1-6d49ade792ee.png)

After :
![after](https://user-images.githubusercontent.com/71015415/204449548-a2ac154d-d03d-4352-9cc7-6582dd6790ea.png)

