### PR TITLE
build(deps): update toml crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2249,7 +2249,7 @@ checksum = "eda0fc3b0fb7c975631757e14d9049da17374063edb6ebbcbc54d880d4fe94e9"
 dependencies = [
  "once_cell",
  "thiserror",
- "toml",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -2651,6 +2651,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c68e921cef53841b8925c2abadd27c9b891d9613bdc43d6b823062866df38e8"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2833,7 +2842,7 @@ dependencies = [
  "systemstat",
  "tempfile",
  "terminal_size",
- "toml",
+ "toml 0.6.0",
  "toml_edit",
  "unicode-segmentation",
  "unicode-width",
@@ -3083,25 +3092,41 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
- "indexmap",
  "serde",
 ]
 
 [[package]]
-name = "toml_datetime"
-version = "0.5.0"
+name = "toml"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "808b51e57d0ef8f71115d8f3a01e7d3750d01c79cac4b3eda910f4389fdf92fd"
+checksum = "4fb9d890e4dc9298b70f740f615f2e05b9db37dce531f6b24fb77ac993f9f217"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4553f467ac8e3d374bc9a177a26801e5d0f9b211aa1673fb137a403afd1c9cf5"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
-version = "0.17.1"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a34cc558345efd7e88b9eda9626df2138b80bb46a7606f695e751c892bc7dac6"
+checksum = "729bfd096e40da9c001f778f5cdecbd2957929a24e10e5883d9392220a751581"
 dependencies = [
  "indexmap",
- "itertools",
  "nom8",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
 ]
 
@@ -3609,7 +3634,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b68db261ef59e9e52806f688020631e987592bd83619edccda9c47d42cde4f6c"
 dependencies = [
- "toml",
+ "toml 0.5.11",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,8 +80,8 @@ starship-battery = { version = "0.7.9", optional = true }
 strsim = "0.10.0"
 systemstat = "=0.2.3"
 terminal_size = "0.2.3"
-toml = { version = "0.5.11", features = ["preserve_order"] }
-toml_edit = "0.17.1"
+toml = { version = "0.6.0", features = ["preserve_order"] }
+toml_edit = "0.18.0"
 unicode-segmentation = "1.10.0"
 unicode-width = "0.1.10"
 urlencoding = "2.1.2"

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -11,7 +11,6 @@ use crate::configs::PROMPT_ORDER;
 use crate::utils;
 use std::fs::File;
 use std::io::Write;
-use toml::Value;
 use toml_edit::Document;
 
 #[cfg(not(windows))]
@@ -222,7 +221,7 @@ fn handle_toggle_configuration(doc: &mut Document, name: &str, key: &str) -> Res
     Ok(())
 }
 
-pub fn get_configuration() -> Value {
+pub fn get_configuration() -> toml::Table {
     let starship_config = StarshipConfig::initialize();
 
     starship_config
@@ -431,7 +430,7 @@ mod tests {
             ok = true
         };
         let actual_config = extract_toml_paths(
-            config,
+            toml::Value::Table(config),
             &[
                 "extract_root".to_owned(),
                 "extract_section".to_owned(),
@@ -439,7 +438,7 @@ mod tests {
             ],
         );
 
-        assert_eq!(expected_config, actual_config);
+        assert_eq!(toml::Value::Table(expected_config), actual_config);
     }
 
     fn create_doc() -> Document {

--- a/src/modules/hg_branch.rs
+++ b/src/modules/hg_branch.rs
@@ -309,7 +309,7 @@ mod tests {
 
     fn expect_hg_branch_with_config(
         repo_dir: &Path,
-        config: Option<toml::Value>,
+        config: Option<toml::Table>,
         expectations: &[Expect],
     ) {
         let actual = ModuleRenderer::new("hg_branch")

--- a/src/modules/kubernetes.rs
+++ b/src/modules/kubernetes.rs
@@ -352,7 +352,7 @@ users: []
         dir.close()
     }
 
-    fn base_test_ctx_alias(ctx_name: &str, config: toml::Value, expected: &str) -> io::Result<()> {
+    fn base_test_ctx_alias(ctx_name: &str, config: toml::Table, expected: &str) -> io::Result<()> {
         let dir = tempfile::tempdir()?;
 
         let filename = dir.path().join("config");
@@ -657,7 +657,7 @@ users: []
 
     fn base_test_user_alias(
         user_name: &str,
-        config: toml::Value,
+        config: toml::Table,
         expected: &str,
     ) -> io::Result<()> {
         let dir = tempfile::tempdir()?;

--- a/src/modules/os.rs
+++ b/src/modules/os.rs
@@ -128,7 +128,7 @@ mod tests {
 
     #[test]
     fn get_symbol_default() {
-        let config = OSConfig::try_load(None);
+        let config = OSConfig::default();
 
         let type_expected_pairs = [
             (Type::Alpine, Some("🏔️ ")),

--- a/src/modules/package.rs
+++ b/src/modules/package.rs
@@ -68,7 +68,7 @@ fn get_node_package_version(context: &Context, config: &PackageConfig) -> Option
     Some(formatted_version)
 }
 
-fn get_poetry_version(pyproject: &toml::Value) -> Option<&str> {
+fn get_poetry_version(pyproject: &toml::Table) -> Option<&str> {
     pyproject
         .get("tool")?
         .get("poetry")?
@@ -76,13 +76,13 @@ fn get_poetry_version(pyproject: &toml::Value) -> Option<&str> {
         .as_str()
 }
 
-fn get_pep621_version(pyproject: &toml::Value) -> Option<&str> {
+fn get_pep621_version(pyproject: &toml::Table) -> Option<&str> {
     pyproject.get("project")?.get("version")?.as_str()
 }
 
 fn get_pyproject_version(context: &Context, config: &PackageConfig) -> Option<String> {
     let file_contents = context.read_file_from_pwd("pyproject.toml")?;
-    let pyproject_toml: toml::Value = toml::from_str(&file_contents).ok()?;
+    let pyproject_toml: toml::Table = toml::from_str(&file_contents).ok()?;
 
     get_pep621_version(&pyproject_toml)
         .or_else(|| get_poetry_version(&pyproject_toml))
@@ -127,7 +127,7 @@ fn get_composer_version(context: &Context, config: &PackageConfig) -> Option<Str
 
 fn get_julia_project_version(context: &Context, config: &PackageConfig) -> Option<String> {
     let file_contents = context.read_file_from_pwd("Project.toml")?;
-    let project_toml: toml::Value = toml::from_str(&file_contents).ok()?;
+    let project_toml: toml::Table = toml::from_str(&file_contents).ok()?;
     let raw_version = project_toml.get("version")?.as_str()?;
 
     format_version(raw_version, config.version_format)
@@ -225,7 +225,7 @@ fn get_sbt_version(context: &Context, config: &PackageConfig) -> Option<String> 
 fn get_cargo_version(context: &Context, config: &PackageConfig) -> Option<String> {
     let mut file_contents = context.read_file_from_pwd("Cargo.toml")?;
 
-    let mut cargo_toml: toml::Value = toml::from_str(&file_contents).ok()?;
+    let mut cargo_toml: toml::Table = toml::from_str(&file_contents).ok()?;
     let cargo_version = cargo_toml.get("package").and_then(|p| p.get("version"));
     let raw_version = if let Some(v) = cargo_version.and_then(toml::Value::as_str) {
         // regular version string
@@ -1416,7 +1416,7 @@ environment:
         file.sync_all()
     }
 
-    fn expect_output(project_dir: &TempDir, contains: Option<&str>, config: Option<toml::Value>) {
+    fn expect_output(project_dir: &TempDir, contains: Option<&str>, config: Option<toml::Table>) {
         let starship_config = config.unwrap_or(toml::toml! {
             [package]
             disabled = false

--- a/src/modules/pijul_channel.rs
+++ b/src/modules/pijul_channel.rs
@@ -164,7 +164,7 @@ mod tests {
 
     fn expect_pijul_with_config(
         repo_dir: &Path,
-        config: Option<toml::Value>,
+        config: Option<toml::Table>,
         expectations: &[Expect],
     ) {
         let actual = ModuleRenderer::new("pijul_channel")

--- a/src/modules/python.rs
+++ b/src/modules/python.rs
@@ -424,7 +424,7 @@ prompt = '(foo)'
         dir.close()
     }
 
-    fn check_python2_renders(dir: &tempfile::TempDir, starship_config: Option<toml::Value>) {
+    fn check_python2_renders(dir: &tempfile::TempDir, starship_config: Option<toml::Table>) {
         let config = starship_config.unwrap_or(toml::toml! {
             [python]
             python_binary = "python2"
@@ -439,7 +439,7 @@ prompt = '(foo)'
         assert_eq!(expected, actual);
     }
 
-    fn check_python3_renders(dir: &tempfile::TempDir, starship_config: Option<toml::Value>) {
+    fn check_python3_renders(dir: &tempfile::TempDir, starship_config: Option<toml::Table>) {
         let config = starship_config.unwrap_or(toml::toml! {
              [python]
              python_binary = "python3"
@@ -456,7 +456,7 @@ prompt = '(foo)'
 
     fn check_multiple_binaries_renders(
         dir: &tempfile::TempDir,
-        starship_config: Option<toml::Value>,
+        starship_config: Option<toml::Table>,
     ) {
         let config = starship_config.unwrap_or(toml::toml! {
              [python]
@@ -472,7 +472,7 @@ prompt = '(foo)'
         assert_eq!(expected, actual);
     }
 
-    fn check_pyenv_renders(dir: &tempfile::TempDir, starship_config: Option<toml::Value>) {
+    fn check_pyenv_renders(dir: &tempfile::TempDir, starship_config: Option<toml::Table>) {
         let config = starship_config.unwrap_or(toml::toml! {
              [python]
              pyenv_version_name = true

--- a/src/serde_utils.rs
+++ b/src/serde_utils.rs
@@ -6,11 +6,43 @@ use serde::de::{
 use std::{cmp::Ordering, fmt};
 use toml::Value;
 
+/// A `toml::Value` that borrows its contents instead of owning them.
+#[derive(Debug, Clone, Copy)]
+pub enum ValueRef<'a> {
+    Boolean(bool),
+    Integer(i64),
+    Float(f64),
+    String(&'a str),
+    Datetime(&'a toml::value::Datetime),
+    Array(&'a [Value]),
+    Table(&'a toml::map::Map<String, Value>),
+}
+
+impl<'de> From<&'de Value> for ValueRef<'de> {
+    fn from(value: &'de Value) -> Self {
+        match value {
+            Value::Boolean(b) => ValueRef::Boolean(*b),
+            Value::Integer(i) => ValueRef::Integer(*i),
+            Value::Float(f) => ValueRef::Float(*f),
+            Value::String(s) => ValueRef::String(s),
+            Value::Array(a) => ValueRef::Array(a),
+            Value::Table(t) => ValueRef::Table(t),
+            Value::Datetime(d) => ValueRef::Datetime(d),
+        }
+    }
+}
+
+impl<'de> From<&'de toml::Table> for ValueRef<'de> {
+    fn from(value: &'de toml::Table) -> Self {
+        ValueRef::Table(value)
+    }
+}
+
 /// A helper struct for deserializing a TOML value references with serde.
 /// This also prints a warning and suggestions if a key is unknown.
 #[derive(Debug)]
 pub struct ValueDeserializer<'de> {
-    value: &'de Value,
+    value: ValueRef<'de>,
     info: Option<StructInfo>,
     current_key: Option<&'de str>,
     error_on_ignored: bool,
@@ -24,9 +56,9 @@ struct StructInfo {
 }
 
 impl<'de> ValueDeserializer<'de> {
-    pub fn new(value: &'de Value) -> Self {
+    pub fn new<T: Into<ValueRef<'de>>>(value: T) -> Self {
         ValueDeserializer {
-            value,
+            value: value.into(),
             info: None,
             current_key: None,
             error_on_ignored: true,
@@ -34,7 +66,7 @@ impl<'de> ValueDeserializer<'de> {
     }
 
     fn with_info(
-        value: &'de Value,
+        value: ValueRef<'de>,
         info: Option<StructInfo>,
         current_key: &'de str,
         ignored: bool,
@@ -86,20 +118,20 @@ impl<'de> Deserializer<'de> for ValueDeserializer<'de> {
         V: Visitor<'de>,
     {
         match self.value {
-            Value::Boolean(b) => visitor.visit_bool(*b),
-            Value::Integer(i) => visitor.visit_i64(*i),
-            Value::Float(f) => visitor.visit_f64(*f),
-            Value::String(s) => visitor.visit_borrowed_str(s),
-            Value::Array(a) => {
+            ValueRef::Boolean(b) => visitor.visit_bool(b),
+            ValueRef::Integer(i) => visitor.visit_i64(i),
+            ValueRef::Float(f) => visitor.visit_f64(f),
+            ValueRef::String(s) => visitor.visit_borrowed_str(s),
+            ValueRef::Array(a) => {
                 let seq = SeqDeserializer::new(a.iter().map(ValueDeserializer::new));
                 seq.deserialize_seq(visitor)
             }
-            Value::Table(t) => {
+            ValueRef::Table(t) => {
                 let map = MapDeserializer::new(t.iter().map(|(k, v)| {
                     (
                         k.as_str(),
                         ValueDeserializer::with_info(
-                            v,
+                            v.into(),
                             self.info,
                             k.as_str(),
                             self.error_on_ignored,
@@ -108,7 +140,7 @@ impl<'de> Deserializer<'de> for ValueDeserializer<'de> {
                 }));
                 map.deserialize_map(visitor)
             }
-            Value::Datetime(d) => visitor.visit_string(d.to_string()),
+            ValueRef::Datetime(d) => visitor.visit_string(d.to_string()),
         }
         .map_err(|e| self.error(e))
     }

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -87,7 +87,7 @@ impl<'a> ModuleRenderer<'a> {
     }
 
     /// Sets the config of the underlying context
-    pub fn config(mut self, config: toml::Value) -> Self {
+    pub fn config(mut self, config: toml::Table) -> Self {
         self.context.root_config = StarshipRootConfig::load(&config);
         self.context.config = StarshipConfig {
             config: Some(config),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR updates the TOML crates. With this release, they should be using the same parser implementation.

`toml::toml!` was changed to return a `toml::Table` instead of a `toml::Value` containing one. I replaced many of the `toml::Value` uses with `toml::Table`.

To still allow for constructing `Value::ValueDeserializer` with both `&Table` and `&toml::Value`, I added a `ValueRef` type, because `&Value` can't be constructed from a `&Table`.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
