### PR TITLE
feat(aws): support aws sso with automatic authentication refresh

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -356,7 +356,7 @@ format = '$all$directory$character'
 The `aws` module shows the current AWS region and profile and an expiration timer when using temporary credentials.
 The output of the module uses the `AWS_REGION`, `AWS_DEFAULT_REGION`, and `AWS_PROFILE` env vars and the `~/.aws/config` and `~/.aws/credentials` files as required.
 
-The module will display a profile only if its credentials are present in `~/.aws/credentials` or if a `credential_process` or `sso_start_url` are defined in `~/.aws/config`. Alternatively, having any of the `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, or `AWS_SESSION_TOKEN` env vars defined will also suffice.
+The module will display a profile only if its credentials are present in `~/.aws/credentials` or if a `credential_process`, `sso_start_url`, or `sso_session` are defined in `~/.aws/config`. Alternatively, having any of the `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, or `AWS_SESSION_TOKEN` env vars defined will also suffice.
 If the option `force_display` is set to `true`, all available information will be displayed even if no credentials per the conditions above are detected.
 
 When using [aws-vault](https://github.com/99designs/aws-vault) the profile


### PR DESCRIPTION
#### Description
Currently, starship only supports AWS SSO with [legacy non-refreshable configuration](https://docs.aws.amazon.com/cli/latest/userguide/sso-configure-profile-legacy.html).

This PR adds a support for the newer and recommended configuration for AWS CLI to authenticate AWS SSO with [automatic authentication refresh](https://docs.aws.amazon.com/cli/latest/userguide/sso-configure-profile-token.html).

Example of the config file with refreshable token (taken from their [documentation](https://docs.aws.amazon.com/cli/latest/userguide/sso-configure-profile-token.html#sso-configure-profile-token-auto-sso)):
```
[profile my-dev-profile]
sso_session = my-sso
sso_account_id = 123456789011
sso_role_name = readOnly
region = us-west-2
output = json

[sso-session my-sso]
sso_region = us-east-1
sso_start_url = https://my-sso-portal.awsapps.com/start
sso_registration_scopes = sso:account:access
```
This PR also renames the test function name for the old SSO configuration to `sso_legacy_set()`

#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
