### PR TITLE
fix(install): clean temporary files after installation

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -175,6 +175,14 @@ elevate_priv() {
   fi
 }
 
+clean_tmp() {
+  archive="$1"
+  ext="$2"
+
+  tmp=${archive%.${ext}} # extract tmp file base name
+  rm -f "${archive}" ${tmp}
+}
+
 install() {
   ext="$1"
 
@@ -189,13 +197,23 @@ install() {
   fi
   info "$msg"
 
-  archive=$(get_tmpfile "$ext")
+  archive=$(get_tmpfile "${ext}")
 
   # download to the temp file
-  download "${archive}" "${URL}"
+  if ! download "${archive}" "${URL}"
+  then
+    clean_tmp "${archive}" "${ext}"
+    exit 1
+  fi
 
   # unpack the temp file to the bin dir, using sudo if required
-  unpack "${archive}" "${BIN_DIR}" "${sudo}"
+  if ! unpack "${archive}" "${BIN_DIR}" "${sudo}"
+  then
+    clean_tmp "${archive}" "${ext}"
+    exit 1
+  fi
+
+  clean_tmp "${archive}" "${ext}"
 }
 
 # Currently supporting:


### PR DESCRIPTION
Delete archive and extracted content from the temporary directory when installation is complete

#### Description

Keep track of the temporary files and delete them before exiting the install function

#### Motivation and Context
Fixes the following issue for Linux : https://github.com/starship/starship/issues/6067
Closes #6067

#### Screenshots (if appropriate):

#### How Has This Been Tested?

Tested by running install.sh (for both installation and update).
Also ran `cargo test`

- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:

- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
