### PR TITLE
style(character): Trailing whitespace

### DIFF
--- a/src/configs/character.rs
+++ b/src/configs/character.rs
@@ -22,7 +22,7 @@ pub struct CharacterConfig<'a> {
 impl<'a> Default for CharacterConfig<'a> {
     fn default() -> Self {
         CharacterConfig {
-            format: "$symbol ",
+            format: "$symbol",
             success_symbol: "[❯](bold green)",
             error_symbol: "[❯](bold red)",
             vimcmd_symbol: "[❮](bold green)",

--- a/src/modules/character.rs
+++ b/src/modules/character.rs
@@ -86,7 +86,7 @@ mod test {
 
     #[test]
     fn success_status() {
-        let expected = Some(format!("{} ", Color::Green.bold().paint("❯")));
+        let expected = Some(format!("{}", Color::Green.bold().paint("❯")));
 
         // Status code 0
         let actual = ModuleRenderer::new("character").status(0).collect();
@@ -99,7 +99,7 @@ mod test {
 
     #[test]
     fn failure_status() {
-        let expected = Some(format!("{} ", Color::Red.bold().paint("❯")));
+        let expected = Some(format!("{}", Color::Red.bold().paint("❯")));
 
         let exit_values = [1, 54321, -5000];
 
@@ -111,8 +111,8 @@ mod test {
 
     #[test]
     fn custom_symbol() {
-        let expected_fail = Some(format!("{} ", Color::Red.bold().paint("✖")));
-        let expected_success = Some(format!("{} ", Color::Green.bold().paint("➜")));
+        let expected_fail = Some(format!("{}", Color::Red.bold().paint("✖")));
+        let expected_success = Some(format!("{}", Color::Green.bold().paint("➜")));
 
         let exit_values = [1, 54321, -5000];
 
@@ -143,9 +143,9 @@ mod test {
 
     #[test]
     fn zsh_keymap() {
-        let expected_vicmd = Some(format!("{} ", Color::Green.bold().paint("❮")));
-        let expected_specified = Some(format!("{} ", Color::Green.bold().paint("V")));
-        let expected_other = Some(format!("{} ", Color::Green.bold().paint("❯")));
+        let expected_vicmd = Some(format!("{}", Color::Green.bold().paint("❮")));
+        let expected_specified = Some(format!("{}", Color::Green.bold().paint("V")));
+        let expected_other = Some(format!("{}", Color::Green.bold().paint("❯")));
 
         // zle keymap is vicmd
         let actual = ModuleRenderer::new("character")
@@ -175,12 +175,12 @@ mod test {
 
     #[test]
     fn fish_keymap() {
-        let expected_vicmd = Some(format!("{} ", Color::Green.bold().paint("❮")));
-        let expected_specified = Some(format!("{} ", Color::Green.bold().paint("V")));
-        let expected_visual = Some(format!("{} ", Color::Yellow.bold().paint("❮")));
-        let expected_replace = Some(format!("{} ", Color::Purple.bold().paint("❮")));
+        let expected_vicmd = Some(format!("{}", Color::Green.bold().paint("❮")));
+        let expected_specified = Some(format!("{}", Color::Green.bold().paint("V")));
+        let expected_visual = Some(format!("{}", Color::Yellow.bold().paint("❮")));
+        let expected_replace = Some(format!("{}", Color::Purple.bold().paint("❮")));
         let expected_replace_one = expected_replace.as_deref();
-        let expected_other = Some(format!("{} ", Color::Green.bold().paint("❯")));
+        let expected_other = Some(format!("{}", Color::Green.bold().paint("❯")));
 
         // fish keymap is default
         let actual = ModuleRenderer::new("character")
@@ -231,9 +231,9 @@ mod test {
 
     #[test]
     fn cmd_keymap() {
-        let expected_vicmd = Some(format!("{} ", Color::Green.bold().paint("❮")));
-        let expected_specified = Some(format!("{} ", Color::Green.bold().paint("V")));
-        let expected_other = Some(format!("{} ", Color::Green.bold().paint("❯")));
+        let expected_vicmd = Some(format!("{}", Color::Green.bold().paint("❮")));
+        let expected_specified = Some(format!("{}", Color::Green.bold().paint("V")));
+        let expected_other = Some(format!("{}", Color::Green.bold().paint("❯")));
 
         // cmd keymap is vi
         let actual = ModuleRenderer::new("character")
@@ -263,9 +263,9 @@ mod test {
 
     #[test]
     fn powershell_keymap() {
-        let expected_vicmd = Some(format!("{} ", Color::Green.bold().paint("❮")));
-        let expected_specified = Some(format!("{} ", Color::Green.bold().paint("V")));
-        let expected_other = Some(format!("{} ", Color::Green.bold().paint("❯")));
+        let expected_vicmd = Some(format!("{}", Color::Green.bold().paint("❮")));
+        let expected_specified = Some(format!("{}", Color::Green.bold().paint("V")));
+        let expected_other = Some(format!("{}", Color::Green.bold().paint("❯")));
 
         // powershell keymap is vi
         let actual = ModuleRenderer::new("character")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Removed the trailing whitespace in the `config::chararacter` module.
I also changed the tests for the character module so they would pass with this change.
I can recognize that this is a bit counterintuitive to the tests but the changes were just removing the hard-coded spaces in the format strings.


#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Every starship module has a trailing space after it.
I can recognize why this consistency is very valuable in keep formatting the same when composing modules together.
Nevertheless, I can also recognize that the `character` module is usually used in a different context than the other modules.
Since it is used to show a symbol next to where text is entered on a terminal, the trailing whitespace that every module has gets in the way of configuring the symbol  in certain contexts.
Furthermore, from what I have been able to read from past PR's, this trailing whitespace is used to work around emojis acting strangely on different systems.
Because of this, I believe the trailing whitespace in the `character` should be removed since this is a very particularly customizable part of the prompt and leaving the hardcoded whitespace would reduce the configurability of the prompt.

#### Screenshots (if appropriate):
Prompt before change:
![before-change](https://github.com/starship/starship/assets/65361987/21f48ce2-0d05-496e-becd-5326f9783371)


Prompt after change:
![after-change](https://github.com/starship/starship/assets/65361987/086b953e-0fbb-40c9-a5b3-4aee99288eaf)


#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
PS. Since the documentation doesn't mention the trailing whitespace I have not updated it. As I saw in other PR's, adding a comment explaining why the space was or wasn't removed might also be a good option going forward.