### PR TITLE
fix(nu): continuation prompt not being displayed correctly

### DIFF
--- a/src/init/starship.nu
+++ b/src/init/starship.nu
@@ -2,8 +2,7 @@
 # - overlay which can be loaded with `overlay use starship.nu`
 # - module which can be used with `use starship.nu`
 # - script which can be used with `source starship.nu`
-export-env { load-env {
-    STARSHIP_SHELL: "nu"
+export-env { $env.STARSHIP_SHELL = "nu"; load-env {
     STARSHIP_SESSION_KEY: (random chars -l 16)
     PROMPT_MULTILINE_INDICATOR: (
         ^::STARSHIP:: prompt --continuation


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

Most minimal change possible. Other simplification are possible but not known to be backwards compatible. Also considered `with-env` or `STARSHIP_SHELL=nu starship` but they'd be worse. Happy to reformat indentation if desired.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #5847:

> The bug is `starship prompt --continuation` reads the `STARSHIP_SHELL` environment variable before it's set. The easiest fix would be to set `$env.STARSHIP_SHELL = "nu";` immediately before `load-env`. Happy to PR.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

Tested locally by replacing my script and loading it both from my config as well as with`nu --no-config`.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly. *N/A*
- [ ] I have updated the tests accordingly. *N/A*