### PR TITLE
Ketan sonar fix install location

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -269,12 +269,11 @@ confirm() {
       exit 1
     fi
     if [ "$yn" != "y" ] && [ "$yn" != "yes" ]; then
-      printf "Enter the location to install to: "
       set +e
-      read -r bd </dev/tty
-      BIN_DIR=$bd
+      read -p "Enter the location to install to: " -e path
       rc=$?
       set -e
+      BIN_DIR=$path
       if [ $rc -ne 0 ]; then
           error "Error reading from prompt (please re-run with the '--yes' option)"
           exit 1

--- a/install/install.sh
+++ b/install/install.sh
@@ -269,8 +269,16 @@ confirm() {
       exit 1
     fi
     if [ "$yn" != "y" ] && [ "$yn" != "yes" ]; then
-      error 'Aborting (please answer "yes" to continue)'
-      exit 1
+      printf "Enter the location to install to: "
+      set +e
+      read -r bd </dev/tty
+      BIN_DIR=$bd
+      rc=$?
+      set -e
+      if [ $rc -ne 0 ]; then
+          error "Error reading from prompt (please re-run with the '--yes' option)"
+          exit 1
+      fi
     fi
   fi
 }


### PR DESCRIPTION
When asking if the user wants to install starship in /usr/local/bin, if the user enters N, instead of aborting the installation, the user will get a prompt to enter the location they want to install in.

#### Description
In the confirm function of the install.sh script, previously it was just aborting the installation when the user entered N. I changed it so that it will show another prompt asking for where to install starship and set that location as BIN_DIR. Also, I check if there was an error when reading prompt and handle it accordingly.

#### Motivation and Context
The user could not set another location for the installation while running the script. This change makes it easier for the user the change the installation location.
Closes #5608

#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**