### PR TITLE
build: Sort toml preset files

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,5 @@
 use std::fs::{self, File};
+use std::io;
 use std::io::Write;
 
 use shadow_rs::SdResult;
@@ -20,11 +21,12 @@ fn main() -> SdResult<()> {
 fn gen_presets_hook(mut file: &File) -> SdResult<()> {
     println!("cargo:rerun-if-changed=docs/.vuepress/public/presets/toml");
     let paths = fs::read_dir("docs/.vuepress/public/presets/toml")?;
+    let mut sortedpaths = paths.collect::<io::Result<Vec<_>>>()?;
+    sortedpaths.sort_by_key(|e| e.path());
 
     let mut presets = String::new();
     let mut match_arms = String::new();
-    for path in paths {
-        let unwrapped = path?;
+    for unwrapped in sortedpaths {
         let file_name = unwrapped.file_name();
         let full_path = dunce::canonicalize(unwrapped.path())?;
         let full_path = full_path.to_str().expect("failed to convert to string");


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Sort toml input file list for reproducible build results.

#### Motivation and Context
Without this patch, the resulting `starship` binary varied, depending on random filesystem readdir order.
See https://reproducible-builds.org/ for why this matters.

This patch was done while working on reproducible builds for openSUSE.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [X] I have tested using **Linux** (build only)
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
