### PR TITLE
ci: enable aarch64 msi building

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,8 +98,7 @@ jobs:
 
       - name: Setup | Install cargo-wix [Windows]
         continue-on-error: true
-        # aarch64 is only supported in wix 4.0 development builds
-        if: matrix.os == 'windows-latest' && matrix.target != 'aarch64-pc-windows-msvc'
+        if: matrix.os == 'windows-latest'
         run: cargo install --version 0.3.4 cargo-wix
         env:
           # cargo-wix does not require static crt
@@ -119,7 +118,7 @@ jobs:
 
       - name: Build | Installer [Windows]
         continue-on-error: true
-        if: matrix.os == 'windows-latest' && matrix.target != 'aarch64-pc-windows-msvc'
+        if: matrix.os == 'windows-latest'
         run: >
           cargo wix -v --no-build --nocapture -I install/windows/main.wxs
           --target ${{ matrix.target }}
@@ -147,7 +146,7 @@ jobs:
 
       - name: Release | Upload installer artifacts [Windows]
         continue-on-error: true
-        if: matrix.os == 'windows-latest' && matrix.target != 'aarch64-pc-windows-msvc'
+        if: matrix.os == 'windows-latest'
         uses: actions/upload-artifact@v4
         with:
           name: starship-${{ matrix.target }}.msi
@@ -320,9 +319,9 @@ jobs:
     needs: [release_please, github_build, upload_artifacts]
     if: ${{ needs.release_please.outputs.release_created == 'true' }}
     env:
-      URL_64: https://github.com/starship/starship/releases/download/${{ needs.release_please.outputs.tag_name }}/starship-x86_64-pc-windows-msvc.msi
-      URL_32: https://github.com/starship/starship/releases/download/${{ needs.release_please.outputs.tag_name }}/starship-i686-pc-windows-msvc.msi
-      URL_ARM: https://github.com/starship/starship/releases/download/${{ needs.release_please.outputs.tag_name }}/starship-aarch64-pc-windows-msvc.zip
+      URL_64: https://github.com/starship/starship/releases/download/${{ needs.release_please.outputs.tag_name }}/starship-x86_64-pc-windows-msvc
+      URL_32: https://github.com/starship/starship/releases/download/${{ needs.release_please.outputs.tag_name }}/starship-i686-pc-windows-msvc
+      URL_ARM: https://github.com/starship/starship/releases/download/${{ needs.release_please.outputs.tag_name }}/starship-aarch64-pc-windows-msvc
     steps:
       # Publishing will fail if the repo is too far behind the upstream
       - run: gh repo sync matchai/winget-pkgs
@@ -331,7 +330,11 @@ jobs:
       - run: |
           $version = '${{ needs.release_please.outputs.tag_name }}'.replace('v', '')
           iwr https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
-          ./wingetcreate.exe update Starship.Starship -s -v $version -u $env:URL_64 $env:URL_32 $env:URL_ARM -t ${{ secrets.GH_PAT }}
+          ./wingetcreate.exe update Starship.Starship -s -v $version `
+            -u ${{ env.URL_64 }}.msi  ${{ env.URL_64 }}.zip `
+               ${{ env.URL_32 }}.msi  ${{ env.URL_32 }}.zip `
+               ${{ env.URL_ARM }}.msi ${{ env.URL_ARM }}.zip `
+            -t ${{ secrets.GH_PAT }}
 
   choco_update:
     name: Update Chocolatey Package


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
The Wix v3 version on the gh windows images has been updated at some point and now supports building `aarch64-pc-windows-msvc` MSI installer without needing to upgrade to wix v4/v5 (#5407).
I uncommented the special checks excluding `aarch64-pc-windows-msvc` and refactored the wingetcreate invocation to push all installers.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
