### PR TITLE
feat(terraform): support opentofu for terraform version detection

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -1741,6 +1741,16 @@
     },
     "terraform": {
       "default": {
+        "commands": [
+          [
+            "terraform",
+            "version"
+          ],
+          [
+            "tofu",
+            "version"
+          ]
+        ],
         "detect_extensions": [
           "tf",
           "tfplan",
@@ -6056,6 +6066,25 @@
           "type": "array",
           "items": {
             "type": "string"
+          }
+        },
+        "commands": {
+          "default": [
+            [
+              "terraform",
+              "version"
+            ],
+            [
+              "tofu",
+              "version"
+            ]
+          ],
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         }
       },

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -4371,10 +4371,11 @@ format = 'via [🏎  $version](red bold)'
 ## Terraform
 
 The `terraform` module shows the currently selected [Terraform workspace](https://www.terraform.io/docs/language/state/workspaces.html) and version.
+It supports both Hashicorp Terraform and OpenTofu for version detection.
 
 ::: tip
 
-By default the Terraform version is not shown, since this is slow for current versions of Terraform when a lot of plugins are in use.
+By default the Terraform/OpenTofu version is not shown, since this is slow for current versions when a lot of plugins are in use.
 If you still want to enable it, [follow the example shown below](#with-terraform-version).
 
 :::
@@ -4386,16 +4387,17 @@ By default the module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Option              | Default                              | Description                                                               |
-| ------------------- | ------------------------------------ | ------------------------------------------------------------------------- |
-| `format`            | `'via [$symbol$workspace]($style) '` | The format string for the module.                                         |
-| `version_format`    | `'v${raw}'`                          | The version format. Available vars are `raw`, `major`, `minor`, & `patch` |
-| `symbol`            | `'💠'`                               | A format string shown before the terraform workspace.                     |
-| `detect_extensions` | `['tf', 'tfplan', 'tfstate']`        | Which extensions should trigger this module.                              |
-| `detect_files`      | `[]`                                 | Which filenames should trigger this module.                               |
-| `detect_folders`    | `['.terraform']`                     | Which folders should trigger this module.                                 |
-| `style`             | `'bold 105'`                         | The style for the module.                                                 |
-| `disabled`          | `false`                              | Disables the `terraform` module.                                          |
+| Option              | Default                                                 | Description                                                               |
+| ------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `format`            | `'via [$symbol$workspace]($style) '`                    | The format string for the module.                                         |
+| `version_format`    | `'v${raw}'`                                             | The version format. Available vars are `raw`, `major`, `minor`, & `patch` |
+| `symbol`            | `'💠'`                                                  | A format string shown before the terraform workspace.                     |
+| `detect_extensions` | `['tf', 'tfplan', 'tfstate']`                           | Which extensions should trigger this module.                              |
+| `detect_files`      | `[]`                                                    | Which filenames should trigger this module.                               |
+| `detect_folders`    | `['.terraform']`                                        | Which folders should trigger this module.                                 |
+| `style`             | `'bold 105'`                                            | The style for the module.                                                 |
+| `disabled`          | `false`                                                 | Disables the `terraform` module.                                          |
+| `commands`          | `[ [ 'terraform', 'version' ], [ 'tofu', 'version' ] ]` | How to detect what the Terraform version is                               |
 
 ### Variables
 
@@ -4416,7 +4418,7 @@ By default the module will be shown if any of the following conditions are met:
 # ~/.config/starship.toml
 
 [terraform]
-format = '[🏎💨 $version$workspace]($style) '
+format = 'via [$symbol$version $workspace]($style) '
 ```
 
 #### Without Terraform version
@@ -4425,7 +4427,7 @@ format = '[🏎💨 $version$workspace]($style) '
 # ~/.config/starship.toml
 
 [terraform]
-format = '[🏎💨 $workspace]($style) '
+format = 'via [$symbol$workspace]($style) '
 ```
 
 ## Time

--- a/src/configs/terraform.rs
+++ b/src/configs/terraform.rs
@@ -16,6 +16,7 @@ pub struct TerraformConfig<'a> {
     pub detect_extensions: Vec<&'a str>,
     pub detect_files: Vec<&'a str>,
     pub detect_folders: Vec<&'a str>,
+    pub commands: Vec<Vec<&'a str>>,
 }
 
 impl<'a> Default for TerraformConfig<'a> {
@@ -29,6 +30,12 @@ impl<'a> Default for TerraformConfig<'a> {
             detect_extensions: vec!["tf", "tfplan", "tfstate"],
             detect_files: vec![],
             detect_folders: vec![".terraform"],
+            commands: vec![
+                // terraform is usually `terraform`
+                vec!["terraform", "version"],
+                // but for opentofu users, it'll be `tofu`
+                vec!["tofu", "version"],
+            ],
         }
     }
 }

--- a/src/modules/terraform.rs
+++ b/src/modules/terraform.rs
@@ -147,6 +147,15 @@ on darwin_arm64
     }
 
     #[test]
+    fn test_parse_opentofu_version_prerelease() {
+        let input = "OpenTofu v1.8.0-alpha1";
+        assert_eq!(
+            parse_terraform_version(input),
+            Some("1.8.0-alpha1".to_string())
+        )
+    }
+
+    #[test]
     fn test_parse_terraform_version_development() {
         let input = "Terraform v0.12.14-dev (cca89f74)";
         assert_eq!(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description

Adds support for detecting the Terraform version when OpenTofu is used instead of Hashicorp Terraform.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I use OpenTofu with my homelab instead of Terraform, and wanted my Starship prompt to show the
version. :)

Closes #6302

#### Screenshots (if appropriate):

<img width="650" alt="Screenshot 2024-07-06 at 10 13 23 AM" src="https://github.com/starship/starship/assets/110747/63fe0b80-b0ca-4695-9806-7f2b511e33ee">

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

Test changes by both introducing unit tests and running a built version of Starship against
a couple of different Terraform/OpenTofu install setups on macOS. I don't have a Windows
machine handy, but can test on Linux if needed.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
