### PR TITLE
fix(style): ensure nested style variables are processed during formatting

### DIFF
--- a/src/formatter/model.rs
+++ b/src/formatter/model.rs
@@ -91,6 +91,7 @@ impl<'a> StyleVariableHolder<Cow<'a, str>> for Vec<FormatElement<'a>> {
         self.iter().fold(BTreeSet::new(), |mut acc, el| match el {
             FormatElement::TextGroup(textgroup) => {
                 acc.extend(textgroup.style.get_style_variables());
+                acc.extend(textgroup.format.get_style_variables());
                 acc
             }
             FormatElement::Conditional(format) => {

--- a/src/formatter/string_formatter.rs
+++ b/src/formatter/string_formatter.rs
@@ -570,6 +570,30 @@ mod tests {
     }
 
     #[test]
+    fn test_style_variable_nested() {
+        const STYLE_VAR_NAME: &str = "style";
+
+        let format_string = format!("[[text](${STYLE_VAR_NAME})](blue)");
+        let inner_style = Some(Color::Red.bold());
+
+        let formatter = StringFormatter::new(&format_string)
+            .unwrap()
+            .map_style(|variable| match variable {
+                STYLE_VAR_NAME => Some(Ok("red bold".to_owned())),
+                _ => None,
+            });
+
+        assert_eq!(
+            BTreeSet::from([STYLE_VAR_NAME.into()]),
+            formatter.get_style_variables()
+        );
+
+        let result = formatter.parse(None, None).unwrap();
+        let mut result_iter = result.iter();
+        match_next!(result_iter, "text", inner_style);
+    }
+
+    #[test]
     fn test_styled_variable_as_text() {
         const FORMAT_STR: &str = "[$var](red bold)";
         let var_style = Some(Color::Red.bold());


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

Current logic used to identify style variables in the `StringFormatter` does not descend into nested `TextGroup`s causing improper style formats when style variables are used in nested contexts. This change trivially fixes that.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #4327

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
