### PR TITLE
Remove `🌐` symbol in plain text symbols preset

### DIFF
--- a/docs/public/presets/toml/plain-text-symbols.toml
+++ b/docs/public/presets/toml/plain-text-symbols.toml
@@ -232,3 +232,6 @@ symbol = "terraform "
 
 [zig]
 symbol = "zig "
+
+[hostname]
+ssh_symbol = ""


### PR DESCRIPTION
#### Description

Before:
```
yvan in 🌐 X270 in guix-config on git master [x!?>] took 9s
```

After:
```
yvan in X270 in guix-config on git master [x!?>] took 9s
```

#### Motivation and Context

From https://starship.rs/presets/plain-text:

> This preset changes the symbols for each module into plain text. Great if you don't have access to Unicode.

So using emojis such as `🌐` should be avoided :)

#### How Has This Been Tested?

- [x] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:

- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
