### PR TITLE
docs(install): update nushell instructions in installation script

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -342,7 +342,7 @@ print_install() {
         source ~/.cache/starship/init.nu"
         warning="${warning} This will change in the future.
   Only Nushell v0.73 or higher is supported.
-  Add the following to the end of ${BOLD}your Nushell env file${NO_COLOR} (find it by running ${BOLD}\$nu.env-path${NO_COLOR} in Nushell): \"mkdir ~/.cache/starship; starship init nu | save ~/.cache/starship/init.nu\""
+  Add the following to the end of ${BOLD}your Nushell env file${NO_COLOR} (find it by running ${BOLD}\$nu.env-path${NO_COLOR} in Nushell): \"mkdir ~/.cache/starship; starship init nu | save -f ~/.cache/starship/init.nu\""
         ;;
     esac
     printf "  %s\n  %s\n  And add the following to the end of %s:\n\n\t%s\n\n" \


### PR DESCRIPTION
#### Description
Consistently use `save -f` rather than `save`; the latter fails if the file already exists

#### Motivation and Context
If Nu has been launched once with Starship, `~/.cache/starship/init.nu` already exists and using `save` without `-f` will fail

#### Screenshots (if appropriate):

#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
