### PR TITLE
feat(memory_usage): add config option to enable displaying used/total fractions with single unit suffix

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -956,6 +956,7 @@
       "default": {
         "disabled": true,
         "format": "via $symbol[$ram( | $swap)]($style) ",
+        "single_unit_fractions": false,
         "style": "white bold dimmed",
         "symbol": "🐏 ",
         "threshold": 75
@@ -4074,6 +4075,10 @@
         },
         "disabled": {
           "default": true,
+          "type": "boolean"
+        },
+        "single_unit_fractions": {
+          "default": false,
           "type": "boolean"
         }
       },

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2620,13 +2620,14 @@ To enable it, set `disabled` to `false` in your configuration file.
 
 ### Options
 
-| Option      | Default                                        | Description                                              |
-| ----------- | ---------------------------------------------- | -------------------------------------------------------- |
-| `threshold` | `75`                                           | Hide the memory usage unless it exceeds this percentage. |
-| `format`    | `'via $symbol [${ram}( \| ${swap})]($style) '` | The format for the module.                               |
-| `symbol`    | `'🐏'`                                         | The symbol used before displaying the memory usage.      |
-| `style`     | `'bold dimmed white'`                          | The style for the module.                                |
-| `disabled`  | `true`                                         | Disables the `memory_usage` module.                      |
+| Option                  | Default                                        | Description                                                      |
+| ----------------------- | ---------------------------------------------- | ---------------------------------------------------------------- |
+| `threshold`             | `75`                                           | Hide the memory usage unless it exceeds this percentage.         |
+| `format`                | `'via $symbol [${ram}( \| ${swap})]($style) '` | The format for the module.                                       |
+| `symbol`                | `'🐏'`                                         | The symbol used before displaying the memory usage.              |
+| `style`                 | `'bold dimmed white'`                          | The style for the module.                                        |
+| `disabled`              | `true`                                         | Disables the `memory_usage` module.                              |
+| `single_unit_fractions` | `false`                                        | Represents fractions using single units when possible (`1/1GB`). |
 
 ### Variables
 

--- a/src/configs/memory_usage.rs
+++ b/src/configs/memory_usage.rs
@@ -13,6 +13,7 @@ pub struct MemoryConfig<'a> {
     pub style: &'a str,
     pub symbol: &'a str,
     pub disabled: bool,
+    pub single_unit_fractions: bool,
 }
 
 impl<'a> Default for MemoryConfig<'a> {
@@ -23,6 +24,7 @@ impl<'a> Default for MemoryConfig<'a> {
             style: "white bold dimmed",
             symbol: "🐏 ",
             disabled: true,
+            single_unit_fractions: false,
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Adds a config option, `single_unit_fractions`, for the `memory_usage` module so that users can enable a more succinct display for used/total fractions.

Given 16GiB total memory and 8GiB used memory:
`single_unit_fractions = disabled`: `8GiB/16GiB`
`single_unit_fractions = enabled`: `8/16GiB`

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #4789 

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
