### PR TITLE
feat(hg_branch): Add support for mercurial topics and find hg root dir

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -750,7 +750,7 @@
     "hg_branch": {
       "default": {
         "disabled": true,
-        "format": "on [$symbol$branch:$topic]($style) ",
+        "format": "on [$symbol$branch(:$topic)]($style) ",
         "style": "bold purple",
         "symbol": " ",
         "truncation_length": 9223372036854775807,
@@ -3533,7 +3533,7 @@
           "type": "string"
         },
         "format": {
-          "default": "on [$symbol$branch]($style) ",
+          "default": "on [$symbol$branch(:$topic)]($style) ",
           "type": "string"
         },
         "truncation_length": {

--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -750,7 +750,7 @@
     "hg_branch": {
       "default": {
         "disabled": true,
-        "format": "on [$symbol$branch]($style) ",
+        "format": "on [$symbol$branch:$topic]($style) ",
         "style": "bold purple",
         "symbol": " ",
         "truncation_length": 9223372036854775807,

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2638,14 +2638,14 @@ The `hg_branch` module shows the active branch and topic of the repo in your cur
 
 ### Options
 
-| Option              | Default                                 | Description                                                                                  |
-| ------------------- | --------------------------------------- | -------------------------------------------------------------------------------------------- |
-| `symbol`            | `' '`                                  | The symbol used before the hg bookmark or branch name of the repo in your current directory. |
-| `style`             | `'bold purple'`                         | The style for the module.                                                                    |
+| Option              | Default                                   | Description                                                                                  |
+| ------------------- | ----------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `symbol`            | `' '`                                    | The symbol used before the hg bookmark or branch name of the repo in your current directory. |
+| `style`             | `'bold purple'`                           | The style for the module.                                                                    |
 | `format`            | `'on [$symbol$branch(:$topic)]($style) '` | The format for the module.                                                                   |
-| `truncation_length` | `2^63 - 1`                              | Truncates the hg branch / topic name to `N` graphemes                                        |
-| `truncation_symbol` | `'…'`                                   | The symbol used to indicate a branch name was truncated.                                     |
-| `disabled`          | `true`                                  | Disables the `hg_branch` module.                                                             |
+| `truncation_length` | `2^63 - 1`                                | Truncates the hg branch / topic name to `N` graphemes                                        |
+| `truncation_symbol` | `'…'`                                     | The symbol used to indicate a branch name was truncated.                                     |
+| `disabled`          | `true`                                    | Disables the `hg_branch` module.                                                             |
 
 ### Variables
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2634,26 +2634,27 @@ style = 'bold dimmed green'
 
 ## Mercurial Branch
 
-The `hg_branch` module shows the active branch of the repo in your current directory.
+The `hg_branch` module shows the active branch and topic of the repo in your current directory.
 
 ### Options
 
-| Option              | Default                          | Description                                                                                  |
-| ------------------- | -------------------------------- | -------------------------------------------------------------------------------------------- |
-| `symbol`            | `' '`                           | The symbol used before the hg bookmark or branch name of the repo in your current directory. |
-| `style`             | `'bold purple'`                  | The style for the module.                                                                    |
-| `format`            | `'on [$symbol$branch]($style) '` | The format for the module.                                                                   |
-| `truncation_length` | `2^63 - 1`                       | Truncates the hg branch name to `N` graphemes                                                |
-| `truncation_symbol` | `'…'`                            | The symbol used to indicate a branch name was truncated.                                     |
-| `disabled`          | `true`                           | Disables the `hg_branch` module.                                                             |
+| Option              | Default                                 | Description                                                                                  |
+| ------------------- | --------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `symbol`            | `' '`                                  | The symbol used before the hg bookmark or branch name of the repo in your current directory. |
+| `style`             | `'bold purple'`                         | The style for the module.                                                                    |
+| `format`            | `'on [$symbol$branch:$topic]($style) '` | The format for the module.                                                                   |
+| `truncation_length` | `2^63 - 1`                              | Truncates the hg branch / topic name to `N` graphemes                                        |
+| `truncation_symbol` | `'…'`                                   | The symbol used to indicate a branch name was truncated.                                     |
+| `disabled`          | `true`                                  | Disables the `hg_branch` module.                                                             |
 
 ### Variables
 
-| Variable | Example  | Description                          |
-| -------- | -------- | ------------------------------------ |
-| branch   | `master` | The active mercurial branch          |
-| symbol   |          | Mirrors the value of option `symbol` |
-| style\*  |          | Mirrors the value of option `style`  |
+| Variable | Example   | Description                          |
+| -------- | --------- | ------------------------------------ |
+| branch   | `master`  | The active mercurial branch          |
+| topic    | `feature` | The active mercurial topic           |
+| symbol   |           | Mirrors the value of option `symbol` |
+| style\*  |           | Mirrors the value of option `style`  |
 
 *: This variable can only be used as a part of a style string
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2642,7 +2642,7 @@ The `hg_branch` module shows the active branch and topic of the repo in your cur
 | ------------------- | --------------------------------------- | -------------------------------------------------------------------------------------------- |
 | `symbol`            | `' '`                                  | The symbol used before the hg bookmark or branch name of the repo in your current directory. |
 | `style`             | `'bold purple'`                         | The style for the module.                                                                    |
-| `format`            | `'on [$symbol$branch:$topic]($style) '` | The format for the module.                                                                   |
+| `format`            | `'on [$symbol$branch(:$topic)]($style) '` | The format for the module.                                                                   |
 | `truncation_length` | `2^63 - 1`                              | Truncates the hg branch / topic name to `N` graphemes                                        |
 | `truncation_symbol` | `'…'`                                   | The symbol used to indicate a branch name was truncated.                                     |
 | `disabled`          | `true`                                  | Disables the `hg_branch` module.                                                             |

--- a/src/configs/hg_branch.rs
+++ b/src/configs/hg_branch.rs
@@ -21,7 +21,7 @@ impl<'a> Default for HgBranchConfig<'a> {
         HgBranchConfig {
             symbol: " ",
             style: "bold purple",
-            format: "on [$symbol$branch]($style) ",
+            format: "on [$symbol$branch:$topic]($style) ",
             truncation_length: std::i64::MAX,
             truncation_symbol: "…",
             disabled: true,

--- a/src/configs/hg_branch.rs
+++ b/src/configs/hg_branch.rs
@@ -21,7 +21,7 @@ impl<'a> Default for HgBranchConfig<'a> {
         HgBranchConfig {
             symbol: " ",
             style: "bold purple",
-            format: "on [$symbol$branch:$topic]($style) ",
+            format: "on [$symbol$branch(:$topic)]($style) ",
             truncation_length: std::i64::MAX,
             truncation_symbol: "…",
             disabled: true,

--- a/src/modules/hg_branch.rs
+++ b/src/modules/hg_branch.rs
@@ -6,8 +6,8 @@ use super::{Context, Module, ModuleConfig};
 
 use crate::configs::hg_branch::HgBranchConfig;
 use crate::formatter::StringFormatter;
-use crate::utils::read_file;
 use crate::modules::utils::path::PathExt;
+use crate::utils::read_file;
 
 struct HgRepo {
     /// If `current_dir` is an hg repository or is contained within one,
@@ -109,7 +109,7 @@ fn get_hg_repo(ctx: &Context) -> Result<HgRepo, Error> {
             .any(|e| e.unwrap().file_name() == ".hg")
         {
             let repo = HgRepo {
-                branch: get_hg_branch_name(root_dir).unwrap_or(String::from("default")),
+                branch: get_hg_branch_name(root_dir).unwrap_or_else(|_| String::from("default")),
                 bookmark: get_hg_current_bookmark(root_dir).ok(),
                 topic: get_hg_topic_name(root_dir).ok(),
             };

--- a/src/modules/hg_branch.rs
+++ b/src/modules/hg_branch.rs
@@ -1,8 +1,8 @@
 use std::io::{Error, ErrorKind};
 use std::path::Path;
 
-use super::{Context, Module, ModuleConfig};
 use super::utils::truncate::truncate_text;
+use super::{Context, Module, ModuleConfig};
 
 use crate::configs::hg_branch::HgBranchConfig;
 use crate::formatter::StringFormatter;
@@ -38,7 +38,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     });
 
     let branch_graphemes = truncate_text(&branch_name, len, config.truncation_symbol);
-    let topic_graphemes = if let Some(topic) = get_hg_topic_name(repo_root).ok() {
+    let topic_graphemes = if let Ok(topic) = get_hg_topic_name(repo_root) {
         truncate_text(&topic, len, config.truncation_symbol)
     } else {
         String::from("")

--- a/src/modules/hg_branch.rs
+++ b/src/modules/hg_branch.rs
@@ -7,6 +7,7 @@ use super::{Context, Module, ModuleConfig};
 use crate::configs::hg_branch::HgBranchConfig;
 use crate::formatter::StringFormatter;
 use crate::utils::read_file;
+use crate::modules::utils::path::PathExt;
 
 struct HgRepo {
     /// If `current_dir` is an hg repository or is contained within one,
@@ -98,7 +99,11 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
 fn get_hg_repo(ctx: &Context) -> Result<HgRepo, Error> {
     let dir = ctx.current_dir.as_path();
+    let dev_id = dir.device_id();
     for root_dir in dir.ancestors() {
+        if dev_id != root_dir.device_id() {
+            break;
+        }
         if root_dir
             .read_dir()?
             .any(|e| e.unwrap().file_name() == ".hg")

--- a/src/modules/hg_branch.rs
+++ b/src/modules/hg_branch.rs
@@ -80,10 +80,7 @@ fn get_hg_repo_root<'a>(ctx: &'a Context) -> Result<&'a Path, Error> {
         if dev_id != root_dir.device_id() {
             break;
         }
-        if root_dir
-            .read_dir()?
-            .any(|e| e.unwrap().file_name() == ".hg")
-        {
+        if root_dir.join(".hg").is_dir() {
             return Ok(root_dir);
         }
     }

--- a/src/modules/hg_branch.rs
+++ b/src/modules/hg_branch.rs
@@ -355,7 +355,7 @@ mod tests {
         let expected = Some(format!(
             "on {} ",
             expect_style.paint(format!(
-                "{expect_symbol} {expect_branch_name}{expect_truncation_symbol}:"
+                "{expect_symbol} {expect_branch_name}{expect_truncation_symbol}"
             )),
         ));
         assert_eq!(expected, actual);

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -249,7 +249,7 @@ pub fn description(module: &str) -> &'static str {
         "haskell" => "The selected version of the Haskell toolchain",
         "haxe" => "The currently installed version of Haxe",
         "helm" => "The currently installed version of Helm",
-        "hg_branch" => "The active branch of the repo in your current directory",
+        "hg_branch" => "The active branch and topic of the repo in your current directory",
         "hostname" => "The system hostname",
         "java" => "The currently installed version of Java",
         "jobs" => "The current number of jobs running",

--- a/src/modules/utils/path.rs
+++ b/src/modules/utils/path.rs
@@ -82,6 +82,11 @@ impl PathExt for Path {
         let (_, path) = normalize::normalize_path(self);
         path
     }
+
+    fn device_id(&self) -> u64 {
+        // Maybe it should us unimplemented!
+        42u64
+    }
 }
 
 // NOTE: Windows path prefixes are only parsed on Windows.

--- a/src/modules/utils/path.rs
+++ b/src/modules/utils/path.rs
@@ -113,7 +113,7 @@ impl PathExt for Path {
         use std::os::linux::fs::MetadataExt;
         match self.metadata() {
             Ok(m) => Some(m.st_dev()),
-            Err(_) => None
+            Err(_) => None,
         }
     }
 
@@ -122,7 +122,7 @@ impl PathExt for Path {
         use std::os::unix::fs::MetadataExt;
         match self.metadata() {
             Ok(m) => Some(m.st_dev()),
-            Err(_) => None
+            Err(_) => None,
         }
     }
 }

--- a/src/modules/utils/path.rs
+++ b/src/modules/utils/path.rs
@@ -13,6 +13,8 @@ pub trait PathExt {
     /// E.g. `\\?\UNC\server\share\foo` => `\foo`
     /// E.g. `/foo/bar` => `/foo/bar`
     fn without_prefix(&self) -> &Path;
+    /// Get device / volume info
+    fn device_id(&self) -> u64;
 }
 
 #[cfg(windows)]
@@ -99,6 +101,20 @@ impl PathExt for Path {
     #[inline]
     fn without_prefix(&self) -> &Path {
         self
+    }
+
+    #[cfg(target_os = "linux")]
+    fn device_id(&self) -> u64 {
+        use std::os::linux::fs::MetadataExt;
+        let m = self.metadata().unwrap();
+        m.st_dev()
+    }
+
+    #[cfg(all(unix, not(target_os = "linux")))]
+    pub fn device_id(&self) -> u64 {
+        use std::os::unix::fs::MetadataExt;
+        let m = self.metadata().unwrap();
+        m.dev()
     }
 }
 

--- a/src/modules/utils/path.rs
+++ b/src/modules/utils/path.rs
@@ -111,7 +111,7 @@ impl PathExt for Path {
     }
 
     #[cfg(all(unix, not(target_os = "linux")))]
-    pub fn device_id(&self) -> u64 {
+    fn device_id(&self) -> u64 {
         use std::os::unix::fs::MetadataExt;
         let m = self.metadata().unwrap();
         m.dev()

--- a/src/modules/utils/path.rs
+++ b/src/modules/utils/path.rs
@@ -14,7 +14,7 @@ pub trait PathExt {
     /// E.g. `/foo/bar` => `/foo/bar`
     fn without_prefix(&self) -> &Path;
     /// Get device / volume info
-    fn device_id(&self) -> u64;
+    fn device_id(&self) -> Option<u64>;
 }
 
 #[cfg(windows)]
@@ -83,9 +83,9 @@ impl PathExt for Path {
         path
     }
 
-    fn device_id(&self) -> u64 {
-        // Maybe it should us unimplemented!
-        42u64
+    fn device_id(&self) -> Option<u64> {
+        // Maybe it should use unimplemented!
+        Some(42u64)
     }
 }
 
@@ -109,17 +109,21 @@ impl PathExt for Path {
     }
 
     #[cfg(target_os = "linux")]
-    fn device_id(&self) -> u64 {
+    fn device_id(&self) -> Option<u64> {
         use std::os::linux::fs::MetadataExt;
-        let m = self.metadata().unwrap();
-        m.st_dev()
+        match self.metadata() {
+            Ok(m) => Some(m.st_dev()),
+            Err(_) => None
+        }
     }
 
     #[cfg(all(unix, not(target_os = "linux")))]
-    fn device_id(&self) -> u64 {
+    fn device_id(&self) -> Option<u64> {
         use std::os::unix::fs::MetadataExt;
-        let m = self.metadata().unwrap();
-        m.dev()
+        match self.metadata() {
+            Ok(m) => Some(m.st_dev()),
+            Err(_) => None
+        }
     }
 }
 

--- a/src/modules/utils/path.rs
+++ b/src/modules/utils/path.rs
@@ -121,7 +121,7 @@ impl PathExt for Path {
     fn device_id(&self) -> Option<u64> {
         use std::os::unix::fs::MetadataExt;
         match self.metadata() {
-            Ok(m) => Some(m.st_dev()),
+            Ok(m) => Some(m.dev()),
             Err(_) => None,
         }
     }


### PR DESCRIPTION
#### Description
This change introduce a new variable that store the active topic name and also it finds the root directory of the mercurial repo.

I am aware that there is already a similar PR : https://github.com/starship/starship/pull/3970 but I noticed it only after I wrote my code :smile:. Anyway I think the remark that @davidkna made on this PR can be fixed by using https://github.com/speedy37/mountpoints-rs/ but I don't know what is the policy regarding including libraries that are quite young and seldomly used.

#### Motivation and Context
`hg_branch` does not work when the directory is not at the root of the repository.
I introduced the topic in this change because we started using it in our project and it's a nice way to have lightweight branches in mercurial.

Closes #3970
Closes #1461 
Closes #1384
Closes #870

#### Screenshots (if appropriate):
![screenshot](https://user-images.githubusercontent.com/44782/209845937-af4871b2-fa6e-4aac-a79c-ca83995ece6d.png)

#### How Has This Been Tested?
I ran this version on my computer.

- [ ] I have tested using **MacOS**
- [X] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [X] I have updated the documentation accordingly.
- [X] I have updated the tests accordingly.
