### PR TITLE
docs(preset): Add `hostname.ssh_symbol` to nerd font preset

### DIFF
--- a/docs/.vuepress/public/presets/toml/nerd-font-symbols.toml
+++ b/docs/.vuepress/public/presets/toml/nerd-font-symbols.toml
@@ -46,6 +46,9 @@ symbol = "⌘ "
 [hg_branch]
 symbol = " "
 
+[hostname]
+ssh_symbol = " "
+
 [java]
 symbol = " "
 


### PR DESCRIPTION
#### Description

My current font shows a square instead of the ssh symbol, even with the nerd font preset, so I guess this is missing in the preset.

I took nf-cod-globe \ueb01 / 

#### Motivation and Context

#### Screenshots (if appropriate):

before:

![ssh](https://user-images.githubusercontent.com/131929/224568132-292cc801-549f-49cb-a3e1-d95f73fa0a56.png)

after:

![ssh_after](https://user-images.githubusercontent.com/131929/224568264-c64bdea0-b7f7-4f66-aa5c-015a2ff2cb78.png)

#### How Has This Been Tested?


- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:

- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
