### PR TITLE
feat: add typechange to git_status module

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1823,6 +1823,7 @@ You can disable the module or use the `windows_starship` option to use a Windows
 | `staged`            | `'+'`                                         | The format of `staged`                                                                                      |
 | `renamed`           | `'»'`                                         | The format of `renamed`                                                                                     |
 | `deleted`           | `'✘'`                                         | The format of `deleted`                                                                                     |
+| `typechange`        | `'⇢'`                                         | The format of `typechange`                                                                                  |
 | `style`             | `'bold red'`                                  | The style for the module.                                                                                   |
 | `ignore_submodules` | `false`                                       | Ignore changes to submodules.                                                                               |
 | `disabled`          | `false`                                       | Disables the `git_status` module.                                                                           |
@@ -1843,6 +1844,7 @@ The following variables can be used in `format`:
 | `staged`       | Displays `staged` when a new file has been added to the staging area.                                         |
 | `renamed`      | Displays `renamed` when a renamed file has been added to the staging area.                                    |
 | `deleted`      | Displays `deleted` when a file's deletion has been added to the staging area.                                 |
+| `typechange`   | Displays `typechange` when a file's type has been changed in the staging area.                                |
 | style\*        | Mirrors the value of option `style`                                                                           |
 
 *: This variable can only be used as a part of a style string

--- a/src/configs/git_status.rs
+++ b/src/configs/git_status.rs
@@ -21,6 +21,7 @@ pub struct GitStatusConfig<'a> {
     pub modified: &'a str,
     pub staged: &'a str,
     pub untracked: &'a str,
+    pub typechange: &'a str,
     pub ignore_submodules: bool,
     pub disabled: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -43,6 +44,7 @@ impl<'a> Default for GitStatusConfig<'a> {
             modified: "!",
             staged: "+",
             untracked: "?",
+            typechange: "⇢",
             ignore_submodules: false,
             disabled: false,
             windows_starship: None,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
Adds tracking/counting of `typechange` changes in `git_status`.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Displays any unstaged typechanges on the prompt and includes any staged typechanges as `is_staged` to avoid surprises on `git commit`.
<!--- If it fixes an open issue, please link to the issue here. -->

#### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/6653063/212796534-6a67b652-2719-44c3-b57b-783db6643b7f.png)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Using the following `git_status` config to include the count for testing:
```
[git_status]
typechange = '[⇢\($count\)](bold green)'
format = '([\[$all_status$ahead_behind\]]($style) )'
```

1.  Create an empty repo with two files committed
2. Replace one of the two files with a symlink to the other file
3. Confirm the the prompt displayed the unstaged typechange as expected
4. Staged the symlink with `git add`
5. Confirmed the staged change displayed as a normal staged change/addition

<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS** (`test result: ok. 941 passed; 0 failed; 32 ignored; 0 measured; 0 filtered out; finished in 8.80s`)
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
- [x] I have run `cargo fmt` and `dprint fmt`