### PR TITLE
fix(install): do not use curl installed through snap

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -43,8 +43,8 @@ has() {
 curl_is_snap() {
   curl_path="$(command -v curl)"
   case "$curl_path" in
-    (/snap/*) return 0 ;;
-    (*) return 1 ;;
+    /snap/*) return 0 ;;
+    *) return 1 ;;
   esac
 }
 
@@ -90,7 +90,7 @@ download() {
   url="$2"
 
   if has curl && curl_is_snap; then
-    warn "curl installed through snap cannot install starship."
+    warn "curl installed through snap cannot download starship."
     warn "See https://github.com/starship/starship/issues/5403 for details."
     warn "Searching for other HTTP download programs..."
   fi

--- a/install/install.sh
+++ b/install/install.sh
@@ -89,14 +89,14 @@ download() {
   file="$1"
   url="$2"
 
-  if has curl; then
-    if curl_is_snap; then
-      cmd="curl --fail --silent --location --output $file $url"
-    else
-      warn "curl installed through snap cannot install starship."
-      warn "See https://github.com/starship/starship/issues/5403 for details."
-      warn "Searching for other HTTP download programs..."
-    fi
+  if has curl && curl_is_snap; then
+    warn "curl installed through snap cannot install starship."
+    warn "See https://github.com/starship/starship/issues/5403 for details."
+    warn "Searching for other HTTP download programs..."
+  fi
+
+  if has curl && ! curl_is_snap; then
+    cmd="curl --fail --silent --location --output $file $url"
   elif has wget; then
     cmd="wget --quiet --output-document=$file $url"
   elif has fetch; then


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
Changes the install script to check if the resolved `curl` is within `/snap`. If it is, the script prints a warning and acts as if `curl` is not installed, searching for other download programs.


#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

For some reason, `curl` which comes from the default package on snapcraft is badly broken. Among its deficiencies are:

  1. Attempting to download from a GitHub URL to a location in the home directory results in an empty file being created, even though cURL reports success.
  2. Attempting to download from a GitHub URL to a location in `/tmp` results in *no* file being created at all, even though cURL reports success.
  3. [Attempting to download to a path with a hidden directory results in spurious failures.](https://askubuntu.com/questions/1356327/cant-write-to-a-hidden-path-using-curl)

While the broken version of the curl program is capable of downloading the install script and piping it to `sh`, we have had strange issues when it is used within the installer (#5403). Given the severity and unpredictability of these problems, I think it is safer to disallow the usage of snap-installed curl until all the outstanding issues are fixed.

Closes #5403 

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

Tested on a fresh install of Ubuntu 23.04 installed with the non-legacy installer. Script works in default setting (since wget is installed by default), correctly bypassing curl if it is snap-installed and using it if it is apt-installed.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
