### PR TITLE
docs: Fixing display_private option in package module

### DIFF
--- a/docs/es-ES/config/README.md
+++ b/docs/es-ES/config/README.md
@@ -3147,7 +3147,7 @@ El módulo `package` se muestra cuando el directorio actual es el repositorio de
 | `symbol`         | `'📦 '`                            | El símbolo usado antes de mostrar la versión del paquete.                               |
 | `version_format` | `'v${raw}'`                       | El formato de versión. Las variables disponibles son `raw`, `major`, `minor`, & `patch` |
 | `style`          | `'bold 208'`                      | El estilo del módulo.                                                                   |
-| `'📦 '`           | `false`                           | Activar la visualización de la versión para los paquetes marcados como privados.        |
+| `display_private`           | `false`                           | Activar la visualización de la versión para los paquetes marcados como privados.        |
 | `disabled`       | `false`                           | Desactiva el módulo `package`.                                                          |
 
 ### Variables


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Update the `display_private` option at the documentation package version in the es-Es language


#### Motivation and Context
Reading the documentation I noticed that the Spanish version had a bad option name for the package version extension.

#### Screenshots (if appropriate):

![CleanShot 2024-01-09 at 09 27 48](https://github.com/starship/starship/assets/6563162/821736ca-e685-4ae8-b79d-1a18e9b438d5)


#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [X] I have tested using **MacOS**
- [X] I have tested using **Linux**
- [X] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have updated the documentation accordingly.
- [X] I have updated the tests accordingly.
