### PR TITLE
fix: Use Bash escape sequence wrapper in PowerShell

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -804,6 +804,20 @@ mod tests {
         assert_eq!(&bresult3, "\\[OH NO\\]");
         assert_eq!(&bresult4, "herpaderp");
         assert_eq!(&bresult5, "");
+
+        let presult0 = wrap_seq_for_shell(test0.to_string(), Shell::PowerShell, '\x1b', 'm');
+        let presult1 = wrap_seq_for_shell(test1.to_string(), Shell::PowerShell, '\x1b', 'm');
+        let presult2 = wrap_seq_for_shell(test2.to_string(), Shell::PowerShell, '\x1b', 'J');
+        let presult3 = wrap_seq_for_shell(test3.to_string(), Shell::PowerShell, 'O', 'O');
+        let presult4 = wrap_seq_for_shell(test4.to_string(), Shell::PowerShell, '\x1b', 'm');
+        let presult5 = wrap_seq_for_shell(test5.to_string(), Shell::PowerShell, '\x1b', 'm');
+
+        assert_eq!(&presult0, "\\[\x1b2m\\]hellomynamekeyes\\[\x1b2m\\]");
+        assert_eq!(&presult1, "\\[\x1b]330;m\\]lol\\[\x1b]0m\\]");
+        assert_eq!(&presult2, "\\[\x1bJ\\]");
+        assert_eq!(&presult3, "\\[OH NO\\]");
+        assert_eq!(&presult4, "herpaderp");
+        assert_eq!(&presult5, "");
     }
 
     #[test]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -495,6 +495,7 @@ pub fn wrap_seq_for_shell(
             if x == escape_begin && !escaped {
                 escaped = true;
                 match shell {
+                    Shell::PowerShell => format!("{BASH_BEG}{escape_begin}"),
                     Shell::Bash => format!("{BASH_BEG}{escape_begin}"),
                     Shell::Zsh => format!("{ZSH_BEG}{escape_begin}"),
                     Shell::Tcsh => format!("{TCSH_BEG}{escape_begin}"),
@@ -503,6 +504,7 @@ pub fn wrap_seq_for_shell(
             } else if x == escape_end && escaped {
                 escaped = false;
                 match shell {
+                    Shell::PowerShell => format!("{escape_end}{BASH_END}"),
                     Shell::Bash => format!("{escape_end}{BASH_END}"),
                     Shell::Zsh => format!("{escape_end}{ZSH_END}"),
                     Shell::Tcsh => format!("{escape_end}{TCSH_END}"),


### PR DESCRIPTION
#### Description
Uses the bash escape sequence wrapper in PowerShell, too.

#### Motivation and Context
Pure theme looks wrong in PowerShell, the zero-width spaces are rendered as actual spaces. PowerShell seems to understand the Bash escape sequence wrapper.

Closes #4927

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows PowerShell 5.1.25300.1000**
- [x] I have tested using **PowerShell 7.3.2 on Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
