### PR TITLE
ci: disable coverage on nightly for now

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -169,6 +169,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Install cargo-llvm-cov
+        if: matrix.rust == 'stable'
         uses: taiki-e/install-action@cargo-llvm-cov
 
       # For windows installer test
@@ -187,7 +188,8 @@ jobs:
         run: brew install mercurial
 
       # Run the ignored tests that expect the above setup
-      - name: Build | Test
+      - name: Build | Test [Coverage]
+        if: matrix.rust == 'stable'
         run: "cargo llvm-cov
           --all-features
           --locked
@@ -197,6 +199,10 @@ jobs:
         env:
           # Avoid -D warnings on nightly builds
           RUSTFLAGS: ""
+      
+      - name: Build | Test [No Coverage]
+        if: matrix.rust == 'nightly'
+        run: cargo test --all-features --locked --workspace -- --include-ignored
 
       - name: Build | Installer [Windows]
         continue-on-error: true
@@ -221,7 +227,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
-        if: github.repository == 'starship/starship'
+        if: github.repository == 'starship/starship' && matrix.rust == 'stable'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Due to a nightly attribute rename, a few dependencies don't compile on nightly with coverage enabled. Disable coverage reporting on nightly to unblock CI until all dependencies have been updated.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
