### PR TITLE
docs(battery): add space after symbol in example

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -569,7 +569,7 @@ style = 'bold red'
 [[battery.display]] # 'bold yellow' style and 💦 symbol when capacity is between 10% and 30%
 threshold = 30
 style = 'bold yellow'
-discharging_symbol = '💦'
+discharging_symbol = '💦 '
 
 # when capacity is over 30%, the battery indicator will not be displayed
 ```


### PR DESCRIPTION
https://github.com/starship/starship/blob/fd32e35c3d144f361f432f9ca05bb2d9340fb949/docs/config/README.md?plain=1#L529-L536

A space follows a symbol.