### PR TITLE
style(presets): added azure and gcloud default configs for plaintext preset

### DIFF
--- a/docs/.vuepress/public/presets/toml/plain-text-symbols.toml
+++ b/docs/.vuepress/public/presets/toml/plain-text-symbols.toml
@@ -64,6 +64,9 @@ symbol = "fnl "
 [fossil_branch]
 symbol = "fossil "
 
+[gcloud]
+symbol = "gcp "
+
 [git_branch]
 symbol = "git "
 

--- a/docs/.vuepress/public/presets/toml/plain-text-symbols.toml
+++ b/docs/.vuepress/public/presets/toml/plain-text-symbols.toml
@@ -16,6 +16,9 @@ deleted = "x"
 [aws]
 symbol = "aws "
 
+[azure]
+symbol = "az "
+
 [bun]
 symbol = "bun "
 


### PR DESCRIPTION
#### Description
Adds a basic default configuration for Azure (`az`) and Google Cloud Platform (`gcp`) in the plaintext preset. Without this, the prompt attempts to use a symbol/unicode.

#### Motivation and Context
AWS already has a plaintext configuration. This brings in the other two major cloud providers and will hopefully reduce some of the manual changes needed after applying this preset for users.

#### Screenshots (if appropriate):
**Before**
<img width="500" alt="image" src="https://user-images.githubusercontent.com/20070360/228601589-5c09f3a9-85b7-4cbc-b25e-bd573890234a.png">

**After**
<img width="328" alt="image" src="https://user-images.githubusercontent.com/20070360/228601629-20fb517f-9586-4332-9b64-a2acfbff3337.png">


#### How Has This Been Tested?
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
