### PR TITLE
I fixed the starship installation command for NixOS in docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Alternatively, install Starship using any of the following package managers:
 | CentOS 7+          | [Copr]                  | `dnf copr enable atim/starship` <br /> `dnf install starship` |
 | Gentoo             | [Gentoo Packages]       | `emerge app-shells/starship`                                  |
 | Manjaro            |                         | `pacman -S starship`                                          |
-| NixOS              | [nixpkgs]               | `nix-env -iA nixpkgs.starship`                                |
+| NixOS              | [nixpkgs]               | `nix-env -iA nixos.starship`                                  |
 | Void Linux         | [Void Linux Packages]   | `xbps-install -S starship`                                    |
 
 </details>

--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ This project is [ISC](https://github.com/starship/starship/blob/master/LICENSE) 
 [linuxbrew]: https://formulae.brew.sh/formula/starship
 [homebrew]: https://formulae.brew.sh/formula/starship
 [macports]: https://ports.macports.org/port/starship
-[nixpkgs]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/tools/misc/starship/default.nix
+[nixpkgs]: https://search.nixos.org/packages?channel=23.05&show=starship&from=0&size=50&sort=relevance&type=packages&query=starship
 [pkgsrc]: https://pkgsrc.se/shells/starship
 [scoop]: https://github.com/ScoopInstaller/Main/blob/master/bucket/starship.json
 [termux]: https://github.com/termux/termux-packages/tree/master/packages/starship

--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ This project is [ISC](https://github.com/starship/starship/blob/master/LICENSE) 
 [linuxbrew]: https://formulae.brew.sh/formula/starship
 [homebrew]: https://formulae.brew.sh/formula/starship
 [macports]: https://ports.macports.org/port/starship
-[nixpkgs]: https://search.nixos.org/packages?channel=23.05&show=starship&from=0&size=50&sort=relevance&type=packages&query=starship
+[nixpkgs]: https://search.nixos.org/packages?&show=starship&from=0&size=50&sort=relevance&type=packages&query=starship
 [pkgsrc]: https://pkgsrc.se/shells/starship
 [scoop]: https://github.com/ScoopInstaller/Main/blob/master/bucket/starship.json
 [termux]: https://github.com/termux/termux-packages/tree/master/packages/starship


### PR DESCRIPTION
#### Description
Fix the starship nix OS installation command in [starship docs](https://starship.rs/guide/#step-1-install-starship).

## Incorrect command
```bash
nix-env -iA nixpkgs.starship
```
## Correct command
```
`nix-env -iA nix-env -iA nixos.starship`
```

I've also changed the GitHub URL to [starship packages URL](https://search.nixos.org/packages?&show=starship&from=0&size=50&sort=relevance&type=packages&query=starship). So the developer quickly finds the installation package on nix packages.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
