### PR TITLE
docs(advanced-config): fix descriptions of the ble.sh settings

### DIFF
--- a/docs/advanced-config/README.md
+++ b/docs/advanced-config/README.md
@@ -114,15 +114,15 @@ the prompt information is not always needed. To enable this, put this in `~/.bas
 `bleopt prompt_ps1_transient=<value>`:
 
 The \<value\> here is a colon-separated list of `always`, `same-dir` and `trim`.
-When `prompt_ps1_final` is empty and this option has a non-empty value,
+When `prompt_ps1_final` is empty and the option `prompt_ps1_transient` has a non-empty \<value\>,
 the prompt specified by `PS1` is erased on leaving the current command line.
-If the value contains a field `trim`, only the last line of multiline `PS1` is
+If \<value\> contains a field `trim`, only the last line of multiline `PS1` is
 preserved and the other lines are erased. Otherwise, the command line will be
-redrawn as if `PS1=` is specified. When a field `same-dir` is contained in the
-value and the current working directory is different from the final directory of
+redrawn as if `PS1=` is specified. When a field `same-dir` is contained in
+\<value\> and the current working directory is different from the final directory of
 the previous command line, this option `prompt_ps1_transient` is ignored.
 
-Make the following changes to your `~/.bashrc` to customize what gets displayed on
+Make the following changes to your `~/.blerc` (or in `~/.config/blesh/init.sh`) to customize what gets displayed on
 the left and on the right:
 
 - To customize what the left side of input gets replaced with, configure the
@@ -130,7 +130,7 @@ the left and on the right:
   module here, you would do
 
 ```bash
-bleopt prompt_ps1_final="$(starship module character)"
+bleopt prompt_ps1_final='$(starship module character)'
 ```
 
 - To customize what the right side of input gets replaced with, configure the
@@ -138,7 +138,7 @@ bleopt prompt_ps1_final="$(starship module character)"
   the time at which the last command was started here, you would do
 
 ```bash
-bleopt prompt_rps1_final="$(starship module time)"
+bleopt prompt_rps1_final='$(starship module time)'
 ```
 
 ## Custom pre-prompt and pre-execution Commands in Cmd
@@ -337,7 +337,7 @@ Note: Continuation prompts are only available in the following shells:
 ```toml
 # ~/.config/starship.toml
 
-# A continuation prompt that displays two filled in arrows
+# A continuation prompt that displays two filled-in arrows
 continuation_prompt = '▶▶ '
 ```
 
@@ -375,6 +375,6 @@ If multiple colors are specified for foreground/background, the last one in the 
 
 Not every style string will be displayed correctly by every terminal. In particular, the following known quirks exist:
 
-- Many terminals disable support for `blink` by default
+- Many terminals disable support for `blink` by default.
 - `hidden` is [not supported on iTerm](https://gitlab.com/gnachman/iterm2/-/issues/4564).
-- `strikethrough` is not supported by the default macOS Terminal.app
+- `strikethrough` is not supported by the default macOS Terminal.app.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

There are six types of changes. The main ones are (1)--(4):

- (1) Replaced *this option* with "*the option `prompt_ps1_transient`*".
- (2) Replaced the phrases "*the value*" with "*\<value\>*".
- (3) Fix "*`~/.bashrc`*" to "*`~/.blerc` (or in `~/.config/blesh/init.sh`)*" for the place to put the `bleopt` settings.
- (4) Fix "*`bleopt prompt_ps1_final="$(starship module character)"`*" to "*`bleopt prompt_ps1_final='$(starship module character)'`*" to use single quotes and delay the evaluation.
- (5) Replace "*filled in*" with "filled-in".
- (6) Add periods to some list items

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

The number corresponds to the change of the same number in the previous section.

- (1) The description seems to be copied from the section of `prompt_ps1_transient` in the manual of ble.sh. However, in the Starship documentation, the description was copied under a different context of the broader section of the transient prompt in Bash. This makes it ambiguous about the original context specifically talking about `prompt_ps1_transient`. I've replaced *this option* with the option `prompt_ps1_transient`.
- (2) For the same reason, "*the value*" in the description is somewhat unclear. In the Starship documentation, we define \<value\> so should use it to mean "*the value*".
- (3) The `bleopt` settings are supposed to be put in `~/.blerc`. Otherwise, the setting will be lost in the current session after `ble-reload` or `ble-update` is performed.
- (4) Single quotes should be used in the setting, which are only evaluated on the initialization. Otherwise, the values will not be updated to reflect the current output of the module.
- (5) "*filled in*" in this context is used as an adjective. It reads better to connect them by a hyphen.
- (6) In the same list, one item ends with a period, and the other two end without periods, which are inconsistent. These are complete sentences, so I added the periods.

<!--- If it fixes an open issue, please link to the issue here. -->

There is no associated issue.

#### Screenshots (if appropriate):

See [starship/docs/advanced-config/README.md at docs-advanced · akinomyoga/starship](https://github.com/akinomyoga/starship/blob/docs-advanced/docs/advanced-config/README.md) for the preview on GitHub. Here's the [permalink](https://github.com/akinomyoga/starship/blob/6fbe5e1f59d08bcc91c57c23b3dc739610fb3e59/docs/advanced-config/README.md) of the initial version.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows** --- I've checked the rendering result in the preview on GitHub interface using Google Chrome.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly. --- Note: This is primarily the documentation change.
- [ ] I have updated the tests accordingly. --- There do not seem to be the tests about the description in the documentation.

