### PR TITLE
perf: Skip unnecessary indirection in starship init zsh

### DIFF
--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -153,10 +153,7 @@ pub fn init_stub(shell_name: &str) -> io::Result<()> {
             "#,
             starship.sprint_posix()?
         ),
-        "zsh" => print!(
-            r#"source <({} init zsh --print-full-init)"#,
-            starship.sprint_posix()?
-        ),
+        "zsh" => print_script(ZSH_INIT, &starship.sprint_posix()?),
         "fish" => print!(
             // Fish does process substitution with pipes and psub instead of bash syntax
             r#"source ({} init fish --print-full-init | psub)"#,


### PR DESCRIPTION
The installation instructions indicate that one should add this snippet to zsh's configuration:

    eval "$(starship init zsh)"

The command `starship init zsh` prints a little shell script for zsh to execute:

    > starship init zsh
    source <(/usr/bin/starship init zsh --print-full-init)%

Running `starship init zsh --print-full-init` prints yet another script that zsh executes. There is an intermediate step that seems redundant; starship prints a script for zsh to execute, and this script prints another script for zsh to execute.

This patch skips the intermediate execution and prints the final script in `starship init`. This is backwards compatible and does not require any changes in the installation instructions, so it could be release without a major version bump.

Note that it would still be possible to update the installation instructions to `source <(starship init zsh)`; this patch works with both `source` and `eval`. Picking the most performant one is beyond this scope of this patch.

See: https://github.com/starship/starship/issues/2637

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
