### PR TITLE
docs: fix symbols in nerd-font-symbols preset

### DIFF
--- a/docs/.vuepress/public/presets/toml/nerd-font-symbols.toml
+++ b/docs/.vuepress/public/presets/toml/nerd-font-symbols.toml
@@ -41,7 +41,7 @@ symbol = " "
 symbol = " "
 
 [haxe]
-symbol = "⌘ "
+symbol = " "
 
 [hg_branch]
 symbol = " "
@@ -118,7 +118,7 @@ Windows = "󰍲 "
 symbol = "󰏗 "
 
 [pijul_channel]
-symbol = "🪺 "
+symbol = " "
 
 [python]
 symbol = " "
@@ -134,6 +134,3 @@ symbol = " "
 
 [scala]
 symbol = " "
-
-[spack]
-symbol = "🅢 "


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
Replace non-nerd-font symbols in the nerd-fonts-symbols preset.

Namely:
- Haxe is set to use the actual Haxe logo (was the mac option key symbol)
- Pijul is set to use the same branch symbol as the other VCSs (was bird nest emoji, even though the vanilla settings use regular branch symbol)
- Spack is removed from the preset since this is the default symbol (🅢)

#### Motivation and Context
Some symbols in the Nerd Font preset were not using symbols from the Nerd Font range.

#### Screenshots (if appropriate):

Screenshots of the new symbols if your browser can't display them:
![image](https://github.com/starship/starship/assets/4580066/1ce06a38-c0a9-4e5b-b662-68e8bb8ca427)
![image](https://github.com/starship/starship/assets/4580066/a6749be4-a287-4e17-b055-f1e00db3937e)


#### How Has This Been Tested?

I checked that this produces the correct symbols using the latest patched JetBrainMono Nerd Font. Should work the same on other OSs and not affect anything else.

- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

This should be no-op since no test or doc changes are necessary.
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.

