### PR TITLE
ci: Fix how version is obtained for pkgbuild

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,6 +176,7 @@ jobs:
     env:
       KEYCHAIN_FILENAME: app-signing.keychain-db
       KEYCHAIN_ENTRY: AC_PASSWORD
+      STARSHIP_VERSION: ${{ needs.release_please.outputs.tag_name }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4

--- a/install/macos_packages/build_component_package.sh
+++ b/install/macos_packages/build_component_package.sh
@@ -87,4 +87,4 @@ trap - INT
 
 # Build the component package
 version="$(starship_version "$starship_program_file")"
-pkgbuild --identifier com.starshipprompt.starship --version "$version" --root $pkgdir starship-component.pkg
+pkgbuild --identifier com.starshipprompt.starship --version "$version" --root "$pkgdir" starship-component.pkg

--- a/install/macos_packages/common.sh
+++ b/install/macos_packages/common.sh
@@ -24,7 +24,7 @@ starship_version() {
     "$starship_program_file" -V | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+'
   else
     pushd "$(git rev-parse --show-toplevel)" || true
-    grep '^version = \"\(.*\)\"' Cargo.toml | head -n 1 | cut -f 2 -d '"'
+    grep '^version = \"\(.*\)\"' Cargo.toml | head -n 1 | cut -f 2 -d '"' | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+'
     popd
   fi
 }

--- a/install/macos_packages/common.sh
+++ b/install/macos_packages/common.sh
@@ -11,12 +11,20 @@ starship_version() {
   if [ "$1" = "${1#/}" ]; then
     starship_program_file="./$starship_program_file"
   fi
-  if "$starship_program_file" -V 2>&1 >/dev/null; then
+
+  # Try to get the version from three sources in the following order:
+  #  - the STARSHIP_VERSION envar (usually set by the CI)
+  #  - Running the binary file
+  #  - By cutting out the first version tag in Cargo.toml
+  # These get increasingly fragile as we go down the list---ideally CI should
+  # always run with STARSHIP_VERSION set to avoid issues in determining version.
+  if [ "$STARSHIP_VERSION" != "" ]; then
+    echo "$STARSHIP_VERSION"
+  elif "$starship_program_file" -V >/dev/null 2>&1; then
     "$starship_program_file" -V | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+'
   else
-    # try to get this information from Cargo.toml
     pushd "$(git rev-parse --show-toplevel)" || true
-    grep '^version = \"\(.*\)\"' Cargo.toml | cut -f 2 -d '"'
+    grep '^version = \"\(.*\)\"' Cargo.toml | head -n 1 | cut -f 2 -d '"'
     popd
   fi
 }

--- a/install/macos_packages/common.sh
+++ b/install/macos_packages/common.sh
@@ -19,12 +19,12 @@ starship_version() {
   # These get increasingly fragile as we go down the list---ideally CI should
   # always run with STARSHIP_VERSION set to avoid issues in determining version.
   if [ "$STARSHIP_VERSION" != "" ]; then
-    echo "$STARSHIP_VERSION"
+    echo "$STARSHIP_VERSION" | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+'
   elif "$starship_program_file" -V >/dev/null 2>&1; then
-    "$starship_program_file" -V | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+'
+    "$starship_program_file" -V 2> /dev/null | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+'
   else
-    pushd "$(git rev-parse --show-toplevel)" || true
+    pushd "$(git rev-parse --show-toplevel)" &> /dev/null || true
     grep '^version = \"\(.*\)\"' Cargo.toml | head -n 1 | cut -f 2 -d '"' | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+'
-    popd
+    popd &> /dev/null || true
   fi
 }


### PR DESCRIPTION
#### Description
Modify how the starship version is obtained in CI to be more strict.

#### Motivation and Context

#5137 notes that the version in the distribution XML is broken. This PR changes how the starship version is obtained to be more robust to the errors that occurred.

1. Use Release Please to set the version as an environment variable, and use this environment variable if it exists, filtering out just the numeric portion.
2. If the first step does not work, try to run the starship binary to obtain a version. This line previously had a bug with the ordering of redirect statements which caused an error message to be printed if this step failed. The version here should suppress all errors.
3. If neither of the two steps work, try to grab the first key from `Cargo.toml` using a grep command. This PR fixes two bugs from the previous version: bash generates output on pushd/popd which needs to be suppressed, and we need to choose the first version tag, since there are now multiple in the Cargo.toml.

Tested locally, but unclear if this will work in the actual CI pipeline.

Potentially addresses #5137, but we cannot test this until we actually fire a release.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
