### PR TITLE
fix: shift to nerd font v3 codepoints

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -30,7 +30,7 @@
         "format": "on [$symbol($subscription)]($style) ",
         "style": "blue bold",
         "subscription_aliases": {},
-        "symbol": "ﴃ "
+        "symbol": " "
       },
       "allOf": [
         {
@@ -40,9 +40,9 @@
     },
     "battery": {
       "default": {
-        "charging_symbol": " ",
+        "charging_symbol": "󰂄 ",
         "disabled": false,
-        "discharging_symbol": " ",
+        "discharging_symbol": "󰂃 ",
         "display": [
           {
             "charging_symbol": null,
@@ -51,10 +51,10 @@
             "threshold": 10
           }
         ],
-        "empty_symbol": " ",
+        "empty_symbol": "󰂎 ",
         "format": "[$symbol$percentage]($style) ",
-        "full_symbol": " ",
-        "unknown_symbol": " "
+        "full_symbol": "󰁹 ",
+        "unknown_symbol": "󰁽 "
       },
       "allOf": [
         {
@@ -1863,7 +1863,7 @@
           "type": "string"
         },
         "symbol": {
-          "default": "ﴃ ",
+          "default": " ",
           "type": "string"
         },
         "style": {
@@ -1888,23 +1888,23 @@
       "type": "object",
       "properties": {
         "full_symbol": {
-          "default": " ",
+          "default": "󰁹 ",
           "type": "string"
         },
         "charging_symbol": {
-          "default": " ",
+          "default": "󰂄 ",
           "type": "string"
         },
         "discharging_symbol": {
-          "default": " ",
+          "default": "󰂃 ",
           "type": "string"
         },
         "unknown_symbol": {
-          "default": " ",
+          "default": "󰁽 ",
           "type": "string"
         },
         "empty_symbol": {
-          "default": " ",
+          "default": "󰂎 ",
           "type": "string"
         },
         "display": {

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -452,7 +452,7 @@ The `azure` module shows the current Azure Subscription. This is based on showin
 | Variable               | Default                                  | Description                                                                           |
 | ---------------------- | ---------------------------------------- | ------------------------------------------------------------------------------------- |
 | `format`               | `'on [$symbol($subscription)]($style) '` | The format for the Azure module to render.                                            |
-| `symbol`               | `'ﴃ '`                                   | The symbol used in the format.                                                        |
+| `symbol`               | `' '`                                   | The symbol used in the format.                                                        |
 | `style`                | `'blue bold'`                            | The style used in the format.                                                         |
 | `disabled`             | `true`                                   | Disables the `azure` module.                                                          |
 | `subscription_aliases` | `{}`                                     | Table of subscription name aliases to display in addition to Azure subscription name. |
@@ -467,7 +467,7 @@ The `azure` module shows the current Azure Subscription. This is based on showin
 [azure]
 disabled = false
 format = 'on [$symbol($subscription)]($style) '
-symbol = 'ﴃ '
+symbol = ' '
 style = 'blue bold'
 ```
 
@@ -479,7 +479,7 @@ style = 'blue bold'
 [azure]
 disabled = false
 format = "on [$symbol($username)]($style) "
-symbol = "ﴃ "
+symbol = " "
 style = "blue bold"
 ```
 
@@ -501,11 +501,11 @@ The module is only visible when the device's battery is below 10%.
 
 | Option               | Default                           | Description                                         |
 | -------------------- | --------------------------------- | --------------------------------------------------- |
-| `full_symbol`        | `' '`                            | The symbol shown when the battery is full.          |
-| `charging_symbol`    | `' '`                            | The symbol shown when the battery is charging.      |
-| `discharging_symbol` | `' '`                            | The symbol shown when the battery is discharging.   |
-| `unknown_symbol`     | `' '`                            | The symbol shown when the battery state is unknown. |
-| `empty_symbol`       | `' '`                            | The symbol shown when the battery state is empty.   |
+| `full_symbol`        | `'󰁹 '`                            | The symbol shown when the battery is full.          |
+| `charging_symbol`    | `'󰂄 '`                            | The symbol shown when the battery is charging.      |
+| `discharging_symbol` | `'󰂃 '`                            | The symbol shown when the battery is discharging.   |
+| `unknown_symbol`     | `'󰁽 '`                            | The symbol shown when the battery state is unknown. |
+| `empty_symbol`       | `'󰂎 '`                            | The symbol shown when the battery state is empty.   |
 | `format`             | `'[$symbol$percentage]($style) '` | The format for the module.                          |
 | `display`            | [link](#battery-display)          | Display threshold and style for the module.         |
 | `disabled`           | `false`                           | Disables the `battery` module.                      |
@@ -3741,7 +3741,7 @@ To enable it, set `disabled` to `false` in your configuration file.
 # ~/.config/starship.toml
 
 [shell]
-fish_indicator = ''
+fish_indicator = '󰈺'
 powershell_indicator = '_'
 unknown_indicator = 'mystery shell'
 style = 'cyan bold'

--- a/src/configs/azure.rs
+++ b/src/configs/azure.rs
@@ -20,7 +20,7 @@ impl<'a> Default for AzureConfig<'a> {
     fn default() -> Self {
         AzureConfig {
             format: "on [$symbol($subscription)]($style) ",
-            symbol: "ﴃ ",
+            symbol: " ",
             style: "blue bold",
             disabled: true,
             subscription_aliases: HashMap::new(),

--- a/src/configs/battery.rs
+++ b/src/configs/battery.rs
@@ -22,11 +22,11 @@ pub struct BatteryConfig<'a> {
 impl<'a> Default for BatteryConfig<'a> {
     fn default() -> Self {
         BatteryConfig {
-            full_symbol: " ",
-            charging_symbol: " ",
-            discharging_symbol: " ",
-            unknown_symbol: " ",
-            empty_symbol: " ",
+            full_symbol: "󰁹 ",
+            charging_symbol: "󰂄 ",
+            discharging_symbol: "󰂃 ",
+            unknown_symbol: "󰁽 ",
+            empty_symbol: "󰂎 ",
             format: "[$symbol$percentage]($style) ",
             display: vec![BatteryDisplayConfig::default()],
             disabled: false,

--- a/src/modules/azure.rs
+++ b/src/modules/azure.rs
@@ -196,7 +196,7 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "on {} ",
-            Color::Blue.bold().paint("ﴃ Subscription 1")
+            Color::Blue.bold().paint(" Subscription 1")
         ));
         assert_eq!(actual, expected);
         dir.close()
@@ -267,7 +267,7 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "on {}",
-            Color::Blue.bold().paint("ﴃ user@domain.com")
+            Color::Blue.bold().paint(" user@domain.com")
         ));
         assert_eq!(actual, expected);
         dir.close()
@@ -338,7 +338,7 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "on {}",
-            Color::Blue.bold().paint("ﴃ :user@domain.com")
+            Color::Blue.bold().paint(" :user@domain.com")
         ));
         assert_eq!(actual, expected);
         dir.close()
@@ -409,7 +409,7 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "on {}",
-            Color::Blue.bold().paint("ﴃ Subscription 1:")
+            Color::Blue.bold().paint(" Subscription 1:")
         ));
         assert_eq!(actual, expected);
         dir.close()
@@ -614,7 +614,7 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "on {}",
-            Color::Blue.bold().paint("ﴃ Subscription 1:user@domain.com")
+            Color::Blue.bold().paint(" Subscription 1:user@domain.com")
         ));
         assert_eq!(actual, expected);
         dir.close()
@@ -689,7 +689,7 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "on {}",
-            Color::Blue.bold().paint("ﴃ tllsn:user@domain.com")
+            Color::Blue.bold().paint(" tllsn:user@domain.com")
         ));
         assert_eq!(actual, expected);
         dir.close()

--- a/src/modules/battery.rs
+++ b/src/modules/battery.rs
@@ -234,7 +234,7 @@ mod tests {
             })
             .battery_info_provider(&mock)
             .collect();
-        let expected = Some(String::from(" 100% "));
+        let expected = Some(String::from("󰁹 100% "));
 
         assert_eq!(expected, actual);
     }
@@ -259,7 +259,7 @@ mod tests {
             })
             .battery_info_provider(&mock)
             .collect();
-        let expected = Some(String::from(" 80% "));
+        let expected = Some(String::from("󰂄 80% "));
 
         assert_eq!(expected, actual);
     }
@@ -284,7 +284,7 @@ mod tests {
             })
             .battery_info_provider(&mock)
             .collect();
-        let expected = Some(String::from(" 80% "));
+        let expected = Some(String::from("󰂃 80% "));
 
         assert_eq!(expected, actual);
     }
@@ -309,7 +309,7 @@ mod tests {
             })
             .battery_info_provider(&mock)
             .collect();
-        let expected = Some(String::from(" 0% "));
+        let expected = Some(String::from("󰁽 0% "));
 
         assert_eq!(expected, actual);
     }
@@ -334,7 +334,7 @@ mod tests {
             })
             .battery_info_provider(&mock)
             .collect();
-        let expected = Some(String::from(" 0% "));
+        let expected = Some(String::from("󰂎 0% "));
 
         assert_eq!(expected, actual);
     }
@@ -384,7 +384,7 @@ mod tests {
             })
             .battery_info_provider(&mock)
             .collect();
-        let expected = Some(format!("{} ", Color::Red.bold().paint(" 40%")));
+        let expected = Some(format!("{} ", Color::Red.bold().paint("󰂃 40%")));
 
         assert_eq!(expected, actual);
     }
@@ -409,7 +409,7 @@ mod tests {
             })
             .battery_info_provider(&mock)
             .collect();
-        let expected = Some(String::from(" 13% "));
+        let expected = Some(String::from("󰂃 13% "));
 
         assert_eq!(expected, actual);
     }

--- a/src/modules/os.rs
+++ b/src/modules/os.rs
@@ -189,10 +189,10 @@ mod tests {
             EndeavourOS = " "
             Fedora = " "
             FreeBSD = " "
-            Garuda = "﯑ "
+            Garuda = "󰛓 "
             Gentoo = " "
-            HardenedBSD = "ﲊ "
-            Illumos = " "
+            HardenedBSD = "󰞌 "
+            Illumos = "󰈸 "
             Linux = " "
             Macos = " "
             Manjaro = " "
@@ -201,19 +201,19 @@ mod tests {
             Mint = " "
             NetBSD = " "
             NixOS = " "
-            OpenBSD = " "
+            OpenBSD = "󰈺 "
             SUSE = " "
-            OracleLinux = " "
+            OracleLinux = "󰌷 "
             Pop = " "
             Raspbian = " "
             Redhat = " "
             RedHatEnterprise = " "
-            Redox = " "
-            Solus = "ﴱ "
+            Redox = "󰀘 "
+            Solus = "󰠳 "
             openSUSE = " "
             Ubuntu = " "
             Unknown = " "
-            Windows = " "
+            Windows = "󰍲 "
         };
 
         let config = OSConfig::load(&config_toml);
@@ -230,10 +230,10 @@ mod tests {
             (Type::EndeavourOS, Some(" ")),
             (Type::Fedora, Some(" ")),
             (Type::FreeBSD, Some(" ")),
-            (Type::Garuda, Some("﯑ ")),
+            (Type::Garuda, Some("󰛓 ")),
             (Type::Gentoo, Some(" ")),
-            (Type::HardenedBSD, Some("ﲊ ")),
-            (Type::Illumos, Some(" ")),
+            (Type::HardenedBSD, Some("󰞌 ")),
+            (Type::Illumos, Some("󰈸 ")),
             (Type::Linux, Some(" ")),
             (Type::Macos, Some(" ")),
             (Type::Manjaro, Some(" ")),
@@ -242,19 +242,19 @@ mod tests {
             (Type::Mint, Some(" ")),
             (Type::NetBSD, Some(" ")),
             (Type::NixOS, Some(" ")),
-            (Type::OpenBSD, Some(" ")),
+            (Type::OpenBSD, Some("󰈺 ")),
             (Type::SUSE, Some(" ")),
-            (Type::OracleLinux, Some(" ")),
+            (Type::OracleLinux, Some("󰌷 ")),
             (Type::Pop, Some(" ")),
             (Type::Raspbian, Some(" ")),
             (Type::Redhat, Some(" ")),
             (Type::RedHatEnterprise, Some(" ")),
-            (Type::Redox, Some(" ")),
-            (Type::Solus, Some("ﴱ ")),
+            (Type::Redox, Some("󰀘 ")),
+            (Type::Solus, Some("󰠳 ")),
             (Type::openSUSE, Some(" ")),
             (Type::Ubuntu, Some(" ")),
             (Type::Unknown, Some(" ")),
-            (Type::Windows, Some(" ")),
+            (Type::Windows, Some("󰍲 ")),
         ];
 
         for (t, e) in type_expected_pairs {


### PR DESCRIPTION
Why?
Since Nerd Fonts v2.3.3 more than 2,000 codepoints / icons were deprecated because they incorrectly used non-latin letters.

How?
Use [nerdfix](https://github.com/loichyan/nerdfix) to update the icons / codepoints accordingly.

Closes #5161

- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
