### PR TITLE
fix(fossil_branch): fossil checkout database file name on windows

### DIFF
--- a/src/modules/fossil_branch.rs
+++ b/src/modules/fossil_branch.rs
@@ -17,9 +17,15 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         return None;
     };
 
+    let checkout_db = if cfg!(windows) {
+        "_FOSSIL_"
+    } else {
+        ".fslckout"
+    };
+
     let is_checkout = context
         .try_begin_scan()?
-        .set_files(&[".fslckout"])
+        .set_files(&[checkout_db])
         .is_match();
 
     if !is_checkout {

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -176,11 +176,16 @@ pub enum FixtureProvider {
 pub fn fixture_repo(provider: FixtureProvider) -> io::Result<TempDir> {
     match provider {
         FixtureProvider::Fossil => {
+            let checkout_db = if cfg!(windows) {
+                "_FOSSIL_"
+            } else {
+                ".fslckout"
+            };
             let path = tempfile::tempdir()?;
             fs::OpenOptions::new()
                 .create(true)
                 .write(true)
-                .open(path.path().join(".fslckout"))?
+                .open(path.path().join(checkout_db))?
                 .sync_all()?;
             Ok(path)
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
When running on Windows, use `_FOSSIL_` as checkout database file name instead of `.fslckout`.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
On Windows, the checkout database file name is `_FOSSIL_` (see [this document](https://www.fossil-scm.org/home/doc/trunk/www/tech_overview.wiki) for details). As a result, the `fossil_branch` module is not able to detect fossil checkout directories.

This PR sets the correct checkout database file name for all platforms, fixing the issue.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
