### PR TITLE
fix(snap): Update snapcraft.yaml to add personal-files interface

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -80,6 +80,7 @@ apps:
     plugs:
       - home
       - removable-media
+      - personal-files
 
 architectures:
   - build-on: amd64


### PR DESCRIPTION
#### Description
<!--- Describe your changes in detail -->
Add the [personal-files](https://forum.snapcraft.io/t/the-personal-files-interface/9357) interface to `snapcraft.yaml` so `starship` can access `$HOME/.config/`

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Documentation currently says to put config in `$HOME/.config` but this breaks with snap, and has to be put into `$HOME/snap/starship/`. This fixes that.

Closes #4987

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

This has not been tested since it's just a snap distribution change to `snapcraft.yaml` and not a change to the application itself.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.

I don't believe these are applicable.