### PR TITLE
feat(directory): Add truncate_repo_length option

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -342,6 +342,7 @@
         "repo_root_style": null,
         "style": "cyan bold",
         "substitutions": {},
+        "truncate_repo_length": 1,
         "truncate_to_repo": true,
         "truncation_length": 3,
         "truncation_symbol": "",
@@ -2688,6 +2689,11 @@
         "truncate_to_repo": {
           "default": true,
           "type": "boolean"
+        },
+        "truncate_repo_length": {
+          "default": 1,
+          "type": "integer",
+          "format": "int64"
         },
         "substitutions": {
           "default": {},

--- a/src/configs/directory.rs
+++ b/src/configs/directory.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 pub struct DirectoryConfig<'a> {
     pub truncation_length: i64,
     pub truncate_to_repo: bool,
+    pub truncate_repo_length: i64,
     pub substitutions: IndexMap<String, &'a str>,
     pub fish_style_pwd_dir_length: i64,
     pub use_logical_path: bool,
@@ -33,6 +34,7 @@ impl<'a> Default for DirectoryConfig<'a> {
         DirectoryConfig {
             truncation_length: 3,
             truncate_to_repo: true,
+            truncate_repo_length: 1,
             fish_style_pwd_dir_length: 0,
             use_logical_path: true,
             substitutions: IndexMap::new(),

--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -55,6 +55,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         context.get_repo().ok()
     } else {
         None
+
     };
     let dir_string = if config.truncate_to_repo {
         repo.and_then(|r| r.workdir.as_ref())
@@ -64,6 +65,8 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         None
     };
 
+    // If truncate_repo_length > 1, expand path to the left of the git repo
+    // Expand only when truncate_to_repo is true
     let dir_string = if config.truncate_to_repo && config.truncate_repo_length > 1 {
         if let Some(dir_string) = dir_string {
             repo.and_then(|r| r.workdir.as_ref()).and_then(|r| {
@@ -1129,6 +1132,36 @@ mod tests {
         assert_eq!(expected, actual);
         tmp_dir.close()
     }
+
+    /*
+    #[test]
+    #[ignore]
+    fn directory_in_git_repo_truncate_repo_length() -> io::Result<()> {
+        let (tmp_dir, _) = make_known_tempdir(Path::new("/tmp"))?;
+        let repo_dir = tmp_dir.path().join("above-repo").join("rocket-controls");
+        let dir = repo_dir.join("src/meters/fuel-gauge");
+        fs::create_dir_all(&dir)?;
+        init_repo(&repo_dir).unwrap();
+
+        let actual = ModuleRenderer::new("directory")
+            .config(toml::toml! {
+                [directory]
+                truncate_to_repo = true
+                truncate_repo_length = 2
+            })
+            .path(dir)
+            .collect();
+        let expected = Some(format!(
+            "{} ",
+            Color::Cyan
+                .bold()
+                .paint(convert_path_sep("above-repo/rocket-controls/src/meters/fuel-gauge"))
+        ));
+
+        assert_eq!(expected, actual);
+        tmp_dir.close()
+    }
+    */
 
     #[test]
     #[ignore]

--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -55,7 +55,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         context.get_repo().ok()
     } else {
         None
-
     };
     let dir_string = if config.truncate_to_repo {
         repo.and_then(|r| r.workdir.as_ref())
@@ -1133,7 +1132,6 @@ mod tests {
         tmp_dir.close()
     }
 
-    /*
     #[test]
     #[ignore]
     fn directory_in_git_repo_truncate_repo_length() -> io::Result<()> {
@@ -1147,21 +1145,23 @@ mod tests {
             .config(toml::toml! {
                 [directory]
                 truncate_to_repo = true
+                // should display <dir to the left>/<truncated path>
                 truncate_repo_length = 2
+                // make truncation_length bigger for not cutting the path
+                truncation_length = 6
             })
             .path(dir)
             .collect();
         let expected = Some(format!(
             "{} ",
-            Color::Cyan
-                .bold()
-                .paint(convert_path_sep("above-repo/rocket-controls/src/meters/fuel-gauge"))
+            Color::Cyan.bold().paint(convert_path_sep(
+                "above-repo/rocket-controls/src/meters/fuel-gauge"
+            ))
         ));
 
         assert_eq!(expected, actual);
         tmp_dir.close()
     }
-    */
 
     #[test]
     #[ignore]

--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -64,6 +64,23 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         None
     };
 
+    let dir_string = if config.truncate_to_repo && config.truncate_repo_length > 1 {
+        if let Some(dir_string) = dir_string {
+            repo.and_then(|r| r.workdir.as_ref()).and_then(|r| {
+                repo_add_left(
+                    display_dir,
+                    r,
+                    &dir_string,
+                    config.truncate_repo_length as usize,
+                )
+            })
+        } else {
+            dir_string
+        }
+    } else {
+        dir_string
+    };
+
     let mut is_truncated = dir_string.is_some();
 
     // the home directory if required.
@@ -271,6 +288,40 @@ fn contract_repo_path(full_path: &Path, top_level_path: &Path) -> Option<String>
         ));
     }
     None
+}
+
+fn repo_add_left(
+    full_path: &Path,
+    top_level_path: &Path,
+    repo_dir: &String,
+    trunc: usize,
+) -> Option<String> {
+    let top_level_real_path = real_path(top_level_path);
+    for (i, ancestor) in full_path.ancestors().enumerate() {
+        let ancestor_real_path = real_path(ancestor);
+        if ancestor_real_path != top_level_real_path {
+            continue;
+        }
+
+        let components: Vec<_> = full_path.components().collect();
+        let left = if components.len() >= i + trunc {
+            components.len() - i - trunc
+        } else {
+            0
+        };
+        // namely components.len()-1-i-1 <= 0, which is the left of the repo dir(components.len()-1-i)
+        if components.len() <= 2 + i {
+            return Some(String::from(repo_dir));
+        }
+        let path = PathBuf::from_iter(&components[left..components.len() - 1 - i]);
+        return Some(format!(
+            "{path}{delimiter}{repo_dir}",
+            path = path.to_slash_lossy(),
+            delimiter = "/",
+            repo_dir = repo_dir,
+        ));
+    }
+    Some(String::from(repo_dir))
 }
 
 fn real_path<P: AsRef<Path>>(path: P) -> PathBuf {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

Expand truncated repo name to the parent directories to preserve more information. 

The default value for `truncate_repo_length` is 1, which doesn't change any behavior that `truncate_to_repo = true` already has.

`truncate_repo_length` will work only when `truncate_to_repo` is set to true.

For example, you are in sub directory `src` where you initialized as a git repo. But you also want to know what it's parent directory is, like `project/src`, you can set `truncate_repo_length = 2` to do that.

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #5774

#### Screenshots (if appropriate):

`starship` is the git repo, when `truncate_repo_length = 2` is set, directories expand to left by one.

<img width="695" alt="截屏2024-03-23 下午11 47 25" src="https://github.com/starship/starship/assets/53141683/0a2f71f9-0156-4f1d-9086-4b12caf65695">


when `truncate_repo_length = 4`

<img width="808" alt="截屏2024-03-23 下午11 49 12" src="https://github.com/starship/starship/assets/53141683/ef09f673-6224-42df-8f93-88615a2f9c7a">



#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
