### PR TITLE
chore(aws): fix unintended test failure of `aws::missing_any_credentials`

### DIFF
--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -802,10 +802,14 @@ aws_secret_access_key=dummy
     #[test]
     fn missing_any_credentials() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
-        let config_path = dir.path().join("config");
-        let mut file = File::create(&config_path)?;
 
-        file.write_all(
+        let credential_path = dir.path().join("credentials");
+        File::create(&credential_path)?;
+
+        let config_path = dir.path().join("config");
+        let mut config_file = File::create(&config_path)?;
+
+        config_file.write_all(
             "[default]
 region = us-east-1
 output = json
@@ -818,6 +822,10 @@ region = us-east-2
 
         let actual = ModuleRenderer::new("aws")
             .env("AWS_CONFIG_FILE", config_path.to_string_lossy().as_ref())
+            .env(
+                "AWS_CREDENTIALS_FILE",
+                credential_path.to_string_lossy().as_ref(),
+            )
             .collect();
         let expected = None;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
Because its mocking is not enough, The test may unintentionally fails if `~/.aws/credentials` exists.
This commit fixes this issue by mocking `credentials` file as well.

#### Motivation and Context
This issue may prevent to build `starship` locally. I hit this issue while building ArchLinux user repository package `starship-git`.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Windows**
- [x] I have tested using **Linux**
having `~/.aws/credentials` setup by AWS CLI.


#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
I don't know whether if this kind of change should be documented. If needed, I'd happy to write them!
- [x] I have updated the tests accordingly.
