### PR TITLE
Docs: Add unusual path warning to configuration section

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -6,6 +6,9 @@ To get started configuring starship, create the following file: `~/.config/stars
 mkdir -p ~/.config && touch ~/.config/starship.toml
 ```
 
+> [!WARNING]
+> Note that the file goes inside `.config` directly, not in a `starship/` subdirectory.
+
 All configuration for starship is done in this [TOML](https://github.com/toml-lang/toml) file:
 
 ```toml


### PR DESCRIPTION
#### Description

This adds a warning to advise the reader to pay attention to the config path.

#### Motivation and Context

I expected config to be in `~/.config/starship/starship.toml` and spent a merry 30 minutes screaming at my computer before I realised my eyes were tricking me!

This callout change might help a few others, I hope! :smile:

#### Screenshot:

> [!WARNING]
> Note that the file goes inside `.config` directly, not in a `starship/` subdirectory.




#### How Has This Been Tested?

- [X]  Tested in the github markdown preview
- [ ] Untested in VuePress

It's possible that the formatting might need to be changed to [their version](https://vuepress.vuejs.org/guide/markdown.html#custom-containers) (which I can do if needed):

```
::: warning
This is a warning
:::
```

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
~~- [ ] I have updated the tests accordingly. (N/A)~~
