### PR TITLE
fix(container): display container and not image name

### DIFF
--- a/src/modules/container.rs
+++ b/src/modules/container.rs
@@ -35,10 +35,9 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 .map(|s| {
                     s.lines()
                         .find_map(|l| {
-                            l.starts_with("image=\"").then(|| {
-                                let r = l.split_at(7).1;
-                                let name = r.rfind('/').map(|n| r.split_at(n + 1).1);
-                                String::from(name.unwrap_or(r).trim_end_matches('"'))
+                            l.starts_with("name=\"").then(|| {
+                                let name = l.split_at(6).1.trim_end_matches('"');
+                                String::from(name)
                             })
                         })
                         .unwrap_or_else(|| "podman".into())
@@ -148,7 +147,11 @@ mod tests {
         fs::create_dir_all(containerenv.parent().unwrap())?;
 
         let contents = match name {
-            Some(name) => format!("image=\"{name}\"\n"),
+            Some(name) => format!(
+                "engine=\"podman-4.9.3\"\n\
+                name=\"{name}\"\n\
+                image=\"registry.fedoraproject.org/fedora-toolbox:39\""
+            ),
             None => String::new(),
         };
         utils::write_file(&containerenv, contents)?;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

Parse and display the value of the container name and not the image name.

If we create a container with `toolbox create dev` or `toolbox create rust` the prompt inside of it will now show `dev` or `rust` respectively.

Previously it showed `fedora-toolbox:39` for all the containers made from that image. Basically this was all the containers created with the `toolbox create` command without explicitly specifying the image.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When I'm in any of my multiple dev containers I get only the image name in the prompt (`fedora-toolbox:39`).
To disambiguate between them the name of the container should be displayed. The image name provides less info to the user than the container name, because image is only a part of a container.

Closes: #3592
Closes: #5193
Closes: #4243
Closes: #5195

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

In a container I ran the following:
```
⬢ [fedora-toolbox:38] ❯ cargo run module container
    Finished dev [unoptimized + debuginfo] target(s) in 0.32s
     Running `target/debug/starship module container`
⬢ [rust] 
```
You can see the old prompt in the first line and the new in the last.

The contents of the `.containerenv` are:
```
⬢ [fedora-toolbox:38] ❯ cat /run/.containerenv 
engine="podman-4.9.3"
name="rust"
id="d7ccf6af87ccede5f0e5e8cd4958caeaa062e95da55315709990b72e5f22c20a"
image="registry.fedoraproject.org/fedora-toolbox:38"
imageid="bfe872bb72c1922b94e3cdcfb6ae8511d55e98860effa6bb7a76f1acc7a892eb"
rootless=1
graphRootMounted=1
```

The `cargo test` command also passed.

No need to test for other platforms since this code is linux only (`#[cfg(target_os = "linux")]`).

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.

I've updated the tests to provide both the image and container name in simulated `.containerenv`. Making sure that the container name is parsed.

The documentation does not need changing since it already refers to the printed name as 'container name' and not 'image name'. So it seems that the current behavior was not in line with the documentation.