### PR TITLE
chore: fix clippy warnings for rust 1.66

### DIFF
--- a/src/bug_report.rs
+++ b/src/bug_report.rs
@@ -38,7 +38,7 @@ pub fn create() {
     if input.trim().to_lowercase() == "y" {
         let link = make_github_issue_link(&issue_body);
         if let Err(e) = open::that(&link) {
-            println!("Failed to open issue report in your browser: {}", e);
+            println!("Failed to open issue report in your browser: {e}");
             println!("Please copy the above report and open an issue manually, or try opening the following link:\n{link}");
         }
     } else {

--- a/src/configs/os.rs
+++ b/src/configs/os.rs
@@ -18,7 +18,7 @@ pub struct OSConfig<'a> {
 
 impl<'a> OSConfig<'a> {
     pub fn get_symbol(&self, key: &Type) -> Option<&'a str> {
-        self.symbols.get(key).cloned()
+        self.symbols.get(key).copied()
     }
 }
 

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -183,7 +183,7 @@ pub fn init_stub(shell_name: &str) -> io::Result<()> {
         "cmd" => print_script(CMDEXE_INIT, &StarshipPath::init()?.sprint_cmdexe()?),
         _ => {
             eprintln!(
-                "{0} is not yet supported by starship.\n\
+                "{shell_basename} is not yet supported by starship.\n\
                  For the time being, we support the following shells:\n\
                  * bash\n\
                  * elvish\n\
@@ -197,9 +197,8 @@ pub fn init_stub(shell_name: &str) -> io::Result<()> {
                  * cmd\n\
                  \n\
                  Please open an issue in the starship repo if you would like to \
-                 see support for {0}:\n\
-                 https://github.com/starship/starship/issues/new\n",
-                shell_basename
+                 see support for {shell_basename}:\n\
+                 https://github.com/starship/starship/issues/new\n"
             )
         }
     };

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -133,6 +133,6 @@ impl log::Log for StarshipLogger {
 }
 
 pub fn init() {
-    log::set_boxed_logger(Box::new(StarshipLogger::default())).unwrap();
+    log::set_boxed_logger(Box::<StarshipLogger>::default()).unwrap();
     log::set_max_level(LevelFilter::Trace);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -184,7 +184,7 @@ fn main() {
                 println!("Supported modules list");
                 println!("----------------------");
                 for modules in ALL_MODULES {
-                    println!("{}", modules);
+                    println!("{modules}");
                 }
             }
             if let Some(module_name) = name {
@@ -198,7 +198,7 @@ fn main() {
                     configure::update_configuration(&name, &value)
                 }
             } else if let Err(reason) = configure::edit_configuration(None) {
-                eprintln!("Could not edit configuration: {}", reason);
+                eprintln!("Could not edit configuration: {reason}");
                 std::process::exit(1);
             }
         }

--- a/src/module.rs
+++ b/src/module.rs
@@ -210,7 +210,7 @@ where
             }
         }
 
-        if let Segment::LineTerm = segment {
+        if matches!(segment, Segment::LineTerm) {
             break;
         }
     }

--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -682,9 +682,8 @@ credential_process = /opt/bin/awscreds-retriever
                     "[astronauts]
 aws_access_key_id=dummy
 aws_secret_access_key=dummy
-{}={}
-",
-                    key, expiration_date
+{key}={expiration_date}
+"
                 )
                 .as_bytes(),
             )

--- a/src/modules/git_branch.rs
+++ b/src/modules/git_branch.rs
@@ -491,10 +491,9 @@ mod tests {
                 toml::from_str(&format!(
                     "
                     [git_branch]
-                        truncation_length = {}
-                        {}
-                ",
-                    truncate_length, config_options
+                        truncation_length = {truncate_length}
+                        {config_options}
+                "
                 ))
                 .unwrap(),
             )
@@ -530,10 +529,9 @@ mod tests {
                 toml::from_str(&format!(
                     r#"
                     [git_branch]
-                        format = "{}"
-                        {}
-                "#,
-                    format, config_options
+                        format = "{format}"
+                        {config_options}
+                "#
                 ))
                 .unwrap(),
             )

--- a/src/modules/haxe.rs
+++ b/src/modules/haxe.rs
@@ -132,7 +132,7 @@ mod tests {
                 "haxe --version",
                 Some(CommandOutput {
                     stdout: "4.3.0-rc.1+\n".to_owned(),
-                    stderr: "".to_owned(),
+                    stderr: String::new(),
                 }),
             )
             .path(dir.path())
@@ -151,7 +151,7 @@ mod tests {
                 "haxe --version",
                 Some(CommandOutput {
                     stdout: "4.3.0-rc.1+\n".to_owned(),
-                    stderr: "".to_owned(),
+                    stderr: String::new(),
                 }),
             )
             .path(dir.path())
@@ -173,7 +173,7 @@ mod tests {
                 "haxe --version",
                 Some(CommandOutput {
                     stdout: "4.3.0-rc.1+\n".to_owned(),
-                    stderr: "".to_owned(),
+                    stderr: String::new(),
                 }),
             )
             .path(dir.path())
@@ -201,7 +201,7 @@ mod tests {
                 "haxe --version",
                 Some(CommandOutput {
                     stdout: "4.3.0-rc.1+\n".to_owned(),
-                    stderr: "".to_owned(),
+                    stderr: String::new(),
                 }),
             )
             .path(dir.path())
@@ -230,7 +230,7 @@ mod tests {
                 "haxe --version",
                 Some(CommandOutput {
                     stdout: "4.3.0-rc.1+\n".to_owned(),
-                    stderr: "".to_owned(),
+                    stderr: String::new(),
                 }),
             )
             .path(dir.path())
@@ -260,7 +260,7 @@ mod tests {
                 "haxe --version",
                 Some(CommandOutput {
                     stdout: "4.3.0-rc.1+\n".to_owned(),
-                    stderr: "".to_owned(),
+                    stderr: String::new(),
                 }),
             )
             .path(dir.path())
@@ -290,7 +290,7 @@ mod tests {
                 "haxe --version",
                 Some(CommandOutput {
                     stdout: "4.3.0-rc.1+\n".to_owned(),
-                    stderr: "".to_owned(),
+                    stderr: String::new(),
                 }),
             )
             .path(dir.path())

--- a/src/modules/hg_branch.rs
+++ b/src/modules/hg_branch.rs
@@ -326,8 +326,7 @@ mod tests {
         let expected = Some(format!(
             "on {} ",
             expect_style.paint(format!(
-                "{} {}{}",
-                expect_symbol, expect_branch_name, expect_truncation_symbol
+                "{expect_symbol} {expect_branch_name}{expect_truncation_symbol}"
             )),
         ));
         assert_eq!(expected, actual);

--- a/src/modules/kubernetes.rs
+++ b/src/modules/kubernetes.rs
@@ -385,12 +385,11 @@ users: []
 apiVersion: v1
 clusters: []
 contexts: []
-current-context: {}
+current-context: {ctx_name}
 kind: Config
 preferences: {{}}
 users: []
-",
-                ctx_name
+"
             )
             .as_bytes(),
         )?;
@@ -695,15 +694,14 @@ clusters: []
 contexts:
   - context:
       cluster: test_cluster
-      user: {}
+      user: {user_name}
       namespace: test_namespace
     name: test_context
 current-context: test_context
 kind: Config
 preferences: {{}}
 users: []
-",
-                user_name
+"
             )
             .as_bytes(),
         )?;

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -11,7 +11,7 @@ mod cobol;
 mod conda;
 mod container;
 mod crystal;
-pub(crate) mod custom;
+pub mod custom;
 mod daml;
 mod dart;
 mod deno;

--- a/src/modules/os.rs
+++ b/src/modules/os.rs
@@ -77,7 +77,7 @@ fn get_type(os: &os_info::Info) -> Option<String> {
 fn get_version(os: &os_info::Info) -> Option<String> {
     Some(os.version())
         .filter(|&x| x != &os_info::Version::Unknown)
-        .map(|x| x.to_string())
+        .map(os_info::Version::to_string)
 }
 
 #[cfg(test)]

--- a/src/modules/rust.rs
+++ b/src/modules/rust.rs
@@ -394,7 +394,7 @@ fn format_rustc_version(rustc_version: &str, version_format: &str) -> Option<Str
         Ok(formatted) => Some(formatted),
         Err(error) => {
             log::warn!("Error formatting `rust` version:\n{}", error);
-            Some(format!("v{}", version))
+            Some(format!("v{version}"))
         }
     }
 }
@@ -402,7 +402,7 @@ fn format_rustc_version(rustc_version: &str, version_format: &str) -> Option<Str
 fn format_toolchain(toolchain: &str, default_host_triple: Option<&str>) -> String {
     default_host_triple
         .map_or(toolchain, |triple| {
-            toolchain.trim_end_matches(&format!("-{}", triple))
+            toolchain.trim_end_matches(&format!("-{triple}"))
         })
         .to_owned()
 }

--- a/src/modules/utils/directory_nix.rs
+++ b/src/modules/utils/directory_nix.rs
@@ -13,6 +13,7 @@ use std::path::Path;
 /// 2a) (not implemented on macOS) one of the supplementary groups of the current user is the
 /// directory group owner and whether it has write access
 /// 3) 'others' part of the access mask has the write access
+#[allow(clippy::useless_conversion)] // On some platforms it is not u32
 pub fn is_write_allowed(folder_path: &Path) -> Result<bool, String> {
     let meta =
         fs::metadata(folder_path).map_err(|e| format!("Unable to stat() directory: {e:?}"))?;
@@ -22,14 +23,15 @@ pub fn is_write_allowed(folder_path: &Path) -> Result<bool, String> {
     if euid.is_root() {
         return Ok(true);
     }
+
     if meta.uid() == euid.as_raw() {
-        Ok(perms & Mode::S_IWUSR.bits() as u32 != 0)
+        Ok(perms & u32::from(Mode::S_IWUSR.bits()) != 0)
     } else if (meta.gid() == Gid::effective().as_raw())
         || (get_supplementary_groups().contains(&meta.gid()))
     {
-        Ok(perms & Mode::S_IWGRP.bits() as u32 != 0)
+        Ok(perms & u32::from(Mode::S_IWGRP.bits()) != 0)
     } else {
-        Ok(perms & Mode::S_IWOTH.bits() as u32 != 0)
+        Ok(perms & u32::from(Mode::S_IWOTH.bits()) != 0)
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -668,8 +668,8 @@ mod tests {
     fn exec_no_output() {
         let result = internal_exec_cmd("true", &[] as &[&OsStr], Duration::from_millis(500));
         let expected = Some(CommandOutput {
-            stdout: String::from(""),
-            stderr: String::from(""),
+            stdout: String::new(),
+            stderr: String::new(),
         });
 
         assert_eq!(result, expected)
@@ -682,7 +682,7 @@ mod tests {
             internal_exec_cmd("/bin/sh", &["-c", "echo hello"], Duration::from_millis(500));
         let expected = Some(CommandOutput {
             stdout: String::from("hello\n"),
-            stderr: String::from(""),
+            stderr: String::new(),
         });
 
         assert_eq!(result, expected)
@@ -697,7 +697,7 @@ mod tests {
             Duration::from_millis(500),
         );
         let expected = Some(CommandOutput {
-            stdout: String::from(""),
+            stdout: String::new(),
             stderr: String::from("hello\n"),
         });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR fixes the clippy warnings as shipped in the [rust 1.66 preview](https://blog.rust-lang.org/inside-rust/2022/12/12/1.66.0-prerelease.html). 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #4696

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
