### PR TITLE
Allow user to set special colour for exit code 130 (ctrl-c)

### DIFF
--- a/src/configs/character.rs
+++ b/src/configs/character.rs
@@ -10,12 +10,15 @@ use serde::{Deserialize, Serialize};
 pub struct CharacterConfig<'a> {
     pub format: &'a str,
     pub success_symbol: &'a str,
+    pub cancel_symbol: &'a str,
     pub error_symbol: &'a str,
     #[serde(alias = "vicmd_symbol")]
-    pub vimcmd_symbol: &'a str,
+    pub vimcmd_success_symbol: &'a str,
     pub vimcmd_visual_symbol: &'a str,
     pub vimcmd_replace_symbol: &'a str,
     pub vimcmd_replace_one_symbol: &'a str,
+    pub vimcmd_cancel_symbol: &'a str,
+    pub vimcmd_error_symbol: &'a str,
     pub disabled: bool,
 }
 
@@ -24,11 +27,14 @@ impl<'a> Default for CharacterConfig<'a> {
         CharacterConfig {
             format: "$symbol ",
             success_symbol: "[❯](bold green)",
+            cancel_symbol: "[❯](bold yellow)",
             error_symbol: "[❯](bold red)",
-            vimcmd_symbol: "[❮](bold green)",
             vimcmd_visual_symbol: "[❮](bold yellow)",
             vimcmd_replace_symbol: "[❮](bold purple)",
             vimcmd_replace_one_symbol: "[❮](bold purple)",
+            vimcmd_success_symbol: "[❮](bold green)",
+            vimcmd_cancel_symbol: "[❮](bold yellow)",
+            vimcmd_error_symbol: "[❮](bold red)",
             disabled: false,
         }
     }


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
This change allows the user to set a colour not only for exit code failure and success, but also exit code 130 (ctrl-c). This is set to yellow by default. This also fixes an issue where even the existing red for exit code failure was cleared by entering vim mode

#### Motivation and Context
I have been using this in a fork for a long time (see the master branch of the source fork of this PR if you really want) and i think others may desire this feature

#### Screenshots (if appropriate):
![image](https://github.com/starship/starship/assets/4983935/1b8c21a1-d135-47a6-9903-8a1d9df8c91c)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
