### PR TITLE
Add support for excluding seconds in render_time and aws module duration

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -10,6 +10,7 @@
     "aws": {
       "default": {
         "disabled": false,
+        "duration_show_seconds": true,
         "expiration_symbol": "X",
         "force_display": false,
         "format": "on [$symbol($profile )(\\($region\\) )(\\[$duration\\] )]($style)",
@@ -1822,6 +1823,11 @@
         "force_display": {
           "description": "If true displays info even if `credentials`, `credential_process` or `sso_start_url` have not been setup.",
           "default": false,
+          "type": "boolean"
+        },
+        "duration_show_seconds": {
+          "description": "Show seconds in duration",
+          "default": true,
           "type": "boolean"
         }
       },

--- a/src/configs/aws.rs
+++ b/src/configs/aws.rs
@@ -43,6 +43,8 @@ pub struct AwsConfig<'a> {
     pub expiration_symbol: &'a str,
     /// If true displays info even if `credentials`, `credential_process` or `sso_start_url` have not been setup.
     pub force_display: bool,
+    /// Show seconds in duration
+    pub duration_show_seconds: bool,
 }
 
 impl<'a> Default for AwsConfig<'a> {
@@ -56,6 +58,7 @@ impl<'a> Default for AwsConfig<'a> {
             profile_aliases: HashMap::new(),
             expiration_symbol: "X",
             force_display: false,
+            duration_show_seconds: true,
         }
     }
 }

--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -224,7 +224,11 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let duration = {
         get_credentials_duration(context, aws_profile.as_ref(), &aws_creds).map(|duration| {
             if duration > 0 {
-                render_time((duration * 1000) as u128, false)
+                render_time(
+                    (duration * 1000) as u128,
+                    config.duration_show_seconds,
+                    false,
+                )
             } else {
                 config.expiration_symbol.to_string()
             }

--- a/src/modules/cmd_duration.rs
+++ b/src/modules/cmd_duration.rs
@@ -34,7 +34,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 _ => None,
             })
             .map(|variable| match variable {
-                "duration" => Some(Ok(render_time(elapsed, config.show_milliseconds))),
+                "duration" => Some(Ok(render_time(elapsed, true, config.show_milliseconds))),
                 _ => None,
             })
             .parse(None, Some(context))

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -591,7 +591,7 @@ pub fn exec_timeout(cmd: &mut Command, time_limit: Duration) -> Option<CommandOu
 }
 
 // Render the time into a nice human-readable string
-pub fn render_time(raw_millis: u128, show_millis: bool) -> String {
+pub fn render_time(raw_millis: u128, show_seconds: bool, show_millis: bool) -> String {
     // Make sure it renders something if the time equals zero instead of an empty string
     if raw_millis == 0 {
         return "0ms".into();
@@ -603,14 +603,17 @@ pub fn render_time(raw_millis: u128, show_millis: bool) -> String {
     let (minutes, raw_hours) = (raw_minutes % 60, raw_minutes / 60);
     let (hours, days) = (raw_hours % 24, raw_hours / 24);
 
-    let components = [days, hours, minutes, seconds];
-    let suffixes = ["d", "h", "m", "s"];
+    let components = [days, hours, minutes];
+    let suffixes = ["d", "h", "m"];
 
     let mut rendered_components: Vec<String> = components
         .iter()
         .zip(&suffixes)
         .map(render_time_component)
         .collect();
+    if show_seconds {
+        rendered_components.push(render_time_component((&seconds, &"s")));
+    }
     if show_millis || raw_millis < 1000 {
         rendered_components.push(render_time_component((&millis, &"ms")));
     }
@@ -650,27 +653,27 @@ mod tests {
 
     #[test]
     fn test_0ms() {
-        assert_eq!(render_time(0_u128, true), "0ms")
+        assert_eq!(render_time(0_u128, true, true), "0ms")
     }
     #[test]
     fn test_500ms() {
-        assert_eq!(render_time(500_u128, true), "500ms")
+        assert_eq!(render_time(500_u128, true, true), "500ms")
     }
     #[test]
     fn test_10s() {
-        assert_eq!(render_time(10_000_u128, true), "10s")
+        assert_eq!(render_time(10_000_u128, true, true), "10s")
     }
     #[test]
     fn test_90s() {
-        assert_eq!(render_time(90_000_u128, true), "1m30s")
+        assert_eq!(render_time(90_000_u128, true, true), "1m30s")
     }
     #[test]
     fn test_10110s() {
-        assert_eq!(render_time(10_110_000_u128, true), "2h48m30s")
+        assert_eq!(render_time(10_110_000_u128, true, true), "2h48m30s")
     }
     #[test]
     fn test_1d() {
-        assert_eq!(render_time(86_400_000_u128, true), "1d")
+        assert_eq!(render_time(86_400_000_u128, true, true), "1d")
     }
 
     #[test]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -603,6 +603,11 @@ pub fn render_time(raw_millis: u128, show_seconds: bool, show_millis: bool) -> S
     let (minutes, raw_hours) = (raw_minutes % 60, raw_minutes / 60);
     let (hours, days) = (raw_hours % 24, raw_hours / 24);
 
+    // Render seconds if show_seconds is false and time is less than one minute
+    if raw_seconds < 60 && !show_seconds {
+        return format!("{raw_seconds}s");
+    }
+
     let components = [days, hours, minutes];
     let suffixes = ["d", "h", "m"];
 
@@ -674,6 +679,14 @@ mod tests {
     #[test]
     fn test_1d() {
         assert_eq!(render_time(86_400_000_u128, true, true), "1d")
+    }
+    #[test]
+    fn test_10s_seconds_disabled() {
+        assert_eq!(render_time(10_000_u128, false, false), "10s")
+    }
+    #[test]
+    fn test_90s_seconds_disabled() {
+        assert_eq!(render_time(90_000_u128, false, false), "1m")
     }
 
     #[test]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Adding support for rendering time without seconds.
Adding support in AWS module to display session duration without seconds.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Motivation for doing this is to be able to reduce the length of the prompt as much as possible, which is nice when displaying the prompt on a single line. In my case, an AWS session lasts a full working day, so displaying seconds in the prompt is not interesting and wastes valuable horizontal line space.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [X] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have updated the documentation accordingly.
- [X] I have updated the tests accordingly.
