### PR TITLE
feat: R lang packages version, remove .Rprofile from rlang detection

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -1396,9 +1396,7 @@
           "Rproj",
           "Rsx"
         ],
-        "detect_files": [
-          ".Rprofile"
-        ],
+        "detect_files": [],
         "detect_folders": [
           ".Rproj.user"
         ],
@@ -5099,9 +5097,7 @@
           }
         },
         "detect_files": {
-          "default": [
-            ".Rprofile"
-          ],
+          "default": [],
           "type": "array",
           "items": {
             "type": "string"

--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -1396,7 +1396,9 @@
           "Rproj",
           "Rsx"
         ],
-        "detect_files": [],
+        "detect_files": [
+          "DESCRIPTION"
+        ],
         "detect_folders": [
           ".Rproj.user"
         ],
@@ -5097,7 +5099,9 @@
           }
         },
         "detect_files": {
-          "default": [],
+          "default": [
+            "DESCRIPTION"
+          ],
           "type": "array",
           "items": {
             "type": "string"

--- a/src/configs/rlang.rs
+++ b/src/configs/rlang.rs
@@ -27,7 +27,7 @@ impl<'a> Default for RLangConfig<'a> {
             symbol: "📐 ",
             disabled: false,
             detect_extensions: vec!["R", "Rd", "Rmd", "Rproj", "Rsx"],
-            detect_files: vec![".Rprofile"],
+            detect_files: vec![],
             detect_folders: vec![".Rproj.user"],
         }
     }

--- a/src/configs/rlang.rs
+++ b/src/configs/rlang.rs
@@ -27,7 +27,7 @@ impl<'a> Default for RLangConfig<'a> {
             symbol: "📐 ",
             disabled: false,
             detect_extensions: vec!["R", "Rd", "Rmd", "Rproj", "Rsx"],
-            detect_files: vec![],
+            detect_files: vec!["DESCRIPTION"],
             detect_folders: vec![".Rproj.user"],
         }
     }

--- a/src/modules/package.rs
+++ b/src/modules/package.rs
@@ -312,7 +312,7 @@ fn get_dart_pub_version(context: &Context, config: &PackageConfig) -> Option<Str
 
 fn get_rlang_version(context: &Context, config: &PackageConfig) -> Option<String> {
     let file_contents = context.read_file_from_pwd("DESCRIPTION")?;
-    let re = Regex::new(r"(?m)^\s*Version\s*:\s*'(?P<version>[^']+)'").unwrap();
+    let re = Regex::new(r"^Version:\s*(?P<version>.*$)").unwrap();
     let caps = re.captures(&file_contents)?;
     format_version(&caps["version"], config.version_format)
 }

--- a/src/modules/package.rs
+++ b/src/modules/package.rs
@@ -310,6 +310,13 @@ fn get_dart_pub_version(context: &Context, config: &PackageConfig) -> Option<Str
     format_version(raw_version, config.version_format)
 }
 
+fn get_rlang_version(context: &Context, config: &PackageConfig) -> Option<String> {
+    let file_contents = context.read_file_from_pwd("DESCRIPTION")?;
+    let re = Regex::new(r"(?m)^\s*Version\s*:\s*'(?P<version>[^']+)'").unwrap();
+    let caps = re.captures(&file_contents)?;
+    format_version(&caps["version"], config.version_format)
+}
+
 fn get_version(context: &Context, config: &PackageConfig) -> Option<String> {
     let package_version_fn: Vec<fn(&Context, &PackageConfig) -> Option<String>> = vec![
         get_cargo_version,
@@ -330,6 +337,7 @@ fn get_version(context: &Context, config: &PackageConfig) -> Option<String> {
         get_sbt_version,
         get_daml_project_version,
         get_dart_pub_version,
+        get_rlang_version,
     ];
 
     package_version_fn.iter().find_map(|f| f(context, config))
@@ -1402,6 +1410,19 @@ environment:
         project_dir.close()
     }
 
+    #[test]
+    fn test_extract_rlang_version() -> io::Result<()> {
+        let config_name = "DESCRIPTION";
+        let config_content = "
+Package: starship
+Version: 1.0.0
+Title: Starship
+";
+        let project_dir = create_project_dir()?;
+        fill_config(&project_dir, config_name, Some(config_content))?;
+        expect_output(&project_dir, Some("v1.0.0"), None);
+        project_dir.close()
+    }
     fn create_project_dir() -> io::Result<TempDir> {
         tempfile::tempdir()
     }

--- a/src/modules/package.rs
+++ b/src/modules/package.rs
@@ -312,7 +312,7 @@ fn get_dart_pub_version(context: &Context, config: &PackageConfig) -> Option<Str
 
 fn get_rlang_version(context: &Context, config: &PackageConfig) -> Option<String> {
     let file_contents = context.read_file_from_pwd("DESCRIPTION")?;
-    let re = Regex::new(r"^Version:\s*(?P<version>.*$)").unwrap();
+    let re = Regex::new(r"(?m)^Version:\s*(?P<version>.*$)").unwrap();
     let caps = re.captures(&file_contents)?;
     format_version(&caps["version"], config.version_format)
 }

--- a/src/modules/rlang.rs
+++ b/src/modules/rlang.rs
@@ -133,14 +133,6 @@ https://www.gnu.org/licenses/."#;
     }
 
     #[test]
-    fn folder_with_rprofile_files() -> io::Result<()> {
-        let dir = tempfile::tempdir()?;
-        File::create(dir.path().join(".Rprofile"))?.sync_all()?;
-        check_r_render(&dir);
-        dir.close()
-    }
-
-    #[test]
     fn folder_with_rproj_user_folder() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         let rprofile = dir.path().join(".Rproj.user");

--- a/src/modules/rlang.rs
+++ b/src/modules/rlang.rs
@@ -141,6 +141,14 @@ https://www.gnu.org/licenses/."#;
         dir.close()
     }
 
+    #[test]
+    fn folder_with_description_files() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join("DESCRIPTION"))?.sync_all()?;
+        check_r_render(&dir);
+        dir.close()
+    }
+
     fn check_r_render(dir: &tempfile::TempDir) {
         let actual = ModuleRenderer::new("rlang").path(dir.path()).collect();
         let expected = Some(format!("via {}", Color::Blue.bold().paint("📐 v4.1.0 ")));

--- a/src/modules/rlang.rs
+++ b/src/modules/rlang.rs
@@ -133,18 +133,18 @@ https://www.gnu.org/licenses/."#;
     }
 
     #[test]
-    fn folder_with_rproj_user_folder() -> io::Result<()> {
+    fn folder_with_description_files() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
-        let rprofile = dir.path().join(".Rproj.user");
-        fs::create_dir_all(rprofile)?;
+        File::create(dir.path().join("DESCRIPTION"))?.sync_all()?;
         check_r_render(&dir);
         dir.close()
     }
 
     #[test]
-    fn folder_with_description_files() -> io::Result<()> {
+    fn folder_with_rproj_user_folder() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
-        File::create(dir.path().join("DESCRIPTION"))?.sync_all()?;
+        let rprofile = dir.path().join(".Rproj.user");
+        fs::create_dir_all(rprofile)?;
         check_r_render(&dir);
         dir.close()
     }


### PR DESCRIPTION
#### Description
- R lang packages version #5586
- remove .Rprofile from rlang detection #2817
- proper detection of R packages #5590

#### Motivation and Context
Closes #5586, closes #2817, closes #5590

#### How Has This Been Tested?
Have not been tested, `cargo test` getting stuck for many minutes with
```
test modules::git_commit::tests::test_latest_tag_shown_with_tag_enabled has been running for over 60 seconds
test modules::git_commit::tests::test_latest_tag_shown_with_tag_enabled_lightweight has been running for over 60 seconds
```
submitting here so at least CI can test it.

#### Checklist:
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
