### PR TITLE
chore: remove version check for unsupported nushell version

### DIFF
--- a/docs/advanced-config/README.md
+++ b/docs/advanced-config/README.md
@@ -263,8 +263,6 @@ the input line in a multi-line prompt, see the [`fill` module](/config/#fill).
 
 `right_format` is currently supported for the following shells: elvish, fish, zsh, xonsh, cmd, nushell.
 
-Note: Nushell 0.71.0 or later is required
-
 ### Example
 
 ```toml

--- a/src/init/starship.nu
+++ b/src/init/starship.nu
@@ -12,28 +12,17 @@ let-env PROMPT_COMMAND = {
     ^::STARSHIP:: prompt $"--cmd-duration=($env.CMD_DURATION_MS)" $"--status=($env.LAST_EXIT_CODE)" $"--terminal-width=($width)"
 }
 
-# Whether we can show right prompt on the last line
-let has_rprompt_last_line_support = (version).version >= 0.71.0
-
 # Whether we have config items
 let has_config_items = (not ($env | get -i config | is-empty))
 
-if $has_rprompt_last_line_support {
-    let config = if $has_config_items {
-        $env.config | upsert render_right_prompt_on_last_line true
-    } else {
-        {render_right_prompt_on_last_line: true}
-    }
-    {config: $config}
+let config = if $has_config_items {
+    $env.config | upsert render_right_prompt_on_last_line true
 } else {
-    { }
-} | load-env
+    {render_right_prompt_on_last_line: true}
+}
+{config: $config} | load-env
 
 let-env PROMPT_COMMAND_RIGHT = {
-    if $has_rprompt_last_line_support {
-        let width = (term size).columns
-        ^::STARSHIP:: prompt --right $"--cmd-duration=($env.CMD_DURATION_MS)" $"--status=($env.LAST_EXIT_CODE)" $"--terminal-width=($width)"
-    } else {
-        ''
-    }
+    let width = (term size).columns
+    ^::STARSHIP:: prompt --right $"--cmd-duration=($env.CMD_DURATION_MS)" $"--status=($env.LAST_EXIT_CODE)" $"--terminal-width=($width)"
 }


### PR DESCRIPTION
#### Description
Removed the nu shell version check codes for supporting older versions of nu shell.

#### Motivation and Context
Closes https://github.com/starship/starship/issues/4778

#### How Has This Been Tested?
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
