### PR TITLE
fix(dotnet): Remove duplicate `v` in dotnet version

### DIFF
--- a/src/modules/dotnet.rs
+++ b/src/modules/dotnet.rs
@@ -294,7 +294,7 @@ fn map_str_to_lower(value: Option<&OsStr>) -> Option<String> {
 
 fn get_version_from_cli(context: &Context) -> Option<String> {
     let version_output = context.exec_cmd("dotnet", &["--version"])?;
-    Some(format!("v{}", version_output.stdout.trim()))
+    Some(version_output.stdout.trim())
 }
 
 fn get_latest_sdk_from_cli(context: &Context) -> Option<String> {

--- a/src/modules/dotnet.rs
+++ b/src/modules/dotnet.rs
@@ -294,7 +294,7 @@ fn map_str_to_lower(value: Option<&OsStr>) -> Option<String> {
 
 fn get_version_from_cli(context: &Context) -> Option<String> {
     let version_output = context.exec_cmd("dotnet", &["--version"])?;
-    Some(version_output.stdout.trim())
+    Some(version_output.stdout.trim().to_string())
 }
 
 fn get_latest_sdk_from_cli(context: &Context) -> Option<String> {


### PR DESCRIPTION
Every language version provider returns the version without a leading 'v', and the shared code then prepends the 'v'. Take a look at Python for example.

The Dotnet provider prepends a 'v' however, causing the version to be printed like 'vv8.0.203'.

This happens for example with this configuration

```
[dotnet]
symbol = '🥅 '
style = 'bg:color_blue'
format = '[[$symbol($version)](fg:color_fg0 bg:color_blue)]($style)'
heuristic = false
```

Where simply `$dotnet\` would be used somewhere in the prompt. Then navigate to a folder contain a dotnet project.

<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
Removes the string formatting which prepends the 'v' character.

#### Motivation and Context
Removes duplicate `v` in dotnet version string.

#### Screenshots (if appropriate):

<img width="451" alt="image" src="https://github.com/starship/starship/assets/4535280/cd791d7b-5002-4013-9361-6a259536841c">


#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
