### PR TITLE
Change gradle icon from G to 

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -711,7 +711,7 @@
         "format": "via [$symbol($version )]($style)",
         "recursive": false,
         "style": "bold bright-cyan",
-        "symbol": "🅶 ",
+        "symbol": " ",
         "version_format": "v${raw}"
       },
       "allOf": [
@@ -3581,7 +3581,7 @@
           "type": "string"
         },
         "symbol": {
-          "default": "🅶 ",
+          "default": " ",
           "type": "string"
         },
         "style": {

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2155,7 +2155,7 @@ The `gradle` module is only able to read your Gradle Wrapper version from your c
 | ------------------- | ------------------------------------ | ------------------------------------------------------------------------- |
 | `format`            | `'via [$symbol($version )]($style)'` | The format for the module.                                                |
 | `version_format`    | `'v${raw}'`                          | The version format. Available vars are `raw`, `major`, `minor`, & `patch` |
-| `symbol`            | `'🅶 '`                               | A format string representing the symbol of Gradle.                        |
+| `symbol`            | `' '`                               | A format string representing the symbol of Gradle.                        |
 | `detect_extensions` | `['gradle', 'gradle.kts']`           | Which extensions should trigger this module.                              |
 | `detect_files`      | `[]`                                 | Which filenames should trigger this module.                               |
 | `detect_folders`    | `['gradle']`                         | Which folders should trigger this module.                                 |

--- a/src/configs/gradle.rs
+++ b/src/configs/gradle.rs
@@ -24,7 +24,7 @@ impl<'a> Default for GradleConfig<'a> {
         GradleConfig {
             format: "via [$symbol($version )]($style)",
             version_format: "v${raw}",
-            symbol: "🅶 ",
+            symbol: " ",
             style: "bold bright-cyan",
             disabled: false,
             recursive: false,

--- a/src/modules/gradle.rs
+++ b/src/modules/gradle.rs
@@ -154,7 +154,7 @@ zipStorePath=wrapper/dists",
 
         let expected = Some(format!(
             "via {}",
-            Color::LightCyan.bold().paint("🅶 v7.5.1 ")
+            Color::LightCyan.bold().paint(" v7.5.1 ")
         ));
         assert_eq!(expected, actual);
         dir.close()
@@ -197,7 +197,7 @@ zipStorePath=wrapper/dists",
 
         let expected = Some(format!(
             "via {}",
-            Color::LightCyan.bold().paint("🅶 v7.5.1 ")
+            Color::LightCyan.bold().paint(" v7.5.1 ")
         ));
         assert_eq!(expected, actual);
         dir.close()


### PR DESCRIPTION
This is a (small) follow-up to https://github.com/starship/starship/pull/4423.

#### Description

This changes the gradle icon from 🅶 (NEGATIVE SQUARED LATIN CAPITAL LETTER G' (U+1F176)) to the "real" Gradle icon .

Old:

![image](https://github.com/starship/starship/assets/1366654/36024a08-d8e1-4e9c-84ef-9f04f798a963)

New:

![image](https://github.com/starship/starship/assets/1366654/dee4859d-9d4d-49a9-b66f-e27a902210d5)

#### Motivation and Context

I had major issues getting the G displayed [on my NixOS machine](https://discourse.nixos.org/t/get-all-characters-working-with-starship-in-gnome-terminal/38749?u=koppor). 

I searched the fonts on my machine, checked the Nerd fonts. Nothing worked. Then, I serached the Nerd Fonts for the gradle icon. This is different from the icon supplied.


<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

Old:

![image](https://github.com/starship/starship/assets/1366654/865b81ec-c37e-4dc5-af31-cd807a7d8777)

New:

![image](https://github.com/starship/starship/assets/1366654/584b2c87-cd4a-412b-9036-feae3c8ebe1c)

#### How Has This Been Tested?

I modified `starship.toml` to contain following configuration

```toml
[gradle]
symbol = " "
```

I carefully did a search and replace in VS.Code.  I reviewed the changes in `git gui`.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
