### PR TITLE
refactor(kubernetes): Remove nested Options

### DIFF
--- a/src/modules/kubernetes.rs
+++ b/src/modules/kubernetes.rs
@@ -160,7 +160,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
                 "namespace" => ctx_components
                     .iter()
-                    .find_map(|kube| kube.user.as_deref())
+                    .find_map(|kube| kube.namespace.as_deref())
                     .map(|namespace| Ok(Cow::Borrowed(namespace))),
 
                 "user" => ctx_components

--- a/src/modules/kubernetes.rs
+++ b/src/modules/kubernetes.rs
@@ -34,10 +34,7 @@ fn get_kube_context(filename: path::PathBuf) -> Option<String> {
     Some(current_ctx.to_string())
 }
 
-fn get_kube_ctx_component(
-    filename: path::PathBuf,
-    current_ctx: String,
-) -> Option<KubeCtxComponents> {
+fn get_kube_ctx_component(filename: path::PathBuf, current_ctx: &str) -> Option<KubeCtxComponents> {
     let contents = utils::read_file(filename).ok()?;
 
     let yaml_docs = YamlLoader::load_from_str(&contents).ok()?;
@@ -120,7 +117,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     };
 
     // If we have some config for doing the directory scan then we use it but if we don't then we
-    // assume we should treat it like the module is enabled to preserve backward compatability.
+    // assume we should treat it like the module is enabled to preserve backward compatibility.
     let have_scan_config = !(config.detect_files.is_empty()
         && config.detect_folders.is_empty()
         && config.detect_extensions.is_empty());
@@ -144,22 +141,9 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
     let kube_ctx = env::split_paths(&kube_cfg).find_map(get_kube_context)?;
 
-    let ctx_components: Vec<Option<KubeCtxComponents>> = env::split_paths(&kube_cfg)
-        .map(|filename| get_kube_ctx_component(filename, kube_ctx.clone()))
+    let ctx_components: Vec<KubeCtxComponents> = env::split_paths(&kube_cfg)
+        .filter_map(|filename| get_kube_ctx_component(filename, &kube_ctx))
         .collect();
-
-    let kube_user = ctx_components.iter().find(|&ctx| match ctx {
-        Some(kube) => kube.user.is_some(),
-        None => false,
-    });
-    let kube_ns = ctx_components.iter().find(|&ctx| match ctx {
-        Some(kube) => kube.namespace.is_some(),
-        None => false,
-    });
-    let kube_cluster = ctx_components.iter().find(|&ctx| match ctx {
-        Some(kube) => kube.cluster.is_some(),
-        None => false,
-    });
 
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter
@@ -174,25 +158,20 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             .map(|variable| match variable {
                 "context" => Some(Ok(get_kube_context_name(&config, &kube_ctx))),
 
-                "namespace" => kube_ns.and_then(|ctx| {
-                    ctx.as_ref().map(|kube| {
-                        // unwrap is safe as kube_ns only holds kube.namespace.is_some()
-                        Ok(Cow::Borrowed(kube.namespace.as_ref().unwrap().as_str()))
-                    })
-                }),
-                "user" => kube_user.and_then(|ctx| {
-                    ctx.as_ref().map(|kube| {
-                        // unwrap is safe as kube_user only holds kube.user.is_some()
-                        Ok(get_kube_user(&config, kube.user.as_ref().unwrap().as_str()))
-                    })
-                }),
-                "cluster" => kube_cluster.and_then(|ctx| {
-                    ctx.as_ref().map(|kube| {
-                        // unwrap is safe as kube_cluster only holds kube.cluster.is_some()
-                        Ok(Cow::Borrowed(kube.cluster.as_ref().unwrap().as_str()))
-                    })
-                }),
+                "namespace" => ctx_components
+                    .iter()
+                    .find_map(|kube| kube.user.as_deref())
+                    .map(|namespace| Ok(Cow::Borrowed(namespace))),
 
+                "user" => ctx_components
+                    .iter()
+                    .find_map(|kube| kube.user.as_deref())
+                    .map(|user| Ok(get_kube_user(&config, user))),
+
+                "cluster" => ctx_components
+                    .iter()
+                    .find_map(|kube| kube.cluster.as_deref())
+                    .map(|cluster| Ok(Cow::Borrowed(cluster))),
                 _ => None,
             })
             .parse(None, Some(context))


### PR DESCRIPTION
#### Description
Kubernetes module was previously a bit messy, with lots of unnecessarily nested options. Clean this up using filter_map and find_map, with two major results:

1. `ctx_components` is now a Vec<KubeCtxComponent> instead of a Vec<Option<KubeCtxComponent>>. This greatly simplified downstream processing of these context components.

2. Instead of storing a partial computation of the namespace in variables `kube_ns`, etc, compute them directly in the formatter mapping. This is made simpler (read: actually doable) by change 1. This change also removes nonlocal commenting (i.e. "This is safe because `var` contains a `Some` value") and replaces it with operations that do not require `unwrap` at all. 

#### Motivation and Context

Nested options made it difficult to understand and manipulate the operations of the Kubernetes module. I suspect this is partially why I initially found #4550 so difficult to understand.

Removing these nested options will hopefully make it easier to understand the code and modify it moving forward.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
