### PR TITLE
feat(jj): add module for Jujutsu current change ID

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -868,6 +868,19 @@
         }
       ]
     },
+    "jj_change": {
+      "default": {
+        "change_id_length": 7,
+        "disabled": true,
+        "format": "[\\($change_id\\)]($style) ",
+        "style": "bold purple"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/JujutsuChangeConfig"
+        }
+      ]
+    },
     "jobs": {
       "default": {
         "disabled": false,
@@ -3935,6 +3948,30 @@
           "items": {
             "type": "string"
           }
+        }
+      },
+      "additionalProperties": false
+    },
+    "JujutsuChangeConfig": {
+      "type": "object",
+      "properties": {
+        "change_id_length": {
+          "default": 7,
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "disabled": {
+          "default": true,
+          "type": "boolean"
+        },
+        "format": {
+          "default": "[\\($change_id\\)]($style) ",
+          "type": "string"
+        },
+        "style": {
+          "default": "bold purple",
+          "type": "string"
         }
       },
       "additionalProperties": false

--- a/docs/.vuepress/public/presets/toml/bracketed-segments.toml
+++ b/docs/.vuepress/public/presets/toml/bracketed-segments.toml
@@ -85,6 +85,9 @@ format = '\[[$symbol$branch]($style)\]'
 [java]
 format = '\[[$symbol($version)]($style)\]'
 
+[jj_change]
+format = '\[[$change_id]($style)\]'
+
 [julia]
 format = '\[[$symbol($version)]($style)\]'
 

--- a/docs/.vuepress/public/presets/toml/gruvbox-rainbow.toml
+++ b/docs/.vuepress/public/presets/toml/gruvbox-rainbow.toml
@@ -9,6 +9,7 @@ $directory\
 [](fg:color_yellow bg:color_aqua)\
 $git_branch\
 $git_status\
+$jj_change\
 [](fg:color_aqua bg:color_blue)\
 $c\
 $rust\
@@ -123,6 +124,10 @@ format = '[[ $symbol( $version) ](fg:color_fg0 bg:color_blue)]($style)'
 symbol = " "
 style = "bg:color_blue"
 format = '[[ $symbol( $version) ](fg:color_fg0 bg:color_blue)]($style)'
+
+[jj_change]
+style = "bg:color_purple"
+format = '[[ $change_id ](fg:color_fg0 bg:color_purple)]($style)'
 
 [kotlin]
 symbol = ""

--- a/docs/.vuepress/public/presets/toml/jetpack.toml
+++ b/docs/.vuepress/public/presets/toml/jetpack.toml
@@ -22,6 +22,7 @@ $git_state\
 $git_metrics\
 $git_status\
 $hg_branch\
+$jj_change\
 $pijul_channel\
 $docker_context\
 $package\
@@ -262,6 +263,9 @@ format = " hs [$symbol($version )]($style)"
 [java]
 symbol = "∪ "
 format = " java [${symbol}(${version} )]($style)"
+
+[jj_change]
+format = " jj [$change_id]($style)"
 
 [julia]
 symbol = "◎ "

--- a/docs/.vuepress/public/presets/toml/pastel-powerline.toml
+++ b/docs/.vuepress/public/presets/toml/pastel-powerline.toml
@@ -7,6 +7,7 @@ $directory\
 [](fg:#DA627D bg:#FCA17D)\
 $git_branch\
 $git_status\
+$jj_change\
 [](fg:#FCA17D bg:#86BBD8)\
 $c\
 $elixir\
@@ -111,6 +112,10 @@ format = '[ $symbol ($version) ]($style)'
 symbol = " "
 style = "bg:#86BBD8"
 format = '[ $symbol ($version) ]($style)'
+
+[jj_change]
+style = "bg:#FCA17D"
+format = '[ $change_id ]($style)'
 
 [julia]
 symbol = " "

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -281,6 +281,7 @@ $git_state\
 $git_metrics\
 $git_status\
 $hg_branch\
+$jj_change\
 $pijul_channel\
 $docker_context\
 $package\
@@ -2443,6 +2444,39 @@ then the module will also show when there are 0 jobs running.
 symbol = '+ '
 number_threshold = 4
 symbol_threshold = 0
+```
+
+## Jujutsu Change
+
+The `jj_change` module shows the current change ID in a [Jujutsu](martinvonz.github.io/jj/) repository.
+When active (`disabled = false`), the module will be shown when your current directory is a Jujutsu directory.
+
+### Options
+
+| Option             | Default                    | Description                                                                                  |
+| ------------------ | -------------------------- | -------------------------------------------------------------------------------------------- |
+| `change_id_length` | `7`                        | Minimum size of the unique prefix to use. Pass `0` to always use the shortest possible size. |
+| `format`           | `'[($change_id)]($style)'` | The format for the module.                                                                   |
+| `style`            | `'bold purple'`            | The style for the module.                                                                    |
+| `disabled`         | `true`                     | Disables the `jj_change` module.                                                             |
+
+### Variables
+
+| Variable  | Example  | Description                         |
+| --------- | -------- | ----------------------------------- |
+| change_id | `mvlssa` | The current change ID               |
+| style\*   |          | Mirrors the value of option `style` |
+
+*: This variable can only be used as a part of a style string
+
+### Example
+
+```toml
+# ~/.config/starship.toml
+
+[jj_change]
+change_id_length = 12
+disabled = false
 ```
 
 ## Julia

--- a/src/configs/jj_change.rs
+++ b/src/configs/jj_change.rs
@@ -1,0 +1,29 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(
+    feature = "config-schema",
+    derive(schemars::JsonSchema),
+    schemars(deny_unknown_fields)
+)]
+#[serde(default)]
+pub struct JujutsuChangeConfig<'a> {
+    pub change_id_length: usize,
+
+    pub disabled: bool,
+    pub format: &'a str,
+    pub style: &'a str,
+}
+
+impl Default for JujutsuChangeConfig<'_> {
+    fn default() -> Self {
+        Self {
+            // Copy the git default
+            change_id_length: 7,
+
+            disabled: true,
+            format: "[\\($change_id\\)]($style) ",
+            style: "bold purple",
+        }
+    }
+}

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -45,6 +45,7 @@ pub mod helm;
 pub mod hg_branch;
 pub mod hostname;
 pub mod java;
+pub mod jj_change;
 pub mod jobs;
 pub mod julia;
 pub mod kotlin;
@@ -195,6 +196,8 @@ pub struct FullConfig<'a> {
     hostname: hostname::HostnameConfig<'a>,
     #[serde(borrow)]
     java: java::JavaConfig<'a>,
+    #[serde(borrow)]
+    jj_change: jj_change::JujutsuChangeConfig<'a>,
     #[serde(borrow)]
     jobs: jobs::JobsConfig<'a>,
     #[serde(borrow)]

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -47,6 +47,7 @@ pub const PROMPT_ORDER: &[&str] = &[
     "git_metrics",
     "git_status",
     "hg_branch",
+    "jj_change",
     "pijul_channel",
     "docker_context",
     "package",

--- a/src/module.rs
+++ b/src/module.rs
@@ -52,6 +52,7 @@ pub const ALL_MODULES: &[&str] = &[
     "hg_branch",
     "hostname",
     "java",
+    "jj_change",
     "jobs",
     "julia",
     "kotlin",

--- a/src/modules/jj_change.rs
+++ b/src/modules/jj_change.rs
@@ -1,0 +1,151 @@
+use super::{Context, Module};
+use crate::config::ModuleConfig;
+use crate::configs::jj_change::JujutsuChangeConfig;
+use crate::formatter::StringFormatter;
+
+const MOD_NAME: &str = "jj_change";
+
+pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let mut module = context.new_module(MOD_NAME);
+    let config = JujutsuChangeConfig::try_load(module.config);
+
+    // Default is `true` so it must be checked here
+    if config.disabled {
+        return None;
+    }
+    let root = context.get_jj_repo()?;
+
+    // If the change ID is not found (not in a JJ repo), just return none and don't display the module
+    let current_jj_change = {
+        let template = format!("change_id.shortest({})", config.change_id_length);
+        let out = context.exec_cmd(
+            "jj",
+            &[
+                "--repository",
+                root,
+                "log",
+                "--color",
+                "never",
+                "--revisions",
+                "@", // Only display the current revision
+                "--no-graph",
+                "--template",
+                &template,
+                "--ignore-working-copy",
+            ],
+        )?;
+        out.stdout.lines().next().map(ToString::to_string)?
+    };
+
+    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
+        formatter
+            .map_style(|variable| (variable == "style").then_some(Ok(config.style)))
+            .map(|variable| {
+                (variable == "change_id")
+                    .then_some(&current_jj_change)
+                    .map(Ok)
+            })
+            .parse(None, Some(context))
+    });
+
+    module.set_segments(match parsed {
+        Ok(segments) => segments,
+        Err(error) => {
+            log::warn!("Error in module `{}`:\n{}", MOD_NAME, error);
+            return None;
+        }
+    });
+
+    Some(module)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io;
+    use std::path::Path;
+
+    use nu_ansi_term::{Color, Style};
+
+    use super::MOD_NAME;
+    use crate::test::{fixture_repo, FixtureProvider, ModuleRenderer};
+
+    enum Expect<'a> {
+        ChangeId(&'a str),
+        Empty,
+        Style(Style),
+    }
+
+    #[test]
+    fn test_show_nothing_on_empty_dir() -> io::Result<()> {
+        let repo_dir = tempfile::tempdir()?;
+
+        let actual = ModuleRenderer::new(MOD_NAME)
+            .path(repo_dir.path())
+            .collect();
+
+        assert_eq!(actual, None);
+        repo_dir.close()
+    }
+
+    #[test]
+    fn test_disabled_per_default() -> io::Result<()> {
+        let tempdir = fixture_repo(FixtureProvider::Jujutsu)?;
+        let repo_dir = tempdir.path();
+        expect_with_config(
+            repo_dir,
+            Some(toml::toml! {
+                [jj_change]
+                change_id_length = 7
+            }),
+            &[Expect::Empty],
+        );
+        tempdir.close()
+    }
+
+    #[test]
+    fn test_configured() -> io::Result<()> {
+        let tempdir = fixture_repo(FixtureProvider::Jujutsu)?;
+        let repo_dir = tempdir.path();
+        expect_with_config(
+            repo_dir,
+            Some(toml::toml! {
+                [jj_change]
+                change_id_length = 3
+                disabled = false
+                style = "underline blue"
+            }),
+            &[
+                Expect::ChangeId("zyx"),
+                Expect::Style(Color::Blue.underline()),
+            ],
+        );
+        tempdir.close()
+    }
+
+    #[track_caller]
+    fn expect_with_config(repo_dir: &Path, config: Option<toml::Table>, expectations: &[Expect]) {
+        let actual = ModuleRenderer::new(MOD_NAME)
+            .path(repo_dir.to_str().unwrap())
+            .config(config.unwrap_or_else(|| {
+                toml::toml! {
+                    [jj_change]
+                    disabled = false
+                }
+            }))
+            .collect();
+
+        let mut expect_change_id = "invalid-change-id";
+        let mut expect_style = Color::Purple.bold();
+
+        for expect in expectations {
+            match expect {
+                Expect::Empty => return assert_eq!(None, actual),
+                Expect::ChangeId(change_id) => expect_change_id = change_id,
+                Expect::Style(style) => expect_style = *style,
+            }
+        }
+
+        let expected = format!("{} ", expect_style.paint(format!("({expect_change_id})")));
+        assert_eq!(actual, Some(expected));
+    }
+}

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -42,6 +42,7 @@ mod helm;
 mod hg_branch;
 mod hostname;
 mod java;
+mod jj_change;
 mod jobs;
 mod julia;
 mod kotlin;
@@ -149,6 +150,7 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
             "hg_branch" => hg_branch::module(context),
             "hostname" => hostname::module(context),
             "java" => java::module(context),
+            "jj_change" => jj_change::module(context),
             "jobs" => jobs::module(context),
             "julia" => julia::module(context),
             "kotlin" => kotlin::module(context),
@@ -267,6 +269,7 @@ pub fn description(module: &str) -> &'static str {
         "hg_branch" => "The active branch and topic of the repo in your current directory",
         "hostname" => "The system hostname",
         "java" => "The currently installed version of Java",
+        "jj_change" => "The active change of the Jujutsu repo in your current directory",
         "jobs" => "The current number of jobs running",
         "julia" => "The currently installed version of Julia",
         "kotlin" => "The currently installed version of Kotlin",

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -168,6 +168,7 @@ pub enum FixtureProvider {
     Git,
     GitBare,
     Hg,
+    Jujutsu,
     Pijul,
 }
 
@@ -250,6 +251,11 @@ pub fn fixture_repo(provider: FixtureProvider) -> io::Result<TempDir> {
                 .arg(path.path())
                 .output()?;
 
+            Ok(path)
+        }
+        FixtureProvider::Jujutsu => {
+            let path = tempfile::tempdir()?;
+            fs::create_dir(path.path().join(".jj"))?;
             Ok(path)
         }
         FixtureProvider::Pijul => {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -287,6 +287,14 @@ Elixir 1.10 (compiled with Erlang/OTP 22)\n",
             stdout: String::from("Scala compiler version 2.13.5 -- Copyright 2002-2020, LAMP/EPFL and Lightbend, Inc."),
             stderr: String::default(),
         }),
+        "jj root --ignore-working-copy" => Some(CommandOutput {
+            stdout: String::from("/tmp/false-jj-root\n"),
+            stderr: String::default()
+        }),
+        "jj --repository /tmp/false-jj-root log --color never --revisions @ --no-graph --template change_id.shortest(3) --ignore-working-copy" => Some(CommandOutput {
+            stdout: String::from("zyx\n"),
+            stderr: String::default()
+        }),
         "julia --version" => Some(CommandOutput {
             stdout: String::from("julia version 1.4.0\n"),
             stderr: String::default(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

Adds support for getting and displaying the current Jujutsu change ID (when in a Jujutsu repo)

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes https://github.com/starship/starship/issues/6076

[Jujutsu](https://github.com/martinvonz/jj) is a new VCS that is change-based.

I want to do several PRs to add various parts of its informations to starship, starting with the  simplest one, the current change ID.

#### Screenshots (if appropriate):

Explained prompt, with the JJ change ID module:

![Screenshot 2024-03-02 at 13 45 29](https://github.com/starship/starship/assets/7951708/ecef8cab-bd95-42fc-916e-550dcf4879a5)

Result of explained prompt above:

![Screenshot 2024-03-02 at 13 45 50](https://github.com/starship/starship/assets/7951708/c872463a-c372-42f0-b5aa-8926079ab1fd)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
