### PR TITLE
feat(azure): subscription name aliases

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -29,6 +29,7 @@
         "disabled": true,
         "format": "on [$symbol($subscription)]($style) ",
         "style": "blue bold",
+        "subscription_aliases": {},
         "symbol": "ﴃ "
       },
       "allOf": [
@@ -1845,6 +1846,13 @@
         "disabled": {
           "default": true,
           "type": "boolean"
+        },
+        "subscription_aliases": {
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
         }
       },
       "additionalProperties": false

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -448,12 +448,12 @@ The `azure` module shows the current Azure Subscription. This is based on showin
 
 ### Options
 
-| Variable               | Default                                  | Description                                |
-| ---------------------- | ---------------------------------------- | ------------------------------------------ |
-| `format`               | `'on [$symbol($subscription)]($style) '` | The format for the Azure module to render. |
-| `symbol`               | `'ﴃ '`                                   | The symbol used in the format.             |
-| `style`                | `'blue bold'`                            | The style used in the format.              |
-| `disabled`             | `true`                                   | Disables the `azure` module.               |
+| Variable               | Default                                  | Description                                                                           |
+| ---------------------- | ---------------------------------------- | ------------------------------------------------------------------------------------- |
+| `format`               | `'on [$symbol($subscription)]($style) '` | The format for the Azure module to render.                                            |
+| `symbol`               | `'ﴃ '`                                   | The symbol used in the format.                                                        |
+| `style`                | `'blue bold'`                            | The style used in the format.                                                         |
+| `disabled`             | `true`                                   | Disables the `azure` module.                                                          |
 | `subscription_aliases` | `{}`                                     | Table of subscription name aliases to display in addition to Azure subscription name. |
 
 ### Examples

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -448,12 +448,13 @@ The `azure` module shows the current Azure Subscription. This is based on showin
 
 ### Options
 
-| Variable   | Default                                  | Description                                |
-| ---------- | ---------------------------------------- | ------------------------------------------ |
-| `format`   | `'on [$symbol($subscription)]($style) '` | The format for the Azure module to render. |
-| `symbol`   | `'ﴃ '`                                   | The symbol used in the format.             |
-| `style`    | `'blue bold'`                            | The style used in the format.              |
-| `disabled` | `true`                                   | Disables the `azure` module.               |
+| Variable               | Default                                  | Description                                |
+| ---------------------- | ---------------------------------------- | ------------------------------------------ |
+| `format`               | `'on [$symbol($subscription)]($style) '` | The format for the Azure module to render. |
+| `symbol`               | `'ﴃ '`                                   | The symbol used in the format.             |
+| `style`                | `'blue bold'`                            | The style used in the format.              |
+| `disabled`             | `true`                                   | Disables the `azure` module.               |
+| `subscription_aliases` | `{}`                                     | Table of subscription name aliases to display in addition to Azure subscription name. |
 
 ### Examples
 
@@ -479,6 +480,15 @@ disabled = false
 format = "on [$symbol($username)]($style) "
 symbol = "ﴃ "
 style = "blue bold"
+```
+
+#### Display Subscription Name Alias
+
+```toml
+# ~/.config/starship.toml
+
+[azure.subscription_aliases]
+very-long-subscription-name = 'vlsn'
 ```
 
 ## Battery
@@ -745,7 +755,7 @@ error_symbol = '[➜](bold red) '
 # ~/.config/starship.toml
 
 [character]
-vicmd_symbol = '[V](bold green) '
+vimcmd_symbol = '[V](bold green) '
 ```
 
 ## CMake
@@ -4346,6 +4356,7 @@ Format strings can also contain shell specific prompt sequences, e.g.
 | ------------------- | ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `command`           | `''`                            | The command whose output should be printed. The command will be passed on stdin to the shell.                                                                                                                                                                                                 |
 | `when`              | `false`                         | Either a boolean value (`true` or `false`, without quotes) or a string shell command used as a condition to show the module. In case of a string, the module will be shown if the command returns a `0` status code.                                                                          |
+| `require_repo`      | `false`                         | If `true`, the module will only be shown in paths containing a (git) repository. This option alone is not sufficient display condition in absence of other options.                                                                                                                           |
 | `shell`             |                                 | [See below](#custom-command-shell)                                                                                                                                                                                                                                                            |
 | `description`       | `'<custom module>'`             | The description of the module that is shown when running `starship explain`.                                                                                                                                                                                                                  |
 | `detect_files`      | `[]`                            | The files that will be searched in the working directory for a match.                                                                                                                                                                                                                         |

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -755,7 +755,7 @@ error_symbol = '[➜](bold red) '
 # ~/.config/starship.toml
 
 [character]
-vimcmd_symbol = '[V](bold green) '
+vicmd_symbol = '[V](bold green) '
 ```
 
 ## CMake
@@ -4356,7 +4356,6 @@ Format strings can also contain shell specific prompt sequences, e.g.
 | ------------------- | ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `command`           | `''`                            | The command whose output should be printed. The command will be passed on stdin to the shell.                                                                                                                                                                                                 |
 | `when`              | `false`                         | Either a boolean value (`true` or `false`, without quotes) or a string shell command used as a condition to show the module. In case of a string, the module will be shown if the command returns a `0` status code.                                                                          |
-| `require_repo`      | `false`                         | If `true`, the module will only be shown in paths containing a (git) repository. This option alone is not sufficient display condition in absence of other options.                                                                                                                           |
 | `shell`             |                                 | [See below](#custom-command-shell)                                                                                                                                                                                                                                                            |
 | `description`       | `'<custom module>'`             | The description of the module that is shown when running `starship explain`.                                                                                                                                                                                                                  |
 | `detect_files`      | `[]`                            | The files that will be searched in the working directory for a match.                                                                                                                                                                                                                         |

--- a/src/configs/azure.rs
+++ b/src/configs/azure.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 #[derive(Clone, Deserialize, Serialize)]
 #[cfg_attr(
@@ -12,6 +13,7 @@ pub struct AzureConfig<'a> {
     pub symbol: &'a str,
     pub style: &'a str,
     pub disabled: bool,
+    pub subscription_aliases: HashMap<String, &'a str>,
 }
 
 impl<'a> Default for AzureConfig<'a> {
@@ -21,6 +23,7 @@ impl<'a> Default for AzureConfig<'a> {
             symbol: "ﴃ ",
             style: "blue bold",
             disabled: true,
+            subscription_aliases: HashMap::new(),
         }
     }
 }

--- a/src/modules/azure.rs
+++ b/src/modules/azure.rs
@@ -56,7 +56,11 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 _ => None,
             })
             .map(|variable| match variable {
-                "subscription" => Some(Ok(&subscription.name)),
+                "subscription" => Some(Ok(config
+                    .subscription_aliases
+                    .get(&subscription.name)
+                    .copied()
+                    .unwrap_or(&subscription.name))),
                 "username" => Some(Ok(&subscription.user.name)),
                 _ => None,
             })
@@ -611,6 +615,81 @@ mod tests {
         let expected = Some(format!(
             "on {}",
             Color::Blue.bold().paint("ﴃ Subscription 1:user@domain.com")
+        ));
+        assert_eq!(actual, expected);
+        dir.close()
+    }
+
+    #[test]
+    fn subscription_name_with_alias() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+
+        let azure_profile_contents = r#"{
+            "installationId": "3deacd2a-b9db-77e1-aa42-23e2f8dfffc3",
+            "subscriptions": [
+                {
+                "id": "f568c543-d12e-de0b-3d85-69843598b565",
+                "name": "VeryLongSubscriptionName",
+                "state": "Enabled",
+                "user": {
+                  "name": "user@domain.com",
+                  "type": "user"
+                },
+                "isDefault": false,
+                "tenantId": "0e8a15ec-b0f5-d355-7062-8ece54c59aee",
+                "environmentName": "AzureCloud",
+                "homeTenantId": "0e8a15ec-b0f5-d355-7062-8ece54c59aee",
+                "managedByTenants": []
+              },
+              {
+                "id": "d4442d26-ea6d-46c4-07cb-4f70b8ae5465",
+                "name": "AnotherLongSubscriptionName",
+                "state": "Enabled",
+                "user": {
+                  "name": "user@domain.com",
+                  "type": "user"
+                },
+                "isDefault": false, 
+                "tenantId": "a4e1bb4b-5330-2d50-339d-b9674d3a87bc",
+                "environmentName": "AzureCloud",
+                "homeTenantId": "a4e1bb4b-5330-2d50-339d-b9674d3a87bc",
+                "managedByTenants": []
+              },
+              {
+                "id": "f3935dc9-92b5-9a93-da7b-42c325d86939",
+                "name": "TheLastLongSubscriptionName",
+                "state": "Enabled",
+                "user": {
+                  "name": "user@domain.com",
+                  "type": "user"
+                },
+                "isDefault": true,
+                "tenantId": "f0273a19-7779-e40a-00a1-53b8331b3bb6",
+                "environmentName": "AzureCloud",
+                "homeTenantId": "f0273a19-7779-e40a-00a1-53b8331b3bb6",
+                "managedByTenants": []
+              }
+            ]
+          }
+        "#;
+
+        generate_test_config(&dir, azure_profile_contents)?;
+        let dir_path = &dir.path().to_string_lossy();
+        let actual = ModuleRenderer::new("azure")
+            .config(toml::toml! {
+                [azure]
+                format = "on [$symbol($subscription:$username)]($style)"
+                disabled = false
+                [azure.subscription_aliases]
+                VeryLongSubscriptionName = "vlsn"
+                AnotherLongSubscriptionName = "alsn"
+                TheLastLongSubscriptionName = "tllsn"
+            })
+            .env("AZURE_CONFIG_DIR", dir_path.as_ref())
+            .collect();
+        let expected = Some(format!(
+            "on {}",
+            Color::Blue.bold().paint("ﴃ tllsn:user@domain.com")
         ));
         assert_eq!(actual, expected);
         dir.close()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

- Added `subscription_aliases` field for the `azure` module.

- Similar to the `gcloud` module, takes `[azure.subscription_aliases]` from `starship.toml` and replaces the subscription name. If there is no alias, defaults to the normal name.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #4448

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
