### PR TITLE
docs(preset): add Jetpack to presets/README.md

### DIFF
--- a/docs/presets/README.md
+++ b/docs/presets/README.md
@@ -74,3 +74,9 @@ This preset is inspired by [tokyo-night-vscode-theme](https://github.com/enkia/t
 This preset is heavily inspired by [Pastel Powerline](./pastel-powerline.md), and [Tokyo Night](./tokyo-night.md).
 
 [![Screenshot of Gruvbox Rainbow preset](/presets/img/gruvbox-rainbow.png "Click to view Gruvbox Rainbow preset")](./gruvbox-rainbow)
+
+## [Jetpack](./jetpack.md)
+
+This is a pseudo minimalist preset inspired by the [geometry](https://github.com/geometry-zsh/geometry) and [spaceship](https://github.com/spaceship-prompt/spaceship-prompt) prompts.
+
+[![Screenshot of Jetpack preset](/presets/img/jetpack.png "Click to view Jetpack preset")](./jetpack)


### PR DESCRIPTION
#### Description
added a new section to presets/README.md so Jetpack preset is visible

#### Motivation and Context
Noticed that the Jetpack preset wasn't added to the main preset page, so just adding it in there

#### Screenshots (if appropriate):
![image](https://github.com/starship/starship/assets/114114079/e0a62af7-006f-401b-b4c2-8bffd0cac0fa)

#### How Has This Been Tested?
built docs with `npm run dev`, everything looks good in my browser
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
