### PR TITLE
fix(package): support alternative gradle module version syntax

### DIFF
--- a/src/modules/package.rs
+++ b/src/modules/package.rs
@@ -110,7 +110,7 @@ fn get_gradle_version(context: &Context, config: &PackageConfig) -> Option<Strin
             format_version(&caps["version"], config.version_format)
         }).or_else(|| {
             let build_file_contents = context.read_file_from_pwd("build.gradle")?;
-            let re = Regex::new(r#"(?m)^version ['"](?P<version>[^'"]+)['"]$"#).unwrap(); /*dark magic*/
+            let re = Regex::new(r#"(?m)^version( |\s*=\s*)['"](?P<version>[^'"]+)['"]$"#).unwrap(); /*dark magic*/
             let caps = re.captures(&build_file_contents)?;
             format_version(&caps["version"], config.version_format)
 
@@ -910,6 +910,25 @@ license = "MIT"
     id 'test.plugin' version '0.2.0'
 }
 version '0.1.0'
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}";
+
+        let project_dir = create_project_dir()?;
+        fill_config(&project_dir, config_name, Some(config_content))?;
+        expect_output(&project_dir, Some("v0.1.0"), None);
+        project_dir.close()
+    }
+
+    #[test]
+    fn test_extract_gradle_version_setter_notation_single_quote() -> io::Result<()> {
+        let config_name = "build.gradle";
+        let config_content = "plugins {
+    id 'java'
+    id 'test.plugin' version '0.2.0'
+}
+version = '0.1.0'
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8


### PR DESCRIPTION


#### Description

I changed the regex in [`src/modules/package.rs:113`](https://github.com/starship/starship/blob/796a411602c9ca4e5103c54247440f4efe892918/src/modules/package.rs#L113)

https://github.com/starship/starship/blob/796a411602c9ca4e5103c54247440f4efe892918/src/modules/package.rs#L113

... so it matches lines like

```groovy
  version = '1.0'
```

... in addition to the syntax that was previously supported. 



#### Motivation and Context

My Gradle projects use the [version setting notation recommended in the documentation](https://docs.gradle.org/current/userguide/java_library_plugin.html#declaring_module_versions) and I want the version to show up in my prompt.

Closes #6079


#### How Has This Been Tested?

Added a unit test and ran `cargo test --lib`.

- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**


#### Checklist:

- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
