### PR TITLE
docs: update snap instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Alternatively, install Starship using any of the following package managers:
 | **_Any_**          | **[crates.io]**         | `cargo install starship --locked`                             |
 | _Any_              | [conda-forge]           | `conda install -c conda-forge starship`                       |
 | _Any_              | [Linuxbrew]             | `brew install starship`                                       |
-| _Any_              | [Snapcraft]             | `snap install starship`                                       |
+| _Any_              | [Snapcraft]             | `snap install --edge starship`                                |
 | Alpine Linux 3.13+ | [Alpine Linux Packages] | `apk add starship`                                            |
 | Arch Linux         | [Arch Linux Community]  | `pacman -S starship`                                          |
 | CentOS 7+          | [Copr]                  | `dnf copr enable atim/starship` <br /> `dnf install starship` |


### PR DESCRIPTION
#### Description

As part of #4954, non-edge packages of Starship were removed from Snapcraft. This means the only way to install Starship is through the `edge` channel using `snap install --edge starship`.

#### Motivation and Context

Relates to #4954.

#### Screenshots (if appropriate):

N/A

#### How Has This Been Tested?

Tested on Pop!_OS 22.04, Ubuntu 22.04 and Raspbian 11.

- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:

- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
