### PR TITLE
feat(logger): add option to disable logging to file

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -65,6 +65,12 @@ Or for Cmd (Windows) would be adding this line to your `starship.lua`:
 os.setenv('STARSHIP_CACHE', 'C:\\Users\\user\\AppData\\Local\\Temp')
 ```
 
+To completely disable logging to a file, and only log to standard error, set the environment variable `STARSHIP_DISABLE_LOG_FILE`:
+
+```sh
+export STARSHIP_DISABLE_LOG_FILE=1
+```
+
 ### Terminology
 
 **Module**: A component in the prompt giving information based on contextual information from your OS. For example, the "nodejs" module shows the version of Node.js that is currently installed on your computer, if your current directory is a Node.js project.


### PR DESCRIPTION
#### Description
Add the option to disable logging to file completely.

#### Motivation and Context
If starship does not have permissions to create the log directory it will complain.

#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [X] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [X] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
