### PR TITLE
fix(bash): add case for vscode integrated terminal

### DIFF
--- a/src/init/starship.bash
+++ b/src/init/starship.bash
@@ -125,6 +125,12 @@ else
     # add multiple instances of the starship function and keep other user functions if any.
     if [[ -z "${PROMPT_COMMAND-}" ]]; then
         PROMPT_COMMAND="starship_precmd"
+    # If we are running in vscode with shell integration
+    elif [[ "$PROMPT_COMMAND" == "__vsc_prompt_cmd_original" ]]; then
+        # if starship_precmd is not in vscode prompt command list, add it
+        if [[ ! ${__vsc_original_prompt_command[@]} =~ $(printf "\<starship_precmd\>") ]]; then
+            __vsc_original_prompt_command+=("starship_precmd")
+        fi
     elif [[ "$PROMPT_COMMAND" != *"starship_precmd"* ]]; then
         # Appending to PROMPT_COMMAND breaks exit status ($?) checking.
         # Prepending to PROMPT_COMMAND breaks "command duration" module.


### PR DESCRIPTION
#### Description

In starship.bash init script, handle vscode integrated terminal `PROMPT_COMMAND` override.

#### Motivation and Context

Fix an issue where manually sourcing a file evaluating `starship init bash` (typically a bashrc) would crash vscode integrated terminal if starship init had already been evaluated at terminal startup.

Closes #5816 

#### Screenshots (if appropriate):

#### How Has This Been Tested?

- Tested on Windows 10 with vscode 1.87.0, with lot of extensions and WSL as the terminal backend
- Tested on Ubuntu 22.04 with vscode 1.86.2, fresh install, no extensions

<details>

<summary>tests details</summary>

After reproducing the bug described in issue #5816 :

##### In vscode

- open a new bash in vscode terminal
- assess that starship init was evaluated with the fancy prompt appearing
- `cd` into starship git repository
- `git checkout fix/vscode-infinite-loop`
- `::STARSHIP::() { starship "$@"; }`
- `eval "$(cat ./src/init/starship.bash)"`
- the terminal does not crash
- starship environment variables are correctly setup, the prompt works as expected
- `__vsc_original_prompt_command=()`
- `eval "$(cat ./src/init/starship.bash)"`
- the terminal does not crash, `${__vsc_original_prompt_command[@]}` contains `starship_precmd` as expected

##### Outside vscode

- tested in WSL and Ubuntu 22.04
- open a new terminal
- assess that starship init was evaluated with the fancy prompt appearing
- `cd` into starship git repository
- `git checkout fix/vscode-infinite-loop`
- `::STARSHIP::() { starship "$@"; }`
- `eval "$(cat ./src/init/starship.bash)"`
- the terminal does not crash

##### Both inside and outside vscode: check we didn't break something

- `unset PROMPT_COMMAND`
- the PS1 does not change anymore, we "broke" starship prompt
- `eval "$(cat ./src/init/starship.bash)"`
- `PROMPT_COMMAND` is restored to `starship_precmd`, the PS1 works as expected
- `starship_precmd() { :; }`
- the PS1 does not change anymore, we "broke" starship function
- `eval "$(cat ./src/init/starship.bash)"`
- the PS1 works as expected

</details>

 ---

- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [x] I have tested using **Windows** (WSL)

#### Checklist:

- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.

I have 2 questions:
- I haven't change any Rust code, and my change does not require any configuration. Do I need to do something more?
- I don't have MacOS, could someone help in testing this please?
