### PR TITLE
fix(fish): enable transient prompt when in vi mode

### DIFF
--- a/src/init/starship.fish
+++ b/src/init/starship.fish
@@ -70,12 +70,18 @@ function transient_execute
     commandline -f execute
 end
 
-function enable_transience
-    bind \r transient_execute
+# --user is the default, but listed anyway to make it explicit.
+function enable_transience --description 'enable transient prompt keybindings'
+    bind --user \r transient_execute
+    bind --user -M insert \r transient_execute
 end
 
-function disable_transience
-    bind \r execute
+# Erase the transient prompt related key bindings.
+# --user is the default, but listed anyway to make it explicit.
+# Erasing a user binding will revert to the preset.
+function disable_transience --description 'remove transient prompt keybindings'
+    bind --user -e \r
+    bind --user -M insert -e \r
 end
 
 # Set up the session key that will be used to store logs


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
Fix prompt transience in `fish` if using vi binding.

#### Motivation and Context
The current `enable_transience` function only works when using emacs/default bindings. This is because a command (`transient_execute`) is bound to `\r`. However with vi binding enabled, the bindings are modal. This PR updates `enable_transience` to also bind `\r` in `insert` mode.

This also updates the `disable_transience` function to erase the new bindings rather than redefine them back to `execute`. This will cause the default "preset" bindings to be effective again. Not strictly required to get transience working in vi mode, but it is closer to what is trying to be accomplished. It also doesn't depend on fish keeping `execute` as the default command.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
