### PR TITLE
refactor(git_status): use `git status --show-stash` instead of `git stash list`

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1877,6 +1877,7 @@ You can disable the module or use the `windows_starship` option to use a Windows
 | `ignore_submodules` | `false`                                       | Ignore changes to submodules.                                                                               |
 | `disabled`          | `false`                                       | Disables the `git_status` module.                                                                           |
 | `windows_starship`  |                                               | Use this (Linux) path to a Windows Starship executable to render `git_status` when on Windows paths in WSL. |
+| `git_version`       | `'2.11.0'`                                      | The assumed git version. This module uses `git status --porcelain=2`, introduced in `2.11.0`. Git `2.35.0` has `git status --show-stash`, which is a bit faster. |
 
 ### Variables
 

--- a/src/configs/git_status.rs
+++ b/src/configs/git_status.rs
@@ -26,6 +26,7 @@ pub struct GitStatusConfig<'a> {
     pub disabled: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub windows_starship: Option<&'a str>,
+    pub git_version: &'a str,
 }
 
 impl<'a> Default for GitStatusConfig<'a> {
@@ -48,6 +49,7 @@ impl<'a> Default for GitStatusConfig<'a> {
             ignore_submodules: false,
             disabled: false,
             windows_starship: None,
+            git_version: "2.11",
         }
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -11,6 +11,7 @@ use gix::{
     sec::{self as git_sec, trust::DefaultForLevel},
     state as git_state, Repository, ThreadSafeRepository,
 };
+use log::debug;
 use once_cell::sync::OnceCell;
 #[cfg(test)]
 use std::collections::HashMap;
@@ -251,6 +252,7 @@ impl<'a> Context<'a> {
     pub fn get_repo(&self) -> Result<&Repo, Box<gix::discover::Error>> {
         self.repo
             .get_or_try_init(|| -> Result<Repo, Box<gix::discover::Error>> {
+                debug!("get_repo start");
                 // custom open options
                 let mut git_open_opts_map =
                     git_sec::trust::Mapping::<gix::open::Options>::default();
@@ -297,6 +299,7 @@ impl<'a> Context<'a> {
                 let branch = get_current_branch(&repository);
                 let remote = get_remote_repository_info(&repository, branch.as_deref());
                 let path = repository.path().to_path_buf();
+                debug!("get_repo end");
                 Ok(Repo {
                     repo: shared_repo,
                     branch,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 #![warn(clippy::disallowed_methods)]
 
 use clap::crate_authors;
+use log::debug;
 use std::io;
 use std::path::PathBuf;
 use std::thread::available_parallelism;
@@ -265,6 +266,7 @@ fn init_global_threadpool() {
         // but restrict the number of threads to 8
         .unwrap_or_else(|| available_parallelism().map(usize::from).unwrap_or(1).min(8));
 
+    debug!("running with {num_threads} threads");
     rayon::ThreadPoolBuilder::new()
         .num_threads(num_threads)
         .build_global()


### PR DESCRIPTION
#### Description

`git status --porcelain=v2` handles the `--show-stash` option since [git 2.35.0 (released Jan 2022)](https://github.com/git/git/blob/5d01301f2b865aa8dba1654d3f447ce9d21db0b5/Documentation/RelNotes/2.35.0.txt#L28)
Note that the `--show-stash` option was introduced in [2.14.0](https://github.com/git/git/commit/c1b5d0194b98bd3d0acc9cec7070808fbbe6a740), but it didn't have porcelain v2 handling until later.

`git status` porcelain v2 was first documented in [2.11.0](https://github.com/git/git/commit/1cd828ddc8a61f6bec93303f4bdbcdbf1c261cb7)

git status option | introduced | added to porcelain v2
-- | -- | --
`--show-stash` | [2.14.0](https://github.com/git/git/commit/c1b5d0194b98bd3d0acc9cec7070808fbbe6a740) | [2.35.0](https://github.com/git/git/blob/5d01301f2b865aa8dba1654d3f447ce9d21db0b5/Documentation/RelNotes/2.35.0.txt#L28)
`--branch` | ? | [2.11.0](https://github.com/git/git/commit/d9fc746cd77910a7dec53abfec36df5c699b33c2)
`--ignore-submodules` | [1.7.2](https://github.com/git/git/commit/46a958b3daa1da336683ec82d7f321d0f51b39c8) | 2.11.0?
`--untracked-files=no` | [1.8.2?](https://github.com/git/git/commit/5823eb2b28696bf0eb25f6ca35b303447869f85c) | 2.11.0?

There is also the `--no-ahead-behind` option introduced in [2.17.0](https://github.com/git/git/commit/d0db9edba0050ada6f6eac68061599690d2a4333), perhaps we could leverage that for some configs?

Summary:
* Currently supported git version seems to be >=2.11.0
* With this change, >=2.14.0 would be fine for all except stash, and >=2.35.0 would have full support
* Maybe we should introduce a config in the `git_status` module to not break compatibility? 2.35.0 (Jan 2022) is quite recent. Perhaps a `git_version` string entry, which we can use to determine which features can be used

#### Motivation and Context
`git_status` performance https://github.com/starship/starship/issues/4305
It improves performance by a small amount (5ms)


#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
- [ ] I have updated the documentation accordingly.
   - We might want to add `git` version info in https://starship.rs/config/#git-status
- [x] I have updated the tests accordingly.
   - There are existing stash checks, see `shows_stashed` and `shows_stashed_with_count`
