### PR TITLE
feat(bash): use PS0 for preexec hook

### DIFF
--- a/src/init/starship.bash
+++ b/src/init/starship.bash
@@ -75,7 +75,7 @@ starship_precmd() {
         STARSHIP_END_TIME=$(::STARSHIP:: time)
         STARSHIP_DURATION=$((STARSHIP_END_TIME - STARSHIP_START_TIME))
         ARGS+=( --cmd-duration="${STARSHIP_DURATION}")
-        unset STARSHIP_START_TIME
+        STARSHIP_START_TIME=""
     fi
     PS1="$(::STARSHIP:: prompt "${ARGS[@]}")"
     if [[ ${BLE_ATTACHED-} ]]; then
@@ -98,17 +98,27 @@ elif [[ "${__bp_imported:-}" == "defined" || -n "${preexec_functions-}" || -n "$
     preexec_functions+=(starship_preexec_all)
     precmd_functions+=(starship_precmd)
 else
-    # We want to avoid destroying an existing DEBUG hook. If we detect one, create
-    # a new function that runs both the existing function AND our function, then
-    # re-trap DEBUG to use this new function. This prevents a trap clobber.
-    dbg_trap="$(trap -p DEBUG | cut -d' ' -f3 | tr -d \')"
-    if [[ -z "$dbg_trap" ]]; then
-        trap 'starship_preexec "$_"' DEBUG
-    elif [[ "$dbg_trap" != 'starship_preexec "$_"' && "$dbg_trap" != 'starship_preexec_all "$_"' ]]; then
-        starship_preexec_all() {
-            local PREV_LAST_ARG=$1 ; $dbg_trap; starship_preexec; : "$PREV_LAST_ARG";
+    if [[ -n "${BASH_VERSION-}" ]] && [[ "${BASH_VERSINFO[0]}" -gt 4 || ( "${BASH_VERSINFO[0]}" -eq 4 && "${BASH_VERSINFO[1]}" -ge 4 ) ]]; then
+        starship_preexec_ps0() {
+            ::STARSHIP:: time
         }
-        trap 'starship_preexec_all "$_"' DEBUG
+        # In order to set STARSHIP_START_TIME use an arithmetic expansion that evaluates to 0
+        # To avoid printing anything, use the return value in an ${var:offset:length} substring expansion
+        # with offset and length evaluating to 0.
+        PS0='${STARSHIP_START_TIME:$((STARSHIP_START_TIME="$(starship_preexec_ps0)",STARSHIP_PREEXEC_READY=0,0)):0}'"${PS0-}"
+    else
+        # We want to avoid destroying an existing DEBUG hook. If we detect one, create
+        # a new function that runs both the existing function AND our function, then
+        # re-trap DEBUG to use this new function. This prevents a trap clobber.
+        dbg_trap="$(trap -p DEBUG | cut -d' ' -f3 | tr -d \')"
+        if [[ -z "$dbg_trap" ]]; then
+            trap 'starship_preexec "$_"' DEBUG
+        elif [[ "$dbg_trap" != 'starship_preexec "$_"' && "$dbg_trap" != 'starship_preexec_all "$_"' ]]; then
+            starship_preexec_all() {
+                local PREV_LAST_ARG=$1 ; $dbg_trap; starship_preexec; : "$PREV_LAST_ARG";
+            }
+            trap 'starship_preexec_all "$_"' DEBUG
+        fi
     fi
 
     # Finally, prepare the precmd function and set up the start time. We will avoid to


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
If ble.sh and bash-preexec are not available, use `PS0` instead of debug traps on bash 4.4+. This may help performance a bit and will hopefully lead to fewer conflicts with other shell scrips (kitty shell integration?).

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
#4973


#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
