### PR TITLE
refactor(modules): use whoami crate to get username

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -944,16 +944,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gethostname"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0176e0459c2e4a1fe232f984bca6890e681076abb9934f6cea7c326f3fc47818"
-dependencies = [
- "libc",
- "windows-targets",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2752,7 +2742,6 @@ dependencies = [
  "deelevate",
  "dirs-next",
  "dunce",
- "gethostname",
  "gix",
  "gix-features",
  "guess_host_triple",
@@ -2794,6 +2783,7 @@ dependencies = [
  "urlencoding",
  "versions",
  "which",
+ "whoami",
  "windows 0.48.0",
  "winres",
  "yaml-rust",
@@ -3354,6 +3344,12 @@ dependencies = [
  "once_cell",
  "rustix 0.38.11",
 ]
+
+[[package]]
+name = "whoami"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22fc3756b8a9133049b26c7f61ab35416c130e8c09b660f5b3958b446f52cc50"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,6 @@ clap = { version = "4.4.6", features = ["derive", "cargo", "unicode"] }
 clap_complete = "4.4.3"
 dirs-next = "2.0.0"
 dunce = "1.0.4"
-gethostname = "0.4.3"
 # default feature restriction addresses https://github.com/starship/starship/issues/4251
 gix = { version = "0.55.2", default-features = false, features = ["max-performance-safe", "revision"] }
 gix-features = { version = "0.36.0", optional = true }
@@ -94,6 +93,7 @@ process_control = { version = "4.0.3", features = ["crossbeam-channel"] }
 guess_host_triple = "0.1.3"
 home = "0.5.5"
 shell-words = "1.1.0"
+whoami = { version = "1.4.1", default-features = false }
 
 [dependencies.schemars]
 version = "0.8.15"

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -1,3 +1,4 @@
+use std::fmt::Write as _;
 use std::process;
 use std::process::Stdio;
 use std::str::FromStr;
@@ -96,8 +97,10 @@ pub fn print_configuration(context: &Context, use_default: bool, paths: &[String
             "# $all is shorthand for {}",
             PROMPT_ORDER
                 .iter()
-                .map(|module_name| format!("${module_name}"))
-                .collect::<String>()
+                .fold(String::new(), |mut output, module_name| {
+                    let _ = write!(output, "${module_name}");
+                    output
+                })
         );
 
         // Unwrapping is fine because config is based on FullConfig
@@ -105,10 +108,10 @@ pub fn print_configuration(context: &Context, use_default: bool, paths: &[String
         if !use_default && !custom_modules.is_empty() {
             println!(
                 "# $custom (excluding any modules already listed in `format`) is shorthand for {}",
-                custom_modules
-                    .keys()
-                    .map(|module_name| format!("${{custom.{module_name}}}"))
-                    .collect::<String>()
+                custom_modules.keys().fold(String::new(), |mut output, b| {
+                    let _ = write!(output, "${{custom.{b}}}");
+                    output
+                })
             );
         }
     }

--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -668,7 +668,7 @@ credential_process = /opt/bin/awscreds-retriever
 
         let expiration_env_vars = ["AWS_SESSION_EXPIRATION", "AWS_CREDENTIAL_EXPIRATION"];
         expiration_env_vars.iter().for_each(|env_var| {
-            let now_plus_half_hour: DateTime<Utc> = chrono::DateTime::from_utc(
+            let now_plus_half_hour: DateTime<Utc> = DateTime::from_naive_utc_and_offset(
                 NaiveDateTime::from_timestamp_opt(chrono::Local::now().timestamp() + 1800, 0)
                     .unwrap(),
                 Utc,
@@ -702,7 +702,7 @@ credential_process = /opt/bin/awscreds-retriever
 
         use chrono::{DateTime, NaiveDateTime, Utc};
 
-        let now_plus_half_hour: DateTime<Utc> = chrono::DateTime::from_utc(
+        let now_plus_half_hour: DateTime<Utc> = DateTime::from_naive_utc_and_offset(
             NaiveDateTime::from_timestamp_opt(chrono::Local::now().timestamp() + 1800, 0).unwrap(),
             Utc,
         );
@@ -789,7 +789,7 @@ aws_secret_access_key=dummy
     fn expiration_date_set_expired() {
         use chrono::{DateTime, NaiveDateTime, SecondsFormat, Utc};
 
-        let now: DateTime<Utc> = chrono::DateTime::from_utc(
+        let now: DateTime<Utc> = DateTime::from_naive_utc_and_offset(
             NaiveDateTime::from_timestamp_opt(chrono::Local::now().timestamp() - 1800, 0).unwrap(),
             Utc,
         );

--- a/src/modules/hostname.rs
+++ b/src/modules/hostname.rs
@@ -23,7 +23,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         return None;
     }
 
-    let os_hostname: OsString = gethostname::gethostname();
+    let os_hostname: OsString = whoami::hostname_os();
 
     let host = match os_hostname.into_string() {
         Ok(host) => host,
@@ -87,7 +87,7 @@ mod tests {
 
     macro_rules! get_hostname {
         () => {
-            if let Ok(hostname) = gethostname::gethostname().into_string() {
+            if let Ok(hostname) = whoami::hostname_os().into_string() {
                 hostname
             } else {
                 println!(

--- a/src/modules/username.rs
+++ b/src/modules/username.rs
@@ -2,21 +2,15 @@ use super::{Context, Module, ModuleConfig};
 
 use crate::configs::username::UsernameConfig;
 use crate::formatter::StringFormatter;
-
-#[cfg(not(target_os = "windows"))]
-const USERNAME_ENV_VAR: &str = "USER";
-
-#[cfg(target_os = "windows")]
+#[cfg(test)]
 const USERNAME_ENV_VAR: &str = "USERNAME";
 
 /// Creates a module with the current user's username
-///
-/// Will display the username if any of the following criteria are met:
-///     - The current user is root (UID = 0) [1]
-///     - The current user isn't the same as the one that is logged in (`$LOGNAME` != `$USER`) [2]
-///     - The user is currently connected as an SSH session (`$SSH_CONNECTION`) [3]
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    #[cfg(test)]
     let mut username = context.get_env(USERNAME_ENV_VAR)?;
+    #[cfg(not(test))]
+    let mut username = whoami::username();
 
     let mut module = context.new_module("username");
     let config: UsernameConfig = UsernameConfig::try_load(module.config);
@@ -151,8 +145,8 @@ mod tests {
         let actual = ModuleRenderer::new("username")
             .env("SSH_CONNECTION", "192.168.223.17 36673 192.168.223.229 22")
             .collect();
-        let expected = None;
 
+        let expected = None;
         assert_eq!(expected, actual);
     }
 

--- a/src/print.rs
+++ b/src/print.rs
@@ -507,8 +507,10 @@ pub fn preset_command(name: Option<Preset>, output: Option<PathBuf>, list: bool)
 fn preset_list() -> String {
     Preset::value_variants()
         .iter()
-        .map(|v| format!("{}\n", v.0))
-        .collect()
+        .fold(String::new(), |mut output, b| {
+            let _ = writeln!(output, "{}", b.0);
+            output
+        })
 }
 
 #[cfg(test)]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
1. get username by `whoami` crate, because the `USER` env may be changed.
2. fix some clippy warning
3. get hostname by `whoami`, and remove the `gethostname` crate from dependencies.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
