### PR TITLE
fix(gradle): add support for unstable Gradle versions

### DIFF
--- a/src/modules/gradle.rs
+++ b/src/modules/gradle.rs
@@ -75,7 +75,7 @@ fn parse_gradle_version_from_properties(wrapper_properties: &str) -> Option<Stri
         .rsplit_once('/')?
         .1
         .strip_prefix("gradle-")?
-        .split_once('-')?
+        .rsplit_once('-')?
         .0;
     Some(version.to_string())
 }

--- a/src/modules/gradle.rs
+++ b/src/modules/gradle.rs
@@ -217,4 +217,27 @@ zipStorePath=wrapper/dists
             Some("7.5.1".to_string())
         );
     }
+
+    #[test]
+    fn test_format_wrapper_properties_unstable_versions() {
+        let input = |version: &str| {
+            format!(
+                "\
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\\://services.gradle.org/distributions/gradle-{version}-bin.zip
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+        "
+            )
+        };
+        assert_eq!(
+            parse_gradle_version_from_properties(&input("8.1-rc-1")),
+            Some("8.1-rc-1".to_string())
+        );
+        assert_eq!(
+            parse_gradle_version_from_properties(&input("7.5.1-20220729132837+0000")),
+            Some("7.5.1-20220729132837+0000".to_string())
+        );
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description

Adjusts how Gradle version is parsed from the wrapper properties to account for pre-release builds.

#### Motivation and Context

It allows for accurately representing release candidates such as `8.1-rc-1` and snapshots such as `7.5.1-20220729132837+0000`, which otherwise show up as `8.1` and `7.5.1` respectively.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
