### PR TITLE
docs(python): Remove a bad config example in the python

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -3508,7 +3508,7 @@ current [Python virtual environment](https://docs.python.org/tutorial/venv.html)
 If `pyenv_version_name` is set to `true`, it will display the pyenv version
 name. Otherwise, it will display the version number from `python --version`.
 
-By default the module will be shown if any of the following conditions are met:
+By default, the module will be shown if any of the following conditions are met:
 
 - The current directory contains a `.python-version` file
 - The current directory contains a `Pipfile` file
@@ -3588,17 +3588,6 @@ python_binary = 'python3'
 [python]
 # Don't trigger for files with the py extension
 detect_extensions = []
-```
-
-```toml
-# ~/.config/starship.toml
-
-[python]
-# Display the version of python from inside a local venv.
-#
-# Note this will only work when the venv is inside the project and it will only
-# work in the directory that contains the venv dir but maybe this is ok?
-python_binary = ['./venv/bin/python', 'python', 'python3', 'python2']
 ```
 
 ## R


### PR DESCRIPTION
Running a unknown binary in a subfolder (in this case `.venv/bin/python`) has at least two drawbacks with some security implication:

- In case of a unknown directory, simply cd'ing into a subdirectory could lead to starship executing a unknown binary (usually the binary MUST be in path so it's a decision taken by the user, e.g. by activating the venv)
 - starship would show the result of the venv python even if the venv is not active but calling `python3` on the cli would NOT run that `python3` in the venv but a different one (most likely the system python3).

Activating the env will of course display the python version within the venv. But that was a conscious decision of the user to activate the venv.

Closes #5582
