### PR TITLE
fix(presets): Added ($style) to format in module 'sudo' in Bracketed Segments Preset

### DIFF
--- a/docs/.vuepress/public/presets/toml/bracketed-segments.toml
+++ b/docs/.vuepress/public/presets/toml/bracketed-segments.toml
@@ -164,7 +164,7 @@ format = '\[[$symbol($version)]($style)\]'
 format = '\[[$symbol$environment]($style)\]'
 
 [sudo]
-format = '\[[as $symbol($style)]\]'
+format = '\[[as $symbol]($style)\]'
 
 [swift]
 format = '\[[$symbol($version)]($style)\]'

--- a/docs/.vuepress/public/presets/toml/bracketed-segments.toml
+++ b/docs/.vuepress/public/presets/toml/bracketed-segments.toml
@@ -164,7 +164,7 @@ format = '\[[$symbol($version)]($style)\]'
 format = '\[[$symbol$environment]($style)\]'
 
 [sudo]
-format = '\[[as $symbol]\]'
+format = '\[[as $symbol($style)]\]'
 
 [swift]
 format = '\[[$symbol($version)]($style)\]'


### PR DESCRIPTION
#### Description
There was no ($style) in format for module `sudo`. I added it. 

#### Motivation and Context
`sudo` module is not working by default when Bracketed Segments preset used. 

#### Screenshots:
Before changes
<img width="892" alt="before changes" src="https://user-images.githubusercontent.com/74624554/234937595-87bc9ea4-c4ee-4e38-a3cd-5caafbf3512c.png">
After changes
<img width="892" alt="image" src="https://user-images.githubusercontent.com/74624554/234938395-425786d5-de6d-4c89-9fa8-eb778307d98d.png">

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
