### PR TITLE
Update README.md

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2277,7 +2277,7 @@ By default the module will be shown if any of the following conditions are met:
 | `detect_extensions` | `['hx', 'hxml']`                                                                                | Which extensions should trigger this module.                              |
 | `detect_files`      | `['project.xml', 'Project.xml', 'application.xml', 'haxelib.json', 'hxformat.json', '.haxerc']` | Which filenames should trigger this module.                               |
 | `detect_folders`    | `['.haxelib', 'haxe_libraries']`                                                                | Which folders should trigger this modules.                                |
-| `symbol`            | `'⌘ '`                                                                                          | A format string representing the symbol of Helm.                          |
+| `symbol`            | `'⌘ '`                                                                                          | A format string representing the symbol of Haxe.                          |
 | `style`             | `'bold fg:202'`                                                                                 | The style for the module.                                                 |
 | `disabled`          | `false`                                                                                         | Disables the `haxe` module.                                               |
 


### PR DESCRIPTION
Fix Helm->Haxe

#### Description
Helm was used instead of Haxe in this section, probably a copy/paste/search/replace error.
