### PR TITLE
Update starship.nu for Nushell 0.74.1

### DIFF
--- a/src/init/starship.nu
+++ b/src/init/starship.nu
@@ -15,7 +15,7 @@ let-env PROMPT_COMMAND = {
 # Whether we have config items
 let has_config_items = (not ($env | get -i config | is-empty))
 
-let config = if $has_config_items {
+let-env config = if $has_config_items {
     $env.config | upsert render_right_prompt_on_last_line true
 } else {
     {render_right_prompt_on_last_line: true}


### PR DESCRIPTION
A warning (to use let-env config instead of let config) appears when starting up Nushell.
