### PR TITLE
build(refactor) - Refactor platform detection for builds

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -18,7 +18,7 @@ SUPPORTED_TARGETS="x86_64-unknown-linux-gnu x86_64-unknown-linux-musl \
                   arm-unknown-linux-musleabihf x86_64-apple-darwin \
                   aarch64-apple-darwin x86_64-pc-windows-msvc \
                   i686-pc-windows-msvc aarch64-pc-windows-msvc \
-                  x86_64-unknown-freebsd"
+                  x86_64-unknown-freebsd x86_64-debian x86_64-ubuntu"
 
 info() {
   printf '%s\n' "${BOLD}${GREY}>${NO_COLOR} $*"
@@ -190,14 +190,37 @@ install() {
 #   - linux
 #   - linux_musl (Alpine)
 #   - freebsd
+
 detect_platform() {
   platform="$(uname -s | tr '[:upper:]' '[:lower:]')"
+  
+  if [ "${platform}" = "linux" ]; then
+    if [ -f /etc/os-release ]; then
+      id=$(awk -F= '/^ID=/{print $2}' /etc/os-release)
+    elif [ -f /etc/lsb-release ]; then
+      id=$(awk -F= '/^DISTRIB_ID=/{print $2}' /etc/lsb-release)
+    else
+      platform="${PLATFORM:-unknown-linux-musl}"
+      id=""
+    fi
+
+    case "${id}" in
+      ubuntu) platform="ubuntu" ;;
+      debian) platform="debian" ;;
+      fedora) platform="fedora" ;;
+      centos) platform="centos" ;;
+      rhel) platform="rhel" ;;
+      sles) platform="sles" ;;
+      opensuse) platform="opensuse" ;;
+      arch) platform="arch" ;;
+      alpine) platform="alpine" ;;
+      *) platform="${platform}" ;;
+    esac
+  fi
 
   case "${platform}" in
-    msys_nt*) platform="pc-windows-msvc" ;;
-    cygwin_nt*) platform="pc-windows-msvc";;
+    msys_nt*|cygwin_nt*|mingw*) platform="pc-windows-msvc" ;;
     # mingw is Git-Bash
-    mingw*) platform="pc-windows-msvc" ;;
     # use the statically compiled musl bins on linux to avoid linking issues.
     linux) platform="unknown-linux-musl" ;;
     darwin) platform="apple-darwin" ;;
@@ -206,6 +229,7 @@ detect_platform() {
 
   printf '%s' "${platform}"
 }
+
 
 # Currently supporting:
 #   - x86_64

--- a/install/install.sh
+++ b/install/install.sh
@@ -205,15 +205,16 @@ detect_platform() {
     fi
 
     case "${id}" in
-      ubuntu) platform="ubuntu" ;;
-      debian) platform="debian" ;;
-      fedora) platform="fedora" ;;
-      centos) platform="centos" ;;
-      rhel) platform="rhel" ;;
-      sles) platform="sles" ;;
-      opensuse) platform="opensuse" ;;
-      arch) platform="arch" ;;
-      alpine) platform="alpine" ;;
+      ubuntu) platform="unknown-linux-gnu" ;;
+      debian) platform="unknown-linux-musl" ;;
+      fedora) platform="unknown-linux-gnu" ;;
+      centos) platform="unknown-linux-gnu" ;;
+      freebsd) platform="unknown-freebsd";;
+      rhel) platform="unknown-linux-gnu" ;;
+      sles) platform="unknown-linux-gnu" ;;
+      opensuse) platform="unknown-linux-gnu" ;;
+      arch) platform="unknown-linux-gnu" ;;
+      alpine) platform="unknown-linux-musl" ;;
       *) platform="${platform}" ;;
     esac
   fi

--- a/install/install.sh
+++ b/install/install.sh
@@ -18,7 +18,7 @@ SUPPORTED_TARGETS="x86_64-unknown-linux-gnu x86_64-unknown-linux-musl \
                   arm-unknown-linux-musleabihf x86_64-apple-darwin \
                   aarch64-apple-darwin x86_64-pc-windows-msvc \
                   i686-pc-windows-msvc aarch64-pc-windows-msvc \
-                  x86_64-unknown-freebsd x86_64-debian x86_64-ubuntu"
+                  x86_64-unknown-freebsd"
 
 info() {
   printf '%s\n' "${BOLD}${GREY}>${NO_COLOR} $*"


### PR DESCRIPTION
Attempt to refactor platform detection for builds in order to better detect WSL/Distributions that return "linux"

#### Description
Some WSL platforms aren't currently detected and detection causes issues with some x86_64 platforms. This PR adds support for WSL detection with current detection as a fallback. Uses OS-release files to try to find OS name.

#### Motivation and Context
This should fix 5022 as well as improve detection for platforms which return "linux" as the platform.
Closes #5022 (I believe?)

https://github.com/starship/starship/issues/5022

#### Screenshots (if appropriate):
Ubuntu WSL:
![image](https://github.com/starship/starship/assets/89496209/34364445-6476-4b90-be64-d6ef8ccd25b7)


#### How Has This Been Tested?
Only in WSL currently. 

- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows** 

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] I have updated the documentation accordingly.
- [ x ] I have updated the tests accordingly.
