### PR TITLE
chore: Minor changes to use more idiomatic Rust (integer max values; complicates nested expressions)

### DIFF
--- a/src/configs/fossil_branch.rs
+++ b/src/configs/fossil_branch.rs
@@ -22,7 +22,7 @@ impl<'a> Default for FossilBranchConfig<'a> {
             format: "on [$symbol$branch]($style) ",
             symbol: " ",
             style: "bold purple",
-            truncation_length: std::i64::MAX,
+            truncation_length: i64::MAX,
             truncation_symbol: "…",
             disabled: true,
         }

--- a/src/configs/git_branch.rs
+++ b/src/configs/git_branch.rs
@@ -25,7 +25,7 @@ impl<'a> Default for GitBranchConfig<'a> {
             format: "on [$symbol$branch(:$remote_branch)]($style) ",
             symbol: " ",
             style: "bold purple",
-            truncation_length: std::i64::MAX,
+            truncation_length: i64::MAX,
             truncation_symbol: "…",
             only_attached: false,
             always_show_remote: false,

--- a/src/configs/hg_branch.rs
+++ b/src/configs/hg_branch.rs
@@ -22,7 +22,7 @@ impl<'a> Default for HgBranchConfig<'a> {
             symbol: " ",
             style: "bold purple",
             format: "on [$symbol$branch(:$topic)]($style) ",
-            truncation_length: std::i64::MAX,
+            truncation_length: i64::MAX,
             truncation_symbol: "…",
             disabled: true,
         }

--- a/src/configs/meson.rs
+++ b/src/configs/meson.rs
@@ -19,7 +19,7 @@ pub struct MesonConfig<'a> {
 impl<'a> Default for MesonConfig<'a> {
     fn default() -> Self {
         MesonConfig {
-            truncation_length: std::u32::MAX,
+            truncation_length: u32::MAX,
             truncation_symbol: "…",
             format: "via [$symbol$project]($style) ",
             symbol: "⬢ ",

--- a/src/configs/pijul_channel.rs
+++ b/src/configs/pijul_channel.rs
@@ -22,7 +22,7 @@ impl<'a> Default for PijulConfig<'a> {
             symbol: " ",
             style: "bold purple",
             format: "on [$symbol$channel]($style) ",
-            truncation_length: std::i64::MAX,
+            truncation_length: i64::MAX,
             truncation_symbol: "…",
             disabled: true,
         }

--- a/src/modules/fossil_branch.rs
+++ b/src/modules/fossil_branch.rs
@@ -33,7 +33,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             "\"truncation_length\" should be a positive value, found {}",
             config.truncation_length
         );
-        std::usize::MAX
+        usize::MAX
     } else {
         config.truncation_length as usize
     };

--- a/src/modules/git_branch.rs
+++ b/src/modules/git_branch.rs
@@ -19,7 +19,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             "\"truncation_length\" should be a positive value, found {}",
             config.truncation_length
         );
-        std::usize::MAX
+        usize::MAX
     } else {
         config.truncation_length as usize
     };

--- a/src/modules/git_status.rs
+++ b/src/modules/git_status.rs
@@ -426,13 +426,13 @@ fn git_status_wsl(context: &Context, conf: &GitStatusConfig) -> Option<String> {
     log::trace!("Using WSL mode");
 
     // Get Windows path
-    let winpath = match create_command("wslpath")
+    let wslpath = create_command("wslpath")
         .map(|mut c| {
             c.arg("-w").arg(&context.current_dir);
             c
         })
-        .and_then(|mut c| c.output())
-    {
+        .and_then(|mut c| c.output());
+    let winpath = match wslpath {
         Ok(r) => r,
         Err(e) => {
             // Not found might means this might not be WSL after all
@@ -472,7 +472,7 @@ fn git_status_wsl(context: &Context, conf: &GitStatusConfig) -> Option<String> {
         |e| e + ":STARSHIP_CONFIG/wp",
     );
 
-    let out = match create_command(starship_exe)
+    let exe = create_command(starship_exe)
         .map(|mut c| {
             c.env(
                 "STARSHIP_CONFIG",
@@ -484,8 +484,9 @@ fn git_status_wsl(context: &Context, conf: &GitStatusConfig) -> Option<String> {
             .args(["module", "git_status", "--path", winpath]);
             c
         })
-        .and_then(|mut c| c.output())
-    {
+        .and_then(|mut c| c.output());
+
+    let out = match exe {
         Ok(r) => r,
         Err(e) => {
             log::error!("Failed to run Git Status module on Windows:\n{}", e);

--- a/src/modules/hg_branch.rs
+++ b/src/modules/hg_branch.rs
@@ -26,7 +26,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             "\"truncation_length\" should be a positive value, found {}",
             config.truncation_length
         );
-        std::usize::MAX
+        usize::MAX
     } else {
         config.truncation_length as usize
     };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

Change the starship code to ask integer types for their maximum values directly, instead of using a constant from the standard library. The standard library constants have been deprecated for some time.

Simplify a couple of `match` expressions to not use nested expressions with blocks in them, to make the code a little easier to follow.
 
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I was going to try to create a new module, and as my first steps I ran `cargo test` (passed) and `cargo clippy` (found problems). I wanted to start from a clean slate, so I'm offering these changes to make the code be more idiomatic for current Rust.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.

(Neither documentation nor tests needed to be changed.)