### PR TITLE
docs: Fix "vimcmd_visual_symbol" description in doc

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -703,7 +703,7 @@ are only supported in fish due to [upstream issues with mode detection in zsh](h
 | `vimcmd_symbol`             | `'[❮](bold green)'`  | The format string used before the text input if the shell is in vim normal mode.        |
 | `vimcmd_replace_one_symbol` | `'[❮](bold purple)'` | The format string used before the text input if the shell is in vim `replace_one` mode. |
 | `vimcmd_replace_symbol`     | `'[❮](bold purple)'` | The format string used before the text input if the shell is in vim replace mode.       |
-| `vimcmd_visual_symbol`      | `'[❮](bold yellow)'` | The format string used before the text input if the shell is in vim replace mode.       |
+| `vimcmd_visual_symbol`      | `'[❮](bold yellow)'` | The format string used before the text input if the shell is in vim visual mode.        |
 | `disabled`                  | `false`              | Disables the `character` module.                                                        |
 
 ### Variables


### PR DESCRIPTION
One word fix of a copy-paste error in the configuration doc.