### PR TITLE
fix(nodejs): apply `style` even if node version is unavailable

### DIFF
--- a/src/modules/nodejs.rs
+++ b/src/modules/nodejs.rs
@@ -92,18 +92,18 @@ fn get_engines_version(context: &Context) -> Option<String> {
     Some(raw_version.to_string())
 }
 
-fn check_engines_version(nodejs_version: Option<&String>, engines_version: Option<String>) -> bool {
+fn check_engines_version(nodejs_version: Option<&str>, engines_version: Option<String>) -> bool {
     let (nodejs_version, engines_version) = match (nodejs_version, engines_version) {
         (Some(nv), Some(ev)) => (nv, ev),
         _ => return true,
     };
-    let r = match VersionReq::parse(&engines_version.unwrap()) {
+    let r = match VersionReq::parse(&engines_version) {
         Ok(r) => r,
         Err(_e) => return true,
     };
     let re = Regex::new(r"\d+\.\d+\.\d+").unwrap();
     let version = re
-        .captures(nodejs_version.unwrap())
+        .captures(nodejs_version)
         .unwrap()
         .get(0)
         .unwrap()

--- a/src/modules/nodejs.rs
+++ b/src/modules/nodejs.rs
@@ -271,4 +271,16 @@ mod tests {
         assert_eq!(expected, actual);
         dir.close()
     }
+    #[test]
+    fn no_node_installed() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join("index.js"))?.sync_all()?;
+        let actual = ModuleRenderer::new("nodejs")
+            .path(dir.path())
+            .cmd("node --version", None)
+            .collect();
+        let expected = Some(format!("via {}", Color::Green.bold().paint(" v12.0.0 ")));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
 }

--- a/src/modules/nodejs.rs
+++ b/src/modules/nodejs.rs
@@ -279,7 +279,7 @@ mod tests {
             .path(dir.path())
             .cmd("node --version", None)
             .collect();
-        let expected = Some(format!("via {}", Color::Green.bold().paint(" v12.0.0 ")));
+        let expected = Some(format!("via {}", Color::Green.bold().paint(" ")));
         assert_eq!(expected, actual);
         dir.close()
     }

--- a/src/modules/nodejs.rs
+++ b/src/modules/nodejs.rs
@@ -45,7 +45,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 "style" => {
                     let engines_version = get_engines_version(context);
                     let in_engines_range =
-                        check_engines_version(nodejs_version.deref().as_ref(), engines_version);
+                        check_engines_version(nodejs_version.as_deref(), engines_version);
                     if in_engines_range {
                         Some(Ok(config.style))
                     } else {

--- a/src/modules/nodejs.rs
+++ b/src/modules/nodejs.rs
@@ -45,7 +45,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 "style" => {
                     let engines_version = get_engines_version(context);
                     let in_engines_range =
-                        check_engines_version(nodejs_version.deref().as_ref()?, engines_version);
+                        check_engines_version(nodejs_version.deref().as_ref(), engines_version);
                     if in_engines_range {
                         Some(Ok(config.style))
                     } else {
@@ -92,8 +92,8 @@ fn get_engines_version(context: &Context) -> Option<String> {
     Some(raw_version.to_string())
 }
 
-fn check_engines_version(nodejs_version: &str, engines_version: Option<String>) -> bool {
-    if engines_version.is_none() {
+fn check_engines_version(nodejs_version: Option<&String>, engines_version: Option<String>) -> bool {
+    if engines_version.is_none() || nodejs_version.is_none() {
         return true;
     }
     let r = match VersionReq::parse(&engines_version.unwrap()) {
@@ -102,7 +102,7 @@ fn check_engines_version(nodejs_version: &str, engines_version: Option<String>) 
     };
     let re = Regex::new(r"\d+\.\d+\.\d+").unwrap();
     let version = re
-        .captures(nodejs_version)
+        .captures(nodejs_version.unwrap())
         .unwrap()
         .get(0)
         .unwrap()

--- a/src/modules/nodejs.rs
+++ b/src/modules/nodejs.rs
@@ -93,9 +93,10 @@ fn get_engines_version(context: &Context) -> Option<String> {
 }
 
 fn check_engines_version(nodejs_version: Option<&String>, engines_version: Option<String>) -> bool {
-    if engines_version.is_none() || nodejs_version.is_none() {
-        return true;
-    }
+    let (nodejs_version, engines_version) = match (nodejs_version, engines_version) {
+        (Some(nv), Some(ev)) => (nv, ev),
+        _ => return true,
+    };
     let r = match VersionReq::parse(&engines_version.unwrap()) {
         Ok(r) => r,
         Err(_e) => return true,


### PR DESCRIPTION
#### Description
Allowed `nodejs_version` to be unset (node isn't installed) and assign the node configuration

#### Motivation and Context
Closes https://github.com/starship/starship/issues/4705

#### Screenshots (if appropriate):
<img width="196" alt="image" src="https://user-images.githubusercontent.com/33375224/207158190-7b7173c2-c633-480d-a10a-017d29c744c1.png">

#### How Has This Been Tested?
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.

I don't believe they are applicable.