### PR TITLE
fix(container): reduce docker, podman and systemd confusion

### DIFF
--- a/src/modules/container.rs
+++ b/src/modules/container.rs
@@ -26,18 +26,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             return Some("OCI".into());
         }
 
-        // WSL with systemd will set the contents of this file to "wsl"
-        // Avoid showing the container module in that case
-        let systemd_path = context_path(context, "/run/systemd/container");
-        if utils::read_file(systemd_path)
-            .ok()
-            .filter(|s| s.trim() != "wsl")
-            .is_some()
-        {
-            // systemd
-            return Some("Systemd".into());
-        }
-
         let container_env_path = context_path(context, "/run/.containerenv");
 
         if container_env_path.exists() {
@@ -58,6 +46,25 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 .unwrap_or_else(|_| "podman".into());
 
             return Some(image_res);
+        }
+
+        // WSL with systemd will set the contents of this file to "wsl"
+        // Avoid showing the container module in that case
+        let systemd_path = context_path(context, "/run/systemd/container");
+        if systemd_path.exists() {
+            let systemd_name = match utils::read_file(systemd_path).ok() {
+                Some(s) => match s.trim() {
+                    "docker" => Some("Docker".into()),
+                    "wsl" => None,
+                    _ => Some("Systemd".into()),
+                },
+                _ => None,
+            };
+
+            if systemd_name.is_some() {
+                // Systemd or Docker
+                return systemd_name;
+            }
         }
 
         if context_path(context, "/.dockerenv").exists() {
@@ -137,6 +144,12 @@ mod tests {
 
         let root_path = renderer.root_path();
 
+        // simulate file found on ubuntu images to ensure podman containerenv is preferred
+        let systemd_path = root_path.join("run/systemd/container");
+
+        fs::create_dir_all(systemd_path.parent().unwrap())?;
+        utils::write_file(&systemd_path, "docker\n")?;
+
         let containerenv = root_path.join("run/.containerenv");
 
         fs::create_dir_all(containerenv.parent().unwrap())?;
@@ -185,9 +198,11 @@ mod tests {
 
         Ok(())
     }
-    #[test]
-    #[cfg(target_os = "linux")]
-    fn test_containerenv_systemd() -> std::io::Result<()> {
+
+    fn containerenv_systemd(
+        name: Option<&str>,
+        display: Option<&str>,
+    ) -> std::io::Result<(Option<String>, Option<String>)> {
         let renderer = ModuleRenderer::new("container")
             // For a custom config
             .config(toml::toml! {
@@ -200,7 +215,12 @@ mod tests {
         let systemd_path = root_path.join("run/systemd/container");
 
         fs::create_dir_all(systemd_path.parent().unwrap())?;
-        utils::write_file(&systemd_path, "systemd-nspawn\n")?;
+
+        let contents = match name {
+            Some(name) => format!("{name}\n"),
+            None => "systemd-nspawn\n".to_string(),
+        };
+        utils::write_file(&systemd_path, contents)?;
 
         // The output of the module
         let actual = renderer
@@ -208,13 +228,23 @@ mod tests {
             .collect();
 
         // The value that should be rendered by the module.
-        let expected = Some(format!(
-            "{} ",
-            Color::Red
-                .bold()
-                .dimmed()
-                .paint(format!("⬢ [{}]", "Systemd"))
-        ));
+        let expected = display.map(|_| {
+            format!(
+                "{} ",
+                Color::Red
+                    .bold()
+                    .dimmed()
+                    .paint(format!("⬢ [{}]", display.unwrap_or("Systemd")))
+            )
+        });
+
+        Ok((actual, expected))
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn test_containerenv_systemd() -> std::io::Result<()> {
+        let (actual, expected) = containerenv_systemd(Some("systemd-nspawn"), Some("Systemd"))?;
 
         // Assert that the actual and expected values are the same
         assert_eq!(actual, expected);
@@ -224,28 +254,19 @@ mod tests {
 
     #[test]
     #[cfg(target_os = "linux")]
-    fn test_containerenv_wsl() -> std::io::Result<()> {
-        let renderer = ModuleRenderer::new("container")
-            // For a custom config
-            .config(toml::toml! {
-               [container]
-               disabled = false
-            });
+    fn test_containerenv_docker_in_systemd() -> std::io::Result<()> {
+        let (actual, expected) = containerenv_systemd(Some("docker"), Some("Docker"))?;
 
-        let root_path = renderer.root_path();
+        // Assert that the actual and expected values are the same
+        assert_eq!(actual, expected);
 
-        let systemd_path = root_path.join("run/systemd/container");
+        Ok(())
+    }
 
-        fs::create_dir_all(systemd_path.parent().unwrap())?;
-        utils::write_file(&systemd_path, "wsl\n")?;
-
-        // The output of the module
-        let actual = renderer
-            // Run the module and collect the output
-            .collect();
-
-        // The value that should be rendered by the module.
-        let expected = None;
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn test_containerenv_wsl_in_systemd() -> std::io::Result<()> {
+        let (actual, expected) = containerenv_systemd(Some("wsl"), None)?;
 
         // Assert that the actual and expected values are the same
         assert_eq!(actual, expected);

--- a/src/modules/container.rs
+++ b/src/modules/container.rs
@@ -50,20 +50,13 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
         // WSL with systemd will set the contents of this file to "wsl"
         // Avoid showing the container module in that case
+        // Honor the contents of this file if "docker" and not running in podman or wsl
         let systemd_path = context_path(context, "/run/systemd/container");
-        if systemd_path.exists() {
-            let systemd_name = match utils::read_file(systemd_path).ok() {
-                Some(s) => match s.trim() {
-                    "docker" => Some("Docker".into()),
-                    "wsl" => None,
-                    _ => Some("Systemd".into()),
-                },
-                _ => None,
-            };
-
-            if systemd_name.is_some() {
-                // Systemd or Docker
-                return systemd_name;
+        if let Ok(s) = utils::read_file(systemd_path) {
+            match s.trim() {
+                "docker" => return Some("Docker".into()),
+                "wsl" => (),
+                _ => return Some("Systemd".into()),
             }
         }
 

--- a/src/modules/container.rs
+++ b/src/modules/container.rs
@@ -199,6 +199,7 @@ mod tests {
         Ok(())
     }
 
+    #[cfg(target_os = "linux")]
     fn containerenv_systemd(
         name: Option<&str>,
         display: Option<&str>,

--- a/src/modules/container.rs
+++ b/src/modules/container.rs
@@ -245,7 +245,7 @@ mod tests {
     #[test]
     #[cfg(target_os = "linux")]
     fn test_containerenv_systemd() -> std::io::Result<()> {
-        let (actual, expected) = containerenv_systemd(Some("systemd-nspawn"), Some("Systemd"))?;
+        let (actual, expected) = containerenv_systemd(None, Some("Systemd"))?;
 
         // Assert that the actual and expected values are the same
         assert_eq!(actual, expected);


### PR DESCRIPTION
#### Description
Ubuntu's LTS images include  `/run/systemd/container` with contents `docker` and were detected as Systemd because that code ran before podman detection. 

Details:
- the module's podman containerenv detection and processing now happens before systemd detection (provides the expected behavior for image running in podman, even when the `/run/systemd/container` file exists)
- if `/run/systemd/container` contains "docker", the module now shows "Docker" (the expected behavior for image running in docker)
- maintains behavior from #4593 to prevent 'Systemd' display on WSL
- refactors tests for systemd detection for general cleanup of duplicate test code

#### Motivation and Context
Closes #3821 

Does NOT address PR #3828  related changes for docker detection, but I see that as a distinct concern from the actual bug report.


#### How Has This Been Tested?
I added relevant test and ensured existing tests addressed the changes.
All tests pass (plus clippy and rustfmt were run per contribution guidelines).

I tested on Fedora with distrobox running on podman with both Fedora and Ubuntu images.
I tested on Ubuntu with distrobox running on docker with an Ubuntu image.
I tested on Windows 10 with Ubuntu in WSL to verify I didn't break that.

- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
