### PR TITLE
fix(bash): Clear out completed jobs before counting NUM_JOBS

### DIFF
--- a/src/init/starship.bash
+++ b/src/init/starship.bash
@@ -37,6 +37,18 @@ starship_precmd() {
         STARSHIP_PIPE_STATUS=(${BP_PIPESTATUS[@]})
     fi
 
+    # Due to a bug in certain Bash versions, any external process launched
+    # inside $PROMPT_COMMAND will be reported by `jobs` as a background job:
+    #
+    #   [1]  42135 Done                    /bin/echo
+    #
+    # This is a workaround - we run `jobs` once to clear out any completed jobs
+    # first, and then we run it again and count the number of jobs.
+    #
+    # More context: https://github.com/starship/starship/issues/5159
+    # Original bug: https://lists.gnu.org/archive/html/bug-bash/2022-07/msg00117.html
+    jobs &>/dev/null
+
     local NUM_JOBS=0
     # Evaluate the number of jobs before running the preserved prompt command, so that tools
     # like z/autojump, which background certain jobs, do not cause spurious background jobs


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description

Fixes https://github.com/starship/starship/issues/5159

#### Motivation and Context

Due to a bug in certain Bash versions, any external process launched inside $PROMPT_COMMAND will be reported by `jobs` as a background job:

```bash
   [1]  42135 Done                    /bin/echo
```

This is a workaround - we run `jobs` once to clear out any completed jobs first, and then we run it again and count the number of jobs.

More context: https://github.com/starship/starship/issues/5159
Original bug: https://lists.gnu.org/archive/html/bug-bash/2022-07/msg00117.html

#### How Has This Been Tested?

- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:

- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
