### PR TITLE
feat: add user overrides for username and hostname modules

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2355,6 +2355,7 @@ The `hostname` module shows the system hostname.
 | `format`          | `'[$ssh_symbol$hostname]($style) in '` | The format for the module.                                                                                                            |
 | `style`           | `'bold dimmed green'`                  | The style for the module.                                                                                                             |
 | `disabled`        | `false`                                | Disables the `hostname` module.                                                                                                       |
+| `user_overrides`  | `{}`                                   | Override the `style`, `format`, `disabled` options based on the currently logged in user.                                             |
 
 ### Variables
 
@@ -2389,6 +2390,22 @@ disabled = false
 ssh_only = false
 detect_env_vars = ['!TMUX', 'SSH_CONNECTION']
 disabled = false
+```
+
+#### Color the module based on the user
+
+```toml
+# ~/.config/starship.toml
+
+[hostname]
+style = 'yellow'
+disabled = false
+
+[hostname.user_overrides.myuser]
+style = 'cyan'
+
+[hostname.user_overrides.root]
+style = 'bold red'
 ```
 
 ## Java
@@ -4513,12 +4530,12 @@ By default, the module will be shown if any of the following conditions are met:
 ## Username
 
 The `username` module shows active user's username.
-The module will be shown if any of the following conditions are met:
+You can configure when to show this module by utilizing the `show_if_*` options,
+which expose the following conditions:
 
 - The current user is root/admin
 - The current user isn't the same as the one that is logged in
 - The user is currently connected as an SSH session
-- The variable `show_always` is set to true
 - The array `detect_env_vars` contains at least the name of one environment variable, that is set
 
 ::: tip
@@ -4531,22 +4548,26 @@ these variables, one workaround is to set one of them with a dummy value.
 
 ### Options
 
-| Option            | Default                 | Description                                               |
-| ----------------- | ----------------------- | --------------------------------------------------------- |
-| `style_root`      | `'bold red'`            | The style used when the user is root/admin.               |
-| `style_user`      | `'bold yellow'`         | The style used for non-root users.                        |
+| Option              | Default                 | Description                                                                               |
+| ------------------- | ----------------------- | ----------------------------------------------------------------------------------------- |
+| `style_root`        | `'bold red'`            | The style used when the user is root/admin.                                               |
+| `style_user`        | `'bold yellow'`         | The style used for non-root users.                                                        |
 | `detect_env_vars` | `[]`                    | Which environment variable(s) should trigger this module. |
-| `format`          | `'[$user]($style) in '` | The format for the module.                                |
-| `show_always`     | `false`                 | Always shows the `username` module.                       |
-| `disabled`        | `false`                 | Disables the `username` module.                           |
+| `format`            | `'[$user]($style) in '` | The format for the module.                                                                |
+| `show_always`       | `false`                 | Always shows the `username` module, disregarding any `show_if_*` settings.                |
+| `show_if_root`      | `true`                  | Shows the `username` module if the user is root.                                          |
+| `show_if_different` | `true`                  | Shows the `username` module if the user is different from the logged-in user.             |
+| `show_if_ssh`       | `true`                  | Shows the `username` module if connected via ssh.                                         |
 | `aliases`         | `{}`                    | Translate system usernames to something else              |
+| `disabled`          | `false`                 | Disables the `username` module.                                                           |
+| `user_overrides`    | `{}`                    | Override the `style`, `format`, `disabled` options based on the currently logged in user. |
 
 ### Variables
 
-| Variable | Example      | Description                                                                                 |
-| -------- | ------------ | ------------------------------------------------------------------------------------------- |
-| `style`  | `'red bold'` | Mirrors the value of option `style_root` when root is logged in and `style_user` otherwise. |
-| `user`   | `'matchai'`  | The currently logged-in user ID.                                                            |
+| Variable | Example      | Description                         |
+| -------- | ------------ | ----------------------------------- |
+| `style`  | `'red bold'` | Mirrors the value of option `style` |
+| `user`   | `'matchai'`  | The currently logged-in user ID.    |
 
 ### Example
 
@@ -4556,12 +4577,14 @@ these variables, one workaround is to set one of them with a dummy value.
 # ~/.config/starship.toml
 
 [username]
-style_user = 'white bold'
-style_root = 'black bold'
+style = 'white bold'
 format = 'user: [$user]($style) '
 disabled = false
 show_always = true
 aliases = { "corpuser034g" = "matchai" }
+
+[username.user_overrides.root]
+style = 'bold red'
 ```
 
 #### Hide the hostname in remote tmux sessions

--- a/src/configs/hostname.rs
+++ b/src/configs/hostname.rs
@@ -1,4 +1,28 @@
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(
+    feature = "config-schema",
+    derive(schemars::JsonSchema),
+    schemars(deny_unknown_fields)
+)]
+#[serde(default)]
+pub struct UserOverrideConfig<'a> {
+    pub format: Option<&'a str>,
+    pub style: Option<&'a str>,
+    pub disabled: bool,
+}
+
+impl<'a> Default for UserOverrideConfig<'a> {
+    fn default() -> Self {
+        UserOverrideConfig {
+            format: None,
+            style: None,
+            disabled: false,
+        }
+    }
+}
 
 #[derive(Clone, Deserialize, Serialize)]
 #[cfg_attr(
@@ -15,6 +39,7 @@ pub struct HostnameConfig<'a> {
     pub format: &'a str,
     pub style: &'a str,
     pub disabled: bool,
+    pub user_overrides: HashMap<String, UserOverrideConfig<'a>>,
 }
 
 impl<'a> Default for HostnameConfig<'a> {
@@ -27,6 +52,7 @@ impl<'a> Default for HostnameConfig<'a> {
             format: "[$ssh_symbol$hostname]($style) in ",
             style: "green dimmed bold",
             disabled: false,
+            user_overrides: HashMap::new(),
         }
     }
 }

--- a/src/configs/username.rs
+++ b/src/configs/username.rs
@@ -1,5 +1,29 @@
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(
+    feature = "config-schema",
+    derive(schemars::JsonSchema),
+    schemars(deny_unknown_fields)
+)]
+#[serde(default)]
+pub struct UserOverrideConfig<'a> {
+    pub format: Option<&'a str>,
+    pub style: Option<&'a str>,
+    pub disabled: bool,
+}
+
+impl<'a> Default for UserOverrideConfig<'a> {
+    fn default() -> Self {
+        UserOverrideConfig {
+            format: None,
+            style: None,
+            disabled: false,
+        }
+    }
+}
 
 #[derive(Clone, Deserialize, Serialize)]
 #[cfg_attr(
@@ -11,9 +35,13 @@ use serde::{Deserialize, Serialize};
 pub struct UsernameConfig<'a> {
     pub detect_env_vars: Vec<&'a str>,
     pub format: &'a str,
-    pub style_root: &'a str,
-    pub style_user: &'a str,
+    pub style: &'a str,
+    #[serde(borrow)]
+    pub user_overrides: HashMap<String, UserOverrideConfig<'a>>,
     pub show_always: bool,
+    pub show_if_root: bool,
+    pub show_if_different: bool,
+    pub show_if_ssh: bool,
     pub disabled: bool,
     pub aliases: IndexMap<String, &'a str>,
 }
@@ -23,9 +51,12 @@ impl<'a> Default for UsernameConfig<'a> {
         UsernameConfig {
             detect_env_vars: vec![],
             format: "[$user]($style) in ",
-            style_root: "red bold",
-            style_user: "yellow bold",
+            style: "yellow bold",
+            user_overrides: HashMap::new(),
             show_always: false,
+            show_if_root: true,
+            show_if_different: true,
+            show_if_ssh: true,
             disabled: false,
             aliases: IndexMap::new(),
         }


### PR DESCRIPTION
#### Description

This PR adds a very simple but powerful override table, that allows to override some attributes based on the currently logged-in user. This allows you to:

- Color the hostname in the same (or any other) color as the user, so for example red for root
- Only show the username if it isn't the currently logged in user OR the user is root. So you can additionally hide the username if it is conveyed by the colored hostname.
- It allows to change the format based on the user, in case you want to style the "@" in user@hostname based on the hostname's color scheme instead of the username.

#### Motivation and Context

I always missed the possibility to set different colors, styles and formats for the username and hostname component, based on what user is logged in. There's rudimentary support to set a different color for the root user, and a compound option to hide the username under certain conditions, but I'd personally like to be able to make more specific format changes based on the current user. This PR adds this functionality by introducing a new override map and without adding any new "complex logic" that would need to be maintained (username detection is reused from the username module).

- The current design allows this to be extended later for usecases such as #680 or #607

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


#### Screenshots (if appropriate):

![image](https://github.com/starship/starship/assets/31919558/7244e098-eb94-4b03-b42f-c17d940fbe8b)


#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
