### PR TITLE
fix(nu): add required || in closure

### DIFF
--- a/src/init/starship.nu
+++ b/src/init/starship.nu
@@ -6,7 +6,7 @@ let-env PROMPT_MULTILINE_INDICATOR = (^::STARSHIP:: prompt --continuation)
 # TODO: Also Use starship vi mode indicators?
 let-env PROMPT_INDICATOR = ""
 
-let-env PROMPT_COMMAND = {
+let-env PROMPT_COMMAND = { ||
     # jobs are not supported
     let width = (term size).columns
     ^::STARSHIP:: prompt $"--cmd-duration=($env.CMD_DURATION_MS)" $"--status=($env.LAST_EXIT_CODE)" $"--terminal-width=($width)"
@@ -21,7 +21,7 @@ let-env config = if $has_config_items {
     {render_right_prompt_on_last_line: true}
 }
 
-let-env PROMPT_COMMAND_RIGHT = {
+let-env PROMPT_COMMAND_RIGHT = { ||
     let width = (term size).columns
     ^::STARSHIP:: prompt --right $"--cmd-duration=($env.CMD_DURATION_MS)" $"--status=($env.LAST_EXIT_CODE)" $"--terminal-width=($width)"
 }


### PR DESCRIPTION
A breaking change was introduce in [v0.78](https://www.nushell.sh/blog/2023-04-04-nushell_0_78.html) of NuShell:

> ### `||` now required in closures
>
> To help differentiate between blocks (which can mutate variables) and closures (which can be used in a pipeline), we've changed the syntax of closures to require `||`. This means the simplest closure now looks like `{|| }`

This fixes the new incompatibility to adding the now-required `||` to the two closures defined to generate the prompt.

This fixes #5060.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
