### PR TITLE
feat(jujutsu): Adds jujutsu module

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -905,6 +905,22 @@
         }
       ]
     },
+    "jujutsu": {
+      "default": {
+        "detect_folders": [
+          ".jj"
+        ],
+        "disabled": false,
+        "format": "$symbol $commit_info ",
+        "symbol": "jj",
+        "template": "\nseparate(\" \",\n  change_id.shortest(6),\n  branches.map(|x| if(\n    x.name().substr(0, 20).starts_with(x.name()),\n    x.name().substr(0, 20),\n    x.name().substr(0, 19) ++ \"…\")\n  ).join(\" \"),\n  if(\n    description.first_line().substr(0, 24).starts_with(description.first_line()),\n    description.first_line().substr(0, 24),\n    description.first_line().substr(0, 23) ++ \"…\"\n  ),\n  if(conflict, \"conflict\"),\n  if(divergent, \"divergent\"),\n  if(hidden, \"hidden\"),\n)"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/JujutsuConfig"
+        }
+      ]
+    },
     "julia": {
       "default": {
         "detect_extensions": [
@@ -4108,6 +4124,37 @@
         "disabled": {
           "default": false,
           "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "JujutsuConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "$symbol $commit_info ",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "jj",
+          "type": "string"
+        },
+        "template": {
+          "default": "\nseparate(\" \",\n  change_id.shortest(6),\n  branches.map(|x| if(\n    x.name().substr(0, 20).starts_with(x.name()),\n    x.name().substr(0, 20),\n    x.name().substr(0, 19) ++ \"…\")\n  ).join(\" \"),\n  if(\n    description.first_line().substr(0, 24).starts_with(description.first_line()),\n    description.first_line().substr(0, 24),\n    description.first_line().substr(0, 23) ++ \"…\"\n  ),\n  if(conflict, \"conflict\"),\n  if(divergent, \"divergent\"),\n  if(hidden, \"hidden\"),\n)",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "detect_folders": {
+          "default": [
+            ".jj"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       },
       "additionalProperties": false

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2530,24 +2530,22 @@ separate(" ",
 )
 ```
 
-
 ### Options
 
-| Option              | Default                  | Description                                                               |
-| ------------------- | ------------------------ | ------------------------------------------------------------------------- |
-| `format`            | `'$symbol $commit_info ` | The format for the module.                                                |
-| `detect_folders`    | `['.jj']`                | Which folders should trigger this modules.                                |
-| `symbol`            | `'jj '`                  | A format string representing the symbol of Jujutsu.                       |
-| `template`          | See the template above   | Jujutsu template collects the `commit_info` value.                        |
-| `disabled`          | `false`                  | Disables the `jujutsu` module.                                            |
+| Option           | Default                 | Description                                         |
+| ---------------- | ----------------------- | --------------------------------------------------- |
+| `format`         | `'$symbol $commit_info` | The format for the module.                          |
+| `detect_folders` | `['.jj']`               | Which folders should trigger this modules.          |
+| `symbol`         | `'jj '`                 | A format string representing the symbol of Jujutsu. |
+| `template`       | See the template above  | Jujutsu template collects the `commit_info` value.  |
+| `disabled`       | `false`                 | Disables the `jujutsu` module.                      |
 
 ## Variables
 
-| Variable     | Example                        | Description                                      |
-| ------------ | ------------------------------ | ------------------------------------------------ |
-| symbol       |                                | Mirrors the value of option `symbol`             |
-| commit_info  | `main szuflg "initial commit"` | The output of the template                       |
-
+| Variable    | Example                        | Description                          |
+| ----------- | ------------------------------ | ------------------------------------ |
+| symbol      |                                | Mirrors the value of option `symbol` |
+| commit_info | `main szuflg "initial commit"` | The output of the template           |
 
 ## Julia
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -280,6 +280,7 @@ $git_commit\
 $git_state\
 $git_metrics\
 $git_status\
+$jujutsu\
 $hg_branch\
 $pijul_channel\
 $docker_context\
@@ -2497,6 +2498,56 @@ symbol = '+ '
 number_threshold = 4
 symbol_threshold = 0
 ```
+
+## Jujutsu
+
+The `jujutsu` module shows the current branch, change id, and description message of the commit.
+
+Information is gathered by running the following command:
+
+```shell
+jj log -r@ -n1 --ignore-working-copy --no-graph --color always -T $TEMPLATE
+```
+
+Default template is defined as follows:
+
+```
+separate(" ",
+  change_id.shortest(6),
+  branches.map(|x| if(
+    x.name().substr(0, 20).starts_with(x.name()),
+    x.name().substr(0, 20),
+    x.name().substr(0, 19) ++ "…")
+  ).join(" "),
+  if(
+    description.first_line().substr(0, 24).starts_with(description.first_line()),
+    description.first_line().substr(0, 24),
+    description.first_line().substr(0, 23) ++ "…"
+  ),
+  if(conflict, "conflict"),
+  if(divergent, "divergent"),
+  if(hidden, "hidden"),
+)
+```
+
+
+### Options
+
+| Option              | Default                  | Description                                                               |
+| ------------------- | ------------------------ | ------------------------------------------------------------------------- |
+| `format`            | `'$symbol $commit_info ` | The format for the module.                                                |
+| `detect_folders`    | `['.jj']`                | Which folders should trigger this modules.                                |
+| `symbol`            | `'jj '`                  | A format string representing the symbol of Jujutsu.                       |
+| `template`          | See the template above   | Jujutsu template collects the `commit_info` value.                        |
+| `disabled`          | `false`                  | Disables the `jujutsu` module.                                            |
+
+## Variables
+
+| Variable     | Example                        | Description                                      |
+| ------------ | ------------------------------ | ------------------------------------------------ |
+| symbol       |                                | Mirrors the value of option `symbol`             |
+| commit_info  | `main szuflg "initial commit"` | The output of the template                       |
+
 
 ## Julia
 

--- a/src/configs/jujutsu.rs
+++ b/src/configs/jujutsu.rs
@@ -1,0 +1,46 @@
+use serde::{Deserialize, Serialize};
+
+static DEFAULT_TEMPLATE: &str = r#"
+separate(" ",
+  change_id.shortest(6),
+  branches.map(|x| if(
+    x.name().substr(0, 20).starts_with(x.name()),
+    x.name().substr(0, 20),
+    x.name().substr(0, 19) ++ "…")
+  ).join(" "),
+  if(
+    description.first_line().substr(0, 24).starts_with(description.first_line()),
+    description.first_line().substr(0, 24),
+    description.first_line().substr(0, 23) ++ "…"
+  ),
+  if(conflict, "conflict"),
+  if(divergent, "divergent"),
+  if(hidden, "hidden"),
+)"#;
+
+#[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(
+    feature = "config-schema",
+    derive(schemars::JsonSchema),
+    schemars(deny_unknown_fields)
+)]
+#[serde(default)]
+pub struct JujutsuConfig<'a> {
+    pub format: &'a str,
+    pub symbol: &'a str,
+    pub template: &'a str,
+    pub disabled: bool,
+    pub detect_folders: Vec<&'a str>,
+}
+
+impl<'a> Default for JujutsuConfig<'a> {
+    fn default() -> Self {
+        Self {
+            format: "$symbol $commit_info ",
+            symbol: "jj",
+            template: DEFAULT_TEMPLATE,
+            disabled: false,
+            detect_folders: vec![".jj"],
+        }
+    }
+}

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -47,6 +47,7 @@ pub mod hg_branch;
 pub mod hostname;
 pub mod java;
 pub mod jobs;
+pub mod jujutsu;
 pub mod julia;
 pub mod kotlin;
 pub mod kubernetes;
@@ -203,6 +204,8 @@ pub struct FullConfig<'a> {
     java: java::JavaConfig<'a>,
     #[serde(borrow)]
     jobs: jobs::JobsConfig<'a>,
+    #[serde(borrow)]
+    jujutsu: jujutsu::JujutsuConfig<'a>,
     #[serde(borrow)]
     julia: julia::JuliaConfig<'a>,
     #[serde(borrow)]

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -47,6 +47,7 @@ pub const PROMPT_ORDER: &[&str] = &[
     "git_state",
     "git_metrics",
     "git_status",
+    "jujutsu",
     "hg_branch",
     "pijul_channel",
     "docker_context",

--- a/src/module.rs
+++ b/src/module.rs
@@ -52,6 +52,7 @@ pub const ALL_MODULES: &[&str] = &[
     "hostname",
     "java",
     "jobs",
+    "jujutsu",
     "julia",
     "kotlin",
     "kubernetes",

--- a/src/modules/jujutsu.rs
+++ b/src/modules/jujutsu.rs
@@ -41,3 +41,29 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
     Some(module)
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::test::ModuleRenderer;
+    use std::fs::create_dir;
+    use std::io;
+
+    #[test]
+    fn folder_without_jj_repo() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let actual = ModuleRenderer::new("jujutsu").path(dir.path()).collect();
+        let expected = None;
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn folder_with_jj_repo() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        create_dir(dir.path().join(".jj"))?;
+        let actual = ModuleRenderer::new("jujutsu").path(dir.path()).collect();
+        let expected = Some("jj main \"initial commit\" ");
+        assert_eq!(expected, actual.as_deref());
+        dir.close()
+    }
+}

--- a/src/modules/jujutsu.rs
+++ b/src/modules/jujutsu.rs
@@ -23,7 +23,22 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             })
             .map(|variable| match variable {
                 "commit_info" => {
-                    let output = &context.exec_cmd("jj", &["log", "-r@", "-n1", "--ignore-working-copy", "--no-graph", "--color","always", "-T", config.template])?.stdout;
+                    let output = &context
+                        .exec_cmd(
+                            "jj",
+                            &[
+                                "log",
+                                "-r@",
+                                "-n1",
+                                "--ignore-working-copy",
+                                "--no-graph",
+                                "--color",
+                                "always",
+                                "-T",
+                                config.template,
+                            ],
+                        )?
+                        .stdout;
                     Some(Ok(output.to_owned()))
                 }
                 _ => None,

--- a/src/modules/jujutsu.rs
+++ b/src/modules/jujutsu.rs
@@ -1,0 +1,43 @@
+use super::{Context, Module, ModuleConfig};
+
+use crate::configs::jujutsu::JujutsuConfig;
+use crate::formatter::StringFormatter;
+
+pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let mut module = context.new_module("jujutsu");
+    let config = JujutsuConfig::try_load(module.config);
+    let is_jj_repo = context
+        .try_begin_scan()?
+        .set_folders(&config.detect_folders)
+        .is_match();
+
+    if !is_jj_repo {
+        return None;
+    }
+
+    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
+        formatter
+            .map_meta(|variable, _| match variable {
+                "symbol" => Some(config.symbol),
+                _ => None,
+            })
+            .map(|variable| match variable {
+                "commit_info" => {
+                    let output = &context.exec_cmd("jj", &["log", "-r@", "-n1", "--ignore-working-copy", "--no-graph", "--color","always", "-T", config.template])?.stdout;
+                    Some(Ok(output.to_owned()))
+                }
+                _ => None,
+            })
+            .parse(None, Some(context))
+    });
+
+    module.set_segments(match parsed {
+        Ok(segments) => segments,
+        Err(error) => {
+            log::warn!("Error in module `jj`:\n{}", error);
+            return None;
+        }
+    });
+
+    Some(module)
+}

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -279,6 +279,7 @@ pub fn description(module: &str) -> &'static str {
         "hostname" => "The system hostname",
         "java" => "The currently installed version of Java",
         "jobs" => "The current number of jobs running",
+        "jujutsu" => "The currently installed version of Jujutsu",
         "julia" => "The currently installed version of Julia",
         "kotlin" => "The currently installed version of Kotlin",
         "kubernetes" => "The current Kubernetes context name and, if set, the namespace",

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -44,6 +44,7 @@ mod hg_branch;
 mod hostname;
 mod java;
 mod jobs;
+mod jujutsu;
 mod julia;
 mod kotlin;
 mod kubernetes;
@@ -156,6 +157,7 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
             "java" => java::module(context),
             "jobs" => jobs::module(context),
             "julia" => julia::module(context),
+            "jujutsu" => jujutsu::module(context),
             "kotlin" => kotlin::module(context),
             "kubernetes" => kubernetes::module(context),
             "line_break" => line_break::module(context),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -299,6 +299,10 @@ Elixir 1.10 (compiled with Erlang/OTP 22)\n",
             stdout: String::from("julia version 1.4.0\n"),
             stderr: String::default(),
         }),
+        s if s.starts_with("jj log -r@") => Some(CommandOutput {
+            stdout: String::from("main \"initial commit\""),
+            stderr: String::default(),
+        }),
         "kotlin -version" => Some(CommandOutput {
             stdout: String::from("Kotlin version 1.4.21-release-411 (JRE 14.0.1+7)\n"),
             stderr: String::default(),


### PR DESCRIPTION
This PR adds a `jujutsu` module for displaying information in repositories using jujutsu.

#### Description
Adds a jujutsu module that uses a default template (which can be customized by the user if needed) to display the branch, change ID and change description messages.

The template is taken from the [jj](https://github.com/martinvonz/jj/wiki/Starship) repository and simplified.

Users can change the template to modify the information line as they like:

```toml
[jujutsu]
template = "change_id.shortest(6) + ' ' + description.first_line()"
```

#### Motivation and Context
Closes #6076.

#### Screenshots (if appropriate):

<img width="772" alt="image" src="https://github.com/user-attachments/assets/b4531fde-1a50-4a3d-bddf-3edc7c65ab3a">

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [X] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
