### PR TITLE
feat(profiles): add right prompt, set via env & add docs

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -1969,10 +1969,15 @@
       }
     },
     "profiles": {
-      "default": {},
+      "default": {
+        "transient": {
+          "format": "$character",
+          "right_format": ""
+        }
+      },
       "type": "object",
       "additionalProperties": {
-        "type": "string"
+        "$ref": "#/definitions/Either_for_String_and_Profile"
       }
     }
   },
@@ -6550,6 +6555,31 @@
           "type": "string"
         }
       ]
+    },
+    "Either_for_String_and_Profile": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/Profile"
+        }
+      ]
+    },
+    "Profile": {
+      "description": "Profiles are either a string containing the format, or a struct containing the format and right_format",
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "",
+          "type": "string"
+        },
+        "right_format": {
+          "default": "",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
     }
   }
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ gix-faster = ["gix-features/zlib-stock", "gix/fast-sha1"]
 
 [dependencies]
 chrono = { version = "0.4.38", default-features = false, features = ["clock", "std", "wasmbind"] }
-clap = { version = "4.5.18", features = ["derive", "cargo", "unicode"] }
+clap = { version = "4.5.18", features = ["derive", "env", "cargo", "unicode"] }
 clap_complete = "4.5.29"
 dirs = "5.0.1"
 dunce = "1.0.5"

--- a/docs/advanced-config/README.md
+++ b/docs/advanced-config/README.md
@@ -20,11 +20,11 @@ this statement in your `$PROFILE`. Transience can be disabled on-the-fly with
 
 By default, the left side of input gets replaced with `>`. To customize this,
 define a new function called `Invoke-Starship-TransientFunction`. For example, to
-display Starship's `character` module here, you would do
+display Starship's `transient` profile with the `character` module:
 
 ```powershell
 function Invoke-Starship-TransientFunction {
-  &starship module character
+  &starship prompt --profile=transient
 }
 
 Invoke-Expression (&starship init powershell)
@@ -48,11 +48,11 @@ to customize what gets displayed on the left and on the right:
 - By default, the left side of input gets replaced with `>`. To customize this,
   define a new function called `starship_transient_prompt_func`. This function
   receives the current prompt as a string that you can utilize. For example, to
-  display Starship's `character` module here, you would do
+  display Starship's default `transient` profile with the `character` module, you would do
 
 ```lua
 function starship_transient_prompt_func(prompt)
-  return io.popen("starship module character"
+  return io.popen("starship prompt --profile=transient"
     .." --keymap="..rl.getvariable('keymap')
   ):read("*a")
 end
@@ -62,11 +62,22 @@ load(io.popen('starship init cmd'):read("*a"))()
 - By default, the right side of input is empty. To customize this, define a new
   function called `starship_transient_rprompt_func`. This function receives the
   current prompt as a string that you can utilize. For example, to display
-  the time at which the last command was started here, you would do
+  the time at which the last command was started here, you could define the following:
+
+```toml
+# ~/.config/starship.toml
+
+[profiles.transient]
+format = "$character"
+right_format = "$time"
+
+[time]
+disabled = false
+```
 
 ```lua
 function starship_transient_rprompt_func(prompt)
-  return io.popen("starship module time"):read("*a")
+  return io.popen("starship prompt --profile=transient --right"):read("*a")
 end
 load(io.popen('starship init cmd'):read("*a"))()
 ```
@@ -84,11 +95,11 @@ and syntactically correct.
 
 - By default, the left side of input gets replaced with a bold-green `❯`. To customize this,
   define a new function called `starship_transient_prompt_func`. For example, to
-  display Starship's `character` module here, you would do
+  display Starship's default `transient` profile with the `character` module, you would do
 
 ```fish
 function starship_transient_prompt_func
-  starship module character
+  starship prompt --profile=transient
 end
 starship init fish | source
 enable_transience
@@ -98,9 +109,20 @@ enable_transience
   function called `starship_transient_rprompt_func`. For example, to display
   the time at which the last command was started here, you would do
 
+```toml
+# ~/.config/starship.toml
+
+[profiles.transient]
+format = "$character"
+right_format = "$time"
+
+[time]
+disabled = false
+```
+
 ```fish
 function starship_transient_rprompt_func
-  starship module time
+  starship prompt --right --profile=transient
 end
 starship init fish | source
 enable_transience

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -210,16 +210,17 @@ This is the list of prompt-wide configuration options.
 
 ### Options
 
-| Option            | Default                        | Description                                                                                                                                                                        |
-| ----------------- | ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `format`          | [link](#default-prompt-format) | Configure the format of the prompt.                                                                                                                                                |
-| `right_format`    | `''`                           | See [Enable Right Prompt](../advanced-config/#enable-right-prompt)                                                                                                                 |
-| `scan_timeout`    | `30`                           | Timeout for starship to scan files (in milliseconds).                                                                                                                              |
-| `command_timeout` | `500`                          | Timeout for commands executed by starship (in milliseconds).                                                                                                                       |
-| `add_newline`     | `true`                         | Inserts blank line between shell prompts.                                                                                                                                          |
-| `palette`         | `''`                           | Sets which color palette from `palettes` to use.                                                                                                                                   |
-| `palettes`        | `{}`                           | Collection of color palettes that assign [colors](../advanced-config/#style-strings) to user-defined names. Note that color palettes cannot reference their own color definitions. |
-| `follow_symlinks` | `true`                         | Follows symlinks to check if they're directories; used in modules such as git.                                                                                                     |
+| Option            | Default                                   | Description                                                                                                                                                                        |
+| ----------------- | ----------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `format`          | [link](#default-prompt-format)            | Configure the format of the prompt.                                                                                                                                                |
+| `right_format`    | `''`                                      | See [Enable Right Prompt](../advanced-config/#enable-right-prompt)                                                                                                                 |
+| `scan_timeout`    | `30`                                      | Timeout for starship to scan files (in milliseconds).                                                                                                                              |
+| `command_timeout` | `500`                                     | Timeout for commands executed by starship (in milliseconds).                                                                                                                       |
+| `add_newline`     | `true`                                    | Inserts blank line between shell prompts.                                                                                                                                          |
+| `palette`         | `''`                                      | Sets which color palette from `palettes` to use.                                                                                                                                   |
+| `palettes`        | `{}`                                      | Collection of color palettes that assign [colors](../advanced-config/#style-strings) to user-defined names. Note that color palettes cannot reference their own color definitions. |
+| `follow_symlinks` | `true`                                    | Follows symlinks to check if they're directories; used in modules such as git.                                                                                                     |
+| `profiles`        | `{ transient: { format: "$character" } }` | Collection of prompt strings that can be used instead of the main `format` and `right_format`. For more information please consult the profile section below.                      |
 
 ::: tip
 
@@ -363,6 +364,29 @@ modules you explicitly add to the format will not be duplicated. Eg.
 ```toml
 # Move the directory to the second line
 format = '$all$directory$character'
+```
+
+### Profiles
+
+Profiles can be used to set a key-value-map with alternate versions of the top-level `format` (the main prompt format string) and `right_format` (the same for the `right_prompt`). To quickly switch to a different profile of the current prompt, you can set the `STARSHIP_PROFILE` environment variable to the name of the profile, for instance by running `export STARSHIP_PROFILE=my_profile` or `$ENV:STARSHIP_PROFILE="my_profile"` in PowerShell. Alternatively, it can also be set via an `--profile=my_profile` flag for commands like `starship prompt` and `starship explain`.
+
+| Option         | Default | Description                                                                             |
+| -------------- | ------- | --------------------------------------------------------------------------------------- |
+| `format`       | `''`    | Configure the format of the prompt profile.                                             |
+| `right_format` | `''`    | [Enable the right prompt of the prompt profile.](/advanced-config/#enable-right-prompt) |
+
+#### Examples
+
+```toml
+# Define custom profiles
+[profiles]
+# Instead of a map you can also set a profile to a simple string instead
+# Starship includes the definition below for use with transient prompts
+transient = "$character"
+
+[profiles.as_map_with_right_format]
+format = "$character"
+right_format = "$git_branch"
 ```
 
 ## AWS

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,7 @@ use std::borrow::Cow;
 use std::clone::Clone;
 use std::collections::HashMap;
 use std::ffi::OsString;
+use std::fmt::Debug;
 use std::io::ErrorKind;
 
 use toml::Value;
@@ -74,6 +75,15 @@ impl<'a, T: Deserialize<'a> + Default> ModuleConfig<'a, ValueError> for T {
 pub enum Either<A, B> {
     First(A),
     Second(B),
+}
+
+impl<A: Debug, B: Debug> Debug for Either<A, B> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Either::First(a) => write!(f, "First({:?})", a),
+            Either::Second(b) => write!(f, "Second({:?})", b),
+        }
+    }
 }
 
 /// A wrapper around `Vec<T>` that implements `ModuleConfig`, and either

--- a/src/context.rs
+++ b/src/context.rs
@@ -58,6 +58,10 @@ pub struct Context<'a> {
     /// Which prompt to print (main, right, ...)
     pub target: Target,
 
+    /// The profile to use for the prompt
+    /// If None, the default profile will be used
+    pub profile: Option<String>,
+
     /// Width of terminal, or zero if width cannot be detected.
     pub width: usize,
 
@@ -148,6 +152,8 @@ impl<'a> Context<'a> {
             properties.status_code = None;
         }
 
+        let profile = properties.profile.take();
+
         // Canonicalize the current path to resolve symlinks, etc.
         // NOTE: On Windows this may convert the path to extended-path syntax.
         let current_dir = Context::expand_tilde(path);
@@ -160,7 +166,6 @@ impl<'a> Context<'a> {
             .map_or_else(StarshipRootConfig::default, StarshipRootConfig::load);
 
         let width = properties.terminal_width;
-
         Context {
             config,
             properties,
@@ -170,6 +175,7 @@ impl<'a> Context<'a> {
             repo: OnceCell::new(),
             shell,
             target,
+            profile,
             width,
             env,
             #[cfg(test)]
@@ -830,12 +836,11 @@ pub enum Shell {
 }
 
 /// Which kind of prompt target to print (main prompt, rprompt, ...)
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Target {
     Main,
     Right,
     Continuation,
-    Profile(String),
 }
 
 /// Properties as passed on from the shell as arguments
@@ -866,6 +871,9 @@ pub struct Properties {
     /// The number of currently running jobs
     #[clap(short, long, default_value_t, value_parser=parse_jobs)]
     pub jobs: i64,
+    /// Print the prompt with the specified profile name (instead of the standard left prompt)
+    #[clap(long, env = "STARSHIP_PROFILE")]
+    pub profile: Option<String>,
 }
 
 impl Default for Properties {
@@ -879,6 +887,7 @@ impl Default for Properties {
             cmd_duration: None,
             keymap: "viins".to_string(),
             jobs: 0,
+            profile: None,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,11 +89,8 @@ enum Commands {
         /// Print the right prompt (instead of the standard left prompt)
         #[clap(long)]
         right: bool,
-        /// Print the prompt with the specified profile name (instead of the standard left prompt)
-        #[clap(long, conflicts_with = "right")]
-        profile: Option<String>,
         /// Print the continuation prompt (instead of the standard left prompt)
-        #[clap(long, conflicts_with = "right", conflicts_with = "profile")]
+        #[clap(long, conflicts_with = "right")]
         continuation: bool,
         #[clap(flatten)]
         properties: Properties,
@@ -179,14 +176,12 @@ fn main() {
         Commands::Prompt {
             properties,
             right,
-            profile,
             continuation,
         } => {
-            let target = match (right, profile, continuation) {
-                (true, _, _) => Target::Right,
-                (_, Some(profile_name), _) => Target::Profile(profile_name),
-                (_, _, true) => Target::Continuation,
-                (_, _, _) => Target::Main,
+            let target = match (right, continuation) {
+                (true, _) => Target::Right,
+                (_, true) => Target::Continuation,
+                (_, _) => Target::Main,
             };
             print::prompt(properties, target);
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
First in addtion to `profiles.name = "format-string"` also allow defining profiles via a table that include a `right_format` string:
```toml
[profiles.name]
format = "a"
right_format = "b"
```
Thus, `--profile` becomes usable together with `--right` (and `--continuation`), and because it has moved `starship explain` will work with `--profile`.

To properly allow switching between profiles, I also made the `profile` settable via the `STARSHIP_PROFILE` env var, by enabling the `clap` `env` feature.

I also amended the transient-prompt docs a bit to make use of a `transient` feature and included such a profile in the default config (and fix #4786).

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #4786
Closes #4812
~~Closes #4953~~
Required to allow #4208 to be used to define transient rprompts(as supported by #4160)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
