### PR TITLE
feat(shlvl): add repeat_offset for repeated symbol

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -1499,6 +1499,7 @@
         "disabled": true,
         "format": "[$symbol$shlvl]($style) ",
         "repeat": false,
+        "repeat_offset": 0,
         "style": "bold yellow",
         "symbol": "↕️  ",
         "threshold": 2
@@ -5242,6 +5243,12 @@
         "repeat": {
           "default": false,
           "type": "boolean"
+        },
+        "repeat_offset": {
+          "default": 0,
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
         },
         "style": {
           "default": "bold yellow",

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -3772,14 +3772,15 @@ set to a number and meets or exceeds the specified threshold.
 
 ### Options
 
-| Option      | Default                      | Description                                                   |
-| ----------- | ---------------------------- | ------------------------------------------------------------- |
-| `threshold` | `2`                          | Display threshold.                                            |
-| `format`    | `'[$symbol$shlvl]($style) '` | The format for the module.                                    |
-| `symbol`    | `'↕️  '`                      | The symbol used to represent the `SHLVL`.                     |
-| `repeat`    | `false`                      | Causes `symbol` to be repeated by the current `SHLVL` amount. |
-| `style`     | `'bold yellow'`              | The style for the module.                                     |
-| `disabled`  | `true`                       | Disables the `shlvl` module.                                  |
+| Option          | Default                      | Description                                                         |
+| --------------- | ---------------------------- | ------------------------------------------------------------------- |
+| `threshold`     | `2`                          | Display threshold.                                                  |
+| `format`        | `'[$symbol$shlvl]($style) '` | The format for the module.                                          |
+| `symbol`        | `'↕️  '`                      | The symbol used to represent the `SHLVL`.                           |
+| `repeat`        | `false`                      | Causes `symbol` to be repeated by the current `SHLVL` amount.       |
+| `repeat_offset` | `0`                          | Decrements number of times `symbol` is repeated by the offset value |
+| `style`         | `'bold yellow'`              | The style for the module.                                           |
+| `disabled`      | `true`                       | Disables the `shlvl` module.                                        |
 
 ### Variables
 
@@ -3800,6 +3801,22 @@ set to a number and meets or exceeds the specified threshold.
 disabled = false
 format = '$shlvl level(s) down'
 threshold = 3
+```
+
+Using `repeat` and `repeat_offset` along with `character` module, one can get
+prompt like `❯❯❯` where last character is colored appropriately for return
+status code and preceeding characters are provided by `shlvl`.
+
+```toml
+# ~/.config/starship.toml
+
+[shlvl]
+disabled = false
+format = '[$symbol$shlvl]($style)'
+repeat = true
+symbol = '❯'
+repeat_offset = 1
+threshold = 0
 ```
 
 ## Singularity

--- a/src/configs/shlvl.rs
+++ b/src/configs/shlvl.rs
@@ -12,6 +12,7 @@ pub struct ShLvlConfig<'a> {
     pub format: &'a str,
     pub symbol: &'a str,
     pub repeat: bool,
+    pub repeat_offset: u64,
     pub style: &'a str,
     pub disabled: bool,
 }
@@ -23,6 +24,7 @@ impl<'a> Default for ShLvlConfig<'a> {
             format: "[$symbol$shlvl]($style) ",
             symbol: "↕️  ", // extra space for emoji
             repeat: false,
+            repeat_offset: 0,
             style: "bold yellow",
             disabled: true,
         }

--- a/src/modules/shlvl.rs
+++ b/src/modules/shlvl.rs
@@ -22,11 +22,20 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
     let shlvl_str = &shlvl.to_string();
 
-    let repeat_count = if config.repeat {
+    let mut repeat_count: usize = if config.repeat {
         shlvl.try_into().unwrap_or(1)
     } else {
         1
     };
+
+    if config.repeat_offset > 0 {
+        repeat_count =
+            repeat_count.saturating_sub(config.repeat_offset.try_into().unwrap_or(usize::MAX));
+        if repeat_count == 0 {
+            return None;
+        }
+    }
+
     let symbol = if repeat_count != 1 {
         Cow::Owned(config.symbol.repeat(repeat_count))
     } else {
@@ -218,5 +227,34 @@ mod tests {
         let expected = Some(format!("{} ", style().paint("~~~>")));
 
         assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn repeat_offset() {
+        fn get_actual(shlvl: usize, repeat_offset: usize, threshold: usize) -> Option<String> {
+            ModuleRenderer::new("shlvl")
+                .config(toml::toml! {
+                    [shlvl]
+                    format = "[$symbol]($style)"
+                    symbol = "~"
+                    repeat = true
+                    repeat_offset = repeat_offset
+                    disabled = false
+                    threshold = threshold
+                })
+                .env(SHLVL_ENV_VAR, format!("{}", shlvl))
+                .collect()
+        }
+
+        assert_eq!(
+            get_actual(2, 0, 0),
+            Some(format!("{}", style().paint("~~")))
+        );
+        assert_eq!(get_actual(2, 1, 0), Some(format!("{}", style().paint("~"))));
+        assert_eq!(get_actual(2, 2, 0), None); // offset same as shlvl; hide
+        assert_eq!(get_actual(2, 3, 0), None); // offset larger than shlvl; hide
+        assert_eq!(get_actual(2, 1, 3), None); // high threshold; hide
+                                               // threshold not high enough; hide
+        assert_eq!(get_actual(2, 1, 2), Some(format!("{}", style().paint("~"))));
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
I've modified `shlvl` module's behavior for repeat. Now it repeat symbol `SHLVL - repeat_offset` times too.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I wanted a prompt where number of symbols correspond to shlvl at the same time I didn't want to lose color coded theme that `character` module provides. Inspiration is from [Greg Hurrell's prompt](https://github.com/wincent/wincent#prompt
).
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #5306
#### Screenshots (if appropriate):

<img width="997" alt="Screenshot 2023-07-01 at 8 49 20 PM" src="https://github.com/starship/starship/assets/163296/0b264fd6-42ba-459f-a4b5-c034d40d3af3">

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I build a local copy from source and tested against it with appropriate settings.
<!--- Include details of your testing environment, tests ran to see how -->
I'm pasting verbatim output from shell.
```sh
$ export PS1='$ '
$ git log --oneline -3 
b14790d7 (HEAD -> repeat-offset-for-shlvl) feat(shlvl): add repeat_offset for repeated symbol
73e3cdc2 (starship/master, starship/HEAD, origin/master, master) build(deps): update rust crate clap to 4.3.10
a26b5b0f build(deps): update crate-ci/typos action to v1.15.9
$ which starship
starship not found
$ export PATH=./target/debug:$PATH    
$ cargo build --quiet
$ which starship                  
./target/debug/starship
$ ./target/debug/starship --version 
starship 1.15.0
branch:repeat-offset-for-shlvl
commit_hash:
build_time:2023-07-01 20:21:01 +05:30
build_env:rustc 1.69.0 (84c898d65 2023-04-16),stable-aarch64-apple-darwin
❯ echo "eval \$(`realpath ./target/debug/starship` init zsh)"               
eval $(/Users/ocrolus/Projects/misc/starship/target/debug/starship init zsh)
❯ cat ~/.config/starship.toml | grep -v -e '^#' -e '^$'
add_newline = false
format = """$shlvl$character"""
[character]
format = '$symbol '
[shlvl]
format = """[$symbol]($style)"""
symbol = "❯"
disabled = false
repeat = true
repeat_offset = 1
threshold = 2
❯ echo $SHLVL
1
❯ zsh
❯❯ zsh
❯❯❯ zsh
❯❯❯❯ zsh
❯❯❯❯❯ zsh
❯❯❯❯❯❯ echo $SHLVL
6
❯❯❯❯❯❯ false
❯❯❯❯❯❯ true
❯❯❯❯❯❯ exit
❯❯❯❯❯ exit
❯❯❯❯ exit
❯❯❯ exit
❯❯ exit
❯ echo $SHLVL
1
❯ 
```

<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
