### PR TITLE
revert: "build(deps): update rust crate gix to 0.61.1"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1058,9 +1058,9 @@ dependencies = [
 
 [[package]]
 name = "gix"
-version = "0.61.1"
+version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d03e6e306a2c85bcd8e1de93dfd061531068ccd45eb05633d80c7e93f7e55fb9"
+checksum = "e4e0e59a44bf00de058ee98d6ecf3c9ed8f8842c1da642258ae4120d41ded8f7"
 dependencies = [
  "gix-actor",
  "gix-commitgraph",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ dirs-next = "2.0.0"
 dunce = "1.0.4"
 gethostname = "0.4.3"
 # default feature restriction addresses https://github.com/starship/starship/issues/4251
-gix = { version = "0.61.1", default-features = false, features = ["max-performance-safe", "revision"] }
+gix = { version = "0.61.0", default-features = false, features = ["max-performance-safe", "revision"] }
 gix-features = { version = "0.38.1", optional = true }
 indexmap = { version = "2.2.6", features = ["serde"] }
 log = { version = "0.4.21", features = ["std"] }


### PR DESCRIPTION
This reverts commit 19ae0fbe8c815af48a0ec5a729ad1a19c16dff24.

<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Related #5876. gix 0.61.1 was yanked, the reason is related to networking, which we don't enable, but it makes installing the binary more difficult.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
