### PR TITLE
fix: Make STARSHIP_PREEXEC_READY work in 'strict mode'

### DIFF
--- a/src/init/starship.bash
+++ b/src/init/starship.bash
@@ -21,7 +21,7 @@ starship_preexec() {
     local PREV_LAST_ARG=$1
 
     # Avoid restarting the timer for commands in the same pipeline
-    if [ "$STARSHIP_PREEXEC_READY" = "true" ]; then
+    if [ "${STARSHIP_PREEXEC_READY:-}" = "true" ]; then
         STARSHIP_PREEXEC_READY=false
         STARSHIP_START_TIME=$(::STARSHIP:: time)
     fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
This PR changes the behavior so that `STARSHIP_PREEXEC_READY` falls back to an empty bound var if the var is not yet bound.


#### Motivation and Context
I am sourcing Starship through a script that uses 'strict mode'  (`set -o nounset`) to exit if an var is unbound.  `STARSHIP_PREEXEC_READY` is unbound if not yet set by `starship_precmd`. 

#### Screenshots (if appropriate):
<img width="742" alt="image" src="https://user-images.githubusercontent.com/32384907/230767679-14156018-206e-4701-b946-bb3e946dde52.png">

https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
Not required
- [ ] I have updated the tests accordingly.
There is no test for the behavior and imho this change neither requires any.