### PR TITLE
Add s390x arch build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,10 @@ jobs:
           - target: aarch64-unknown-linux-musl
             os: ubuntu-latest
             name: starship-aarch64-unknown-linux-musl.tar.gz
+            
+          - target: s390x-unknown-linux-gnu
+            os: ubuntu-latest
+            name: starship-s390x-unknown-linux-gnu.tar.gz
 
           - target: arm-unknown-linux-musleabihf
             os: ubuntu-latest

--- a/install/install.sh
+++ b/install/install.sh
@@ -18,7 +18,7 @@ SUPPORTED_TARGETS="x86_64-unknown-linux-gnu x86_64-unknown-linux-musl \
                   arm-unknown-linux-musleabihf x86_64-apple-darwin \
                   aarch64-apple-darwin x86_64-pc-windows-msvc \
                   i686-pc-windows-msvc aarch64-pc-windows-msvc \
-                  x86_64-unknown-freebsd"
+                  x86_64-unknown-freebsd s390x-unknown-linux-gnu"
 
 info() {
   printf '%s\n' "${BOLD}${GREY}>${NO_COLOR} $*"
@@ -225,6 +225,7 @@ detect_platform() {
 #   - i386
 #   - arm
 #   - arm64
+#   - s390x
 detect_arch() {
   arch="$(uname -m | tr '[:upper:]' '[:lower:]')"
 


### PR DESCRIPTION
rust using cross build tool
so it can build out s390x binary from x86 platform

fix: #5808

<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
