### PR TITLE
ci: add preliminary windows codesigning via signpath

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,7 +123,33 @@ jobs:
         run: >
           cargo wix -v --no-build --nocapture -I install/windows/main.wxs
           --target ${{ matrix.target }}
-          --output target/wix/starship-${{ matrix.target }}.msi
+          --output target/${{ matrix.target }}/release/starship-${{ matrix.target }}.msi
+
+      - name: Sign | Upload [Windows]
+        continue-on-error: true
+        if: matrix.os == 'windows-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: unsigned-${{ matrix.name }}
+          path: |
+            target/${{ matrix.target }}/release/starship.exe
+            target/${{ matrix.target }}/release/starship-${{ matrix.target }}.msi
+
+      - name: Sign | Sign [Windows]
+        continue-on-error: true
+        if: matrix.os == 'windows-latest'
+        uses: signpath/github-action-submit-signing-request@v0.3
+        with:
+          api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
+          organization-id: '${{ vars.SIGNPATH_ORGANIZATION_ID }}'
+          project-slug: 'starship'
+          signing-policy-slug: 'test-signing'
+          github-artifact-name: 'unsigned-${{ matrix.name }}'
+          wait-for-completion: false
+          # TODO use release-signing certificate:
+          # signing-policy-slug: 'release-signing'
+          # wait-for-completion: true
+          # output-artifact-directory: 'target/${{ matrix.target }}/release'
 
       - name: Post Build | Prepare artifacts [Windows]
         if: matrix.os == 'windows-latest'
@@ -151,7 +177,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: starship-${{ matrix.target }}.msi
-          path: target/wix/starship-${{ matrix.target }}.msi
+          path: target/${{ matrix.target }}/release/starship-${{ matrix.target }}.msi
 
   # Notarize starship binaries for MacOS and build notarized pkg installers
   notarize_and_pkgbuild:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -201,7 +201,9 @@ jobs:
       - name: Build | Installer [Windows]
         continue-on-error: true
         if: matrix.os == 'windows-latest' && matrix.rust == 'stable'
-        run: cargo wix --dbg-build -v --nocapture -I install/windows/main.wxs
+        run: >
+          cargo wix --dbg-build -v --nocapture -I install/windows/main.wxs
+          --output target/debug/starship-x86_64-pc-windows-msvc.msi
 
       - name: Build | Chocolatey Package [Windows]
         continue-on-error: true
@@ -218,6 +220,29 @@ jobs:
           pwsh ./install/windows/choco/update.ps1
         env:
           STARSHIP_VERSION: v1.2.3
+
+      - name: Sign | Upload Executable [Windows]
+        uses: actions/upload-artifact@v4
+        continue-on-error: true
+        if: matrix.os == 'windows-latest' && matrix.rust == 'stable' && github.event_name == 'push' && github.repository == 'starship/starship'
+        with:
+          name: unsigned-artifacts-dbg
+          path: |
+            target/debug/starship.exe
+            target/debug/starship-x86_64-pc-windows-msvc.msi
+
+      - name: Sign | Sign [Windows]
+        uses: signpath/github-action-submit-signing-request@v0.3
+        continue-on-error: true
+        if: matrix.os == 'windows-latest' && matrix.rust == 'stable' && github.event_name == 'push' && github.repository == 'starship/starship'
+        with:
+          api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
+          organization-id: '${{ vars.SIGNPATH_ORGANIZATION_ID }}'
+          project-slug: 'starship'
+          github-artifact-name: 'unsigned-artifacts-dbg'
+          signing-policy-slug: 'test-signing'
+          wait-for-completion: true
+          output-artifact-directory: target/debug
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/README.md
+++ b/README.md
@@ -433,6 +433,8 @@ Please check out these previous works that helped inspire the creation of starsh
 
 Support this project by [becoming a sponsor](https://github.com/sponsors/starship). Your name or logo will show up here with a link to your website.
 
+- Free code signing provided by [SignPath.io], certificate by [SignPath Foundation]
+
 <p align="center">
     <br>
     <img width="100" src="https://raw.githubusercontent.com/starship/starship/master/media/icon.png" alt="Starship rocket icon">
@@ -458,6 +460,8 @@ This project is [ISC](https://github.com/starship/starship/blob/master/LICENSE) 
 [OSS]: https://software.opensuse.org/package/starship
 [pkgsrc]: https://pkgsrc.se/shells/starship
 [scoop]: https://github.com/ScoopInstaller/Main/blob/master/bucket/starship.json
+[SignPath Foundation]: https://signpath.org
+[SignPath.io]: https://signpath.io
 [termux]: https://github.com/termux/termux-packages/tree/master/packages/starship
 [void linux packages]: https://github.com/void-linux/void-packages/tree/master/srcpkgs/starship
 [winget]: https://github.com/microsoft/winget-pkgs/tree/master/manifests/s/Starship/Starship


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR adds windows code signing via signpath on a preliminary basis to test the integration until we are issued a release certificate.
To sign the executables and installers at the same time, I also modified the workflows to put both in the same directory.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
