### PR TITLE
fix: replace all remaining paths referring to vuepress

### DIFF
--- a/.dprint.json
+++ b/.dprint.json
@@ -14,7 +14,7 @@
   ],
   "excludes": [
     "CHANGELOG.md",
-    "docs/.vuepress/dist/**",
+    "docs/.vitepress/dist/**",
     "**/node_modules",
     "**/*-lock.json",
     ".github/*",

--- a/.github/workflows/format-workflow.yml
+++ b/.github/workflows/format-workflow.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install | Taplo
         run: cargo install --debug --locked --version 0.9.0 taplo-cli
       - name: Presets | Validate with schema
-        run: taplo lint --schema "file://${GITHUB_WORKSPACE}/.github/config-schema.json" docs/.vuepress/public/presets/toml/*.toml
+        run: taplo lint --schema "file://${GITHUB_WORKSPACE}/.github/config-schema.json" docs/public/presets/toml/*.toml
 
   # If this is not a Crowdin PR, block changes to translated documentation
   block-crowdin:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ include = [
   "build.rs",
   "LICENSE",
   "/README.md",
-  "docs/.vuepress/public/presets/toml/",
+  "docs/public/presets/toml/",
   ".github/config-schema.json",
 ]
 keywords = ["prompt", "shell", "bash", "fish", "zsh"]

--- a/install/macos_packages/build_and_notarize.sh
+++ b/install/macos_packages/build_and_notarize.sh
@@ -65,7 +65,7 @@ starship_docs_dir="$2"
 arch="$3"
 pkgname="${4:-}"
 
-if [[ ! -d "$starship_docs_dir/.vuepress/dist" ]]; then
+if [[ ! -d "$starship_docs_dir/.vitepress/dist" ]]; then
   error "Documentation does not appear to have been built!"
 fi
 
@@ -87,7 +87,7 @@ unzip starship.zip
 
 # Create the component package
 echo ">>>> Building Component Package"
-bash "$script_dir/build_component_package.sh" "starship" "$starship_docs_dir/.vuepress/dist"
+bash "$script_dir/build_component_package.sh" "starship" "$starship_docs_dir/.vitepress/dist"
 
 # Create the distribution package
 echo ">>>> Building Distribution Package"

--- a/install/macos_packages/build_component_package.sh
+++ b/install/macos_packages/build_component_package.sh
@@ -13,7 +13,7 @@ usage() {
     echo "Assumes that the following items already exist:"
     echo "    - A starship binary which has already been notarized"
     echo "    - Documentation created by \`npm run build\`, usually in a dist"
-    echo "      directory at <repo>/docs/.vuepress/dist"
+    echo "      directory at <repo>/docs/.vitepress/dist"
     echo "Usage: $0 <path-to-starship-binary> <path-to-dist-directory>"
 }
 

--- a/src/modules/os.rs
+++ b/src/modules/os.rs
@@ -327,8 +327,8 @@ mod tests {
         // - crate::modules::os::tests
         // - docs/config/README.md/#Configuration/#OS/#Options
         // - docs/config/README.md/#Configuration/#OS/#Example
-        // - docs/.vuepress/public/presets/toml/plain-text-symbols.toml
-        // - dosc/.vuepress/public/presets/toml/nerd-font-symbols.toml
+        // - docs/public/presets/toml/plain-text-symbols.toml
+        // - dosc/public/presets/toml/nerd-font-symbols.toml
         // - .github/config-schema.json
         let _ = |t: Type| match t {
             Type::AIX => "➿ ",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Some files were still referencing the old locations used by vuepress instead of those used by vitepress. The incorrect in `Cargo.toml` is likely the cause for the failed publishing to crates.io.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Related #5865

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
