### PR TITLE
feat: add additional exit status code meanings from libc

### DIFF
--- a/src/modules/status.rs
+++ b/src/modules/status.rs
@@ -189,6 +189,24 @@ fn status_common_meaning(ex: ExitCode) -> Option<&'static str> {
         0 => Some(""), // SUCCESS can be defined by $success_symbol if the user wishes too.
         1 => Some("ERROR"),
         2 => Some("USAGE"),
+
+        // status codes 64-78 from libc
+        64 => Some("USAGE"),
+        65 => Some("DATAERR"),
+        66 => Some("NOINPUT"),
+        67 => Some("NOUSER"),
+        68 => Some("NOHOST"),
+        69 => Some("UNAVAILABLE"),
+        70 => Some("SOFTWARE"),
+        71 => Some("OSERR"),
+        72 => Some("OSFILE"),
+        73 => Some("CANTCREAT"),
+        74 => Some("IOERR"),
+        75 => Some("TEMPFAIL"),
+        76 => Some("PROTOCOL"),
+        77 => Some("NOPERM"),
+        78 => Some("CONFIG"),
+
         126 => Some("NOPERM"),
         127 => Some("NOTFOUND"),
         _ => None,
@@ -409,10 +427,28 @@ mod tests {
 
     #[test]
     fn exit_code_name_no_signal() {
-        let exit_values = [1, 2, 126, 127, 130, 101, 132];
+        let exit_values = [
+            1, 2, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 126, 127, 130, 101,
+            132,
+        ];
         let exit_values_name = [
             Some("ERROR"),
             Some("USAGE"),
+            Some("USAGE"),
+            Some("DATAERR"),
+            Some("NOINPUT"),
+            Some("NOUSER"),
+            Some("NOHOST"),
+            Some("UNAVAILABLE"),
+            Some("SOFTWARE"),
+            Some("OSERR"),
+            Some("OSFILE"),
+            Some("CANTCREAT"),
+            Some("IOERR"),
+            Some("TEMPFAIL"),
+            Some("PROTOCOL"),
+            Some("NOPERM"),
+            Some("CONFIG"),
             Some("NOPERM"),
             Some("NOTFOUND"),
             None,


### PR DESCRIPTION
#### Description
This PR adds additional exit status code meaning mappings from the [standard C library (/usr/include/sysexits.h)](https://manpages.ubuntu.com/manpages/lunar/man3/sysexits.h.3head.html) to the status module, specifically status codes 64 to 78. In addition to libc the [Python standard library](https://docs.python.org/3/library/os.html#os.EX_USAGE) also includes defined constants for these status codes.

#### Motivation and Context
This change provides additional meaning and context when applications exit with status codes 64­­ to 78
Closes #5051 

#### Screenshots (if appropriate):
![image](https://github.com/starship/starship/assets/61805721/dc4352f5-6949-485f-a32a-20981d5a6116)



#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
