### PR TITLE
chore: fix upcoming rust 1.77 clippy issues and chrono deprecations

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -38,9 +38,9 @@ pub struct Context<'a> {
     /// The current working directory that starship is being called in.
     pub current_dir: PathBuf,
 
-    /// A logical directory path which should represent the same directory as current_dir,
+    /// A logical directory path which should represent the same directory as `current_dir`,
     /// though may appear different.
-    /// E.g. when navigating to a PSDrive in PowerShell, or a path without symlinks resolved.
+    /// E.g. when navigating to a `PSDrive` in `PowerShell`, or a path without symlinks resolved.
     pub logical_dir: PathBuf,
 
     /// A struct containing directory contents in a lookup-optimized format.
@@ -61,10 +61,10 @@ pub struct Context<'a> {
     /// Width of terminal, or zero if width cannot be detected.
     pub width: usize,
 
-    /// A HashMap of environment variable mocks
+    /// A `HashMap` of environment variable mocks
     pub env: Env<'a>,
 
-    /// A HashMap of command mocks
+    /// A `HashMap` of command mocks
     #[cfg(test)]
     pub cmd: HashMap<&'a str, Option<CommandOutput>>,
 

--- a/src/context_env.rs
+++ b/src/context_env.rs
@@ -6,7 +6,7 @@ use std::ffi::OsString;
 
 #[derive(Default)]
 pub struct Env<'a> {
-    /// A HashMap of environment variable mocks
+    /// A `HashMap` of environment variable mocks
     #[cfg(test)]
     pub env: HashMap<&'a str, String>,
 

--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -684,15 +684,12 @@ credential_process = /opt/bin/awscreds-retriever
 
     #[test]
     fn expiration_date_set() {
-        use chrono::{DateTime, NaiveDateTime, SecondsFormat, Utc};
+        use chrono::{DateTime, SecondsFormat, Utc};
 
         let expiration_env_vars = ["AWS_SESSION_EXPIRATION", "AWS_CREDENTIAL_EXPIRATION"];
         expiration_env_vars.iter().for_each(|env_var| {
-            let now_plus_half_hour: DateTime<Utc> = DateTime::from_naive_utc_and_offset(
-                NaiveDateTime::from_timestamp_opt(chrono::Local::now().timestamp() + 1800, 0)
-                    .unwrap(),
-                Utc,
-            );
+            let now_plus_half_hour: DateTime<Utc> =
+                DateTime::from_timestamp(chrono::Local::now().timestamp() + 1800, 0).unwrap();
 
             let actual = ModuleRenderer::new("aws")
                 .env("AWS_PROFILE", "astronauts")
@@ -727,12 +724,10 @@ credential_process = /opt/bin/awscreds-retriever
         let credentials_path = dir.path().join("credentials");
         let mut file = File::create(&credentials_path)?;
 
-        use chrono::{DateTime, NaiveDateTime, Utc};
+        use chrono::{DateTime, Utc};
 
-        let now_plus_half_hour: DateTime<Utc> = DateTime::from_naive_utc_and_offset(
-            NaiveDateTime::from_timestamp_opt(chrono::Local::now().timestamp() + 1800, 0).unwrap(),
-            Utc,
-        );
+        let now_plus_half_hour: DateTime<Utc> =
+            DateTime::from_timestamp(chrono::Local::now().timestamp() + 1800, 0).unwrap();
 
         let expiration_date = now_plus_half_hour.to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
 
@@ -800,12 +795,10 @@ aws_secret_access_key=dummy
 
     #[test]
     fn expiration_date_set_expired() {
-        use chrono::{DateTime, NaiveDateTime, SecondsFormat, Utc};
+        use chrono::{DateTime, SecondsFormat, Utc};
 
-        let now: DateTime<Utc> = DateTime::from_naive_utc_and_offset(
-            NaiveDateTime::from_timestamp_opt(chrono::Local::now().timestamp() - 1800, 0).unwrap(),
-            Utc,
-        );
+        let now: DateTime<Utc> =
+            DateTime::from_timestamp(chrono::Local::now().timestamp() - 1800, 0).unwrap();
 
         let symbol = "!!!";
 

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -70,7 +70,9 @@ impl<'a> ModuleRenderer<'a> {
         T: Into<PathBuf>,
     {
         self.context.current_dir = path.into();
-        self.context.logical_dir = self.context.current_dir.clone();
+        self.context
+            .logical_dir
+            .clone_from(&self.context.current_dir);
         self
     }
 

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -184,6 +184,7 @@ pub fn fixture_repo(provider: FixtureProvider) -> io::Result<TempDir> {
             fs::OpenOptions::new()
                 .create(true)
                 .write(true)
+                .truncate(false)
                 .open(path.path().join(checkout_db))?
                 .sync_all()?;
             Ok(path)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Rust 1.77 will be released soon with an update to clippy. This PR uses this occasion to a new warning, other nightly-clippy warning, and the use of deprecated `chrono` functions.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
