### PR TITLE
feat(config): update nushell config command usage from `is-empty` to `length`

### DIFF
--- a/src/init/starship.nu
+++ b/src/init/starship.nu
@@ -16,7 +16,7 @@ let-env PROMPT_COMMAND = {
 let has_rprompt_last_line_support = (version).version >= 0.71.0
 
 # Whether we have config items
-let has_config_items = (not ($env | get -i config | is-empty))
+let has_config_items = (not ($env | get -i config | length) == 0)
 
 if $has_rprompt_last_line_support {
     let config = if $has_config_items {


### PR DESCRIPTION
Update the Nushell `$HOME/.cache/starship/starship.nu` config file on line 19 to use `(not ($env | get -i config | length) == 0)` instead of `(not ($env | get -i config | is-empty))` since `is-empty` is no longer a valid external command in Nushell according to latest issues on the Nushell repo indicating that commands with `-` dashes in them no longer exist.

Got this error when creating a fresh install of Nushell & Starship. Version information is listen below.
```
❯ version
╭────────────────────┬─────────────────────────────────────╮
│ version            │ 0.61.0                              │
│ branch             │ master                              │
│ tag                │                                     │
│ build_os           │ macos-aarch64                       │
│ build_os           │ aarch64-apple-darwin                │
│ rust_version       │ rustc 1.59.0 (9d1b2106e 2022-02-23) │
│ rust_channel       │ stable-aarch64-apple-darwin         │
│ cargo_version      │ cargo 1.59.0 (49d8809dc 2022-02-10) │
│ pkg_version        │ 0.61.0                              │
│ build_time         │ 2022-12-25 09:10:29 +11:00          │
│ build_rust_channel │ release                             │
│ features           │ default, trash, which, zip          │
│ installed_plugins  │                                     │
╰────────────────────┴─────────────────────────────────────╯

```
#### Description
According to multiple issues & PRs in the Nushell repo, commands that feature a `-` dash are no longer valid commands, but the referencing documentation isn't updated to show these changes. Installing a fresh install of Nushell & starship, the check in the file `$HOME/.cache/starship/starship.nu` on line 19 uses `is-empty` which is invalid on new installs currently, instead I've updated it to use `(not ($env | get -i config | length) == 0)` which is valid in the latest release of Nushell.

#### Motivation and Context
What does it solve? Deprecation issue relating to Nushell command references in the Nushell configuration file for Starship.

#### How Has This Been Tested?
Tested & working once changing the `starship.nu` config file with the change, with the command `source $HOME/.cache/starship/starship.nu` no longer throwing an external command not found error.
- [X] I have tested using **MacOS**
- [X] I have tested using **Linux (Debian - WSL2)**

#### Checklist:
- [X] I have updated the documentation accordingly.
  - No documentation changes needed as far as I can tell
- [ ] I have updated the tests accordingly.
  - Unsure what tests would be required to change, if any, so leaving this for anyone that has a clue about it.
