### PR TITLE
feat(zsh): display named directories

### DIFF
--- a/src/init/starship.zsh
+++ b/src/init/starship.zsh
@@ -87,6 +87,6 @@ VIRTUAL_ENV_DISABLE_PROMPT=1
 
 setopt promptsubst
 
-PROMPT='$('::STARSHIP::' prompt --terminal-width="$COLUMNS" --keymap="${KEYMAP:-}" --status="$STARSHIP_CMD_STATUS" --pipestatus="${STARSHIP_PIPE_STATUS[*]}" --cmd-duration="${STARSHIP_DURATION:-}" --jobs="$STARSHIP_JOBS_COUNT")'
-RPROMPT='$('::STARSHIP::' prompt --right --terminal-width="$COLUMNS" --keymap="${KEYMAP:-}" --status="$STARSHIP_CMD_STATUS" --pipestatus="${STARSHIP_PIPE_STATUS[*]}" --cmd-duration="${STARSHIP_DURATION:-}" --jobs="$STARSHIP_JOBS_COUNT")'
+PROMPT='$('::STARSHIP::' prompt --terminal-width="$COLUMNS" --keymap="${KEYMAP:-}" --status="$STARSHIP_CMD_STATUS" --pipestatus="${STARSHIP_PIPE_STATUS[*]}" --cmd-duration="${STARSHIP_DURATION:-}" --jobs="$STARSHIP_JOBS_COUNT" --logical-path "${(%):-%~}")'
+RPROMPT='$('::STARSHIP::' prompt --right --terminal-width="$COLUMNS" --keymap="${KEYMAP:-}" --status="$STARSHIP_CMD_STATUS" --pipestatus="${STARSHIP_PIPE_STATUS[*]}" --cmd-duration="${STARSHIP_DURATION:-}" --jobs="$STARSHIP_JOBS_COUNT" --logical-path "${(%):-%~}")'
 PROMPT2="$(::STARSHIP:: prompt --continuation)"


### PR DESCRIPTION
Pass Zsh's [`%~` prompt specifier](https://man.archlinux.org/man/zshmisc.1#Shell_state) to `--logical-path` in `PROMPT`/`RPROMPT`

<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description

Display the current directory using zsh's `%~` specifier, which shortens paths if they refer to a [named directory](https://man.archlinux.org/man/zshexpn.1#Static_named_directories).

<!--- Describe your changes in detail -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Named directories are a great feature of zsh and most common zsh prompts use the `%~` specifier to display the current directory in shortened form when possible.

#### Screenshots (if appropriate):
Before (With `directory.truncate_to_repo = false` for emphasis)
![image](https://github.com/LunarLambda/starship/assets/38919842/655c37ef-2ba6-4cb5-bd45-8be5c1ae1fd9)
After (named directory set with `hash -d nvim=~/cfg/nvim`)
![image](https://github.com/LunarLambda/starship/assets/38919842/ace74f16-5fd1-4740-a84a-df565018465c)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.

Unsure what testing/documentation this needs, since it's just passing an existing flag to `starship prompt`. I would be happy to make any necessary adjustments.

However, I did notice that passing `--logical-path` overrides `directory.truncate_to_repo` completely, I'm not sure if that's intentional/desired.