### PR TITLE
chore: handle chrono deprecations & add ci clippy flags

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -55,6 +55,8 @@ jobs:
 
       - name: Build | Lint
         uses: giraffate/clippy-action@871cc4173f2594435c7ea6b0bce499cf6c2164a1
+        with:
+          clippy_flags: --workspace --locked --all-targets --all-features -- -D clippy::all
 
   # Ensure that the project could be successfully compiled
   cargo_check:

--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -668,7 +668,7 @@ credential_process = /opt/bin/awscreds-retriever
 
         let expiration_env_vars = ["AWS_SESSION_EXPIRATION", "AWS_CREDENTIAL_EXPIRATION"];
         expiration_env_vars.iter().for_each(|env_var| {
-            let now_plus_half_hour: DateTime<Utc> = chrono::DateTime::from_utc(
+            let now_plus_half_hour: DateTime<Utc> = chrono::DateTime::from_naive_utc_and_offset(
                 NaiveDateTime::from_timestamp_opt(chrono::Local::now().timestamp() + 1800, 0)
                     .unwrap(),
                 Utc,
@@ -702,7 +702,7 @@ credential_process = /opt/bin/awscreds-retriever
 
         use chrono::{DateTime, NaiveDateTime, Utc};
 
-        let now_plus_half_hour: DateTime<Utc> = chrono::DateTime::from_utc(
+        let now_plus_half_hour: DateTime<Utc> = chrono::DateTime::from_naive_utc_and_offset(
             NaiveDateTime::from_timestamp_opt(chrono::Local::now().timestamp() + 1800, 0).unwrap(),
             Utc,
         );
@@ -789,7 +789,7 @@ aws_secret_access_key=dummy
     fn expiration_date_set_expired() {
         use chrono::{DateTime, NaiveDateTime, SecondsFormat, Utc};
 
-        let now: DateTime<Utc> = chrono::DateTime::from_utc(
+        let now: DateTime<Utc> = chrono::DateTime::from_naive_utc_and_offset(
             NaiveDateTime::from_timestamp_opt(chrono::Local::now().timestamp() - 1800, 0).unwrap(),
             Utc,
         );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Move deprecated `chrono::DateTime::from_utc` and `chrono::DateTime::from_naive_utc_and_offset`.
The new clippy action was missing the extra flags the previous actions-rs version used, add them back to ensure this gets caught on CI.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
