### PR TITLE
fix(docs): correct username options

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -4550,7 +4550,7 @@ these variables, one workaround is to set one of them with a dummy value.
 
 ### Example
 
-#### Always show the hostname
+#### Always show the username
 
 ```toml
 # ~/.config/starship.toml
@@ -4562,17 +4562,6 @@ format = 'user: [$user]($style) '
 disabled = false
 show_always = true
 aliases = { "corpuser034g" = "matchai" }
-```
-
-#### Hide the hostname in remote tmux sessions
-
-```toml
-# ~/.config/starship.toml
-
-[hostname]
-ssh_only = false
-detect_env_vars = ['!TMUX', 'SSH_CONNECTION']
-disabled = false
 ```
 
 ## Vagrant


### PR DESCRIPTION
These seem to have been copied from hostname and did not make sense

#### Description
These username config options seem to have been copied from hostname and did not make sense

#### Motivation and Context
Make the docs less confusing

#### Screenshots (if appropriate):

#### How Has This Been Tested?
its a doc change

#### Checklist:
it is a doc change and there are no tests
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
