### PR TITLE
fix: Implement a better way to check for sudo on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,7 +110,8 @@ features = [
   "Win32_UI_Shell",
   "Win32_Security",
   "Win32_System_Threading",
-  "Win32_Storage_FileSystem",
+  "Win32_System_SystemServices",
+  "Win32_Storage_FileSystem"
 ]
 
 [target.'cfg(not(windows))'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,7 +111,7 @@ features = [
   "Win32_Security",
   "Win32_System_Threading",
   "Win32_System_SystemServices",
-  "Win32_Storage_FileSystem"
+  "Win32_Storage_FileSystem",
 ]
 
 [target.'cfg(not(windows))'.dependencies]

--- a/src/modules/utils/mod.rs
+++ b/src/modules/utils/mod.rs
@@ -8,4 +8,6 @@ pub mod directory_nix;
 
 pub mod path;
 
+#[cfg(target_os = "windows")]
+pub mod sudo;
 pub mod truncate;

--- a/src/modules/utils/sudo.rs
+++ b/src/modules/utils/sudo.rs
@@ -1,0 +1,41 @@
+use windows::Win32::{
+    Foundation::{BOOL, HANDLE, PSID},
+    Security, System,
+};
+
+pub fn is_sudo() -> Result<bool, String> {
+    let mut sid = PSID::default();
+    let admin_group = Security::SECURITY_NT_AUTHORITY;
+
+    let rc = unsafe {
+        Security::AllocateAndInitializeSid(
+            &admin_group,
+            2,
+            System::SystemServices::SECURITY_BUILTIN_DOMAIN_RID as u32,
+            System::SystemServices::DOMAIN_ALIAS_RID_ADMINS as u32,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            &mut sid,
+        )
+    };
+
+    if let Err(e) = rc.ok() {
+        return Err(format!("Failed to allocate and initialize sid: {e:?}"));
+    }
+
+    let mut is_member = BOOL::default();
+    let nullptr = HANDLE::default();
+
+    unsafe {
+        if let Err(e) = Security::CheckTokenMembership(nullptr, sid, &mut is_member).ok() {
+            return Err(format!("Failed to check token membership: {e:?}"));
+        }
+        Security::FreeSid(sid);
+    }
+
+    Ok(is_member.as_bool())
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
Changes the way starship checks for sudo on Windows. Uses the same [method](https://github.com/JanDeDobbeleer/oh-my-posh/blob/main/src/platform/shell_windows.go#L16-L5 ) as oh-my-posh 

#### Motivation and Context
This method removes cmd window popping out every time you press enter while in sudo, and constant gsudo popouts when you're not.

#### How Has This Been Tested?
- Replaced original exe in binary folder and checked if sudo module worked as expected.
- Changes don't affect anything else.
- Tested on Windows 11 23H2
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
_Not sure if these 2 are needed, but lmk_
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
