### PR TITLE
perf(git_status): avoid running in bare repos

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -8,6 +8,7 @@ use crate::modules;
 use crate::utils;
 use clap::Parser;
 use gix::{
+    repository::Kind,
     sec::{self as git_sec, trust::DefaultForLevel},
     state as git_state, Repository, ThreadSafeRepository,
 };
@@ -351,6 +352,7 @@ impl<'a> Context<'a> {
                     state: repository.state(),
                     remote,
                     fs_monitor_value_is_true,
+                    kind: repository.kind(),
                 })
             })
     }
@@ -640,6 +642,9 @@ pub struct Repo {
     /// Contains `true` if the value of `core.fsmonitor` is set to `true`.
     /// If not `true`, `fsmonitor` is explicitly disabled in git commands.
     fs_monitor_value_is_true: bool,
+
+    // Kind of repository, work tree or bare
+    pub kind: Kind,
 }
 
 impl Repo {

--- a/src/modules/git_status.rs
+++ b/src/modules/git_status.rs
@@ -34,6 +34,12 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     // Return None if not in git repository
     let repo = context.get_repo().ok()?;
 
+    if repo.kind.is_bare() {
+        // git_status not applicable for a bare repository
+        log::debug!("This is a bare repository, git_status is not applicable");
+        return None;
+    }
+
     if let Some(git_status) = git_status_wsl(context, &config) {
         if git_status.is_empty() {
             return None;
@@ -215,11 +221,6 @@ fn get_repo_status(
 
     let mut repo_status = RepoStatus::default();
 
-    // can't run git status against a bare repo
-    if repo.repo.work_tree.is_none() {
-        log::debug!("This is a bare repository, not generating git status");
-        return Some(repo_status);
-    }
     let mut args = vec!["status", "--porcelain=2"];
 
     // for performance reasons, only pass flags if necessary...

--- a/src/modules/git_status.rs
+++ b/src/modules/git_status.rs
@@ -35,7 +35,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let repo = context.get_repo().ok()?;
 
     if repo.kind.is_bare() {
-        // git_status not applicable for a bare repository
         log::debug!("This is a bare repository, git_status is not applicable");
         return None;
     }
@@ -220,7 +219,6 @@ fn get_repo_status(
     log::debug!("New repo status created");
 
     let mut repo_status = RepoStatus::default();
-
     let mut args = vec!["status", "--porcelain=2"];
 
     // for performance reasons, only pass flags if necessary...

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -232,10 +232,12 @@ pub fn fixture_repo(provider: FixtureProvider) -> io::Result<TempDir> {
         }
         FixtureProvider::GitBare => {
             let path = tempfile::tempdir()?;
-            create_command("git")?
-                .current_dir(path.path())
-                .args(["--bare", "init"])
-                .output()?;
+            gix::ThreadSafeRepository::init(
+                &path,
+                gix::create::Kind::Bare,
+                gix::create::Options::default(),
+            )
+            .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
             Ok(path)
         }
         FixtureProvider::Hg => {

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -166,6 +166,7 @@ impl<'a> ModuleRenderer<'a> {
 pub enum FixtureProvider {
     Fossil,
     Git,
+    GitBare,
     Hg,
     Pijul,
 }
@@ -227,6 +228,14 @@ pub fn fixture_repo(provider: FixtureProvider) -> io::Result<TempDir> {
                 .current_dir(path.path())
                 .output()?;
 
+            Ok(path)
+        }
+        FixtureProvider::GitBare => {
+            let path = tempfile::tempdir()?;
+            create_command("git")?
+                .current_dir(path.path())
+                .args(["--bare", "init"])
+                .output()?;
             Ok(path)
         }
         FixtureProvider::Hg => {


### PR DESCRIPTION
#### Description
This change adjusts the git_status module to no longer attempt to generate git_status for a bare repository as this is not possible when a repository does not have a work tree.

#### Motivation and Context
Currently entering a bare repository throws an error, as described in the associated issue.
Closes #5544 

#### Screenshots (if appropriate):
When entering a bare repository the error is no longer visible:
![image](https://github.com/starship/starship/assets/61805721/2425ca97-857c-4b9c-8929-ed0faefdd31d)
#### How Has This Been Tested?
Locally by entering a bare repository as per the above screenshot.
You can also see the correct behaviour from the unit test output (I believe I've used the fixture correctly although not familiar with the setup):
```
cargo test --package starship --lib -- modules::git_status::tests::doesnt_generate_git_status_for_bare_repo --exact --nocapture
    Finished test [unoptimized + debuginfo] target(s) in 0.69s
     Running unittests src/lib.rs (target/debug/deps/starship-49403b2d84e0acbb)

running 1 test
[TRACE] - (starship::utils): Trying to read from "/Users/will/.config/starship.toml"
[TRACE] - (starship::utils): File read successfully
[TRACE] - (starship::config): Config file content: "
# ~/.config/starship.toml

[status]
style = 'bg:blue'
symbol = '🔴 '
success_symbol = '🟢 SUCCESS'
format = '[\[$symbol$common_meaning$signal_name$maybe_int\]]($style) '
map_symbol = true
disabled = false

"
[DEBUG] - (starship::config): Config parsed: {"status": Table({"style": String("bg:blue"), "symbol": String("🔴 "), "success_symbol": String("🟢 SUCCESS"), "format": String("[\\[$symbol$common_meaning$signal_name$maybe_int\\]]($style) "), "map_symbol": Boolean(true), "disabled": Boolean(false)})}
[TRACE] - (starship::context): Received completed pipestatus of None
[TRACE] - (starship::context): Found git repo: Repository { kind: Bare, git_dir: "/var/folders/zk/ctx002wn22l7tg0_rk4m_dyh0000gn/T/.tmp9ehSuN", work_dir: None }, (trust: Full)
[DEBUG] - (starship::modules::git_status): This is a bare repository, git_status is not applicable
[TRACE] - (starship::modules): Took 2.212191ms to compute module "git_status"
test modules::git_status::tests::doesnt_generate_git_status_for_bare_repo ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 1043 filtered out; finished in 0.07s
```
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
