### PR TITLE
ci: reduce renovate PR noise

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,6 +9,7 @@
         "workarounds:all",
         // automerge minor updates
         ":automergeMinor",
+        ":automergeBranch"
     ],
     "labels": ["📦 dependencies"],
     "semanticCommits": "enabled",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -15,6 +15,7 @@
     "semanticCommits": "enabled",
     "semanticCommitType": "build",
     "rangeStrategy": "bump",
+    "rebaseWhen": "conflicted",
     "packageRules": [
         // group updates to related packages
         {

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,8 +1,6 @@
 name: Main workflow
 on:
   push:
-    branches:
-      - master
     paths-ignore:
       - "docs/**"
       - "**.md"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

Enables ["Branch Automerging"](https://docs.renovatebot.com/noise-reduction/#branch-automerging) in Renovate.
Configure Renovate to try performing version updates and status checks on a branch rather than in a PR, only opening a PR if the status checks fail. Passing version bumps will be committed directly to `master`.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Reduces the amount of PR noise that we get from Renovate, which doesn't require intervention.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
