### PR TITLE
docs(directory): specify option name in example

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1109,12 +1109,12 @@ The `directory` module shows the path to your current directory, truncated to
 three parent folders. Your directory will also be truncated to the root of the
 git repo that you're currently in.
 
-When using the fish style pwd option, instead of hiding the path that is
+When using the `fish_style_pwd_dir_length` option, instead of hiding the path that is
 truncated, you will see a shortened name of each directory based on the number
 you enable for the option.
 
 For example, given `~/Dev/Nix/nixpkgs/pkgs` where `nixpkgs` is the repo root,
-and the option `fish_style_pwd_dir_length` set to `1`. You will now see `~/D/N/nixpkgs/pkgs`, whereas before
+and the option set to `1`. You will now see `~/D/N/nixpkgs/pkgs`, whereas before
 it would have been `nixpkgs/pkgs`.
 
 ### Options

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1114,7 +1114,7 @@ truncated, you will see a shortened name of each directory based on the number
 you enable for the option.
 
 For example, given `~/Dev/Nix/nixpkgs/pkgs` where `nixpkgs` is the repo root,
-and the option set to `1`. You will now see `~/D/N/nixpkgs/pkgs`, whereas before
+and the option `fish_style_pwd_dir_length` set to `1`. You will now see `~/D/N/nixpkgs/pkgs`, whereas before
 it would have been `nixpkgs/pkgs`.
 
 ### Options


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

Specify the name of the option being referenced in the example.  (`fish_style_pwd_dir_length`)

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

It took me longer than I'd like to admit to figure out what option this example was referring to. It didn't help that the referenced option is hidden in a collapsible, which evaded any attempt made through the browser's find (`ctrl+f`) functionality.
