### PR TITLE
fix: let-env warning when using nushell

### DIFF
--- a/src/init/starship.nu
+++ b/src/init/starship.nu
@@ -15,12 +15,11 @@ let-env PROMPT_COMMAND = {
 # Whether we have config items
 let has_config_items = (not ($env | get -i config | is-empty))
 
-let config = if $has_config_items {
+let-env config = if $has_config_items {
     $env.config | upsert render_right_prompt_on_last_line true
 } else {
     {render_right_prompt_on_last_line: true}
 }
-{config: $config} | load-env
 
 let-env PROMPT_COMMAND_RIGHT = {
     let width = (term size).columns


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

The nushell warns about not using `let-env` for configuring `config`. I have removed the `load-env` and just added a `let-env` for the `config` as the documentation recommends: https://www.nushell.sh/book/environment.html#let-env.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The fix solves a warning that is visible when opening nushell with starship. I haven't seen any issues  opened explaining this.

I haven't contributed to anything of this size before, and my motivation of getting nushell and starship was to try to help out on a couple of rust projects. I actually just compiled and set up starship and nushell, to get started using these tools, when i saw this error. I am therefore _not_ a nushell expert, so i have spent a couple of days reading up on nushell, before trying out this fix.

It would be advised to get a nushell expert to look this through, because i am new to Nushell and the Nu programming language. I feel like the `let-env` is a new contstruct to ease the loading of environment variables, because the other solution to the problem would be to use `load-env` with a predefined `let config` variable, that was used here.

<!--- If it fixes an open issue, please link to the issue here. -->

#### Screenshots (if appropriate):
Warning looks like this:
![image](https://user-images.githubusercontent.com/544655/217748379-21ce7d51-6d42-4b71-86f9-3fb749c7b3da.png)

When applying my fix, ithe warning goes away
![image](https://user-images.githubusercontent.com/544655/217750225-5730a2a6-e0fe-44a9-b87f-c28c82383844.png)


#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

I have tested this using:
1. Fedora 37 workstation edition - 64 bit
2. Gnome 43.2
3. Surfacebook 2 - with modded kernel
4. Starship 1.12.0 - parent commit hash 93c7eca5 - build from master
5. Nushell 0.75.1
6. Alacritty 0.12.0-dev (2d27fff)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
