### PR TITLE
chore: fix rust 1.79 lint warnings

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -2095,12 +2095,14 @@
           "type": "string"
         },
         "charging_symbol": {
+          "default": null,
           "type": [
             "string",
             "null"
           ]
         },
         "discharging_symbol": {
+          "default": null,
           "type": [
             "string",
             "null"
@@ -2771,12 +2773,14 @@
           "type": "string"
         },
         "repo_root_style": {
+          "default": null,
           "type": [
             "string",
             "null"
           ]
         },
         "before_repo_root_style": {
+          "default": null,
           "type": [
             "string",
             "null"
@@ -4291,30 +4295,35 @@
           "type": "string"
         },
         "user_pattern": {
+          "default": null,
           "type": [
             "string",
             "null"
           ]
         },
         "symbol": {
+          "default": null,
           "type": [
             "string",
             "null"
           ]
         },
         "style": {
+          "default": null,
           "type": [
             "string",
             "null"
           ]
         },
         "context_alias": {
+          "default": null,
           "type": [
             "string",
             "null"
           ]
         },
         "user_alias": {
+          "default": null,
           "type": [
             "string",
             "null"

--- a/src/context.rs
+++ b/src/context.rs
@@ -86,7 +86,7 @@ impl<'a> Context<'a> {
     /// Identify the current working directory and create an instance of Context
     /// for it. "logical-path" is used when a shell allows the "current working directory"
     /// to be something other than a file system path (like powershell provider specific paths).
-    pub fn new(arguments: Properties, target: Target) -> Context<'a> {
+    pub fn new(arguments: Properties, target: Target) -> Self {
         let shell = Context::get_shell();
 
         // Retrieve the "current directory".
@@ -126,7 +126,7 @@ impl<'a> Context<'a> {
         path: PathBuf,
         logical_path: PathBuf,
         env: Env<'a>,
-    ) -> Context<'a> {
+    ) -> Self {
         let config = StarshipConfig::initialize(&get_config_path_os(&env));
 
         // If the vector is zero-length, we should pretend that we didn't get a
@@ -184,7 +184,7 @@ impl<'a> Context<'a> {
     }
 
     /// Sets the context config, overwriting the existing config
-    pub fn set_config(mut self, config: toml::Table) -> Context<'a> {
+    pub fn set_config(mut self, config: toml::Table) -> Self {
         self.root_config = StarshipRootConfig::load(&config);
         self.config = StarshipConfig {
             config: Some(config),

--- a/src/module.rs
+++ b/src/module.rs
@@ -122,7 +122,7 @@ pub struct Module<'a> {
 
 impl<'a> Module<'a> {
     /// Creates a module with no segments.
-    pub fn new(name: &str, desc: &str, config: Option<&'a toml::Value>) -> Module<'a> {
+    pub fn new(name: &str, desc: &str, config: Option<&'a toml::Value>) -> Self {
         Module {
             config,
             name: name.to_string(),

--- a/src/modules/username.rs
+++ b/src/modules/username.rs
@@ -119,7 +119,6 @@ fn is_ssh_session(context: &Context) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use gix::config::key;
 
     use crate::test::ModuleRenderer;
 

--- a/src/print.rs
+++ b/src/print.rs
@@ -125,7 +125,7 @@ pub fn get_prompt(context: Context) -> String {
     // color sequences for this specific shell
     let shell_wrapped_output =
         wrap_colorseq_for_shell(AnsiStrings(&module_strings).to_string(), context.shell);
-    write!(buf, "{}", shell_wrapped_output).unwrap();
+    write!(buf, "{shell_wrapped_output}").unwrap();
 
     if context.target == Target::Right {
         // right prompts generally do not allow newlines

--- a/src/serde_utils.rs
+++ b/src/serde_utils.rs
@@ -103,9 +103,9 @@ impl ValueDeserializer<'_> {
 }
 
 impl<'de> IntoDeserializer<'de> for ValueDeserializer<'de> {
-    type Deserializer = ValueDeserializer<'de>;
+    type Deserializer = Self;
 
-    fn into_deserializer(self) -> ValueDeserializer<'de> {
+    fn into_deserializer(self) -> Self {
         self
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Rust 1.79 has just released with an update to clippy. This PR also uses this occasion to update the config-schema (`null` was removed and added back in updates that were nevertheless auto-merged) ~~and fix more warnings from nightly clippy~~ (dropped).

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
