### PR TITLE
feat(character): allow specifying more exit codes as successful

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -177,6 +177,7 @@
         "format": "$symbol ",
         "success_symbol": "[❯](bold green)",
         "error_symbol": "[❯](bold red)",
+        "success_exit_codes": [],
         "vimcmd_symbol": "[❮](bold green)",
         "vimcmd_visual_symbol": "[❮](bold yellow)",
         "vimcmd_replace_symbol": "[❮](bold purple)",
@@ -2281,6 +2282,14 @@
         "error_symbol": {
           "type": "string",
           "default": "[❯](bold red)"
+        },
+        "success_exit_codes": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "default": []
         },
         "vimcmd_symbol": {
           "type": "string",

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -790,6 +790,7 @@ look at [this example](#with-custom-error-shape).
 | `format`                    | `'$symbol '`         | The format string used before the text input.                                           |
 | `success_symbol`            | `'[❯](bold green)'`  | The format string used before the text input if the previous command succeeded.         |
 | `error_symbol`              | `'[❯](bold red)'`    | The format string used before the text input if the previous command failed.            |
+| `success_exit_codes`        | `[]`                 | List of additional exit codes that are rendered as a success (0 is always a success).   |
 | `vimcmd_symbol`             | `'[❮](bold green)'`  | The format string used before the text input if the shell is in vim normal mode.        |
 | `vimcmd_replace_one_symbol` | `'[❮](bold purple)'` | The format string used before the text input if the shell is in vim `replace_one` mode. |
 | `vimcmd_replace_symbol`     | `'[❮](bold purple)'` | The format string used before the text input if the shell is in vim replace mode.       |

--- a/src/configs/character.rs
+++ b/src/configs/character.rs
@@ -11,6 +11,7 @@ pub struct CharacterConfig<'a> {
     pub format: &'a str,
     pub success_symbol: &'a str,
     pub error_symbol: &'a str,
+    pub success_exit_codes: Vec<i32>,
     #[serde(alias = "vicmd_symbol")]
     pub vimcmd_symbol: &'a str,
     pub vimcmd_visual_symbol: &'a str,
@@ -25,6 +26,7 @@ impl Default for CharacterConfig<'_> {
             format: "$symbol ",
             success_symbol: "[❯](bold green)",
             error_symbol: "[❯](bold red)",
+            success_exit_codes: vec![],
             vimcmd_symbol: "[❮](bold green)",
             vimcmd_visual_symbol: "[❮](bold yellow)",
             vimcmd_replace_symbol: "[❮](bold purple)",

--- a/src/modules/character.rs
+++ b/src/modules/character.rs
@@ -25,9 +25,14 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let config: CharacterConfig = CharacterConfig::try_load(module.config);
 
     let props = &context.properties;
-    let exit_code = props.status_code.as_deref().unwrap_or("0");
+    let exit_code = props
+        .status_code
+        .as_deref()
+        .unwrap_or("0")
+        .parse::<i32>()
+        .unwrap_or(0);
     let keymap = props.keymap.as_str();
-    let exit_success = exit_code == "0";
+    let exit_success = exit_code == 0 || config.success_exit_codes.contains(&exit_code);
 
     // Match shell "keymap" names to normalized vi modes
     // NOTE: in vi mode, fish reports normal mode as "default".
@@ -106,6 +111,35 @@ mod test {
         for status in &exit_values {
             let actual = ModuleRenderer::new("character").status(*status).collect();
             assert_eq!(expected, actual);
+        }
+    }
+
+    #[test]
+    fn success_exit_codes_handling() {
+        let module_config = toml::toml! {
+            [character]
+            success_exit_codes = [146, 42]
+        };
+        let expected_success = Some(format!("{} ", Color::Green.bold().paint("❯")));
+        let expected_fail = Some(format!("{} ", Color::Red.bold().paint("❯")));
+
+        let exit_values_success = [0, 42, 146];
+        let exit_values_fail = [-5000, 1, 145, 147];
+
+        for status in &exit_values_success {
+            let actual = ModuleRenderer::new("character")
+                .config(module_config.clone())
+                .status(*status)
+                .collect();
+            assert_eq!(expected_success, actual);
+        }
+
+        for status in &exit_values_fail {
+            let actual = ModuleRenderer::new("character")
+                .config(module_config.clone())
+                .status(*status)
+                .collect();
+            assert_eq!(expected_fail, actual);
         }
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Allow specifying more exit codes as "success" for the purpose of rendering the character style.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When a process is suspended using ^Z key combo the shell receives an exit code of 148, this comes from adding the `SIGTSTP` (20) to 128 (see <https://www.gnu.org/software/libc/manual/html_node/Job-Control-Signals.html#index-SIGTSTP> and <https://tldp.org/LDP/abs/html/exitcodes.html> for detailed information). I'd like to render the `character` module as a success in those cases. As this is just a personal preference I opted for adding a new configuration option that anyone can use to customize this aspect and add whatever exit codes should be regarded as a success by the `character` module.

Fixes issue #6301.

#### Screenshots (if appropriate):
![2024-07-04 191659](https://github.com/starship/starship/assets/896399/0d5221b7-a298-4cb7-9285-fb058f9ffec7)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
