### PR TITLE
fix(pastel-powerline): remove `$path` from docker-context module format string

### DIFF
--- a/docs/.vuepress/public/presets/toml/pastel-powerline.toml
+++ b/docs/.vuepress/public/presets/toml/pastel-powerline.toml
@@ -72,7 +72,7 @@ format = '[ $symbol ($version) ]($style)'
 [docker_context]
 symbol = " "
 style = "bg:#06969A"
-format = '[ $symbol $context ]($style) $path'
+format = '[ $symbol $context ]($style)'
 
 [elixir]
 symbol = " "


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
I removed the `$path` attribute for the docker context in the Pastel Powerline preset. The `$path` attribute does not exist for docker context as per your [documentation](https://starship.rs/config/#docker-context). 

With the `$path` present.  there is an unpleasant one letter wide vertical gap in the prompt background where the non-existent  `$path` is not rendered. 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes a visual bug in the pastel powerline preset. 

#### Screenshots (if appropriate):
Before removal of `$path`:
![Screenshot 2023-10-27 at 17 16 40](https://github.com/starship/starship/assets/32773644/24bfb1e8-5ccc-4823-8ffa-8bf95868d89b)

After removal of `$path`:
![Screenshot 2023-10-27 at 17 17 58](https://github.com/starship/starship/assets/32773644/93126fef-1027-436e-bb33-210e99704be7)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**


- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
