### PR TITLE
fix(status): fix pipestatus width calculation

### DIFF
--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -132,6 +132,11 @@ impl<'a> ModuleRenderer<'a> {
         self
     }
 
+    pub fn width(mut self, width: usize) -> Self {
+        self.context.width = width;
+        self
+    }
+
     #[cfg(feature = "battery")]
     pub fn battery_info_provider(
         mut self,
@@ -159,6 +164,12 @@ impl<'a> ModuleRenderer<'a> {
         // the case (to get durations for all modules). So here we make it so, that an empty
         // module returns None in the tests...
         ret.filter(|s| !s.is_empty())
+    }
+}
+
+impl<'a> From<ModuleRenderer<'a>> for Context<'a> {
+    fn from(renderer: ModuleRenderer<'a>) -> Self {
+        renderer.context
     }
 }
 


### PR DESCRIPTION
This is a revival of the work done by @davidkna in https://github.com/starship/starship/pull/5036
I have some time now that I can use to get this merged

#### Description

The pipestatus string was passed as a string instead of a list of segments, which lead to the ANSI color escapes being included in width calculations. This PR is an updated version of #3741

#### Motivation and Context
Closes https://github.com/starship/starship/pull/3741
Closes https://github.com/starship/starship/issues/3162

#### Screenshots (if appropriate):

#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
