### PR TITLE
feat(color): add prevfg,prevbg as color specifiers based on the previous foreground/background colors respectively

### DIFF
--- a/docs/advanced-config/README.md
+++ b/docs/advanced-config/README.md
@@ -321,7 +321,9 @@ Style strings are a list of words, separated by whitespace. The words are not ca
 - `<color>`
 - `none`
 
-where `<color>` is a color specifier (discussed below). `fg:<color>` and `<color>` currently do the same thing, though this may change in the future. `inverted` swaps the background and foreground colors. The order of words in the string does not matter.
+where `<color>` is a color specifier (discussed below). `fg:<color>` and `<color>` currently do the same thing, though this may change in the future.
+`<color>` can also have the value `prevfg` or `prevbg` which takes the previous segment's foreground or background color respectively (if available).
+`inverted` swaps the background and foreground colors. The order of words in the string does not matter.
 
 The `none` token overrides all other tokens in a string if it is not part of a `bg:` specifier, so that e.g. `fg:red none fg:blue` will still create a string with no styling. `bg:none` sets the background to the default color so `fg:red bg:none` is equivalent to `red` or `fg:red` and `bg:green fg:red bg:none` is also equivalent to `fg:red` or `red`. It may become an error to use `none` in conjunction with other tokens in the future.
 

--- a/src/formatter/string_formatter.rs
+++ b/src/formatter/string_formatter.rs
@@ -1,4 +1,3 @@
-use nu_ansi_term::Style;
 use pest::error::Error as PestError;
 use rayon::prelude::*;
 use std::borrow::Cow;
@@ -6,7 +5,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::error::Error;
 use std::fmt;
 
-use crate::config::parse_style_string;
+use crate::config::{parse_style_string, CustomStyle};
 use crate::context::{Context, Shell};
 use crate::segment::Segment;
 
@@ -236,7 +235,7 @@ impl<'a> StringFormatter<'a> {
     /// - Variable mapper returns an error.
     pub fn parse(
         self,
-        default_style: Option<Style>,
+        default_style: Option<CustomStyle>,
         context: Option<&Context>,
     ) -> Result<Vec<Segment>, StringFormatterError> {
         fn parse_textgroup<'a>(
@@ -259,7 +258,7 @@ impl<'a> StringFormatter<'a> {
             style: Vec<StyleElement>,
             variables: &'a StyleVariableMapType<'a>,
             context: Option<&Context>,
-        ) -> Option<Result<Style, StringFormatterError>> {
+        ) -> Option<Result<CustomStyle, StringFormatterError>> {
             let style_strings = style
                 .into_iter()
                 .map(|style| match style {
@@ -284,7 +283,7 @@ impl<'a> StringFormatter<'a> {
 
         fn parse_format<'a>(
             format: Vec<FormatElement<'a>>,
-            style: Option<Style>,
+            style: Option<CustomStyle>,
             variables: &'a VariableMapType<'a>,
             style_variables: &'a StyleVariableMapType<'a>,
             context: Option<&Context>,
@@ -487,7 +486,7 @@ mod tests {
         let style = Some(Color::Red.bold());
 
         let formatter = StringFormatter::new(FORMAT_STR).unwrap().map(empty_mapper);
-        let result = formatter.parse(style, None).unwrap();
+        let result = formatter.parse(style.map(|s| s.into()), None).unwrap();
         let mut result_iter = result.iter();
         match_next!(result_iter, "text", style);
     }
@@ -562,7 +561,9 @@ mod tests {
         let inner_style = Some(Color::Blue.normal());
 
         let formatter = StringFormatter::new(FORMAT_STR).unwrap().map(empty_mapper);
-        let result = formatter.parse(outer_style, None).unwrap();
+        let result = formatter
+            .parse(outer_style.map(|s| s.into()), None)
+            .unwrap();
         let mut result_iter = result.iter();
         match_next!(result_iter, "outer ", outer_style);
         match_next!(result_iter, "middle ", middle_style);
@@ -594,9 +595,9 @@ mod tests {
 
         let mut segments: Vec<Segment> = Vec::new();
         segments.extend(Segment::from_text(None, "styless"));
-        segments.extend(Segment::from_text(styled_style, "styled"));
+        segments.extend(Segment::from_text(styled_style.map(|s| s.into()), "styled"));
         segments.extend(Segment::from_text(
-            styled_no_modifier_style,
+            styled_no_modifier_style.map(|s| s.into()),
             "styled_no_modifier",
         ));
 

--- a/src/module.rs
+++ b/src/module.rs
@@ -209,7 +209,7 @@ where
             }
             _ => {
                 used += segment.width_graphemes();
-                current.push(segment.ansi_string());
+                current.push(segment.ansi_string(current.last()));
             }
         }
 

--- a/src/module.rs
+++ b/src/module.rs
@@ -209,7 +209,7 @@ where
             }
             _ => {
                 used += segment.width_graphemes();
-                current.push(segment.ansi_string(current.last()));
+                current.push(segment.ansi_string(current.last().map(|s| s.style_ref())));
             }
         }
 

--- a/src/modules/status.rs
+++ b/src/modules/status.rs
@@ -75,7 +75,11 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                     context,
                 )
                 .ok()
-                .map(|segments| segments.into_iter().map(|s| s.to_string()))
+                .map(|segments| {
+                    segments
+                        .into_iter()
+                        .map(|s| format!("{}", s.ansi_string(None)))
+                })
             })
             .flatten()
             .collect::<String>(),

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -17,7 +17,7 @@ pub struct TextSegment {
 
 impl TextSegment {
     // Returns the AnsiString of the segment value
-    fn ansi_string(&self, prev: Option<&AnsiString>) -> AnsiString {
+    fn ansi_string(&self, prev: Option<&Style>) -> AnsiString {
         match self.style {
             Some(style) => style.custom(prev).paint(&self.value),
             None => AnsiString::from(&self.value),
@@ -161,7 +161,7 @@ impl Segment {
     }
 
     // Returns the AnsiString of the segment value, not including its prefix and suffix
-    pub fn ansi_string(&self, prev: Option<&AnsiString>) -> AnsiString {
+    pub fn ansi_string(&self, prev: Option<&Style>) -> AnsiString {
         match self {
             Self::Fill(fs) => fs.ansi_string(None),
             Self::Text(ts) => ts.ansi_string(prev),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description

This PR adds the `prevfg` and `prevbg` specifiers that are allowed to appear in `fg:` or `bg:` style elements. The value will be based on the previous segment's `AnsiString`. This allows powerline-like separators to have the correct colors when so configured.

<!--- Describe your changes in detail -->

#### Motivation and Context

I am migrating from [powerline](https://github.com/powerline/powerline) and one of the features of the prompt strings there is pretty filled status segments. This PR is based off a suggestion in #528 to allow the previous foreground/background color to be available in style specifiers. This PR does not enable all the functionality of Powerline (e.g. directory separators, pipestatus colors would need to be enhanced) but is crucial to allowing the specification of segment styles depending on the previous segment. It is also a much smaller change than other approaches would suggest e.g. #1235

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #528

#### Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/884807/221677384-fe0a348a-7ef9-4ebe-87bd-754dec469d6a.png)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- [x] Add unit tests

- [x] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
