### PR TITLE
feat: allow battery styling to differ based on whether the battery is charging

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -45,7 +45,9 @@
         "discharging_symbol": "󰂃 ",
         "display": [
           {
+            "charging_style": null,
             "charging_symbol": null,
+            "discharging_style": null,
             "discharging_symbol": null,
             "style": "red bold",
             "threshold": 10
@@ -1913,7 +1915,9 @@
         "display": {
           "default": [
             {
+              "charging_style": null,
               "charging_symbol": null,
+              "discharging_style": null,
               "discharging_symbol": null,
               "style": "red bold",
               "threshold": 10
@@ -1946,6 +1950,20 @@
         "style": {
           "default": "red bold",
           "type": "string"
+        },
+        "charging_style": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "discharging_style": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "charging_symbol": {
           "default": null,

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -542,6 +542,8 @@ The `display` option is an array of the following table.
 | -------------------- | ------------ | --------------------------------------------------------------------------------------------------------- |
 | `threshold`          | `10`         | The upper bound for the display option.                                                                   |
 | `style`              | `'red bold'` | The style used if the display option is in use.                                                           |
+| `charging_style`     |              | The style used if the display option is in use and the battery is charging, defaults to `style`.          |
+| `discharging_style`  |              | The style used if the display option is in use and the battery is discharging, defaults to `style`.       |
 | `charging_symbol`    |              | Optional symbol displayed if display option is in use, defaults to battery's `charging_symbol` option.    |
 | `discharging_symbol` |              | Optional symbol displayed if display option is in use, defaults to battery's `discharging_symbol` option. |
 
@@ -552,9 +554,10 @@ The `display` option is an array of the following table.
 threshold = 10
 style = 'bold red'
 
-[[battery.display]] # 'bold yellow' style and 💦 symbol when capacity is between 10% and 30%
+[[battery.display]] # 'bold yellow' style and 💦 symbol when capacity is between 10% and 30%, or 'bold green' style if the battery is charging
 threshold = 30
 style = 'bold yellow'
+charging_style = 'bold green'
 discharging_symbol = '💦'
 
 # when capacity is over 30%, the battery indicator will not be displayed

--- a/src/configs/battery.rs
+++ b/src/configs/battery.rs
@@ -44,6 +44,8 @@ impl<'a> Default for BatteryConfig<'a> {
 pub struct BatteryDisplayConfig<'a> {
     pub threshold: i64,
     pub style: &'a str,
+    pub charging_style: Option<&'a str>,
+    pub discharging_style: Option<&'a str>,
     pub charging_symbol: Option<&'a str>,
     pub discharging_symbol: Option<&'a str>,
 }
@@ -53,6 +55,8 @@ impl<'a> Default for BatteryDisplayConfig<'a> {
         BatteryDisplayConfig {
             threshold: 10,
             style: "red bold",
+            charging_style: None,
+            discharging_style: None,
             charging_symbol: None,
             discharging_symbol: None,
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
adds configuration options `charging_style` and `discharging_style` to the battery display configuration.

#### Motivation and Context
it's distracting to have the battery display in bright red if i've already addressed the issue by plugging my laptop in.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

i wrote automated tests and also ran it locally with `charging_style` and `discharging_style` configuration options set and observed the desired behavior.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
