### PR TITLE
feat: add new command `check`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -38,9 +38,7 @@ fn gen_presets_hook(mut file: &File) -> SdResult<()> {
             format!(
                 r#"
 "{name}" => {{
-        let stdout = io::stdout();
-        let mut stdout = stdout.lock();
-        let _ = stdout.write_all(include_bytes!(r"{full_path}"));
+        include_bytes!(r"{full_path}")
 }}
 "#
             )
@@ -60,11 +58,17 @@ pub fn get_preset_list<'a>() -> &'a [print::Preset] {{
     ]
 }}
 
-pub fn print_preset_content(name: &str) {{
+pub fn get_preset_content(name: &str) -> &'static [u8]{{
     match name {{
     {match_arms}
-    _ => {{}}
+    _ => {{b""}}
     }}
+}}
+
+pub fn print_preset_content(name: &str) {{
+    let stdout = io::stdout();
+    let mut stdout = stdout.lock();
+    let _ = stdout.write_all(get_preset_content(name));
 }}
 "#
     )?;

--- a/docs/faq/README.md
+++ b/docs/faq/README.md
@@ -129,6 +129,15 @@ Unfortunately, getting font configuration correct is sometimes difficult. Users
 on the Discord may be able to help. If both symbols display correctly, but
 you still don't see them in starship, [file a bug report!](https://github.com/starship/starship/issues/new/choose)
 
+A more complete test can be performed by running the `check` command:
+
+```sh
+startship check
+```
+
+Output from this command is dependant on your local configuration and can vary
+from one run to another.
+
 ## How do I uninstall Starship?
 
 Starship is just as easy to uninstall as it is to install in the first place.

--- a/src/check.rs
+++ b/src/check.rs
@@ -1,7 +1,11 @@
 use crate::config::{get_palette, parse_style_string};
 use crate::context::{Context, Properties, Target};
+use crate::print::{UnicodeWidthGraphemes, compute_modules};
+use crate::shadow;
 use nu_ansi_term::AnsiString;
+use std::collections::HashSet;
 use std::iter;
+use std::cmp;
 
 pub fn show_check(args: Properties) {
     let context = Context::new(args, Target::Main);
@@ -24,54 +28,105 @@ pub fn show_check(args: Properties) {
         "bright-cyan",
         "bright-white",
     ];
-    for color in build_color_table(&predefined_colors, None) {
-        print!("{}", color);
-    }
-    print!("\n\n");
+    println!("{}\n", build_color_table(&predefined_colors, &context));
 
     if let Some(palette) = get_palette(
         &context.root_config.palettes,
         context.root_config.palette.as_deref(),
     ) {
-        for color in build_color_table(&palette.keys().collect::<Vec<&String>>(), Some(&context)) {
-            print!("{}", color);
-        }
-        print!("\n\n");
+        
+        println!("{}\n", build_color_table(&palette.keys().collect::<Vec<&String>>(), &context));
     }
 
-    print!("{}", build_used_graphemes_line());
-    print!("\n");
+    let user_modules = build_user_module_output(&context);
+    let preset_modules = build_preset_module_output();
+
+    println!("{}\n", filter_emoji(&user_modules));
+    println!("{}\n", filter_emoji(&preset_modules));
+
+    println!("{}\n", filter_nerdfonts(&user_modules));
+    println!("{}\n", filter_nerdfonts(&preset_modules));
 }
 
-/// When printed, this iterator will display all permutations of colors
-/// as fg and bg such that it they will generally fit on a single screen of
-/// width 80 columns
-fn build_color_table<'a, T: AsRef<str> + std::fmt::Display>(
-    colors: &'a [T],
-    context: Option<&'a Context>,
-) -> impl Iterator<Item = AnsiString<'a>> + 'a {
-    let maxw: usize = 16;
-    let rown = 80 / maxw;
+fn build_color_table<T: AsRef<str> + std::fmt::Display>(
+    colors: &[T],
+    context: &Context,
+) -> String {
+    let maxw: usize = colors.iter().fold(4, |w, c| cmp::max(w, c.width_graphemes()));
+    // color table looks much better when only one bg is used per row
+    let row_width = colors.len() / ((colors.len() * maxw + context.width - 1) / context.width);
     colors
         .iter()
         .enumerate()
         .flat_map(move |(i, bg)| {
             colors.iter().enumerate().flat_map(move |(j, fg)| {
-                if ((colors.len() * i) + j) % rown == 0 {
+                if ((colors.len() * i) + j) % row_width == 0 {
                     iter::once(AnsiString::from("\n"))
                 } else {
                     iter::once(AnsiString::from(""))
                 }
                 .chain(iter::once(
-                    parse_style_string(format!("fg:{fg} bg:{bg}").as_str(), context)
+                    parse_style_string(format!("fg:{fg} bg:{bg}").as_str(), Some(context))
                         .unwrap()
                         .paint(format!("{: ^maxw$}", *fg)),
                 ))
             })
         })
+        .map(|ansi| ansi.to_string())
         .skip(1)
+        .collect::<Vec<String>>().join("")
 }
 
-fn build_used_graphemes_line() -> AnsiString {
-    AnsiString::from("\u{01f680}")
+fn build_user_module_output(context: &Context) -> String {
+    Vec::from_iter(
+        compute_modules(context)
+            .iter()
+            .flat_map(|m| m.segments.iter())
+            .map(|s| s.value())
+    ).join("")
+}
+
+fn build_preset_module_output() -> String {
+    String::from_utf8(
+        shadow::get_preset_list()
+            .iter()
+            .flat_map(|m| shadow::get_preset_content(m.0).to_vec())
+            .collect(),
+    )
+    .unwrap()
+}
+
+fn filter_emoji(input: &String) -> AnsiString<'static> {
+    // These are some overly-broad, not exhaustive, ranges to guess at emoji
+    // from https://www.unicode.org/Public/emoji/15.0/emoji-sequences.txt
+    filter_graphemes(input, vec![[0x002139, 0x003299], [0x01F004, 0x01FAF8]])
+}
+
+fn filter_nerdfonts(input: &String) -> AnsiString<'static> {
+    // The unicode private block used by nerd-fonts plus the few glyphs that fall outside
+    // from https://github.com/ryanoasis/nerd-fonts/wiki/Glyph-Sets-and-Code-Points
+    filter_graphemes(input, vec![
+        [0x23FB, 0x23FE],
+        [0x02665, 0x02665],
+        [0x026A1, 0x026A1],
+        [0x02B58, 0x02B58],
+        [0x00E000, 0x00F8FF],
+    ])
+}
+
+fn filter_graphemes(
+    possible_graphemes: &String,
+    bounds: Vec<[u32; 2]>,
+) -> AnsiString<'static> {
+    let line: HashSet<String> = HashSet::from_iter(
+        possible_graphemes
+            .chars()
+            .filter(|&c| {
+                bounds
+                    .iter()
+                    .any(|[low, high]| low <= &(c as u32) && &(c as u32) <= high)
+            })
+            .map(|c| c.to_string()),
+    );
+    AnsiString::from(Vec::from_iter(line).join(" "))
 }

--- a/src/check.rs
+++ b/src/check.rs
@@ -1,44 +1,22 @@
 use crate::config::{get_palette, parse_style_string};
 use crate::context::{Context, Properties, Target};
-use crate::print::{UnicodeWidthGraphemes, compute_modules};
+use crate::print::{compute_modules, UnicodeWidthGraphemes};
 use crate::shadow;
 use nu_ansi_term::AnsiString;
+use std::cmp;
 use std::collections::HashSet;
 use std::iter;
-use std::cmp;
 
 pub fn show_check(args: Properties) {
-    let context = Context::new(args, Target::Main);
+    let context = &Context::new(args, Target::Main);
 
-    let predefined_colors = [
-        "black",
-        "red",
-        "green",
-        "yellow",
-        "blue",
-        "purple",
-        "cyan",
-        "white",
-        "bright-black",
-        "bright-red",
-        "bright-green",
-        "bright-yellow",
-        "bright-blue",
-        "bright-purple",
-        "bright-cyan",
-        "bright-white",
-    ];
-    println!("{}\n", build_color_table(&predefined_colors, &context));
+    println!("{}\n", build_predefined_color_table(context));
 
-    if let Some(palette) = get_palette(
-        &context.root_config.palettes,
-        context.root_config.palette.as_deref(),
-    ) {
-        
-        println!("{}\n", build_color_table(&palette.keys().collect::<Vec<&String>>(), &context));
+    if let Some(palette_table) = build_palette_color_table(context) {
+        println!("{}\n", palette_table);
     }
 
-    let user_modules = build_user_module_output(&context);
+    let user_modules = build_user_module_output(context);
     let preset_modules = build_preset_module_output();
 
     println!("{}\n", filter_emoji(&user_modules));
@@ -48,11 +26,42 @@ pub fn show_check(args: Properties) {
     println!("{}\n", filter_nerdfonts(&preset_modules));
 }
 
-fn build_color_table<T: AsRef<str> + std::fmt::Display>(
-    colors: &[T],
-    context: &Context,
-) -> String {
-    let maxw: usize = colors.iter().fold(4, |w, c| cmp::max(w, c.width_graphemes()));
+fn build_predefined_color_table(context: &Context) -> String {
+    build_color_table(
+        &[
+            "black",
+            "red",
+            "green",
+            "yellow",
+            "blue",
+            "purple",
+            "cyan",
+            "white",
+            "bright-black",
+            "bright-red",
+            "bright-green",
+            "bright-yellow",
+            "bright-blue",
+            "bright-purple",
+            "bright-cyan",
+            "bright-white",
+        ],
+        context,
+    )
+}
+
+fn build_palette_color_table(context: &Context) -> Option<String> {
+    get_palette(
+        &context.root_config.palettes,
+        context.root_config.palette.as_deref(),
+    )
+    .map(|p| build_color_table(&p.keys().collect::<Vec<&String>>(), context))
+}
+
+fn build_color_table<T: AsRef<str> + std::fmt::Display>(colors: &[T], context: &Context) -> String {
+    let maxw: usize = colors
+        .iter()
+        .fold(4, |w, c| cmp::max(w, c.width_graphemes()));
     // color table looks much better when only one bg is used per row
     let row_width = colors.len() / ((colors.len() * maxw + context.width - 1) / context.width);
     colors
@@ -74,7 +83,8 @@ fn build_color_table<T: AsRef<str> + std::fmt::Display>(
         })
         .map(|ansi| ansi.to_string())
         .skip(1)
-        .collect::<Vec<String>>().join("")
+        .collect::<Vec<String>>()
+        .join("")
 }
 
 fn build_user_module_output(context: &Context) -> String {
@@ -82,8 +92,9 @@ fn build_user_module_output(context: &Context) -> String {
         compute_modules(context)
             .iter()
             .flat_map(|m| m.segments.iter())
-            .map(|s| s.value())
-    ).join("")
+            .map(|s| s.value()),
+    )
+    .join("")
 }
 
 fn build_preset_module_output() -> String {
@@ -96,29 +107,29 @@ fn build_preset_module_output() -> String {
     .unwrap()
 }
 
-fn filter_emoji(input: &String) -> AnsiString<'static> {
+fn filter_emoji(input: &str) -> String {
     // These are some overly-broad, not exhaustive, ranges to guess at emoji
     // from https://www.unicode.org/Public/emoji/15.0/emoji-sequences.txt
     filter_graphemes(input, vec![[0x002139, 0x003299], [0x01F004, 0x01FAF8]])
 }
 
-fn filter_nerdfonts(input: &String) -> AnsiString<'static> {
+fn filter_nerdfonts(input: &str) -> String {
     // The unicode private block used by nerd-fonts plus the few glyphs that fall outside
     // from https://github.com/ryanoasis/nerd-fonts/wiki/Glyph-Sets-and-Code-Points
-    filter_graphemes(input, vec![
-        [0x23FB, 0x23FE],
-        [0x02665, 0x02665],
-        [0x026A1, 0x026A1],
-        [0x02B58, 0x02B58],
-        [0x00E000, 0x00F8FF],
-    ])
+    filter_graphemes(
+        input,
+        vec![
+            [0x23FB, 0x23FE],
+            [0x02665, 0x02665],
+            [0x026A1, 0x026A1],
+            [0x02B58, 0x02B58],
+            [0x00E000, 0x00F8FF],
+        ],
+    )
 }
 
-fn filter_graphemes(
-    possible_graphemes: &String,
-    bounds: Vec<[u32; 2]>,
-) -> AnsiString<'static> {
-    let line: HashSet<String> = HashSet::from_iter(
+fn filter_graphemes(possible_graphemes: &str, bounds: Vec<[u32; 2]>) -> String {
+    Vec::from_iter::<HashSet<String>>(HashSet::from_iter(
         possible_graphemes
             .chars()
             .filter(|&c| {
@@ -127,6 +138,6 @@ fn filter_graphemes(
                     .any(|[low, high]| low <= &(c as u32) && &(c as u32) <= high)
             })
             .map(|c| c.to_string()),
-    );
-    AnsiString::from(Vec::from_iter(line).join(" "))
+    ))
+    .join(" ")
 }

--- a/src/check.rs
+++ b/src/check.rs
@@ -1,16 +1,11 @@
-use crate::config::parse_style_string;
+use crate::config::{get_palette, parse_style_string};
+use crate::context::{Context, Properties, Target};
 use nu_ansi_term::AnsiString;
 use std::iter;
 
-pub fn show_check() {
-    show_color_table();
-    println!("");
-    show_default_emoji();
-    println!("");
-    show_default_nerdfonts();
-}
+pub fn show_check(args: Properties) {
+    let context = Context::new(args, Target::Main);
 
-fn show_color_table() {
     let predefined_colors = [
         "black",
         "red",
@@ -29,15 +24,32 @@ fn show_color_table() {
         "bright-cyan",
         "bright-white",
     ];
-    for color in build_color_table(&predefined_colors) {
-        println!("{}", color);
+    for color in build_color_table(&predefined_colors, None) {
+        print!("{}", color);
     }
+    print!("\n\n");
+
+    if let Some(palette) = get_palette(
+        &context.root_config.palettes,
+        context.root_config.palette.as_deref(),
+    ) {
+        for color in build_color_table(&palette.keys().collect::<Vec<&String>>(), Some(&context)) {
+            print!("{}", color);
+        }
+        print!("\n\n");
+    }
+
+    print!("{}", build_used_graphemes_line());
+    print!("\n");
 }
 
 /// When printed, this iterator will display all permutations of colors
 /// as fg and bg such that it they will generally fit on a single screen of
 /// width 80 columns
-fn build_color_table<'a>(colors: &'a [&'a str]) -> impl Iterator<Item = AnsiString<'a>> {
+fn build_color_table<'a, T: AsRef<str> + std::fmt::Display>(
+    colors: &'a [T],
+    context: Option<&'a Context>,
+) -> impl Iterator<Item = AnsiString<'a>> + 'a {
     let maxw: usize = 16;
     let rown = 80 / maxw;
     colors
@@ -51,7 +63,7 @@ fn build_color_table<'a>(colors: &'a [&'a str]) -> impl Iterator<Item = AnsiStri
                     iter::once(AnsiString::from(""))
                 }
                 .chain(iter::once(
-                    parse_style_string(["fg:", fg, " ", "bg:", bg].join("").as_str(), None)
+                    parse_style_string(format!("fg:{fg} bg:{bg}").as_str(), context)
                         .unwrap()
                         .paint(format!("{: ^maxw$}", *fg)),
                 ))
@@ -60,10 +72,6 @@ fn build_color_table<'a>(colors: &'a [&'a str]) -> impl Iterator<Item = AnsiStri
         .skip(1)
 }
 
-fn show_default_emoji() {
-    println!("\u{01f680}");
-}
-
-fn show_default_nerdfonts() {
-    println!("@_@");
+fn build_used_graphemes_line() -> AnsiString {
+    AnsiString::from("\u{01f680}")
 }

--- a/src/check.rs
+++ b/src/check.rs
@@ -7,7 +7,13 @@ use std::cmp;
 use std::collections::HashSet;
 use std::iter;
 
-pub fn show_check(text: Option<String>, mut colors: bool, palette: Option<String>, mut fonts: bool, user_style: Option<String>) {
+pub fn show_check(
+    text: Option<String>,
+    mut colors: bool,
+    palette: Option<String>,
+    mut fonts: bool,
+    user_style: Option<String>,
+) {
     let context = &Context::new(Properties::default(), Target::Main);
     let extra_style = &user_style.map_or("".to_string(), |style| {
         parse_style_string(&style, Some(context)).map_or("".to_string(), move |_s| style)
@@ -43,13 +49,12 @@ pub fn show_check(text: Option<String>, mut colors: bool, palette: Option<String
                 context
             ))
         );
-        let check_palette = palette.as_deref().or(context.root_config.palette.as_deref());
+        let check_palette = palette
+            .as_deref()
+            .or(context.root_config.palette.as_deref());
 
-        if let Some(palette_table) = get_palette(
-            &context.root_config.palettes,
-            check_palette,
-        )
-        .map(|p| p.keys().collect::<Vec<&String>>())
+        if let Some(palette_table) = get_palette(&context.root_config.palettes, check_palette)
+            .map(|p| p.keys().collect::<Vec<&String>>())
         {
             println!(
                 "{}\n",
@@ -73,7 +78,12 @@ pub fn show_check(text: Option<String>, mut colors: bool, palette: Option<String
     };
 
     if let Some(check_text) = text {
-        println!("{}\n", parse_style_string(extra_style, Some(context)).unwrap_or_else(Style::new).paint(check_text));
+        println!(
+            "{}\n",
+            parse_style_string(extra_style, Some(context))
+                .unwrap_or_else(Style::new)
+                .paint(check_text)
+        );
     };
 }
 
@@ -357,7 +367,7 @@ mod test {
     #[test]
     fn module_lines() {
         let ctx = &Context::new(Properties::default(), Target::Main);
-        assert!(build_preset_module_line().len() > 0);
-        assert!(build_user_module_line(ctx).len() > 0);
+        assert!(!build_preset_module_line().is_empty());
+        assert!(!build_user_module_line(ctx).is_empty());
     }
 }

--- a/src/check.rs
+++ b/src/check.rs
@@ -1,0 +1,69 @@
+use crate::config::parse_style_string;
+use nu_ansi_term::AnsiString;
+use std::iter;
+
+pub fn show_check() {
+    show_color_table();
+    println!("");
+    show_default_emoji();
+    println!("");
+    show_default_nerdfonts();
+}
+
+fn show_color_table() {
+    let predefined_colors = [
+        "black",
+        "red",
+        "green",
+        "yellow",
+        "blue",
+        "purple",
+        "cyan",
+        "white",
+        "bright-black",
+        "bright-red",
+        "bright-green",
+        "bright-yellow",
+        "bright-blue",
+        "bright-purple",
+        "bright-cyan",
+        "bright-white",
+    ];
+    for color in build_color_table(&predefined_colors) {
+        println!("{}", color);
+    }
+}
+
+/// When printed, this iterator will display all permutations of colors
+/// as fg and bg such that it they will generally fit on a single screen of
+/// width 80 columns
+fn build_color_table<'a>(colors: &'a [&'a str]) -> impl Iterator<Item = AnsiString<'a>> {
+    let maxw: usize = 16;
+    let rown = 80 / maxw;
+    colors
+        .iter()
+        .enumerate()
+        .flat_map(move |(i, bg)| {
+            colors.iter().enumerate().flat_map(move |(j, fg)| {
+                if ((colors.len() * i) + j) % rown == 0 {
+                    iter::once(AnsiString::from("\n"))
+                } else {
+                    iter::once(AnsiString::from(""))
+                }
+                .chain(iter::once(
+                    parse_style_string(["fg:", fg, " ", "bg:", bg].join("").as_str(), None)
+                        .unwrap()
+                        .paint(format!("{: ^maxw$}", *fg)),
+                ))
+            })
+        })
+        .skip(1)
+}
+
+fn show_default_emoji() {
+    println!("\u{01f680}");
+}
+
+fn show_default_nerdfonts() {
+    println!("@_@");
+}

--- a/src/check.rs
+++ b/src/check.rs
@@ -47,8 +47,10 @@ pub fn show_check(args: Properties) {
         );
     }
 
-    let user_modules = build_user_module_output(context);
-    let preset_modules = build_preset_module_output();
+    println!("{}\n", AnsiStrings(&build_style_line(context)));
+
+    let user_modules = build_user_module_line(context);
+    let preset_modules = build_preset_module_line();
 
     println!("{}\n", filter_emoji(&user_modules));
     println!("{}\n", filter_emoji(&preset_modules));
@@ -89,7 +91,23 @@ fn build_color_table<'a, T: AsRef<str> + std::fmt::Display>(
         .collect::<Vec<AnsiString>>()
 }
 
-fn build_user_module_output(context: &Context) -> String {
+fn build_style_line<'a>(context: &'a Context<'a>) -> Vec<AnsiString<'a>> {
+    let width = 13;
+    [
+        "bold",
+        "italic",
+        "underline",
+        "dimmed",
+        "inverted",
+        "blink",
+        "hidden",
+        "strikethrough",
+    ].iter().map(
+        |s| parse_style_string(s, Some(context)).unwrap().paint(format!("{: ^width$}", *s))
+    ).collect::<Vec<AnsiString>>()
+}
+
+fn build_user_module_line(context: &Context) -> String {
     Vec::from_iter(
         compute_modules(context)
             .iter()
@@ -99,7 +117,7 @@ fn build_user_module_output(context: &Context) -> String {
     .join("")
 }
 
-fn build_preset_module_output() -> String {
+fn build_preset_module_line() -> String {
     String::from_utf8(
         shadow::get_preset_list()
             .iter()
@@ -169,7 +187,7 @@ mod test {
         let one_color_table = build_color_table(&["1"], ctx);
         for row in unstyle(&AnsiStrings(&one_color_table)).lines() {
             assert_eq!(row.width_graphemes(), cell_size);
-            line_count = line_count + 1;
+            line_count += 1;
         }
         assert_eq!(line_count, 1);
 
@@ -177,7 +195,7 @@ mod test {
         let three_color_table = build_color_table(&["1", "2", "3"], ctx);
         for row in unstyle(&AnsiStrings(&three_color_table)).lines() {
             assert_eq!(row.width_graphemes(), cell_size * 3);
-            line_count = line_count + 1;
+            line_count += 1;
         }
         assert_eq!(line_count, 3);
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -429,7 +429,7 @@ fn parse_color_string(
     predefined_color
 }
 
-fn get_palette<'a>(
+pub fn get_palette<'a>(
     palettes: &'a HashMap<String, Palette>,
     palette_name: Option<&str>,
 ) -> Option<&'a Palette> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ shadow!(shadow);
 
 // Lib is present to allow for benchmarking
 pub mod bug_report;
+pub mod check;
 pub mod config;
 pub mod configs;
 pub mod configure;

--- a/src/main.rs
+++ b/src/main.rs
@@ -228,7 +228,13 @@ fn main() {
         Commands::PrintConfig { default, name } => configure::print_configuration(default, &name),
         Commands::Toggle { name, value } => configure::toggle_configuration(&name, &value),
         Commands::BugReport => bug_report::create(),
-        Commands::Check { text, colors, palette, fonts, style } => check::show_check(text, colors, palette, fonts, style),
+        Commands::Check {
+            text,
+            colors,
+            palette,
+            fonts,
+            style,
+        } => check::show_check(text, colors, palette, fonts, style),
         Commands::Time => {
             match SystemTime::now()
                 .duration_since(SystemTime::UNIX_EPOCH)

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@ enum Commands {
         shell: CompletionShell,
     },
     /// Print example output that the user can use to judge appearance
-    Check,
+    Check(Properties),
     /// Edit the starship configuration
     Config {
         /// Configuration key to edit
@@ -218,7 +218,7 @@ fn main() {
         Commands::PrintConfig { default, name } => configure::print_configuration(default, &name),
         Commands::Toggle { name, value } => configure::toggle_configuration(&name, &value),
         Commands::BugReport => bug_report::create(),
-        Commands::Check => check::show_check(),
+        Commands::Check(props) => check::show_check(props),
         Commands::Time => {
             match SystemTime::now()
                 .duration_since(SystemTime::UNIX_EPOCH)

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,13 @@ enum Commands {
     },
     /// Print example output that the user can use to judge appearance
     Check {
+        text: Option<String>,
+        #[clap(long)]
+        colors: bool,
+        #[clap(long)]
+        palette: Option<String>,
+        #[clap(long)]
+        fonts: bool,
         #[clap(long)]
         style: Option<String>,
     },
@@ -221,7 +228,7 @@ fn main() {
         Commands::PrintConfig { default, name } => configure::print_configuration(default, &name),
         Commands::Toggle { name, value } => configure::toggle_configuration(&name, &value),
         Commands::BugReport => bug_report::create(),
-        Commands::Check { style } => check::show_check(style),
+        Commands::Check { text, colors, palette, fonts, style } => check::show_check(text, colors, palette, fonts, style),
         Commands::Time => {
             match SystemTime::now()
                 .duration_since(SystemTime::UNIX_EPOCH)

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,8 @@ enum Commands {
         #[clap(value_enum)]
         shell: CompletionShell,
     },
+    /// Print example output that the user can use to judge appearance
+    Check,
     /// Edit the starship configuration
     Config {
         /// Configuration key to edit
@@ -216,6 +218,7 @@ fn main() {
         Commands::PrintConfig { default, name } => configure::print_configuration(default, &name),
         Commands::Toggle { name, value } => configure::toggle_configuration(&name, &value),
         Commands::BugReport => bug_report::create(),
+        Commands::Check => check::show_check(),
         Commands::Time => {
             match SystemTime::now()
                 .duration_since(SystemTime::UNIX_EPOCH)

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,10 @@ enum Commands {
         shell: CompletionShell,
     },
     /// Print example output that the user can use to judge appearance
-    Check(Properties),
+    Check {
+        #[clap(long)]
+        style: Option<String>,
+    },
     /// Edit the starship configuration
     Config {
         /// Configuration key to edit
@@ -218,7 +221,7 @@ fn main() {
         Commands::PrintConfig { default, name } => configure::print_configuration(default, &name),
         Commands::Toggle { name, value } => configure::toggle_configuration(&name, &value),
         Commands::BugReport => bug_report::create(),
-        Commands::Check(props) => check::show_check(props),
+        Commands::Check { style } => check::show_check(style),
         Commands::Time => {
             match SystemTime::now()
                 .duration_since(SystemTime::UNIX_EPOCH)

--- a/src/print.rs
+++ b/src/print.rs
@@ -288,7 +288,7 @@ pub fn explain(args: Properties) {
     }
 }
 
-fn compute_modules<'a>(context: &'a Context) -> Vec<Module<'a>> {
+pub fn compute_modules<'a>(context: &'a Context) -> Vec<Module<'a>> {
     let mut prompt_order: Vec<Module<'a>> = Vec::new();
 
     let (_formatter, modules) = load_formatter_and_modules(context);


### PR DESCRIPTION
#### Description
This adds a new top-level command argument `check` that prints interesting color combinations and graphemes which can be use to locally debug terminal issues or test out configuration styles.

#### Motivation and Context
Closes #4746

#### Screenshots (if appropriate):
![starship-full-width](https://user-images.githubusercontent.com/28751151/215847889-b18901cb-ea98-411e-b8a9-b9e7e6094a0c.png)
![starship-half-width](https://user-images.githubusercontent.com/28751151/215847926-b8910be4-1823-409d-994c-7e7faa1029e3.png)
![starship-quarter-width](https://user-images.githubusercontent.com/28751151/215903940-8dd9c2d6-e30a-466d-add3-1d2b873e2d2c.png)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
