### PR TITLE
feat(pwsh): Support vi command mode indicator

### DIFF
--- a/src/init/starship.ps1
+++ b/src/init/starship.ps1
@@ -141,6 +141,10 @@ $null = New-Module starship {
 
         $arguments += "--status=$($lastExitCodeForPrompt)"
 
+        if ([Microsoft.PowerShell.PSConsoleReadLine]::InViCommandMode()) {
+            $arguments += "--keymap=vi"
+        }
+
         # Invoke Starship
         $promptText = if ($script:TransientPrompt) {
             $script:TransientPrompt = $false
@@ -205,6 +209,12 @@ $null = New-Module starship {
             "--continuation"
         )
     )
+
+    try {
+        Set-PSReadLineOption -ViModeIndicator script -ViModeChangeHandler {
+            [Microsoft.PowerShell.PSConsoleReadLine]::InvokePrompt()
+        }
+    } catch {}
 
     Export-ModuleMember -Function @(
         "Enable-TransientPrompt"

--- a/src/modules/character.rs
+++ b/src/modules/character.rs
@@ -35,9 +35,9 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     // We do some environment detection in src/init.rs to translate.
     // The result: in non-vi fish, keymap is always reported as "insert"
     let mode = match (&context.shell, keymap) {
-        (Shell::Fish, "default") | (Shell::Zsh, "vicmd") | (Shell::Cmd, "vi") => {
-            ShellEditMode::Normal
-        }
+        (Shell::Fish, "default")
+        | (Shell::Zsh, "vicmd")
+        | (Shell::Cmd | Shell::PowerShell, "vi") => ShellEditMode::Normal,
         (Shell::Fish, "visual") => ShellEditMode::Visual,
         (Shell::Fish, "replace") => ShellEditMode::Replace,
         (Shell::Fish, "replace_one") => ShellEditMode::ReplaceOne,
@@ -256,6 +256,38 @@ mod test {
         // cmd keymap is other
         let actual = ModuleRenderer::new("character")
             .shell(Shell::Cmd)
+            .keymap("visual")
+            .collect();
+        assert_eq!(expected_other, actual);
+    }
+
+    #[test]
+    fn powershell_keymap() {
+        let expected_vicmd = Some(format!("{} ", Color::Green.bold().paint("❮")));
+        let expected_specified = Some(format!("{} ", Color::Green.bold().paint("V")));
+        let expected_other = Some(format!("{} ", Color::Green.bold().paint("❯")));
+
+        // powershell keymap is vi
+        let actual = ModuleRenderer::new("character")
+            .shell(Shell::PowerShell)
+            .keymap("vi")
+            .collect();
+        assert_eq!(expected_vicmd, actual);
+
+        // specified vicmd character
+        let actual = ModuleRenderer::new("character")
+            .config(toml::toml! {
+                [character]
+                vicmd_symbol = "[V](bold green)"
+            })
+            .shell(Shell::PowerShell)
+            .keymap("vi")
+            .collect();
+        assert_eq!(expected_specified, actual);
+
+        // powershell keymap is other
+        let actual = ModuleRenderer::new("character")
+            .shell(Shell::PowerShell)
             .keymap("visual")
             .collect();
         assert_eq!(expected_other, actual);


### PR DESCRIPTION
#### Description
Updates the `character` module to support showing vicmd-mode when specified for powershell, and changes `starship.ps1` to detect the mode when drawing the prompt and trigger a prompt redraw when needed. The triggering of prompt redraw doesn't work on PS5's builtin version of PSReadLine, so an error when setting it up is silently ignored.

#### Motivation and Context
Increases feature parity of the PowerShell support with other shells.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
- [x] I have tested using **Windows**

Tested on PowerShell 7.3.2 with PSReadLine 2.2.6 and PowerShell 5.1 with PSReadLine 2.2.6 and 2.0.0 (which doesn't _work_ because you can't get it to redraw the prompt, but it still runs as it did previously).

#### Checklist:
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
