### PR TITLE
fix(git_branch): fall back to "HEAD" when there is no current branch

### DIFF
--- a/src/modules/git_branch.rs
+++ b/src/modules/git_branch.rs
@@ -30,13 +30,13 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         return None;
     }
 
-    let branch_name = repo.branch.as_ref()?;
+    let branch_name = repo.branch.as_deref().unwrap_or("HEAD");
     let mut graphemes: Vec<&str> = branch_name.graphemes(true).collect();
 
     if config
         .ignore_branches
         .iter()
-        .any(|ignored| branch_name.eq(ignored))
+        .any(|&ignored| branch_name.eq(ignored))
     {
         return None;
     }

--- a/src/modules/git_branch.rs
+++ b/src/modules/git_branch.rs
@@ -428,6 +428,29 @@ mod tests {
         remote_dir.close()
     }
 
+    #[test]
+    fn test_branch_fallback_on_detached() -> io::Result<()> {
+        let repo_dir = fixture_repo(FixtureProvider::Git)?;
+
+        create_command("git")?
+            .args(["checkout", "@~1"])
+            .current_dir(repo_dir.path())
+            .output()?;
+
+        let actual = ModuleRenderer::new("git_branch")
+            .config(toml::toml! {
+                [git_branch]
+                format = "$branch"
+            })
+            .path(repo_dir.path())
+            .collect();
+
+        let expected = Some("HEAD".into());
+
+        assert_eq!(expected, actual);
+        repo_dir.close()
+    }
+
     // This test is not possible until we switch to `git status --porcelain`
     // where we can mock the env for the specific git process. This is because
     // git2 does not care about our mocking and when we set the real `GIT_DIR`


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
According to [the docs](https://github.com/starship/starship/blob/fed7445ecf8959a32a8690a5fa36c4d9765663ba/docs/config/README.md?plain=1#L1799), the `branch` variable in the git branch module should fall back to `HEAD` if there's no current branch (detached HEAD). The code has been changed to do this.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The existing code sets `branch` to be empty in the case that there isn't a current branch.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
