### PR TITLE
feat(nix): support new `nix shell` command

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -947,10 +947,12 @@
       "default": {
         "disabled": false,
         "format": "via [$symbol$state( \\($name\\))]($style) ",
+        "heuristic": false,
         "impure_msg": "impure",
         "pure_msg": "pure",
         "style": "bold blue",
-        "symbol": "❄️  "
+        "symbol": "❄️  ",
+        "unknown_msg": ""
       },
       "allOf": [
         {
@@ -3919,7 +3921,15 @@
           "default": "pure",
           "type": "string"
         },
+        "unknown_msg": {
+          "default": "",
+          "type": "string"
+        },
         "disabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "heuristic": {
           "default": false,
           "type": "boolean"
         }

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2640,14 +2640,15 @@ The module will be shown when inside a nix-shell environment.
 
 ### Options
 
-| Option       | Default                                      | Description                                           |
-| ------------ | -------------------------------------------- | ----------------------------------------------------- |
-| `format`     | `'via [$symbol$state( \($name\))]($style) '` | The format for the module.                            |
-| `symbol`     | `'❄️ '`                                       | A format string representing the symbol of nix-shell. |
-| `style`      | `'bold blue'`                                | The style for the module.                             |
-| `impure_msg` | `'impure'`                                   | A format string shown when the shell is impure.       |
-| `pure_msg`   | `'pure'`                                     | A format string shown when the shell is pure.         |
-| `disabled`   | `false`                                      | Disables the `nix_shell` module.                      |
+| Option        | Default                                      | Description                                                           |
+| ------------- | -------------------------------------------- | --------------------------------------------------------------------- |
+| `format`      | `'via [$symbol$state( \($name\))]($style) '` | The format for the module.                                            |
+| `symbol`      | `'❄️ '`                                       | A format string representing the symbol of nix-shell.                 |
+| `style`       | `'bold blue'`                                | The style for the module.                                             |
+| `impure_msg`  | `'impure'`                                   | A format string shown when the shell is impure.                       |
+| `pure_msg`    | `'pure'`                                     | A format string shown when the shell is pure.                         |
+| `unknown_msg` | `''`                                         | A format string shown when it is unknown if the shell is pure/impure. |
+| `disabled`    | `false`                                      | Disables the `nix_shell` module.                                      |
 
 ### Variables
 
@@ -2669,6 +2670,7 @@ The module will be shown when inside a nix-shell environment.
 disabled = true
 impure_msg = '[impure shell](bold red)'
 pure_msg = '[pure shell](bold green)'
+unknown_msg = '[unknown shell](bold yellow)'
 format = 'via [☃️ $state( \($name\))](bold blue) '
 ```
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2649,6 +2649,7 @@ The module will be shown when inside a nix-shell environment.
 | `pure_msg`    | `'pure'`                                     | A format string shown when the shell is pure.                         |
 | `unknown_msg` | `''`                                         | A format string shown when it is unknown if the shell is pure/impure. |
 | `disabled`    | `false`                                      | Disables the `nix_shell` module.                                      |
+| `heuristic`   | `false`                                      | Attempts to detect new `nix shell`-style shells with a heuristic.     |
 
 ### Variables
 

--- a/src/configs/nix_shell.rs
+++ b/src/configs/nix_shell.rs
@@ -15,6 +15,7 @@ pub struct NixShellConfig<'a> {
     pub pure_msg: &'a str,
     pub unknown_msg: &'a str,
     pub disabled: bool,
+    pub heuristic: bool,
 }
 
 /* The trailing double spaces in `symbol` are needed to work around issues with
@@ -30,6 +31,7 @@ impl<'a> Default for NixShellConfig<'a> {
             pure_msg: "pure",
             unknown_msg: "",
             disabled: false,
+            heuristic: false,
         }
     }
 }

--- a/src/configs/nix_shell.rs
+++ b/src/configs/nix_shell.rs
@@ -13,6 +13,7 @@ pub struct NixShellConfig<'a> {
     pub style: &'a str,
     pub impure_msg: &'a str,
     pub pure_msg: &'a str,
+    pub unknown_msg: &'a str,
     pub disabled: bool,
 }
 
@@ -27,6 +28,7 @@ impl<'a> Default for NixShellConfig<'a> {
             style: "bold blue",
             impure_msg: "impure",
             pure_msg: "pure",
+            unknown_msg: "",
             disabled: false,
         }
     }

--- a/src/modules/nix_shell.rs
+++ b/src/modules/nix_shell.rs
@@ -41,14 +41,17 @@ impl NixShellType {
 /// determine if it's inside a nix-shell and the name of it.
 ///
 /// The following options are availables:
-///     - `impure_msg` (string) // change the impure msg
-///     - `pure_msg` (string)   // change the pure msg
+///     - `impure_msg` (string)  // change the impure msg
+///     - `pure_msg` (string)    // change the pure msg
+///     - `unknown_msg` (string) // change the unknown message
 ///
 /// Will display the following:
 ///     - pure (name)    // $name == "name" in a pure nix-shell
 ///     - impure (name)  // $name == "name" in an impure nix-shell
 ///     - pure           // $name == "" in a pure nix-shell
 ///     - impure         // $name == "" in an impure nix-shell
+///     - unknown (name) // $name == "name" in an unknown nix-shell
+///     - unknown        // $name == "" in an unknown nix-shell
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let mut module = context.new_module("nix_shell");
     let config: NixShellConfig = NixShellConfig::try_load(module.config);
@@ -58,7 +61,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let shell_type_format = match shell_type {
         NixShellType::Pure => config.pure_msg,
         NixShellType::Impure => config.impure_msg,
-        NixShellType::Unknown => "",
+        NixShellType::Unknown => config.unknown_msg,
     };
 
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {

--- a/src/modules/nix_shell.rs
+++ b/src/modules/nix_shell.rs
@@ -181,4 +181,14 @@ mod tests {
 
         assert_eq!(expected, actual);
     }
+
+    #[test]
+    fn no_new_nix_shell_with_nix_store_subdirectory() {
+        let actual = ModuleRenderer::new("nix_shell")
+            .env("PATH", "/Users/user/some/nix/store/subdirectory")
+            .collect();
+        let expected = None;
+
+        assert_eq!(expected, actual);
+    }
 }

--- a/src/modules/nix_shell.rs
+++ b/src/modules/nix_shell.rs
@@ -3,7 +3,6 @@ use super::{Context, Module, ModuleConfig};
 use crate::configs::nix_shell::NixShellConfig;
 use crate::formatter::StringFormatter;
 
-#[derive(Debug)]
 enum NixShellType {
     Pure,
     Impure,

--- a/src/modules/nix_shell.rs
+++ b/src/modules/nix_shell.rs
@@ -29,7 +29,9 @@ impl NixShellType {
     fn in_new_nix_shell(context: &Context) -> Option<()> {
         let path = context.get_env("PATH")?;
 
-        path.contains("/nix/store").then_some(())
+        std::env::split_paths(&path)
+            .any(|path| path.starts_with("/nix/store"))
+            .then_some(())
     }
 }
 


### PR DESCRIPTION
#### Description
Closes #2950.

Adds two options for `nix_shell`:
- `heuristic`: Enables detection of `nix shell` with the heuristic described below (default: disabled)
- `unknown_msg`: Like `pure/impure_msg` for when we can't detect which shell type it is

#### Motivation and Context
The current `nix_shell` module only works with `nix-shell`, not `nix shell`.

There's no straightforward way to detect if we're in a `nix shell` yet, so I've used a workaround that checks if we have a nix store path in our `PATH` to detect if we're in a `nix shell`.



#### How Has This Been Tested?
I've added tests in the `nix_shell` module.

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
