### PR TITLE
docs(nu): Add `-f` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ Add the following to the end of your Nushell env file (find it by running `$nu.e
 
 ```sh
 mkdir ~/.cache/starship
-starship init nu | save ~/.cache/starship/init.nu
+starship init nu | save -f ~/.cache/starship/init.nu
 ```
 
 And add the following to the end of your Nushell configuration (find it by running `$nu.config-path`):
@@ -341,7 +341,7 @@ And add the following to the end of your Nushell configuration (find it by runni
 source ~/.cache/starship/init.nu
 ```
 
-Note: Only Nushell v0.61+ is supported
+Note: Only Nushell v0.71+ is supported
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ And add the following to the end of your Nushell configuration (find it by runni
 source ~/.cache/starship/init.nu
 ```
 
-Note: Only Nushell v0.71+ is supported
+Note: Only Nushell v0.73+ is supported
 
 </details>
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -138,14 +138,14 @@ description: Starship is the minimal, blazing fast, and extremely customizable p
    ::: warning
 
    This will change in the future.
-   Only Nushell v0.61+ is supported.
+   Only Nushell v0.71+ is supported.
 
    :::
 
    Add the following to the end of your Nushell env file (find it by running `$nu.env-path` in Nushell):
    ```sh
    mkdir ~/.cache/starship
-   starship init nu | save ~/.cache/starship/init.nu
+   starship init nu | save -f ~/.cache/starship/init.nu
    ```
 
    And add the following to the end of your Nushell configuration (find it by running `$nu.config-path`):

--- a/docs/README.md
+++ b/docs/README.md
@@ -138,7 +138,7 @@ description: Starship is the minimal, blazing fast, and extremely customizable p
    ::: warning
 
    This will change in the future.
-   Only Nushell v0.71+ is supported.
+   Only Nushell v0.73+ is supported.
 
    :::
 

--- a/install/install.sh
+++ b/install/install.sh
@@ -338,10 +338,10 @@ print_install() {
         # shellcheck disable=SC2088
         config_file="${BOLD}your nu config file${NO_COLOR} (find it by running ${BOLD}\$nu.config-path${NO_COLOR} in Nushell)"
         config_cmd="mkdir ~/.cache/starship
-        starship init nu | save ~/.cache/starship/init.nu
+        starship init nu | save -f ~/.cache/starship/init.nu
         source ~/.cache/starship/init.nu"
         warning="${warning} This will change in the future.
-  Only Nushell v0.61 or higher is supported.
+  Only Nushell v0.71 or higher is supported.
   Add the following to the end of ${BOLD}your Nushell env file${NO_COLOR} (find it by running ${BOLD}\$nu.env-path${NO_COLOR} in Nushell): \"mkdir ~/.cache/starship; starship init nu | save ~/.cache/starship/init.nu\""
         ;;
     esac

--- a/install/install.sh
+++ b/install/install.sh
@@ -341,7 +341,7 @@ print_install() {
         starship init nu | save -f ~/.cache/starship/init.nu
         source ~/.cache/starship/init.nu"
         warning="${warning} This will change in the future.
-  Only Nushell v0.71 or higher is supported.
+  Only Nushell v0.73 or higher is supported.
   Add the following to the end of ${BOLD}your Nushell env file${NO_COLOR} (find it by running ${BOLD}\$nu.env-path${NO_COLOR} in Nushell): \"mkdir ~/.cache/starship; starship init nu | save ~/.cache/starship/init.nu\""
         ;;
     esac


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
I noticed that I had to edit an instruction to make the integration with NuShell work (see https://github.com/starship/starship/issues/4701). All that was needed was to add a '-f' flag, but the documentation did not include that. Without this flag, a file would not be overwritten, which causes an error on startup.

Closes #4701
Closes #4757

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
