### PR TITLE
refactor(Context): `set_config` method for `Context`

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -951,16 +951,6 @@ mod tests {
     }
 
     #[test]
-    fn set_config_method_overwrites_constructor() {
-        let context = default_context();
-        let mod_context = default_context().set_config(toml::toml! {
-            add_newline = true
-        });
-
-        assert_ne!(context.config.config, mod_context.config.config);
-    }
-
-    #[test]
     fn context_constructor_should_fall_back_to_tilde_replacement_when_canonicalization_fails() {
         use utils::home_dir;
 
@@ -981,6 +971,16 @@ mod tests {
 
         let expected_logical_dir = test_path;
         assert_eq!(expected_logical_dir, context.logical_dir);
+    }
+
+    #[test]
+    fn set_config_method_overwrites_constructor() {
+        let context = default_context();
+        let mod_context = default_context().set_config(toml::toml! {
+            add_newline = true
+        });
+
+        assert_ne!(context.config.config, mod_context.config.config);
     }
 
     #[cfg(windows)]

--- a/src/context.rs
+++ b/src/context.rs
@@ -784,6 +784,7 @@ fn parse_width(width: &str) -> Result<usize, ParseIntError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test::default_context;
     use std::io;
 
     fn testdir(paths: &[&str]) -> Result<tempfile::TempDir, std::io::Error> {
@@ -951,22 +952,8 @@ mod tests {
 
     #[test]
     fn set_config_method_overwrites_constructor() {
-        let test_path = Path::new("/test_path").to_path_buf();
-        let context = Context::new_with_shell_and_path(
-            Default::default(),
-            Shell::Unknown,
-            Target::Main,
-            test_path.clone(),
-            test_path.clone(),
-        );
-        let mod_context = Context::new_with_shell_and_path(
-            Default::default(),
-            Shell::Unknown,
-            Target::Main,
-            test_path.clone(),
-            test_path,
-        )
-        .set_config(toml::toml! {
+        let context = default_context();
+        let mod_context = default_context().set_config(toml::toml! {
             add_newline = true
         });
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -175,6 +175,15 @@ impl<'a> Context<'a> {
         }
     }
 
+    // Sets the context config, overwriting the existing config
+    pub fn set_config(mut self, config: toml::Table) -> Context<'a> {
+        self.root_config = StarshipRootConfig::load(&config);
+        self.config = StarshipConfig {
+            config: Some(config),
+        };
+        self
+    }
+
     // Tries to retrieve home directory from a table in testing mode or else retrieves it from the os
     pub fn get_home(&self) -> Option<PathBuf> {
         if cfg!(test) {
@@ -938,6 +947,30 @@ mod tests {
 
         let expected_logical_dir = &test_path;
         assert_eq!(expected_logical_dir, &context.logical_dir);
+    }
+
+    #[test]
+    fn set_config_method_overwrites_constructor() {
+        let test_path = Path::new("/test_path").to_path_buf();
+        let context = Context::new_with_shell_and_path(
+            Default::default(),
+            Shell::Unknown,
+            Target::Main,
+            test_path.clone(),
+            test_path.clone(),
+        );
+        let mod_context = Context::new_with_shell_and_path(
+            Default::default(),
+            Shell::Unknown,
+            Target::Main,
+            test_path.clone(),
+            test_path,
+        )
+        .set_config(toml::toml! {
+            add_newline = true
+        });
+
+        assert_ne!(context.config.config, mod_context.config.config);
     }
 
     #[test]

--- a/src/context.rs
+++ b/src/context.rs
@@ -175,7 +175,7 @@ impl<'a> Context<'a> {
         }
     }
 
-    // Sets the context config, overwriting the existing config
+    /// Sets the context config, overwriting the existing config
     pub fn set_config(mut self, config: toml::Table) -> Context<'a> {
         self.root_config = StarshipRootConfig::load(&config);
         self.config = StarshipConfig {

--- a/src/print.rs
+++ b/src/print.rs
@@ -504,10 +504,7 @@ mod test {
                 [character]
                 format=">\n>"
         });
-
-        context.root_config.format = "$character".to_string();
         context.target = Target::Main;
-        context.root_config.add_newline = false;
 
         let expected = String::from(">\n>");
         let actual = get_prompt(context);
@@ -521,8 +518,6 @@ mod test {
                 [character]
                 format=">\n>"
         });
-
-        context.root_config.right_format = "$character".to_string();
         context.target = Target::Right;
 
         let expected = String::from(">>"); // should strip new lines
@@ -539,13 +534,7 @@ mod test {
                 [character]
                 format=">>"
         });
-
-        context
-            .root_config
-            .profiles
-            .insert("test".to_string(), "0_0$character".to_string());
         context.target = Target::Profile("test".to_string());
-        context.root_config.add_newline = false;
 
         let expected = String::from("0_0>>");
         let actual = get_prompt(context);
@@ -561,13 +550,7 @@ mod test {
                 [character]
                 format=">>"
         });
-
-        context
-            .root_config
-            .profiles
-            .insert("test".to_string(), "0_0$character".to_string());
         context.target = Target::Profile("wrong_prompt".to_string());
-        context.root_config.add_newline = false;
 
         let expected = String::from(">");
         let actual = get_prompt(context);
@@ -579,8 +562,6 @@ mod test {
         let mut context = default_context().set_config(toml::toml! {
                 continuation_prompt="><>"
         });
-
-        context.root_config.continuation_prompt = "><>".to_string();
         context.target = Target::Continuation;
 
         let expected = String::from("><>");
@@ -634,8 +615,6 @@ mod test {
         });
         context.current_dir = dir.path().to_path_buf();
 
-        context.root_config.format = "$custom".to_string();
-
         let expected = String::from("\nab");
         let actual = get_prompt(context);
         assert_eq!(expected, actual);
@@ -654,8 +633,6 @@ mod test {
                 [env_var.c]
                 format="$env_value"
         });
-
-        context.root_config.format = "$env_var".to_string();
         context.env.insert("a", "a".to_string());
         context.env.insert("b", "b".to_string());
         context.env.insert("c", "c".to_string());
@@ -680,9 +657,7 @@ mod test {
                 when=true
                 format="c"
         });
-
         context.current_dir = dir.path().to_path_buf();
-        context.root_config.format = "${custom.c}$custom${custom.b}".to_string();
 
         let expected = String::from("\ncab");
         let actual = get_prompt(context);
@@ -704,8 +679,6 @@ mod test {
                 [env_var.c]
                 format="$env_value"
         });
-
-        context.root_config.format = "${env_var.c}$env_var${env_var.b}".to_string();
         context.env.insert("a", "a".to_string());
         context.env.insert("b", "b".to_string());
         context.env.insert("c", "c".to_string());
@@ -728,9 +701,7 @@ mod test {
                 when=true
                 format="b"
         });
-
         context.current_dir = dir.path().to_path_buf();
-        context.root_config.format = "${custom.b}".to_string();
 
         let expected = String::from("\nb");
         let actual = get_prompt(context);
@@ -747,9 +718,7 @@ mod test {
                 when=true
                 format="a"
         });
-
         context.current_dir = dir.path().to_path_buf();
-        context.root_config.format = "${custom.b}".to_string();
 
         let expected = String::from("\n");
         let actual = get_prompt(context);

--- a/src/print.rs
+++ b/src/print.rs
@@ -493,21 +493,18 @@ fn preset_list() -> String {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::config::StarshipConfig;
     use crate::test::default_context;
     use crate::utils;
 
     #[test]
     fn main_prompt() {
-        let mut context = default_context();
-        context.config = StarshipConfig {
-            config: Some(toml::toml! {
+        let mut context = default_context().set_config(toml::toml! {
                 add_newline=false
                 format="$character"
                 [character]
                 format=">\n>"
-            }),
-        };
+        });
+
         context.root_config.format = "$character".to_string();
         context.target = Target::Main;
         context.root_config.add_newline = false;
@@ -519,14 +516,12 @@ mod test {
 
     #[test]
     fn right_prompt() {
-        let mut context = default_context();
-        context.config = StarshipConfig {
-            config: Some(toml::toml! {
+        let mut context = default_context().set_config(toml::toml! {
                 right_format="$character"
                 [character]
                 format=">\n>"
-            }),
-        };
+        });
+
         context.root_config.right_format = "$character".to_string();
         context.target = Target::Right;
 
@@ -537,16 +532,14 @@ mod test {
 
     #[test]
     fn custom_prompt() {
-        let mut context = default_context();
-        context.config = StarshipConfig {
-            config: Some(toml::toml! {
+        let mut context = default_context().set_config(toml::toml! {
                 add_newline = false
                 [profiles]
                 test="0_0$character"
                 [character]
                 format=">>"
-            }),
-        };
+        });
+
         context
             .root_config
             .profiles
@@ -561,16 +554,14 @@ mod test {
 
     #[test]
     fn custom_prompt_fallback() {
-        let mut context = default_context();
-        context.config = StarshipConfig {
-            config: Some(toml::toml! {
+        let mut context = default_context().set_config(toml::toml! {
                 add_newline=false
                 [profiles]
                 test="0_0$character"
                 [character]
                 format=">>"
-            }),
-        };
+        });
+
         context
             .root_config
             .profiles
@@ -585,12 +576,10 @@ mod test {
 
     #[test]
     fn continuation_prompt() {
-        let mut context = default_context();
-        context.config = StarshipConfig {
-            config: Some(toml::toml! {
+        let mut context = default_context().set_config(toml::toml! {
                 continuation_prompt="><>"
-            }),
-        };
+        });
+
         context.root_config.continuation_prompt = "><>".to_string();
         context.target = Target::Continuation;
 
@@ -634,10 +623,7 @@ mod test {
     #[test]
     fn custom_expands() -> std::io::Result<()> {
         let dir = tempfile::tempdir()?;
-        let mut context = default_context();
-        context.current_dir = dir.path().to_path_buf();
-        context.config = StarshipConfig {
-            config: Some(toml::toml! {
+        let mut context = default_context().set_config(toml::toml! {
                 format="$custom"
                 [custom.a]
                 when=true
@@ -645,8 +631,9 @@ mod test {
                 [custom.b]
                 when=true
                 format="b"
-            }),
-        };
+        });
+        context.current_dir = dir.path().to_path_buf();
+
         context.root_config.format = "$custom".to_string();
 
         let expected = String::from("\nab");
@@ -657,9 +644,7 @@ mod test {
 
     #[test]
     fn env_expands() {
-        let mut context = default_context();
-        context.config = StarshipConfig {
-            config: Some(toml::toml! {
+        let mut context = default_context().set_config(toml::toml! {
                 format="$env_var"
                 [env_var]
                 format="$env_value"
@@ -668,8 +653,8 @@ mod test {
                 format="$env_value"
                 [env_var.c]
                 format="$env_value"
-            }),
-        };
+        });
+
         context.root_config.format = "$env_var".to_string();
         context.env.insert("a", "a".to_string());
         context.env.insert("b", "b".to_string());
@@ -683,10 +668,7 @@ mod test {
     #[test]
     fn custom_mixed() -> std::io::Result<()> {
         let dir = tempfile::tempdir()?;
-        let mut context = default_context();
-        context.current_dir = dir.path().to_path_buf();
-        context.config = StarshipConfig {
-            config: Some(toml::toml! {
+        let mut context = default_context().set_config(toml::toml! {
                 format="${custom.c}$custom${custom.b}"
                 [custom.a]
                 when=true
@@ -697,8 +679,9 @@ mod test {
                 [custom.c]
                 when=true
                 format="c"
-            }),
-        };
+        });
+
+        context.current_dir = dir.path().to_path_buf();
         context.root_config.format = "${custom.c}$custom${custom.b}".to_string();
 
         let expected = String::from("\ncab");
@@ -709,9 +692,7 @@ mod test {
 
     #[test]
     fn env_mixed() {
-        let mut context = default_context();
-        context.config = StarshipConfig {
-            config: Some(toml::toml! {
+        let mut context = default_context().set_config(toml::toml! {
                 format="${env_var.c}$env_var${env_var.b}"
                 [env_var]
                 format="$env_value"
@@ -722,8 +703,8 @@ mod test {
                 format="$env_value"
                 [env_var.c]
                 format="$env_value"
-            }),
-        };
+        });
+
         context.root_config.format = "${env_var.c}$env_var${env_var.b}".to_string();
         context.env.insert("a", "a".to_string());
         context.env.insert("b", "b".to_string());
@@ -738,10 +719,7 @@ mod test {
     #[test]
     fn custom_subset() -> std::io::Result<()> {
         let dir = tempfile::tempdir()?;
-        let mut context = default_context();
-        context.current_dir = dir.path().to_path_buf();
-        context.config = StarshipConfig {
-            config: Some(toml::toml! {
+        let mut context = default_context().set_config(toml::toml! {
                 format="${custom.b}"
                 [custom.a]
                 when=true
@@ -749,8 +727,9 @@ mod test {
                 [custom.b]
                 when=true
                 format="b"
-            }),
-        };
+        });
+
+        context.current_dir = dir.path().to_path_buf();
         context.root_config.format = "${custom.b}".to_string();
 
         let expected = String::from("\nb");
@@ -762,16 +741,14 @@ mod test {
     #[test]
     fn custom_missing() -> std::io::Result<()> {
         let dir = tempfile::tempdir()?;
-        let mut context = default_context();
-        context.current_dir = dir.path().to_path_buf();
-        context.config = StarshipConfig {
-            config: Some(toml::toml! {
+        let mut context = default_context().set_config(toml::toml! {
                 format="${custom.b}"
                 [custom.a]
                 when=true
                 format="a"
-            }),
-        };
+        });
+
+        context.current_dir = dir.path().to_path_buf();
         context.root_config.format = "${custom.b}".to_string();
 
         let expected = String::from("\n");

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -1,8 +1,7 @@
 use crate::context::{Context, Shell, Target};
 use crate::logger::StarshipLogger;
 use crate::{
-    config::{ModuleConfig, StarshipConfig},
-    configs::StarshipRootConfig,
+    config::StarshipConfig,
     utils::{create_command, CommandOutput},
 };
 use log::{Level, LevelFilter};
@@ -88,10 +87,7 @@ impl<'a> ModuleRenderer<'a> {
 
     /// Sets the config of the underlying context
     pub fn config(mut self, config: toml::Table) -> Self {
-        self.context.root_config = StarshipRootConfig::load(&config);
-        self.context.config = StarshipConfig {
-            config: Some(config),
-        };
+        self.context = self.context.set_config(config);
         self
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Since the `ModuleRenderer` config method simply manipulates the context config fields, I added a `.set_config()` method within `Context` that directly overrides the config fields, and let the `config` method in `ModuleRenderer` call that method instead. 

This way, any tests that use a module renderer will continue functioning like normal, and now maintainers can use `set_config` to directly set the configuration of `Context` structs.

I've added a test to show that the configuration is completely overwritten by calling the method. Let me know if this seems like a good idea or not!

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Implemented an idea from @davidkna about giving a `.config()` method to `Context` to match `ModuleRenderer`. Mentioned in #5077.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
