### PR TITLE
chore(context): explicitly avoid erroring on no git-ceiling-dir-match

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -319,7 +319,10 @@ impl<'a> Context<'a> {
                 let shared_repo =
                     match ThreadSafeRepository::discover_with_environment_overrides_opts(
                         &self.current_dir,
-                        Default::default(),
+                        gix::discover::upwards::Options {
+                            match_ceiling_dir_or_error: false,
+                            ..Default::default()
+                        },
                         git_open_opts_map,
                     ) {
                         Ok(repo) => repo,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
See: https://github.com/Byron/gitoxide/pull/1191

The default behavior will change with the next version of `gix`, explicitly set `match_ceiling_dir_or_error` to avoid opting into the change.


#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
