### PR TITLE
Docs: Updated gleam documentation to reference gleam in symbols section instead of go

### DIFF
--- a/docs/ar-SA/config/README.md
+++ b/docs/ar-SA/config/README.md
@@ -1981,7 +1981,7 @@ The `gleam` module shows the currently installed version of [Gleam](https://glea
 | ------------------- | ------------------------------------ | ------------------------------------------------------------------------- |
 | `format`            | `'via [$symbol($version )]($style)'` | The format for the module.                                                |
 | `version_format`    | `'v${raw}'`                          | The version format. Available vars are `raw`, `major`, `minor`, & `patch` |
-| `symbol`            | `'⭐ '`                               | A format string representing the symbol of Go.                            |
+| `symbol`            | `'⭐ '`                               | A format string representing the symbol of Gleam.                            |
 | `detect_extensions` | `['gleam']`                          | Which extensions should trigger this module.                              |
 | `detect_files`      | `['gleam.toml']`                     | Which filenames should trigger this module.                               |
 | `style`             | `'bold #FFAFF3'`                     | The style for the module.                                                 |

--- a/docs/bn-BD/config/README.md
+++ b/docs/bn-BD/config/README.md
@@ -1981,7 +1981,7 @@ The `gleam` module shows the currently installed version of [Gleam](https://glea
 | ------------------- | ------------------------------------ | ------------------------------------------------------------------------- |
 | `format`            | `'via [$symbol($version )]($style)'` | The format for the module.                                                |
 | `version_format`    | `'v${raw}'`                          | The version format. Available vars are `raw`, `major`, `minor`, & `patch` |
-| `symbol`            | `'⭐ '`                               | A format string representing the symbol of Go.                            |
+| `symbol`            | `'⭐ '`                               | A format string representing the symbol of Gleam.                            |
 | `detect_extensions` | `['gleam']`                          | Which extensions should trigger this module.                              |
 | `detect_files`      | `['gleam.toml']`                     | Which filenames should trigger this module.                               |
 | `style`             | `'bold #FFAFF3'`                     | The style for the module.                                                 |

--- a/docs/ckb-IR/config/README.md
+++ b/docs/ckb-IR/config/README.md
@@ -1981,7 +1981,7 @@ The `gleam` module shows the currently installed version of [Gleam](https://glea
 | ------------------- | ------------------------------------ | ------------------------------------------------------------------------- |
 | `format`            | `'via [$symbol($version )]($style)'` | The format for the module.                                                |
 | `version_format`    | `'v${raw}'`                          | The version format. Available vars are `raw`, `major`, `minor`, & `patch` |
-| `symbol`            | `'⭐ '`                               | A format string representing the symbol of Go.                            |
+| `symbol`            | `'⭐ '`                               | A format string representing the symbol of Gleam.                            |
 | `detect_extensions` | `['gleam']`                          | Which extensions should trigger this module.                              |
 | `detect_files`      | `['gleam.toml']`                     | Which filenames should trigger this module.                               |
 | `style`             | `'bold #FFAFF3'`                     | The style for the module.                                                 |

--- a/docs/es-ES/config/README.md
+++ b/docs/es-ES/config/README.md
@@ -1981,7 +1981,7 @@ The `gleam` module shows the currently installed version of [Gleam](https://glea
 | ------------------- | ------------------------------------ | --------------------------------------------------------------------------------------- |
 | `format`            | `'via [$symbol($version )]($style)'` | El formato del módulo.                                                                  |
 | `version_format`    | `'v${raw}'`                          | El formato de versión. Las variables disponibles son `raw`, `major`, `minor`, & `patch` |
-| `symbol`            | `'⭐ '`                               | Una cadena de formato que representa el símbolo de Go.                                  |
+| `symbol`            | `'⭐ '`                               | Una cadena de formato que representa el símbolo de Gleam.                                  |
 | `detect_extensions` | `['gleam']`                          | Qué extensiones deberían activar este módulo.                                           |
 | `detect_files`      | `['gleam.toml']`                     | Qué nombres de archivo deberían activar este módulo.                                    |
 | `style`             | `'bold #FFAFF3'`                     | El estilo del módulo.                                                                   |

--- a/docs/fr-FR/config/README.md
+++ b/docs/fr-FR/config/README.md
@@ -1981,7 +1981,7 @@ The `gleam` module shows the currently installed version of [Gleam](https://glea
 | ------------------------------------ | ------------------------------------ | ------------------------------------------------------------------------------------------ |
 | `format`                             | `'via [$symbol($version )]($style)'` | Format du module.                                                                          |
 | `version_format`                     | `'v${raw}'`                          | Le format de la version. Les variables disponibles sont `raw`, `major`, `minor`, & `patch` |
-| `symbole`                            | `'⭐ '`                               | Une chaîne de caractères représentant le symbole de Go.                                    |
+| `symbole`                            | `'⭐ '`                               | Une chaîne de caractères représentant le symbole de Gleam.                                    |
 | `detect_extensionsdetect_extensions` | `['gleam']`                          | Les extensions qui déclenchent ce module.                                                  |
 | `detect_files`                       | `['gleam.toml']`                     | Les fichiers qui activent ce module.                                                       |
 | `style`                              | `'bold #FFAFF3'`                     | Le style pour le module.                                                                   |

--- a/docs/id-ID/config/README.md
+++ b/docs/id-ID/config/README.md
@@ -1981,7 +1981,7 @@ The `gleam` module shows the currently installed version of [Gleam](https://glea
 | ------------------- | ------------------------------------ | ----------------------------------------------------------------------------------- |
 | `format`            | `'via [$symbol($version )]($style)'` | Format dari modul.                                                                  |
 | `version_format`    | `'v${raw}'`                          | Format dari versi. Variabel yang tersedia adalah `raw`, `major`, `minor`, & `patch` |
-| `symbol`            | `'⭐ '`                               | A format string representing the symbol of Go.                                      |
+| `symbol`            | `'⭐ '`                               | A format string representing the symbol of Gleam.                                      |
 | `detect_extensions` | `['gleam']`                          | Ekstensi mana yang sebaiknya memicu modul ini.                                      |
 | `detect_files`      | `['gleam.toml']`                     | filenames mana yang sebaiknya memicu modul ini.                                     |
 | `style`             | `'bold #FFAFF3'`                     | Gaya penataan untuk modul.                                                          |

--- a/docs/it-IT/config/README.md
+++ b/docs/it-IT/config/README.md
@@ -1981,7 +1981,7 @@ The `gleam` module shows the currently installed version of [Gleam](https://glea
 | ------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------- |
 | `format`            | `'via [$symbol($version )]($style)'` | The format for the module.                                                                  |
 | `version_format`    | `'v${raw}'`                          | Il formato della versione. Le variabili disponibili sono `raw`, `major`, `minor`, & `patch` |
-| `symbol`            | `'⭐ '`                               | A format string representing the symbol of Go.                                              |
+| `symbol`            | `'⭐ '`                               | A format string representing the symbol of Gleam.                                              |
 | `detect_extensions` | `['gleam']`                          | Quali estensioni dovrebbero attivare questo modulo.                                         |
 | `detect_files`      | `['gleam.toml']`                     | Quali nomi di file dovrebbero attivare questo modulo.                                       |
 | `style`             | `'bold #FFAFF3'`                     | Lo stile per il modulo.                                                                     |

--- a/docs/ko-KR/config/README.md
+++ b/docs/ko-KR/config/README.md
@@ -1981,7 +1981,7 @@ The `gleam` module shows the currently installed version of [Gleam](https://glea
 | ------------------- | ------------------------------------ | ------------------------------------------------------------------------- |
 | `format`            | `'via [$symbol($version )]($style)'` | The format for the module.                                                |
 | `version_format`    | `'v${raw}'`                          | The version format. Available vars are `raw`, `major`, `minor`, & `patch` |
-| `기호`                | `'⭐ '`                               | A format string representing the symbol of Go.                            |
+| `기호`                | `'⭐ '`                               | A format string representing the symbol of Gleam.                            |
 | `detect_extensions` | `['gleam']`                          | Which extensions should trigger this module.                              |
 | `detect_files`      | `['gleam.toml']`                     | Which filenames should trigger this module.                               |
 | `style`             | `'bold #FFAFF3'`                     | The style for the module.                                                 |

--- a/docs/nl-NL/config/README.md
+++ b/docs/nl-NL/config/README.md
@@ -1981,7 +1981,7 @@ The `gleam` module shows the currently installed version of [Gleam](https://glea
 | ------------------- | ------------------------------------ | ------------------------------------------------------------------------- |
 | `format`            | `'via [$symbol($version )]($style)'` | The format for the module.                                                |
 | `version_format`    | `'v${raw}'`                          | The version format. Available vars are `raw`, `major`, `minor`, & `patch` |
-| `symbol`            | `'⭐ '`                               | A format string representing the symbol of Go.                            |
+| `symbol`            | `'⭐ '`                               | A format string representing the symbol of Gleam.                            |
 | `detect_extensions` | `['gleam']`                          | Which extensions should trigger this module.                              |
 | `detect_files`      | `['gleam.toml']`                     | Which filenames should trigger this module.                               |
 | `style`             | `'bold #FFAFF3'`                     | The style for the module.                                                 |

--- a/docs/no-NO/config/README.md
+++ b/docs/no-NO/config/README.md
@@ -1981,7 +1981,7 @@ The `gleam` module shows the currently installed version of [Gleam](https://glea
 | ------------------- | ------------------------------------ | ------------------------------------------------------------------------- |
 | `format`            | `'via [$symbol($version )]($style)'` | The format for the module.                                                |
 | `version_format`    | `'v${raw}'`                          | The version format. Available vars are `raw`, `major`, `minor`, & `patch` |
-| `symbol`            | `'⭐ '`                               | A format string representing the symbol of Go.                            |
+| `symbol`            | `'⭐ '`                               | A format string representing the symbol of Gleam.                            |
 | `detect_extensions` | `['gleam']`                          | Which extensions should trigger this module.                              |
 | `detect_files`      | `['gleam.toml']`                     | Which filenames should trigger this module.                               |
 | `style`             | `'bold #FFAFF3'`                     | The style for the module.                                                 |

--- a/docs/pl-PL/config/README.md
+++ b/docs/pl-PL/config/README.md
@@ -1981,7 +1981,7 @@ The `gleam` module shows the currently installed version of [Gleam](https://glea
 | ------------------- | ------------------------------------ | ------------------------------------------------------------------------- |
 | `format`            | `'via [$symbol($version )]($style)'` | The format for the module.                                                |
 | `version_format`    | `'v${raw}'`                          | The version format. Available vars are `raw`, `major`, `minor`, & `patch` |
-| `symbol`            | `'⭐ '`                               | A format string representing the symbol of Go.                            |
+| `symbol`            | `'⭐ '`                               | A format string representing the symbol of Gleam.                            |
 | `detect_extensions` | `['gleam']`                          | Which extensions should trigger this module.                              |
 | `detect_files`      | `['gleam.toml']`                     | Which filenames should trigger this module.                               |
 | `style`             | `'bold #FFAFF3'`                     | The style for the module.                                                 |

--- a/docs/pt-BR/config/README.md
+++ b/docs/pt-BR/config/README.md
@@ -1981,7 +1981,7 @@ The `gleam` module shows the currently installed version of [Gleam](https://glea
 | ------------------- | ------------------------------------ | ----------------------------------------------------------------------------------- |
 | `format`            | `'via [$symbol($version )]($style)'` | O formato do módulo.                                                                |
 | `version_format`    | `'v${raw}'`                          | A versão formatada. As variáveis disponíveis são `raw`, `major`, `minor`, & `patch` |
-| `symbol`            | `'⭐ '`                               | O formato da string que representa o simbolo do Go.                                 |
+| `symbol`            | `'⭐ '`                               | O formato da string que representa o simbolo do Gleam.                                 |
 | `detect_extensions` | `['gleam']`                          | Quais extensões devem ativar este módulo.                                           |
 | `detect_files`      | `['gleam.toml']`                     | Quais nomes de arquivos devem ativar este módulo.                                   |
 | `style`             | `'bold #FFAFF3'`                     | O estilo do módulo.                                                                 |

--- a/docs/pt-PT/config/README.md
+++ b/docs/pt-PT/config/README.md
@@ -1981,7 +1981,7 @@ The `gleam` module shows the currently installed version of [Gleam](https://glea
 | ------------------- | ------------------------------------ | ------------------------------------------------------------------------- |
 | `format`            | `'via [$symbol($version )]($style)'` | The format for the module.                                                |
 | `version_format`    | `'v${raw}'`                          | The version format. Available vars are `raw`, `major`, `minor`, & `patch` |
-| `symbol`            | `'⭐ '`                               | A format string representing the symbol of Go.                            |
+| `symbol`            | `'⭐ '`                               | A format string representing the symbol of Gleam.                            |
 | `detect_extensions` | `['gleam']`                          | Which extensions should trigger this module.                              |
 | `detect_files`      | `['gleam.toml']`                     | Which filenames should trigger this module.                               |
 | `style`             | `'bold #FFAFF3'`                     | The style for the module.                                                 |

--- a/docs/ru-RU/config/README.md
+++ b/docs/ru-RU/config/README.md
@@ -1981,7 +1981,7 @@ The `gleam` module shows the currently installed version of [Gleam](https://glea
 | ------------------- | ------------------------------------ | ------------------------------------------------------------------------- |
 | `format`            | `'via [$symbol($version )]($style)'` | Формат модуля.                                                            |
 | `version_format`    | `'v${raw}'`                          | The version format. Available vars are `raw`, `major`, `minor`, & `patch` |
-| `symbol`            | `'⭐ '`                               | A format string representing the symbol of Go.                            |
+| `symbol`            | `'⭐ '`                               | A format string representing the symbol of Gleam.                            |
 | `detect_extensions` | `['gleam']`                          | Which extensions should trigger this module.                              |
 | `detect_files`      | `['gleam.toml']`                     | Which filenames should trigger this module.                               |
 | `style`             | `'bold #FFAFF3'`                     | Стиль модуля.                                                             |

--- a/docs/tr-TR/config/README.md
+++ b/docs/tr-TR/config/README.md
@@ -1981,7 +1981,7 @@ The `gleam` module shows the currently installed version of [Gleam](https://glea
 | ------------------- | ------------------------------------ | ------------------------------------------------------------------------- |
 | `format`            | `'via [$symbol($version )]($style)'` | The format for the module.                                                |
 | `version_format`    | `'v${raw}'`                          | The version format. Available vars are `raw`, `major`, `minor`, & `patch` |
-| `symbol`            | `'⭐ '`                               | A format string representing the symbol of Go.                            |
+| `symbol`            | `'⭐ '`                               | A format string representing the symbol of Gleam.                            |
 | `detect_extensions` | `['gleam']`                          | Which extensions should trigger this module.                              |
 | `detect_files`      | `['gleam.toml']`                     | Which filenames should trigger this module.                               |
 | `stil`              | `'bold #FFAFF3'`                     | The style for the module.                                                 |

--- a/docs/vi-VN/config/README.md
+++ b/docs/vi-VN/config/README.md
@@ -1981,7 +1981,7 @@ The `gleam` module shows the currently installed version of [Gleam](https://glea
 | ------------------- | ------------------------------------ | ------------------------------------------------------------------------- |
 | `format`            | `'via [$symbol($version )]($style)'` | Định dạng cho module.                                                     |
 | `version_format`    | `'v${raw}'`                          | The version format. Available vars are `raw`, `major`, `minor`, & `patch` |
-| `symbol`            | `'⭐ '`                               | Một format string đại diện cho biểu tượng của Go.                         |
+| `symbol`            | `'⭐ '`                               | Một format string đại diện cho biểu tượng của Gleam.                         |
 | `detect_extensions` | `['gleam']`                          | Những tiện ích mở rộng nào sẽ kích hoạt mô-đun này.                       |
 | `detect_files`      | `['gleam.toml']`                     | Những tên tệp nào sẽ kích hoạt mô-đun này.                                |
 | `style`             | `'bold #FFAFF3'`                     | Kiểu cho module.                                                          |

--- a/docs/zh-CN/config/README.md
+++ b/docs/zh-CN/config/README.md
@@ -1981,7 +1981,7 @@ The `gleam` module shows the currently installed version of [Gleam](https://glea
 | ------------------- | ------------------------------------ | ---------------------------------------------- |
 | `format`            | `'via [$symbol($version )]($style)'` | 组件格式化模板。                                       |
 | `version_format`    | `'v${raw}'`                          | 版本格式 可用的有 `raw`, `major`, `minor` 和 `patch`    |
-| `符号`                | `'⭐ '`                               | A format string representing the symbol of Go. |
+| `符号`                | `'⭐ '`                               | A format string representing the symbol of Gleam. |
 | `detect_extensions` | `['gleam']`                          | Which extensions should trigger this module.   |
 | `detect_files`      | `['gleam.toml']`                     | 哪些文件应触发此组件                                     |
 | `style`             | `'bold #FFAFF3'`                     | 此组件的样式。                                        |

--- a/docs/zh-TW/config/README.md
+++ b/docs/zh-TW/config/README.md
@@ -1981,7 +1981,7 @@ The `gleam` module shows the currently installed version of [Gleam](https://glea
 | ------------------- | ------------------------------------ | ------------------------------------------------------------------------- |
 | `format`            | `'via [$symbol($version )]($style)'` | The format for the module.                                                |
 | `version_format`    | `'v${raw}'`                          | The version format. Available vars are `raw`, `major`, `minor`, & `patch` |
-| `symbol`            | `'⭐ '`                               | A format string representing the symbol of Go.                            |
+| `symbol`            | `'⭐ '`                               | A format string representing the symbol of Gleam.                            |
 | `detect_extensions` | `['gleam']`                          | Which extensions should trigger this module.                              |
 | `detect_files`      | `['gleam.toml']`                     | Which filenames should trigger this module.                               |
 | `style`             | `'bold #FFAFF3'`                     | 這個模組的風格。                                                                  |


### PR DESCRIPTION
In the gleam documentation it was referencing go under the symbol instead of gleam. Missed during copy & paste I imagine.

#### Description
Updates all the language files that was using the word go in the gleam section to reference the symbol correctly.


#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [x] I have tested using **Windows**

Documentation-only change, no tests


#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
