### PR TITLE
feat: Added possibility to have different last character of prompt if the user is "root".

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -143,6 +143,8 @@
         "error_symbol": "[❯](bold red)",
         "format": "$symbol ",
         "success_symbol": "[❯](bold green)",
+        "root_error_symbol": "[❯](bold purple)",
+        "root_success_symbol": "[❯](bold blue)",
         "vimcmd_replace_one_symbol": "[❮](bold purple)",
         "vimcmd_replace_symbol": "[❮](bold purple)",
         "vimcmd_symbol": "[❮](bold green)",
@@ -2192,6 +2194,14 @@
         },
         "error_symbol": {
           "default": "[❯](bold red)",
+          "type": "string"
+        },
+        "root_success_symbol": {
+          "default": "[❯](bold blue)",
+          "type": "string"
+        },
+        "root_error_symbol": {
+          "default": "[❯](bold purple)",
           "type": "string"
         },
         "vimcmd_symbol": {

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -721,16 +721,18 @@ are only supported in fish due to [upstream issues with mode detection in zsh](h
 
 ### Options
 
-| Option                      | Default              | Description                                                                             |
-| --------------------------- | -------------------- | --------------------------------------------------------------------------------------- |
-| `format`                    | `'$symbol '`         | The format string used before the text input.                                           |
-| `success_symbol`            | `'[❯](bold green)'`  | The format string used before the text input if the previous command succeeded.         |
-| `error_symbol`              | `'[❯](bold red)'`    | The format string used before the text input if the previous command failed.            |
-| `vimcmd_symbol`             | `'[❮](bold green)'`  | The format string used before the text input if the shell is in vim normal mode.        |
-| `vimcmd_replace_one_symbol` | `'[❮](bold purple)'` | The format string used before the text input if the shell is in vim `replace_one` mode. |
-| `vimcmd_replace_symbol`     | `'[❮](bold purple)'` | The format string used before the text input if the shell is in vim replace mode.       |
-| `vimcmd_visual_symbol`      | `'[❮](bold yellow)'` | The format string used before the text input if the shell is in vim visual mode.        |
-| `disabled`                  | `false`              | Disables the `character` module.                                                        |
+| Option                      | Default              | Description                                                                                 |
+| --------------------------- | -------------------- | ------------------------------------------------------------------------------------------- |
+| `format`                    | `'$symbol '`         | The format string used before the text input.                                               |
+| `success_symbol`            | `'[❯](bold green)'`  | The format string used before the text input if the previous command succeeded.             |
+| `error_symbol`              | `'[❯](bold red)'`    | The format string used before the text input if the previous command failed.                |
+| `root_success_symbol`       | `'[❯](bold blue)'`   | The format string used before the text input if the previous command succeeded (root user). |
+| `root_error_symbol`         | `'[❯](bold purple)`  | The format string used before the text input if the previous command failed (root user).    |
+| `vimcmd_symbol`             | `'[❮](bold green)'`  | The format string used before the text input if the shell is in vim normal mode.            |
+| `vimcmd_replace_one_symbol` | `'[❮](bold purple)'` | The format string used before the text input if the shell is in vim `replace_one` mode.     |
+| `vimcmd_replace_symbol`     | `'[❮](bold purple)'` | The format string used before the text input if the shell is in vim replace mode.           |
+| `vimcmd_visual_symbol`      | `'[❮](bold yellow)'` | The format string used before the text input if the shell is in vim visual mode.            |
+| `disabled`                  | `false`              | Disables the `character` module.                                                            |
 
 ### Variables
 
@@ -748,6 +750,8 @@ are only supported in fish due to [upstream issues with mode detection in zsh](h
 [character]
 success_symbol = '[➜](bold green) '
 error_symbol = '[✗](bold red) '
+root_success_symbol = '[➜](bold blue) '
+root_error_symbol = '[✗](bold purple) '
 ```
 
 #### Without custom error shape
@@ -758,6 +762,8 @@ error_symbol = '[✗](bold red) '
 [character]
 success_symbol = '[➜](bold green) '
 error_symbol = '[➜](bold red) '
+root_success_symbol = '[➜](bold blue) '
+root_error_symbol = '[➜](bold purple) '
 ```
 
 #### With custom vim shape

--- a/src/configs/character.rs
+++ b/src/configs/character.rs
@@ -11,6 +11,8 @@ pub struct CharacterConfig<'a> {
     pub format: &'a str,
     pub success_symbol: &'a str,
     pub error_symbol: &'a str,
+    pub root_success_symbol: &'a str,
+    pub root_error_symbol: &'a str,
     #[serde(alias = "vicmd_symbol")]
     pub vimcmd_symbol: &'a str,
     pub vimcmd_visual_symbol: &'a str,
@@ -25,6 +27,8 @@ impl<'a> Default for CharacterConfig<'a> {
             format: "$symbol ",
             success_symbol: "[❯](bold green)",
             error_symbol: "[❯](bold red)",
+            root_success_symbol: "[❯](bold blue)",
+            root_error_symbol: "[❯](bold purple)",
             vimcmd_symbol: "[❮](bold green)",
             vimcmd_visual_symbol: "[❮](bold yellow)",
             vimcmd_replace_symbol: "[❮](bold purple)",

--- a/src/modules/character.rs
+++ b/src/modules/character.rs
@@ -112,13 +112,11 @@ fn is_root_user() -> bool {
 }
 
 #[cfg(all(target_os = "windows", test))]
-#[allow(unused)]
 fn is_root_user() -> bool {
     false
 }
 
 #[cfg(not(target_os = "windows"))]
-#[allow(unused)]
 fn is_root_user() -> bool {
     nix::unistd::geteuid() == nix::unistd::ROOT
 }

--- a/src/modules/character.rs
+++ b/src/modules/character.rs
@@ -7,9 +7,10 @@ use crate::formatter::StringFormatter;
 /// The character segment prints an arrow character in a color dependent on the
 /// exit-code of the last executed command:
 /// - If the exit-code was "0", it will be formatted with `success_symbol`
-///   (green arrow by default)
+///   (green arrow by default) or `root_success_symbol` (blue arrow by default)
 /// - If the exit-code was anything else, it will be formatted with
-///   `error_symbol` (red arrow by default)
+///   `error_symbol` (red arrow by default) or `root_error_symbol` (purple arrow
+///   by default)
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     enum ShellEditMode {
         Normal,
@@ -20,6 +21,8 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     }
     const ASSUMED_MODE: ShellEditMode = ShellEditMode::Insert;
     // TODO: extend config to more modes
+
+    let is_root = is_root_user();
 
     let mut module = context.new_module("character");
     let config: CharacterConfig = CharacterConfig::try_load(module.config);
@@ -50,10 +53,18 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         ShellEditMode::Replace => config.vimcmd_replace_symbol,
         ShellEditMode::ReplaceOne => config.vimcmd_replace_one_symbol,
         ShellEditMode::Insert => {
-            if exit_success {
-                config.success_symbol
+            if is_root {
+                if exit_success {
+                    config.root_success_symbol
+                } else {
+                    config.root_error_symbol
+                }
             } else {
-                config.error_symbol
+                if exit_success {
+                    config.success_symbol
+                } else {
+                    config.error_symbol
+                }
             }
         }
     };
@@ -76,6 +87,40 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     });
 
     Some(module)
+}
+
+#[cfg(all(target_os = "windows", not(test)))]
+fn is_root_user() -> bool {
+    use deelevate::{PrivilegeLevel, Token};
+    let token = match Token::with_current_process() {
+        Ok(token) => token,
+        Err(e) => {
+            log::warn!("Failed to get process token: {e:?}");
+            return false;
+        }
+    };
+    matches!(
+        match token.privilege_level() {
+            Ok(level) => level,
+            Err(e) => {
+                log::warn!("Failed to get privilege level: {e:?}");
+                return false;
+            }
+        },
+        PrivilegeLevel::Elevated | PrivilegeLevel::HighIntegrityAdmin
+    )
+}
+
+#[cfg(all(target_os = "windows", test))]
+#[allow(unused)]
+fn is_root_user() -> bool {
+    false
+}
+
+#[cfg(not(target_os = "windows"))]
+#[allow(unused)]
+fn is_root_user() -> bool {
+    nix::unistd::geteuid() == nix::unistd::ROOT
 }
 
 #[cfg(test)]
@@ -116,6 +161,8 @@ mod test {
 
         let exit_values = [1, 54321, -5000];
 
+        // TODO: test if user is root
+
         // Test failure values
         for status in &exit_values {
             let actual = ModuleRenderer::new("character")
@@ -123,6 +170,8 @@ mod test {
                     [character]
                     success_symbol = "[➜](bold green)"
                     error_symbol = "[✖](bold red)"
+                    root_success_symbol = "[➜](bold blue)"
+                    root_error_symbol = "[✖](bold purple)"
                 })
                 .status(*status)
                 .collect();
@@ -135,6 +184,8 @@ mod test {
                 [character]
                 success_symbol = "[➜](bold green)"
                 error_symbol = "[✖](bold red)"
+                root_success_symbol = "[➜](bold blue)"
+                root_error_symbol = "[✖](bold purple)"
             })
             .status(0)
             .collect();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
If sudo is not run as login shell (eg: "sudo -s") and the HOME is kept in sudo, it is hard to recognize the commands are running as root or a simple user. In Linux the default behaviour is to have different last character if user is root. With this change it is possible to set the root symbols separately. 


#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #5397 

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

The idea and a piece of code was taken from module "username". I tried to write proper test for it, but this is my first Rust code, so i'm sure this is not enough. The code was built on linux and i use it now.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
