### PR TITLE
Show `battery` module only while running on battery power

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -2025,7 +2025,7 @@
           ]
         }
       },
-      "dislay_on_charging": {
+      "display_on_charging": {
         "default": true,
         "type": "boolean"
       },

--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -2025,6 +2025,10 @@
           ]
         }
       },
+      "dislay_on_charging": {
+        "default": true,
+        "type": "boolean"
+      },
       "additionalProperties": false
     },
     "BufConfig": {

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -558,6 +558,7 @@ The `display` option is an array of the following table.
 | `style`              | `'red bold'` | The style used if the display option is in use.                                                           |
 | `charging_symbol`    |              | Optional symbol displayed if display option is in use, defaults to battery's `charging_symbol` option.    |
 | `discharging_symbol` |              | Optional symbol displayed if display option is in use, defaults to battery's `discharging_symbol` option. |
+|`dispplay_on_charging`|`true`| Controls displaying of battery module when the device is on power.
 
 #### Example
 

--- a/src/configs/battery.rs
+++ b/src/configs/battery.rs
@@ -46,6 +46,7 @@ pub struct BatteryDisplayConfig<'a> {
     pub style: &'a str,
     pub charging_symbol: Option<&'a str>,
     pub discharging_symbol: Option<&'a str>,
+    pub display_on_charging: bool,
 }
 
 impl<'a> Default for BatteryDisplayConfig<'a> {
@@ -55,6 +56,7 @@ impl<'a> Default for BatteryDisplayConfig<'a> {
             style: "red bold",
             charging_symbol: None,
             discharging_symbol: None,
+            display_on_charging: true,
         }
     }
 }

--- a/src/modules/battery.rs
+++ b/src/modules/battery.rs
@@ -51,7 +51,9 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
             match formatter.parse(None, Some(context)) {
                 Ok(format_string) => {
-                    module.set_segments(format_string);
+                    if !(!display_style.display_on_charging && state == battery::State::Charging) {
+                        module.set_segments(format_string);
+                    }
                     Some(module)
                 }
                 Err(e) => {

--- a/src/modules/battery.rs
+++ b/src/modules/battery.rs
@@ -51,7 +51,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
             match formatter.parse(None, Some(context)) {
                 Ok(format_string) => {
-                    if !(!display_style.display_on_charging && state == battery::State::Charging) {
+                    if display_style.display_on_charging || state != battery::State::Charging {
                         module.set_segments(format_string);
                     }
                     Some(module)


### PR DESCRIPTION
#### Description
This pull request fixes issue #5628 by modifying the `battery` module to only display when the laptop is running on battery power. The changes include adding a new configuration option `display_on_charging` to control whether the module should be displayed while charging.
If `display_on_charging` is by default true and if set to false disables the battery module while charging.

#### Motivation and Context
It eliminates unnecessary displaying of  battery module when device is on power for those who don't want it to be displayed.
Closes #5628 

#### Screenshots (if appropriate):

#### How Has This Been Tested?

- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
