### PR TITLE
Add godot module

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -630,6 +630,25 @@
         }
       ]
     },
+    "godot": {
+      "default": {
+        "disabled": false,
+        "format": "via [$symbol($version )]($style)",
+        "show_version": false,
+        "style": "bold blue",
+        "symbol": "godot ",
+        "version_command": [
+          "godot",
+          "--version"
+        ],
+        "version_format": "v${raw}"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/GodotConfig"
+        }
+      ]
+    },
     "golang": {
       "default": {
         "detect_extensions": [
@@ -3346,6 +3365,46 @@
             "string",
             "null"
           ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "GodotConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "via [$symbol($version )]($style)",
+          "type": "string"
+        },
+        "version_format": {
+          "default": "v${raw}",
+          "type": "string"
+        },
+        "style": {
+          "default": "bold blue",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "godot ",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "show_version": {
+          "default": false,
+          "type": "boolean"
+        },
+        "version_command": {
+          "default": [
+            "godot",
+            "--version"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       },
       "additionalProperties": false

--- a/docs/.vuepress/public/presets/toml/bracketed-segments.toml
+++ b/docs/.vuepress/public/presets/toml/bracketed-segments.toml
@@ -61,6 +61,9 @@ format = '\[[$symbol$branch]($style)\]'
 [git_status]
 format = '([\[$all_status$ahead_behind\]]($style))'
 
+[godot]
+format = '\[[$symbol($version)]($style)\]'
+
 [golang]
 format = '\[[$symbol($version)]($style)\]'
 

--- a/docs/.vuepress/public/presets/toml/nerd-font-symbols.toml
+++ b/docs/.vuepress/public/presets/toml/nerd-font-symbols.toml
@@ -31,6 +31,9 @@ symbol = " "
 [git_branch]
 symbol = " "
 
+[godot]
+symbol = " "
+
 [golang]
 symbol = " "
 

--- a/docs/.vuepress/public/presets/toml/no-empty-icons.toml
+++ b/docs/.vuepress/public/presets/toml/no-empty-icons.toml
@@ -40,6 +40,9 @@ format = '(via [$symbol($version )]($style))'
 [fennel]
 format = '(via [$symbol($version )]($style))'
 
+[godot]
+format = '(via [$symbol($version )]($style))'
+
 [golang]
 format = '(via [$symbol($version )]($style))'
 

--- a/docs/.vuepress/public/presets/toml/no-runtime-versions.toml
+++ b/docs/.vuepress/public/presets/toml/no-runtime-versions.toml
@@ -37,6 +37,9 @@ format = 'via [$symbol]($style)'
 [fennel]
 format = 'via [$symbol]($style)'
 
+[godot]
+format = 'via [$symbol]($style)'
+
 [golang]
 format = 'via [$symbol]($style)'
 

--- a/docs/.vuepress/public/presets/toml/plain-text-symbols.toml
+++ b/docs/.vuepress/public/presets/toml/plain-text-symbols.toml
@@ -73,6 +73,9 @@ symbol = "gcp "
 [git_branch]
 symbol = "git "
 
+[godot]
+symbol = "godot "
+
 [golang]
 symbol = "go "
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -286,6 +286,7 @@ $elixir\
 $elm\
 $erlang\
 $fennel\
+$godot\
 $golang\
 $guix_shell\
 $haskell\
@@ -2011,6 +2012,42 @@ format = 'via [🏎💨 $version](bold cyan) '
 
 [golang]
 format = 'via [$symbol($version )($mod_version )]($style)'
+```
+
+## Godot
+
+The `godot` module tells whether the current directory is in a [Godot](https://godotengine.org/) project by looking for a `project.godot` file in the current directory or any ancestor. This module can optionally display the version of a godot installation on your system.
+
+### Options
+
+| Option            | Default                              | Description                                                                |
+| ----------------- | ------------------------------------ | -------------------------------------------------------------------------- |
+| `format`          | `'via [$symbol($version )]($style)'` | The format for the module.                                                 |
+| `version_format`  | `'v${raw}'`                          | The version format. Available vars are `raw`, `major`, `minor`, & `patch`. |
+| `symbol`          | `'godot '`                           | A format string representing the symbol of godot.                          |
+| `style`           | `'bold blue'`                        | The style for the module.                                                  |
+| `show_version`    | `false`                              | Whether or not to show the godot version.                                  |
+| `version_command` | `['godot', '--version']`             | Command to get godot version from.                                         |
+| `disabled`        | `false`                              | Disables the `godot` module.                                               |
+
+### Variables
+
+| Variable | Example  | Description                          |
+| -------- | -------- | ------------------------------------ |
+| version  | `v4.0.3` | The version of `godot`               |
+| symbol   |          | Mirrors the value of option `symbol` |
+| style\*  |          | Mirrors the value of option `style`  |
+
+*: This variable can only be used as a part of a style string
+
+### Example
+
+```toml
+# ~/.config/starship.toml
+
+[godot]
+show_version = true
+version_command = ['/path/to/godot_custom', '--version']
 ```
 
 ## Guix-shell

--- a/src/configs/godot.rs
+++ b/src/configs/godot.rs
@@ -1,0 +1,32 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(
+    feature = "config-schema",
+    derive(schemars::JsonSchema),
+    schemars(deny_unknown_fields)
+)]
+#[serde(default)]
+pub struct GodotConfig<'a> {
+    pub format: &'a str,
+    pub version_format: &'a str,
+    pub style: &'a str,
+    pub symbol: &'a str,
+    pub disabled: bool,
+    pub show_version: bool,
+    pub version_command: Vec<&'a str>,
+}
+
+impl<'a> Default for GodotConfig<'a> {
+    fn default() -> Self {
+        GodotConfig {
+            format: "via [$symbol($version )]($style)",
+            version_format: "v${raw}",
+            style: "bold blue",
+            symbol: "godot ",
+            disabled: false,
+            show_version: false,
+            version_command: vec!["godot", "--version"],
+        }
+    }
+}

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -35,6 +35,7 @@ pub mod git_metrics;
 pub mod git_state;
 pub mod git_status;
 pub mod go;
+pub mod godot;
 pub mod gradle;
 pub mod guix_shell;
 pub mod haskell;
@@ -170,6 +171,8 @@ pub struct FullConfig<'a> {
     git_state: git_state::GitStateConfig<'a>,
     #[serde(borrow)]
     git_status: git_status::GitStatusConfig<'a>,
+    #[serde(borrow)]
+    godot: godot::GodotConfig<'a>,
     #[serde(borrow)]
     golang: go::GoConfig<'a>,
     #[serde(borrow)]

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -62,6 +62,7 @@ pub const PROMPT_ORDER: &[&str] = &[
     "elm",
     "erlang",
     "fennel",
+    "godot",
     "golang",
     "gradle",
     "haskell",

--- a/src/module.rs
+++ b/src/module.rs
@@ -41,6 +41,7 @@ pub const ALL_MODULES: &[&str] = &[
     "git_metrics",
     "git_state",
     "git_status",
+    "godot",
     "golang",
     "gradle",
     "guix_shell",

--- a/src/modules/godot.rs
+++ b/src/modules/godot.rs
@@ -1,0 +1,192 @@
+use crate::configs::godot::GodotConfig;
+
+use super::{Context, Module};
+
+/// Creates a module that tells if the current directory is in a Godot project.
+pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    use super::ModuleConfig;
+    use crate::formatter::StringFormatter;
+    use crate::formatter::VersionFormatter;
+
+    let godot_project_root = context
+        .begin_ancestor_scan()
+        .set_files(&["project.godot"])
+        .scan();
+    godot_project_root?;
+
+    let mut module = context.new_module("godot");
+    let config: GodotConfig = GodotConfig::try_load(module.config);
+
+    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
+        formatter
+            .map_meta(|variable, _| match variable {
+                "symbol" => Some(config.symbol),
+                _ => None,
+            })
+            .map_style(|variable| match variable {
+                "style" => Some(Ok(config.style)),
+                _ => None,
+            })
+            .map(|variable| match variable {
+                "version" => match config.show_version {
+                    true => {
+                        let version_string = get_godot_version(context, &config)?;
+                        VersionFormatter::format_module_version(
+                            module.get_name(),
+                            &version_string,
+                            config.version_format,
+                        )
+                        .map(Ok)
+                    }
+                    false => None,
+                },
+                _ => None,
+            })
+            .parse(None, Some(context))
+    });
+
+    module.set_segments(match parsed {
+        Ok(segments) => segments,
+        Err(error) => {
+            log::warn!("Error in module `godot`:\n{}", error);
+            return None;
+        }
+    });
+
+    Some(module)
+}
+
+/// Gets the godot version using the configured command.
+fn get_godot_version(context: &Context, config: &GodotConfig) -> Option<String> {
+    let version_output = context
+        .exec_cmd(config.version_command[0], &config.version_command[1..])?
+        .stdout;
+    let version_vec: Vec<&str> = version_output
+        .split('.')
+        .take(3)
+        .take_while(|substring| substring.parse::<u64>().is_ok())
+        .collect();
+    if version_vec.len() < 3 {
+        return None;
+    }
+    Some(version_vec.join("."))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{test::ModuleRenderer, utils::CommandOutput};
+    use nu_ansi_term::Color;
+    use std::fs::{create_dir_all, File};
+    use std::io;
+
+    #[test]
+    fn folder_without_godot_file() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+
+        let actual = ModuleRenderer::new("godot").path(dir.path()).collect();
+
+        let expected = None;
+
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn folder_with_godot_file_in_current_directory() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join("project.godot"))?.sync_all()?;
+
+        let actual = ModuleRenderer::new("godot").path(dir.path()).collect();
+
+        let expected = Some(format!("via {}", Color::Blue.bold().paint("godot ")));
+
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn folder_with_godot_file_in_ancestor() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join("project.godot"))?.sync_all()?;
+        let current_dir = dir.path().join("some/child/folders");
+        create_dir_all(&current_dir)?;
+
+        let actual = ModuleRenderer::new("godot").path(current_dir).collect();
+
+        let expected = Some(format!("via {}", Color::Blue.bold().paint("godot ")));
+
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn showing_version() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join("project.godot"))?.sync_all()?;
+
+        let actual = ModuleRenderer::new("godot")
+            .path(dir.path())
+            .config(toml::toml! {
+                [godot]
+                show_version = true
+            })
+            .collect();
+
+        let expected = Some(format!("via {}", Color::Blue.bold().paint("godot v4.0.3 ")));
+
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn version_command_gives_too_few_numbers() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join("project.godot"))?.sync_all()?;
+
+        let actual = ModuleRenderer::new("godot")
+            .path(dir.path())
+            .config(toml::toml! {
+                [godot]
+                show_version = true
+            })
+            .cmd(
+                "godot --version",
+                Some(CommandOutput {
+                    stdout: String::from("4.0.not.numbers"),
+                    stderr: String::default(),
+                }),
+            )
+            .collect();
+
+        let expected = Some(format!("via {}", Color::Blue.bold().paint("godot ")));
+
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn version_command_gives_garbage_output() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join("project.godot"))?.sync_all()?;
+
+        let actual = ModuleRenderer::new("godot")
+            .path(dir.path())
+            .config(toml::toml! {
+                [godot]
+                show_version = true
+            })
+            .cmd(
+                "godot --version",
+                Some(CommandOutput {
+                    stdout: String::from("Garbage output that won't parse correctly."),
+                    stderr: String::default(),
+                }),
+            )
+            .collect();
+
+        let expected = Some(format!("via {}", Color::Blue.bold().paint("godot ")));
+
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+}

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -31,6 +31,7 @@ mod git_commit;
 mod git_metrics;
 mod git_state;
 mod git_status;
+mod godot;
 mod golang;
 mod gradle;
 mod guix_shell;
@@ -135,6 +136,7 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
             "git_metrics" => git_metrics::module(context),
             "git_state" => git_state::module(context),
             "git_status" => git_status::module(context),
+            "godot" => godot::module(context),
             "golang" => golang::module(context),
             "gradle" => gradle::module(context),
             "guix_shell" => guix_shell::module(context),
@@ -250,6 +252,7 @@ pub fn description(module: &str) -> &'static str {
         "git_metrics" => "The currently added/deleted lines in your repo",
         "git_state" => "The current git operation, and it's progress",
         "git_status" => "Symbol representing the state of the repo",
+        "godot" => "Signifies the presence of a Godot project and optionally the installed version of Godot",
         "golang" => "The currently installed version of Golang",
         "gradle" => "The currently installed version of Gradle",
         "guix_shell" => "The guix-shell environment",

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -265,6 +265,10 @@ Elixir 1.10 (compiled with Erlang/OTP 22)\n",
             stdout: String::from("go version go1.12.1 linux/amd64\n"),
             stderr: String::default(),
         }),
+        "godot --version" => Some(CommandOutput {
+            stdout: String::from("4.0.3.stable.official.5222a99f5\n"),
+            stderr: String::default(),
+        }),
         "ghc --numeric-version" => Some(CommandOutput {
             stdout: String::from("9.2.1\n"),
             stderr: String::default(),


### PR DESCRIPTION
The godot module tells whether or not the current directory is within a [Godot](https://godotengine.org/) project folder and optionally shows the version of a godot installation on the user's system.

#### Description

In order to check if the current directory is within a godot project folder, this module looks for the presence of a `project.godot` file in the current directory or one of its ancestors.

This module can also optionally show the version of a godot installation on the user's system, but this feature is disabled by default because it's not uncommon for godot to not be in the user's path, and the executable is not guaranteed to have a predictable name. The user can configure a custom command to get the version from.

#### Motivation and Context
Godot users may find this feature useful.

#### Screenshots (if appropriate):
![image](https://github.com/starship/starship/assets/3267627/50441b0b-052d-4078-b108-94948bcc35b1)

#### How Has This Been Tested?
I've tested this with the default configuration, as well as with a custom `version_command`. I've tested both inside and outside of a godot project folder.

- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
