### PR TITLE
chore: bump libz-sys crates to 1.1.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1770,9 +1770,9 @@ dependencies = [
 
 [[package]]
 name = "libz-ng-sys"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dd9f43e75536a46ee0f92b758f6b63846e594e86638c61a9251338a65baea63"
+checksum = "601c27491de2c76b43c9f52d639b2240bfb9b02112009d3b754bfa90d891492d"
 dependencies = [
  "cmake",
  "libc",
@@ -1780,9 +1780,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97137b25e321a73eef1418d1d5d2eda4d77e12813f8e6dead84bc52c5870a7b"
+checksum = "5f526fdd09d99e19742883e43de41e1aa9e36db0c7ab7f935165d611c5cccc66"
 dependencies = [
  "cc",
  "pkg-config",


### PR DESCRIPTION
so `aarch64-pc-windows-gnullvm` will become buildable again

<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
update libz-sys deps

#### Motivation and Context
this is needed for supporting `aarch64-pc-windows-gnullvm` as it contains important fix

#### How Has This Been Tested?
patch bumping, I don't think it's needed to be tested :)

#### Checklist:
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.

that's surely not about deps...
