### PR TITLE
chore: Don't run crowdin workflow on forks

### DIFF
--- a/.github/workflows/crowdin-pretranslate.yml
+++ b/.github/workflows/crowdin-pretranslate.yml
@@ -8,6 +8,8 @@ jobs:
   trigger_crowdin_tm:
     name: Crowdin Translation Memory Trigger
     runs-on: ubuntu-latest
+    # Prevent this workflow from running (and failing) on forks
+    if: github.repository == 'starship/starship'
     steps:
       - uses: starship/crowdin-pretranslate-action@v0.1.1
         with:


### PR DESCRIPTION

#### Description

I get a weekly email that the crowdin workflow has failed in my fork. This change should prevent that from happening by only running the task on the primary repo (starship/starship) 