### PR TITLE
refactor: simplify `shadow-rs` setup in `build.rs`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -4,7 +4,6 @@ use std::io::Write;
 use shadow_rs::SdResult;
 
 fn main() -> SdResult<()> {
-    shadow_rs::new().map_err(|err| err.to_string())?;
     shadow_rs::new_hook(gen_presets_hook)?;
 
     #[cfg(windows)]


### PR DESCRIPTION
#### Description
the shadow_rs [new function](https://github.com/baoyachi/shadow-rs/blob/618e28af4d/src/lib.rs#L222-L225) vs [new_hook function](https://github.com/baoyachi/shadow-rs/blob/618e28af4d/src/lib.rs#L271-L276) is similar, but the difference is that `new_hook` function exposes file handles for external use. So, if use `new_hook` function, can remove the `new` function.