### PR TITLE
fix(character): also handle vi edit mode in pwsh

### DIFF
--- a/src/modules/character.rs
+++ b/src/modules/character.rs
@@ -37,7 +37,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let mode = match (&context.shell, keymap) {
         (Shell::Fish, "default")
         | (Shell::Zsh, "vicmd")
-        | (Shell::Cmd | Shell::PowerShell, "vi") => ShellEditMode::Normal,
+        | (Shell::Cmd | Shell::PowerShell | Shell::Pwsh , "vi") => ShellEditMode::Normal,
         (Shell::Fish, "visual") => ShellEditMode::Visual,
         (Shell::Fish, "replace") => ShellEditMode::Replace,
         (Shell::Fish, "replace_one") => ShellEditMode::ReplaceOne,

--- a/src/modules/character.rs
+++ b/src/modules/character.rs
@@ -37,7 +37,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let mode = match (&context.shell, keymap) {
         (Shell::Fish, "default")
         | (Shell::Zsh, "vicmd")
-        | (Shell::Cmd | Shell::PowerShell | Shell::Pwsh , "vi") => ShellEditMode::Normal,
+        | (Shell::Cmd | Shell::PowerShell | Shell::Pwsh, "vi") => ShellEditMode::Normal,
         (Shell::Fish, "visual") => ShellEditMode::Visual,
         (Shell::Fish, "replace") => ShellEditMode::Replace,
         (Shell::Fish, "replace_one") => ShellEditMode::ReplaceOne,


### PR DESCRIPTION
After landing #5478 vi edit mode doesn't update the character as expected. This adds the new Shell type to properly show it on Pwsh.

#### Description
Mentioned in https://github.com/starship/starship/pull/5478#issuecomment-1886829331 that this broke. This works correctly in powershell.exe, but char doesn't update in pwsh.exe

#### Motivation and Context
This will fix the character change for Pwsh.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
