### PR TITLE
feat(nats): Add NATS Context

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -1027,7 +1027,7 @@
         "disabled": true,
         "format": "[$symbol$name]($style)",
         "style": "bold purple",
-        "symbol": ""
+        "symbol": "✉️ "
       },
       "allOf": [
         {
@@ -4388,7 +4388,7 @@
           "type": "string"
         },
         "symbol": {
-          "default": "",
+          "default": "✉️ ",
           "type": "string"
         },
         "style": {

--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -2053,14 +2053,12 @@
           "type": "string"
         },
         "charging_symbol": {
-          "default": null,
           "type": [
             "string",
             "null"
           ]
         },
         "discharging_symbol": {
-          "default": null,
           "type": [
             "string",
             "null"
@@ -2731,14 +2729,12 @@
           "type": "string"
         },
         "repo_root_style": {
-          "default": null,
           "type": [
             "string",
             "null"
           ]
         },
         "before_repo_root_style": {
-          "default": null,
           "type": [
             "string",
             "null"
@@ -4195,35 +4191,30 @@
           "type": "string"
         },
         "user_pattern": {
-          "default": null,
           "type": [
             "string",
             "null"
           ]
         },
         "symbol": {
-          "default": null,
           "type": [
             "string",
             "null"
           ]
         },
         "style": {
-          "default": null,
           "type": [
             "string",
             "null"
           ]
         },
         "context_alias": {
-          "default": null,
           "type": [
             "string",
             "null"
           ]
         },
         "user_alias": {
-          "default": null,
           "type": [
             "string",
             "null"

--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -1025,7 +1025,7 @@
     "nats": {
       "default": {
         "disabled": true,
-        "format": "[$symbol$name]($style)",
+        "format": "[$symbol($name )]($style)",
         "style": "bold purple",
         "symbol": "✉️ "
       },
@@ -4384,7 +4384,7 @@
       "type": "object",
       "properties": {
         "format": {
-          "default": "[$symbol$name]($style)",
+          "default": "[$symbol($name )]($style)",
           "type": "string"
         },
         "symbol": {

--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -1022,6 +1022,19 @@
         }
       ]
     },
+    "nats": {
+      "default": {
+        "disabled": true,
+        "format": "[$symbol$name]($style)",
+        "style": "bold purple",
+        "symbol": ""
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/NatsConfig"
+        }
+      ]
+    },
     "nim": {
       "default": {
         "detect_extensions": [
@@ -4362,6 +4375,28 @@
         },
         "disabled": {
           "default": false,
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "NatsConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "[$symbol$name]($style)",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "",
+          "type": "string"
+        },
+        "style": {
+          "default": "bold purple",
+          "type": "string"
+        },
+        "disabled": {
+          "default": true,
           "type": "boolean"
         }
       },

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2904,7 +2904,7 @@ The `nats` module shows the name of the current [NATS](https://nats.io) context.
 
 | Option     | Default                    | Description                                                  |
 | ---------- | -------------------------- | ------------------------------------------------------------ |
-| `symbol`   | `'✉️ '`                       | The symbol used before the NATS context (defaults to empty). |
+| `symbol`   | `'✉️ '`                     | The symbol used before the NATS context (defaults to empty). |
 | `style`    | `'bold purple'`            | The style for the module.                                    |
 | `format`   | `'[$symbol$name]($style)'` | The format for the module.                                   |
 | `disabled` | `false`                    | Disables the `nats` module.                                  |

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -338,6 +338,7 @@ $aws\
 $gcloud\
 $openstack\
 $azure\
+$nats\
 $direnv\
 $env_var\
 $crystal\
@@ -2893,6 +2894,35 @@ The `hg_branch` module shows the active branch and topic of the repo in your cur
 format = 'on [🌱 $branch](bold purple)'
 truncation_length = 4
 truncation_symbol = ''
+```
+
+## NATS
+
+The `nats` module shows the name of the current [NATS](https://nats.io) context.
+
+### Options
+
+| Option     | Default                    | Description                                                  |
+| ---------- | -------------------------- | ------------------------------------------------------------ |
+| `symbol`   | `''`                       | The symbol used before the NATS context (defaults to empty). |
+| `style`    | `'bold purple'`            | The style for the module.                                    |
+| `format`   | `'[$symbol$name]($style)'` | The format for the module.                                   |
+| `disabled` | `false`                    | Disables the `nats` module.                                  |
+
+### Variables
+
+| Variable | Example     | Description                          |
+| -------- | ----------- | ------------------------------------ |
+| name     | `localhost` | The name of the NATS context         |
+| symbol   |             | Mirrors the value of option `symbol` |
+| style\*  |             | Mirrors the value of option `style`  |
+
+### Example
+
+```toml
+[nats]
+format = '[$symbol]($style)'
+style = 'bold purple'
 ```
 
 ## Nim

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2904,7 +2904,7 @@ The `nats` module shows the name of the current [NATS](https://nats.io) context.
 
 | Option     | Default                    | Description                                                  |
 | ---------- | -------------------------- | ------------------------------------------------------------ |
-| `symbol`   | `''`                       | The symbol used before the NATS context (defaults to empty). |
+| `symbol`   | `'✉️ '`                       | The symbol used before the NATS context (defaults to empty). |
 | `style`    | `'bold purple'`            | The style for the module.                                    |
 | `format`   | `'[$symbol$name]($style)'` | The format for the module.                                   |
 | `disabled` | `false`                    | Disables the `nats` module.                                  |

--- a/docs/public/presets/toml/plain-text-symbols.toml
+++ b/docs/public/presets/toml/plain-text-symbols.toml
@@ -106,6 +106,9 @@ symbol = "memory "
 [meson]
 symbol = "meson "
 
+[nats]
+symbol = "nats "
+
 [nim]
 symbol = "nim "
 

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -54,6 +54,7 @@ pub mod localip;
 pub mod lua;
 pub mod memory_usage;
 pub mod meson;
+pub mod nats;
 pub mod nim;
 pub mod nix_shell;
 pub mod nodejs;
@@ -213,6 +214,8 @@ pub struct FullConfig<'a> {
     memory_usage: memory_usage::MemoryConfig<'a>,
     #[serde(borrow)]
     meson: meson::MesonConfig<'a>,
+    #[serde(borrow)]
+    nats: nats::NatsConfig<'a>,
     #[serde(borrow)]
     nim: nim::NimConfig<'a>,
     #[serde(borrow)]

--- a/src/configs/nats.rs
+++ b/src/configs/nats.rs
@@ -1,0 +1,26 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(
+    feature = "config-schema",
+    derive(schemars::JsonSchema),
+    schemars(deny_unknown_fields)
+)]
+#[serde(default)]
+pub struct NatsConfig<'a> {
+    pub format: &'a str,
+    pub symbol: &'a str,
+    pub style: &'a str,
+    pub disabled: bool,
+}
+
+impl<'a> Default for NatsConfig<'a> {
+    fn default() -> Self {
+        NatsConfig {
+            format: "[$symbol$name]($style)",
+            symbol: "",
+            style: "bold purple",
+            disabled: true,
+        }
+    }
+}

--- a/src/configs/nats.rs
+++ b/src/configs/nats.rs
@@ -17,7 +17,7 @@ pub struct NatsConfig<'a> {
 impl<'a> Default for NatsConfig<'a> {
     fn default() -> Self {
         NatsConfig {
-            format: "[$symbol$name]($style)",
+            format: "[$symbol($name )]($style)",
             symbol: "✉️ ",
             style: "bold purple",
             disabled: true,

--- a/src/configs/nats.rs
+++ b/src/configs/nats.rs
@@ -18,7 +18,7 @@ impl<'a> Default for NatsConfig<'a> {
     fn default() -> Self {
         NatsConfig {
             format: "[$symbol$name]($style)",
-            symbol: "",
+            symbol: "✉️ ",
             style: "bold purple",
             disabled: true,
         }

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -37,6 +37,7 @@ pub const PROMPT_ORDER: &[&str] = &[
     "shlvl",
     "singularity",
     "kubernetes",
+    "nats",
     "directory",
     "vcsh",
     "fossil_branch",

--- a/src/module.rs
+++ b/src/module.rs
@@ -61,6 +61,7 @@ pub const ALL_MODULES: &[&str] = &[
     "lua",
     "memory_usage",
     "meson",
+    "nats",
     "nim",
     "nix_shell",
     "nodejs",

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -51,6 +51,7 @@ mod localip;
 mod lua;
 mod memory_usage;
 mod meson;
+mod nats;
 mod nim;
 mod nix_shell;
 mod nodejs;
@@ -159,6 +160,7 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
             "lua" => lua::module(context),
             "memory_usage" => memory_usage::module(context),
             "meson" => meson::module(context),
+            "nats" => nats::module(context),
             "nim" => nim::module(context),
             "nix_shell" => nix_shell::module(context),
             "nodejs" => nodejs::module(context),
@@ -280,6 +282,7 @@ pub fn description(module: &str) -> &'static str {
         "meson" => {
             "The current Meson environment, if $MESON_DEVENV and $MESON_PROJECT_NAME are set"
         }
+        "nats" => "The current NATS context",
         "nim" => "The currently installed version of Nim",
         "nix_shell" => "The nix-shell environment",
         "nodejs" => "The currently installed version of NodeJS",

--- a/src/modules/nats.rs
+++ b/src/modules/nats.rs
@@ -60,17 +60,12 @@ mod tests {
     #[test]
     fn show_context() -> io::Result<()> {
         let actual = ModuleRenderer::new("nats")
-            .config(
-                toml::from_str(&format!(
-                    "
+            .config(toml::toml! {
                 [nats]
-                format = \"[$symbol$name](bold purple)\"
-                symbol = \"\"
+                format = "[$symbol$name](bold purple)"
+                symbol = ""
                 disabled = false
-                "
-                ))
-                .unwrap(),
-            )
+            })
             .collect();
         let expected = Some(format!("{}", Color::Purple.bold().paint("localhost")));
         assert_eq!(expected, actual);
@@ -80,19 +75,14 @@ mod tests {
     #[test]
     fn test_with_symbol() -> io::Result<()> {
         let actual = ModuleRenderer::new("nats")
-            .config(
-                toml::from_str(&format!(
-                    "
+            .config(toml::toml! {
                 [nats]
-                format = \"[$symbol$name](bold red)\"
-                symbol = \"N \"
+                format = "[$symbol$name](bold red)"
+                symbol = "✉️ "
                 disabled = false
-                "
-                ))
-                .unwrap(),
-            )
+            })
             .collect();
-        let expected = Some(format!("{}", Color::Red.bold().paint("N localhost")));
+        let expected = Some(format!("{}", Color::Red.bold().paint("✉️ localhost")));
         assert_eq!(expected, actual);
         Ok(())
     }

--- a/src/modules/nats.rs
+++ b/src/modules/nats.rs
@@ -1,0 +1,96 @@
+use super::{Context, Module, ModuleConfig};
+use serde_json as json;
+
+use crate::configs::nats::NatsConfig;
+use crate::formatter::StringFormatter;
+
+pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let mut module = context.new_module("nats");
+    let config = NatsConfig::try_load(module.config);
+
+    if config.disabled {
+        return None;
+    };
+
+    let ctx_str = context
+        .exec_cmd("nats", &["context", "info", "--json"])?
+        .stdout;
+    let nats_context: json::Value = json::from_str(&ctx_str).ok()?;
+    let name = nats_context.get("name")?.as_str()?;
+
+    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
+        formatter
+            .map_meta(|var, _| match var {
+                "symbol" => Some(config.symbol),
+                _ => None,
+            })
+            .map_style(|variable| match variable {
+                "style" => Some(Ok(config.style)),
+                _ => None,
+            })
+            .map(|variable| match variable {
+                "name" => Some(Ok(name)),
+                _ => None,
+            })
+            .parse(None, Some(context))
+    });
+
+    module.set_segments(match parsed {
+        Ok(segments) => segments,
+        Err(error) => {
+            log::warn!("Error in module `nats`:\n{}", error);
+            return None;
+        }
+    });
+
+    Some(module)
+}
+
+#[cfg(test)]
+mod tests {
+    use nu_ansi_term::Color;
+    use std::io;
+
+    use crate::test::ModuleRenderer;
+    use crate::utils::create_command;
+
+    #[test]
+    fn show_context() -> io::Result<()> {
+        let actual = ModuleRenderer::new("nats")
+            .config(
+                toml::from_str(&format!(
+                    "
+                [nats]
+                format = \"[$symbol$name](bold purple)\"
+                symbol = \"\"
+                disabled = false
+                "
+                ))
+                .unwrap(),
+            )
+            .collect();
+        let expected = Some(format!("{}", Color::Purple.bold().paint("localhost")));
+        assert_eq!(expected, actual);
+        Ok(())
+    }
+
+    #[test]
+    fn test_with_symbol() -> io::Result<()> {
+        let actual = ModuleRenderer::new("nats")
+            .config(
+                toml::from_str(&format!(
+                    "
+                [nats]
+                format = \"[$symbol$name](bold red)\"
+                symbol = \"N \"
+                disabled = false
+                "
+                ))
+                .unwrap(),
+            )
+            .collect();
+        let expected = Some(format!("{}", Color::Red.bold().paint("N localhost")));
+        assert_eq!(expected, actual);
+        Ok(())
+    }
+}

--- a/src/modules/nats.rs
+++ b/src/modules/nats.rs
@@ -18,7 +18,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let nats_context: json::Value = json::from_str(&ctx_str)
         .map_err(|e| {
             log::warn!("Error parsing nats context JSON: {}\n", e);
-            return e;
+            drop(e);
         })
         .ok()?;
 
@@ -56,7 +56,6 @@ mod tests {
     use std::io;
 
     use crate::test::ModuleRenderer;
-    use crate::utils::create_command;
 
     #[test]
     fn show_context() -> io::Result<()> {

--- a/src/modules/nats.rs
+++ b/src/modules/nats.rs
@@ -15,12 +15,12 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let ctx_str = context
         .exec_cmd("nats", &["context", "info", "--json"])?
         .stdout;
-    let nats_context: json::Value = json::from_str(&ctx_str).or_else(
-        |e| {
+    let nats_context: json::Value = json::from_str(&ctx_str)
+        .map_err(|e| {
             log::warn!("Error parsing nats context JSON: {}\n", e);
-            return Err(e);
-        }
-    ).ok()?;
+            return e;
+        })
+        .ok()?;
 
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter
@@ -33,9 +33,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 _ => None,
             })
             .map(|variable| match variable {
-                "name" => {
-                    Some(Ok(nats_context.get("name")?.as_str()?))
-                }
+                "name" => Some(Ok(nats_context.get("name")?.as_str()?)),
                 _ => None,
             })
             .parse(None, Some(context))

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -307,6 +307,10 @@ Elixir 1.10 (compiled with Erlang/OTP 22)\n",
             stdout: String::from("LuaJIT 2.0.5 -- Copyright (C) 2005-2017 Mike Pall. http://luajit.org/\n"),
             stderr: String::default(),
         }),
+        "nats context info --json" => Some(CommandOutput{
+            stdout: String::from("{\"name\":\"localhost\",\"url\":\"nats://localhost:4222\"}"),
+            stderr: String::default(),
+        }),
         "nim --version" => Some(CommandOutput {
             stdout: String::from(
                 "\


### PR DESCRIPTION
#### Description
Adds a module for getting the current NATS context. Uses the nats cli to get the current context name.

#### Motivation and Context
This is similar to having the Kubernetes context displayed so it's always known which context you are in.

#### Screenshots (if appropriate):

<img width="552" alt="Screenshot 2024-03-30 at 17 41 46" src="https://github.com/starship/starship/assets/17015451/6fc47358-4577-4110-9c93-98cb3d7651ec">


#### How Has This Been Tested?
Added the mock nats cli and then created tests to make sure styling matched.
Also built locally and tested changing contexts and styles.

<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.