### PR TITLE
fix(docker_context): ignore unix domain socket path from Docker Context

### DIFF
--- a/src/modules/docker_context.rs
+++ b/src/modules/docker_context.rs
@@ -57,7 +57,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         }
     };
 
-    if ctx == "default" {
+    if ctx == "default" || ctx.starts_with("unix://") {
         return None;
     }
 
@@ -72,9 +72,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 _ => None,
             })
             .map(|variable| match variable {
-                "context" => { 
-                    Some(Ok(if ctx.contains("unix://") { "" } else { ctx.as_str() }))
-                },
+                "context" => Some(Ok(ctx.as_str())),
                 _ => None,
             })
             .parse(None, Some(context))
@@ -306,10 +304,7 @@ mod tests {
                 only_with_files = false
             })
             .collect();
-        let expected = Some(format!(
-        "via {} ",
-        Color::Blue.bold().paint("🐳 ")
-    ));
+        let expected = None;
 
         assert_eq!(expected, actual);
 


### PR DESCRIPTION
 fix(modules): ignore unix domain socket path from Docker Context

#### Description
Implemented functionality to slice long Unix domain socket paths in Docker Context within the terminal prompt. This optimization ensures the prompt remains concise and user-friendly, especially in environments where Unix domain socket paths are lengthy.

#### Motivation and Context
This enhancement addresses the issue of excessively long terminal prompts when Unix domain sockets are used in Docker Contexts. The change is aimed at improving the user experience by maintaining a manageable prompt length. Relevant issue:
Closes #5548

#### Screenshots (if appropriate):
Before:
![image](https://github.com/starship/starship/assets/12180395/dc51caaa-b316-4313-b405-7de49d73e90a)
After: 
![image](https://github.com/starship/starship/assets/12180395/5f6a4a5f-3356-43a4-bebc-76d85041b9df)

#### How Has This Been Tested?
- [x] I have tested using **MacOS**

#### Checklist:
- [x] I have updated the tests accordingly.
