### PR TITLE
fix(direnv): replace nonexistent "orange" color with "bright-yellow"

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -367,7 +367,7 @@
         "format": "[$symbol$loaded/$allowed]($style) ",
         "loaded_msg": "loaded",
         "not_allowed_msg": "not allowed",
-        "style": "bold orange",
+        "style": "bold bright-yellow",
         "symbol": "direnv ",
         "unloaded_msg": "not loaded"
       },
@@ -2082,14 +2082,12 @@
           "type": "string"
         },
         "charging_symbol": {
-          "default": null,
           "type": [
             "string",
             "null"
           ]
         },
         "discharging_symbol": {
-          "default": null,
           "type": [
             "string",
             "null"
@@ -2760,14 +2758,12 @@
           "type": "string"
         },
         "repo_root_style": {
-          "default": null,
           "type": [
             "string",
             "null"
           ]
         },
         "before_repo_root_style": {
-          "default": null,
           "type": [
             "string",
             "null"
@@ -2812,7 +2808,7 @@
           "type": "string"
         },
         "style": {
-          "default": "bold orange",
+          "default": "bold bright-yellow",
           "type": "string"
         },
         "disabled": {
@@ -4282,35 +4278,30 @@
           "type": "string"
         },
         "user_pattern": {
-          "default": null,
           "type": [
             "string",
             "null"
           ]
         },
         "symbol": {
-          "default": null,
           "type": [
             "string",
             "null"
           ]
         },
         "style": {
-          "default": null,
           "type": [
             "string",
             "null"
           ]
         },
         "context_alias": {
-          "default": null,
           "type": [
             "string",
             "null"
           ]
         },
         "user_alias": {
-          "default": null,
           "type": [
             "string",
             "null"

--- a/src/configs/direnv.rs
+++ b/src/configs/direnv.rs
@@ -27,7 +27,7 @@ impl<'a> Default for DirenvConfig<'a> {
         Self {
             format: "[$symbol$loaded/$allowed]($style) ",
             symbol: "direnv ",
-            style: "bold orange",
+            style: "bold bright-yellow",
             disabled: true,
             detect_extensions: vec![],
             detect_files: vec![".envrc"],

--- a/src/modules/direnv.rs
+++ b/src/modules/direnv.rs
@@ -184,6 +184,7 @@ mod tests {
 
     use crate::test::ModuleRenderer;
     use crate::utils::CommandOutput;
+    use nu_ansi_term::Color;
     use std::io;
     use std::path::Path;
     #[test]
@@ -227,7 +228,7 @@ mod tests {
 
         std::fs::File::create(rc_path)?.sync_all()?;
 
-        let renderer = ModuleRenderer::new("direnv")
+        let actual = ModuleRenderer::new("direnv")
             .config(toml::toml! {
                 [direnv]
                 disabled = false
@@ -239,13 +240,14 @@ mod tests {
                     stdout: status_cmd_output_with_rc(dir.path(), false, "0", true),
                     stderr: String::default(),
                 }),
-            );
+            )
+            .collect();
+        let expected = Some(format!(
+            "{} ",
+            Color::LightYellow.bold().paint("direnv not loaded/allowed")
+        ));
 
-        assert_eq!(
-            Some("direnv not loaded/allowed ".to_string()),
-            renderer.collect()
-        );
-
+        assert_eq!(expected, actual);
         dir.close()
     }
     #[test]
@@ -255,7 +257,7 @@ mod tests {
 
         std::fs::File::create(rc_path)?.sync_all()?;
 
-        let renderer = ModuleRenderer::new("direnv")
+        let actual = ModuleRenderer::new("direnv")
             .config(toml::toml! {
                 [direnv]
                 disabled = false
@@ -267,13 +269,14 @@ mod tests {
                     stdout: status_cmd_output_with_rc_json(dir.path(), 1, 0),
                     stderr: String::default(),
                 }),
-            );
+            )
+            .collect();
+        let expected = Some(format!(
+            "{} ",
+            Color::LightYellow.bold().paint("direnv not loaded/allowed")
+        ));
 
-        assert_eq!(
-            Some("direnv not loaded/allowed ".to_string()),
-            renderer.collect()
-        );
-
+        assert_eq!(expected, actual);
         dir.close()
     }
     #[test]
@@ -283,7 +286,7 @@ mod tests {
 
         std::fs::File::create(rc_path)?.sync_all()?;
 
-        let renderer = ModuleRenderer::new("direnv")
+        let actual = ModuleRenderer::new("direnv")
             .config(toml::toml! {
                 [direnv]
                 disabled = false
@@ -295,13 +298,14 @@ mod tests {
                     stdout: status_cmd_output_with_rc(dir.path(), true, "0", true),
                     stderr: String::default(),
                 }),
-            );
+            )
+            .collect();
+        let expected = Some(format!(
+            "{} ",
+            Color::LightYellow.bold().paint("direnv loaded/allowed")
+        ));
 
-        assert_eq!(
-            Some("direnv loaded/allowed ".to_string()),
-            renderer.collect()
-        );
-
+        assert_eq!(expected, actual);
         dir.close()
     }
     #[test]
@@ -311,7 +315,7 @@ mod tests {
 
         std::fs::File::create(rc_path)?.sync_all()?;
 
-        let renderer = ModuleRenderer::new("direnv")
+        let actual = ModuleRenderer::new("direnv")
             .config(toml::toml! {
                 [direnv]
                 disabled = false
@@ -323,13 +327,14 @@ mod tests {
                     stdout: status_cmd_output_with_rc_json(dir.path(), 0, 0),
                     stderr: String::default(),
                 }),
-            );
+            )
+            .collect();
+        let expected = Some(format!(
+            "{} ",
+            Color::LightYellow.bold().paint("direnv loaded/allowed")
+        ));
 
-        assert_eq!(
-            Some("direnv loaded/allowed ".to_string()),
-            renderer.collect()
-        );
-
+        assert_eq!(expected, actual);
         dir.close()
     }
     #[test]
@@ -339,7 +344,7 @@ mod tests {
 
         std::fs::File::create(rc_path)?.sync_all()?;
 
-        let renderer = ModuleRenderer::new("direnv")
+        let actual = ModuleRenderer::new("direnv")
             .config(toml::toml! {
                 [direnv]
                 disabled = false
@@ -351,13 +356,14 @@ mod tests {
                     stdout: status_cmd_output_with_rc(dir.path(), true, "2", true),
                     stderr: String::default(),
                 }),
-            );
+            )
+            .collect();
+        let expected = Some(format!(
+            "{} ",
+            Color::LightYellow.bold().paint("direnv loaded/denied")
+        ));
 
-        assert_eq!(
-            Some("direnv loaded/denied ".to_string()),
-            renderer.collect()
-        );
-
+        assert_eq!(expected, actual);
         dir.close()
     }
     #[test]
@@ -367,7 +373,7 @@ mod tests {
 
         std::fs::File::create(rc_path)?.sync_all()?;
 
-        let renderer = ModuleRenderer::new("direnv")
+        let actual = ModuleRenderer::new("direnv")
             .config(toml::toml! {
                 [direnv]
                 disabled = false
@@ -379,13 +385,14 @@ mod tests {
                     stdout: status_cmd_output_with_rc_json(dir.path(), 0, 1),
                     stderr: String::default(),
                 }),
-            );
+            )
+            .collect();
+        let expected = Some(format!(
+            "{} ",
+            Color::LightYellow.bold().paint("direnv loaded/not allowed")
+        ));
 
-        assert_eq!(
-            Some("direnv loaded/not allowed ".to_string()),
-            renderer.collect()
-        );
-
+        assert_eq!(expected, actual);
         dir.close()
     }
     #[test]
@@ -395,7 +402,7 @@ mod tests {
 
         std::fs::File::create(rc_path)?.sync_all()?;
 
-        let renderer = ModuleRenderer::new("direnv")
+        let actual = ModuleRenderer::new("direnv")
             .config(toml::toml! {
                 [direnv]
                 disabled = false
@@ -407,13 +414,14 @@ mod tests {
                     stdout: status_cmd_output_with_rc_json(dir.path(), 0, 2),
                     stderr: String::default(),
                 }),
-            );
+            )
+            .collect();
+        let expected = Some(format!(
+            "{} ",
+            Color::LightYellow.bold().paint("direnv loaded/denied")
+        ));
 
-        assert_eq!(
-            Some("direnv loaded/denied ".to_string()),
-            renderer.collect()
-        );
-
+        assert_eq!(expected, actual);
         dir.close()
     }
     fn status_cmd_output_without_rc() -> String {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
`bold orange` doesn't exist in `predefined_color` and the module text was therefore just white.

#### How Has This Been Tested?
- [x] I have tested using **Linux**

By manually adjusting my config to be `style = 'bold bright-yellow'.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
  - Can I directly update the default in all translations?

