### PR TITLE
fix(java): wrong version number when using Android Studio JDK

### DIFF
--- a/src/modules/java.rs
+++ b/src/modules/java.rs
@@ -5,7 +5,8 @@ use crate::utils::get_command_string_output;
 use std::path::PathBuf;
 
 use regex::Regex;
-const JAVA_VERSION_PATTERN: &str = "(?:JRE.*\\(|OpenJ9 )(?P<version>[\\d]+(?:\\.\\d+){0,2})";
+const JAVA_VERSION_PATTERN: &str =
+    "(?:JRE.*\\(|OpenJ9 )(?P<version>\\d+(?:\\.\\d+){0,2}).*, built on";
 
 /// Creates a module with the current Java version
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
@@ -152,6 +153,12 @@ mod tests {
     fn test_parse_java_version_sapmachine() {
         let java_11 = "OpenJDK 64-Bit Server VM (11.0.4+11-LTS-sapmachine) for linux-amd64 JRE (11.0.4+11-LTS-sapmachine), built on Jul 17 2019 08:58:43 by \"\" with gcc 7.3.0";
         assert_eq!(parse_java_version(java_11), Some("11.0.4".to_string()));
+    }
+
+    #[test]
+    fn test_parse_java_version_android_studio_jdk() {
+        let java_11 = "OpenJDK 64-Bit Server VM (11.0.15+0-b2043.56-8887301) for linux-amd64 JRE (11.0.15+0-b2043.56-8887301), built on Jul 29 2022 22:12:21 by \"androidbuild\" with gcc Android (7284624, based on r416183b) Clang 12.0.5 (https://android.googlesource.com/toolchain/llvm-project c935d99d7cf2016289302412d708641d52d2f7ee)}";
+        assert_eq!(parse_java_version(java_11), Some("11.0.15".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description

When using the JDK provided by Android Studio, the Java version number is `v7284624`. This is because the regular expression used to extract the version catch an SVN revision found later in the returned string.

Add `, built on` to the end of the regex to ensure it stops earlier.

#### Screenshots (if appropriate):

Screenshot below shows the prompt before and after the fix.

![image](https://user-images.githubusercontent.com/3575/223152411-bcfe315a-9d02-49a6-833e-9c75287aecd8.png)

#### How Has This Been Tested?

- Extended unit-test
- Built starship with the changes and used it
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
