### PR TITLE
feat: show module when typing command on ZSH for custom command modules

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -6142,6 +6142,13 @@
             "type": "string"
           }
         },
+        "detect_keywords": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "os": {
           "type": [
             "string",

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -4564,6 +4564,7 @@ These modules will be shown if any of the following conditions are met:
 - The current directory contains a file whose name is in `detect_files`
 - The current directory contains a directory whose name is in `detect_folders`
 - The current directory contains a file whose extension is in `detect_extensions`
+- The buffer contains a keyword which is in `detect_keywords` (zsh only)
 - The `when` command returns 0
 - The current Operating System (std::env::consts::OS) matches with `os` field if defined.
 
@@ -4613,6 +4614,7 @@ Format strings can also contain shell specific prompt sequences, e.g.
 | `detect_files`      | `[]`                            | The files that will be searched in the working directory for a match.                                                                                                                                                                                                                         |
 | `detect_folders`    | `[]`                            | The directories that will be searched in the working directory for a match.                                                                                                                                                                                                                   |
 | `detect_extensions` | `[]`                            | The extensions that will be searched in the working directory for a match.                                                                                                                                                                                                                    |
+| `detect_keywords`   | `[]`                            | The keywords that will matched against the content of the command line buffer.                                                                                                                                                                                                                |
 | `symbol`            | `''`                            | The symbol used before displaying the command output.                                                                                                                                                                                                                                         |
 | `style`             | `'bold green'`                  | The style for the module.                                                                                                                                                                                                                                                                     |
 | `format`            | `'[$symbol($output )]($style)'` | The format for the module.                                                                                                                                                                                                                                                                    |

--- a/src/configs/custom.rs
+++ b/src/configs/custom.rs
@@ -25,6 +25,8 @@ pub struct CustomConfig<'a> {
     pub detect_extensions: Vec<&'a str>,
     #[serde(alias = "directories")]
     pub detect_folders: Vec<&'a str>,
+    #[serde(alias = "keywords")]
+    pub detect_keywords: Vec<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub os: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -47,6 +49,7 @@ impl<'a> Default for CustomConfig<'a> {
             detect_files: Vec::default(),
             detect_extensions: Vec::default(),
             detect_folders: Vec::default(),
+            detect_keywords: Vec::default(),
             os: None,
             use_stdin: None,
             ignore_timeout: false,

--- a/src/context.rs
+++ b/src/context.rs
@@ -868,6 +868,9 @@ pub struct Properties {
     /// The number of currently running jobs
     #[clap(short, long, default_value_t, value_parser=parse_jobs)]
     pub jobs: i64,
+    /// The list of keywords in the command line buffer
+    #[clap(long, default_value = "", value_delimiter = ' ')]
+    pub keywords: Vec<String>,
 }
 
 impl Default for Properties {
@@ -881,6 +884,7 @@ impl Default for Properties {
             cmd_duration: None,
             keymap: "viins".to_string(),
             jobs: 0,
+            keywords: Vec::new(),
         }
     }
 }

--- a/src/init/starship.zsh
+++ b/src/init/starship.zsh
@@ -80,6 +80,7 @@ fi
 starship_zle-line-pre-redraw() {
     # Only redraw if there are no more keys queued
     if [[ $KEYS_QUEUED_COUNT -eq 0 && $PENDING -eq 0 ]]; then
+        local KEYWORDS=${(z)BUFFER}
         zle reset-prompt
     fi
 }
@@ -111,6 +112,6 @@ VIRTUAL_ENV_DISABLE_PROMPT=1
 
 setopt promptsubst
 
-PROMPT='$('::STARSHIP::' prompt --terminal-width="$COLUMNS" --keymap="${KEYMAP:-}" --status="$STARSHIP_CMD_STATUS" --pipestatus="${STARSHIP_PIPE_STATUS[*]}" --cmd-duration="${STARSHIP_DURATION:-}" --jobs="$STARSHIP_JOBS_COUNT")'
-RPROMPT='$('::STARSHIP::' prompt --right --terminal-width="$COLUMNS" --keymap="${KEYMAP:-}" --status="$STARSHIP_CMD_STATUS" --pipestatus="${STARSHIP_PIPE_STATUS[*]}" --cmd-duration="${STARSHIP_DURATION:-}" --jobs="$STARSHIP_JOBS_COUNT")'
+PROMPT='$(::STARSHIP:: prompt --terminal-width="$COLUMNS" --keymap="${KEYMAP:-}" --status="$STARSHIP_CMD_STATUS" --pipestatus="${STARSHIP_PIPE_STATUS[*]}" --cmd-duration="${STARSHIP_DURATION:-}" --jobs="$STARSHIP_JOBS_COUNT" --keywords="$KEYWORDS")'
+RPROMPT='$(::STARSHIP:: prompt --right --terminal-width="$COLUMNS" --keymap="${KEYMAP:-}" --status="$STARSHIP_CMD_STATUS" --pipestatus="${STARSHIP_PIPE_STATUS[*]}" --cmd-duration="${STARSHIP_DURATION:-}" --jobs="$STARSHIP_JOBS_COUNT" --keywords="$KEYWORDS")'
 PROMPT2="$(::STARSHIP:: prompt --continuation)"

--- a/src/init/starship.zsh
+++ b/src/init/starship.zsh
@@ -76,27 +76,30 @@ else
     zle -N zle-keymap-select starship_zle-keymap-select-wrapped;
 fi
 
-# Set a function to redraw the prompt when the line is redrawn
-starship_zle-line-pre-redraw() {
-    # Only redraw if there are no more keys queued
-    if [[ $KEYS_QUEUED_COUNT -eq 0 && $PENDING -eq 0 ]]; then
-        local KEYWORDS=${(z)BUFFER}
-        zle reset-prompt
-    fi
-}
-
-## Check for existing line-pre-redraw widget.
-# zle-line-pre-redraw is a special widget so it'll be "user:fnName" or nothing. Let's get fnName only.
-__starship_preserved_zle_line_pre_redraw=${widgets[zle-line-pre-redraw]#user:}
-if [[ -z $__starship_preserved_zle_line_pre_redraw ]]; then
-    zle -N zle-line-pre-redraw starship_zle-line-pre-redraw;
-else
-    # Define a wrapper fn to call the original widget fn and then Starship's.
-    starship_zle-line-pre-redraw-wrapped() {
-        $__starship_preserved_zle_line_pre_redraw "$@";
-        starship_zle-line-pre-redraw "$@";
+# If the detect keywords feature is enabled, set up a function to watch for buffer changes
+if [[ ::ENABLE_DETECT_KEYWORDS:: = 1 ]]; then
+    # Set a function to redraw the prompt when the line is redrawn
+    starship_zle-line-pre-redraw() {
+        # Only redraw if there are no more keys queued
+        if [[ $KEYS_QUEUED_COUNT -eq 0 && $PENDING -eq 0 ]]; then
+            local KEYWORDS=${(z)BUFFER}
+            zle reset-prompt
+        fi
     }
-    zle -N zle-line-pre-redraw starship_zle-line-pre-redraw-wrapped;
+
+    ## Check for existing line-pre-redraw widget.
+    # zle-line-pre-redraw is a special widget so it'll be "user:fnName" or nothing. Let's get fnName only.
+    __starship_preserved_zle_line_pre_redraw=${widgets[zle-line-pre-redraw]#user:}
+    if [[ -z $__starship_preserved_zle_line_pre_redraw ]]; then
+        zle -N zle-line-pre-redraw starship_zle-line-pre-redraw;
+    else
+        # Define a wrapper fn to call the original widget fn and then Starship's.
+        starship_zle-line-pre-redraw-wrapped() {
+            $__starship_preserved_zle_line_pre_redraw "$@";
+            starship_zle-line-pre-redraw "$@";
+        }
+        zle -N zle-line-pre-redraw starship_zle-line-pre-redraw-wrapped;
+    fi
 fi
 
 __starship_get_time && STARSHIP_START_TIME=$STARSHIP_CAPTURED_TIME

--- a/src/init/starship.zsh
+++ b/src/init/starship.zsh
@@ -76,6 +76,30 @@ else
     zle -N zle-keymap-select starship_zle-keymap-select-wrapped;
 fi
 
+# Set a function to redraw the prompt when the line is redrawn
+starship_zle-line-pre-redraw() {
+    # Only redraw if there are no more keys queued
+    if [[ $KEYS_QUEUED_COUNT -eq 0 && $PENDING -eq 0 ]]; then
+        zle reset-prompt
+    fi
+}
+
+## Check for existing line-pre-redraw widget.
+# zle-line-pre-redraw is a special widget so it'll be "user:fnName" or nothing. Let's get fnName only.
+__starship_preserved_zle_line_pre_redraw=${widgets[zle-line-pre-redraw]#user:}
+if [[ -z $__starship_preserved_zle_line_pre_redraw ]]; then
+    zle -N zle-line-pre-redraw starship_zle-line-pre-redraw;
+else
+    # Define a wrapper fn to call the original widget fn and then Starship's.
+    starship_zle-line-pre-redraw-wrapped() {
+        $__starship_preserved_zle_line_pre_redraw "$@";
+        starship_zle-line-pre-redraw "$@";
+    }
+    zle -N zle-line-pre-redraw starship_zle-line-pre-redraw-wrapped;
+fi
+
+__starship_get_time && STARSHIP_START_TIME=$STARSHIP_CAPTURED_TIME
+
 export STARSHIP_SHELL="zsh"
 
 # Set up the session key that will be used to store logs

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,8 @@ enum Commands {
         shell: String,
         #[clap(long)]
         print_full_init: bool,
+        #[clap(long)]
+        enable_detect_keywords: bool,
     },
     ///  Prints a specific prompt module
     Module {
@@ -169,11 +171,12 @@ fn main() {
         Commands::Init {
             shell,
             print_full_init,
+            enable_detect_keywords,
         } => {
             if print_full_init {
-                init::init_main(&shell).expect("can't init_main");
+                init::init_main(&shell, enable_detect_keywords).expect("can't init_main");
             } else {
-                init::init_stub(&shell).expect("can't init_stub");
+                init::init_stub(&shell, enable_detect_keywords).expect("can't init_stub");
             }
         }
         Commands::Prompt {

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -132,6 +132,11 @@ impl<'a> ModuleRenderer<'a> {
         self
     }
 
+    pub fn keywords(mut self, keywords: Vec<String>) -> Self {
+        self.context.properties.keywords = keywords;
+        self
+    }
+
     #[cfg(feature = "battery")]
     pub fn battery_info_provider(
         mut self,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
This PR implements a `Show on command` feature like Powerlevel10k. It allows some modules to appear when certain keywords appear and disappear from the command line buffer.  

The PR adds a `detect_keywords` field in the configuration file for the custom command module and a `--keywords` flag for the `prompt` subcommand. The custom command module is then showed only when one of the keywords passed in the prompt command is also in the `detect_keywords` entry of the custom command module. Additionally, the prompt is redrawn each time the line editor sees a change to the buffer.

For now, I've only made the implementation for the `custom` module and in the `zsh` init file. But I plan to implement it for other shells, and maybe some other modules in subsequent pull requests.   

Because this change makes the prompt redraw on each input, it definitely has a big impact on performance. It cannot be used in conjunction with modules that take a long time to redraw (for example git_status in large repositories, or custom modules).

To avoid causing problems for people who don't need this feature, I propose to make it optional through a flag (`--enable-detect-keywords`) passed to the init command.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When working with a lot of tools like terraform, kubectl, gcloud, aws, etc there is no way (as far as I'm aware) to dynamically display the corresponding module. So you either display all modules all the time making the prompt too crowded which is not suited for some smaller terminals like inside an IDE or display none at all. It makes it a lot harder to grab the right info directly.
<!--- If it fixes an open issue, please link to the issue here. -->

#### Screenshots (if appropriate):

https://github.com/starship/starship/assets/101594032/370f3c4e-adc3-4ca5-bf52-32003cdd2dc0

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I added the `$custom` variable to my prompt as well as the following toml block in the starship.toml:
```toml
[custom.foo]
command = 'echo foo' # shows output of command
detect_keywords= [ 'foo' ]
format = '$output'
```
In my zshrc, I added the following line:
```zsh
eval $(starship init zsh --enable-detect-keywords)
```

I have tested on Windows Terminal with zsh in wsl and in iTerm2 on MacOS as well as Alacritty on Linux
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
