### PR TITLE
refactor: update the nushell init file and make it valid module and overlay

### DIFF
--- a/src/init/starship.nu
+++ b/src/init/starship.nu
@@ -1,6 +1,8 @@
 let-env STARSHIP_SHELL = "nu"
 let-env STARSHIP_SESSION_KEY = (random chars -l 16)
-let-env PROMPT_MULTILINE_INDICATOR = (^::STARSHIP:: prompt --continuation)
+let-env PROMPT_MULTILINE_INDICATOR = (
+    ^::STARSHIP:: prompt --continuation
+)
 
 # Does not play well with default character module.
 # TODO: Also Use starship vi mode indicators?
@@ -8,8 +10,12 @@ let-env PROMPT_INDICATOR = ""
 
 let-env PROMPT_COMMAND = { ||
     # jobs are not supported
-    let width = (term size).columns
-    ^::STARSHIP:: prompt $"--cmd-duration=($env.CMD_DURATION_MS)" $"--status=($env.LAST_EXIT_CODE)" $"--terminal-width=($width)"
+    (
+        ^::STARSHIP:: prompt
+            $"--cmd-duration=($env.CMD_DURATION_MS)"
+            $"--status=($env.LAST_EXIT_CODE)"
+            $"--terminal-width=((term size).columns)"
+    )
 }
 
 # Whether we have config items
@@ -22,6 +28,11 @@ let-env config = if $has_config_items {
 }
 
 let-env PROMPT_COMMAND_RIGHT = { ||
-    let width = (term size).columns
-    ^::STARSHIP:: prompt --right $"--cmd-duration=($env.CMD_DURATION_MS)" $"--status=($env.LAST_EXIT_CODE)" $"--terminal-width=($width)"
+    (
+        ^::STARSHIP:: prompt
+            --right
+            $"--cmd-duration=($env.CMD_DURATION_MS)"
+            $"--status=($env.LAST_EXIT_CODE)"
+            $"--terminal-width=((term size).columns)"
+    )
 }

--- a/src/init/starship.nu
+++ b/src/init/starship.nu
@@ -1,33 +1,35 @@
-let-env STARSHIP_SHELL = "nu"
-let-env STARSHIP_SESSION_KEY = (random chars -l 16)
-let-env PROMPT_MULTILINE_INDICATOR = (
-    ^::STARSHIP:: prompt --continuation
-)
-
-# Does not play well with default character module.
-# TODO: Also Use starship vi mode indicators?
-let-env PROMPT_INDICATOR = ""
-
-let-env PROMPT_COMMAND = {||
-    # jobs are not supported
-    (
-        ^::STARSHIP:: prompt
-            --cmd-duration $env.CMD_DURATION_MS
-            $"--status=($env.LAST_EXIT_CODE)"
-            --terminal-width (term size).columns
+export-env { load-env {
+    STARSHIP_SHELL: "nu"
+    STARSHIP_SESSION_KEY: (random chars -l 16)
+    PROMPT_MULTILINE_INDICATOR: (
+        ^::STARSHIP:: prompt --continuation
     )
-}
 
-let-env config = ($env.config? | default {} | merge {
-    render_right_prompt_on_last_line: true
-})
+    # Does not play well with default character module.
+    # TODO: Also Use starship vi mode indicators?
+    PROMPT_INDICATOR: ""
 
-let-env PROMPT_COMMAND_RIGHT = {||
-    (
-        ^::STARSHIP:: prompt
-            --right
-            --cmd-duration $env.CMD_DURATION_MS
-            $"--status=($env.LAST_EXIT_CODE)"
-            --terminal-width (term size).columns
-    )
-}
+    PROMPT_COMMAND: {||
+        # jobs are not supported
+        (
+            ^::STARSHIP:: prompt
+                --cmd-duration $env.CMD_DURATION_MS
+                $"--status=($env.LAST_EXIT_CODE)"
+                --terminal-width (term size).columns
+        )
+    }
+
+    config: ($env.config? | default {} | merge {
+        render_right_prompt_on_last_line: true
+    })
+
+    PROMPT_COMMAND_RIGHT: {||
+        (
+            ^::STARSHIP:: prompt
+                --right
+                --cmd-duration $env.CMD_DURATION_MS
+                $"--status=($env.LAST_EXIT_CODE)"
+                --terminal-width (term size).columns
+        )
+    }
+}}

--- a/src/init/starship.nu
+++ b/src/init/starship.nu
@@ -18,14 +18,9 @@ let-env PROMPT_COMMAND = {||
     )
 }
 
-# Whether we have config items
-let has_config_items = (not ($env | get -i config | is-empty))
-
-let-env config = if $has_config_items {
-    $env.config | upsert render_right_prompt_on_last_line true
-} else {
-    {render_right_prompt_on_last_line: true}
-}
+let-env config = ($env.config? | default {} | merge {
+    render_right_prompt_on_last_line: true
+})
 
 let-env PROMPT_COMMAND_RIGHT = {||
     (

--- a/src/init/starship.nu
+++ b/src/init/starship.nu
@@ -8,7 +8,7 @@ let-env PROMPT_MULTILINE_INDICATOR = (
 # TODO: Also Use starship vi mode indicators?
 let-env PROMPT_INDICATOR = ""
 
-let-env PROMPT_COMMAND = { ||
+let-env PROMPT_COMMAND = {||
     # jobs are not supported
     (
         ^::STARSHIP:: prompt
@@ -27,7 +27,7 @@ let-env config = if $has_config_items {
     {render_right_prompt_on_last_line: true}
 }
 
-let-env PROMPT_COMMAND_RIGHT = { ||
+let-env PROMPT_COMMAND_RIGHT = {||
     (
         ^::STARSHIP:: prompt
             --right

--- a/src/init/starship.nu
+++ b/src/init/starship.nu
@@ -12,9 +12,9 @@ let-env PROMPT_COMMAND = {||
     # jobs are not supported
     (
         ^::STARSHIP:: prompt
-            $"--cmd-duration=($env.CMD_DURATION_MS)"
+            --cmd-duration $env.CMD_DURATION_MS
             $"--status=($env.LAST_EXIT_CODE)"
-            $"--terminal-width=((term size).columns)"
+            --terminal-width (term size).columns
     )
 }
 
@@ -31,8 +31,8 @@ let-env PROMPT_COMMAND_RIGHT = {||
     (
         ^::STARSHIP:: prompt
             --right
-            $"--cmd-duration=($env.CMD_DURATION_MS)"
+            --cmd-duration $env.CMD_DURATION_MS
             $"--status=($env.LAST_EXIT_CODE)"
-            $"--terminal-width=((term size).columns)"
+            --terminal-width (term size).columns
     )
 }


### PR DESCRIPTION
i've been using Nushell for quite some time now and started combining it with `starship` not so long a go :blush: 

i thought i could try to *improve* the init file generated by `starship init nu` to make it more aligned with the current feel of Nushell and the new features.

> **Note**
> i've tried to make the commits as atomic and clear as possible!
> they should be best reviewed one at a time :+1: 

#### Description
this PR 
- breaks the long commands into multiple lines for readability and maintainability
- fixes some of the format of commands and closures
- simplifies the `render_right_prompt_on_last_line` block with the new `?` syntax
- wrap all the `let-env`s in an `export-env { load-env { ... }}` block

the last item in the list above is particularily interesting for the following reason: **we are thinking of removing the `source` command from Nushell** :scream: 

with this PR, `init.nu` would be both a valid (1) script, (2) module and (3) overlay :muscle: 

> **Note**  
> in my config, i save the output of `starship init nu` as `starship.nu` and add the directory in which i save it to `NU_LIB_DIRS`, so that i can just `<cmd> starship.nu` without giving a path :ok_hand: 
> > see my [`env.nu`](https://github.com/goatfiles/dotfiles/blob/3e9b8c1/.config/nushell/env.nu#L190-L195)
> the following still applies by adding the path to the `init.nu` file :thumbsup: 
 
the last bullet point (and commit) allows, without any loss of features compared to before this PR, to
- `source starship.nu` as before
- `use starship.nu`
- `overlay use starship.nu` which is particularly nice for two reasons
    - we can see `starship` being activated in `overlay list`
    - we can `overlay hide starship` to get the default prompt temporarily and reactivate it once done with `overlay use starship` from the REPL of Nushell

#### Motivation and Context
i did not see any related issue nor PR, this is just an improvement attempt :wink: 

#### Screenshots (if appropriate):
```
$nothing
```
this should not affect the look and feel of the prompt at all :relieved: 

#### How Has This Been Tested?
i've just
```
cargo install --path /path/to/amtoine/starship
```
and noticed it did not change the look and feel of the prompt as expected.
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly. (the functionality of `init.nu` should not have changed at all)
