### PR TITLE
feat: $gemset variable for Ruby module

### DIFF
--- a/.dprint.json
+++ b/.dprint.json
@@ -41,7 +41,7 @@
     "target/"
   ],
   "plugins": [
-    "https://github.com/dprint/dprint-plugin-typescript/releases/download/0.86.2/plugin.wasm",
+    "https://github.com/dprint/dprint-plugin-typescript/releases/download/0.87.1/plugin.wasm",
     "https://github.com/dprint/dprint-plugin-json/releases/download/0.17.4/plugin.wasm",
     "https://github.com/dprint/dprint-plugin-markdown/releases/download/0.16.0/plugin.wasm",
     "https://github.com/dprint/dprint-plugin-toml/releases/download/0.5.4/plugin.wasm"

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -3681,11 +3681,12 @@ Starship gets the current Ruby version by running `ruby -v`.
 
 ### Variables
 
-| Variable | Example  | Description                          |
-| -------- | -------- | ------------------------------------ |
-| version  | `v2.5.1` | The version of `ruby`                |
-| symbol   |          | Mirrors the value of option `symbol` |
-| style\*  |          | Mirrors the value of option `style`  |
+| Variable | Example      | Description                                                                |
+| -------- | ------------ | -------------------------------------------------------------------------- |
+| version  | `v2.5.1`     | The version of `ruby`                                                      |
+| symbol   |              | Mirrors the value of option `symbol`                                       |
+| style\*  |              | Mirrors the value of option `style`                                        |
+| gemset   | `2.0.0@test` | Reads the Gemset and its version from the environment variable `GEM_HOME`. |
 
 *: This variable can only be used as a part of a style string
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -3681,12 +3681,12 @@ Starship gets the current Ruby version by running `ruby -v`.
 
 ### Variables
 
-| Variable | Example      | Description                                                                |
-| -------- | ------------ | -------------------------------------------------------------------------- |
-| version  | `v2.5.1`     | The version of `ruby`                                                      |
-| symbol   |              | Mirrors the value of option `symbol`                                       |
-| style\*  |              | Mirrors the value of option `style`                                        |
-| gemset   | `2.0.0@test` | Reads the Gemset and its version from the environment variable `GEM_HOME`. |
+| Variable | Example  | Description                                 |
+| -------- | -------- | ------------------------------------------- |
+| version  | `v2.5.1` | The version of `ruby`                       |
+| symbol   |          | Mirrors the value of option `symbol`        |
+| style\*  |          | Mirrors the value of option `style`         |
+| gemset   | `test`   | Optional, gets the current RVM gemset name. |
 
 *: This variable can only be used as a part of a style string
 

--- a/src/modules/ruby.rs
+++ b/src/modules/ruby.rs
@@ -216,6 +216,27 @@ mod tests {
     }
 
     #[test]
+    fn no_gemset_env_set() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join("any.rb"))?.sync_all()?;
+
+        let actual = ModuleRenderer::new("ruby")
+            .path(dir.path())
+            .config(toml::toml! {
+                [ruby]
+                format = "via [$symbol($gemset )]($style)"
+            })
+            .collect();
+        let expected = Some(format!(
+            "via {}",
+            Color::Red.bold().paint("💎 ")
+        ));
+
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
     fn test_format_ruby_version() {
         let config = RubyConfig::default();
         assert_eq!(

--- a/src/modules/ruby.rs
+++ b/src/modules/ruby.rs
@@ -227,10 +227,7 @@ mod tests {
                 format = "via [$symbol($gemset )]($style)"
             })
             .collect();
-        let expected = Some(format!(
-            "via {}",
-            Color::Red.bold().paint("💎 ")
-        ));
+        let expected = Some(format!("via {}", Color::Red.bold().paint("💎 ")));
 
         assert_eq!(expected, actual);
         dir.close()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Adding an assignable variable called `$gemset` to the Ruby module. This will read the path provided by the environment variable `GEM_HOME` and capture the gemset information at the end of the path.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #5305

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
