### PR TITLE
feat(separator): support adding separator line with full context width

### DIFF
--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -18,6 +18,8 @@ pub struct StarshipRootConfig {
     pub scan_timeout: u64,
     pub command_timeout: u64,
     pub add_newline: bool,
+    pub add_separator: bool,
+    pub separator_pattern: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub palette: Option<String>,
     pub palettes: HashMap<String, Palette>,
@@ -133,6 +135,8 @@ impl Default for StarshipRootConfig {
             scan_timeout: 30,
             command_timeout: 500,
             add_newline: true,
+            add_separator: false,
+            separator_pattern: "═".to_string(),
             palette: None,
             palettes: HashMap::default(),
         }


### PR DESCRIPTION
#### Description
Support adding separator line with full context width.

#### Motivation and Context
I'd like to have a clear visual way to separate each command and result in terminal, as shown in the screenshot, the config for the screen shot is:

```
add_newline = false
add_separator = true
```

You can also define `separator_pattern` in the config (type is String, will be repeated to fill the whole context width), note that the way to calculate the display size is assuming each character take only single char space (so wider unicode characters such as Chinese characters will have wrong size), since I don't know how to calculate unicode display size without using extra crates, and I don't think this is really needed for normal usages, so it's not a good idea to add an extra dependency.

#### Screenshots (if appropriate):
![image](https://github.com/starship/starship/assets/776215/379745df-ef4f-4ce8-bacd-788ba368a3be)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.

Haven't updated the documentation yet, not sure this is a useful feature to other people, or my implementation is in an acceptable way.