### PR TITLE
feat: support xdg-conformant config file location

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -8,13 +8,13 @@ To get started configuring starship, create one of the following file:
 mkdir -p ~/.config && touch ~/.config/starship.toml
 ```
 
-- `~/.config/starship/config.toml`
+- `~/.config/starship/config.toml` or `$XDG_CONFIG_HOME/starship/config.toml` if `$XDG_CONFIG_HOME` is set.
 
 ```sh
 mkdir -p ~/.config/starship && touch ~/.config/starship/config.toml
 ```
 
-Note: if you have both files available, the `starship.toml` will take higher priority.
+Note: if you have both files available, the `~/.config/starship.toml` will take higher priority.
 
 All configuration for starship is done in this [TOML](https://github.com/toml-lang/toml) file:
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1,10 +1,20 @@
 # Configuration
 
-To get started configuring starship, create the following file: `~/.config/starship.toml`.
+To get started configuring starship, create one of the following file:
+
+- `~/.config/starship.toml`.
 
 ```sh
 mkdir -p ~/.config && touch ~/.config/starship.toml
 ```
+
+- `~/.config/starship/config.toml`
+
+```sh
+mkdir -p ~/.config/starship && touch ~/.config/starship/config.toml
+```
+
+NOTE: if you have both files available, the `starship.toml` will take higher priority.
 
 All configuration for starship is done in this [TOML](https://github.com/toml-lang/toml) file:
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -14,7 +14,7 @@ mkdir -p ~/.config && touch ~/.config/starship.toml
 mkdir -p ~/.config/starship && touch ~/.config/starship/config.toml
 ```
 
-NOTE: if you have both files available, the `starship.toml` will take higher priority.
+Note: if you have both files available, the `starship.toml` will take higher priority.
 
 All configuration for starship is done in this [TOML](https://github.com/toml-lang/toml) file:
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -431,7 +431,16 @@ fn get_config_path_os(env: &Env) -> Option<OsString> {
     if let Some(config_path) = env.get_env_os("STARSHIP_CONFIG") {
         return Some(config_path);
     }
-    Some(home_dir(env)?.join(".config").join("starship.toml").into())
+
+    let config_dir = home_dir(env)?.join(".config");
+    let config_file_path = config_dir.join("starship.toml");
+    let folder_based_config_file_path = config_dir.join("starship/config.toml");
+
+    if config_file_path.exists() {
+        Some(config_file_path.into())
+    } else {
+        Some(folder_based_config_file_path.into())
+    }
 }
 
 #[derive(Debug)]

--- a/src/context.rs
+++ b/src/context.rs
@@ -427,11 +427,15 @@ fn home_dir(env: &Env) -> Option<PathBuf> {
     utils::home_dir()
 }
 
+fn config_dir(env: &Env) -> Option<PathBuf> {
+    Some(home_dir(env)?.join(".config"))
+}
+
 fn config_home_dir(env: &Env) -> Option<PathBuf> {
     if let Some(xdg_config_home) = env.get_env("XDG_CONFIG_HOME") {
         Some(PathBuf::from(xdg_config_home))
     } else {
-        Some(home_dir(env)?.join(".config"))
+        config_dir(env)
     }
 }
 
@@ -440,9 +444,8 @@ fn get_config_path_os(env: &Env) -> Option<OsString> {
         return Some(config_path);
     }
 
-    let config_dir = config_home_dir(env)?;
-    let config_file_path = config_dir.join("starship.toml");
-    let folder_based_config_file_path = config_dir.join("starship/config.toml");
+    let config_file_path = config_dir(env)?.join("starship.toml");
+    let folder_based_config_file_path = config_home_dir(env)?.join("starship/config.toml");
 
     if config_file_path.exists() {
         Some(config_file_path.into())

--- a/src/context.rs
+++ b/src/context.rs
@@ -427,12 +427,20 @@ fn home_dir(env: &Env) -> Option<PathBuf> {
     utils::home_dir()
 }
 
+fn config_home_dir(env: &Env) -> Option<PathBuf> {
+    if let Some(xdg_config_home) = env.get_env("XDG_CONFIG_HOME") {
+        Some(PathBuf::from(xdg_config_home))
+    } else {
+        Some(home_dir(env)?.join(".config"))
+    }
+}
+
 fn get_config_path_os(env: &Env) -> Option<OsString> {
     if let Some(config_path) = env.get_env_os("STARSHIP_CONFIG") {
         return Some(config_path);
     }
 
-    let config_dir = home_dir(env)?.join(".config");
+    let config_dir = config_home_dir(env)?;
     let config_file_path = config_dir.join("starship.toml");
     let folder_based_config_file_path = config_dir.join("starship/config.toml");
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Users now can have an ability to put their default config in `starship/config.toml`. If users have both `starship.toml` and `starship/config.toml`, the former should take higher priority even if it's invalid.
 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I've used this repo for a long time and wait for the feature to put the configuration file in a folder like `.config/starship/config.toml` by default so that my `.config` folder could be more tidy and manageable (especially when working with `dotfiles`).

<!--- If it fixes an open issue, please link to the issue here. -->
Closes #896

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
