### PR TITLE
fix(bash): unbound variable error with STARSHIP_PREEXEC_READY

### DIFF
--- a/src/init/starship.bash
+++ b/src/init/starship.bash
@@ -21,7 +21,7 @@ starship_preexec() {
     local PREV_LAST_ARG=$1
 
     # Avoid restarting the timer for commands in the same pipeline
-    if [ "$STARSHIP_PREEXEC_READY" = "true" ]; then
+    if [ "${STARSHIP_PREEXEC_READY:-}" = "true" ]; then
         STARSHIP_PREEXEC_READY=false
         STARSHIP_START_TIME=$(::STARSHIP:: time)
     fi


### PR DESCRIPTION
I am installing starship on a Docker container, and every now and then I see the following:

`/dev/fd/63: line 24: STARSHIP_PREEXEC_READY: unbound variable`

On this particular use case I installed https://github.com/junegunn/fzf on the container and then running:

`/opt/fzf/install --help` just gives the above error. Not sure why it. doesn't happen to every command.

I figured this is because STARSHIP_PREEXEC_READY can be non existent at some point. Exporting STARSHIP_PREEXEC_READY=true in the terminal fixes it.

I propose to account for this scenario in the bash-init script.

EDIT: I made a script to easily reproduce this:

Obviously is the `set -u` that triggers it

```bash
#!/usr/bin/env bash

set -u

sleep 1
```