### PR TITLE
chore: apply clippy for rust 1.76 & bump msrv

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ license = "ISC"
 readme = "README.md"
 repository = "https://github.com/starship/starship"
 # Note: MSRV is only intended as a hint, and only the latest version is officially supported in starship.
-rust-version = "1.65"
+rust-version = "1.71"
 description = """
 The minimal, blazing-fast, and infinitely customizable prompt for any shell! ☄🌌️
 """

--- a/src/context.rs
+++ b/src/context.rs
@@ -339,10 +339,8 @@ impl<'a> Context<'a> {
                 );
 
                 let branch = get_current_branch(&repository);
-                let remote = get_remote_repository_info(
-                    &repository,
-                    branch.as_ref().map(|name| name.as_ref()),
-                );
+                let remote =
+                    get_remote_repository_info(&repository, branch.as_ref().map(AsRef::as_ref));
                 let path = repository.path().to_path_buf();
 
                 let fs_monitor_value_is_true = repository

--- a/src/modules/direnv.rs
+++ b/src/modules/direnv.rs
@@ -85,7 +85,7 @@ impl FromStr for DirenvState {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match serde_json::from_str::<RawDirenvState>(s) {
-            Ok(raw) => Ok(DirenvState {
+            Ok(raw) => Ok(Self {
                 rc_path: raw.state.found_rc.path,
                 allowed: raw.state.found_rc.allowed.try_into()?,
                 loaded: matches!(
@@ -93,7 +93,7 @@ impl FromStr for DirenvState {
                     AllowStatus::Allowed
                 ),
             }),
-            Err(_) => DirenvState::from_lines(s),
+            Err(_) => Self::from_lines(s),
         }
     }
 }
@@ -225,7 +225,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         let rc_path = dir.path().join(".envrc");
 
-        std::fs::File::create(&rc_path)?.sync_all()?;
+        std::fs::File::create(rc_path)?.sync_all()?;
 
         let renderer = ModuleRenderer::new("direnv")
             .config(toml::toml! {
@@ -242,7 +242,7 @@ mod tests {
             );
 
         assert_eq!(
-            Some(format!("direnv not loaded/allowed ")),
+            Some("direnv not loaded/allowed ".to_string()),
             renderer.collect()
         );
 
@@ -281,7 +281,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         let rc_path = dir.path().join(".envrc");
 
-        std::fs::File::create(&rc_path)?.sync_all()?;
+        std::fs::File::create(rc_path)?.sync_all()?;
 
         let renderer = ModuleRenderer::new("direnv")
             .config(toml::toml! {
@@ -297,7 +297,10 @@ mod tests {
                 }),
             );
 
-        assert_eq!(Some(format!("direnv loaded/allowed ")), renderer.collect());
+        assert_eq!(
+            Some("direnv loaded/allowed ".to_string()),
+            renderer.collect()
+        );
 
         dir.close()
     }
@@ -334,7 +337,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         let rc_path = dir.path().join(".envrc");
 
-        std::fs::File::create(&rc_path)?.sync_all()?;
+        std::fs::File::create(rc_path)?.sync_all()?;
 
         let renderer = ModuleRenderer::new("direnv")
             .config(toml::toml! {
@@ -350,7 +353,10 @@ mod tests {
                 }),
             );
 
-        assert_eq!(Some(format!("direnv loaded/denied ")), renderer.collect());
+        assert_eq!(
+            Some("direnv loaded/denied ".to_string()),
+            renderer.collect()
+        );
 
         dir.close()
     }
@@ -359,7 +365,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         let rc_path = dir.path().join(".envrc");
 
-        std::fs::File::create(&rc_path)?.sync_all()?;
+        std::fs::File::create(rc_path)?.sync_all()?;
 
         let renderer = ModuleRenderer::new("direnv")
             .config(toml::toml! {
@@ -376,7 +382,7 @@ mod tests {
             );
 
         assert_eq!(
-            Some(format!("direnv loaded/not allowed ")),
+            Some("direnv loaded/not allowed ".to_string()),
             renderer.collect()
         );
 

--- a/src/modules/dotnet.rs
+++ b/src/modules/dotnet.rs
@@ -270,7 +270,7 @@ fn get_local_dotnet_files(context: &Context) -> Result<Vec<DotNetFile>, std::io:
 fn get_dotnet_file_type(path: &Path) -> Option<FileType> {
     let file_name_lower = map_str_to_lower(path.file_name());
 
-    match file_name_lower.as_ref().map(std::convert::AsRef::as_ref) {
+    match file_name_lower.as_ref().map(AsRef::as_ref) {
         Some(GLOBAL_JSON_FILE) => return Some(FileType::GlobalJson),
         Some(PROJECT_JSON_FILE) => return Some(FileType::ProjectJson),
         _ => (),
@@ -278,7 +278,7 @@ fn get_dotnet_file_type(path: &Path) -> Option<FileType> {
 
     let extension_lower = map_str_to_lower(path.extension());
 
-    match extension_lower.as_ref().map(std::convert::AsRef::as_ref) {
+    match extension_lower.as_ref().map(AsRef::as_ref) {
         Some("sln") => return Some(FileType::SolutionFile),
         Some("csproj" | "fsproj" | "xproj") => return Some(FileType::ProjectFile),
         Some("props" | "targets") => return Some(FileType::MsBuildFile),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -136,7 +136,7 @@ pub fn display_command<T: AsRef<OsStr> + Debug, U: AsRef<OsStr> + Debug>(
     args: &[U],
 ) -> String {
     std::iter::once(cmd.as_ref())
-        .chain(args.iter().map(std::convert::AsRef::as_ref))
+        .chain(args.iter().map(AsRef::as_ref))
         .map(|i| i.to_string_lossy().into_owned())
         .collect::<Vec<String>>()
         .join(" ")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Rust 1.76 has been released recently with update clippy. This PR uses this occasion to fix some in-repo clippy warnings. I also updated the MSRV to align with the current requirements.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #5712

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
