### PR TITLE
feat: allow battery `display` to differ based on charging-state

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -48,7 +48,14 @@
             "charging_symbol": null,
             "discharging_symbol": null,
             "style": "red bold",
-            "threshold": 10
+            "threshold": 10,
+            "when": [
+              "unknown",
+              "charging",
+              "discharging",
+              "empty",
+              "full"
+            ]
           }
         ],
         "empty_symbol": "󰂎 ",
@@ -1931,7 +1938,14 @@
               "charging_symbol": null,
               "discharging_symbol": null,
               "style": "red bold",
-              "threshold": 10
+              "threshold": 10,
+              "when": [
+                "unknown",
+                "charging",
+                "discharging",
+                "empty",
+                "full"
+              ]
             }
           ],
           "type": "array",
@@ -1975,9 +1989,47 @@
             "string",
             "null"
           ]
+        },
+        "when": {
+          "default": [
+            "unknown",
+            "charging",
+            "discharging",
+            "empty",
+            "full"
+          ],
+          "allOf": [
+            {
+              "$ref": "#/definitions/Either_for_State_and_Array_of_State"
+            }
+          ]
         }
       },
       "additionalProperties": false
+    },
+    "Either_for_State_and_Array_of_State": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/State"
+        },
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/State"
+          }
+        }
+      ]
+    },
+    "State": {
+      "description": "Possible battery state values.\n\nUnknown can mean either controller returned unknown, or not able to retrieve state due to some error.",
+      "type": "string",
+      "enum": [
+        "unknown",
+        "charging",
+        "discharging",
+        "empty",
+        "full"
+      ]
     },
     "BufConfig": {
       "type": "object",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3074,6 +3074,8 @@ dependencies = [
  "mach2",
  "nix 0.26.2",
  "num-traits",
+ "schemars",
+ "serde",
  "uom",
  "winapi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ The minimal, blazing-fast, and infinitely customizable prompt for any shell! ☄
 [features]
 default = ["battery", "notify", "gix-max-perf"]
 battery = ["starship-battery"]
-config-schema = ["schemars"]
+config-schema = ["schemars", "starship-battery?/config-schema"]
 notify = ["notify-rust"]
 
 # Enables most of the `max-performance` features of the `gix` module for better performance.
@@ -76,7 +76,7 @@ sha1 = "0.10.5"
 shadow-rs = { version = "0.23.0", default-features = false }
 # battery is optional (on by default) because the crate doesn't currently build for Termux
 # see: https://github.com/svartalf/rust-battery/issues/33
-starship-battery = { version = "0.8.2", optional = true }
+starship-battery = { version = "0.8.2", optional = true, features = ["serde"] }
 strsim = "0.10.0"
 systemstat = "=0.2.3"
 terminal_size = "0.2.6"

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -531,6 +531,13 @@ If no `display` is provided. The default is as shown:
 [[battery.display]]
 threshold = 10
 style = 'bold red'
+when = [
+  'unknown',
+  'charging',
+  'discharging',
+  'empty',
+  'full',
+]
 ```
 
 The default value for the `charging_symbol` and `discharging_symbol` option is respectively the value of `battery`'s `charging_symbol` and `discharging_symbol` option.
@@ -539,12 +546,13 @@ The default value for the `charging_symbol` and `discharging_symbol` option is r
 
 The `display` option is an array of the following table.
 
-| Option               | Default      | Description                                                                                               |
-| -------------------- | ------------ | --------------------------------------------------------------------------------------------------------- |
-| `threshold`          | `10`         | The upper bound for the display option.                                                                   |
-| `style`              | `'red bold'` | The style used if the display option is in use.                                                           |
-| `charging_symbol`    |              | Optional symbol displayed if display option is in use, defaults to battery's `charging_symbol` option.    |
-| `discharging_symbol` |              | Optional symbol displayed if display option is in use, defaults to battery's `discharging_symbol` option. |
+| Option               | Default                                                   | Description                                                                                                                                                                                                |
+| -------------------- | --------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `threshold`          | `10`                                                      | The upper bound for the display option.                                                                                                                                                                    |
+| `when`               | `['unknown', 'charging', 'discharging', 'empty', 'full']` | A list of battery states or a single battery state that the battery needs to have to use this display config. The possible states are `'unknown'`, `'charging'`, `'discharging'`, `'empty'`, and `'full'`. |
+| `style`              | `'red bold'`                                              | The style used if the display option is in use.                                                                                                                                                            |
+| `charging_symbol`    |                                                           | Optional symbol displayed if display option is in use, defaults to battery's `charging_symbol` option.                                                                                                     |
+| `discharging_symbol` |                                                           | Optional symbol displayed if display option is in use, defaults to battery's `discharging_symbol` option.                                                                                                  |
 
 #### Example
 
@@ -553,8 +561,9 @@ The `display` option is an array of the following table.
 threshold = 10
 style = 'bold red'
 
-[[battery.display]] # 'bold yellow' style and 💦 symbol when capacity is between 10% and 30%
+[[battery.display]] # 'bold yellow' style and 💦 symbol when capacity is between 10% and 30% and discharging
 threshold = 30
+when = 'discharging'
 style = 'bold yellow'
 discharging_symbol = '💦'
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

This PR implements the `when` option discussed in #3849, for now, without the aid of #3941. The when option allows restricting a `[[battery.display]]` block to one or more charging states (`charging`, `discharging`, ...).

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #3849
Closes #5317

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
