### PR TITLE
feat(scanner): add option not to follow symlinks

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -1794,6 +1794,10 @@
       "default": true,
       "type": "boolean"
     },
+    "follow_symlinks": {
+      "default": true,
+      "type": "boolean"
+    },
     "palette": {
       "type": [
         "string",

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -219,6 +219,14 @@ This is the list of prompt-wide configuration options.
 | `add_newline`     | `true`                         | Inserts blank line between shell prompts.                                                                                                                                        |
 | `palette`         | `''`                           | Sets which color palette from `palettes` to use.                                                                                                                                 |
 | `palettes`        | `{}`                           | Collection of color palettes that assign [colors](/advanced-config/#style-strings) to user-defined names. Note that color palettes cannot reference their own color definitions. |
+| `follow_symlinks` | `true`                         | Follows symlinks to check if they're directories; used in modules such as git.                                                                                                   |
+
+::: tip
+
+If you have symlinks to networked filesystems, consider setting
+`follow_symlinks` to `false`.
+
+:::
 
 ### Example
 

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -18,6 +18,7 @@ pub struct StarshipRootConfig {
     pub scan_timeout: u64,
     pub command_timeout: u64,
     pub add_newline: bool,
+    pub follow_symlinks: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub palette: Option<String>,
     pub palettes: HashMap<String, Palette>,
@@ -134,6 +135,7 @@ impl Default for StarshipRootConfig {
             scan_timeout: 30,
             command_timeout: 500,
             add_newline: true,
+            follow_symlinks: true,
             palette: None,
             palettes: HashMap::default(),
         }


### PR DESCRIPTION
Never consider a symlink to be a subdirectory; this prevents hanging when the symlink points to a slow/inaccessible filesystem.

#### Description

Instead of using `is_dir`, which follows symlinks, use [`symlink_metadata`](https://doc.rust-lang.org/std/fs/fn.symlink_metadata.html), which doesn't.

#### Motivation and Context

If the current directory has a symlink to a slow filesystem (e.g. an inaccessible network filesystem), `is_dir` hangs indefinitely, disregarding `scan_timeout`.

This should help with some instances of #312.

#### Screenshots (if appropriate):

n/a

#### How Has This Been Tested?

- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

I've tested by running `starship timings` with network disconnected in a directory which includes a symlink to a network filesystem. Without my change it hangs, with my change it doesn't.

#### Checklist:

- [x] I have updated the documentation accordingly
- [x] I have updated the tests accordingly
