### PR TITLE
feat(gcloud): Disabled gcloud module when active config hasn't been set

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -2095,12 +2095,14 @@
           "type": "string"
         },
         "charging_symbol": {
+          "default": null,
           "type": [
             "string",
             "null"
           ]
         },
         "discharging_symbol": {
+          "default": null,
           "type": [
             "string",
             "null"
@@ -2771,12 +2773,14 @@
           "type": "string"
         },
         "repo_root_style": {
+          "default": null,
           "type": [
             "string",
             "null"
           ]
         },
         "before_repo_root_style": {
+          "default": null,
           "type": [
             "string",
             "null"
@@ -4291,30 +4295,35 @@
           "type": "string"
         },
         "user_pattern": {
+          "default": null,
           "type": [
             "string",
             "null"
           ]
         },
         "symbol": {
+          "default": null,
           "type": [
             "string",
             "null"
           ]
         },
         "style": {
+          "default": null,
           "type": [
             "string",
             "null"
           ]
         },
         "context_alias": {
+          "default": null,
           "type": [
             "string",
             "null"
           ]
         },
         "user_alias": {
+          "default": null,
           "type": [
             "string",
             "null"

--- a/src/modules/gcloud.rs
+++ b/src/modules/gcloud.rs
@@ -467,6 +467,16 @@ project = very-long-project-name
     }
 
     #[test]
+    fn no_active_config() {
+        let actual = ModuleRenderer::new("gcloud")
+            .env("CLOUDSDK_ACTIVE_CONFIG_NAME", "NONE")
+            .collect();
+        let expected = None;
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
     fn active_config_manually_overridden() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         let active_config_path = dir.path().join("active_config");

--- a/src/modules/gcloud.rs
+++ b/src/modules/gcloud.rs
@@ -89,6 +89,10 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     }
 
     let (config_name, config_path) = get_current_config(context)?;
+
+    if config_name == "NONE" {
+        return None;
+    }
     let gcloud_context = GcloudContext::new(&config_name, &config_path);
     let account: Lazy<Option<Account<'_>>, _> = Lazy::new(|| gcloud_context.get_account());
 


### PR DESCRIPTION
This change will disable Google Cloud module when there is no active config set

#### Description
<!--- Describe your changes in detail -->

#### Motivation and Context
It has been suggested to implement there https://github.com/starship/starship/issues/3658


This PR is based on those:
closes #4092
closes #3692
closes #3658


#### How Has This Been Tested?

- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
