### PR TITLE
perf:  Use `elixir --short-version` for better performance

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -410,7 +410,7 @@
         ],
         "detect_folders": [],
         "disabled": false,
-        "format": "via [$symbol($version \\(OTP $otp_version\\) )]($style)",
+        "format": "via [$symbol($version )]($style)",
         "style": "bold purple",
         "symbol": "💧 ",
         "version_format": "v${raw}"
@@ -2726,7 +2726,7 @@
       "type": "object",
       "properties": {
         "format": {
-          "default": "via [$symbol($version \\(OTP $otp_version\\) )]($style)",
+          "default": "via [$symbol($version )]($style)",
           "type": "string"
         },
         "version_format": {

--- a/src/configs/elixir.rs
+++ b/src/configs/elixir.rs
@@ -21,7 +21,7 @@ pub struct ElixirConfig<'a> {
 impl<'a> Default for ElixirConfig<'a> {
     fn default() -> Self {
         ElixirConfig {
-            format: "via [$symbol($version \\(OTP $otp_version\\) )]($style)",
+            format: "via [$symbol($version )]($style)",
             version_format: "v${raw}",
             symbol: "💧 ",
             style: "bold purple",

--- a/src/modules/elixir.rs
+++ b/src/modules/elixir.rs
@@ -120,10 +120,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("mix.exs"))?.sync_all()?;
 
-        let expected = Some(format!(
-            "via {}",
-            Color::Purple.bold().paint("💧 v1.10 ")
-        ));
+        let expected = Some(format!("via {}", Color::Purple.bold().paint("💧 v1.10 ")));
         let output = ModuleRenderer::new("elixir").path(dir.path()).collect();
 
         assert_eq!(output, expected);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -234,7 +234,7 @@ Default target: x86_64-apple-macosx\n",
         }),
         "elixir --short-version" => Some(CommandOutput {
             stdout: String::from(
-                "1.14.2",
+                "1.10",
             ),
             stderr: String::default(),
         }),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -232,12 +232,9 @@ Default target: x86_64-apple-macosx\n",
             stdout: String::from("stdout ok!\n"),
             stderr: String::from("stderr ok!\n"),
         }),
-        "elixir --version" => Some(CommandOutput {
+        "elixir --short-version" => Some(CommandOutput {
             stdout: String::from(
-                "\
-Erlang/OTP 22 [erts-10.6.4] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1] [hipe]
-
-Elixir 1.10 (compiled with Erlang/OTP 22)\n",
+                "1.14.2",
             ),
             stderr: String::default(),
         }),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
This change the elixir version helper to use `elixir --short-version`. This command is about 5x faster than `elixir --version`.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Often then existing elixir module times out trying to get the version. This speeds it up considerably.
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #4825 

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
