### PR TITLE
fix(bash): fix handling of the preserved DEBUG trap (used in Bash <= 4.3)

### DIFF
--- a/src/init/starship.bash
+++ b/src/init/starship.bash
@@ -65,8 +65,8 @@ starship_precmd() {
     # command pipeline, which may rely on it.
     _starship_set_return "$STARSHIP_CMD_STATUS"
 
-    if [[ -n "${_PRESERVED_PROMPT_COMMAND-}" ]]; then
-        eval "$_PRESERVED_PROMPT_COMMAND"
+    if [[ -n "${STARSHIP_PROMPT_COMMAND-}" ]]; then
+        eval "$STARSHIP_PROMPT_COMMAND"
     fi
 
     local -a ARGS=(--terminal-width="${COLUMNS}" --status="${STARSHIP_CMD_STATUS}" --pipestatus="${STARSHIP_PIPE_STATUS[*]}" --jobs="${NUM_JOBS}")
@@ -110,12 +110,12 @@ else
         # We want to avoid destroying an existing DEBUG hook. If we detect one, create
         # a new function that runs both the existing function AND our function, then
         # re-trap DEBUG to use this new function. This prevents a trap clobber.
-        dbg_trap="$(trap -p DEBUG | cut -d' ' -f3 | tr -d \')"
-        if [[ -z "$dbg_trap" ]]; then
+        STARSHIP_DEBUG_TRAP="$(trap -p DEBUG | cut -d' ' -f3 | tr -d \')"
+        if [[ -z "$STARSHIP_DEBUG_TRAP" ]]; then
             trap 'starship_preexec "$_"' DEBUG
-        elif [[ "$dbg_trap" != 'starship_preexec "$_"' && "$dbg_trap" != 'starship_preexec_all "$_"' ]]; then
+        elif [[ "$STARSHIP_DEBUG_TRAP" != 'starship_preexec "$_"' && "$STARSHIP_DEBUG_TRAP" != 'starship_preexec_all "$_"' ]]; then
             starship_preexec_all() {
-                local PREV_LAST_ARG=$1 ; $dbg_trap; starship_preexec; : "$PREV_LAST_ARG";
+                local PREV_LAST_ARG=$1 ; $STARSHIP_DEBUG_TRAP; starship_preexec; : "$PREV_LAST_ARG";
             }
             trap 'starship_preexec_all "$_"' DEBUG
         fi
@@ -130,7 +130,7 @@ else
         # Prepending to PROMPT_COMMAND breaks "command duration" module.
         # So, we are preserving the existing PROMPT_COMMAND
         # which will be executed later in the starship_precmd function
-        _PRESERVED_PROMPT_COMMAND="$PROMPT_COMMAND"
+        STARSHIP_PROMPT_COMMAND="$PROMPT_COMMAND"
         PROMPT_COMMAND="starship_precmd"
     fi
 fi

--- a/src/init/starship.bash
+++ b/src/init/starship.bash
@@ -110,7 +110,8 @@ else
         # We want to avoid destroying an existing DEBUG hook. If we detect one, create
         # a new function that runs both the existing function AND our function, then
         # re-trap DEBUG to use this new function. This prevents a trap clobber.
-        STARSHIP_DEBUG_TRAP="$(trap -p DEBUG | cut -d' ' -f3 | tr -d \')"
+        eval "STARSHIP_DEBUG_TRAP=($(trap -p DEBUG))"
+        STARSHIP_DEBUG_TRAP=("${STARSHIP_DEBUG_TRAP[2]}")
         if [[ -z "$STARSHIP_DEBUG_TRAP" ]]; then
             trap 'starship_preexec "$_"' DEBUG
         elif [[ "$STARSHIP_DEBUG_TRAP" != 'starship_preexec "$_"' && "$STARSHIP_DEBUG_TRAP" != 'starship_preexec_all "$_"' ]]; then

--- a/src/init/starship.bash
+++ b/src/init/starship.bash
@@ -116,7 +116,7 @@ else
             trap 'starship_preexec "$_"' DEBUG
         elif [[ "$STARSHIP_DEBUG_TRAP" != 'starship_preexec "$_"' && "$STARSHIP_DEBUG_TRAP" != 'starship_preexec_all "$_"' ]]; then
             starship_preexec_all() {
-                local PREV_LAST_ARG=$1 ; $STARSHIP_DEBUG_TRAP; starship_preexec; : "$PREV_LAST_ARG";
+                local PREV_LAST_ARG=$1 ; eval -- "$STARSHIP_DEBUG_TRAP"; starship_preexec; : "$PREV_LAST_ARG";
             }
             trap 'starship_preexec_all "$_"' DEBUG
         fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

### Description

> Describe your changes in detail

Three changes are included in this PR. Two of them are fixes to the handling of the DEBUG trap (used in Bash <= 4.3 for `starship_preexec`), and the other is a related variable name change. I include these changes in one PR here because they overlap with each other. However, if you would like separate PRs, I can happily separate them into four PRs and submit them one by one (because otherwise, they would produce conflicts).

- a46625ad This commit fixes the problem that the original `DEBUG` trap containing space is not correctly preserved. For example, when the user sets a custom DEBUG trap e.g. `trap 'echo hello' DEBUG` before Starship is initialized, Starship only preserves the first word, `echo`, for *the preserved DEBUG trap*. This is because the current code tries to extract the third word of the output of `trap -p DEBUG` (which will write `trap -- 'echo hello' DEBUG` to `stdout`) using `cut -d' ' -f3`. In this PR, we evaluate the output of `trap -p DEBUG` within the array assignment as `eval "DEBUG_TRAP=($(trap -p DEBUG))"` because `trap -p DEBUG` is produced in a format which can be evaluated for the shell execution. Then, we can pick the third element of the array.
- 13ed3563 This commit fixes the problem that the quote removal and other shell expansions in the preserved DEBUG trap string are not executed by Starship's DEBUG handler. The trap string is the general shell command that can contain shell expansions and quoting, so just running `$STARSHIP_DEBUG_TRAP` is not the right way to execute it. In this PR, we use `eval --
  "$STARSHIP_DEBUG_TRAP"`. The first option `--` is needed in case `$STARSHIP_DEBUG_TRAP` is `--`.
- 47286817 This is a refactoring commit. It is better to save the original DEBUG trap in `STARSHIP_DEBUG_TRAP` or another variable with its name starting with `_starship_` or `starship_` instead of putting them in a global variable named `dbg_trap`.

### Motivation and Context

> Why is this change required? What problem does it solve?

- a46625ad This change is required because, without this change, the current Starship integration does not correctly preserve the original DEBUG trap string containing spaces.  This PR solves the problem that only the first word in the trap string is recorded and executed by Starship's DEBUG trap handler.
- 13ed3563 This change is required because, without this change, shell expansions and quote removal that are expected to be executed for the original `DEBUG` trap string are not performed.  This PR solves the problem that processing of those expansions and quote removal is not performed.
- 47286817 This change is required because, without this change, the variable `dbg_trap` used to save the original `DEBUG` trap string may conflict with the user's shell variable or the variable set by other scripts.  This PR solves the conflicts by prefixing `STARSHIP_` to the variables used by Starship and separating their namespace.

> If it fixes an open issue, please link to the issue here.

Closes #3749 -- This fixes the issue reported in #3749 that the existing DEBUG trap string `"set_win_title \${BASH_COMMAND}"` is not correctly preserved.  This is partially fixed by PR #5020 and is finally fixed by commits cbb0da16 and 1adae699 provided by this PR.  On the other hand, the reported behavior that the existing DEBUG trap is executed is not an issue because the DEBUG trap is expected to be executed for any commands including the ones to initialize Starship.

### Screenshots (if appropriate):

For demonstration, let us consider the situation where a new Bash-4.3 session is started using the following `bashrc`:

```bash
# bashrc

trap 'echo "Hello World"' DEBUG
eval "$(starship.master init bash)"
```

#### In the current master

The result looks like this:

> <img title="master" width="70%" src="https://github.com/starship/starship/assets/8982192/5817e8ca-0651-4cb7-a397-11ae01716ca4" />

We see that the messages `Hello World` are initially printed as expected. However, they stop at some point and start to produce empty lines, which is not expected.

#### After the first fix for the trap string containing spaces

The result becomes this:

> <img title="fix1" width="70%" src="https://github.com/starship/starship/assets/8982192/027b80ed-135f-4242-87d3-96fe99fa69ed" />

Now, we see that the string `Hello World` is preserved in the trap string, but extra quoting `""` is also printed.

#### After the second fix for the not-evaluated trap string

The result becomes this (which is expected):

> <img title="fix2" width="70%" src="https://github.com/starship/starship/assets/8982192/4b491d87-faff-4af9-9f54-ee1c69d78c0c" />

This is the expected behavior.

### How Has This Been Tested?

> Please describe in detail how you tested your changes.

<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.

These are internal changes and fixes, so I think we do not need to update the documentation. If there would be places to update, please let me know. I'll happily update the necessary parts.

- [ ] I have updated the tests accordingly.

I checked `CONTRIBUTING.md`, but it seems to mention only the testing of the Rust codes. This patch only touches the Bash code and does not change the Rust code. There don't seem to be existing tests for the shell codes, so I didn't include tests. If the tests are needed, I'd appreciate it if you could point me to which place to look to prepare the tests for the shell integration.
