### PR TITLE
fix(xonsh): remove `| cat` workaround from xonsh init

### DIFF
--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -231,7 +231,14 @@ pub fn init_main(shell_name: &str) -> io::Result<()> {
 }
 
 fn print_script(script: &str, path: &str) {
-    let script = script.replace("::STARSHIP::", path);
+    /* Due to a workaround using |cat inside starship.xsh the XONSH script causes errors on Windows
+    since the cat command is not found so it is replaced with the Windows equivalent type 
+    https://github.com/starship/starship/issues/4900 */
+    #[cfg(windows)]
+    let script = script.replace("::STARSHIP::", path).replace("::TYPECAT::", "type");
+    #[cfg(not(windows))]
+    let script: String = script.replace("::STARSHIP::", path).replalce("::TYPECAT::", "cat");
+
     print!("{script}");
 }
 

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -1,4 +1,5 @@
 use crate::utils::create_command;
+use io::Write;
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 use std::{env, io};
@@ -175,12 +176,16 @@ pub fn init_stub(shell_name: &str) -> io::Result<()> {
             r#"eval `({} init tcsh --print-full-init)`"#,
             starship.sprint_posix()?
         ),
-        "nu" => print_script(NU_INIT, &StarshipPath::init()?.sprint()?),
+        "nu" => print_script(NU_INIT, &StarshipPath::init()?.sprint()?, io::stdout()),
         "xonsh" => print!(
             r#"execx($({} init xonsh --print-full-init))"#,
             starship.sprint_posix()?
         ),
-        "cmd" => print_script(CMDEXE_INIT, &StarshipPath::init()?.sprint_cmdexe()?),
+        "cmd" => print_script(
+            CMDEXE_INIT,
+            &StarshipPath::init()?.sprint_cmdexe()?,
+            io::stdout(),
+        ),
         _ => {
             eprintln!(
                 "{shell_basename} is not yet supported by starship.\n\
@@ -211,14 +216,14 @@ pub fn init_main(shell_name: &str) -> io::Result<()> {
     let starship_path = StarshipPath::init()?;
 
     match shell_name {
-        "bash" => print_script(BASH_INIT, &starship_path.sprint_posix()?),
-        "zsh" => print_script(ZSH_INIT, &starship_path.sprint_posix()?),
-        "fish" => print_script(FISH_INIT, &starship_path.sprint_posix()?),
-        "powershell" => print_script(PWSH_INIT, &starship_path.sprint_pwsh()?),
-        "ion" => print_script(ION_INIT, &starship_path.sprint()?),
-        "elvish" => print_script(ELVISH_INIT, &starship_path.sprint_posix()?),
-        "tcsh" => print_script(TCSH_INIT, &starship_path.sprint_posix()?),
-        "xonsh" => print_script(XONSH_INIT, &starship_path.sprint_posix()?),
+        "bash" => print_script(BASH_INIT, &starship_path.sprint_posix()?, io::stdout()),
+        "zsh" => print_script(ZSH_INIT, &starship_path.sprint_posix()?, io::stdout()),
+        "fish" => print_script(FISH_INIT, &starship_path.sprint_posix()?, io::stdout()),
+        "powershell" => print_script(PWSH_INIT, &starship_path.sprint_pwsh()?, io::stdout()),
+        "ion" => print_script(ION_INIT, &starship_path.sprint()?, io::stdout()),
+        "elvish" => print_script(ELVISH_INIT, &starship_path.sprint_posix()?, io::stdout()),
+        "tcsh" => print_script(TCSH_INIT, &starship_path.sprint_posix()?, io::stdout()),
+        "xonsh" => print_script(XONSH_INIT, &starship_path.sprint_posix()?, io::stdout()),
         _ => {
             println!(
                 "printf \"Shell name detection failed on phase two init.\\n\
@@ -230,7 +235,7 @@ pub fn init_main(shell_name: &str) -> io::Result<()> {
     Ok(())
 }
 
-fn print_script(script: &str, path: &str) {
+fn print_script(script: &str, path: &str, mut out: impl Write) {
     /* Due to a workaround using |cat inside starship.xsh the XONSH script causes errors on Windows
     since the cat command is not found so it is replaced with the Windows equivalent type
     https://github.com/starship/starship/issues/4900 */
@@ -243,7 +248,7 @@ fn print_script(script: &str, path: &str) {
         .replace("::STARSHIP::", path)
         .replace("::TYPECAT::", "cat");
 
-    print!("{script}");
+    write!(out, "{script}").unwrap();
 }
 
 /* GENERAL INIT SCRIPT NOTES
@@ -320,6 +325,27 @@ mod tests {
             starship_path.sprint_cmdexe()?,
             r#""C:\Cool Tools\starship.exe""#
         );
+        Ok(())
+    }
+
+    #[test]
+    fn test_print_script() -> io::Result<()> {
+        use std::string::String;
+
+        let mut output = Vec::new();
+
+        print_script(
+            "::TYPECAT:: ::STARSHIP:: test2 test3 test4",
+            "test1",
+            &mut output,
+        );
+
+        let message = String::from_utf8(output).unwrap();
+        #[cfg(windows)]
+        assert_eq!(message, "type test1 test2 test3 test4");
+
+        #[cfg(not(windows))]
+        assert_eq!(message, "cat test1 test2 test3 test4");
         Ok(())
     }
 }

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -237,7 +237,7 @@ fn print_script(script: &str, path: &str) {
     #[cfg(windows)]
     let script = script.replace("::STARSHIP::", path).replace("::TYPECAT::", "type");
     #[cfg(not(windows))]
-    let script: String = script.replace("::STARSHIP::", path).replalce("::TYPECAT::", "cat");
+    let script: String = script.replace("::STARSHIP::", path).replace("::TYPECAT::", "cat");
 
     print!("{script}");
 }

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -231,9 +231,11 @@ pub fn init_main(shell_name: &str) -> io::Result<()> {
 }
 
 fn print_script(script: &str, path: &str) {
-    /* Due to a workaround using |cat inside starship.xsh the XONSH script causes errors on Windows
-    since the cat command is not found so it is replaced with the Windows equivalent type 
-    https://github.com/starship/starship/issues/4900 */
+    /* 
+     * Due to a workaround using |cat inside starship.xsh the XONSH script causes errors on Windows
+     * since the cat command is not found so it is replaced with the Windows equivalent type 
+     * https://github.com/starship/starship/issues/4900 
+     */
     #[cfg(windows)]
     let script = script
         .replace("::STARSHIP::", path)

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -235,9 +235,13 @@ fn print_script(script: &str, path: &str) {
     since the cat command is not found so it is replaced with the Windows equivalent type 
     https://github.com/starship/starship/issues/4900 */
     #[cfg(windows)]
-    let script = script.replace("::STARSHIP::", path).replace("::TYPECAT::", "type");
+    let script = script
+        .replace("::STARSHIP::", path)
+        .replace("::TYPECAT::", "type");
     #[cfg(not(windows))]
-    let script: String = script.replace("::STARSHIP::", path).replace("::TYPECAT::", "cat");
+    let script: String = script
+        .replace("::STARSHIP::", path)
+        .replace("::TYPECAT::", "cat");
 
     print!("{script}");
 }

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -231,9 +231,9 @@ pub fn init_main(shell_name: &str) -> io::Result<()> {
 }
 
 fn print_script(script: &str, path: &str) {
-	/* Due to a workaround using |cat inside starship.xsh the XONSH script causes errors on Windows
-	since the cat command is not found so it is replaced with the Windows equivalent type 
-	https://github.com/starship/starship/issues/4900 */
+    /* Due to a workaround using |cat inside starship.xsh the XONSH script causes errors on Windows
+    since the cat command is not found so it is replaced with the Windows equivalent type
+    https://github.com/starship/starship/issues/4900 */
     #[cfg(windows)]
     let script = script
         .replace("::STARSHIP::", path)

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -231,11 +231,9 @@ pub fn init_main(shell_name: &str) -> io::Result<()> {
 }
 
 fn print_script(script: &str, path: &str) {
-    /* 
-     * Due to a workaround using |cat inside starship.xsh the XONSH script causes errors on Windows
-     * since the cat command is not found so it is replaced with the Windows equivalent type 
-     * https://github.com/starship/starship/issues/4900 
-     */
+	/* Due to a workaround using |cat inside starship.xsh the XONSH script causes errors on Windows
+	since the cat command is not found so it is replaced with the Windows equivalent type 
+	https://github.com/starship/starship/issues/4900 */
     #[cfg(windows)]
     let script = script
         .replace("::STARSHIP::", path)

--- a/src/init/starship.xsh
+++ b/src/init/starship.xsh
@@ -9,7 +9,8 @@ def starship_prompt():
     jobs = sum(1 for job in __xonsh__.all_jobs.values() if job['obj'] and job['obj'].poll() is None)
     duration = round((last_cmd.ts[1] - last_cmd.ts[0]) * 1000) if last_cmd else 0
     # The `| cat` is a workaround for https://github.com/xonsh/xonsh/issues/3786. See https://github.com/starship/starship/pull/2807#discussion_r667316323.
-    return $(::STARSHIP:: prompt --status=@(status) --jobs=@(jobs) --cmd-duration=@(duration) | cat)
+    # The ::TYPECAT:: is in place to correctly choose between cat or type based on platform. https://github.com/starship/starship/issues/4900.
+    return $(::STARSHIP:: prompt --status=@(status) --jobs=@(jobs) --cmd-duration=@(duration) | ::TYPECAT::)
 
 def starship_rprompt():
     last_cmd = __xonsh__.history[-1] if __xonsh__.history else None
@@ -19,7 +20,8 @@ def starship_rprompt():
     jobs = sum(1 for job in __xonsh__.all_jobs.values() if job['obj'] and job['obj'].poll() is None)
     duration = round((last_cmd.ts[1] - last_cmd.ts[0]) * 1000) if last_cmd else 0
     # The `| cat` is a workaround for https://github.com/xonsh/xonsh/issues/3786. See https://github.com/starship/starship/pull/2807#discussion_r667316323.
-    return $(::STARSHIP:: prompt --status=@(status) --jobs=@(jobs) --cmd-duration=@(duration) --right | cat)
+    # The ::TYPECAT:: is in place to correctly choose between cat or type based on platform. https://github.com/starship/starship/issues/4900.
+    return $(::STARSHIP:: prompt --status=@(status) --jobs=@(jobs) --cmd-duration=@(duration) --right | ::TYPECAT::)
 
 
 $PROMPT = starship_prompt

--- a/src/init/starship.xsh
+++ b/src/init/starship.xsh
@@ -8,9 +8,7 @@ def starship_prompt():
     # but we can't use that function because of https://gitter.im/xonsh/xonsh?at=60e8832d82dd9050f5e0c96a
     jobs = sum(1 for job in __xonsh__.all_jobs.values() if job['obj'] and job['obj'].poll() is None)
     duration = round((last_cmd.ts[1] - last_cmd.ts[0]) * 1000) if last_cmd else 0
-    # The `| cat` is a workaround for https://github.com/xonsh/xonsh/issues/3786. See https://github.com/starship/starship/pull/2807#discussion_r667316323.
-    # The ::TYPECAT:: is in place to correctly choose between cat or type based on platform. https://github.com/starship/starship/issues/4900.
-    return $(::STARSHIP:: prompt --status=@(status) --jobs=@(jobs) --cmd-duration=@(duration) | ::TYPECAT::)
+    return $(::STARSHIP:: prompt --status=@(status) --jobs=@(jobs) --cmd-duration=@(duration))
 
 def starship_rprompt():
     last_cmd = __xonsh__.history[-1] if __xonsh__.history else None
@@ -19,9 +17,7 @@ def starship_rprompt():
     # but we can't use that function because of https://gitter.im/xonsh/xonsh?at=60e8832d82dd9050f5e0c96a
     jobs = sum(1 for job in __xonsh__.all_jobs.values() if job['obj'] and job['obj'].poll() is None)
     duration = round((last_cmd.ts[1] - last_cmd.ts[0]) * 1000) if last_cmd else 0
-    # The `| cat` is a workaround for https://github.com/xonsh/xonsh/issues/3786. See https://github.com/starship/starship/pull/2807#discussion_r667316323.
-    # The ::TYPECAT:: is in place to correctly choose between cat or type based on platform. https://github.com/starship/starship/issues/4900.
-    return $(::STARSHIP:: prompt --status=@(status) --jobs=@(jobs) --cmd-duration=@(duration) --right | ::TYPECAT::)
+    return $(::STARSHIP:: prompt --status=@(status) --jobs=@(jobs) --cmd-duration=@(duration) --right)
 
 
 $PROMPT = starship_prompt


### PR DESCRIPTION
Caused by use of cat on Windows platforms.
Removed |cat thanks to davidkna pointing out that the workaround that introduced it has been fixed upstream.

#### Description
Removed cat within starship.xsh as it is no longer needed and causes issues on Windows.

#### Motivation and Context
cat does not work on Windows and causes problems when running starship with xonsh
Closes #4900
Closes #3795
Closes #3646

#### How Has This Been Tested?
Ran starship with xonsh with both the latest release and my fork (the error was removed)
Ran cargo test to ensure tests are still passing
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
