### PR TITLE
fix: Remove printing the ASCII clear screen code in fish

### DIFF
--- a/src/print.rs
+++ b/src/print.rs
@@ -76,12 +76,6 @@ pub fn get_prompt(context: Context) -> String {
         _ => {}
     }
 
-    // A workaround for a fish bug (see #739,#279). Applying it to all shells
-    // breaks things (see #808,#824,#834). Should only be printed in fish.
-    if Shell::Fish == context.shell && context.target == Target::Main {
-        buf.push_str("\x1b[J"); // An ASCII control code to clear screen
-    }
-
     let (formatter, modules) = load_formatter_and_modules(&context);
 
     let formatter = formatter.map_variables_to_segments(|module| {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Remove [printing the ASCII clear screen code in fish](https://github.com/starship/starship/pull/865/commits/eb24540a18a64d250e97dc1c4bca8428b43bb277). It's not needed any more since fish 3.2.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The clear screen code breaks the highlighting of successful/erroneous return codes in the [shell integration of iTerm2](https://iterm2.com/documentation-shell-integration.html). Removing this workaround works with newer versions of fish. According to https://github.com/fish-shell/fish-shell/issues/3550#issuecomment-751476180 the issue was fixed in March 2021 with version 3.2.0.

This code was added with https://github.com/starship/starship/pull/739 to fix https://github.com/starship/starship/issues/279 and restricted to fish with https://github.com/starship/starship/pull/865.

I hope dropping workarounds for shells older than 2021 to re-enable another feature is OK?

_Workaround_

Unset `STARSHIP_SHELL` after initializing Starship and before loading iterm's shell integration in config.fish.

```fish
starship init fish | source
set -e STARSHIP_SHELL # Breaks iterm shell integration
source {$HOME}/.iterm2_shell_integration.fish
```

#### Screenshots (if appropriate):
<img width="1097" alt="SCR-20231016-lgsy" src="https://github.com/starship/starship/assets/61654/27a44f51-a551-475a-a826-1bd76934bbf0">

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [X] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

Regressions that I tested:

- <kbd>ALT</kbd>-<kbd>LEFT</kbd>/<kbd>RIGHT</kbd> to change dir in fish works with and without `line_break` and with and without `add_newline = false` (all four combinations) (#279)
- `ls`<kbd>TAB</kbd> works in zsh without `line_break` (#834)
- Multiline editing works in zsh (#824)
- `cd`<kbd>TAB</kbd> works in zsh (#824)
- <kbd>CTRL</kbd>-<kbd>R</kbd> in bash without `line_break` works (#808)

Tested using zsh 5.9, bash 5.2.15 and fish 3.6.1.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
