### PR TITLE
fix: replace unmaintained crates `yaml-rust`, `dirs-next`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,6 +111,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
 
 [[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -716,7 +722,16 @@ version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys 0.4.1",
 ]
 
 [[package]]
@@ -738,6 +753,18 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -783,6 +810,70 @@ name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+
+[[package]]
+name = "encoding"
+version = "0.2.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b0d943856b990d12d3b55b359144ff341533e516d94098b1d3fc1ac666d36ec"
+dependencies = [
+ "encoding-index-japanese",
+ "encoding-index-korean",
+ "encoding-index-simpchinese",
+ "encoding-index-singlebyte",
+ "encoding-index-tradchinese",
+]
+
+[[package]]
+name = "encoding-index-japanese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04e8b2ff42e9a05335dbf8b5c6f7567e5591d0d916ccef4e0b1710d32a0d0c91"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-korean"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dc33fb8e6bcba213fe2f14275f0963fd16f0a02c878e3095ecfdf5bee529d81"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-simpchinese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87a7194909b9118fc707194baa434a4e3b0fb6a5a757c73c3adb07aa25031f7"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-singlebyte"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3351d5acffb224af9ca265f435b859c7c01537c0849754d3db3fdf2bfe2ae84a"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding-index-tradchinese"
+version = "1.20141219.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd0e20d5688ce3cab59eb3ef3a2083a5c77bf496cb798dc6fcdb75f323890c18"
+dependencies = [
+ "encoding_index_tests",
+]
+
+[[package]]
+name = "encoding_index_tests"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
 
 [[package]]
 name = "enumflags2"
@@ -1593,6 +1684,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashlink"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
+dependencies = [
+ "hashbrown 0.14.3",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1811,12 +1911,6 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
-
-[[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2104,6 +2198,12 @@ dependencies = [
  "libc",
  "pathdiff",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
@@ -2862,7 +2962,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "deelevate",
- "dirs-next",
+ "dirs 5.0.1",
  "dunce",
  "gethostname",
  "gix",
@@ -2908,7 +3008,7 @@ dependencies = [
  "which",
  "windows 0.54.0",
  "winres",
- "yaml-rust",
+ "yaml-rust2",
 ]
 
 [[package]]
@@ -3014,7 +3114,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da31aef70da0f6352dbcb462683eb4dd2bfad01cf3fc96cf204547b9a839a585"
 dependencies = [
- "dirs",
+ "dirs 4.0.0",
  "fnv",
  "nom 5.1.3",
  "phf",
@@ -3728,12 +3828,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "yaml-rust"
-version = "0.4.5"
+name = "yaml-rust2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+checksum = "777f823b2efee8266b47d35cc79ab1130250c2e4d5dbd3baf0bf3f776ea03a0a"
 dependencies = [
- "linked-hash-map",
+ "arraydeque",
+ "encoding",
+ "hashlink",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ gix-faster = ["gix-features/zlib-stock", "gix/fast-sha1"]
 chrono = { version = "0.4.35", default-features = false, features = ["clock", "std", "wasmbind"] }
 clap = { version = "4.5.4", features = ["derive", "cargo", "unicode"] }
 clap_complete = "4.5.1"
-dirs-next = "2.0.0"
+dirs = "5.0.1"
 dunce = "1.0.4"
 gethostname = "0.4.3"
 # default feature restriction addresses https://github.com/starship/starship/issues/4251
@@ -87,7 +87,7 @@ unicode-width = "0.1.11"
 urlencoding = "2.1.3"
 versions = "6.2.0"
 which = "6.0.1"
-yaml-rust = "0.4.5"
+yaml-rust2 = "0.7.0"
 
 process_control = { version = "4.1.0", features = ["crossbeam-channel"] }
 

--- a/src/bug_report.rs
+++ b/src/bug_report.rs
@@ -201,8 +201,7 @@ fn get_terminal_info() -> TerminalInfo {
 
 fn get_config_path(shell: &str) -> Option<PathBuf> {
     if shell == "nu" {
-        return dirs_next::config_dir()
-            .map(|config_dir| config_dir.join("nushell").join("config.nu"));
+        return dirs::config_dir().map(|config_dir| config_dir.join("nushell").join("config.nu"));
     }
 
     utils::home_dir().and_then(|home_dir| {

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -26,7 +26,7 @@ pub fn get_log_dir() -> PathBuf {
         .unwrap_or_else(|| {
             utils::home_dir()
                 .map(|home| home.join(".cache"))
-                .or_else(dirs_next::cache_dir)
+                .or_else(dirs::cache_dir)
                 .unwrap_or_else(std::env::temp_dir)
                 .join("starship")
         })

--- a/src/modules/daml.rs
+++ b/src/modules/daml.rs
@@ -66,7 +66,7 @@ fn get_daml_sdk_version(context: &Context) -> Option<String> {
 
 fn read_sdk_version_from_daml_yaml(context: &Context) -> Option<String> {
     let file_contents = context.read_file_from_pwd(DAML_YAML)?;
-    let daml_yaml = yaml_rust::YamlLoader::load_from_str(&file_contents).ok()?;
+    let daml_yaml = yaml_rust2::YamlLoader::load_from_str(&file_contents).ok()?;
     let sdk_version = daml_yaml.first()?[DAML_SDK_VERSION].as_str()?;
     Some(sdk_version.to_string())
 }

--- a/src/modules/haskell.rs
+++ b/src/modules/haskell.rs
@@ -64,7 +64,7 @@ fn get_snapshot(context: &Context) -> Option<String> {
         return None;
     }
     let file_contents = context.read_file_from_pwd("stack.yaml")?;
-    let yaml = yaml_rust::YamlLoader::load_from_str(&file_contents).ok()?;
+    let yaml = yaml_rust2::YamlLoader::load_from_str(&file_contents).ok()?;
     let version = yaml.first()?["resolver"]
         .as_str()
         .or_else(|| yaml.first()?["snapshot"].as_str())

--- a/src/modules/haskell.rs
+++ b/src/modules/haskell.rs
@@ -105,7 +105,7 @@ mod tests {
     fn folder_stack() -> io::Result<()> {
         let cases = vec![
             ("resolver: lts-18.12\n", "lts-18.12"),
-            ("snapshot:\tnightly-2011-11-11", "nightly-2011-11-11"),
+            ("snapshot: nightly-2011-11-11", "nightly-2011-11-11"),
             ("snapshot: ghc-8.10.7", "ghc-8.10.7"),
             (
                 "snapshot: https://github.com/whatever/xxx.yaml\n",

--- a/src/modules/kubernetes.rs
+++ b/src/modules/kubernetes.rs
@@ -1,4 +1,4 @@
-use yaml_rust::YamlLoader;
+use yaml_rust2::YamlLoader;
 
 use std::borrow::Cow;
 use std::env;

--- a/src/modules/openstack.rs
+++ b/src/modules/openstack.rs
@@ -1,4 +1,4 @@
-use yaml_rust::YamlLoader;
+use yaml_rust2::YamlLoader;
 
 use super::{Context, Module, ModuleConfig};
 

--- a/src/modules/package.rs
+++ b/src/modules/package.rs
@@ -135,7 +135,7 @@ fn get_julia_project_version(context: &Context, config: &PackageConfig) -> Optio
 
 fn get_helm_package_version(context: &Context, config: &PackageConfig) -> Option<String> {
     let file_contents = context.read_file_from_pwd("Chart.yaml")?;
-    let yaml = yaml_rust::YamlLoader::load_from_str(&file_contents).ok()?;
+    let yaml = yaml_rust2::YamlLoader::load_from_str(&file_contents).ok()?;
     let version = yaml.first()?["version"].as_str()?;
 
     format_version(version, config.version_format)
@@ -286,7 +286,7 @@ fn get_nimble_version(context: &Context, config: &PackageConfig) -> Option<Strin
 fn get_shard_version(context: &Context, config: &PackageConfig) -> Option<String> {
     let file_contents = context.read_file_from_pwd("shard.yml")?;
 
-    let data = yaml_rust::YamlLoader::load_from_str(&file_contents).ok()?;
+    let data = yaml_rust2::YamlLoader::load_from_str(&file_contents).ok()?;
     let raw_version = data.first()?["version"].as_str()?;
 
     format_version(raw_version, config.version_format)
@@ -295,7 +295,7 @@ fn get_shard_version(context: &Context, config: &PackageConfig) -> Option<String
 fn get_daml_project_version(context: &Context, config: &PackageConfig) -> Option<String> {
     let file_contents = context.read_file_from_pwd("daml.yaml")?;
 
-    let daml_yaml = yaml_rust::YamlLoader::load_from_str(&file_contents).ok()?;
+    let daml_yaml = yaml_rust2::YamlLoader::load_from_str(&file_contents).ok()?;
     let raw_version = daml_yaml.first()?["version"].as_str()?;
 
     format_version(raw_version, config.version_format)
@@ -304,7 +304,7 @@ fn get_daml_project_version(context: &Context, config: &PackageConfig) -> Option
 fn get_dart_pub_version(context: &Context, config: &PackageConfig) -> Option<String> {
     let file_contents = context.read_file_from_pwd("pubspec.yaml")?;
 
-    let data = yaml_rust::YamlLoader::load_from_str(&file_contents).ok()?;
+    let data = yaml_rust2::YamlLoader::load_from_str(&file_contents).ok()?;
     let raw_version = data.first()?["version"].as_str()?;
 
     format_version(raw_version, config.version_format)

--- a/src/modules/pulumi.rs
+++ b/src/modules/pulumi.rs
@@ -7,7 +7,7 @@ use std::fs::File;
 use std::io::{BufReader, Read};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
-use yaml_rust::{Yaml, YamlLoader};
+use yaml_rust2::{Yaml, YamlLoader};
 
 use super::{Context, Module, ModuleConfig};
 use crate::configs::pulumi::PulumiConfig;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -649,7 +649,7 @@ fn render_time_component((component, suffix): (&u128, &&str)) -> String {
 }
 
 pub fn home_dir() -> Option<PathBuf> {
-    dirs_next::home_dir()
+    dirs::home_dir()
 }
 
 const HEXTABLE: &[char] = &[


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
`yaml-rust` was declared unmaintained, the suggested alternative is `yaml-rust`.

`dirs-next` is not declared unmaintained outright, but seems close to being unmaintained. At least it looks like `dirs` again has more maintenance right now.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
