### PR TITLE
feat/CUDA module with tests

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -261,6 +261,35 @@
         }
       ]
     },
+    "cuda": {
+      "default": {
+        "commands": [
+          [
+            "nvcc",
+            "--version"
+          ],
+          [
+            "nvidia-smi",
+            "--query"
+          ]
+        ],
+        "detect_extensions": [
+          "cu"
+        ],
+        "detect_files": [],
+        "detect_folders": [],
+        "disabled": false,
+        "format": "via [$symbol($version(-$name) )]($style)",
+        "style": "bold #76b900",
+        "symbol": "NV ",
+        "version_format": "v${raw}"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/CudaConfig"
+        }
+      ]
+    },
     "daml": {
       "default": {
         "detect_extensions": [],
@@ -2438,6 +2467,74 @@
           "type": "array",
           "items": {
             "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "CudaConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "via [$symbol($version(-$name) )]($style)",
+          "type": "string"
+        },
+        "version_format": {
+          "default": "v${raw}",
+          "type": "string"
+        },
+        "style": {
+          "default": "bold #76b900",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "NV ",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "detect_extensions": {
+          "default": [
+            "cu"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_files": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_folders": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "commands": {
+          "default": [
+            [
+              "nvcc",
+              "--version"
+            ],
+            [
+              "nvidia-smi",
+              "--query"
+            ]
+          ],
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         }
       },

--- a/docs/.vuepress/public/presets/toml/jetpack.toml
+++ b/docs/.vuepress/public/presets/toml/jetpack.toml
@@ -28,6 +28,7 @@ $package\
 $c\
 $cmake\
 $cobol\
+$cuda\
 $daml\
 $dart\
 $deno\

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -996,9 +996,6 @@ The `cuda` module shows some information about your `nvcc` compiler or nVIDIA dr
 | `format`            | `'via [$symbol($version)]($style)'`                                | The format string for the module.                                         |
 | `version_format`    | `'v${raw}'`                                                                 | The version format. |
 | `symbol`            | `'NV '`                                                                      | The symbol used before displaying the compiler or driver details                    |
-| `detect_extensions` | `[]`                                                                | Which extensions should trigger this module.                              |
-| `detect_files`      | `[]`                                                                        | Which filenames should trigger this module.                               |
-| `detect_folders`    | `[]`                                                                        | Which folders should trigger this module.                                 |
 | `commands`          | `[ [ 'nvcc', '--version' ], [ 'nvidia-smi', '--query' ] ]` | How to detect what the compiler is and what the driver is                                        |
 | `style`             | `'bold #76b900'`                                                                | The style for the module.                                                 |
 | `disabled`          | `false`                                                                     | Disables the `cuda` module.                                                  |
@@ -1007,8 +1004,7 @@ The `cuda` module shows some information about your `nvcc` compiler or nVIDIA dr
 
 | Variable | Example | Description                          |
 | -------- | ------- | ------------------------------------ |
-| name     | clang   | The name of the compiler             |
-| version  | 13.0.0  | The version of the compiler          |
+| version  | 12.0    | The version of `nvcc` or installed `CUDA`|
 | symbol   |         | Mirrors the value of option `symbol` |
 | style    |         | Mirrors the value of option `style`  |
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -987,7 +987,7 @@ format = 'via [✨ $version](bold blue) '
 
 # CUDA
 
-The `cuda` module shows some information about your `nvcc` compiler or nVIDIA driver from `nvidia-smi`. By default the module will be shown if the current directory contains a `.cu` file.
+The `cuda` module shows some information about your `nvcc` compiler or nVIDIA driver from `nvidia-smi`. By default the module will be shown if `nvcc` or `nvidia-smi` is detected.
 
 ### Options
 
@@ -996,7 +996,7 @@ The `cuda` module shows some information about your `nvcc` compiler or nVIDIA dr
 | `format`            | `'via [$symbol($version)]($style)'`                                | The format string for the module.                                         |
 | `version_format`    | `'v${raw}'`                                                                 | The version format. |
 | `symbol`            | `'NV '`                                                                      | The symbol used before displaying the compiler or driver details                    |
-| `detect_extensions` | `['cu']`                                                                | Which extensions should trigger this module.                              |
+| `detect_extensions` | `[]`                                                                | Which extensions should trigger this module.                              |
 | `detect_files`      | `[]`                                                                        | Which filenames should trigger this module.                               |
 | `detect_folders`    | `[]`                                                                        | Which folders should trigger this module.                                 |
 | `commands`          | `[ [ 'nvcc', '--version' ], [ 'nvidia-smi', '--query' ] ]` | How to detect what the compiler is and what the driver is                                        |

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -277,6 +277,7 @@ $pijul_channel\
 $docker_context\
 $package\
 $c\
+$cuda\
 $cmake\
 $cobol\
 $daml\
@@ -678,6 +679,52 @@ The `commands` option accepts a list of commands to determine the compiler versi
 Each command is represented as a list of the executable name, followed by its arguments, usually something like `['mycc', '--version']`. Starship will try executing each command until it gets a result on STDOUT.
 
 If a C compiler is not supported by this module, you can request it by [raising an issue on GitHub](https://github.com/starship/starship/).
+
+### Example
+
+```toml
+# ~/.config/starship.toml
+
+[c]
+format = 'via [$name $version]($style)'
+```
+
+# CUDA
+
+The `cuda` module shows some information about your `nvcc` compiler or nVIDIA driver from `nvidia-smi`. By default the module will be shown if the current directory contains a `.cu` file.
+
+### Options
+
+| Option              | Default                                                                     | Description                                                               |
+| ------------------- | --------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `format`            | `'via [$symbol($version(-$name) )]($style)'`                                | The format string for the module.                                         |
+| `version_format`    | `'v${raw}'`                                                                 | The version format. |
+| `symbol`            | `'NV '`                                                                      | The symbol used before displaying the compiler or driver details                    |
+| `detect_extensions` | `['cu']`                                                                | Which extensions should trigger this module.                              |
+| `detect_files`      | `[]`                                                                        | Which filenames should trigger this module.                               |
+| `detect_folders`    | `[]`                                                                        | Which folders should trigger this module.                                 |
+| `commands`          | `[ [ 'nvcc', '--version' ], [ 'nvidia-smi' ] ]` | How to detect what the compiler is and what the driver is                                        |
+| `style`             | `'bold #76b900'`                                                                | The style for the module.                                                 |
+| `disabled`          | `false`                                                                     | Disables the `cuda` module.                                                  |
+
+### Variables
+
+| Variable | Example | Description                          |
+| -------- | ------- | ------------------------------------ |
+| name     | clang   | The name of the compiler             |
+| version  | 13.0.0  | The version of the compiler          |
+| symbol   |         | Mirrors the value of option `symbol` |
+| style    |         | Mirrors the value of option `style`  |
+
+NB that `version` is not in the default format.
+
+### Commands
+
+The `commands` option accepts a list of commands to determine the compiler version and name.
+
+Each command is represented as a list of the executable name, followed by its arguments, usually something like `['nvcc', '--version']`. We also support the `nvidia-smi` command to retrieve detail of the driver. Starship will try executing each command until it gets a result on STDOUT.
+
+If a CUDA compiler or driver is not supported by this module, you can request it by [raising an issue on GitHub](https://github.com/starship/starship/).
 
 ### Example
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -277,9 +277,9 @@ $pijul_channel\
 $docker_context\
 $package\
 $c\
-$cuda\
 $cmake\
 $cobol\
+$cuda\
 $daml\
 $dart\
 $deno\
@@ -689,52 +689,6 @@ If a C compiler is not supported by this module, you can request it by [raising 
 format = 'via [$name $version]($style)'
 ```
 
-# CUDA
-
-The `cuda` module shows some information about your `nvcc` compiler or nVIDIA driver from `nvidia-smi`. By default the module will be shown if the current directory contains a `.cu` file.
-
-### Options
-
-| Option              | Default                                                                     | Description                                                               |
-| ------------------- | --------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| `format`            | `'via [$symbol($version(-$name) )]($style)'`                                | The format string for the module.                                         |
-| `version_format`    | `'v${raw}'`                                                                 | The version format. |
-| `symbol`            | `'NV '`                                                                      | The symbol used before displaying the compiler or driver details                    |
-| `detect_extensions` | `['cu']`                                                                | Which extensions should trigger this module.                              |
-| `detect_files`      | `[]`                                                                        | Which filenames should trigger this module.                               |
-| `detect_folders`    | `[]`                                                                        | Which folders should trigger this module.                                 |
-| `commands`          | `[ [ 'nvcc', '--version' ], [ 'nvidia-smi' ] ]` | How to detect what the compiler is and what the driver is                                        |
-| `style`             | `'bold #76b900'`                                                                | The style for the module.                                                 |
-| `disabled`          | `false`                                                                     | Disables the `cuda` module.                                                  |
-
-### Variables
-
-| Variable | Example | Description                          |
-| -------- | ------- | ------------------------------------ |
-| name     | clang   | The name of the compiler             |
-| version  | 13.0.0  | The version of the compiler          |
-| symbol   |         | Mirrors the value of option `symbol` |
-| style    |         | Mirrors the value of option `style`  |
-
-NB that `version` is not in the default format.
-
-### Commands
-
-The `commands` option accepts a list of commands to determine the compiler version and name.
-
-Each command is represented as a list of the executable name, followed by its arguments, usually something like `['nvcc', '--version']`. We also support the `nvidia-smi` command to retrieve detail of the driver. Starship will try executing each command until it gets a result on STDOUT.
-
-If a CUDA compiler or driver is not supported by this module, you can request it by [raising an issue on GitHub](https://github.com/starship/starship/).
-
-### Example
-
-```toml
-# ~/.config/starship.toml
-
-[c]
-format = 'via [$name $version]($style)'
-```
-
 ## Character
 
 The `character` module shows a character (usually an arrow) beside where the text
@@ -1029,6 +983,52 @@ By default the module will be shown if any of the following conditions are met:
 
 [crystal]
 format = 'via [✨ $version](bold blue) '
+```
+
+# CUDA
+
+The `cuda` module shows some information about your `nvcc` compiler or nVIDIA driver from `nvidia-smi`. By default the module will be shown if the current directory contains a `.cu` file.
+
+### Options
+
+| Option              | Default                                                                     | Description                                                               |
+| ------------------- | --------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `format`            | `'via [$symbol($version(-$name) )]($style)'`                                | The format string for the module.                                         |
+| `version_format`    | `'v${raw}'`                                                                 | The version format. |
+| `symbol`            | `'NV '`                                                                      | The symbol used before displaying the compiler or driver details                    |
+| `detect_extensions` | `['cu']`                                                                | Which extensions should trigger this module.                              |
+| `detect_files`      | `[]`                                                                        | Which filenames should trigger this module.                               |
+| `detect_folders`    | `[]`                                                                        | Which folders should trigger this module.                                 |
+| `commands`          | `[ [ 'nvcc', '--version' ], [ 'nvidia-smi' ] ]` | How to detect what the compiler is and what the driver is                                        |
+| `style`             | `'bold #76b900'`                                                                | The style for the module.                                                 |
+| `disabled`          | `false`                                                                     | Disables the `cuda` module.                                                  |
+
+### Variables
+
+| Variable | Example | Description                          |
+| -------- | ------- | ------------------------------------ |
+| name     | clang   | The name of the compiler             |
+| version  | 13.0.0  | The version of the compiler          |
+| symbol   |         | Mirrors the value of option `symbol` |
+| style    |         | Mirrors the value of option `style`  |
+
+NB that `version` is not in the default format.
+
+### Commands
+
+The `commands` option accepts a list of commands to determine the compiler version and name.
+
+Each command is represented as a list of the executable name, followed by its arguments, usually something like `['nvcc', '--version']`. We also support the `nvidia-smi` command to retrieve detail of the driver. Starship will try executing each command until it gets a result on STDOUT.
+
+If a CUDA compiler or driver is not supported by this module, you can request it by [raising an issue on GitHub](https://github.com/starship/starship/).
+
+### Example
+
+```toml
+# ~/.config/starship.toml
+
+[c]
+format = 'via [$name $version]($style)'
 ```
 
 ## Daml

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -993,13 +993,13 @@ The `cuda` module shows some information about your `nvcc` compiler or nVIDIA dr
 
 | Option              | Default                                                                     | Description                                                               |
 | ------------------- | --------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| `format`            | `'via [$symbol($version(-$name) )]($style)'`                                | The format string for the module.                                         |
+| `format`            | `'via [$symbol($version)]($style)'`                                | The format string for the module.                                         |
 | `version_format`    | `'v${raw}'`                                                                 | The version format. |
 | `symbol`            | `'NV '`                                                                      | The symbol used before displaying the compiler or driver details                    |
 | `detect_extensions` | `['cu']`                                                                | Which extensions should trigger this module.                              |
 | `detect_files`      | `[]`                                                                        | Which filenames should trigger this module.                               |
 | `detect_folders`    | `[]`                                                                        | Which folders should trigger this module.                                 |
-| `commands`          | `[ [ 'nvcc', '--version' ], [ 'nvidia-smi' ] ]` | How to detect what the compiler is and what the driver is                                        |
+| `commands`          | `[ [ 'nvcc', '--version' ], [ 'nvidia-smi', '--query' ] ]` | How to detect what the compiler is and what the driver is                                        |
 | `style`             | `'bold #76b900'`                                                                | The style for the module.                                                 |
 | `disabled`          | `false`                                                                     | Disables the `cuda` module.                                                  |
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -991,22 +991,22 @@ The `cuda` module shows some information about your `nvcc` compiler or nVIDIA dr
 
 ### Options
 
-| Option              | Default                                                                     | Description                                                               |
-| ------------------- | --------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| `format`            | `'via [$symbol($version)]($style)'`                                | The format string for the module.                                         |
-| `version_format`    | `'v${raw}'`                                                                 | The version format. |
-| `symbol`            | `'NV '`                                                                      | The symbol used before displaying the compiler or driver details                    |
-| `commands`          | `[ [ 'nvcc', '--version' ], [ 'nvidia-smi', '--query' ] ]` | How to detect what the compiler is and what the driver is                                        |
-| `style`             | `'bold #76b900'`                                                                | The style for the module.                                                 |
-| `disabled`          | `false`                                                                     | Disables the `cuda` module.                                                  |
+| Option           | Default                                                    | Description                                                      |
+| ---------------- | ---------------------------------------------------------- | ---------------------------------------------------------------- |
+| `format`         | `'via [$symbol($version)]($style)'`                        | The format string for the module.                                |
+| `version_format` | `'v${raw}'`                                                | The version format.                                              |
+| `symbol`         | `'NV '`                                                    | The symbol used before displaying the compiler or driver details |
+| `commands`       | `[ [ 'nvcc', '--version' ], [ 'nvidia-smi', '--query' ] ]` | How to detect what the compiler is and what the driver is        |
+| `style`          | `'bold #76b900'`                                           | The style for the module.                                        |
+| `disabled`       | `false`                                                    | Disables the `cuda` module.                                      |
 
 ### Variables
 
-| Variable | Example | Description                          |
-| -------- | ------- | ------------------------------------ |
-| version  | 12.0    | The version of `nvcc` or installed `CUDA`|
-| symbol   |         | Mirrors the value of option `symbol` |
-| style    |         | Mirrors the value of option `style`  |
+| Variable | Example | Description                               |
+| -------- | ------- | ----------------------------------------- |
+| version  | 12.0    | The version of `nvcc` or installed `CUDA` |
+| symbol   |         | Mirrors the value of option `symbol`      |
+| style    |         | Mirrors the value of option `style`       |
 
 NB that `version` is not in the default format.
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1027,7 +1027,7 @@ If a CUDA compiler or driver is not supported by this module, you can request it
 ```toml
 # ~/.config/starship.toml
 
-[c]
+[cuda]
 format = 'via [$name $version]($style)'
 ```
 

--- a/src/configs/cuda.rs
+++ b/src/configs/cuda.rs
@@ -27,7 +27,7 @@ impl<'a> Default for CudaConfig<'a> {
             style: "bold #76b900",
             symbol: "NV ",
             disabled: false,
-            detect_extensions: vec!["cu"],
+            detect_extensions: vec![],
             detect_files: vec![],
             detect_folders: vec![],
             commands: vec![

--- a/src/configs/cuda.rs
+++ b/src/configs/cuda.rs
@@ -1,0 +1,42 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(
+    feature = "config-schema",
+    derive(schemars::JsonSchema),
+    schemars(deny_unknown_fields)
+)]
+#[serde(default)]
+pub struct CudaConfig<'a> {
+    pub format: &'a str,
+    pub version_format: &'a str,
+    pub style: &'a str,
+    pub symbol: &'a str,
+    pub disabled: bool,
+    pub detect_extensions: Vec<&'a str>,
+    pub detect_files: Vec<&'a str>,
+    pub detect_folders: Vec<&'a str>,
+    pub commands: Vec<Vec<&'a str>>,
+}
+
+impl<'a> Default for CudaConfig<'a> {
+    fn default() -> Self {
+        CudaConfig {
+            format: "via [$symbol($version)]($style)",
+            version_format: "v${raw}",
+            style: "bold #76b900",
+            symbol: "NV ",
+            disabled: false,
+            detect_extensions: vec!["cu"],
+            detect_files: vec![],
+            detect_folders: vec![],
+            commands: vec![
+                // the compiler is usually nvcc
+                vec!["nvcc", "--version"],
+                // For some users, they do not install the compiler
+                // but install the driver only.
+                vec!["nvidia-smi", "--query"],
+            ],
+        }
+    }
+}

--- a/src/configs/cuda.rs
+++ b/src/configs/cuda.rs
@@ -13,9 +13,6 @@ pub struct CudaConfig<'a> {
     pub style: &'a str,
     pub symbol: &'a str,
     pub disabled: bool,
-    pub detect_extensions: Vec<&'a str>,
-    pub detect_files: Vec<&'a str>,
-    pub detect_folders: Vec<&'a str>,
     pub commands: Vec<Vec<&'a str>>,
 }
 
@@ -27,9 +24,6 @@ impl<'a> Default for CudaConfig<'a> {
             style: "bold #76b900",
             symbol: "NV ",
             disabled: false,
-            detect_extensions: vec![],
-            detect_files: vec![],
-            detect_folders: vec![],
             commands: vec![
                 // the compiler is usually nvcc
                 vec!["nvcc", "--version"],

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -14,6 +14,7 @@ pub mod cobol;
 pub mod conda;
 pub mod container;
 pub mod crystal;
+pub mod cuda;
 pub mod custom;
 pub mod daml;
 pub mod dart;
@@ -133,6 +134,8 @@ pub struct FullConfig<'a> {
     container: container::ContainerConfig<'a>,
     #[serde(borrow)]
     crystal: crystal::CrystalConfig<'a>,
+    #[serde(borrow)]
+    cuda: cuda::CudaConfig<'a>,
     #[serde(borrow)]
     daml: daml::DamlConfig<'a>,
     #[serde(borrow)]

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -55,6 +55,7 @@ pub const PROMPT_ORDER: &[&str] = &[
     "c",
     "cmake",
     "cobol",
+    "cuda",
     "daml",
     "dart",
     "deno",

--- a/src/module.rs
+++ b/src/module.rs
@@ -23,6 +23,7 @@ pub const ALL_MODULES: &[&str] = &[
     "conda",
     "container",
     "crystal",
+    "cuda",
     "daml",
     "dart",
     "deno",

--- a/src/modules/cuda.rs
+++ b/src/modules/cuda.rs
@@ -28,16 +28,6 @@ fn parse_cuda_version(s: &str) -> Option<String> {
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let mut module = context.new_module("cuda");
     let config: CudaConfig = CudaConfig::try_load(module.config);
-    let is_cuda_project = context
-        .try_begin_scan()?
-        .set_extensions(&config.detect_extensions)
-        .set_files(&config.detect_files)
-        .set_folders(&config.detect_folders)
-        .is_match();
-
-    if !is_cuda_project {
-        return None;
-    }
 
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         // The cuda compiler or driver info

--- a/src/modules/cuda.rs
+++ b/src/modules/cuda.rs
@@ -90,6 +90,202 @@ mod tests {
     use nu_ansi_term::Color;
     use std::io;
 
+    const NVCC_SUCCESS_OUTPUT: &str = "\
+nvcc: NVIDIA (R) Cuda compiler driver
+Copyright (c) 2005-2022 NVIDIA Corporation
+Built on Thu_Feb_10_18:23:41_PST_2022
+Cuda compilation tools, release 11.6, V11.6.112
+Build cuda_11.6.r11.6/compiler.30978841_0";
+
+    const NVIDIA_SMI_SUCCESS_OUTPUT: &str = "\
+==============NVSMI LOG==============
+
+Timestamp                                 : Tue Oct 17 11:17:13 2023
+Driver Version                            : 525.125.06
+CUDA Version                              : 12.0
+
+Attached GPUs                             : 1
+GPU 00000000:01:00.0
+    Product Name                          : NVIDIA GeForce RTX 3090
+    Product Brand                         : GeForce
+    Product Architecture                  : Ampere
+    Display Mode                          : Disabled
+    Display Active                        : Disabled
+    Persistence Mode                      : Disabled
+    MIG Mode
+        Current                           : N/A
+        Pending                           : N/A
+    Accounting Mode                       : Disabled
+    Accounting Mode Buffer Size           : 4000
+    Driver Model
+        Current                           : N/A
+        Pending                           : N/A
+    Serial Number                         : N/A
+    GPU UUID                              : GPU-58f16df2-6eee-bfac-bdc1-13e0091441b5
+    Minor Number                          : 0
+    VBIOS Version                         : 94.02.42.80.9F
+    MultiGPU Board                        : No
+    Board ID                              : 0x100
+    Board Part Number                     : N/A
+    GPU Part Number                       : 2204-300-A1
+    Module ID                             : 1
+    Inforom Version
+        Image Version                     : G001.0000.03.03
+        OEM Object                        : 2.0
+        ECC Object                        : N/A
+        Power Management Object           : N/A
+    GPU Operation Mode
+        Current                           : N/A
+        Pending                           : N/A
+    GSP Firmware Version                  : N/A
+    GPU Virtualization Mode
+        Virtualization Mode               : None
+        Host VGPU Mode                    : N/A
+    IBMNPU
+        Relaxed Ordering Mode             : N/A
+    PCI
+        Bus                               : 0x01
+        Device                            : 0x00
+        Domain                            : 0x0000
+        Device Id                         : 0x220410DE
+        Bus Id                            : 00000000:01:00.0
+        Sub System Id                     : 0x161319DA
+        GPU Link Info
+            PCIe Generation
+                Max                       : 4
+                Current                   : 4
+                Device Current            : 4
+                Device Max                : 4
+                Host Max                  : 4
+            Link Width
+                Max                       : 16x
+                Current                   : 16x
+        Bridge Chip
+            Type                          : N/A
+            Firmware                      : N/A
+        Replays Since Reset               : 0
+        Replay Number Rollovers           : 0
+        Tx Throughput                     : 1829000 KB/s
+        Rx Throughput                     : 12000 KB/s
+        Atomic Caps Inbound               : N/A
+        Atomic Caps Outbound              : N/A
+    Fan Speed                             : 70 %
+    Performance State                     : P3
+    Clocks Throttle Reasons
+        Idle                              : Active
+        Applications Clocks Setting       : Not Active
+        SW Power Cap                      : Not Active
+        HW Slowdown                       : Not Active
+            HW Thermal Slowdown           : Not Active
+            HW Power Brake Slowdown       : Not Active
+        Sync Boost                        : Not Active
+        SW Thermal Slowdown               : Not Active
+        Display Clock Setting             : Not Active
+    FB Memory Usage
+        Total                             : 24576 MiB
+        Reserved                          : 316 MiB
+        Used                              : 1788 MiB
+        Free                              : 22471 MiB
+    BAR1 Memory Usage
+        Total                             : 256 MiB
+        Used                              : 5 MiB
+        Free                              : 251 MiB
+    Compute Mode                          : Default
+    Utilization
+        Gpu                               : 35 %
+        Memory                            : 7 %
+        Encoder                           : 0 %
+        Decoder                           : 0 %
+    Encoder Stats
+        Active Sessions                   : 0
+        Average FPS                       : 0
+        Average Latency                   : 0
+    FBC Stats
+        Active Sessions                   : 0
+        Average FPS                       : 0
+        Average Latency                   : 0
+    Ecc Mode
+        Current                           : N/A
+        Pending                           : N/A
+    ECC Errors
+        Volatile
+            SRAM Correctable              : N/A
+            SRAM Uncorrectable            : N/A
+            DRAM Correctable              : N/A
+            DRAM Uncorrectable            : N/A
+        Aggregate
+            SRAM Correctable              : N/A
+            SRAM Uncorrectable            : N/A
+            DRAM Correctable              : N/A
+            DRAM Uncorrectable            : N/A
+    Retired Pages
+        Single Bit ECC                    : N/A
+        Double Bit ECC                    : N/A
+        Pending Page Blacklist            : N/A
+    Remapped Rows                         : N/A
+    Temperature
+        GPU Current Temp                  : 58 C
+        GPU T.Limit Temp                  : N/A
+        GPU Shutdown Temp                 : 98 C
+        GPU Slowdown Temp                 : 95 C
+        GPU Max Operating Temp            : 93 C
+        GPU Target Temperature            : 83 C
+        Memory Current Temp               : N/A
+        Memory Max Operating Temp         : N/A
+    Power Readings
+        Power Management                  : Supported
+        Power Draw                        : 83.48 W
+        Power Limit                       : 350.00 W
+        Default Power Limit               : 350.00 W
+        Enforced Power Limit              : 350.00 W
+        Min Power Limit                   : 100.00 W
+        Max Power Limit                   : 385.00 W
+    Clocks
+        Graphics                          : 810 MHz
+        SM                                : 810 MHz
+        Memory                            : 5001 MHz
+        Video                             : 945 MHz
+    Applications Clocks
+        Graphics                          : N/A
+        Memory                            : N/A
+    Default Applications Clocks
+        Graphics                          : N/A
+        Memory                            : N/A
+    Deferred Clocks
+        Memory                            : N/A
+    Max Clocks
+        Graphics                          : 2115 MHz
+        SM                                : 2115 MHz
+        Memory                            : 9751 MHz
+        Video                             : 1950 MHz
+    Max Customer Boost Clocks
+        Graphics                          : N/A
+    Clock Policy
+        Auto Boost                        : N/A
+        Auto Boost Default                : N/A
+    Voltage
+        Graphics                          : 725.000 mV
+    Fabric
+        State                             : N/A
+        Status                            : N/A
+    Processes
+        GPU instance ID                   : N/A
+        Compute instance ID               : N/A
+        Process ID                        : 1624
+            Type                          : G
+            Name                          : /usr/lib/xorg/Xorg
+            Used GPU Memory               : 630 MiB";
+
+    const NVCC_NOT_FOUND_OUTPUT: &str = "\
+zsh: command not found: nvcc
+";
+
+    const NVIDIA_SMI_NOT_FOUND_OUTPUT: &str = "\
+zsh: command not found: nvidia-smi
+";
+    const NVIDIA_SMI_ERROR_OUTPUT: &str = "\
+NVIDIA-SMI has failed because it couldn't communicate with the NVIDIA driver. Make sure that the latest NVIDIA driver is installed and running.";
+
     #[test]
     fn nvcc_version() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
@@ -97,14 +293,7 @@ mod tests {
             .cmd(
                 "nvcc --version",
                 Some(CommandOutput {
-                    stdout: String::from(
-                        "\
-nvcc: NVIDIA (R) Cuda compiler driver
-Copyright (c) 2005-2022 NVIDIA Corporation
-Built on Thu_Feb_10_18:23:41_PST_2022
-Cuda compilation tools, release 11.6, V11.6.112
-Build cuda_11.6.r11.6/compiler.30978841_0",
-                    ),
+                    stdout: String::from(NVCC_SUCCESS_OUTPUT),
                     stderr: String::default(),
                 }),
             )
@@ -115,6 +304,98 @@ Build cuda_11.6.r11.6/compiler.30978841_0",
             "via {}",
             Color::Rgb(118, 185, 0).bold().paint("NV v11.6")
         ));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn nvidia_smi_version() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let actual = ModuleRenderer::new("cuda")
+            .cmd(
+                "nvidia-smi --query",
+                Some(CommandOutput {
+                    stdout: String::from(NVIDIA_SMI_SUCCESS_OUTPUT),
+                    stderr: String::default(),
+                }),
+            )
+            .path(dir.path())
+            .collect();
+
+        let expected = Some(format!(
+            "via {}",
+            Color::Rgb(118, 185, 0).bold().paint("NV v12.0")
+        ));
+
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn no_nvcc() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let actual = ModuleRenderer::new("cuda")
+            .cmd(
+                "nvcc --version",
+                Some(CommandOutput {
+                    stdout: String::default(),
+                    stderr: String::from(NVCC_NOT_FOUND_OUTPUT),
+                }),
+            )
+            .path(dir.path())
+            .collect();
+
+        let expected = Some(format!(
+            "via {}",
+            Color::Rgb(118, 185, 0).bold().paint("NV ")
+        ));
+
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn nvidia_smi_error() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let actual = ModuleRenderer::new("cuda")
+            .cmd(
+                "nvidia-smi --query",
+                Some(CommandOutput {
+                    stdout: String::default(),
+                    stderr: String::from(NVIDIA_SMI_ERROR_OUTPUT),
+                }),
+            )
+            .path(dir.path())
+            .collect();
+
+        let expected = Some(format!(
+            "via {}",
+            Color::Rgb(118, 185, 0).bold().paint("NV ")
+        ));
+
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn no_nvidia_smi() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let actual = ModuleRenderer::new("cuda")
+            .cmd(
+                "nvidia-smi --query",
+                Some(CommandOutput {
+                    stdout: String::default(),
+                    stderr: String::from(NVIDIA_SMI_NOT_FOUND_OUTPUT),
+                }),
+            )
+            .path(dir.path())
+            .collect();
+
+        let expected = Some(format!(
+            "via {}",
+            Color::Rgb(118, 185, 0).bold().paint("NV ")
+        ));
+
         assert_eq!(expected, actual);
         dir.close()
     }

--- a/src/modules/cuda.rs
+++ b/src/modules/cuda.rs
@@ -1,0 +1,236 @@
+use super::{Context, Module, ModuleConfig};
+
+use crate::configs::cuda::CudaConfig;
+use crate::formatter::StringFormatter;
+use crate::formatter::VersionFormatter;
+
+use once_cell::sync::Lazy;
+use regex::Regex;
+use std::borrow::Cow;
+use std::ops::Deref;
+
+const NVCC_MATCH_PATTERN: &str = r"release\s(?P<version>\d+\.\d+),";
+const SMI_MATCH_PATTERN: &str = r"CUDA Version\s+:\s+(?P<version>\d+\.\d+)";
+
+fn parse_cuda_version(s: &str) -> Option<String> {
+    return [NVCC_MATCH_PATTERN, SMI_MATCH_PATTERN]
+        .iter()
+        .map(|pat| Regex::new(pat).unwrap())
+        .map(|re| re.captures(s))
+        .fold(None, |acc, caps| {
+            acc.or(caps
+                .map(|caps| caps.name("version").map(|v| v.as_str().to_string()))
+                .flatten())
+        });
+}
+
+/// Creates a module with the current C compiler and version
+pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let mut module = context.new_module("cuda");
+    let config: CudaConfig = CudaConfig::try_load(module.config);
+    let is_cuda_project = context
+        .try_begin_scan()?
+        .set_extensions(&config.detect_extensions)
+        .set_files(&config.detect_files)
+        .set_folders(&config.detect_folders)
+        .is_match();
+
+    if !is_cuda_project {
+        return None;
+    }
+
+    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
+        // The cuda compiler or driver info
+        let cuda_info = Lazy::new(|| context.exec_cmds_return_first(config.commands));
+
+        formatter
+            .map_meta(|var, _| match var {
+                "symbol" => Some(config.symbol),
+                _ => None,
+            })
+            .map_style(|variable| match variable {
+                "style" => Some(Ok(config.style)),
+                _ => None,
+            })
+            .map(|variable| match variable {
+                "version" => {
+                    let cuda_info = &cuda_info.deref().as_ref()?.stdout;
+                    let parsed_info = parse_cuda_version(cuda_info)?;
+
+                    // nvcc --version says ...
+                    //   nvcc: NVIDIA (R) Cuda compiler driver
+                    //   Copyright (c) 2005-2022 NVIDIA Corporation
+                    //   Built on Thu_Feb_10_18:23:41_PST_2022
+                    //   Cuda compilation tools, release 11.6, V11.6.112
+                    //   Build cuda_11.6.r11.6/compiler.30978841_0
+                    // We are trying to get the word after release
+
+                    // nvidia-smi --query says ...
+                    //   Timestamp                                 : Mon Oct 16 01:11:08 2023
+                    //   Driver Version                            : 525.125.06
+                    //   CUDA Version                              : 12.0
+                    // We'd like to find the line with CUDA Version
+                    VersionFormatter::format_module_version(
+                        module.get_name(),
+                        &parsed_info,
+                        config.version_format,
+                    )
+                    .map(Cow::Owned)
+                    .map(Ok)
+                }
+                _ => None,
+            })
+            .parse(None, Some(context))
+    });
+
+    module.set_segments(match parsed {
+        Ok(segments) => segments,
+        Err(error) => {
+            log::warn!("Error in module `c`:\n{}", error);
+            return None;
+        }
+    });
+
+    Some(module)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{test::ModuleRenderer, utils::CommandOutput};
+    use nu_ansi_term::Color;
+    use std::fs::File;
+    use std::io;
+
+    #[test]
+    fn folder_without_c_files() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+
+        let actual = ModuleRenderer::new("c").path(dir.path()).collect();
+
+        let expected = None;
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn folder_with_c_file() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join("any.c"))?.sync_all()?;
+
+        // What happens when `cc --version` says it's modern gcc?
+        // The case when it claims to be clang is covered in folder_with_h_file,
+        // and uses the mock in src/test/mod.rs.
+        let actual = ModuleRenderer::new("c")
+            .cmd(
+                "cc --version",
+                Some(CommandOutput {
+                    stdout: String::from(
+                        "\
+cc (Debian 10.2.1-6) 10.2.1 20210110
+Copyright (C) 2020 Free Software Foundation, Inc.
+This is free software; see the source for copying conditions.  There is NO
+warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.",
+                    ),
+                    stderr: String::default(),
+                }),
+            )
+            .path(dir.path())
+            .collect();
+        let expected = Some(format!(
+            "via {}",
+            Color::Fixed(149).bold().paint("C v10.2.1-gcc ")
+        ));
+        assert_eq!(expected, actual);
+
+        // What happens when `cc --version` says it's ancient gcc?
+        let actual = ModuleRenderer::new("c")
+            .cmd(
+                "cc --version",
+                Some(CommandOutput {
+                    stdout: String::from(
+                        "\
+cc (GCC) 3.3.5 (Debian 1:3.3.5-13)
+Copyright (C) 2003 Free Software Foundation, Inc.
+This is free software; see the source for copying conditions.  There is NO
+warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.",
+                    ),
+                    stderr: String::default(),
+                }),
+            )
+            .path(dir.path())
+            .collect();
+        let expected = Some(format!(
+            "via {}",
+            Color::Fixed(149).bold().paint("C v3.3.5-gcc ")
+        ));
+        assert_eq!(expected, actual);
+
+        // What happens with an unknown C compiler? Needless to say, we're
+        // not running on a Z80 so we're never going to see this one in reality!
+        let actual = ModuleRenderer::new("c")
+            .cmd(
+                "cc --version",
+                Some(CommandOutput {
+                    stdout: String::from("HISOFT-C Compiler  V1.2\nCopyright © 1984 HISOFT"),
+                    stderr: String::default(),
+                }),
+            )
+            .path(dir.path())
+            .collect();
+        let expected = Some(format!("via {}", Color::Fixed(149).bold().paint("C ")));
+        assert_eq!(expected, actual);
+
+        // What happens when 'cc --version' doesn't work, but 'gcc --version' does?
+        // This stubs out `cc` but we'll fall back to `gcc --version` as defined in
+        // src/test/mod.rs.
+        // Also we don't bother to redefine the config for this one, as we've already
+        // proved we can parse its version.
+        let actual = ModuleRenderer::new("c")
+            .cmd("cc --version", None)
+            .path(dir.path())
+            .collect();
+        let expected = Some(format!(
+            "via {}",
+            Color::Fixed(149).bold().paint("C v10.2.1-gcc ")
+        ));
+        assert_eq!(expected, actual);
+
+        // Now with both 'cc' and 'gcc' not working, this should fall back to 'clang --version'
+        let actual = ModuleRenderer::new("c")
+            .cmd("cc --version", None)
+            .cmd("gcc --version", None)
+            .path(dir.path())
+            .collect();
+        let expected = Some(format!(
+            "via {}",
+            Color::Fixed(149).bold().paint("C v11.1.0-clang ")
+        ));
+        assert_eq!(expected, actual);
+
+        // What happens when we can't find any of cc, gcc or clang?
+        let actual = ModuleRenderer::new("c")
+            .cmd("cc --version", None)
+            .cmd("gcc --version", None)
+            .cmd("clang --version", None)
+            .path(dir.path())
+            .collect();
+        let expected = Some(format!("via {}", Color::Fixed(149).bold().paint("C ")));
+        assert_eq!(expected, actual);
+
+        dir.close()
+    }
+
+    #[test]
+    fn folder_with_h_file() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join("any.h"))?.sync_all()?;
+
+        let actual = ModuleRenderer::new("c").path(dir.path()).collect();
+        let expected = Some(format!(
+            "via {}",
+            Color::Fixed(149).bold().paint("C v11.0.1-clang ")
+        ));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+}

--- a/src/modules/cuda.rs
+++ b/src/modules/cuda.rs
@@ -88,137 +88,32 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 mod tests {
     use crate::{test::ModuleRenderer, utils::CommandOutput};
     use nu_ansi_term::Color;
-    use std::fs::File;
     use std::io;
 
     #[test]
-    fn folder_without_c_files() -> io::Result<()> {
+    fn nvcc_version() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
-
-        let actual = ModuleRenderer::new("c").path(dir.path()).collect();
-
-        let expected = None;
-        assert_eq!(expected, actual);
-        dir.close()
-    }
-
-    #[test]
-    fn folder_with_c_file() -> io::Result<()> {
-        let dir = tempfile::tempdir()?;
-        File::create(dir.path().join("any.c"))?.sync_all()?;
-
-        // What happens when `cc --version` says it's modern gcc?
-        // The case when it claims to be clang is covered in folder_with_h_file,
-        // and uses the mock in src/test/mod.rs.
-        let actual = ModuleRenderer::new("c")
+        let actual = ModuleRenderer::new("cuda")
             .cmd(
-                "cc --version",
+                "nvcc --version",
                 Some(CommandOutput {
                     stdout: String::from(
                         "\
-cc (Debian 10.2.1-6) 10.2.1 20210110
-Copyright (C) 2020 Free Software Foundation, Inc.
-This is free software; see the source for copying conditions.  There is NO
-warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.",
+nvcc: NVIDIA (R) Cuda compiler driver
+Copyright (c) 2005-2022 NVIDIA Corporation
+Built on Thu_Feb_10_18:23:41_PST_2022
+Cuda compilation tools, release 11.6, V11.6.112
+Build cuda_11.6.r11.6/compiler.30978841_0",
                     ),
                     stderr: String::default(),
                 }),
             )
             .path(dir.path())
             .collect();
+
         let expected = Some(format!(
             "via {}",
-            Color::Fixed(149).bold().paint("C v10.2.1-gcc ")
-        ));
-        assert_eq!(expected, actual);
-
-        // What happens when `cc --version` says it's ancient gcc?
-        let actual = ModuleRenderer::new("c")
-            .cmd(
-                "cc --version",
-                Some(CommandOutput {
-                    stdout: String::from(
-                        "\
-cc (GCC) 3.3.5 (Debian 1:3.3.5-13)
-Copyright (C) 2003 Free Software Foundation, Inc.
-This is free software; see the source for copying conditions.  There is NO
-warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.",
-                    ),
-                    stderr: String::default(),
-                }),
-            )
-            .path(dir.path())
-            .collect();
-        let expected = Some(format!(
-            "via {}",
-            Color::Fixed(149).bold().paint("C v3.3.5-gcc ")
-        ));
-        assert_eq!(expected, actual);
-
-        // What happens with an unknown C compiler? Needless to say, we're
-        // not running on a Z80 so we're never going to see this one in reality!
-        let actual = ModuleRenderer::new("c")
-            .cmd(
-                "cc --version",
-                Some(CommandOutput {
-                    stdout: String::from("HISOFT-C Compiler  V1.2\nCopyright © 1984 HISOFT"),
-                    stderr: String::default(),
-                }),
-            )
-            .path(dir.path())
-            .collect();
-        let expected = Some(format!("via {}", Color::Fixed(149).bold().paint("C ")));
-        assert_eq!(expected, actual);
-
-        // What happens when 'cc --version' doesn't work, but 'gcc --version' does?
-        // This stubs out `cc` but we'll fall back to `gcc --version` as defined in
-        // src/test/mod.rs.
-        // Also we don't bother to redefine the config for this one, as we've already
-        // proved we can parse its version.
-        let actual = ModuleRenderer::new("c")
-            .cmd("cc --version", None)
-            .path(dir.path())
-            .collect();
-        let expected = Some(format!(
-            "via {}",
-            Color::Fixed(149).bold().paint("C v10.2.1-gcc ")
-        ));
-        assert_eq!(expected, actual);
-
-        // Now with both 'cc' and 'gcc' not working, this should fall back to 'clang --version'
-        let actual = ModuleRenderer::new("c")
-            .cmd("cc --version", None)
-            .cmd("gcc --version", None)
-            .path(dir.path())
-            .collect();
-        let expected = Some(format!(
-            "via {}",
-            Color::Fixed(149).bold().paint("C v11.1.0-clang ")
-        ));
-        assert_eq!(expected, actual);
-
-        // What happens when we can't find any of cc, gcc or clang?
-        let actual = ModuleRenderer::new("c")
-            .cmd("cc --version", None)
-            .cmd("gcc --version", None)
-            .cmd("clang --version", None)
-            .path(dir.path())
-            .collect();
-        let expected = Some(format!("via {}", Color::Fixed(149).bold().paint("C ")));
-        assert_eq!(expected, actual);
-
-        dir.close()
-    }
-
-    #[test]
-    fn folder_with_h_file() -> io::Result<()> {
-        let dir = tempfile::tempdir()?;
-        File::create(dir.path().join("any.h"))?.sync_all()?;
-
-        let actual = ModuleRenderer::new("c").path(dir.path()).collect();
-        let expected = Some(format!(
-            "via {}",
-            Color::Fixed(149).bold().paint("C v11.0.1-clang ")
+            Color::Rgb(118, 185, 0).bold().paint("NV v11.6")
         ));
         assert_eq!(expected, actual);
         dir.close()

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -11,6 +11,7 @@ mod cobol;
 mod conda;
 mod container;
 mod crystal;
+mod cuda;
 pub mod custom;
 mod daml;
 mod dart;
@@ -117,6 +118,7 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
             "cobol" => cobol::module(context),
             "conda" => conda::module(context),
             "container" => container::module(context),
+            "cuda" => cuda::module(context),
             "daml" => daml::module(context),
             "dart" => dart::module(context),
             "deno" => deno::module(context),
@@ -234,6 +236,7 @@ pub fn description(module: &str) -> &'static str {
         "conda" => "The current conda environment, if $CONDA_DEFAULT_ENV is set",
         "container" => "The container indicator, if inside a container.",
         "crystal" => "The currently installed version of Crystal",
+        "cuda" => "The currently installed version of nvcc compiler or CUDA driver",
         "daml" => "The Daml SDK version of your project",
         "dart" => "The currently installed version of Dart",
         "deno" => "The currently installed version of Deno",


### PR DESCRIPTION
#### Description

This PR introduces a new CUDA module with its main functionalities. It allows the module to detect and handle .cu files and nvcc tests. The CUDA module has been added to the Starship configurations, accompanied by unit tests to ensure everything is working as expected. 

The README has been updated with examples of the CUDA module, and the CUDA section has been placed according to its alphabetic order. The document for the CUDA module has also been added.

#### Motivation and Context

The motivation for these changes is to assist deep learning researchers and CUDA engineers in identifying the nvcc they are using (different version of cuda are often employed to handle multiple projects), and for informing general users about their installed CUDA version.


#### Screenshots (if appropriate):

- with `nvcc` present
![image](https://github.com/starship/starship/assets/31263714/50bf4b38-b3fb-4189-93ba-aa4938e0e502)

- with `nvidia-smi` present
![image](https://github.com/starship/starship/assets/31263714/6a4b563e-8669-4f9d-a57b-38191728e3de)


#### How Has This Been Tested?

The functionality of `nvcc` and `nvidia-smi` are tested locally and all tests passed. 
- [X] I have tested using **MacOS**
- [X] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [X] I have updated the documentation accordingly.
- [X] I have updated the tests accordingly.
