### PR TITLE
feat(color): add prevfg,prevbg as color specifiers based on the previous foreground/background colors respectively

### DIFF
--- a/docs/advanced-config/README.md
+++ b/docs/advanced-config/README.md
@@ -321,7 +321,9 @@ Style strings are a list of words, separated by whitespace. The words are not ca
 - `<color>`
 - `none`
 
-where `<color>` is a color specifier (discussed below). `fg:<color>` and `<color>` currently do the same thing, though this may change in the future. `inverted` swaps the background and foreground colors. The order of words in the string does not matter.
+where `<color>` is a color specifier (discussed below). `fg:<color>` and `<color>` currently do the same thing, though this may change in the future.
+`<color>` can also be set to `prev_fg` or `prev_bg` which evaluates to the previous item's foreground or background color respectively if available or `none` otherwise.
+`inverted` swaps the background and foreground colors. The order of words in the string does not matter.
 
 The `none` token overrides all other tokens in a string if it is not part of a `bg:` specifier, so that e.g. `fg:red none fg:blue` will still create a string with no styling. `bg:none` sets the background to the default color so `fg:red bg:none` is equivalent to `red` or `fg:red` and `bg:green fg:red bg:none` is also equivalent to `fg:red` or `red`. It may become an error to use `none` in conjunction with other tokens in the future.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -294,21 +294,21 @@ impl Style {
                 match self.bg_prev {
                     Some(PreviousColorFrom::Background) => {
                         current.background = prev_style.background;
-                    },
+                    }
                     Some(PreviousColorFrom::Foreground) => {
                         current.background = prev_style.foreground;
-                    },
-                    None => {},
+                    }
+                    None => {}
                 }
 
                 match self.fg_prev {
                     Some(PreviousColorFrom::Background) => {
                         current.foreground = prev_style.background;
-                    },
+                    }
                     Some(PreviousColorFrom::Foreground) => {
                         current.foreground = prev_style.foreground;
-                    },
-                    None => {},
+                    }
+                    None => {}
                 }
 
                 current
@@ -939,11 +939,17 @@ mod tests {
 
         assert_eq!(
             both_prev_fg.modify(None),
-            nu_ansi_term::Style::new().fg(Color::Black).bold().underline()
+            nu_ansi_term::Style::new()
+                .fg(Color::Black)
+                .bold()
+                .underline()
         );
 
         // But if there is a style on the previous string, then use that
-        let prev_style = nu_ansi_term::Style::new().underline().fg(Color::Yellow).on(Color::Red);
+        let prev_style = nu_ansi_term::Style::new()
+            .underline()
+            .fg(Color::Yellow)
+            .on(Color::Red);
 
         assert_eq!(
             both_prev_fg.modify(Some(&prev_style)),
@@ -1006,7 +1012,9 @@ mod tests {
         let multi_style = <StyleWrapper>::from_config(&config).unwrap().0;
         assert_eq!(
             multi_style.style(),
-            &nu_ansi_term::Style::new().fg(Color::Fixed(125)).on(Color::Fixed(127))
+            &nu_ansi_term::Style::new()
+                .fg(Color::Fixed(125))
+                .on(Color::Fixed(127))
         );
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -285,12 +285,11 @@ impl CustomStyle {
         Default::default()
     }
 
-    pub fn custom(&self, prev: Option<&nu_ansi_term::AnsiString>) -> nu_ansi_term::Style {
+    pub fn custom(&self, prev: Option<&nu_ansi_term::Style>) -> nu_ansi_term::Style {
         match prev {
             None => self.style,
-            Some(prev_string) => {
+            Some(prev_style) => {
                 let mut current = self.style;
-                let prev_style = prev_string.style_ref();
                 if self.bg_prev_bg {
                     current.background = prev_style.background;
                 } else if self.bg_prev_fg {
@@ -917,6 +916,66 @@ mod tests {
         assert_eq!(
             <StyleWrapper>::from_config(&config).unwrap().0,
             Color::Red.bold().into()
+        );
+    }
+
+    #[test]
+    fn table_get_styles_previous() {
+        // Test that previous has no effect when there is no previous style
+        let both_prevfg = <StyleWrapper>::from_config(&Value::from(
+            "bold fg:black fg:prevbg bg:prevfg underline",
+        ))
+        .unwrap()
+        .0;
+
+        assert_eq!(
+            both_prevfg.custom(None),
+            Style::new().fg(Color::Black).bold().underline()
+        );
+
+        // But if there is a style on the previous string, then use that
+        let prev_style = Style::new().underline().fg(Color::Yellow).on(Color::Red);
+
+        assert_eq!(
+            both_prevfg.custom(Some(&prev_style)),
+            Style::new()
+                .fg(Color::Red)
+                .on(Color::Yellow)
+                .bold()
+                .underline()
+        );
+
+        // Test that all the combinations of previous colors work
+        let fg_prev_fg = <StyleWrapper>::from_config(&Value::from("fg:prevfg"))
+            .unwrap()
+            .0;
+        assert_eq!(
+            fg_prev_fg.custom(Some(&prev_style)),
+            Style::new().fg(Color::Yellow)
+        );
+
+        let fg_prev_bg = <StyleWrapper>::from_config(&Value::from("fg:prevbg"))
+            .unwrap()
+            .0;
+        assert_eq!(
+            fg_prev_bg.custom(Some(&prev_style)),
+            Style::new().fg(Color::Red)
+        );
+
+        let bg_prev_fg = <StyleWrapper>::from_config(&Value::from("bg:prevfg"))
+            .unwrap()
+            .0;
+        assert_eq!(
+            bg_prev_fg.custom(Some(&prev_style)),
+            Style::new().on(Color::Yellow)
+        );
+
+        let bg_prev_bg = <StyleWrapper>::from_config(&Value::from("bg:prevbg"))
+            .unwrap()
+            .0;
+        assert_eq!(
+            bg_prev_bg.custom(Some(&prev_style)),
+            Style::new().on(Color::Red)
         );
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -285,7 +285,7 @@ pub struct Style {
 }
 
 impl Style {
-    pub fn new(&self, prev: Option<&nu_ansi_term::Style>) -> nu_ansi_term::Style {
+    pub fn modify(&self, prev: Option<&nu_ansi_term::Style>) -> nu_ansi_term::Style {
         match prev {
             None => self.style,
             Some(prev_style) => {
@@ -938,7 +938,7 @@ mod tests {
         .0;
 
         assert_eq!(
-            both_prev_fg.new(None),
+            both_prev_fg.modify(None),
             nu_ansi_term::Style::new().fg(Color::Black).bold().underline()
         );
 
@@ -946,7 +946,7 @@ mod tests {
         let prev_style = nu_ansi_term::Style::new().underline().fg(Color::Yellow).on(Color::Red);
 
         assert_eq!(
-            both_prev_fg.new(Some(&prev_style)),
+            both_prev_fg.modify(Some(&prev_style)),
             nu_ansi_term::Style::new()
                 .fg(Color::Red)
                 .on(Color::Yellow)
@@ -959,7 +959,7 @@ mod tests {
             .unwrap()
             .0;
         assert_eq!(
-            fg_prev_fg.new(Some(&prev_style)),
+            fg_prev_fg.modify(Some(&prev_style)),
             nu_ansi_term::Style::new().fg(Color::Yellow)
         );
 
@@ -967,7 +967,7 @@ mod tests {
             .unwrap()
             .0;
         assert_eq!(
-            fg_prev_bg.new(Some(&prev_style)),
+            fg_prev_bg.modify(Some(&prev_style)),
             nu_ansi_term::Style::new().fg(Color::Red)
         );
 
@@ -975,7 +975,7 @@ mod tests {
             .unwrap()
             .0;
         assert_eq!(
-            bg_prev_fg.new(Some(&prev_style)),
+            bg_prev_fg.modify(Some(&prev_style)),
             nu_ansi_term::Style::new().on(Color::Yellow)
         );
 
@@ -983,7 +983,7 @@ mod tests {
             .unwrap()
             .0;
         assert_eq!(
-            bg_prev_bg.new(Some(&prev_style)),
+            bg_prev_bg.modify(Some(&prev_style)),
             nu_ansi_term::Style::new().on(Color::Red)
         );
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -261,13 +261,111 @@ impl StarshipConfig {
 }
 
 /// Deserialize a style string in the starship format with serde
-pub fn deserialize_style<'de, D>(de: D) -> Result<nu_ansi_term::Style, D::Error>
+pub fn deserialize_style<'de, D>(de: D) -> Result<CustomStyle, D::Error>
 where
     D: Deserializer<'de>,
 {
     Cow::<'_, str>::deserialize(de).and_then(|s| {
         parse_style_string(s.as_ref(), None).ok_or_else(|| D::Error::custom("Invalid style string"))
     })
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+/// Wrapper for `nu_ansi_term::Style` that supports referencing the previous style's foreground/background color.
+pub struct CustomStyle {
+    style: nu_ansi_term::Style,
+    bg_prev_fg: bool,
+    bg_prev_bg: bool,
+    fg_prev_fg: bool,
+    fg_prev_bg: bool,
+}
+
+impl CustomStyle {
+    fn new() -> CustomStyle {
+        Default::default()
+    }
+
+    pub fn custom(&self, prev: Option<&nu_ansi_term::AnsiString>) -> nu_ansi_term::Style {
+        match prev {
+            None => self.style,
+            Some(prev_string) => {
+                let mut current = self.style;
+                let prev_style = prev_string.style_ref();
+                if self.bg_prev_bg {
+                    current.background = prev_style.background;
+                } else if self.bg_prev_fg {
+                    current.background = prev_style.foreground;
+                }
+                if self.fg_prev_fg {
+                    current.foreground = prev_style.foreground;
+                } else if self.fg_prev_bg {
+                    current.foreground = prev_style.background;
+                }
+
+                current
+            }
+        }
+    }
+
+    pub fn style(&self) -> &nu_ansi_term::Style {
+        &self.style
+    }
+
+    fn map_style<F>(&self, f: F) -> Self
+    where
+        F: FnOnce(&nu_ansi_term::Style) -> nu_ansi_term::Style,
+    {
+        CustomStyle {
+            style: f(&self.style),
+            ..*self
+        }
+    }
+
+    fn prev_fg(&self, col_fg: bool) -> Self {
+        if col_fg {
+            CustomStyle {
+                fg_prev_fg: true,
+                ..*self
+            }
+        } else {
+            CustomStyle {
+                bg_prev_fg: true,
+                ..*self
+            }
+        }
+    }
+
+    fn prev_bg(&self, col_fg: bool) -> Self {
+        if col_fg {
+            CustomStyle {
+                fg_prev_bg: true,
+                ..*self
+            }
+        } else {
+            CustomStyle {
+                bg_prev_bg: true,
+                ..*self
+            }
+        }
+    }
+}
+
+impl From<nu_ansi_term::Style> for CustomStyle {
+    fn from(value: nu_ansi_term::Style) -> Self {
+        CustomStyle {
+            style: value,
+            ..Default::default()
+        }
+    }
+}
+
+impl From<nu_ansi_term::Color> for CustomStyle {
+    fn from(value: nu_ansi_term::Color) -> Self {
+        CustomStyle {
+            style: value.into(),
+            ..Default::default()
+        }
+    }
 }
 
 /** Parse a style string which represents an ansi style. Valid tokens in the style
@@ -279,12 +377,11 @@ where
  - 'italic'
  - 'inverted'
  - 'blink'
+ - 'prevfg'        (specifies the color should be the previous foreground color)
+ - 'prevbg'        (specifies the color should be the previous background color)
  - '<color>'       (see the `parse_color_string` doc for valid color strings)
 */
-pub fn parse_style_string(
-    style_string: &str,
-    context: Option<&Context>,
-) -> Option<nu_ansi_term::Style> {
+pub fn parse_style_string(style_string: &str, context: Option<&Context>) -> Option<CustomStyle> {
     style_string
         .split_whitespace()
         .try_fold(nu_ansi_term::Style::new(), |style, token| {
@@ -309,6 +406,8 @@ pub fn parse_style_string(
                 "blink" => Some(style.blink()),
                 "hidden" => Some(style.hidden()),
                 "strikethrough" => Some(style.strikethrough()),
+                "prevfg" => Some(style.prev_fg(col_fg)),
+                "prevbg" => Some(style.prev_bg(col_fg)),
                 // When the string is supposed to be a color:
                 // Decide if we yield none, reset background or set color.
                 color_string => {
@@ -445,7 +544,7 @@ mod tests {
 
     // Small wrapper to allow deserializing Style without a struct with #[serde(deserialize_with=)]
     #[derive(Default, Clone, Debug, PartialEq)]
-    struct StyleWrapper(Style);
+    struct StyleWrapper(CustomStyle);
 
     impl<'de> Deserialize<'de> for StyleWrapper {
         fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
@@ -493,7 +592,7 @@ mod tests {
         struct SegmentDisplayConfig<'a> {
             pub value: &'a str,
             #[serde(deserialize_with = "deserialize_style")]
-            pub style: Style,
+            pub style: CustomStyle,
         }
 
         let config = toml::toml! {
@@ -507,14 +606,14 @@ mod tests {
             git_status_config.untracked,
             SegmentDisplayConfig {
                 value: "x",
-                style: Style::default(),
+                style: CustomStyle::default(),
             }
         );
         assert_eq!(
             git_status_config.modified,
             SegmentDisplayConfig {
                 value: "∙",
-                style: Color::Red.normal(),
+                style: Color::Red.normal().into(),
             }
         );
     }
@@ -624,7 +723,7 @@ mod tests {
         let config = Value::from("red bold");
         assert_eq!(
             <StyleWrapper>::from_config(&config).unwrap().0,
-            Color::Red.bold()
+            Color::Red.bold().into()
         );
     }
 
@@ -662,13 +761,13 @@ mod tests {
     fn table_get_styles_bold_italic_underline_green_dimmed_silly_caps() {
         let config = Value::from("bOlD ItAlIc uNdErLiNe GrEeN diMMeD");
         let mystyle = <StyleWrapper>::from_config(&config).unwrap().0;
-        assert!(mystyle.is_bold);
-        assert!(mystyle.is_italic);
-        assert!(mystyle.is_underline);
-        assert!(mystyle.is_dimmed);
+        assert!(mystyle.style().is_bold);
+        assert!(mystyle.style().is_italic);
+        assert!(mystyle.style().is_underline);
+        assert!(mystyle.style().is_dimmed);
         assert_eq!(
-            mystyle,
-            nu_ansi_term::Style::new()
+            mystyle.style(),
+            &nu_ansi_term::Style::new()
                 .bold()
                 .italic()
                 .underline()
@@ -681,14 +780,14 @@ mod tests {
     fn table_get_styles_bold_italic_underline_green_dimmed_inverted_silly_caps() {
         let config = Value::from("bOlD ItAlIc uNdErLiNe GrEeN diMMeD InVeRTed");
         let mystyle = <StyleWrapper>::from_config(&config).unwrap().0;
-        assert!(mystyle.is_bold);
-        assert!(mystyle.is_italic);
-        assert!(mystyle.is_underline);
-        assert!(mystyle.is_dimmed);
-        assert!(mystyle.is_reverse);
+        assert!(mystyle.style().is_bold);
+        assert!(mystyle.style().is_italic);
+        assert!(mystyle.style().is_underline);
+        assert!(mystyle.style().is_dimmed);
+        assert!(mystyle.style().is_reverse);
         assert_eq!(
-            mystyle,
-            nu_ansi_term::Style::new()
+            mystyle.style(),
+            &nu_ansi_term::Style::new()
                 .bold()
                 .italic()
                 .underline()
@@ -702,14 +801,14 @@ mod tests {
     fn table_get_styles_bold_italic_underline_green_dimmed_blink_silly_caps() {
         let config = Value::from("bOlD ItAlIc uNdErLiNe GrEeN diMMeD bLiNk");
         let mystyle = <StyleWrapper>::from_config(&config).unwrap().0;
-        assert!(mystyle.is_bold);
-        assert!(mystyle.is_italic);
-        assert!(mystyle.is_underline);
-        assert!(mystyle.is_dimmed);
-        assert!(mystyle.is_blink);
+        assert!(mystyle.style().is_bold);
+        assert!(mystyle.style().is_italic);
+        assert!(mystyle.style().is_underline);
+        assert!(mystyle.style().is_dimmed);
+        assert!(mystyle.style().is_blink);
         assert_eq!(
-            mystyle,
-            nu_ansi_term::Style::new()
+            mystyle.style(),
+            &nu_ansi_term::Style::new()
                 .bold()
                 .italic()
                 .underline()
@@ -723,14 +822,14 @@ mod tests {
     fn table_get_styles_bold_italic_underline_green_dimmed_hidden_silly_caps() {
         let config = Value::from("bOlD ItAlIc uNdErLiNe GrEeN diMMeD hIDDen");
         let mystyle = <StyleWrapper>::from_config(&config).unwrap().0;
-        assert!(mystyle.is_bold);
-        assert!(mystyle.is_italic);
-        assert!(mystyle.is_underline);
-        assert!(mystyle.is_dimmed);
-        assert!(mystyle.is_hidden);
+        assert!(mystyle.style().is_bold);
+        assert!(mystyle.style().is_italic);
+        assert!(mystyle.style().is_underline);
+        assert!(mystyle.style().is_dimmed);
+        assert!(mystyle.style().is_hidden);
         assert_eq!(
-            mystyle,
-            nu_ansi_term::Style::new()
+            mystyle.style(),
+            &nu_ansi_term::Style::new()
                 .bold()
                 .italic()
                 .underline()
@@ -744,14 +843,14 @@ mod tests {
     fn table_get_styles_bold_italic_underline_green_dimmed_strikethrough_silly_caps() {
         let config = Value::from("bOlD ItAlIc uNdErLiNe GrEeN diMMeD StRiKEthROUgh");
         let mystyle = <StyleWrapper>::from_config(&config).unwrap().0;
-        assert!(mystyle.is_bold);
-        assert!(mystyle.is_italic);
-        assert!(mystyle.is_underline);
-        assert!(mystyle.is_dimmed);
-        assert!(mystyle.is_strikethrough);
+        assert!(mystyle.style().is_bold);
+        assert!(mystyle.style().is_italic);
+        assert!(mystyle.style().is_underline);
+        assert!(mystyle.style().is_dimmed);
+        assert!(mystyle.style().is_strikethrough);
         assert_eq!(
-            mystyle,
-            nu_ansi_term::Style::new()
+            mystyle.style(),
+            &nu_ansi_term::Style::new()
                 .bold()
                 .italic()
                 .underline()
@@ -766,7 +865,7 @@ mod tests {
         // Test a "plain" style with no formatting
         let config = Value::from("");
         let plain_style = <StyleWrapper>::from_config(&config).unwrap().0;
-        assert_eq!(plain_style, nu_ansi_term::Style::new());
+        assert_eq!(plain_style.style(), &nu_ansi_term::Style::new());
 
         // Test a string that's clearly broken
         let config = Value::from("djklgfhjkldhlhk;j");
@@ -803,21 +902,21 @@ mod tests {
         let config = Value::from("fg:red bg:none");
         assert_eq!(
             <StyleWrapper>::from_config(&config).unwrap().0,
-            Color::Red.normal()
+            Color::Red.normal().into()
         );
 
         // Test that bg:none will yield a style
         let config = Value::from("fg:red bg:none bold");
         assert_eq!(
             <StyleWrapper>::from_config(&config).unwrap().0,
-            Color::Red.bold()
+            Color::Red.bold().into()
         );
 
         // Test that bg:none will overwrite the previous background colour
         let config = Value::from("fg:red bg:green bold bg:none");
         assert_eq!(
             <StyleWrapper>::from_config(&config).unwrap().0,
-            Color::Red.bold()
+            Color::Red.bold().into()
         );
     }
 
@@ -827,8 +926,8 @@ mod tests {
         let config = Value::from("bg:#050505 underline fg:120");
         let flipped_style = <StyleWrapper>::from_config(&config).unwrap().0;
         assert_eq!(
-            flipped_style,
-            Style::new()
+            flipped_style.style(),
+            &Style::new()
                 .underline()
                 .fg(Color::Fixed(120))
                 .on(Color::Rgb(5, 5, 5))
@@ -838,8 +937,8 @@ mod tests {
         let config = Value::from("bg:120 bg:125 bg:127 fg:127 122 125");
         let multi_style = <StyleWrapper>::from_config(&config).unwrap().0;
         assert_eq!(
-            multi_style,
-            Style::new().fg(Color::Fixed(125)).on(Color::Fixed(127))
+            multi_style.style(),
+            &Style::new().fg(Color::Fixed(125)).on(Color::Fixed(127))
         );
     }
 

--- a/src/formatter/string_formatter.rs
+++ b/src/formatter/string_formatter.rs
@@ -5,7 +5,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::error::Error;
 use std::fmt;
 
-use crate::config::{parse_style_string, CustomStyle};
+use crate::config::{parse_style_string, Style};
 use crate::context::{Context, Shell};
 use crate::segment::Segment;
 
@@ -235,7 +235,7 @@ impl<'a> StringFormatter<'a> {
     /// - Variable mapper returns an error.
     pub fn parse(
         self,
-        default_style: Option<CustomStyle>,
+        default_style: Option<Style>,
         context: Option<&Context>,
     ) -> Result<Vec<Segment>, StringFormatterError> {
         fn parse_textgroup<'a>(
@@ -258,7 +258,7 @@ impl<'a> StringFormatter<'a> {
             style: Vec<StyleElement>,
             variables: &'a StyleVariableMapType<'a>,
             context: Option<&Context>,
-        ) -> Option<Result<CustomStyle, StringFormatterError>> {
+        ) -> Option<Result<Style, StringFormatterError>> {
             let style_strings = style
                 .into_iter()
                 .map(|style| match style {
@@ -283,7 +283,7 @@ impl<'a> StringFormatter<'a> {
 
         fn parse_format<'a>(
             format: Vec<FormatElement<'a>>,
-            style: Option<CustomStyle>,
+            style: Option<Style>,
             variables: &'a VariableMapType<'a>,
             style_variables: &'a StyleVariableMapType<'a>,
             context: Option<&Context>,

--- a/src/formatter/string_formatter.rs
+++ b/src/formatter/string_formatter.rs
@@ -1,4 +1,3 @@
-use nu_ansi_term::Style;
 use pest::error::Error as PestError;
 use rayon::prelude::*;
 use std::borrow::Cow;
@@ -6,7 +5,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::error::Error;
 use std::fmt;
 
-use crate::config::parse_style_string;
+use crate::config::{parse_style_string, CustomStyle};
 use crate::context::{Context, Shell};
 use crate::segment::Segment;
 
@@ -236,7 +235,7 @@ impl<'a> StringFormatter<'a> {
     /// - Variable mapper returns an error.
     pub fn parse(
         self,
-        default_style: Option<Style>,
+        default_style: Option<CustomStyle>,
         context: Option<&Context>,
     ) -> Result<Vec<Segment>, StringFormatterError> {
         fn parse_textgroup<'a>(
@@ -259,7 +258,7 @@ impl<'a> StringFormatter<'a> {
             style: Vec<StyleElement>,
             variables: &'a StyleVariableMapType<'a>,
             context: Option<&Context>,
-        ) -> Option<Result<Style, StringFormatterError>> {
+        ) -> Option<Result<CustomStyle, StringFormatterError>> {
             let style_strings = style
                 .into_iter()
                 .map(|style| match style {
@@ -284,7 +283,7 @@ impl<'a> StringFormatter<'a> {
 
         fn parse_format<'a>(
             format: Vec<FormatElement<'a>>,
-            style: Option<Style>,
+            style: Option<CustomStyle>,
             variables: &'a VariableMapType<'a>,
             style_variables: &'a StyleVariableMapType<'a>,
             context: Option<&Context>,
@@ -487,7 +486,7 @@ mod tests {
         let style = Some(Color::Red.bold());
 
         let formatter = StringFormatter::new(FORMAT_STR).unwrap().map(empty_mapper);
-        let result = formatter.parse(style, None).unwrap();
+        let result = formatter.parse(style.map(|s| s.into()), None).unwrap();
         let mut result_iter = result.iter();
         match_next!(result_iter, "text", style);
     }
@@ -562,7 +561,9 @@ mod tests {
         let inner_style = Some(Color::Blue.normal());
 
         let formatter = StringFormatter::new(FORMAT_STR).unwrap().map(empty_mapper);
-        let result = formatter.parse(outer_style, None).unwrap();
+        let result = formatter
+            .parse(outer_style.map(|s| s.into()), None)
+            .unwrap();
         let mut result_iter = result.iter();
         match_next!(result_iter, "outer ", outer_style);
         match_next!(result_iter, "middle ", middle_style);
@@ -618,9 +619,9 @@ mod tests {
 
         let mut segments: Vec<Segment> = Vec::new();
         segments.extend(Segment::from_text(None, "styless"));
-        segments.extend(Segment::from_text(styled_style, "styled"));
+        segments.extend(Segment::from_text(styled_style.map(|s| s.into()), "styled"));
         segments.extend(Segment::from_text(
-            styled_no_modifier_style,
+            styled_no_modifier_style.map(|s| s.into()),
             "styled_no_modifier",
         ));
 

--- a/src/module.rs
+++ b/src/module.rs
@@ -211,7 +211,7 @@ where
             }
             _ => {
                 used += segment.width_graphemes();
-                current.push(segment.ansi_string());
+                current.push(segment.ansi_string(current.last()));
             }
         }
 

--- a/src/module.rs
+++ b/src/module.rs
@@ -211,7 +211,7 @@ where
             }
             _ => {
                 used += segment.width_graphemes();
-                current.push(segment.ansi_string(current.last()));
+                current.push(segment.ansi_string(current.last().map(|s| s.style_ref())));
             }
         }
 

--- a/src/module.rs
+++ b/src/module.rs
@@ -201,10 +201,11 @@ where
 {
     let mut used = 0usize;
     let mut current: Vec<AnsiString> = Vec::new();
-    let mut chunks: Vec<(Vec<AnsiString>, &FillSegment, Option<::nu_ansi_term::Style>)> = Vec::new();
+    let mut chunks: Vec<(Vec<AnsiString>, &FillSegment, Option<::nu_ansi_term::Style>)> =
+        Vec::new();
 
     for segment in segments {
-        let prev_style = current.last().map(|s| s.style_ref().clone());
+        let prev_style = current.last().map(|s| *s.style_ref());
         match segment {
             Segment::Fill(fs) => {
                 chunks.push((current, fs, prev_style));
@@ -230,8 +231,9 @@ where
         chunks
             .into_iter()
             .flat_map(|(strs, fill, prev_style)| {
-                strs.into_iter()
-                    .chain(std::iter::once(fill.ansi_string(prev_style.as_ref(), fill_size)))
+                strs.into_iter().chain(std::iter::once(
+                    fill.ansi_string(prev_style.as_ref(), fill_size),
+                ))
             })
             .chain(current)
             .collect::<Vec<AnsiString>>()

--- a/src/module.rs
+++ b/src/module.rs
@@ -201,17 +201,18 @@ where
 {
     let mut used = 0usize;
     let mut current: Vec<AnsiString> = Vec::new();
-    let mut chunks: Vec<(Vec<AnsiString>, &FillSegment)> = Vec::new();
+    let mut chunks: Vec<(Vec<AnsiString>, &FillSegment, Option<::nu_ansi_term::Style>)> = Vec::new();
 
     for segment in segments {
+        let prev_style = current.last().map(|s| s.style_ref().clone());
         match segment {
             Segment::Fill(fs) => {
-                chunks.push((current, fs));
+                chunks.push((current, fs, prev_style));
                 current = Vec::new();
             }
             _ => {
                 used += segment.width_graphemes();
-                current.push(segment.ansi_string(current.last().map(|s| s.style_ref())));
+                current.push(segment.ansi_string(prev_style.as_ref()));
             }
         }
 
@@ -228,9 +229,9 @@ where
             .map(|remaining| remaining / chunks.len());
         chunks
             .into_iter()
-            .flat_map(|(strs, fill)| {
+            .flat_map(|(strs, fill, prev_style)| {
                 strs.into_iter()
-                    .chain(std::iter::once(fill.ansi_string(fill_size)))
+                    .chain(std::iter::once(fill.ansi_string(prev_style.as_ref(), fill_size)))
             })
             .chain(current)
             .collect::<Vec<AnsiString>>()

--- a/src/modules/status.rs
+++ b/src/modules/status.rs
@@ -75,7 +75,11 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                     context,
                 )
                 .ok()
-                .map(|segments| segments.into_iter().map(|s| s.to_string()))
+                .map(|segments| {
+                    segments
+                        .into_iter()
+                        .map(|s| format!("{}", s.ansi_string(None)))
+                })
             })
             .flatten()
             .collect::<String>(),

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -17,7 +17,7 @@ pub struct TextSegment {
 
 impl TextSegment {
     // Returns the AnsiString of the segment value
-    fn ansi_string(&self, prev: Option<&AnsiString>) -> AnsiString {
+    fn ansi_string(&self, prev: Option<&Style>) -> AnsiString {
         match self.style {
             Some(style) => style.custom(prev).paint(&self.value),
             None => AnsiString::from(&self.value),
@@ -161,7 +161,7 @@ impl Segment {
     }
 
     // Returns the AnsiString of the segment value, not including its prefix and suffix
-    pub fn ansi_string(&self, prev: Option<&AnsiString>) -> AnsiString {
+    pub fn ansi_string(&self, prev: Option<&Style>) -> AnsiString {
         match self {
             Self::Fill(fs) => fs.ansi_string(None),
             Self::Text(ts) => ts.ansi_string(prev),

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -1,15 +1,15 @@
 use crate::{
-    config::CustomStyle,
+    config::Style,
     print::{Grapheme, UnicodeWidthGraphemes},
 };
-use nu_ansi_term::{AnsiString, Style};
+use nu_ansi_term::AnsiString;
 use unicode_segmentation::UnicodeSegmentation;
 
 /// Type that holds text with an associated style
 #[derive(Clone)]
 pub struct TextSegment {
     /// The segment's style. If None, will inherit the style of the module containing it.
-    style: Option<CustomStyle>,
+    style: Option<Style>,
 
     /// The string value of the current segment.
     value: String,
@@ -17,9 +17,9 @@ pub struct TextSegment {
 
 impl TextSegment {
     // Returns the AnsiString of the segment value
-    fn ansi_string(&self, prev: Option<&Style>) -> AnsiString {
+    fn ansi_string(&self, prev: Option<&nu_ansi_term::Style>) -> AnsiString {
         match self.style {
-            Some(style) => style.custom(prev).paint(&self.value),
+            Some(style) => style.new(prev).paint(&self.value),
             None => AnsiString::from(&self.value),
         }
     }
@@ -29,7 +29,7 @@ impl TextSegment {
 #[derive(Clone)]
 pub struct FillSegment {
     /// The segment's style. If None, will inherit the style of the module containing it.
-    style: Option<CustomStyle>,
+    style: Option<Style>,
 
     /// The string value of the current segment.
     value: String,
@@ -100,7 +100,7 @@ pub enum Segment {
 
 impl Segment {
     /// Creates new segments from a text with a style; breaking out `LineTerminators`.
-    pub fn from_text<T>(style: Option<CustomStyle>, value: T) -> Vec<Self>
+    pub fn from_text<T>(style: Option<Style>, value: T) -> Vec<Self>
     where
         T: Into<String>,
     {
@@ -118,7 +118,7 @@ impl Segment {
     }
 
     /// Creates a new fill segment
-    pub fn fill<T>(style: Option<CustomStyle>, value: T) -> Self
+    pub fn fill<T>(style: Option<Style>, value: T) -> Self
     where
         T: Into<String>,
     {
@@ -128,7 +128,7 @@ impl Segment {
         })
     }
 
-    pub fn style(&self) -> Option<Style> {
+    pub fn style(&self) -> Option<nu_ansi_term::Style> {
         match self {
             Self::Fill(fs) => fs.style.map(|cs| cs.style().to_owned()),
             Self::Text(ts) => ts.style.map(|cs| cs.style().to_owned()),
@@ -136,7 +136,7 @@ impl Segment {
         }
     }
 
-    pub fn set_style_if_empty(&mut self, style: Option<CustomStyle>) {
+    pub fn set_style_if_empty(&mut self, style: Option<Style>) {
         match self {
             Self::Fill(fs) => {
                 if fs.style.is_none() {
@@ -161,7 +161,7 @@ impl Segment {
     }
 
     // Returns the AnsiString of the segment value, not including its prefix and suffix
-    pub fn ansi_string(&self, prev: Option<&Style>) -> AnsiString {
+    pub fn ansi_string(&self, prev: Option<&nu_ansi_term::Style>) -> AnsiString {
         match self {
             Self::Fill(fs) => fs.ansi_string(None),
             Self::Text(ts) => ts.ansi_string(prev),

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -37,7 +37,11 @@ pub struct FillSegment {
 
 impl FillSegment {
     // Returns the AnsiString of the segment value, not including its prefix and suffix
-    pub fn ansi_string(&self, prev: Option<&nu_ansi_term::Style>, width: Option<usize>) -> AnsiString {
+    pub fn ansi_string(
+        &self,
+        prev: Option<&nu_ansi_term::Style>,
+        width: Option<usize>,
+    ) -> AnsiString {
         let s = match width {
             Some(w) => self
                 .value
@@ -85,7 +89,7 @@ mod fill_seg_tests {
                 value: String::from(*text),
                 style: Some(style.into()),
             };
-            let actual = f.ansi_string(Some(&prev.into()), Some(width));
+            let actual = f.ansi_string(Some(&prev), Some(width));
             assert_eq!(style.paint(*expected), actual);
         }
     }

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -19,7 +19,7 @@ impl TextSegment {
     // Returns the AnsiString of the segment value
     fn ansi_string(&self, prev: Option<&nu_ansi_term::Style>) -> AnsiString {
         match self.style {
-            Some(style) => style.new(prev).paint(&self.value),
+            Some(style) => style.modify(prev).paint(&self.value),
             None => AnsiString::from(&self.value),
         }
     }
@@ -37,7 +37,7 @@ pub struct FillSegment {
 
 impl FillSegment {
     // Returns the AnsiString of the segment value, not including its prefix and suffix
-    pub fn ansi_string(&self, width: Option<usize>) -> AnsiString {
+    pub fn ansi_string(&self, prev: Option<&nu_ansi_term::Style>, width: Option<usize>) -> AnsiString {
         let s = match width {
             Some(w) => self
                 .value
@@ -55,7 +55,7 @@ impl FillSegment {
             None => String::from(&self.value),
         };
         match self.style {
-            Some(style) => style.style().paint(s),
+            Some(style) => style.modify(prev).paint(s),
             None => AnsiString::from(s),
         }
     }
@@ -70,6 +70,7 @@ mod fill_seg_tests {
     fn ansi_string_width() {
         let width: usize = 10;
         let style = Color::Blue.bold();
+        let prev = Color::Red.bold();
 
         let inputs = vec![
             (".", ".........."),
@@ -84,7 +85,7 @@ mod fill_seg_tests {
                 value: String::from(*text),
                 style: Some(style.into()),
             };
-            let actual = f.ansi_string(Some(width));
+            let actual = f.ansi_string(Some(&prev.into()), Some(width));
             assert_eq!(style.paint(*expected), actual);
         }
     }
@@ -163,7 +164,7 @@ impl Segment {
     // Returns the AnsiString of the segment value, not including its prefix and suffix
     pub fn ansi_string(&self, prev: Option<&nu_ansi_term::Style>) -> AnsiString {
         match self {
-            Self::Fill(fs) => fs.ansi_string(None),
+            Self::Fill(fs) => fs.ansi_string(prev, None),
             Self::Text(ts) => ts.ansi_string(prev),
             Self::LineTerm => AnsiString::from(LINE_TERMINATOR_STRING),
         }


### PR DESCRIPTION
This is a continuation of https://github.com/starship/starship/pull/4945, which seems to have stalled.

#### Description
This PR adds the `prev_fg` and `prev_bg` specifiers that are allowed to appear in `fg:` or `bg:` style elements. The value will be based on the previous segment's `AnsiString`. This allows powerline-like separators to have the correct colors when so configured.

#### Motivation and Context
I am migrating from [powerline](https://github.com/powerline/powerline) and one of the features of the prompt strings there is pretty filled status segments. This PR is based off a suggestion in #528 to allow the previous foreground/background color to be available in style specifiers. This PR does not enable all the functionality of Powerline (e.g. directory separators, pipestatus colors would need to be enhanced) but is crucial to allowing the specification of segment styles depending on the previous segment. It is also a much smaller change than other approaches would suggest e.g. #1235

Updated example config: https://github.com/vhdirk/starship-theme-powerline

Closes #528

#### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/884807/221677384-fe0a348a-7ef9-4ebe-87bd-754dec469d6a.png)

#### How Has This Been Tested?
* [x]  Add unit tests
* [x]  I have tested using **MacOS**
* [x]  I have tested using **Linux**
* [ ]  I have tested using **Windows**

#### Checklist:
* [x]  I have updated the documentation accordingly.
* [x]  I have updated the tests accordingly.

