### PR TITLE
docs(preset): add missing config for Java to no-runtime-version

### DIFF
--- a/docs/.vuepress/public/presets/toml/no-runtime-versions.toml
+++ b/docs/.vuepress/public/presets/toml/no-runtime-versions.toml
@@ -49,6 +49,9 @@ format = 'via [$symbol]($style)'
 [helm]
 format = 'via [$symbol]($style)'
 
+[java]
+format = 'via [$symbol]($style)'
+
 [julia]
 format = 'via [$symbol]($style)'
 


### PR DESCRIPTION
#### Description
The preset `no-runtime-version` does not provide any configuration for Java. This looks like an outlier to me and by summoning the `no-runtime-version` preset, I would have expected no runtime version for java as well.


#### Motivation and Context
The `no-runtime-version` preset should generate a default for all languages with Java being no exception.

#### How Has This Been Tested?
Manually checked the build and the output of `starship preset no-runtime-versions` showing the newly added config for Java as follows:
```
❯ cargo run -- preset no-runtime-versions | rg -C 5 java
    Finished dev [unoptimized + debuginfo] target(s) in 0.11s
     Running `target/debug/starship preset no-runtime-versions`
format = 'via [$symbol]($style)'

[helm]
format = 'via [$symbol]($style)'

[java]
format = 'via [$symbol]($style)'

[julia]
format = 'via [$symbol]($style)'
```

Also checked the actual prompt behavior after applying this preset in the Starship repo and a Java repo:
```
~/E/foo on  develop via ☕ v19.0.2
❯

~/E/r/starship on  no-java-runtime-version via 🦀 v1.68.0
❯ cargo run -- preset no-runtime-versions >> ~/.config/starship.toml
    Finished dev [unoptimized + debuginfo] target(s) in 0.11s
     Running `target/debug/starship preset no-runtime-versions`

~/E/r/starship on  no-java-runtime-version via 🦀
❯

~/foo on  develop via ☕
❯
```

- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- As far as I oversee this change, there are neither documentation nor tests affected. 
