### PR TITLE
feat(gcloud): add `detect_env_vars` option

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -522,11 +522,11 @@
     },
     "gcloud": {
       "default": {
+        "detect_env_vars": [],
         "disabled": false,
         "format": "on [$symbol$account(@$domain)(\\($region\\))]($style) ",
         "project_aliases": {},
         "region_aliases": {},
-        "detect_env_vars": [],
         "style": "bold blue",
         "symbol": "☁️  "
       },

--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -526,6 +526,7 @@
         "format": "on [$symbol$account(@$domain)(\\($region\\))]($style) ",
         "project_aliases": {},
         "region_aliases": {},
+        "detect_env_vars": [],
         "style": "bold blue",
         "symbol": "☁️  "
       },
@@ -3095,6 +3096,13 @@
           "default": {},
           "type": "object",
           "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "detect_env_vars": {
+          "default": [],
+          "type": "array",
+          "items": {
             "type": "string"
           }
         }

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1609,6 +1609,10 @@ truncation_symbol = ''
 The `gcloud` module shows the current configuration for [`gcloud`](https://cloud.google.com/sdk/gcloud) CLI.
 This is based on the `~/.config/gcloud/active_config` file and the `~/.config/gcloud/configurations/config_{CONFIG NAME}` file and the `CLOUDSDK_CONFIG` env var.
 
+When the module is enabled it will always be active, unless `detect_env_vars` has
+been set in which case the module will only be active be active when one of the
+environment variables has been set.
+
 ### Options
 
 | Option            | Default                                                  | Description                                                      |
@@ -1617,6 +1621,7 @@ This is based on the `~/.config/gcloud/active_config` file and the `~/.config/gc
 | `symbol`          | `'☁️  '`                                                  | The symbol used before displaying the current GCP profile.       |
 | `region_aliases`  | `{}`                                                     | Table of region aliases to display in addition to the GCP name.  |
 | `project_aliases` | `{}`                                                     | Table of project aliases to display in addition to the GCP name. |
+| `detect_env_vars` | `[]`                                                     | Which environmental variables should trigger this module         |
 | `style`           | `'bold blue'`                                            | The style for the module.                                        |
 | `disabled`        | `false`                                                  | Disables the `gcloud` module.                                    |
 

--- a/src/configs/gcloud.rs
+++ b/src/configs/gcloud.rs
@@ -15,6 +15,7 @@ pub struct GcloudConfig<'a> {
     pub disabled: bool,
     pub region_aliases: HashMap<String, &'a str>,
     pub project_aliases: HashMap<String, &'a str>,
+    pub detect_env_vars: Vec<&'a str>,
 }
 
 impl<'a> Default for GcloudConfig<'a> {
@@ -26,6 +27,7 @@ impl<'a> Default for GcloudConfig<'a> {
             disabled: false,
             region_aliases: HashMap::new(),
             project_aliases: HashMap::new(),
+            detect_env_vars: vec![],
         }
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -235,6 +235,10 @@ impl<'a> Context<'a> {
         disabled == Some(true)
     }
 
+    pub fn detect_env_vars(&'a self, env_vars: &'a [&'a str]) -> bool {
+        env_vars.is_empty() || (env_vars.iter().any(|e| self.get_env(e).is_some()))
+    }
+
     // returns a new ScanDir struct with reference to current dir_files of context
     // see ScanDir for methods
     pub fn try_begin_scan(&'a self) -> Option<ScanDir<'a>> {


### PR DESCRIPTION
#### Description
This implements a `detect_env_vars` feature to allow flexibly disabling the `gcloud` module, following the discussion in #2671 . 


Closes: #2671

#### How Has This Been Tested?
- [X] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [X] I have updated the documentation accordingly.
- [X] I have updated the tests accordingly.
