### PR TITLE
Fixed Winget Installation Error

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ Install the latest version for your system with the MSI-installers from the [rel
 Install Starship using any of the following package managers:
 
 | Repository      | Instructions                                            |
-| --------------- | --------------------------------------------------------|
+| --------------- | ------------------------------------------------------- |
 | **[crates.io]** | `cargo install starship --locked`                       |
 | [Chocolatey]    | `choco install starship`                                |
 | [conda-forge]   | `conda install -c conda-forge starship`                 |

--- a/README.md
+++ b/README.md
@@ -264,12 +264,12 @@ Install the latest version for your system with the MSI-installers from the [rel
 
 Install Starship using any of the following package managers:
 
-| Repository      | Instructions                            |
-| --------------- | --------------------------------------- |
-| **[crates.io]** | `cargo install starship --locked`       |
-| [Chocolatey]    | `choco install starship`                |
-| [conda-forge]   | `conda install -c conda-forge starship` |
-| [Scoop]         | `scoop install starship`                |
+| Repository      | Instructions                                            |
+| --------------- | --------------------------------------------------------|
+| **[crates.io]** | `cargo install starship --locked`                       |
+| [Chocolatey]    | `choco install starship`                                |
+| [conda-forge]   | `conda install -c conda-forge starship`                 |
+| [Scoop]         | `scoop install starship`                                |
 | [winget]        | `winget install --id Starship.Starship --source winget` |
 
 </details>

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ Install Starship using any of the following package managers:
 | [Chocolatey]    | `choco install starship`                |
 | [conda-forge]   | `conda install -c conda-forge starship` |
 | [Scoop]         | `scoop install starship`                |
-| [winget]        | `winget install --id Starship.Starship -- source winget` |
+| [winget]        | `winget install --id Starship.Starship --source winget` |
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ Install Starship using any of the following package managers:
 | [Chocolatey]    | `choco install starship`                |
 | [conda-forge]   | `conda install -c conda-forge starship` |
 | [Scoop]         | `scoop install starship`                |
-| [winget]        | `winget install --id Starship.Starship` |
+| [winget]        | `winget install --id Starship.Starship -- source winget` |
 
 </details>
 


### PR DESCRIPTION
The Winget installation command is missing the source flag I have added that 

<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
The installation command is causing the error
`winget install --id Starship.Starship`


```cmd

C:\Users\user>winget install --id Starship.Starship
Failed when searching source: msstore
An unexpected error occurred while executing the command:
WinHttpSendRequest: 12030: The connection with the server was terminated abnormally


The following packages were found among the working sources.
Please specify one of them using the --source option to proceed.
Name     Id                Source
---------------------------------
starship Starship.Starship winget

```

#### Motivation and Context
When I tried to install using the winget command it caused source not defined error. If the source is defined it will easy for installation. 

#### Screenshots (if appropriate):


#### How Has This Been Tested?

- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
