### PR TITLE
feat(purescript): add support for spago-next configuration files

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -1376,7 +1376,9 @@
           "purs"
         ],
         "detect_files": [
-          "spago.dhall"
+          "spago.dhall",
+          "spago.yaml",
+          "spago.lock"
         ],
         "detect_folders": [],
         "disabled": false,
@@ -2095,12 +2097,14 @@
           "type": "string"
         },
         "charging_symbol": {
+          "default": null,
           "type": [
             "string",
             "null"
           ]
         },
         "discharging_symbol": {
+          "default": null,
           "type": [
             "string",
             "null"
@@ -2771,12 +2775,14 @@
           "type": "string"
         },
         "repo_root_style": {
+          "default": null,
           "type": [
             "string",
             "null"
           ]
         },
         "before_repo_root_style": {
+          "default": null,
           "type": [
             "string",
             "null"
@@ -4291,30 +4297,35 @@
           "type": "string"
         },
         "user_pattern": {
+          "default": null,
           "type": [
             "string",
             "null"
           ]
         },
         "symbol": {
+          "default": null,
           "type": [
             "string",
             "null"
           ]
         },
         "style": {
+          "default": null,
           "type": [
             "string",
             "null"
           ]
         },
         "context_alias": {
+          "default": null,
           "type": [
             "string",
             "null"
           ]
         },
         "user_alias": {
+          "default": null,
           "type": [
             "string",
             "null"
@@ -5147,7 +5158,9 @@
         },
         "detect_files": {
           "default": [
-            "spago.dhall"
+            "spago.dhall",
+            "spago.yaml",
+            "spago.lock"
           ],
           "type": "array",
           "items": {

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -3593,20 +3593,22 @@ The `purescript` module shows the currently installed version of [PureScript](ht
 By default the module will be shown if any of the following conditions are met:
 
 - The current directory contains a `spago.dhall` file
+- The current directory contains a `spago.yaml` file
+- The current directory contains a `spago.lock` file
 - The current directory contains a file with the `.purs` extension
 
 ### Options
 
-| Option              | Default                              | Description                                                               |
-| ------------------- | ------------------------------------ | ------------------------------------------------------------------------- |
-| `format`            | `'via [$symbol($version )]($style)'` | The format for the module.                                                |
-| `version_format`    | `'v${raw}'`                          | The version format. Available vars are `raw`, `major`, `minor`, & `patch` |
-| `symbol`            | `'<=> '`                             | The symbol used before displaying the version of PureScript.              |
-| `detect_extensions` | `['purs']`                           | Which extensions should trigger this module.                              |
-| `detect_files`      | `['spago.dhall']`                    | Which filenames should trigger this module.                               |
-| `detect_folders`    | `[]`                                 | Which folders should trigger this module.                                 |
-| `style`             | `'bold white'`                       | The style for the module.                                                 |
-| `disabled`          | `false`                              | Disables the `purescript` module.                                         |
+| Option              | Default                                       | Description                                                               |
+| ------------------- | --------------------------------------------- | ------------------------------------------------------------------------- |
+| `format`            | `'via [$symbol($version )]($style)'`          | The format for the module.                                                |
+| `version_format`    | `'v${raw}'`                                   | The version format. Available vars are `raw`, `major`, `minor`, & `patch` |
+| `symbol`            | `'<=> '`                                      | The symbol used before displaying the version of PureScript.              |
+| `detect_extensions` | `['purs']`                                    | Which extensions should trigger this module.                              |
+| `detect_files`      | `['spago.dhall', 'spago.yaml', 'spago.lock']` | Which filenames should trigger this module.                               |
+| `detect_folders`    | `[]`                                          | Which folders should trigger this module.                                 |
+| `style`             | `'bold white'`                                | The style for the module.                                                 |
+| `disabled`          | `false`                                       | Disables the `purescript` module.                                         |
 
 ### Variables
 

--- a/src/configs/purescript.rs
+++ b/src/configs/purescript.rs
@@ -27,7 +27,7 @@ impl<'a> Default for PureScriptConfig<'a> {
             style: "bold white",
             disabled: false,
             detect_extensions: vec!["purs"],
-            detect_files: vec!["spago.dhall"],
+            detect_files: vec!["spago.dhall", "spago.yaml", "spago.lock"],
             detect_folders: vec![],
         }
     }

--- a/src/modules/purescript.rs
+++ b/src/modules/purescript.rs
@@ -92,4 +92,26 @@ mod tests {
         assert_eq!(expected, actual);
         dir.close()
     }
+
+    #[test]
+    fn folder_with_spago_yaml_file() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join("spago.yaml"))?.sync_all()?;
+
+        let actual = ModuleRenderer::new("purescript").path(dir.path()).collect();
+        let expected = Some(format!("via {}", Color::White.bold().paint("<=> v0.13.5 ")));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn folder_with_spago_lock_file() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join("spago.yaml"))?.sync_all()?;
+
+        let actual = ModuleRenderer::new("purescript").path(dir.path()).collect();
+        let expected = Some(format!("via {}", Color::White.bold().paint("<=> v0.13.5 ")));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
 }

--- a/src/modules/purescript.rs
+++ b/src/modules/purescript.rs
@@ -107,7 +107,7 @@ mod tests {
     #[test]
     fn folder_with_spago_lock_file() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
-        File::create(dir.path().join("spago.yaml"))?.sync_all()?;
+        File::create(dir.path().join("spago.lock"))?.sync_all()?;
 
         let actual = ModuleRenderer::new("purescript").path(dir.path()).collect();
         let expected = Some(format!("via {}", Color::White.bold().paint("<=> v0.13.5 ")));


### PR DESCRIPTION
Updates purescript detection for spago-next projects

<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
In upcoming spago projects, the configuration file is changing from spago.dhall -> spago.yaml and spago.lock. This will detect both styles for the time being. See [intro post](https://discourse.purescript.org/t/announcing-spago-next-a-purescript-rewrite-registry-support-and-more/3737) for further details

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Will support detection of newer created purescript projects started with spago

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
