### PR TITLE
fix: #5608

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -257,7 +257,6 @@ detect_target() {
   printf '%s' "${target}"
 }
 
-
 confirm() {
   if [ -z "${FORCE-}" ]; then
     printf "%s " "${MAGENTA}?${NO_COLOR} $* ${BOLD}[y/N]${NO_COLOR}"
@@ -270,11 +269,18 @@ confirm() {
       exit 1
     fi
     if [ "$yn" != "y" ] && [ "$yn" != "yes" ]; then
-      error 'Aborting (please answer "yes" to continue)'
-      exit 1
+      set +e
+      read -p "Enter the location where you want to install this to: " path
+      rc=$?
+      set -e
+      if [ $rc -ne 0 ]; then
+        error "Error reading from prompt (please re-run with the '--yes' option)"
+        exit 1
     fi
   fi
 }
+
+
 
 check_bin_dir() {
   bin_dir="${1%/}"

--- a/src/configs/flutter.rs
+++ b/src/configs/flutter.rs
@@ -1,0 +1,34 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(
+    feature = "config-schema",
+    derive(schemars::JsonSchema),
+    schemars(deny_unknown_fields)
+)]
+#[serde(default)]
+pub struct FLutterConfig<'a> {
+    pub format: &'a str,
+    pub version_format: &'a str,
+    pub symbol: &'a str,
+    pub style: &'a str,
+    pub disabled: bool,
+    pub detect_extensions: Vec<&'a str>,
+    pub detect_files: Vec<&'a str>,
+    pub detect_folders: Vec<&'a str>,
+}
+
+impl<'a> Default for FlutterConfig<'a> {
+    fn default() -> Self {
+        FlutterConfig {
+            format: "via [$symbol($version )]($style)",
+            version_format: "v${raw}",
+            symbol: "🐦 ",
+            style: "bold blue",
+            disabled: false,
+            detect_extensions: vec!["dart"],
+            detect_files: vec!["pubspec.yaml", "pubspec.yml", "pubspec.lock"],
+            detect_folders: vec![".dart_tool", "ios", "android"],
+        }
+    }
+}

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -28,6 +28,7 @@ pub mod env_var;
 pub mod erlang;
 pub mod fennel;
 pub mod fill;
+pub mod flutter;
 pub mod fossil_branch;
 pub mod fossil_metrics;
 pub mod gcloud;
@@ -161,6 +162,8 @@ pub struct FullConfig<'a> {
     fennel: fennel::FennelConfig<'a>,
     #[serde(borrow)]
     fill: fill::FillConfig<'a>,
+    #[serde(borrow)]
+    flutter: flutter::FlutterConfig<'a>,
     #[serde(borrow)]
     fossil_branch: fossil_branch::FossilBranchConfig<'a>,
     #[serde(borrow)]

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -39,6 +39,7 @@ pub const PROMPT_ORDER: &[&str] = &[
     "kubernetes",
     "directory",
     "vcsh",
+    "flutter",
     "fossil_branch",
     "fossil_metrics",
     "git_branch",

--- a/src/module.rs
+++ b/src/module.rs
@@ -35,6 +35,7 @@ pub const ALL_MODULES: &[&str] = &[
     "erlang",
     "fennel",
     "fill",
+    "flutter",
     "fossil_branch",
     "fossil_metrics",
     "gcloud",

--- a/src/modules/git_state.rs
+++ b/src/modules/git_state.rs
@@ -95,7 +95,7 @@ fn get_state_description<'a>(
             current: None,
             total: None,
         }),
-        InProgress::Rebase => Some(describe_rebase(repo, config.rebase)),
+        InProgress::Rebase => Some(gigit_rebase(repo, config.rebase)),
         InProgress::RebaseInteractive => Some(describe_rebase(repo, config.rebase)),
     }
 }

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -25,6 +25,7 @@ mod env_var;
 mod erlang;
 mod fennel;
 mod fill;
+mod flutter;
 mod fossil_branch;
 mod fossil_metrics;
 mod gcloud;
@@ -132,6 +133,7 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
             "env_var" => env_var::module(None, context),
             "fennel" => fennel::module(context),
             "fill" => fill::module(context),
+            "flutter" => fill::module(context),
             "fossil_branch" => fossil_branch::module(context),
             "fossil_metrics" => fossil_metrics::module(context),
             "gcloud" => gcloud::module(context),
@@ -249,6 +251,7 @@ pub fn description(module: &str) -> &'static str {
         "elm" => "The currently installed version of Elm",
         "erlang" => "Current OTP version",
         "fennel" => "The currently installed version of Fennel",
+        "flutter" => "The currently installed version of Flutter",
         "fill" => "Fills the remaining space on the line with a pad string",
         "fossil_branch" => "The active branch of the check-out in your current directory",
         "fossil_metrics" => "The currently added/deleted lines in your check-out",


### PR DESCRIPTION
Previously, when user Entered N, the program would exit but now user with prompted with the path they want to install.

#### Description
The exit 1, which used to terminate the program has been replaced 
by set +e and a prompt for user to add  a custom path.

#### Motivation and Context
The user had to either accept the default location or they couldn't install where they wanted starship to be.

Closes #5608 

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
