### PR TITLE
chore(deps): handle signpath update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,6 +127,7 @@ jobs:
       - name: Sign | Upload [Windows]
         continue-on-error: true
         if: matrix.os == 'windows-latest'
+        id: unsigned-artifacts
         uses: actions/upload-artifact@v4
         with:
           name: unsigned-${{ matrix.name }}
@@ -143,7 +144,7 @@ jobs:
           organization-id: '${{ vars.SIGNPATH_ORGANIZATION_ID }}'
           project-slug: 'starship'
           signing-policy-slug: 'test-signing'
-          github-artifact-name: 'unsigned-${{ matrix.name }}'
+          github-artifact-id: '${{ steps.unsigned-artifacts.outputs.artifact-id }}'
           wait-for-completion: false
           # TODO use release-signing certificate:
           # signing-policy-slug: 'release-signing'

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -224,6 +224,7 @@ jobs:
       - name: Sign | Upload Executable [Windows]
         uses: actions/upload-artifact@v4
         continue-on-error: true
+        id: unsigned-artifacts
         if: matrix.os == 'windows-latest' && matrix.rust == 'stable' && github.event_name == 'push' && github.repository == 'starship/starship'
         with:
           name: unsigned-artifacts-dbg
@@ -239,7 +240,7 @@ jobs:
           api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
           organization-id: '${{ vars.SIGNPATH_ORGANIZATION_ID }}'
           project-slug: 'starship'
-          github-artifact-name: 'unsigned-artifacts-dbg'
+          github-artifact-id: '${{ steps.unsigned-artifacts.outputs.artifact-id }}'
           signing-policy-slug: 'test-signing'
           wait-for-completion: true
           output-artifact-directory: target/debug


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Renovate inadvertently broke the signpath integration because an upcoming breaking change to the action parameters did not cause a CI failure.
~~Signpath infrastructure doesn't support v0.4 either until Monday, so I will keep this PR as a draft until then.~~

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
