### PR TITLE
chore: test git's `GIT_CEILING_DIRECTORIES`

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -280,7 +280,7 @@ impl<'a> Context<'a> {
                 let shared_repo =
                     match ThreadSafeRepository::discover_with_environment_overrides_opts(
                         &self.current_dir,
-                        Default::default(),
+                        git::discover::upwards::Options::default().apply_environment(),
                         git_open_opts_map,
                     ) {
                         Ok(repo) => repo,

--- a/src/context.rs
+++ b/src/context.rs
@@ -280,7 +280,7 @@ impl<'a> Context<'a> {
                 let shared_repo =
                     match ThreadSafeRepository::discover_with_environment_overrides_opts(
                         &self.current_dir,
-                        git::discover::upwards::Options::default().apply_environment(),
+                        Default::default(),
                         git_open_opts_map,
                     ) {
                         Ok(repo) => repo,

--- a/src/modules/git_commit.rs
+++ b/src/modules/git_commit.rs
@@ -109,6 +109,7 @@ mod tests {
         std::fs::create_dir(&level1)?;
         std::fs::create_dir(&level2)?;
         std::fs::create_dir(&level3)?;
+        let level1 = dunce::canonicalize(level1)?;
 
         // Set ceiling directory
         const CEILING_DIRECTORY_VAR: &str = "GIT_CEILING_DIRECTORIES";
@@ -121,13 +122,15 @@ mod tests {
             }
             None => OsString::new(),
         };
-        let parent_dir = repo_dir
-            .path()
-            .parent()
-            .expect("tempdir should always have a parent");
-        ceiling.push(parent_dir);
+        let parent_dir = dunce::canonicalize(
+            repo_dir
+                .path()
+                .parent()
+                .expect("tempdir should always have a parent"),
+        )?;
+        ceiling.push(&parent_dir);
         ceiling.push(CEILING_DIRECTORY_SEP);
-        ceiling.push(parent_dir);
+        ceiling.push(&parent_dir);
         ceiling.push(CEILING_DIRECTORY_SEP);
         ceiling.push(&level1);
 

--- a/src/modules/git_commit.rs
+++ b/src/modules/git_commit.rs
@@ -130,6 +130,8 @@ mod tests {
         ceiling.push(parent_dir);
         ceiling.push(CEILING_DIRECTORY_SEP);
         ceiling.push(&level1);
+
+        #[allow(clippy::disallowed_methods)]
         env::set_var(CEILING_DIRECTORY_VAR, ceiling);
 
         let assert_discovery = |cwd: &Path| -> io::Result<()> {

--- a/src/modules/git_commit.rs
+++ b/src/modules/git_commit.rs
@@ -109,6 +109,7 @@ mod tests {
         const CEILING_DIRECTORY_VAR: &str = "GIT_CEILING_DIRECTORIES";
 
         let prev_ceiling = std::env::var_os(CEILING_DIRECTORY_VAR);
+        #[allow(clippy::disallowed_methods)]
         std::env::set_var(CEILING_DIRECTORY_VAR, level1.as_os_str());
 
         let actual = ModuleRenderer::new("git_commit")

--- a/src/modules/git_commit.rs
+++ b/src/modules/git_commit.rs
@@ -123,6 +123,7 @@ mod tests {
         let expected = None;
 
         match prev_ceiling {
+            #[allow(clippy::disallowed_methods)]
             Some(ceiling) => std::env::set_var(CEILING_DIRECTORY_VAR, ceiling),
             None => std::env::remove_var(CEILING_DIRECTORY_VAR),
         };

--- a/src/modules/git_commit.rs
+++ b/src/modules/git_commit.rs
@@ -121,7 +121,10 @@ mod tests {
             }
             None => OsString::new(),
         };
-        let parent_dir = repo_dir.path().parent().expect("tempdir should always have a parent");
+        let parent_dir = repo_dir
+            .path()
+            .parent()
+            .expect("tempdir should always have a parent");
         ceiling.push(parent_dir);
         ceiling.push(CEILING_DIRECTORY_SEP);
         ceiling.push(parent_dir);
@@ -131,10 +134,10 @@ mod tests {
 
         let assert_discovery = |cwd: &Path| -> io::Result<()> {
             let mut git_output = create_command("git")?
-            .args(["rev-parse", "HEAD"])
-            .current_dir(cwd)
-            .output()?
-            .stdout;
+                .args(["rev-parse", "HEAD"])
+                .current_dir(cwd)
+                .output()?
+                .stdout;
             git_output.truncate(7);
             let expected_hash = str::from_utf8(&git_output).unwrap();
 
@@ -174,7 +177,7 @@ mod tests {
         assert_no_discovery(&level2)?;
         assert_discovery(&level1)?;
         assert_discovery(repo_dir.path())?;
-        
+
         repo_dir.close()
     }
 

--- a/src/modules/git_commit.rs
+++ b/src/modules/git_commit.rs
@@ -128,6 +128,7 @@ mod tests {
                 .parent()
                 .expect("tempdir should always have a parent"),
         )?;
+        ceiling.push(CEILING_DIRECTORY_SEP);
         ceiling.push(&parent_dir);
         ceiling.push(CEILING_DIRECTORY_SEP);
         ceiling.push(&parent_dir);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

This PR adds a test for `GIT_CEILING_DIRECTORIES` - the handling for this on Windows will be fixed in the next gitoxide release (https://github.com/Byron/gitoxide/pull/718).

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1996

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
  _I don't think this should be explicitly mentioned since it can be assumed, that starship respects this variable._
- [x] I have updated the tests accordingly.
