### PR TITLE
feat(nodejs): Add `expected_version` variable

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2832,7 +2832,7 @@ By default the module will be shown if any of the following conditions are met:
 | Variable        | Example    | Description                                                                                                                                                             |
 | --------------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | version         | `v13.12.0` | The version of `node`                                                                                                                                                   |
-| engines_version | `>=12.0.0` | `node` version as set in the engines property of `package.json`. Will show if installed node version does not match with the set engines value, is otherwise invisible. |
+| engines_version | `>=12.0.0` | `node` version requirement as set in the engines property of `package.json`. Will only show if the version requirement does not match the `node` version. |
 | symbol          |            | Mirrors the value of option `symbol`                                                                                                                                    |
 | style\*         |            | Mirrors the value of option `style`                                                                                                                                     |
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2829,12 +2829,12 @@ By default the module will be shown if any of the following conditions are met:
 
 ### Variables
 
-| Variable         | Example    | Description                                                              |
-| ---------------- | ---------- | ------------------------------------------------------------------------ |
-| version          | `v13.12.0` | The version of `node`                                                    |
-| expected_version | `>=12.0.0` | Optional `node` version as set in the engines property of `package.json` |
-| symbol           |            | Mirrors the value of option `symbol`                                     |
-| style\*          |            | Mirrors the value of option `style`                                      |
+| Variable        | Example    | Description                                                                                                                                                             |
+| --------------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| version         | `v13.12.0` | The version of `node`                                                                                                                                                   |
+| engines_version | `>=12.0.0` | `node` version as set in the engines property of `package.json`. Will show if installed node version does not match with the set engines value, is otherwise invisible. |
+| symbol          |            | Mirrors the value of option `symbol`                                                                                                                                    |
+| style\*         |            | Mirrors the value of option `style`                                                                                                                                     |
 
 *: This variable can only be used as a part of a style string
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2829,11 +2829,12 @@ By default the module will be shown if any of the following conditions are met:
 
 ### Variables
 
-| Variable | Example    | Description                          |
-| -------- | ---------- | ------------------------------------ |
-| version  | `v13.12.0` | The version of `node`                |
-| symbol   |            | Mirrors the value of option `symbol` |
-| style\*  |            | Mirrors the value of option `style`  |
+| Variable         | Example    | Description                                                              |
+| ---------------- | ---------- | ------------------------------------------------------------------------ |
+| version          | `v13.12.0` | The version of `node`                                                    |
+| expected_version | `>=12.0.0` | Optional `node` version as set in the engines property of `package.json` |
+| symbol           |            | Mirrors the value of option `symbol`                                     |
+| style\*          |            | Mirrors the value of option `style`                                      |
 
 *: This variable can only be used as a part of a style string
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2829,12 +2829,12 @@ By default the module will be shown if any of the following conditions are met:
 
 ### Variables
 
-| Variable        | Example    | Description                                                                                                                                                             |
-| --------------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| version         | `v13.12.0` | The version of `node`                                                                                                                                                   |
+| Variable        | Example    | Description                                                                                                                                               |
+| --------------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| version         | `v13.12.0` | The version of `node`                                                                                                                                     |
 | engines_version | `>=12.0.0` | `node` version requirement as set in the engines property of `package.json`. Will only show if the version requirement does not match the `node` version. |
-| symbol          |            | Mirrors the value of option `symbol`                                                                                                                                    |
-| style\*         |            | Mirrors the value of option `style`                                                                                                                                     |
+| symbol          |            | Mirrors the value of option `symbol`                                                                                                                      |
+| style\*         |            | Mirrors the value of option `style`                                                                                                                       |
 
 *: This variable can only be used as a part of a style string
 

--- a/src/modules/nodejs.rs
+++ b/src/modules/nodejs.rs
@@ -340,6 +340,24 @@ mod tests {
     }
 
     #[test]
+    fn do_not_show_expected_version_if_no_set_engines_version() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join("package.json"))?.sync_all()?;
+
+        let actual = ModuleRenderer::new("nodejs")
+            .path(dir.path())
+            .config(toml::toml! {
+                [nodejs]
+                format = "via [$symbol($version )($expected_version )]($style)"
+            })
+            .collect();
+        let expected = Some(format!("via {}", Color::Green.bold().paint(" v12.0.0 ")));
+
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
     fn no_node_installed() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("index.js"))?.sync_all()?;

--- a/src/modules/nodejs.rs
+++ b/src/modules/nodejs.rs
@@ -71,12 +71,8 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                     .map(Ok)
                 }
                 "engines_version" => {
-                    let eng_ver = engines_version.deref();
-
-                    match (eng_ver, in_engines_range) {
-                        (Some(ver), false) => Some(Ok(ver.to_string())),
-                        _ => None,
-                    }
+                    let eng_ver = engines_version.as_deref()?.to_string();
+                    (!in_engines_range).then_some(Ok(eng_ver))
                 }
                 _ => None,
             })

--- a/src/modules/nodejs.rs
+++ b/src/modules/nodejs.rs
@@ -36,8 +36,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             .map(|cmd| cmd.stdout)
     });
     let engines_version = Lazy::new(|| get_engines_version(context));
-    let in_engines_range =
-        check_engines_version(nodejs_version.as_deref(), engines_version.as_deref());
 
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter
@@ -47,6 +45,11 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             })
             .map_style(|variable| match variable {
                 "style" => {
+                    let in_engines_range = check_engines_version(
+                        nodejs_version.as_deref(),
+                        engines_version.as_deref(),
+                    );
+
                     if in_engines_range {
                         Some(Ok(config.style))
                     } else {
@@ -71,7 +74,12 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                     .map(Ok)
                 }
                 "engines_version" => {
+                    let in_engines_range = check_engines_version(
+                        nodejs_version.as_deref(),
+                        engines_version.as_deref(),
+                    );
                     let eng_ver = engines_version.as_deref()?.to_string();
+
                     (!in_engines_range).then_some(Ok(eng_ver))
                 }
                 _ => None,

--- a/src/modules/nodejs.rs
+++ b/src/modules/nodejs.rs
@@ -71,6 +71,26 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 }
                 _ => None,
             })
+            .map(|variable| match variable {
+                "expected_version" => {
+                    let version = nodejs_version.as_deref();
+                    let expected_version = get_engines_version(context);
+                    let versions_in_range = check_engines_version(version, get_engines_version(context));
+
+                    match (expected_version, versions_in_range) {
+                        (Some(ver), false) => {
+                            VersionFormatter::format_module_version(
+                                module.get_name(),
+                                &ver,
+                                config.version_format,
+                            )
+                            .map(Ok)
+                        }
+                        _ => None,
+                    }
+                }
+                _ => None,
+            })
             .parse(None, Some(context))
     });
 
@@ -269,6 +289,53 @@ mod tests {
         assert_eq!(expected, actual);
         dir.close()
     }
+
+    #[test]
+    fn show_expected_version_when_engines_does_not_match() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let mut file = File::create(dir.path().join("package.json"))?;
+        file.write_all(
+            b"{
+            \"engines\":{
+                \"node\":\"11.0.0\"
+            }
+        }",
+        )?;
+        file.sync_all()?;
+
+        let actual = ModuleRenderer::new("nodejs").path(dir.path()).config(toml::toml! {
+            [nodejs]
+            format = "via [$symbol($version )($expected_version )]($style)"
+        }).collect();
+        let expected = Some(format!("via {}", Color::Red.bold().paint(" v12.0.0 v11.0.0 ")));
+    
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn do_not_show_expected_version_if_engines_match() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let mut file = File::create(dir.path().join("package.json"))?;
+        file.write_all(
+            b"{
+            \"engines\":{
+                \"node\":\"12.0.0\"
+            }
+        }",
+        )?;
+        file.sync_all()?;
+
+        let actual = ModuleRenderer::new("nodejs").path(dir.path()).config(toml::toml! [
+            [nodejs]
+            format = "via [$symbol($version )($expected_version )]($style)"
+        ]).collect();
+        let expected = Some(format!("via {}", Color::Green.bold().paint(" v12.0.0 ")));
+
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
     #[test]
     fn no_node_installed() -> io::Result<()> {
         let dir = tempfile::tempdir()?;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Allow users to use `$expected_version` as a variable for `nodejs`. Mirrors the value of `$.engines.node` in the `package.json` file. Currently set to show only if the node version does not match the parameters set in `package.json`, will be hidden otherwise.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #5066. As raised by the person who opened the issue, a similar implementation of this can also be used for other modules that have declarative versioning.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
