### PR TITLE
docs(config): clarify git-commit tag variable

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1640,10 +1640,11 @@ The `git_commit` module shows the current commit hash and also the tag (if any) 
 
 ### Variables
 
-| Variable | Example   | Description                         |
-| -------- | --------- | ----------------------------------- |
-| hash     | `b703eb3` | The current git commit hash         |
-| style\*  |           | Mirrors the value of option `style` |
+| Variable | Example   | Description                                  |
+| -------- | --------- | -------------------------------------------- |
+| hash     | `b703eb3` | The current git commit hash                  |
+| tag      | `v1.0.0`  | The tag name if showing tag info is enabled. |
+| style\*  |           | Mirrors the value of option `style`          |
 
 *: This variable can only be used as a part of a style string
 


### PR DESCRIPTION
The `git_commit` module uses a `tag` variable in its format string, which is not explained in the Variables section of this module.

Missing clarification of this `tag` variable is added to the documentation of the `git_commit` module.

Closes #4640
