### PR TITLE
feat(username): add detect_env_vars as option

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -1717,6 +1717,7 @@
     },
     "username": {
       "default": {
+        "detect_env_vars": [],
         "disabled": false,
         "format": "[$user]($style) in ",
         "show_always": false,
@@ -5878,6 +5879,13 @@
     "UsernameConfig": {
       "type": "object",
       "properties": {
+        "detect_env_vars": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "format": {
           "default": "[$user]($style) in ",
           "type": "string"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2771,9 +2771,9 @@ dependencies = [
 
 [[package]]
 name = "shadow-rs"
-version = "0.27.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc90f58262c9783799e542c15a936977c32f59f5c9637b9a5ea09ec6a7adaa25"
+checksum = "7960cbd6ba74691bb15e7ebf97f7136bd02d1115f5695a58c1f31d5645750128"
 dependencies = [
  "const_format",
  "is_debug",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ semver = "1.0.22"
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.114"
 sha1 = "0.10.6"
-shadow-rs = { version = "0.27.0", default-features = false }
+shadow-rs = { version = "0.27.1", default-features = false }
 # battery is optional (on by default) because the crate doesn't currently build for Termux
 # see: https://github.com/svartalf/rust-battery/issues/33
 starship-battery = { version = "0.8.2", optional = true }
@@ -117,7 +117,7 @@ features = [
 nix = { version = "0.28.0", default-features = false, features = ["feature", "fs", "user"] }
 
 [build-dependencies]
-shadow-rs = { version = "0.27.0", default-features = false }
+shadow-rs = { version = "0.27.1", default-features = false }
 dunce = "1.0.4"
 
 [target.'cfg(windows)'.build-dependencies]

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -4357,6 +4357,7 @@ The module will be shown if any of the following conditions are met:
 - The current user isn't the same as the one that is logged in
 - The user is currently connected as an SSH session
 - The variable `show_always` is set to true
+- The array `detect_env_vars` contains at least the name of one environment variable, that is set
 
 ::: tip
 
@@ -4368,13 +4369,14 @@ these variables, one workaround is to set one of them with a dummy value.
 
 ### Options
 
-| Option        | Default                 | Description                                 |
-| ------------- | ----------------------- | ------------------------------------------- |
-| `style_root`  | `'bold red'`            | The style used when the user is root/admin. |
-| `style_user`  | `'bold yellow'`         | The style used for non-root users.          |
-| `format`      | `'[$user]($style) in '` | The format for the module.                  |
-| `show_always` | `false`                 | Always shows the `username` module.         |
-| `disabled`    | `false`                 | Disables the `username` module.             |
+| Option            | Default                 | Description                                               |
+| ----------------- | ----------------------- | --------------------------------------------------------- |
+| `style_root`      | `'bold red'`            | The style used when the user is root/admin.               |
+| `style_user`      | `'bold yellow'`         | The style used for non-root users.                        |
+| `detect_env_vars` | `[]`                    | Which environment variable(s) should trigger this module. |
+| `format`          | `'[$user]($style) in '` | The format for the module.                                |
+| `show_always`     | `false`                 | Always shows the `username` module.                       |
+| `disabled`        | `false`                 | Disables the `username` module.                           |
 
 ### Variables
 
@@ -4385,6 +4387,8 @@ these variables, one workaround is to set one of them with a dummy value.
 
 ### Example
 
+#### Always show the hostname
+
 ```toml
 # ~/.config/starship.toml
 
@@ -4394,6 +4398,17 @@ style_root = 'black bold'
 format = 'user: [$user]($style) '
 disabled = false
 show_always = true
+```
+
+#### Hide the hostname in remote tmux sessions
+
+```toml
+# ~/.config/starship.toml
+
+[hostname]
+ssh_only = false
+detect_env_vars = ['!TMUX', 'SSH_CONNECTION']
+disabled = false
 ```
 
 ## Vagrant

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "devDependencies": {
-        "vitepress": "^1.0.0-rc.44"
+        "vitepress": "^1.0.0-rc.45"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -1697,9 +1697,9 @@
       }
     },
     "node_modules/vitepress": {
-      "version": "1.0.0-rc.44",
-      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.0.0-rc.44.tgz",
-      "integrity": "sha512-tO5taxGI7fSpBK1D8zrZTyJJERlyU9nnt0jHSt3fywfq3VKn977Hg0wUuTkEmwXlFYwuW26+6+3xorf4nD3XvA==",
+      "version": "1.0.0-rc.45",
+      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.0.0-rc.45.tgz",
+      "integrity": "sha512-/OiYsu5UKpQKA2c0BAZkfyywjfauDjvXyv6Mo4Ra57m5n4Bxg1HgUGoth1CLH2vwUbR/BHvDA9zOM0RDvgeSVQ==",
       "dev": true,
       "dependencies": {
         "@docsearch/css": "^3.5.2",

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,6 +5,6 @@
     "preview": "vitepress preview"
   },
   "devDependencies": {
-    "vitepress": "^1.0.0-rc.44"
+    "vitepress": "^1.0.0-rc.45"
   }
 }

--- a/src/configs/username.rs
+++ b/src/configs/username.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 )]
 #[serde(default)]
 pub struct UsernameConfig<'a> {
+    pub detect_env_vars: Vec<&'a str>,
     pub format: &'a str,
     pub style_root: &'a str,
     pub style_user: &'a str,
@@ -18,6 +19,7 @@ pub struct UsernameConfig<'a> {
 impl<'a> Default for UsernameConfig<'a> {
     fn default() -> Self {
         UsernameConfig {
+            detect_env_vars: vec![],
             format: "[$user]($style) in ",
             style_root: "red bold",
             style_user: "yellow bold",

--- a/src/modules/username.rs
+++ b/src/modules/username.rs
@@ -15,22 +15,29 @@ const USERNAME_ENV_VAR: &str = "USERNAME";
 ///     - The current user is root (UID = 0) [1]
 ///     - The current user isn't the same as the one that is logged in (`$LOGNAME` != `$USER`) [2]
 ///     - The user is currently connected as an SSH session (`$SSH_CONNECTION`) [3]
+///     - The option `username.detect_env_vars` is set with a not negated environment variable [4]
+/// Does not display the username:
+///     - If the option `username.detect_env_vars` is set with a negated environment variable [A]
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let mut username = context.get_env(USERNAME_ENV_VAR)?;
 
     let mut module = context.new_module("username");
     let config: UsernameConfig = UsernameConfig::try_load(module.config);
+    let has_detected_env_var = context.detect_env_vars(&config.detect_env_vars);
 
     let is_root = is_root_user();
     if cfg!(target_os = "windows") && is_root {
         username = "Administrator".to_string();
     }
+
     let show_username = config.show_always
         || is_root // [1]
         || !is_login_user(context, &username) // [2]
-        || is_ssh_session(context); // [3]
+        || is_ssh_session(context) // [3]
+        || has_detected_env_var; // [4]
 
-    if !show_username {
+    if !show_username || !has_detected_env_var {
+        // [A]
         return None;
     }
 
@@ -109,10 +116,68 @@ fn is_ssh_session(context: &Context) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use gix::config::key;
+
     use crate::test::ModuleRenderer;
 
     // TODO: Add tests for if root user (UID == 0)
     // Requires mocking
+
+    #[test]
+    fn ssh_with_empty_detect_env_vars() {
+        let actual = ModuleRenderer::new("username")
+            .env(super::USERNAME_ENV_VAR, "astronaut")
+            .env("SSH_CONNECTION", "192.168.223.17 36673 192.168.223.229 22")
+            // Test output should not change when run by root/non-root user
+            .config(toml::toml! {
+                [username]
+                style_root = ""
+                style_user = ""
+                detect_env_vars = []
+            })
+            .collect();
+
+        let expected = Some("astronaut in ");
+        assert_eq!(expected, actual.as_deref());
+    }
+
+    #[test]
+    fn ssh_with_matching_detect_env_vars() {
+        let actual = ModuleRenderer::new("username")
+            .env(super::USERNAME_ENV_VAR, "astronaut")
+            .env("SSH_CONNECTION", "192.168.223.17 36673 192.168.223.229 22")
+            .env("FORCE_USERNAME", "true")
+            // Test output should not change when run by root/non-root user
+            .config(toml::toml! {
+                [username]
+                style_root = ""
+                style_user = ""
+                detect_env_vars = ["FORCE_USERNAME"]
+            })
+            .collect();
+
+        let expected = Some("astronaut in ");
+        assert_eq!(expected, actual.as_deref());
+    }
+
+    #[test]
+    fn ssh_with_matching_negated_detect_env_vars() {
+        let actual = ModuleRenderer::new("username")
+            .env(super::USERNAME_ENV_VAR, "astronaut")
+            .env("SSH_CONNECTION", "192.168.223.17 36673 192.168.223.229 22")
+            .env("NEGATED", "true")
+            // Test output should not change when run by root/non-root user
+            .config(toml::toml! {
+                [username]
+                style_root = ""
+                style_user = ""
+                detect_env_vars = ["!NEGATED"]
+            })
+            .collect();
+
+        let expected = None;
+        assert_eq!(expected, actual.as_deref());
+    }
 
     #[test]
     fn no_env_variables() {

--- a/src/modules/username.rs
+++ b/src/modules/username.rs
@@ -1,5 +1,3 @@
-use gix::hashtable::hash_map;
-
 use super::{Context, Module, ModuleConfig};
 
 use crate::configs::username::UsernameConfig;

--- a/src/modules/username.rs
+++ b/src/modules/username.rs
@@ -117,8 +117,6 @@ fn is_ssh_session(context: &Context) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use gix::config::key;
-
     use crate::test::ModuleRenderer;
 
     // TODO: Add tests for if root user (UID == 0)


### PR DESCRIPTION
Hello everybody,

#### Motivation and Context

I don't use the default `username` module and instead use a custom module because I frequently use terminal multiplexers like `tmux`, `screen`, or `Zellji`. These multiplexers display the hostname in the status bar, so I don't want or need to see it in the terminal as well.

#### Description

To achieve this, I added the `context::detect_env_vars` function to the `username` module, analogous to the `hostname` module.


#### How Has This Been Tested?
- [X] I have tested using **macOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [X] I have updated the documentation accordingly.
- [X] I have updated the tests accordingly.
