### PR TITLE
 fix(container): Corrected systemd-nspawn identification

### DIFF
--- a/src/modules/container.rs
+++ b/src/modules/container.rs
@@ -1,4 +1,5 @@
 use super::{Context, Module};
+use std::fs;
 
 #[cfg(not(target_os = "linux"))]
 pub fn module<'a>(_context: &'a Context) -> Option<Module<'a>> {
@@ -20,10 +21,17 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             // OpenVZ
             return Some("OpenVZ".into());
         }
-
         if context_path(context, "/run/host/container-manager").exists() {
-            // OCI
-            return Some("OCI".into());
+            match fs::read_to_string("/run/host/container-manager"){
+                Ok(content) => {
+                    if content.contains("systemd-nspawn"){
+                        return Some("nspawn".into())
+                    } else{
+                        return Some("OCI".into())
+                    }
+                },
+                Err(_) => return None,
+            }
         }
 
         let container_env_path = context_path(context, "/run/.containerenv");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
I have added a check, that will read the contents of "container-manger" file before deciding to show 'OCI' or 'nspawn'.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix to Issue : https://github.com/starship/starship/issues/5937

#### Screenshots (if appropriate):
BEFORE : 
![Screenshot from 2024-04-25 14-34-33](https://github.com/starship/starship/assets/167696496/46bbc70d-27dc-497b-9c3c-8a0e9825ef78)

AFTER : 
![Screenshot from 2024-04-28 10-51-40](https://github.com/starship/starship/assets/167696496/bb06ca50-0da8-4193-8e38-8734de3966a9)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

