### PR TITLE
feat(git_metrics): add option to ignore submodules

### DIFF
--- a/.devenv/profile
+++ b/.devenv/profile
@@ -1,1 +1,0 @@
-/nix/store/kzwr00qay6njqzj3ypw7wc2zpm1ajzj7-devenv-profile

--- a/.devenv/profile
+++ b/.devenv/profile
@@ -1,0 +1,1 @@
+/nix/store/kzwr00qay6njqzj3ypw7wc2zpm1ajzj7-devenv-profile

--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -575,8 +575,8 @@
         "deleted_style": "bold red",
         "disabled": true,
         "format": "([+$added]($added_style) )([-$deleted]($deleted_style) )",
-        "only_nonzero_diffs": true,
-				"ignore_submodules": false
+        "ignore_submodules": false,
+        "only_nonzero_diffs": true
       },
       "allOf": [
         {
@@ -3176,6 +3176,10 @@
         },
         "disabled": {
           "default": true,
+          "type": "boolean"
+        },
+        "ignore_submodules": {
+          "default": false,
           "type": "boolean"
         }
       },

--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -575,7 +575,8 @@
         "deleted_style": "bold red",
         "disabled": true,
         "format": "([+$added]($added_style) )([-$deleted]($deleted_style) )",
-        "only_nonzero_diffs": true
+        "only_nonzero_diffs": true,
+				"ignore_submodules": false
       },
       "allOf": [
         {

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1810,6 +1810,7 @@ To enable it, set `disabled` to `false` in your configuration file.
 | `only_nonzero_diffs` | `true`                                                       | Render status only for changed items. |
 | `format`             | `'([+$added]($added_style) )([-$deleted]($deleted_style) )'` | The format for the module.            |
 | `disabled`           | `true`                                                       | Disables the `git_metrics` module.    |
+| `ignore_submodules`  | `false`                                                      | Ignore changes to submodules          |
 
 ### Variables
 

--- a/src/configs/git_metrics.rs
+++ b/src/configs/git_metrics.rs
@@ -13,6 +13,7 @@ pub struct GitMetricsConfig<'a> {
     pub only_nonzero_diffs: bool,
     pub format: &'a str,
     pub disabled: bool,
+    pub ignore_submodules: bool,
 }
 
 impl<'a> Default for GitMetricsConfig<'a> {
@@ -23,6 +24,7 @@ impl<'a> Default for GitMetricsConfig<'a> {
             only_nonzero_diffs: true,
             format: "([+$added]($added_style) )([-$deleted]($deleted_style) )",
             disabled: true,
+            ignore_submodules: false,
         }
     }
 }

--- a/src/modules/git_metrics.rs
+++ b/src/modules/git_metrics.rs
@@ -23,20 +23,21 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let repo = context.get_repo().ok()?;
     let repo_root = repo.workdir.as_ref()?;
 
-    let diff = context
-        .exec_cmd(
-            "git",
-            &[
-                OsStr::new("--git-dir"),
-                repo.path.as_os_str(),
-                OsStr::new("--work-tree"),
-                repo_root.as_os_str(),
-                OsStr::new("--no-optional-locks"),
-                OsStr::new("diff"),
-                OsStr::new("--shortstat"),
-            ],
-        )?
-        .stdout;
+    let mut args = vec![
+        OsStr::new("--git-dir"),
+        repo.path.as_os_str(),
+        OsStr::new("--work-tree"),
+        repo_root.as_os_str(),
+        OsStr::new("--no-optional-locks"),
+        OsStr::new("diff"),
+        OsStr::new("--shortstat"),
+    ];
+
+    if config.ignore_submodules {
+        args.push(OsStr::new("--ignore-submodules"));
+    }
+
+    let diff = context.exec_cmd("git", &args)?.stdout;
 
     let stats = GitDiff::parse(&diff);
 

--- a/src/modules/git_metrics.rs
+++ b/src/modules/git_metrics.rs
@@ -117,7 +117,6 @@ mod tests {
     use std::path::Path;
     use std::process::Stdio;
 
-    use log::debug;
     use nu_ansi_term::Color;
 
     use crate::test::ModuleRenderer;

--- a/src/modules/git_metrics.rs
+++ b/src/modules/git_metrics.rs
@@ -117,6 +117,7 @@ mod tests {
     use std::path::Path;
     use std::process::Stdio;
 
+    use log::debug;
     use nu_ansi_term::Color;
 
     use crate::test::ModuleRenderer;
@@ -223,6 +224,33 @@ mod tests {
             "{} {} ",
             Color::Green.bold().paint("+1"),
             Color::Red.bold().paint("-0")
+        ));
+
+        assert_eq!(expected, actual);
+        repo_dir.close()
+    }
+
+    #[test]
+    fn shows_all_changes_with_ignored_submodules() -> io::Result<()> {
+        let repo_dir = create_repo_with_commit()?;
+        let path = repo_dir.path();
+
+        let file_path = path.join("the_file");
+        write_file(file_path, "\nSecond Line\n\nModified\nAdded\n")?;
+
+        let actual = ModuleRenderer::new("git_metrics")
+            .config(toml::toml! {
+                    [git_metrics]
+                    disabled = false
+                    ignore_submodules = true
+            })
+            .path(path)
+            .collect();
+
+        let expected = Some(format!(
+            "{} {} ",
+            Color::Green.bold().paint("+4"),
+            Color::Red.bold().paint("-2")
         ));
 
         assert_eq!(expected, actual);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
There's an option in [`git_status`](https://starship.rs/config/#git-status) to ignore git submodules, this does the same for the `git_metrics` module.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I have a repository with a Very Large Git Submodule™️ causing the git_metrics module to not show in my starship prompt due to the starship timeout configuration. It's inconvenient having the prompt not paint for ~300ms (my timeout configuration) so this adds a configuration option to the `git_metrics` module to pass the `--ignore-submodules` flag to `git diff`.

#### Screenshots (if appropriate):
N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
  - (I'm using Nix, so I'm omitting irrelevant steps/info)
  - Add `git_metrics.ignore_submodules = true` to my starship config
  - Build my edited version of starship
  - `export PATH="/path/to/starship/repo/target/debug:$PATH"`
  - `eval $(starship init zsh)`
  - went to my repo with the Very Large Git Submodule™️
  - noticed presence of git metrics module
  - `starship timings` showed the module took 15ms to render
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
