### PR TITLE
perf(scala): use scala-cli first to avoid timeout

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -287,6 +287,10 @@ Elixir 1.10 (compiled with Erlang/OTP 22)\n",
             stdout: String::from("OpenJDK 64-Bit Server VM (13.0.2+8) for bsd-amd64 JRE (13.0.2+8), built on Feb  6 2020 02:07:52 by \"brew\" with clang 4.2.1 Compatible Apple LLVM 11.0.0 (clang-1100.0.33.17)"),
             stderr: String::default(),
         }),
+        "scala-cli version --scala" => Some(CommandOutput {
+            stdout: String::from("3.4.1"),
+            stderr: String::default(),
+        }),
         "scalac -version" => Some(CommandOutput {
             stdout: String::from("Scala compiler version 2.13.5 -- Copyright 2002-2020, LAMP/EPFL and Lightbend, Inc."),
             stderr: String::default(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description

- update Scala module to try first to retrieve the current version with `scala-cli` and fallback to current ( slower ) `scclac` 
- update `utils.rs` mock commands to call `scala-cli` and get back the current Scala version `3.4.1` before `scalac` which returns `... 2.13.5 ...` . Keep them distinct for clearer testing.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Partial fix to #5583

`scalac --version` has some noticeable ( most likely jvm ) startup time. Depending on the computer, this can cause a timeout. `scala-cli version --scala` usually has little to no startup time since it is either compiled to a native binary or use its own embedded GraalVM. It also outputs exactly and only the version number which avoids some string parsing.

![image](https://github.com/starship/starship/assets/55251330/c1e77fe2-f362-4142-8e3f-57c36459eec5)


This can only be considered a partial fix as `scala-cli` is not a hard requirement to work with Scala whereas `scalac` is.

#### Screenshots (if appropriate):

![image](https://github.com/starship/starship/assets/55251330/ebaa778b-e759-46ae-950e-698f73b26152)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
