### PR TITLE
fix(zsh): clear exit code between prompts

### DIFF
--- a/src/init/starship.zsh
+++ b/src/init/starship.zsh
@@ -23,23 +23,22 @@ else
     }
 fi
 
-
 # The two functions below follow the naming convention `prompt_<theme>_<hook>`
 # for compatibility with Zsh's prompt system. See
 # https://github.com/zsh-users/zsh/blob/2876c25a28b8052d6683027998cc118fc9b50157/Functions/Prompts/promptinit#L155
 
 # Runs before each new command line.
 prompt_starship_precmd() {
-    # Save the status, because commands in this pipeline will change $?
+    # Save the status, because subsequent commands in this function will change $?
     STARSHIP_CMD_STATUS=$? STARSHIP_PIPE_STATUS=(${pipestatus[@]})
 
-    # Compute cmd_duration, if we have a time to consume, otherwise clear the
-    # previous duration
+    # Calculate duration if a command was executed
     if (( ${+STARSHIP_START_TIME} )); then
         __starship_get_time && (( STARSHIP_DURATION = STARSHIP_CAPTURED_TIME - STARSHIP_START_TIME ))
         unset STARSHIP_START_TIME
+    # Drop status and duration otherwise
     else
-        unset STARSHIP_DURATION
+        unset STARSHIP_DURATION STARSHIP_CMD_STATUS STARSHIP_PIPE_STATUS
     fi
 
     # Use length of jobstates array as number of jobs. Expansion fails inside
@@ -47,7 +46,8 @@ prompt_starship_precmd() {
     STARSHIP_JOBS_COUNT=${#jobstates}
 }
 
-# Runs after the user submits the command line, but before it is executed.
+# Runs after the user submits the command line, but before it is executed and
+# only if there's an actual command to run
 prompt_starship_preexec() {
     __starship_get_time && STARSHIP_START_TIME=$STARSHIP_CAPTURED_TIME
 }
@@ -76,8 +76,6 @@ else
     zle -N zle-keymap-select starship_zle-keymap-select-wrapped;
 fi
 
-__starship_get_time && STARSHIP_START_TIME=$STARSHIP_CAPTURED_TIME
-
 export STARSHIP_SHELL="zsh"
 
 # Set up the session key that will be used to store logs
@@ -92,4 +90,3 @@ setopt promptsubst
 PROMPT='$(::STARSHIP:: prompt --terminal-width="$COLUMNS" --keymap="${KEYMAP:-}" --status="$STARSHIP_CMD_STATUS" --pipestatus="${STARSHIP_PIPE_STATUS[*]}" --cmd-duration="${STARSHIP_DURATION:-}" --jobs="$STARSHIP_JOBS_COUNT")'
 RPROMPT='$(::STARSHIP:: prompt --right --terminal-width="$COLUMNS" --keymap="${KEYMAP:-}" --status="$STARSHIP_CMD_STATUS" --pipestatus="${STARSHIP_PIPE_STATUS[*]}" --cmd-duration="${STARSHIP_DURATION:-}" --jobs="$STARSHIP_JOBS_COUNT")'
 PROMPT2="$(::STARSHIP:: prompt --continuation)"
-


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
Using Zsh with Status module enabled, the exit code sticks around for as long as there's another command being run.
This change clears the exit code between prompts if no command was being executed, resulting in the correct behavior.


```sh
# BEFORE                                                          # exit code in rprompt
~/GitHub/starship zsh-fix-status-code ❯ return 1
~/GitHub/starship zsh-fix-status-code ❯                           ↵ 1
~/GitHub/starship zsh-fix-status-code ❯                           ↵ 1 # not cleared

# AFTER
~/GitHub/starship zsh-fix-status-code ❯ return 1
~/GitHub/starship zsh-fix-status-code ❯                           ↵ 1
~/GitHub/starship zsh-fix-status-code ❯                               # cleared
```

#### Motivation and Context

Having an irrelevant status code sticking around is slightly annoying.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
