### PR TITLE
feat(cmd_duration): add the possibility to format the duration

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -335,11 +335,11 @@ impl<'a> Context<'a> {
     }
 
     // TODO: This should be used directly by clap parse
-    pub fn get_cmd_duration(&self) -> Option<u128> {
+    pub fn get_cmd_duration(&self) -> Option<u64> {
         self.properties
             .cmd_duration
             .as_deref()
-            .and_then(|cd| cd.parse::<u128>().ok())
+            .and_then(|cd| cd.parse::<u64>().ok())
     }
 
     /// Execute a command and return the output on stdout and stderr if successful

--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -8,9 +8,9 @@ use once_cell::unsync::OnceCell;
 
 use super::{Context, Module, ModuleConfig};
 
+use super::utils::duration::Duration;
 use crate::configs::aws::AwsConfig;
 use crate::formatter::StringFormatter;
-use crate::utils::render_time;
 
 type Profile = String;
 type Region = String;
@@ -224,7 +224,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let duration = {
         get_credentials_duration(context, aws_profile.as_ref(), &aws_creds).map(|duration| {
             if duration > 0 {
-                render_time((duration * 1000) as u128, false)
+                Duration::from((duration * 1000) as u64).fmt_humanized(false)
             } else {
                 config.expiration_symbol.to_string()
             }

--- a/src/modules/cmd_duration.rs
+++ b/src/modules/cmd_duration.rs
@@ -2,7 +2,7 @@ use super::{Context, Module, ModuleConfig};
 
 use crate::configs::cmd_duration::CmdDurationConfig;
 use crate::formatter::StringFormatter;
-use crate::utils::render_time;
+use crate::modules::utils::duration::Duration;
 
 /// Outputs the time it took the last command to execute
 ///
@@ -21,11 +21,13 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     }
 
     let elapsed = context.get_cmd_duration()?;
-    let config_min = config.min_time as u128;
+    let config_min = config.min_time as u64;
 
     if elapsed < config_min {
         return None;
     }
+
+    let duration = Duration::from(elapsed);
 
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter
@@ -34,7 +36,17 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 _ => None,
             })
             .map(|variable| match variable {
-                "duration" => Some(Ok(render_time(elapsed, config.show_milliseconds))),
+                "duration" | "humanized" => {
+                    Some(Ok(duration.fmt_humanized(config.show_milliseconds)))
+                }
+                "d" => Some(Ok(duration.fmt_days(false))),
+                "dd" => Some(Ok(duration.fmt_days(true))),
+                "h" => Some(Ok(duration.fmt_hours(false))),
+                "hh" => Some(Ok(duration.fmt_hours(true))),
+                "m" => Some(Ok(duration.fmt_minutes(false))),
+                "mm" => Some(Ok(duration.fmt_minutes(true))),
+                "s" => Some(Ok(duration.fmt_seconds(false))),
+                "ss" => Some(Ok(duration.fmt_seconds(true))),
                 _ => None,
             })
             .parse(None, Some(context))
@@ -56,7 +68,7 @@ fn undistract_me<'a>(
     module: Module<'a>,
     _config: &CmdDurationConfig,
     _context: &'a Context,
-    _elapsed: u128,
+    _elapsed: u64,
 ) -> Module<'a> {
     module
 }
@@ -66,12 +78,12 @@ fn undistract_me<'a>(
     module: Module<'a>,
     config: &CmdDurationConfig,
     context: &'a Context,
-    elapsed: u128,
+    elapsed: u64,
 ) -> Module<'a> {
     use notify_rust::{Notification, Timeout};
     use nu_ansi_term::{unstyle, AnsiStrings};
 
-    if config.show_notifications && config.min_time_to_notify as u128 <= elapsed {
+    if config.show_notifications && config.min_time_to_notify as u64 <= elapsed {
         if cfg!(target_os = "linux") {
             let in_graphical_session = ["DISPLAY", "WAYLAND_DISPLAY", "MIR_SOCKET"]
                 .iter()
@@ -186,6 +198,67 @@ mod tests {
             .collect();
 
         let expected = Some(format!("underwent {} ", Color::Yellow.bold().paint("5s")));
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn config_format_hhmmss_duration_5s() {
+        let actual = ModuleRenderer::new("cmd_duration")
+            .config(toml::toml! {
+                [cmd_duration]
+                format = "[${hh}:${mm}:${ss}]($style) "
+            })
+            .cmd_duration(5000)
+            .collect();
+
+        let expected = Some(format!("{} ", Color::Yellow.bold().paint("00:00:05")));
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn config_format_hms_duration_12h5m4s() {
+        let actual = ModuleRenderer::new("cmd_duration")
+            .config(toml::toml! {
+                [cmd_duration]
+                format = "[${h}:${m}:${s}]($style) "
+            })
+            .cmd_duration(43_504_000)
+            .collect();
+
+        let expected = Some(format!("{} ", Color::Yellow.bold().paint("12:5:4")));
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn config_format_hhmmss_duration_3h30m15s_prefix_underwent() {
+        let actual = ModuleRenderer::new("cmd_duration")
+            .config(toml::toml! {
+                [cmd_duration]
+                format = "underwent [${hh}:${mm}:${ss}]($style) "
+            })
+            .cmd_duration(12_615_000)
+            .collect();
+
+        let expected = Some(format!(
+            "underwent {} ",
+            Color::Yellow.bold().paint("03:30:15")
+        ));
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn config_humanized_duration_337ms() {
+        let actual = ModuleRenderer::new("cmd_duration")
+            .config(toml::toml! {
+                [cmd_duration]
+                min_time = 200
+                show_milliseconds = true
+                format = "[${duration}]($style) "
+            })
+            .cmd_duration(337)
+            .collect();
+
+        let expected = Some(format!("{} ", Color::Yellow.bold().paint("337ms")));
         assert_eq!(expected, actual);
     }
 }

--- a/src/modules/utils/duration.rs
+++ b/src/modules/utils/duration.rs
@@ -1,0 +1,119 @@
+// Duration is a struct that represents a duration of time. It is used to handle the time elapsed of a
+// command execution.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub struct Duration {
+    total: u64,
+    milliseconds: u64,
+    seconds: u64,
+    minutes: u64,
+    hours: u64,
+    days: u64,
+}
+
+impl From<u64> for Duration {
+    fn from(raw: u64) -> Self {
+        let (milliseconds, leftover_seconds) = (raw % 1000, raw / 1000);
+        let (seconds, leftover_minutes) = (leftover_seconds % 60, leftover_seconds / 60);
+        let (minutes, leftover_hours) = (leftover_minutes % 60, leftover_minutes / 60);
+        let (hours, days) = (leftover_hours % 24, leftover_hours / 24);
+
+        Self {
+            total: raw,
+            milliseconds,
+            seconds,
+            minutes,
+            hours,
+            days,
+        }
+    }
+}
+
+impl Duration {
+    fn format(value: u64, padded: bool) -> String {
+        if padded {
+            return format!("{value:02}");
+        }
+
+        value.to_string()
+    }
+
+    pub fn fmt_days(self, padded: bool) -> String {
+        Self::format(self.days, padded)
+    }
+
+    pub fn fmt_hours(self, padded: bool) -> String {
+        Self::format(self.hours, padded)
+    }
+
+    pub fn fmt_minutes(self, padded: bool) -> String {
+        Self::format(self.minutes, padded)
+    }
+
+    pub fn fmt_seconds(self, padded: bool) -> String {
+        Self::format(self.seconds, padded)
+    }
+
+    pub fn fmt_humanized(self, show_milliseconds: bool) -> String {
+        // Make sure it renders something if the time equals zero instead of an empty string
+        if self.total == 0 {
+            return "0ms".into();
+        }
+
+        let components = [self.days, self.hours, self.minutes, self.seconds];
+        let suffixes = ["d", "h", "m", "s"];
+
+        let mut rendered_components: Vec<String> = components
+            .iter()
+            .zip(&suffixes)
+            .map(Self::humanized_component)
+            .collect();
+
+        if show_milliseconds || self.total < 1000 {
+            rendered_components.push(Self::humanized_component((&self.milliseconds, &"ms")));
+        }
+
+        rendered_components.join("")
+    }
+
+    fn humanized_component((component, suffix): (&u64, &&str)) -> String {
+        match component {
+            0 => String::new(),
+            n => format!("{n}{suffix}"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_0ms() {
+        assert_eq!(Duration::from(0).fmt_humanized(true), "0ms")
+    }
+
+    #[test]
+    fn test_500ms() {
+        assert_eq!(Duration::from(500).fmt_humanized(true), "500ms")
+    }
+
+    #[test]
+    fn test_10s() {
+        assert_eq!(Duration::from(10_000).fmt_humanized(true), "10s")
+    }
+
+    #[test]
+    fn test_90s() {
+        assert_eq!(Duration::from(90_000).fmt_humanized(true), "1m30s")
+    }
+
+    #[test]
+    fn test_10110s() {
+        assert_eq!(Duration::from(10_110_000).fmt_humanized(true), "2h48m30s")
+    }
+
+    #[test]
+    fn test_1d() {
+        assert_eq!(Duration::from(86_400_000).fmt_humanized(true), "1d")
+    }
+}

--- a/src/modules/utils/mod.rs
+++ b/src/modules/utils/mod.rs
@@ -9,3 +9,5 @@ pub mod directory_nix;
 pub mod path;
 
 pub mod truncate;
+
+pub mod duration;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -578,41 +578,6 @@ pub fn exec_timeout(cmd: &mut Command, time_limit: Duration) -> Option<CommandOu
     }
 }
 
-// Render the time into a nice human-readable string
-pub fn render_time(raw_millis: u128, show_millis: bool) -> String {
-    // Make sure it renders something if the time equals zero instead of an empty string
-    if raw_millis == 0 {
-        return "0ms".into();
-    }
-
-    // Calculate a simple breakdown into days/hours/minutes/seconds/milliseconds
-    let (millis, raw_seconds) = (raw_millis % 1000, raw_millis / 1000);
-    let (seconds, raw_minutes) = (raw_seconds % 60, raw_seconds / 60);
-    let (minutes, raw_hours) = (raw_minutes % 60, raw_minutes / 60);
-    let (hours, days) = (raw_hours % 24, raw_hours / 24);
-
-    let components = [days, hours, minutes, seconds];
-    let suffixes = ["d", "h", "m", "s"];
-
-    let mut rendered_components: Vec<String> = components
-        .iter()
-        .zip(&suffixes)
-        .map(render_time_component)
-        .collect();
-    if show_millis || raw_millis < 1000 {
-        rendered_components.push(render_time_component((&millis, &"ms")));
-    }
-    rendered_components.join("")
-}
-
-/// Render a single component of the time string, giving an empty string if component is zero
-fn render_time_component((component, suffix): (&u128, &&str)) -> String {
-    match component {
-        0 => String::new(),
-        n => format!("{n}{suffix}"),
-    }
-}
-
 pub fn home_dir() -> Option<PathBuf> {
     dirs_next::home_dir()
 }
@@ -635,31 +600,6 @@ pub fn encode_to_hex(slice: &[u8]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_0ms() {
-        assert_eq!(render_time(0_u128, true), "0ms")
-    }
-    #[test]
-    fn test_500ms() {
-        assert_eq!(render_time(500_u128, true), "500ms")
-    }
-    #[test]
-    fn test_10s() {
-        assert_eq!(render_time(10_000_u128, true), "10s")
-    }
-    #[test]
-    fn test_90s() {
-        assert_eq!(render_time(90_000_u128, true), "1m30s")
-    }
-    #[test]
-    fn test_10110s() {
-        assert_eq!(render_time(10_110_000_u128, true), "2h48m30s")
-    }
-    #[test]
-    fn test_1d() {
-        assert_eq!(render_time(86_400_000_u128, true), "1d")
-    }
 
     #[test]
     fn exec_mocked_command() {


### PR DESCRIPTION
#### Description

This pull request introduces the possibility to easily format the elapsed time provided by cmd_duration.
Previously it was only possible to display the time in the form of `$duration` (e.g. `1s37ms`). 

The following variables have been introduced:
- `dd` to represent days preceded by 0
- `d` to represent days
- `hh` to represent hours with a preceding 0
- `h` to represent hours
- `mm` to represent minutes with a preceding 0
- `m` to represent minutes
- `ss` to represent seconds preceded by a 0
- `s` to represent seconds

The previous configuration `show_milliseconds` is still available, but is used exclusively for the already existing variable `$duration`.

#### Motivation and Context

Closes #3034

#### Screenshots (if appropriate):

#### How Has This Been Tested?

- [x] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:

- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
