### PR TITLE
revert: refactor(modules): use whoami crate to get username

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1024,6 +1024,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0176e0459c2e4a1fe232f984bca6890e681076abb9934f6cea7c326f3fc47818"
+dependencies = [
+ "libc",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2830,6 +2840,7 @@ dependencies = [
  "deelevate",
  "dirs-next",
  "dunce",
+ "gethostname",
  "gix",
  "gix-features",
  "guess_host_triple",
@@ -2871,7 +2882,6 @@ dependencies = [
  "urlencoding",
  "versions",
  "which",
- "whoami",
  "windows 0.48.0",
  "winres",
  "yaml-rust",
@@ -3434,12 +3444,6 @@ dependencies = [
  "rustix 0.38.28",
  "windows-sys 0.48.0",
 ]
-
-[[package]]
-name = "whoami"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22fc3756b8a9133049b26c7f61ab35416c130e8c09b660f5b3958b446f52cc50"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ clap = { version = "4.4.11", features = ["derive", "cargo", "unicode"] }
 clap_complete = "4.4.5"
 dirs-next = "2.0.0"
 dunce = "1.0.4"
+gethostname = "0.4.3"
 # default feature restriction addresses https://github.com/starship/starship/issues/4251
 gix = { version = "0.56.0", default-features = false, features = ["max-performance-safe", "revision"] }
 gix-features = { version = "0.36.1", optional = true }
@@ -93,7 +94,6 @@ process_control = { version = "4.0.3", features = ["crossbeam-channel"] }
 guess_host_triple = "0.1.3"
 home = "0.5.9"
 shell-words = "1.1.0"
-whoami = { version = "1.4.1", default-features = false }
 
 [dependencies.schemars]
 version = "0.8.16"

--- a/src/modules/hostname.rs
+++ b/src/modules/hostname.rs
@@ -23,7 +23,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         return None;
     }
 
-    let os_hostname: OsString = whoami::hostname_os();
+    let os_hostname: OsString = gethostname::gethostname();
 
     let host = match os_hostname.into_string() {
         Ok(host) => host,
@@ -87,7 +87,7 @@ mod tests {
 
     macro_rules! get_hostname {
         () => {
-            if let Ok(hostname) = whoami::hostname_os().into_string() {
+            if let Ok(hostname) = gethostname::gethostname().into_string() {
                 hostname
             } else {
                 println!(

--- a/src/modules/username.rs
+++ b/src/modules/username.rs
@@ -2,15 +2,21 @@ use super::{Context, Module, ModuleConfig};
 
 use crate::configs::username::UsernameConfig;
 use crate::formatter::StringFormatter;
-#[cfg(test)]
+
+#[cfg(not(target_os = "windows"))]
+const USERNAME_ENV_VAR: &str = "USER";
+
+#[cfg(target_os = "windows")]
 const USERNAME_ENV_VAR: &str = "USERNAME";
 
 /// Creates a module with the current user's username
+///
+/// Will display the username if any of the following criteria are met:
+///     - The current user is root (UID = 0) [1]
+///     - The current user isn't the same as the one that is logged in (`$LOGNAME` != `$USER`) [2]
+///     - The user is currently connected as an SSH session (`$SSH_CONNECTION`) [3]
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
-    #[cfg(test)]
     let mut username = context.get_env(USERNAME_ENV_VAR)?;
-    #[cfg(not(test))]
-    let mut username = whoami::username();
 
     let mut module = context.new_module("username");
     let config: UsernameConfig = UsernameConfig::try_load(module.config);
@@ -145,8 +151,8 @@ mod tests {
         let actual = ModuleRenderer::new("username")
             .env("SSH_CONNECTION", "192.168.223.17 36673 192.168.223.229 22")
             .collect();
-
         let expected = None;
+
         assert_eq!(expected, actual);
     }
 


### PR DESCRIPTION
Reverts starship/starship#5521

The switch to `whoami` was causing too many issues. Revert the change for now until the fallible API is available, and we can get the unmodified hostname.

Closes #5587
Closes #5666