### PR TITLE
feat: Add `opt_in_modules` config option

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -1892,6 +1892,10 @@
       "additionalProperties": {
         "type": "string"
       }
+    },
+    "opt_in_modules": {
+      "default": false,
+      "type": "boolean"
     }
   },
   "additionalProperties": false,

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -220,6 +220,7 @@ This is the list of prompt-wide configuration options.
 | `palette`         | `''`                           | Sets which color palette from `palettes` to use.                                                                                                                                   |
 | `palettes`        | `{}`                           | Collection of color palettes that assign [colors](../advanced-config/#style-strings) to user-defined names. Note that color palettes cannot reference their own color definitions. |
 | `follow_symlinks` | `true`                         | Follows symlinks to check if they're directories; used in modules such as git.                                                                                                     |
+| `opt_in_modules`  | `false`                        | Inverts the default value for each modules `disabled` key. When set to `true`, omitting the `disabled` key for a module is equivalent to setting `disabled = true`.                |
 
 ::: tip
 

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -23,6 +23,7 @@ pub struct StarshipRootConfig {
     pub palette: Option<String>,
     pub palettes: HashMap<String, Palette>,
     pub profiles: IndexMap<String, String>,
+    pub opt_in_modules: bool,
 }
 
 pub type Palette = HashMap<String, String>;
@@ -141,6 +142,7 @@ impl Default for StarshipRootConfig {
             follow_symlinks: true,
             palette: None,
             palettes: HashMap::default(),
+            opt_in_modules: false,
         }
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -233,7 +233,7 @@ impl<'a> Context<'a> {
         // If the segment has "disabled" set to "true", don't show it
         let disabled = config.and_then(|table| table.as_table()?.get("disabled")?.as_bool());
 
-        disabled == Some(true)
+        disabled.or(Some(self.root_config.opt_in_modules)) == Some(true)
     }
 
     /// Returns true when a negated environment variable is defined in `env_vars` and is present


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
When `true`, it turns module selection into opt-in (all modules are disabled by default, with some exceptions), instead of opt-out as it is now.

Technically, if `opt_in_modules` is true, the default value for any `disabled` module key will then be false.

The default value for this new option is `false` meaning the default value for any `disabled` module key will be true, as it is now.

#### Motivation and Context
Starship frequently adds new modules to cover the diverse projects and environments of all most/users. Now, from the point of view of individual users, their environment seldom change, and those who care about performance (like me) only disable all modules we know we are not going to use.

In my case, every time I update `starship` I go through the chore of scanning the release note(s) take note of all the newly added modules, determine which I would like to use (which is almost always none), then disable the rest by adding them all to `~/.config/starship.toml` with `disabled = true`.

Closes #4312

<!--- #### Screenshots (if appropriate): -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
