### PR TITLE
feat(notifications): Add support for transient notifications

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -182,7 +182,8 @@
         "min_time_to_notify": 45000,
         "show_milliseconds": false,
         "show_notifications": false,
-        "style": "yellow bold"
+        "style": "yellow bold",
+        "transient": false
       },
       "allOf": [
         {
@@ -2286,6 +2287,10 @@
           ],
           "format": "uint32",
           "minimum": 0.0
+        },
+        "transient": {
+          "default": false,
+          "type": "boolean"
         }
       },
       "additionalProperties": false

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -860,7 +860,7 @@ running `eval $(starship init $0)`, and then proceed as normal.
 | `show_notifications`   | `false`                       | Show desktop notifications when command completes.                                                                                                                |
 | `min_time_to_notify`   | `45_000`                      | Shortest duration for notification (in milliseconds).                                                                                                             |
 | `notification_timeout` |                               | Duration to show notification for (in milliseconds). If unset, notification timeout will be determined by daemon. Not all notification daemons honor this option. |
-| `transient`            | `false`                       | Set the notifications to disappear once shown. Not all notification daemons honor this option.                                                                    |
+| `transient`            | `false`                       | Set the notifications to disappear once shown. Only available on Linux, and not supported by all notification daemons.                                            |
 
 ### Variables
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -860,6 +860,7 @@ running `eval $(starship init $0)`, and then proceed as normal.
 | `show_notifications`   | `false`                       | Show desktop notifications when command completes.                                                                                                                |
 | `min_time_to_notify`   | `45_000`                      | Shortest duration for notification (in milliseconds).                                                                                                             |
 | `notification_timeout` |                               | Duration to show notification for (in milliseconds). If unset, notification timeout will be determined by daemon. Not all notification daemons honor this option. |
+| `transient`            | `false`                       | Set the notifications to disappear once shown. Not all notification daemons honor this option.                                                                    |
 
 ### Variables
 

--- a/src/configs/cmd_duration.rs
+++ b/src/configs/cmd_duration.rs
@@ -15,6 +15,7 @@ pub struct CmdDurationConfig<'a> {
     pub disabled: bool,
     pub show_notifications: bool,
     pub min_time_to_notify: i64,
+    pub transient: bool,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub notification_timeout: Option<u32>,
@@ -31,6 +32,7 @@ impl<'a> Default for CmdDurationConfig<'a> {
             show_notifications: false,
             min_time_to_notify: 45_000,
             notification_timeout: None,
+            transient: false,
         }
     }
 }

--- a/src/modules/cmd_duration.rs
+++ b/src/modules/cmd_duration.rs
@@ -68,7 +68,7 @@ fn undistract_me<'a>(
     context: &'a Context,
     elapsed: u128,
 ) -> Module<'a> {
-    use notify_rust::{Notification, Timeout};
+    use notify_rust::{Hint, Notification, Timeout};
     use nu_ansi_term::{unstyle, AnsiStrings};
 
     if config.show_notifications && config.min_time_to_notify as u128 <= elapsed {
@@ -99,6 +99,10 @@ fn undistract_me<'a>(
             .body(&body)
             .icon("utilities-terminal")
             .timeout(timeout);
+
+        if config.transient {
+            notification.hint(Hint::Transient(true));
+        }
 
         if let Err(err) = notification.show() {
             log::trace!("Cannot show notification: {}", err);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Adds an option to set notifications as `transient`, meaning that they will not persist once shown.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Notifications only contain the time taken in the previous command, so they lack the necessary context to be useful for long periods of time for most people.

Having notifications be transient is an option that many people would likely prefer.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
