### PR TITLE
fix(buf): broken icon on windows 10

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -1854,7 +1854,7 @@
           "type": "string"
         },
         "symbol": {
-          "default": "🦬 ",
+          "default": "🐃 ",
           "type": "string"
         },
         "style": {

--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -73,7 +73,7 @@
         "disabled": false,
         "format": "with [$symbol($version )]($style)",
         "style": "bold blue",
-        "symbol": "🦬 ",
+        "symbol": "🐃 ",
         "version_format": "v${raw}"
       },
       "allOf": [

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -558,7 +558,7 @@ The `buf` module shows the currently installed version of [Buf](https://buf.buil
 | ------------------- | ----------------------------------------------- | ----------------------------------------------------- |
 | `format`            | `'with [$symbol($version )]($style)'`           | The format for the `buf` module.                      |
 | `version_format`    | `'v${raw}'`                                     | The version format.                                   |
-| `symbol`            | `'🦬 '`                                         | The symbol used before displaying the version of Buf. |
+| `symbol`            | `'🐃 '`                                         | The symbol used before displaying the version of Buf. |
 | `detect_extensions` | `[]`                                            | Which extensions should trigger this module.          |
 | `detect_files`      | `['buf.yaml', 'buf.gen.yaml', 'buf.work.yaml']` | Which filenames should trigger this module.           |
 | `detect_folders`    | `[]`                                            | Which folders should trigger this modules.            |

--- a/src/configs/buf.rs
+++ b/src/configs/buf.rs
@@ -26,10 +26,10 @@ impl<'a> Default for BufConfig<'a> {
             let version_str = os_info::get().version().to_string();
             let mut nums_of_version = version_str.split(".");
             
-            // Gets either version 11 or lower for windows 11 or lower
+            // Gets either version 11 or not
             let version = nums_of_version.next().unwrap().parse::<i32>().unwrap();
 
-            if version < 11 {
+            if version != 11 {
 
                 return BufConfig {
                     format: "with [$symbol($version )]($style)",

--- a/src/configs/buf.rs
+++ b/src/configs/buf.rs
@@ -1,4 +1,3 @@
-use os_info;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]

--- a/src/configs/buf.rs
+++ b/src/configs/buf.rs
@@ -21,31 +21,10 @@ pub struct BufConfig<'a> {
 
 impl<'a> Default for BufConfig<'a> {
     fn default() -> Self {
-        if cfg!(windows) {
-            let version_str = os_info::get().version().to_string();
-            let mut nums_of_version = version_str.split('.');
-
-            // Gets either version 11 or not
-            let version = nums_of_version.next().unwrap().parse::<i32>().unwrap();
-
-            if version != 11 {
-                return BufConfig {
-                    format: "with [$symbol($version )]($style)",
-                    version_format: "v${raw}",
-                    symbol: "🐃 ",
-                    style: "bold blue",
-                    disabled: false,
-                    detect_extensions: vec![],
-                    detect_files: vec!["buf.yaml", "buf.gen.yaml", "buf.work.yaml"],
-                    detect_folders: vec![],
-                };
-            }
-        }
-
         BufConfig {
             format: "with [$symbol($version )]($style)",
             version_format: "v${raw}",
-            symbol: "🦬 ",
+            symbol: "🐃 ",
             style: "bold blue",
             disabled: false,
             detect_extensions: vec![],

--- a/src/configs/buf.rs
+++ b/src/configs/buf.rs
@@ -1,5 +1,5 @@
-use serde::{Deserialize, Serialize};
 use os_info;
+use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
 #[cfg_attr(
@@ -21,16 +21,14 @@ pub struct BufConfig<'a> {
 
 impl<'a> Default for BufConfig<'a> {
     fn default() -> Self {
-
         if cfg!(windows) {
             let version_str = os_info::get().version().to_string();
-            let mut nums_of_version = version_str.split(".");
-            
+            let mut nums_of_version = version_str.split('.');
+
             // Gets either version 11 or not
             let version = nums_of_version.next().unwrap().parse::<i32>().unwrap();
 
             if version != 11 {
-
                 return BufConfig {
                     format: "with [$symbol($version )]($style)",
                     version_format: "v${raw}",
@@ -41,9 +39,7 @@ impl<'a> Default for BufConfig<'a> {
                     detect_files: vec!["buf.yaml", "buf.gen.yaml", "buf.work.yaml"],
                     detect_folders: vec![],
                 };
-
             }
-
         }
 
         BufConfig {
@@ -56,6 +52,5 @@ impl<'a> Default for BufConfig<'a> {
             detect_files: vec!["buf.yaml", "buf.gen.yaml", "buf.work.yaml"],
             detect_folders: vec![],
         }
-
     }
 }

--- a/src/configs/buf.rs
+++ b/src/configs/buf.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use os_info;
 
 #[derive(Clone, Deserialize, Serialize)]
 #[cfg_attr(
@@ -20,6 +21,31 @@ pub struct BufConfig<'a> {
 
 impl<'a> Default for BufConfig<'a> {
     fn default() -> Self {
+
+        if cfg!(windows) {
+            let version_str = os_info::get().version().to_string();
+            let mut nums_of_version = version_str.split(".");
+            
+            // Gets either version 11 or lower for windows 11 or lower
+            let version = nums_of_version.next().unwrap().parse::<i32>().unwrap();
+
+            if version < 11 {
+
+                return BufConfig {
+                    format: "with [$symbol($version )]($style)",
+                    version_format: "v${raw}",
+                    symbol: "🐃 ",
+                    style: "bold blue",
+                    disabled: false,
+                    detect_extensions: vec![],
+                    detect_files: vec!["buf.yaml", "buf.gen.yaml", "buf.work.yaml"],
+                    detect_folders: vec![],
+                };
+
+            }
+
+        }
+
         BufConfig {
             format: "with [$symbol($version )]($style)",
             version_format: "v${raw}",
@@ -30,5 +56,6 @@ impl<'a> Default for BufConfig<'a> {
             detect_files: vec!["buf.yaml", "buf.gen.yaml", "buf.work.yaml"],
             detect_folders: vec![],
         }
+
     }
 }

--- a/src/modules/buf.rs
+++ b/src/modules/buf.rs
@@ -66,7 +66,6 @@ mod tests {
     use nu_ansi_term::Color;
     use std::fs::File;
     use std::io;
-    use os_info;
 
     #[test]
     fn buf_version() {
@@ -93,7 +92,6 @@ mod tests {
 
     #[test]
     fn folder_with_buf_config() {
-
         let ok_files = ["buf.yaml", "buf.gen.yaml", "buf.work.yaml"];
         let not_ok_files = ["buf.json"];
 
@@ -106,9 +104,8 @@ mod tests {
             let actual = ModuleRenderer::new("buf").path(dir.path()).collect();
 
             if cfg!(windows) {
-
                 let version_str = os_info::get().version().to_string();
-                let mut nums_of_version = version_str.split(".");
+                let mut nums_of_version = version_str.split('.');
 
                 // Gets either version 11 or not
                 let version = nums_of_version.next().unwrap().parse::<i32>().unwrap();
@@ -116,13 +113,11 @@ mod tests {
                 if version != 11 {
                     let expected = Some(format!("with {}", Color::Blue.bold().paint("🐃 v1.0.0 ")));
                     assert_eq!(expected, actual);
-                }else{
+                } else {
                     let expected = Some(format!("with {}", Color::Blue.bold().paint("🦬 v1.0.0 ")));
                     assert_eq!(expected, actual);
                 }
-
-
-            }else{
+            } else {
                 let expected = Some(format!("with {}", Color::Blue.bold().paint("🦬 v1.0.0 ")));
                 assert_eq!(expected, actual);
             }

--- a/src/modules/buf.rs
+++ b/src/modules/buf.rs
@@ -1,5 +1,4 @@
 use super::{Context, Module, ModuleConfig};
-use os_info;
 use crate::configs::buf::BufConfig;
 use crate::formatter::StringFormatter;
 use crate::formatter::VersionFormatter;
@@ -67,6 +66,7 @@ mod tests {
     use nu_ansi_term::Color;
     use std::fs::File;
     use std::io;
+    use os_info;
 
     #[test]
     fn buf_version() {
@@ -93,6 +93,7 @@ mod tests {
 
     #[test]
     fn folder_with_buf_config() {
+
         let ok_files = ["buf.yaml", "buf.gen.yaml", "buf.work.yaml"];
         let not_ok_files = ["buf.json"];
 

--- a/src/modules/buf.rs
+++ b/src/modules/buf.rs
@@ -103,24 +103,8 @@ mod tests {
                 .unwrap();
             let actual = ModuleRenderer::new("buf").path(dir.path()).collect();
 
-            if cfg!(windows) {
-                let version_str = os_info::get().version().to_string();
-                let mut nums_of_version = version_str.split('.');
-
-                // Gets either version 11 or not
-                let version = nums_of_version.next().unwrap().parse::<i32>().unwrap();
-
-                if version != 11 {
-                    let expected = Some(format!("with {}", Color::Blue.bold().paint("🐃 v1.0.0 ")));
-                    assert_eq!(expected, actual);
-                } else {
-                    let expected = Some(format!("with {}", Color::Blue.bold().paint("🦬 v1.0.0 ")));
-                    assert_eq!(expected, actual);
-                }
-            } else {
-                let expected = Some(format!("with {}", Color::Blue.bold().paint("🦬 v1.0.0 ")));
-                assert_eq!(expected, actual);
-            }
+            let expected = Some(format!("with {}", Color::Blue.bold().paint("🐃 v1.0.0 ")));
+            assert_eq!(expected, actual);
 
             dir.close().unwrap();
         }

--- a/src/modules/buf.rs
+++ b/src/modules/buf.rs
@@ -1,5 +1,5 @@
 use super::{Context, Module, ModuleConfig};
-
+use os_info;
 use crate::configs::buf::BufConfig;
 use crate::formatter::StringFormatter;
 use crate::formatter::VersionFormatter;
@@ -103,8 +103,29 @@ mod tests {
                 .sync_all()
                 .unwrap();
             let actual = ModuleRenderer::new("buf").path(dir.path()).collect();
-            let expected = Some(format!("with {}", Color::Blue.bold().paint("🦬 v1.0.0 ")));
-            assert_eq!(expected, actual);
+
+            if cfg!(windows) {
+
+                let version_str = os_info::get().version().to_string();
+                let mut nums_of_version = version_str.split(".");
+
+                // Gets either version 11 or not
+                let version = nums_of_version.next().unwrap().parse::<i32>().unwrap();
+
+                if version != 11 {
+                    let expected = Some(format!("with {}", Color::Blue.bold().paint("🐃 v1.0.0 ")));
+                    assert_eq!(expected, actual);
+                }else{
+                    let expected = Some(format!("with {}", Color::Blue.bold().paint("🦬 v1.0.0 ")));
+                    assert_eq!(expected, actual);
+                }
+
+
+            }else{
+                let expected = Some(format!("with {}", Color::Blue.bold().paint("🦬 v1.0.0 ")));
+                assert_eq!(expected, actual);
+            }
+
             dir.close().unwrap();
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR changes the symbol for the buf icon from the buffalo/bison emoji to a 🐃 (Water Buffalo).

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The buf icon for the Windows operating system is broken if the user is using a Windows operating system other than Windows 11. This change gives a fixed icon to users who are using Windows 10 or any other Windows operating system.

<!--- If it fixes an open issue, please link to the issue here. -->
Closes #4608

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
