### PR TITLE
fix(preset): add output-flag to avoid encoding issues

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -34,24 +34,12 @@ fn gen_presets_hook(mut file: &File) -> SdResult<()> {
             .and_then(|v| v.strip_suffix(".toml"))
             .expect("Failed to process filename");
         presets.push_str(format!("print::Preset(\"{name}\"),\n").as_str());
-        match_arms.push_str(
-            format!(
-                r#"
-"{name}" => {{
-        let stdout = io::stdout();
-        let mut stdout = stdout.lock();
-        let _ = stdout.write_all(include_bytes!(r"{full_path}"));
-}}
-"#
-            )
-            .as_str(),
-        );
+        match_arms.push_str(format!(r#""{name}" => include_bytes!(r"{full_path}"),"#).as_str());
     }
 
     writeln!(
         file,
         r#"
-use std::io::{{self, Write}};
 use crate::print;
 
 pub fn get_preset_list<'a>() -> &'a [print::Preset] {{
@@ -60,10 +48,10 @@ pub fn get_preset_list<'a>() -> &'a [print::Preset] {{
     ]
 }}
 
-pub fn print_preset_content(name: &str) {{
+pub fn get_preset_content(name: &str) -> &[u8] {{
     match name {{
     {match_arms}
-    _ => {{}}
+    _ => unreachable!(),
     }}
 }}
 "#

--- a/docs/presets/bracketed-segments.md
+++ b/docs/presets/bracketed-segments.md
@@ -10,7 +10,7 @@ in brackets instead of using the default Starship wording ("via", "on", etc.).
 ### Configuration
 
 ```sh
-starship preset bracketed-segments > ~/.config/starship.toml
+starship preset bracketed-segments -o ~/.config/starship.toml
 ```
 
 [Click to download TOML](/presets/toml/bracketed-segments.toml)

--- a/docs/presets/nerd-font.md
+++ b/docs/presets/nerd-font.md
@@ -13,7 +13,7 @@ This preset changes the symbols for each module to use Nerd Font symbols.
 ### Configuration
 
 ```sh
-starship preset nerd-font-symbols > ~/.config/starship.toml
+starship preset nerd-font-symbols -o ~/.config/starship.toml
 ```
 
 [Click to download TOML](/presets/toml/nerd-font-symbols.toml)

--- a/docs/presets/no-empty-icons.md
+++ b/docs/presets/no-empty-icons.md
@@ -9,7 +9,7 @@ If toolset files are identified the toolset icon is displayed. If the toolset is
 ### Configuration
 
 ```sh
-starship preset no-empty-icons > ~/.config/starship.toml
+starship preset no-empty-icons -o ~/.config/starship.toml
 ```
 
 [Click to download TOML](/presets/toml/no-empty-icons.toml)

--- a/docs/presets/no-nerd-font.md
+++ b/docs/presets/no-nerd-font.md
@@ -12,7 +12,7 @@ This preset will become the default preset in a future release of starship.
 ### Configuration
 
 ```sh
-starship preset no-nerd-font > ~/.config/starship.toml
+starship preset no-nerd-font -o ~/.config/starship.toml
 ```
 
 [Click to download TOML](/presets/toml/no-nerd-font.toml)

--- a/docs/presets/no-runtimes.md
+++ b/docs/presets/no-runtimes.md
@@ -9,7 +9,7 @@ This preset hides the version of language runtimes. If you work in containers or
 ### Configuration
 
 ```sh
-starship preset no-runtime-versions > ~/.config/starship.toml
+starship preset no-runtime-versions -o ~/.config/starship.toml
 ```
 
 [Click to download TOML](/presets/toml/no-runtime-versions.toml)

--- a/docs/presets/pastel-powerline.md
+++ b/docs/presets/pastel-powerline.md
@@ -14,7 +14,7 @@ It also shows how path substitution works in starship.
 ### Configuration
 
 ```sh
-starship preset pastel-powerline > ~/.config/starship.toml
+starship preset pastel-powerline -o ~/.config/starship.toml
 ```
 
 [Click to download TOML](/presets/toml/pastel-powerline.toml)

--- a/docs/presets/plain-text.md
+++ b/docs/presets/plain-text.md
@@ -10,7 +10,7 @@ don't have access to Unicode.
 ### Configuration
 
 ```sh
-starship preset plain-text-symbols > ~/.config/starship.toml
+starship preset plain-text-symbols -o ~/.config/starship.toml
 ```
 
 [Click to download TOML](/presets/toml/plain-text-symbols.toml)

--- a/docs/presets/pure-preset.md
+++ b/docs/presets/pure-preset.md
@@ -9,7 +9,7 @@ This preset emulates the look and behavior of [Pure](https://github.com/sindreso
 ### Configuration
 
 ```sh
-starship preset pure-preset > ~/.config/starship.toml
+starship preset pure-preset -o ~/.config/starship.toml
 ```
 
 [Click to download TOML](/presets/toml/pure-preset.toml)

--- a/docs/presets/tokyo-night.md
+++ b/docs/presets/tokyo-night.md
@@ -13,7 +13,7 @@ This preset is inspired by [tokyo-night-vscode-theme](https://github.com/enkia/t
 ### Configuration
 
 ```sh
-starship preset tokyo-night > ~/.config/starship.toml
+starship preset tokyo-night -o ~/.config/starship.toml
 ```
 
 [Click to download TOML](/presets/toml/tokyo-night.toml)

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 
 use clap::crate_authors;
 use std::io;
+use std::path::PathBuf;
 use std::thread::available_parallelism;
 use std::time::SystemTime;
 
@@ -68,6 +69,9 @@ enum Commands {
         /// The name of preset to be printed
         #[clap(required_unless_present("list"), value_enum)]
         name: Option<print::Preset>,
+        /// Output the preset to a file instead of stdout
+        #[clap(short, long, conflicts_with = "list")]
+        output: Option<PathBuf>,
         /// List out all preset names
         #[clap(short, long)]
         list: bool,
@@ -202,7 +206,7 @@ fn main() {
                 print::module(&module_name, properties);
             }
         }
-        Commands::Preset { name, list } => print::preset_command(name, list),
+        Commands::Preset { name, list, output } => print::preset_command(name, output, list),
         Commands::Config { name, value } => {
             if let Some(name) = name {
                 if let Some(value) = value {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Using pipes to store preset files on PowerShell may modify their encoding format, to avoid this adds a flag to have starship write the files by itself (`-o`,`--output`).

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #4866

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
