### PR TITLE
feat(line_break): add break_below_width option

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -970,6 +970,7 @@
     },
     "line_break": {
       "default": {
+        "break_below_width": null,
         "disabled": false
       },
       "allOf": [
@@ -4325,6 +4326,15 @@
         "disabled": {
           "default": false,
           "type": "boolean"
+        },
+        "break_below_width": {
+          "default": null,
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint",
+          "minimum": 0.0
         }
       },
       "additionalProperties": false

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2724,9 +2724,10 @@ The `line_break` module separates the prompt into two lines.
 
 ### Options
 
-| Option     | Default | Description                                                        |
-| ---------- | ------- | ------------------------------------------------------------------ |
-| `disabled` | `false` | Disables the `line_break` module, making the prompt a single line. |
+| Option              | Default | Description                                                                    |
+| ------------------- | ------- | ------------------------------------------------------------------------------ |
+| `disabled`          | `false` | Disables the `line_break` module, making the prompt a single line.             |
+| `break_below_width` |         | If specified, insert a line break only when your terminal is below this width. |
 
 ### Example
 

--- a/src/configs/line_break.rs
+++ b/src/configs/line_break.rs
@@ -9,4 +9,5 @@ use serde::{Deserialize, Serialize};
 #[serde(default)]
 pub struct LineBreakConfig {
     pub disabled: bool,
+    pub break_below_width: Option<usize>,
 }

--- a/src/modules/line_break.rs
+++ b/src/modules/line_break.rs
@@ -1,11 +1,18 @@
 use super::{Context, Module};
-use crate::segment::Segment;
+use crate::{config::ModuleConfig, configs::line_break::LineBreakConfig, segment::Segment};
 
 /// Creates a module for the line break
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let mut module = context.new_module("line_break");
+    let config = LineBreakConfig::try_load(module.config);
 
-    module.set_segments(vec![Segment::LineTerm]);
+    let should_break = match config.break_below_width {
+        Some(break_below_width) => context.width < break_below_width,
+        None => true,
+    };
+    if should_break {
+        module.set_segments(vec![Segment::LineTerm]);
+    }
 
     Some(module)
 }
@@ -19,5 +26,36 @@ mod test {
         let expected = Some(String::from("\n"));
         let actual = ModuleRenderer::new("line_break").collect();
         assert_eq!(expected, actual);
+    }
+
+    fn check_break_below_width_behaviour(
+        break_below_width: usize,
+        term_width: usize,
+        expected: Option<String>,
+    ) {
+        let config = toml::toml! {
+            [line_break]
+            break_below_width = break_below_width
+        };
+        let renderer = ModuleRenderer::new("line_break")
+            .config(config)
+            .width(term_width);
+        let actual = renderer.collect();
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn break_below_width_wide_terminal() {
+        check_break_below_width_behaviour(80, 80, None);
+    }
+
+    #[test]
+    fn break_below_width_narrow_terminal() {
+        check_break_below_width_behaviour(80, 79, Some(String::from("\n")));
+    }
+
+    #[test]
+    fn break_below_width_undetected_width() {
+        check_break_below_width_behaviour(80, 0, Some(String::from("\n")));
     }
 }


### PR DESCRIPTION
#### Description

When specified, this option will change `line_break`'s behaviour to only insert a line break when the width of the terminal is below the given value.

#### Motivation and Context

I value being able to see as much of my terminal history as possible, so my current starship configuration disables `line_break`. This is disadvantageous in narrow terminals, as commands I type are more likely to wrap and my right prompt may not be displayed at all.

Setting an appropriate `break_below_width` value allows users like me to increase the vertical space used by their prompt only when horizontal space is at a premium: I don't "lose" lines of history off the top of my screen except when doing so will give me more space to type and/or mean that my right prompt will be displayed.

#### Screenshots (if appropriate):

These screenshots are of the same prompt with only the width of the terminal changed:

![startship-bbw-wide](https://github.com/starship/starship/assets/62736/7c30de0a-3b60-4eb9-9c65-44c64cfde43f)
![starship-bbw-narrow](https://github.com/starship/starship/assets/62736/3082d8b0-b4a9-4dca-b4a5-2bed4cc14158)

#### How Has This Been Tested?

I have built `starship` locally with this change (on an Ubuntu 20.04 system) and tested it by:
* setting `break_below_width` and resizing my terminal across the boundary to observe its behaviour
* unsetting `break_below_width` and confirming that a line break is always emitted

Additionally, there are `cargo test` tests to ensure that the correct output is being emitted.

- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.