### PR TITLE
feat(AzureRm) Adds a basic Azure Powershell module. 

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -38,6 +38,20 @@
         }
       ]
     },
+    "azurerm": {
+      "default": {
+        "disabled": false,
+        "format": "on [$symbol($subscription)]($style) ",
+        "style": "blue bold",
+        "subscription_aliases": {},
+        "symbol": "󰠅 "
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/AzureRMConfig"
+        }
+      ]
+    },
     "battery": {
       "default": {
         "charging_symbol": "󰂄 ",
@@ -1967,6 +1981,35 @@
         },
         "disabled": {
           "default": true,
+          "type": "boolean"
+        },
+        "subscription_aliases": {
+          "default": {},
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "AzureRMConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "on [$symbol($subscription)]($style) ",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "󰠅 ",
+          "type": "string"
+        },
+        "style": {
+          "default": "blue bold",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
           "type": "boolean"
         },
         "subscription_aliases": {

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -507,6 +507,55 @@ style = "blue bold"
 very-long-subscription-name = 'vlsn'
 ```
 
+## AzureRM
+
+The `azurerm` module shows the current Azure Subscription for the AzureRM and Az PowerShell module(s). This is based on showing the name of the default subscription or the username, as defined in the `~/.azurerm/AzureRm_Context.json` file.
+
+### Options
+
+| Variable               | Default                                  | Description                                                                           |
+| ---------------------- | ---------------------------------------- | ------------------------------------------------------------------------------------- |
+| `format`               | `'on [$symbol($subscription)]($style) '` | The format for the Azure module to render.                                            |
+| `symbol`               | `'󰠅 '`                                   | The symbol used in the format.                                                        |
+| `style`                | `'blue bold'`                            | The style used in the format.                                                         |
+| `disabled`             | `true`                                   | Disables the `azurerm` module.                                                          |
+| `subscription_aliases` | `{}`                                     | Table of subscription name aliases to display in addition to Azure subscription name. |
+
+### Examples
+
+#### Display Subscription Name
+
+```toml
+# ~/.config/starship.toml
+
+[azurerm]
+disabled = false
+format = 'on [$symbol($subscription)]($style) '
+symbol = '󰠅 '
+style = 'blue bold'
+```
+
+#### Display Username
+
+```toml
+# ~/.config/starship.toml
+
+[azurerm]
+disabled = false
+format = "on [$symbol($username)]($style) "
+symbol = "󰠅 "
+style = "blue bold"
+```
+
+#### Display Subscription Name Alias
+
+```toml
+# ~/.config/starship.toml
+
+[azurerm.subscription_aliases]
+very-long-subscription-name = 'vlsn'
+```
+
 ## Battery
 
 The `battery` module shows how charged the device's battery is and its current charging status.

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -518,7 +518,7 @@ The `azurerm` module shows the current Azure Subscription for the AzureRM and Az
 | `format`               | `'on [$symbol($subscription)]($style) '` | The format for the Azure module to render.                                            |
 | `symbol`               | `'󰠅 '`                                   | The symbol used in the format.                                                        |
 | `style`                | `'blue bold'`                            | The style used in the format.                                                         |
-| `disabled`             | `true`                                   | Disables the `azurerm` module.                                                          |
+| `disabled`             | `true`                                   | Disables the `azurerm` module.                                                        |
 | `subscription_aliases` | `{}`                                     | Table of subscription name aliases to display in addition to Azure subscription name. |
 
 ### Examples

--- a/src/configs/azurerm.rs
+++ b/src/configs/azurerm.rs
@@ -1,0 +1,29 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(
+    feature = "config-schema",
+    derive(schemars::JsonSchema),
+    schemars(deny_unknown_fields)
+)]
+#[serde(default)]
+pub struct AzureRMConfig<'a> {
+    pub format: &'a str,
+    pub symbol: &'a str,
+    pub style: &'a str,
+    pub disabled: bool,
+    pub subscription_aliases: HashMap<String, &'a str>,
+}
+
+impl<'a> Default for AzureRMConfig<'a> {
+    fn default() -> Self {
+        AzureRMConfig {
+            format: "on [$symbol($subscription)]($style) ",
+            symbol: "󰠅 ",
+            style: "blue bold",
+            disabled: false ,
+            subscription_aliases: HashMap::new(),
+        }
+    }
+}

--- a/src/configs/azurerm.rs
+++ b/src/configs/azurerm.rs
@@ -22,7 +22,7 @@ impl<'a> Default for AzureRMConfig<'a> {
             format: "on [$symbol($subscription)]($style) ",
             symbol: "󰠅 ",
             style: "blue bold",
-            disabled: false ,
+            disabled: false,
             subscription_aliases: HashMap::new(),
         }
     }

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -3,6 +3,7 @@ use serde::{self, Deserialize, Serialize};
 
 pub mod aws;
 pub mod azure;
+pub mod azurerm;
 pub mod battery;
 pub mod buf;
 pub mod bun;
@@ -114,6 +115,8 @@ pub struct FullConfig<'a> {
     aws: aws::AwsConfig<'a>,
     #[serde(borrow)]
     azure: azure::AzureConfig<'a>,
+    #[serde(borrow)]
+    azurerm: azurerm::AzureRMConfig<'a>,
     #[serde(borrow)]
     battery: battery::BatteryConfig<'a>,
     #[serde(borrow)]

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -108,6 +108,7 @@ pub const PROMPT_ORDER: &[&str] = &[
     "gcloud",
     "openstack",
     "azure",
+    "azurerm",
     "direnv",
     "env_var",
     "crystal",

--- a/src/module.rs
+++ b/src/module.rs
@@ -11,6 +11,7 @@ use std::time::Duration;
 pub const ALL_MODULES: &[&str] = &[
     "aws",
     "azure",
+    "azurerm",
     #[cfg(feature = "battery")]
     "battery",
     "buf",

--- a/src/modules/azurerm.rs
+++ b/src/modules/azurerm.rs
@@ -28,7 +28,7 @@ struct PSAzureContext {
     tenant: PSAzureTenant,
     // #[serde(default, skip_serializing_if = "Option::is_none")]
     // subscription: Option<PSAzureSubscription>,
-    #[serde(default, deserialize_with="parse_subscription", flatten)]
+    #[serde(default, deserialize_with="parse_subscription")]
     subscription: PSAzureSubscription,
     environment: PSAzureEnvironment,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -148,13 +148,13 @@ fn get_azure_profile_info(context: &Context) -> Option<PSAzureSubscription> {
 
     let azurerm_contexts = load_azure_profile(&config_path)?;
     let azurerm_context_key = &azurerm_contexts.default_context_key;
-    let azurerm_context  = azurerm_contexts.contexts.get(azurerm_context_key).unwrap();
+    let azurerm_context  = azurerm_contexts.contexts.get(azurerm_context_key).unwrap().clone();
        
     // let context = 
     //     azurerm_contexts
     //     .contexts
     //     .get(azurerm_context_key).unwrap_or_default();
-    Some(azurerm_context.to_owned().subscription)
+    Some(azurerm_context.subscription)
 }
 
 fn load_azure_profile(config_path: &PathBuf) -> Option<AzureRMContext> {

--- a/src/modules/azurerm.rs
+++ b/src/modules/azurerm.rs
@@ -29,7 +29,7 @@ struct PSAzureContext {
 struct PSAzureSubscription {
     name: String,
     id: String,
-    extended_properties: PSAzureSubscriptionProperties
+    extended_properties: PSAzureSubscriptionProperties,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -37,7 +37,7 @@ struct PSAzureSubscription {
 struct PSAzureSubscriptionProperties {
     environment: String,
     account: String,
-    home_tenant: String
+    home_tenant: String,
 }
 
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
@@ -56,7 +56,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     }
     let azurerm_context = azurerm_context.unwrap();
     let subscription = azurerm_context.subscription.unwrap();
-        
+
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter
             .map_meta(|variable, _| match variable {
@@ -102,11 +102,10 @@ fn get_azurerm_context_info(context: &Context) -> Option<PSAzureContext> {
         .to_owned();
 
     if azurerm_context.subscription.is_none() {
-      return None;
+        return None;
     }
 
     return Some(azurerm_context);
-    
 }
 
 fn load_azurerm_context(config_path: &PathBuf) -> Option<AzureRMContext> {
@@ -149,7 +148,7 @@ mod tests {
             azurerm_context_contents.to_string(),
             String::from("AzureRmContext.json"),
         )?;
-        
+
         Ok(())
     }
 
@@ -261,7 +260,6 @@ mod tests {
         dir.close()
     }
 
-
     #[test]
     fn subscription_name_missing_from_profile() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
@@ -308,7 +306,6 @@ mod tests {
         assert_eq!(actual, expected);
         dir.close()
     }
-
 
     #[test]
     fn user_name_set_correctly() -> io::Result<()> {
@@ -359,7 +356,7 @@ mod tests {
         assert_eq!(actual, expected);
         dir.close()
     }
-    
+
     #[test]
     fn user_name_missing_from_profile() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
@@ -405,7 +402,6 @@ mod tests {
         assert_eq!(actual, expected);
         dir.close()
     }
-
 
     #[test]
     fn user_name_empty() -> io::Result<()> {
@@ -458,7 +454,6 @@ mod tests {
         dir.close()
     }
 
-
     #[test]
     fn subscription_name_and_username_found() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
@@ -508,7 +503,6 @@ mod tests {
         assert_eq!(actual, expected);
         dir.close()
     }
-
 
     #[test]
     fn subscription_name_with_alias() -> io::Result<()> {
@@ -560,26 +554,26 @@ mod tests {
             "ExtendedProperties": {}
         }"#;
 
-            generate_test_config(&dir, azurerm_context_contents)?;
-            let dir_path = &dir.path().to_string_lossy();
-            let actual = ModuleRenderer::new("azurerm")
-                .config(toml::toml! {
-                    [azurerm]
-                    format = "on [$symbol($subscription:$username)]($style)"
-                    disabled = false
-                    [azurerm.subscription_aliases]
-                    VeryLongSubscriptionName = "vlsn"
-                    AnotherLongSubscriptionName = "alsn"
-                    TheLastLongSubscriptionName = "tllsn"
-                })
-                .env("AZURE_CONFIG_DIR", dir_path.as_ref())
-                .collect();
-            let expected = Some(format!(
-                "on {}",
-                Color::Blue.bold().paint("󰠅 vlsn:user@domain.com")
-            ));
-            assert_eq!(actual, expected);
-            dir.close()
+        generate_test_config(&dir, azurerm_context_contents)?;
+        let dir_path = &dir.path().to_string_lossy();
+        let actual = ModuleRenderer::new("azurerm")
+            .config(toml::toml! {
+                [azurerm]
+                format = "on [$symbol($subscription:$username)]($style)"
+                disabled = false
+                [azurerm.subscription_aliases]
+                VeryLongSubscriptionName = "vlsn"
+                AnotherLongSubscriptionName = "alsn"
+                TheLastLongSubscriptionName = "tllsn"
+            })
+            .env("AZURE_CONFIG_DIR", dir_path.as_ref())
+            .collect();
+        let expected = Some(format!(
+            "on {}",
+            Color::Blue.bold().paint("󰠅 vlsn:user@domain.com")
+        ));
+        assert_eq!(actual, expected);
+        dir.close()
     }
 
     #[test]
@@ -635,19 +629,19 @@ mod tests {
             "ExtendedProperties": {}
         }"#;
 
-            generate_test_config(&dir, azurerm_context_contents)?;
-            let dir_path = &dir.path().to_string_lossy();
-            let actual = ModuleRenderer::new("azurerm")
-                .config(toml::toml! {
-                    [azurerm]
-                    format = "on [$symbol($subscription)]($style)"
-                    disabled = false
-                })
-                .env("AZURE_CONFIG_DIR", dir_path.as_ref())
-                .collect();
-            let expected = None;
-            assert_eq!(actual, expected);
-            dir.close()
+        generate_test_config(&dir, azurerm_context_contents)?;
+        let dir_path = &dir.path().to_string_lossy();
+        let actual = ModuleRenderer::new("azurerm")
+            .config(toml::toml! {
+                [azurerm]
+                format = "on [$symbol($subscription)]($style)"
+                disabled = false
+            })
+            .env("AZURE_CONFIG_DIR", dir_path.as_ref())
+            .collect();
+        let expected = None;
+        assert_eq!(actual, expected);
+        dir.close()
     }
 
     #[test]
@@ -703,21 +697,21 @@ mod tests {
             "ExtendedProperties": {}
         }"#;
 
-            generate_test_config(&dir, azurerm_context_contents)?;
-            let dir_path = &dir.path().to_string_lossy();
-            let actual = ModuleRenderer::new("azurerm")
-                .config(toml::toml! {
-                    [azurerm]
-                    disabled = false
-                })
-                .env("AZURE_CONFIG_DIR", dir_path.as_ref())
-                .collect();
-            let expected = Some(format!(
-                "on {} ",
-                Color::Blue.bold().paint("󰠅 Subscription 1")
-            ));
-            assert_eq!(actual, expected);
-            dir.close()
+        generate_test_config(&dir, azurerm_context_contents)?;
+        let dir_path = &dir.path().to_string_lossy();
+        let actual = ModuleRenderer::new("azurerm")
+            .config(toml::toml! {
+                [azurerm]
+                disabled = false
+            })
+            .env("AZURE_CONFIG_DIR", dir_path.as_ref())
+            .collect();
+        let expected = Some(format!(
+            "on {} ",
+            Color::Blue.bold().paint("󰠅 Subscription 1")
+        ));
+        assert_eq!(actual, expected);
+        dir.close()
     }
 
     #[test]
@@ -733,5 +727,4 @@ mod tests {
         assert_eq!(actual, expected);
         dir.close()
     }
-
 }

--- a/src/modules/azurerm.rs
+++ b/src/modules/azurerm.rs
@@ -1,4 +1,4 @@
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
@@ -102,10 +102,12 @@ fn get_azurerm_context_info(context: &Context) -> Option<PSAzureContext> {
         .to_owned();
 
     if azurerm_context.subscription.is_none() {
-        return None;
+        None
+    }
+    else {
+        Some(azurerm_context)
     }
 
-    return Some(azurerm_context);
 }
 
 fn load_azurerm_context(config_path: &PathBuf) -> Option<AzureRMContext> {

--- a/src/modules/azurerm.rs
+++ b/src/modules/azurerm.rs
@@ -16,30 +16,18 @@ struct AzureRMContext {
     contexts: HashMap<String, PSAzureContext>,
 }
 
-
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "PascalCase")]
 struct PSAzureContext {
     account: PSAzureAccount,
-    tenant: PSAzureTenant,
-    #[serde(default, deserialize_with="parse_subscription")]
+    #[serde(default, deserialize_with="parse_azurerm_subscription")]
     subscription: PSAzureSubscription,
-    environment: PSAzureEnvironment,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "PascalCase")]
 struct PSAzureAccount {
   id: String,
-  // #[serde(rename = "Type")]
-  // account_type: String,
-}
-
-#[derive(Serialize, Deserialize, Clone)]
-#[serde(rename_all = "PascalCase")]
-struct PSAzureTenant {
-  id: String,
-  directory: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Default)]
@@ -49,17 +37,11 @@ struct PSAzureSubscription {
   id: String, 
 }
 
-fn parse_subscription<'de, D>(d: D) -> Result<PSAzureSubscription, D::Error> where D: Deserializer<'de> {
+fn parse_azurerm_subscription<'de, D>(d: D) -> Result<PSAzureSubscription, D::Error> where D: Deserializer<'de> {
   Deserialize::deserialize(d)
       .map(|x: Option<_>| {
           x.unwrap_or_default()
       })
-}
-
-#[derive(Serialize, Deserialize, Clone)]
-#[serde(rename_all = "PascalCase",)]
-struct PSAzureEnvironment {
-  name: String,
 }
 
 

--- a/src/modules/azurerm.rs
+++ b/src/modules/azurerm.rs
@@ -12,38 +12,32 @@ use crate::formatter::StringFormatter;
 #[serde(rename_all = "PascalCase")]
 struct AzureRMContext {
     default_context_key: String,
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
     contexts: HashMap<String, PSAzureContext>,
+}
+
+// TODO: Remove Clone trait
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all = "PascalCase")]
+struct PSAzureContext {
+    // #[serde(deserialize_with = "parse_azurerm_subscription")]
+    subscription: Option<PSAzureSubscription>,
 }
 
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "PascalCase")]
-struct PSAzureContext {
-    #[serde(default, deserialize_with = "parse_azurerm_subscription")]
-    subscription: PSAzureSubscription,
-}
-
-#[derive(Serialize, Deserialize, Clone, Default)]
-#[serde(rename_all = "PascalCase", default)]
 struct PSAzureSubscription {
     name: String,
     id: String,
     extended_properties: PSAzureSubscriptionProperties
 }
 
-#[derive(Serialize, Deserialize, Clone, Default)]
-#[serde(rename_all = "PascalCase", default)]
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all = "PascalCase")]
 struct PSAzureSubscriptionProperties {
     environment: String,
     account: String,
     home_tenant: String
-}
-
-fn parse_azurerm_subscription<'de, D>(d: D) -> Result<PSAzureSubscription, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    Deserialize::deserialize(d).map(|x: Option<_>| x.unwrap_or_default())
 }
 
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
@@ -61,8 +55,8 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         return None;
     }
     let azurerm_context = azurerm_context.unwrap();
-    let subscription = azurerm_context.subscription;
-
+    let subscription = azurerm_context.subscription.unwrap();
+        
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter
             .map_meta(|variable, _| match variable {
@@ -107,7 +101,12 @@ fn get_azurerm_context_info(context: &Context) -> Option<PSAzureContext> {
         .get(&azurerm_context_key)?
         .to_owned();
 
-    Some(azurerm_context)
+    if azurerm_context.subscription.is_none() {
+      return None;
+    }
+
+    return Some(azurerm_context);
+    
 }
 
 fn load_azurerm_context(config_path: &PathBuf) -> Option<AzureRMContext> {
@@ -130,4 +129,609 @@ fn get_config_file_location(context: &Context) -> Option<PathBuf> {
             home.push(".azure");
             Some(home)
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::modules::azurerm::load_azurerm_context;
+    use crate::test::ModuleRenderer;
+    use ini::Ini;
+    use nu_ansi_term::Color;
+    use std::fs::File;
+    use std::io::{self, Write};
+    use std::path::PathBuf;
+
+    use tempfile::TempDir;
+
+    fn generate_test_config(dir: &TempDir, azurerm_context_contents: &str) -> io::Result<()> {
+        save_string_to_file(
+            dir,
+            azurerm_context_contents.to_string(),
+            String::from("AzureRmContext.json"),
+        )?;
+        
+        Ok(())
+    }
+
+    fn save_string_to_file(
+        dir: &TempDir,
+        contents: String,
+        file_name: String,
+    ) -> Result<PathBuf, io::Error> {
+        let bom_file_path = dir.path().join(file_name);
+        let mut bom_file = File::create(&bom_file_path)?;
+        bom_file.write_all(contents.as_bytes())?;
+        bom_file.sync_all()?;
+        Ok(bom_file_path)
+    }
+
+    #[test]
+    fn subscription_set_correctly() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+
+        let azurerm_context_contents = r#"{
+            "DefaultContextKey": "Subscription 1",
+            "EnvironmentTable": {},
+            "Contexts": {
+              "Subscription 1": {
+                "Subscription": {
+                  "Id": "9602c987-ef4d-4fe9-befb-c89158c8ad20",
+                  "Name": "Subscription 1",
+                  "State": "Enabled",
+                  "ExtendedProperties": {
+                    "AuthorizationSource": "RoleBased",
+                    "HomeTenant": "8cf684f2-bc34-4b60-b75d-a75ab47ee27b",
+                    "Environment": "AzureCloud",
+                    "Tenants": "8cf684f2-bc34-4b60-b75d-a75ab47ee27b",
+                    "Account": "user@domain.com"
+                  }
+                },
+                "VersionProfile": null,
+                "TokenCache": {
+                  "CacheData": null
+                },
+                "ExtendedProperties": {}
+              }
+            },
+            "ExtendedProperties": {}
+          }"#;
+
+        generate_test_config(&dir, azurerm_context_contents)?;
+        let dir_path = &dir.path().to_string_lossy();
+        let actual = ModuleRenderer::new("azurerm")
+            .config(toml::toml! {
+            [azurerm]
+            disabled = false
+            })
+            .env("AZURE_CONFIG_DIR", dir_path.as_ref())
+            .collect();
+        let expected = Some(format!(
+            "on {} ",
+            Color::Blue.bold().paint("󰠅 Subscription 1")
+        ));
+        assert_eq!(actual, expected);
+        dir.close()
+    }
+
+    #[test]
+    fn subscription_name_empty() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+
+        let azurerm_context_contents = r#"{
+        {
+            "DefaultContextKey": "Subscription 1",
+            "EnvironmentTable": {},
+            "Contexts": {
+                "Subscription 1": {
+                    "Subscription": {
+                        "Id": "9602c987-ef4d-4fe9-befb-c89158c8ad20",
+                        "Name": "",
+                        "State": "Enabled",
+                        "ExtendedProperties": {
+                            "AuthorizationSource": "RoleBased",
+                            "HomeTenant": "8cf684f2-bc34-4b60-b75d-a75ab47ee27b",
+                            "Environment": "AzureCloud",
+                            "Tenants": "8cf684f2-bc34-4b60-b75d-a75ab47ee27b",
+                            "Account": "user@domain.com"
+                        }
+                    },
+                    "VersionProfile": null,
+                    "TokenCache": {
+                        "CacheData": null
+                    },
+                    "ExtendedProperties": {}
+                }
+            },
+            "ExtendedProperties": {}
+            }        
+        "#;
+
+        generate_test_config(&dir, azurerm_context_contents)?;
+        let dir_path = &dir.path().to_string_lossy();
+        let actual = ModuleRenderer::new("azurerm")
+            .config(toml::toml! {
+            [azurerm]
+            format = "on [$symbol($subscription:$username)]($style)"
+            disabled = false
+            })
+            .env("AZURE_CONFIG_DIR", dir_path.as_ref())
+            .collect();
+        let expected = None;
+        assert_eq!(actual, expected);
+        dir.close()
+    }
+
+
+    #[test]
+    fn subscription_name_missing_from_profile() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+
+        let azurerm_context_contents = r#"{
+        {
+            "DefaultContextKey": "Subscription 1",
+            "EnvironmentTable": {},
+            "Contexts": {
+                "Subscription 1": {
+                    "Subscription": {
+                        "Id": "9602c987-ef4d-4fe9-befb-c89158c8ad20",
+                        "State": "Enabled",
+                        "ExtendedProperties": {
+                            "AuthorizationSource": "RoleBased",
+                            "HomeTenant": "8cf684f2-bc34-4b60-b75d-a75ab47ee27b",
+                            "Environment": "AzureCloud",
+                            "Tenants": "8cf684f2-bc34-4b60-b75d-a75ab47ee27b",
+                            "Account": "user@domain.com"
+                        }
+                    },
+                    "VersionProfile": null,
+                    "TokenCache": {
+                        "CacheData": null
+                    },
+                    "ExtendedProperties": {}
+                }
+            },
+            "ExtendedProperties": {}
+            }        
+        "#;
+
+        generate_test_config(&dir, azurerm_context_contents)?;
+        let dir_path = &dir.path().to_string_lossy();
+        let actual = ModuleRenderer::new("azurerm")
+            .config(toml::toml! {
+            [azurerm]
+            format = "on [$symbol($subscription:$username)]($style)"
+            disabled = false
+            })
+            .env("AZURE_CONFIG_DIR", dir_path.as_ref())
+            .collect();
+        let expected = None;
+        assert_eq!(actual, expected);
+        dir.close()
+    }
+
+
+    #[test]
+    fn user_name_set_correctly() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+
+        let azurerm_context_contents = r#"{
+            "DefaultContextKey": "Subscription 1",
+            "EnvironmentTable": {},
+            "Contexts": {
+                "Subscription 1": {
+                    "Subscription": {
+                        "Id": "9602c987-ef4d-4fe9-befb-c89158c8ad20",
+                        "Name": "Subscription 1",
+                        "State": "Enabled",
+                        "ExtendedProperties": {
+                            "AuthorizationSource": "RoleBased",
+                            "HomeTenant": "8cf684f2-bc34-4b60-b75d-a75ab47ee27b",
+                            "Environment": "AzureCloud",
+                            "Tenants": "8cf684f2-bc34-4b60-b75d-a75ab47ee27b",
+                            "Account": "user@domain.com"
+                        }
+                    },
+                    "VersionProfile": null,
+                    "TokenCache": {
+                        "CacheData": null
+                    },
+                    "ExtendedProperties": {}
+                }
+            },
+            "ExtendedProperties": {}
+        }         
+        "#;
+
+        generate_test_config(&dir, azurerm_context_contents)?;
+        let dir_path = &dir.path().to_string_lossy();
+        let actual = ModuleRenderer::new("azurerm")
+            .config(toml::toml! {
+            [azurerm]
+            format = "on [$symbol($username)]($style)"
+            disabled = false
+            })
+            .env("AZURE_CONFIG_DIR", dir_path.as_ref())
+            .collect();
+        let expected = Some(format!(
+            "on {}",
+            Color::Blue.bold().paint("󰠅 user@domain.com")
+        ));
+        assert_eq!(actual, expected);
+        dir.close()
+    }
+    
+    #[test]
+    fn user_name_missing_from_profile() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+
+        let azurerm_context_contents = r#"{
+            "DefaultContextKey": "Subscription 1",
+            "EnvironmentTable": {},
+            "Contexts": {
+              "Subscription 1": {
+                "Subscription": {
+                  "Id": "9602c987-ef4d-4fe9-befb-c89158c8ad20",
+                  "Name": "Subscription 1",
+                  "State": "Enabled",
+                  "ExtendedProperties": {
+                    "AuthorizationSource": "RoleBased",
+                    "HomeTenant": "8cf684f2-bc34-4b60-b75d-a75ab47ee27b",
+                    "Environment": "AzureCloud",
+                    "Tenants": "8cf684f2-bc34-4b60-b75d-a75ab47ee27b",
+                  }
+                },
+                "VersionProfile": null,
+                "TokenCache": {
+                  "CacheData": null
+                },
+                "ExtendedProperties": {}
+              }
+            },
+            "ExtendedProperties": {}
+          }          
+        "#;
+
+        generate_test_config(&dir, azurerm_context_contents)?;
+        let dir_path = &dir.path().to_string_lossy();
+        let actual = ModuleRenderer::new("azurerm")
+            .config(toml::toml! {
+            [azurerm]
+            format = "on [$symbol($subscription:$username)]($style)"
+            disabled = false
+            })
+            .env("AZURE_CONFIG_DIR", dir_path.as_ref())
+            .collect();
+        let expected = None;
+        assert_eq!(actual, expected);
+        dir.close()
+    }
+
+
+    #[test]
+    fn user_name_empty() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+
+        let azurerm_context_contents = r#"
+        {
+            "DefaultContextKey": "Subscription 1",
+            "EnvironmentTable": {},
+            "Contexts": {
+                "Subscription 1": {
+                "Subscription": {
+                    "Id": "9602c987-ef4d-4fe9-befb-c89158c8ad20",
+                    "Name": "Subscription 1",
+                    "State": "Enabled",
+                    "ExtendedProperties": {
+                        "AuthorizationSource": "RoleBased",
+                        "HomeTenant": "8cf684f2-bc34-4b60-b75d-a75ab47ee27b",
+                        "Environment": "AzureCloud",
+                        "Tenants": "8cf684f2-bc34-4b60-b75d-a75ab47ee27b",
+                        "Account": ""
+                    }
+                },
+                "VersionProfile": null,
+                "TokenCache": {
+                    "CacheData": null
+                },
+                "ExtendedProperties": {}
+                }
+            },
+            "ExtendedProperties": {}
+        }        
+        "#;
+
+        generate_test_config(&dir, azurerm_context_contents)?;
+        let dir_path = &dir.path().to_string_lossy();
+        let actual = ModuleRenderer::new("azurerm")
+            .config(toml::toml! {
+            [azurerm]
+            format = "on [$symbol($subscription:$username)]($style)"
+            disabled = false
+            })
+            .env("AZURE_CONFIG_DIR", dir_path.as_ref())
+            .collect();
+        let expected = Some(format!(
+            "on {}",
+            Color::Blue.bold().paint("󰠅 Subscription 1:")
+        ));
+        assert_eq!(actual, expected);
+        dir.close()
+    }
+
+
+    #[test]
+    fn subscription_name_and_username_found() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+
+        let azurerm_context_contents = r#"{
+            "DefaultContextKey": "Subscription 1",
+            "EnvironmentTable": {},
+            "Contexts": {
+              "Subscription 1": {
+                "Subscription": {
+                  "Id": "9602c987-ef4d-4fe9-befb-c89158c8ad20",
+                  "Name": "Subscription 1",
+                  "State": "Enabled",
+                  "ExtendedProperties": {
+                    "AuthorizationSource": "RoleBased",
+                    "HomeTenant": "8cf684f2-bc34-4b60-b75d-a75ab47ee27b",
+                    "Environment": "AzureCloud",
+                    "Tenants": "8cf684f2-bc34-4b60-b75d-a75ab47ee27b",
+                    "Account": "user@domain.com"
+                  }
+                },
+                "VersionProfile": null,
+                "TokenCache": {
+                  "CacheData": null
+                },
+                "ExtendedProperties": {}
+              }
+            },
+            "ExtendedProperties": {}
+          }          
+        "#;
+
+        generate_test_config(&dir, azurerm_context_contents)?;
+        let dir_path = &dir.path().to_string_lossy();
+        let actual = ModuleRenderer::new("azurerm")
+            .config(toml::toml! {
+            [azurerm]
+            format = "on [$symbol($subscription:$username)]($style)"
+            disabled = false
+            })
+            .env("AZURE_CONFIG_DIR", dir_path.as_ref())
+            .collect();
+        let expected = Some(format!(
+            "on {}",
+            Color::Blue.bold().paint("󰠅 Subscription 1:user@domain.com")
+        ));
+        assert_eq!(actual, expected);
+        dir.close()
+    }
+
+
+    #[test]
+    fn subscription_name_with_alias() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+
+        let azurerm_context_contents = r#"{
+            "DefaultContextKey": "VeryLongSubscriptionName",
+            "EnvironmentTable": {},
+            "Contexts": {
+                "Subscription 1": {
+                    "Subscription": {
+                        "Id": "9602c987-ef4d-4fe9-befb-c89158c8ad20",
+                        "Name": "Subscription 1",
+                        "State": "Enabled",
+                        "ExtendedProperties": {
+                            "AuthorizationSource": "RoleBased",
+                            "HomeTenant": "8cf684f2-bc34-4b60-b75d-a75ab47ee27b",
+                            "Environment": "AzureCloud",
+                            "Tenants": "8cf684f2-bc34-4b60-b75d-a75ab47ee27b",
+                            "Account": "user@domain.com"
+                        }
+                    },
+                    "VersionProfile": null,
+                    "TokenCache": {
+                        "CacheData": null
+                    },
+                    "ExtendedProperties": {}
+                },
+                "VeryLongSubscriptionName": {
+                    "Subscription": {
+                        "Id": "9602c987-ef4d-4fe9-befb-c89158c8ad20",
+                        "Name": "VeryLongSubscriptionName",
+                        "State": "Enabled",
+                        "ExtendedProperties": {
+                            "AuthorizationSource": "RoleBased",
+                            "HomeTenant": "8cf684f2-bc34-4b60-b75d-a75ab47ee27b",
+                            "Environment": "AzureCloud",
+                            "Tenants": "8cf684f2-bc34-4b60-b75d-a75ab47ee27b",
+                            "Account": "user@domain.com"
+                        }
+                    },
+                    "VersionProfile": null,
+                    "TokenCache": {
+                        "CacheData": null
+                    },
+                    "ExtendedProperties": {}
+                }
+            },
+            "ExtendedProperties": {}
+        }"#;
+
+            generate_test_config(&dir, azurerm_context_contents)?;
+            let dir_path = &dir.path().to_string_lossy();
+            let actual = ModuleRenderer::new("azurerm")
+                .config(toml::toml! {
+                    [azurerm]
+                    format = "on [$symbol($subscription:$username)]($style)"
+                    disabled = false
+                    [azurerm.subscription_aliases]
+                    VeryLongSubscriptionName = "vlsn"
+                    AnotherLongSubscriptionName = "alsn"
+                    TheLastLongSubscriptionName = "tllsn"
+                })
+                .env("AZURE_CONFIG_DIR", dir_path.as_ref())
+                .collect();
+            let expected = Some(format!(
+                "on {}",
+                Color::Blue.bold().paint("󰠅 vlsn:user@domain.com")
+            ));
+            assert_eq!(actual, expected);
+            dir.close()
+    }
+
+    #[test]
+    fn active_context_subscription_is_null() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+
+        let azurerm_context_contents = r#"{
+            "DefaultContextKey": "Context A",
+            "EnvironmentTable": {},
+            "Contexts": {
+                "Context A": {
+                    "Subscription": null
+                },
+                "Context B": {
+                    "Subscription": {
+                        "Id": "9602c987-ef4d-4fe9-befb-c89158c8ad20",
+                        "Name": "Subscription 1",
+                        "State": "Enabled",
+                        "ExtendedProperties": {
+                            "AuthorizationSource": "RoleBased",
+                            "HomeTenant": "8cf684f2-bc34-4b60-b75d-a75ab47ee27b",
+                            "Environment": "AzureCloud",
+                            "Tenants": "8cf684f2-bc34-4b60-b75d-a75ab47ee27b",
+                            "Account": "user@domain.com"
+                        }
+                    },
+                    "VersionProfile": null,
+                    "TokenCache": {
+                        "CacheData": null
+                    },
+                    "ExtendedProperties": {}
+                },
+                "Context C": {
+                    "Subscription": {
+                        "Id": "9602c987-ef4d-4fe9-befb-c89158c8ad20",
+                        "Name": "VeryLongSubscriptionName",
+                        "State": "Enabled",
+                        "ExtendedProperties": {
+                            "AuthorizationSource": "RoleBased",
+                            "HomeTenant": "8cf684f2-bc34-4b60-b75d-a75ab47ee27b",
+                            "Environment": "AzureCloud",
+                            "Tenants": "8cf684f2-bc34-4b60-b75d-a75ab47ee27b",
+                            "Account": "user@domain.com"
+                        }
+                    },
+                    "VersionProfile": null,
+                    "TokenCache": {
+                        "CacheData": null
+                    },
+                    "ExtendedProperties": {}
+                }
+            },
+            "ExtendedProperties": {}
+        }"#;
+
+            generate_test_config(&dir, azurerm_context_contents)?;
+            let dir_path = &dir.path().to_string_lossy();
+            let actual = ModuleRenderer::new("azurerm")
+                .config(toml::toml! {
+                    [azurerm]
+                    format = "on [$symbol($subscription)]($style)"
+                    disabled = false
+                })
+                .env("AZURE_CONFIG_DIR", dir_path.as_ref())
+                .collect();
+            let expected = None;
+            assert_eq!(actual, expected);
+            dir.close()
+    }
+
+    #[test]
+    fn inactive_context_subscription_is_null() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+
+        let azurerm_context_contents = r#"{
+            "DefaultContextKey": "Context B",
+            "EnvironmentTable": {},
+            "Contexts": {
+                "Context A": {
+                    "Subscription": null
+                },
+                "Context B": {
+                    "Subscription": {
+                        "Id": "9602c987-ef4d-4fe9-befb-c89158c8ad20",
+                        "Name": "Subscription 1",
+                        "State": "Enabled",
+                        "ExtendedProperties": {
+                            "AuthorizationSource": "RoleBased",
+                            "HomeTenant": "8cf684f2-bc34-4b60-b75d-a75ab47ee27b",
+                            "Environment": "AzureCloud",
+                            "Tenants": "8cf684f2-bc34-4b60-b75d-a75ab47ee27b",
+                            "Account": "user@domain.com"
+                        }
+                    },
+                    "VersionProfile": null,
+                    "TokenCache": {
+                        "CacheData": null
+                    },
+                    "ExtendedProperties": {}
+                },
+                "Context C": {
+                    "Subscription": {
+                        "Id": "9602c987-ef4d-4fe9-befb-c89158c8ad20",
+                        "Name": "VeryLongSubscriptionName",
+                        "State": "Enabled",
+                        "ExtendedProperties": {
+                            "AuthorizationSource": "RoleBased",
+                            "HomeTenant": "8cf684f2-bc34-4b60-b75d-a75ab47ee27b",
+                            "Environment": "AzureCloud",
+                            "Tenants": "8cf684f2-bc34-4b60-b75d-a75ab47ee27b",
+                            "Account": "user@domain.com"
+                        }
+                    },
+                    "VersionProfile": null,
+                    "TokenCache": {
+                        "CacheData": null
+                    },
+                    "ExtendedProperties": {}
+                }
+            },
+            "ExtendedProperties": {}
+        }"#;
+
+            generate_test_config(&dir, azurerm_context_contents)?;
+            let dir_path = &dir.path().to_string_lossy();
+            let actual = ModuleRenderer::new("azurerm")
+                .config(toml::toml! {
+                    [azurerm]
+                    disabled = false
+                })
+                .env("AZURE_CONFIG_DIR", dir_path.as_ref())
+                .collect();
+            let expected = Some(format!(
+                "on {} ",
+                Color::Blue.bold().paint("󰠅 Subscription 1")
+            ));
+            assert_eq!(actual, expected);
+            dir.close()
+    }
+
+    #[test]
+    fn files_missing() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+
+        let dir_path = &dir.path().to_string_lossy();
+
+        let actual = ModuleRenderer::new("azurerm")
+            .env("AZURE_CONFIG_DIR", dir_path.as_ref())
+            .collect();
+        let expected = None;
+        assert_eq!(actual, expected);
+        dir.close()
+    }
+
 }

--- a/src/modules/azurerm.rs
+++ b/src/modules/azurerm.rs
@@ -19,15 +19,8 @@ struct AzureRMContext {
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "PascalCase")]
 struct PSAzureContext {
-    account: PSAzureAccount,
     #[serde(default, deserialize_with = "parse_azurerm_subscription")]
     subscription: PSAzureSubscription,
-}
-
-#[derive(Serialize, Deserialize, Clone)]
-#[serde(rename_all = "PascalCase")]
-struct PSAzureAccount {
-    id: String,
 }
 
 #[derive(Serialize, Deserialize, Clone, Default)]
@@ -35,6 +28,15 @@ struct PSAzureAccount {
 struct PSAzureSubscription {
     name: String,
     id: String,
+    extended_properties: PSAzureSubscriptionProperties
+}
+
+#[derive(Serialize, Deserialize, Clone, Default)]
+#[serde(rename_all = "PascalCase", default)]
+struct PSAzureSubscriptionProperties {
+    environment: String,
+    account: String,
+    home_tenant: String
 }
 
 fn parse_azurerm_subscription<'de, D>(d: D) -> Result<PSAzureSubscription, D::Error>
@@ -60,7 +62,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     }
     let azurerm_context = azurerm_context.unwrap();
     let subscription = azurerm_context.subscription;
-    let account = azurerm_context.account;
 
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter
@@ -78,7 +79,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                     .get(&subscription.name)
                     .copied()
                     .unwrap_or(&subscription.name))),
-                "username" => Some(Ok(&account.id)),
+                "username" => Some(Ok(&subscription.extended_properties.account)),
                 _ => None,
             })
             .parse(None, Some(context))

--- a/src/modules/azurerm.rs
+++ b/src/modules/azurerm.rs
@@ -1,0 +1,183 @@
+use serde::{Deserialize, Serialize, Deserializer};
+use std::fs;
+use std::path::PathBuf;
+use std::collections::HashMap;
+
+use super::{Context, Module, ModuleConfig};
+
+use crate::configs::azurerm::AzureRMConfig;
+use crate::formatter::StringFormatter;
+
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct AzureRMContext {
+    default_context_key: String,
+    // #[serde(default, skip)]
+    // environment_table: any,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    contexts: HashMap<String, PSAzureContext>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    extended_properties: HashMap<String, String>,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all = "PascalCase")]
+struct PSAzureContext {
+    account: PSAzureAccount,
+    tenant: PSAzureTenant,
+    // #[serde(default, skip_serializing_if = "Option::is_none")]
+    // subscription: Option<PSAzureSubscription>,
+    #[serde(default, deserialize_with="parse_subscription", flatten)]
+    subscription: PSAzureSubscription,
+    environment: PSAzureEnvironment,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    version_profile: Option<String>,
+    // #[serde(default, skip)]
+    // token_cache: String,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    extended_properties: HashMap<String, String>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Default)]
+#[serde(rename_all = "PascalCase", default)]
+struct PSAzureSubscription {
+  name: String,
+  id: String,
+  state: String,
+  #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+  extended_properties: HashMap<String, String>,
+}
+
+fn parse_subscription<'de, D>(d: D) -> Result<PSAzureSubscription, D::Error> where D: Deserializer<'de> {
+    Deserialize::deserialize(d)
+        .map(|x: Option<_>| {
+            x.unwrap_or_default()
+        })
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all = "PascalCase")]
+struct PSAzureAccount {
+  id: String,
+  #[serde(rename(deserialize = "Type"))]
+  account_type: String,
+  credential: Option<String>,
+  #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+  extended_properties: HashMap<String, String>,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all = "PascalCase")]
+struct PSAzureTenant {
+  id: String,
+  directory: Option<String>,
+  is_home: bool,
+  #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+  extended_properties: HashMap<String, String>,
+}
+
+
+
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all = "PascalCase")]
+struct PSAzureEnvironment {
+  name: String,
+  #[serde(rename(deserialize = "Type"))]
+  environment_type: String,
+  on_premise: bool,
+  #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+  extended_properties: HashMap<String, String>,
+  // ad_tenant: String
+}
+
+
+pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let mut module = context.new_module("azurerm");
+    let config = AzureRMConfig::try_load(module.config);
+
+    if config.disabled {
+        return None;
+    };
+
+    let subscription: Option<PSAzureSubscription> = get_azure_profile_info(context);
+
+    if subscription.is_none() {
+        log::info!("Could not find Subscriptions in azureProfile.json");
+        return None;
+    }
+
+    let subscription = subscription.unwrap();
+
+    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
+        formatter
+            .map_meta(|variable, _| match variable {
+                "symbol" => Some(config.symbol),
+                _ => None,
+            })
+            .map_style(|variable| match variable {
+                "style" => Some(Ok(config.style)),
+                _ => None,
+            })
+            .map(|variable| match variable {
+                "subscription" => Some(Ok(config
+                    .subscription_aliases
+                    .get(&subscription.name)
+                    .copied()
+                    .unwrap_or(&subscription.name))),
+                // "username" => Some(Ok(&subscription.user.name)),
+                _ => None,
+            })
+            .parse(None, Some(context))
+    });
+
+    module.set_segments(match parsed {
+        Ok(segments) => segments,
+        Err(error) => {
+            log::warn!("Error in module `azurerm`:\n{}", error);
+            return None;
+        }
+    });
+
+    Some(module)
+}
+
+fn get_azure_profile_info(context: &Context) -> Option<PSAzureSubscription> {
+    let mut config_path = get_config_file_location(context)?;
+    config_path.push("AzureRmContext.json");
+
+    let azurerm_contexts = load_azure_profile(&config_path)?;
+    let azurerm_context_key = &azurerm_contexts.default_context_key;
+    let azurerm_context  = azurerm_contexts.contexts.get(azurerm_context_key).unwrap();
+       
+    // let context = 
+    //     azurerm_contexts
+    //     .contexts
+    //     .get(azurerm_context_key).unwrap_or_default();
+    Some(azurerm_context.to_owned().subscription)
+}
+
+fn load_azure_profile(config_path: &PathBuf) -> Option<AzureRMContext> {
+    let json_data = fs::read_to_string(config_path).ok()?;
+    let sanitized_json_data = json_data.strip_prefix('\u{feff}').unwrap_or(&json_data);
+    if let Ok(azurerm_contexts) = serde_json::from_str::<AzureRMContext>(sanitized_json_data) {
+        // let azurerm_context_key = azure_profile.default_context_key;
+        // let azurerm_context = azure_profile.contexts.get(&azurerm_context_key);
+        // Some(azurerm_context)
+        Some(azurerm_contexts)
+    } else {
+        log::info!("Failed to parse azure profile.");
+        None
+    }
+}
+
+fn get_config_file_location(context: &Context) -> Option<PathBuf> {
+    context
+        .get_env("AZURE_CONFIG_DIR")
+        .map(PathBuf::from)
+        .or_else(|| {
+            let mut home = context.get_home()?;
+            home.push(".azure");
+            Some(home)
+        })
+}

--- a/src/modules/azurerm.rs
+++ b/src/modules/azurerm.rs
@@ -103,11 +103,9 @@ fn get_azurerm_context_info(context: &Context) -> Option<PSAzureContext> {
 
     if azurerm_context.subscription.is_none() {
         None
-    }
-    else {
+    } else {
         Some(azurerm_context)
     }
-
 }
 
 fn load_azurerm_context(config_path: &PathBuf) -> Option<AzureRMContext> {

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -229,6 +229,7 @@ pub fn description(module: &str) -> &'static str {
     match module {
         "aws" => "The current AWS region and profile",
         "azure" => "The current Azure subscription",
+        "azurerm" => "The current Azure subscription for the Azure PowerShell modules",
         "battery" => "The current charge of the device's battery and its current charging status",
         "buf" => "The currently installed version of the Buf CLI",
         "bun" => "The currently installed version of the Bun",

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -1,6 +1,7 @@
 // While adding out new module add out module to src/module.rs ALL_MODULES const array also.
 mod aws;
 mod azure;
+mod azurerm;
 mod buf;
 mod bun;
 mod c;
@@ -109,6 +110,7 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
             // Default ordering is handled in configs/starship_root.rs
             "aws" => aws::module(context),
             "azure" => azure::module(context),
+            "azurerm" => azurerm::module(context),
             #[cfg(feature = "battery")]
             "battery" => battery::module(context),
             "buf" => buf::module(context),


### PR DESCRIPTION
#### Description
Adds a alternative version of the Azure module for use with Azure PowerShell, as they store their context files separately using different formats. ~It still needs some tests to be written up for it.~

#### Motivation and Context
I use both the Azure PowerShell module and Azure CLI for my work, and the existing Azure module only supports Azure CLI. Originally I wanted to augment the existing module, I decided to make it a separate module instead as the context file structure is more complicated than what AzureCLI uses. 

#### Screenshots (if appropriate):
![image](https://github.com/starship/starship/assets/11744820/b5cda57f-6c85-4dfd-a4a8-72755f99d4b9)

#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [X] I have tested using **Linux**
- [X] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
