### PR TITLE
fix(unix): improve readonly check reliability

### DIFF
--- a/src/modules/utils/directory_nix.rs
+++ b/src/modules/utils/directory_nix.rs
@@ -1,52 +1,15 @@
-use nix::sys::stat::Mode;
-use nix::unistd::{Gid, Uid};
-use std::fs;
-use std::os::unix::fs::MetadataExt;
-use std::os::unix::fs::PermissionsExt;
+use nix::errno::Errno::ENOENT;
+use nix::unistd::access;
+use nix::unistd::AccessFlags;
 use std::path::Path;
 
 /// Checks if the current user can write to the `folder_path`.
-///
-/// It extracts Unix access rights from the directory and checks whether
-/// 1) the current user is the owner of the directory and whether it has the write access
-/// 2) the current user's primary group is the directory group owner whether if it has write access
-/// 2a) (not implemented on macOS) one of the supplementary groups of the current user is the
-/// directory group owner and whether it has write access
-/// 3) 'others' part of the access mask has the write access
-#[allow(clippy::useless_conversion)] // On some platforms it is not u32
 pub fn is_write_allowed(folder_path: &Path) -> Result<bool, String> {
-    let meta =
-        fs::metadata(folder_path).map_err(|e| format!("Unable to stat() directory: {e:?}"))?;
-    let perms = meta.permissions().mode();
-
-    let euid = Uid::effective();
-    if euid.is_root() {
-        return Ok(true);
+    match access(folder_path, AccessFlags::W_OK) {
+        Ok(()) => Ok(true),
+        Err(ENOENT) => Err(format!("Unable to stat() directory: {}", ENOENT)),
+        Err(_) => Ok(false),
     }
-
-    if meta.uid() == euid.as_raw() {
-        Ok(perms & u32::from(Mode::S_IWUSR.bits()) != 0)
-    } else if (meta.gid() == Gid::effective().as_raw())
-        || (get_supplementary_groups().contains(&meta.gid()))
-    {
-        Ok(perms & u32::from(Mode::S_IWGRP.bits()) != 0)
-    } else {
-        Ok(perms & u32::from(Mode::S_IWOTH.bits()) != 0)
-    }
-}
-
-#[cfg(all(unix, not(any(target_os = "macos", target_os = "ios"))))]
-fn get_supplementary_groups() -> Vec<u32> {
-    match nix::unistd::getgroups() {
-        Err(_) => Vec::new(),
-        Ok(v) => v.into_iter().map(nix::unistd::Gid::as_raw).collect(),
-    }
-}
-
-#[cfg(all(unix, any(target_os = "macos", target_os = "ios")))]
-fn get_supplementary_groups() -> Vec<u32> {
-    // at the moment nix crate does not provide it for macOS
-    Vec::new()
 }
 
 #[cfg(test)]

--- a/src/modules/utils/directory_nix.rs
+++ b/src/modules/utils/directory_nix.rs
@@ -1,11 +1,11 @@
 use nix::errno::Errno::ENOENT;
-use nix::unistd::access;
+use nix::unistd::eaccess;
 use nix::unistd::AccessFlags;
 use std::path::Path;
 
 /// Checks if the current user can write to the `folder_path`.
 pub fn is_write_allowed(folder_path: &Path) -> Result<bool, String> {
-    match access(folder_path, AccessFlags::W_OK) {
+    match eaccess(folder_path, AccessFlags::W_OK) {
         Ok(()) => Ok(true),
         Err(ENOENT) => Err(format!("Unable to stat() directory: {}", ENOENT)),
         Err(_) => Ok(false),


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Reimplement check if directory is writable with `access` syscall.


#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The current implementation does not always accurately determine if the directory is writable.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
