### PR TITLE
docs(nu): Simplify Nushell integration instructions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,21 +344,15 @@ Since Nu does [not support `eval`](https://www.nushell.sh/book/how_nushell_code_
 ```nushell
 '
 let starship_path = $nu.default-config-dir | path join scripts starship.nu
-if $nu.is-interactive {
-  starship init nu | save $starship_path --force
-}' | save $nu.env-path --append
-'
-if $nu.is-interactive {
-  use starship.nu
-}' | save $nu.config-path --append
+starship init nu | save $starship_path --force
+' | save $nu.env-path --append
+"\nuse starship.nu" | save $nu.config-path --append
 ```
 
 If you prefer to keep your dotfiles clean you can save it to a different directory then update `$env.NU_LIB_DIRS`:
 
 ```nushell
-'
-$env.NU_LIB_DIRS ++= ($starship_path | path dirname | to nuon)
-' | save $nu.env-path --append
+"\n$env.NU_LIB_DIRS ++= ($starship_path | path dirname | to nuon)" | save $nu.env-path --append
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -339,20 +339,27 @@ eval $(starship init ion)
 <details>
 <summary>Nushell</summary>
 
-Add the following to the end of your Nushell env file (find it by running `$nu.env-path` in Nushell):
+Since Nu does [not support `eval`](https://www.nushell.sh/book/how_nushell_code_gets_run.html#eval-function) the initialization script is saved in `env.nu`:
 
-```sh
-mkdir ~/.cache/starship
-starship init nu | save -f ~/.cache/starship/init.nu
+```nushell
+'
+let starship_path = $nu.default-config-dir | path join scripts starship.nu
+if $nu.is-interactive {
+  starship init nu | save $starship_path --force
+}' | save $nu.env-path --append
+'
+if $nu.is-interactive {
+  use starship.nu
+}' | save $nu.config-path --append
 ```
 
-And add the following to the end of your Nushell configuration (find it by running `$nu.config-path`):
+If you prefer to keep your dotfiles clean you can save it to a different directory then update `$env.NU_LIB_DIRS`:
 
-```sh
-use ~/.cache/starship/init.nu
+```nushell
+'
+$env.NU_LIB_DIRS ++= ($starship_path | path dirname | to nuon)
+' | save $nu.env-path --append
 ```
-
-Note: Only Nushell v0.78+ is supported
 
 </details>
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -137,24 +137,26 @@ description: Starship is the minimal, blazing fast, and extremely customizable p
 
    #### Nushell
 
-   Since Nu does [not support `eval`](https://www.nushell.sh/book/how_nushell_code_gets_run.html#eval-function) you must save the initialization script:
+   Since Nu does [not support `eval`](https://www.nushell.sh/book/how_nushell_code_gets_run.html#eval-function) the initialization script is saved in `env.nu`:
 
    ```nushell
+   '
    let starship_path = $nu.default-config-dir | path join scripts starship.nu
-   starship init nu | save $starship_path --force
-   "\nuse starship.nu" | save $nu.config-path --append
+   if $nu.is-interactive {
+     starship init nu | save $starship_path --force
+   }' | save $nu.env-path --append
+   '
+   if $nu.is-interactive {
+     use starship.nu
+   }' | save $nu.config-path --append
    ```
 
-   If you prefer to keep your dotfiles clean you can save it to another directory then update `$env.NU_LIB_DIRS`:
+   If you prefer to keep your dotfiles clean you can save it to a different directory then update `$env.NU_LIB_DIRS`:
 
    ```nushell
-   "\n$env.NU_LIB_DIRS ++= ($starship_path | path dirname | to nuon)" | save $nu.env-path --append
-   ```
-
-   You can update the generated script at any time by re-running:
-
-   ```nushell
-   starship init nu | save $starship_path --force
+   '
+   $env.NU_LIB_DIRS ++= ($starship_path | path dirname | to nuon)
+   ' | save $nu.env-path --append
    ```
 
    #### Xonsh

--- a/docs/README.md
+++ b/docs/README.md
@@ -142,21 +142,15 @@ description: Starship is the minimal, blazing fast, and extremely customizable p
    ```nushell
    '
    let starship_path = $nu.default-config-dir | path join scripts starship.nu
-   if $nu.is-interactive {
-     starship init nu | save $starship_path --force
-   }' | save $nu.env-path --append
-   '
-   if $nu.is-interactive {
-     use starship.nu
-   }' | save $nu.config-path --append
+   starship init nu | save $starship_path --force
+   ' | save $nu.env-path --append
+   "\nuse starship.nu" | save $nu.config-path --append
    ```
 
    If you prefer to keep your dotfiles clean you can save it to a different directory then update `$env.NU_LIB_DIRS`:
 
    ```nushell
-   '
-   $env.NU_LIB_DIRS ++= ($starship_path | path dirname | to nuon)
-   ' | save $nu.env-path --append
+   "\n$env.NU_LIB_DIRS ++= ($starship_path | path dirname | to nuon)" | save $nu.env-path --append
    ```
 
    #### Xonsh

--- a/docs/README.md
+++ b/docs/README.md
@@ -137,24 +137,24 @@ description: Starship is the minimal, blazing fast, and extremely customizable p
 
    #### Nushell
 
-   ::: warning
+   Since Nu does [not support `eval`](https://www.nushell.sh/book/how_nushell_code_gets_run.html#eval-function) you must save the initialization script:
 
-   This will change in the future.
-   Only Nushell v0.78+ is supported.
-
-   :::
-
-   Add the following to the end of your Nushell env file (find it by running `$nu.env-path` in Nushell):
-
-   ```sh
-   mkdir ~/.cache/starship
-   starship init nu | save -f ~/.cache/starship/init.nu
+   ```nushell
+   let starship_path = $nu.default-config-dir | path join scripts starship.nu
+   starship init nu | save $starship_path --force
+   "\nuse starship.nu" | save $nu.config-path --append
    ```
 
-   And add the following to the end of your Nushell configuration (find it by running `$nu.config-path`):
+   If you prefer to keep your dotfiles clean you can save it to another directory then update `$env.NU_LIB_DIRS`:
 
-   ```sh
-   use ~/.cache/starship/init.nu
+   ```nushell
+   "\n$env.NU_LIB_DIRS ++= ($starship_path | path dirname | to nuon)" | save $nu.env-path --append
+   ```
+
+   You can update the generated script at any time by re-running:
+
+   ```nushell
+   starship init nu | save $starship_path --force
    ```
 
    #### Xonsh


### PR DESCRIPTION
Implements @davidkna's astute feedback in #5844. Always runs unless non-interactive (a script). Clarifies and simplifies installation while reducing (possibly concurrent) file writes. RFC @amtoine (previous committer) @fdncred.