### PR TITLE
docs(bun): Add nodejs override to bun config documentation

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -634,7 +634,7 @@ By default the module will be shown if any of the following conditions are met:
 | `style`             | `'bold red'`                         | The style for the module.                                                 |
 | `disabled`          | `false`                              | Disables the `bun` module.                                                |
 
-You can override the `detect_files` property of [the nodejs module](#Node.js) in your config so as to only show the bun runtime:
+You can override the `detect_files` property of [the nodejs module](#nodejs) in your config so as to only show the bun runtime:
 
 ```
 [nodejs]

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -627,12 +627,19 @@ By default the module will be shown if any of the following conditions are met:
 | ------------------- | ------------------------------------ | ------------------------------------------------------------------------- |
 | `format`            | `'via [$symbol($version )]($style)'` | The format for the module.                                                |
 | `version_format`    | `'v${raw}'`                          | The version format. Available vars are `raw`, `major`, `minor`, & `patch` |
-| `symbol`            | `'🍞 '`                              | A format string representing the symbol of Bun.                           |
+| `symbol`            | `'🍞 '`                               | A format string representing the symbol of Bun.                           |
 | `detect_extensions` | `[]`                                 | Which extensions should trigger this module.                              |
 | `detect_files`      | `['bun.lockb', 'bunfig.toml']`       | Which filenames should trigger this module.                               |
 | `detect_folders`    | `[]`                                 | Which folders should trigger this module.                                 |
 | `style`             | `'bold red'`                         | The style for the module.                                                 |
 | `disabled`          | `false`                              | Disables the `bun` module.                                                |
+
+You can override the `detect_files` property of [the nodejs module](#Node.js) in your config so as to only show the bun runtime:
+
+```
+[nodejs]
+detect_files = ['package.json', '.node-version', '!bunfig.toml', '!bun.lockb']
+```
 
 ### Variables
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -634,13 +634,6 @@ By default the module will be shown if any of the following conditions are met:
 | `style`             | `'bold red'`                         | The style for the module.                                                 |
 | `disabled`          | `false`                              | Disables the `bun` module.                                                |
 
-You can override the `detect_files` property of [the nodejs module](#nodejs) in your config so as to only show the bun runtime:
-
-```
-[nodejs]
-detect_files = ['package.json', '.node-version', '!bunfig.toml', '!bun.lockb']
-```
-
 ### Variables
 
 | Variable | Example  | Description                          |
@@ -651,13 +644,24 @@ detect_files = ['package.json', '.node-version', '!bunfig.toml', '!bun.lockb']
 
 *: This variable can only be used as a part of a style string
 
-### Example
+### Examples
+
+#### Customize the format
 
 ```toml
 # ~/.config/starship.toml
 
 [bun]
 format = 'via [🍔 $version](bold green) '
+```
+
+#### Replace Node.js
+
+You can override the `detect_files` property of [the nodejs module](#nodejs) in your config so as to only show the bun runtime:
+
+```
+[nodejs]
+detect_files = ['package.json', '.node-version', '!bunfig.toml', '!bun.lockb']
 ```
 
 ## C

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -627,7 +627,7 @@ By default the module will be shown if any of the following conditions are met:
 | ------------------- | ------------------------------------ | ------------------------------------------------------------------------- |
 | `format`            | `'via [$symbol($version )]($style)'` | The format for the module.                                                |
 | `version_format`    | `'v${raw}'`                          | The version format. Available vars are `raw`, `major`, `minor`, & `patch` |
-| `symbol`            | `'🍞 '`                               | A format string representing the symbol of Bun.                           |
+| `symbol`            | `'🍞 '`                              | A format string representing the symbol of Bun.                           |
 | `detect_extensions` | `[]`                                 | Which extensions should trigger this module.                              |
 | `detect_files`      | `['bun.lockb', 'bunfig.toml']`       | Which filenames should trigger this module.                               |
 | `detect_folders`    | `[]`                                 | Which folders should trigger this module.                                 |


### PR DESCRIPTION
As discussed in #5805 using the bun module creates a "double prompt" situation which is easily remedied in user config.

Adding it to the default shipped config I think does not make sense.