### PR TITLE
docs: Include openSUSE in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,19 +221,19 @@ curl -sS https://starship.rs/install.sh | sh
 
 Alternatively, install Starship using any of the following package managers:
 
-| Distribution        | Repository              | Instructions                                                  |
-| ------------------- | ----------------------- | ------------------------------------------------------------- |
-| **_Any_**           | **[crates.io]**         | `cargo install starship --locked`                             |
-| _Any_               | [conda-forge]           | `conda install -c conda-forge starship`                       |
-| _Any_               | [Linuxbrew]             | `brew install starship`                                       |
-| Alpine Linux 3.13+  | [Alpine Linux Packages] | `apk add starship`                                            |
-| Arch Linux          | [Arch Linux Extra]      | `pacman -S starship`                                          |
-| CentOS 7+           | [Copr]                  | `dnf copr enable atim/starship` <br /> `dnf install starship` |
-| Gentoo              | [Gentoo Packages]       | `emerge app-shells/starship`                                  |
-| Manjaro             |                         | `pacman -S starship`                                          |
-| NixOS               | [nixpkgs]               | `nix-env -iA nixpkgs.starship`                                |
-| openSUSE            | [OSS]                   | `zypper in starship`                                          |
-| Void Linux          | [Void Linux Packages]   | `xbps-install -S starship`                                    |
+| Distribution       | Repository              | Instructions                                                  |
+| ------------------ | ----------------------- | ------------------------------------------------------------- |
+| **_Any_**          | **[crates.io]**         | `cargo install starship --locked`                             |
+| _Any_              | [conda-forge]           | `conda install -c conda-forge starship`                       |
+| _Any_              | [Linuxbrew]             | `brew install starship`                                       |
+| Alpine Linux 3.13+ | [Alpine Linux Packages] | `apk add starship`                                            |
+| Arch Linux         | [Arch Linux Extra]      | `pacman -S starship`                                          |
+| CentOS 7+          | [Copr]                  | `dnf copr enable atim/starship` <br /> `dnf install starship` |
+| Gentoo             | [Gentoo Packages]       | `emerge app-shells/starship`                                  |
+| Manjaro            |                         | `pacman -S starship`                                          |
+| NixOS              | [nixpkgs]               | `nix-env -iA nixpkgs.starship`                                |
+| openSUSE           | [OSS]                   | `zypper in starship`                                          |
+| Void Linux         | [Void Linux Packages]   | `xbps-install -S starship`                                    |
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ Alternatively, install Starship using any of the following package managers:
 | Gentoo              | [Gentoo Packages]       | `emerge app-shells/starship`                                  |
 | Manjaro             |                         | `pacman -S starship`                                          |
 | NixOS               | [nixpkgs]               | `nix-env -iA nixpkgs.starship`                                |
-| openSUSE Tumbleweed | [OSS]                   | `zypper in starship`                                          |
+| openSUSE            | [OSS]                   | `zypper in starship`                                          |
 | Void Linux          | [Void Linux Packages]   | `xbps-install -S starship`                                    |
 
 </details>

--- a/README.md
+++ b/README.md
@@ -221,18 +221,19 @@ curl -sS https://starship.rs/install.sh | sh
 
 Alternatively, install Starship using any of the following package managers:
 
-| Distribution       | Repository              | Instructions                                                  |
-| ------------------ | ----------------------- | ------------------------------------------------------------- |
-| **_Any_**          | **[crates.io]**         | `cargo install starship --locked`                             |
-| _Any_              | [conda-forge]           | `conda install -c conda-forge starship`                       |
-| _Any_              | [Linuxbrew]             | `brew install starship`                                       |
-| Alpine Linux 3.13+ | [Alpine Linux Packages] | `apk add starship`                                            |
-| Arch Linux         | [Arch Linux Extra]      | `pacman -S starship`                                          |
-| CentOS 7+          | [Copr]                  | `dnf copr enable atim/starship` <br /> `dnf install starship` |
-| Gentoo             | [Gentoo Packages]       | `emerge app-shells/starship`                                  |
-| Manjaro            |                         | `pacman -S starship`                                          |
-| NixOS              | [nixpkgs]               | `nix-env -iA nixpkgs.starship`                                |
-| Void Linux         | [Void Linux Packages]   | `xbps-install -S starship`                                    |
+| Distribution        | Repository              | Instructions                                                  |
+| ------------------- | ----------------------- | ------------------------------------------------------------- |
+| **_Any_**           | **[crates.io]**         | `cargo install starship --locked`                             |
+| _Any_               | [conda-forge]           | `conda install -c conda-forge starship`                       |
+| _Any_               | [Linuxbrew]             | `brew install starship`                                       |
+| Alpine Linux 3.13+  | [Alpine Linux Packages] | `apk add starship`                                            |
+| Arch Linux          | [Arch Linux Extra]      | `pacman -S starship`                                          |
+| CentOS 7+           | [Copr]                  | `dnf copr enable atim/starship` <br /> `dnf install starship` |
+| Gentoo              | [Gentoo Packages]       | `emerge app-shells/starship`                                  |
+| Manjaro             |                         | `pacman -S starship`                                          |
+| NixOS               | [nixpkgs]               | `nix-env -iA nixpkgs.starship`                                |
+| openSUSE Tumbleweed | [OSS]                   | `zypper in starship`                                          |
+| Void Linux          | [Void Linux Packages]   | `xbps-install -S starship`                                    |
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -459,6 +459,7 @@ This project is [ISC](https://github.com/starship/starship/blob/master/LICENSE) 
 [homebrew]: https://formulae.brew.sh/formula/starship
 [macports]: https://ports.macports.org/port/starship
 [nixpkgs]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/tools/misc/starship/default.nix
+[OSS]: https://software.opensuse.org/package/starship
 [pkgsrc]: https://pkgsrc.se/shells/starship
 [scoop]: https://github.com/ScoopInstaller/Main/blob/master/bucket/starship.json
 [termux]: https://github.com/termux/termux-packages/tree/master/packages/starship


### PR DESCRIPTION
#### Description
Added installation instructions for openSUSE Tumbleweed package manager.

#### Motivation and Context
Providing additional installation options is always nice.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
Installed it myself like this.

- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
