### PR TITLE
fix(fish): improve fish transient prompt

### DIFF
--- a/src/init/starship.fish
+++ b/src/init/starship.fish
@@ -19,6 +19,7 @@ function fish_prompt
         else
             printf "\e[1;32m❯\e[0m "
         end
+        set -g TRANSIENT 0
     else
         ::STARSHIP:: prompt --terminal-width="$COLUMNS" --status=$STARSHIP_CMD_STATUS --pipestatus="$STARSHIP_CMD_PIPESTATUS" --keymap=$STARSHIP_KEYMAP --cmd-duration=$STARSHIP_DURATION --jobs=$STARSHIP_JOBS
     end
@@ -36,12 +37,13 @@ function fish_right_prompt
     # Account for changes in variable name between v2.7 and v3.0
     set STARSHIP_DURATION "$CMD_DURATION$cmd_duration"
     set STARSHIP_JOBS (count (jobs -p))
-    if test "$TRANSIENT" = "1"
+    if test "$RIGHT_TRANSIENT" = "1"
         if type -q starship_transient_rprompt_func
             starship_transient_rprompt_func
         else
             printf ""
         end
+        set -g RIGHT_TRANSIENT 0
     else
         ::STARSHIP:: prompt --right --terminal-width="$COLUMNS" --status=$STARSHIP_CMD_STATUS --pipestatus="$STARSHIP_CMD_PIPESTATUS" --keymap=$STARSHIP_KEYMAP --cmd-duration=$STARSHIP_DURATION --jobs=$STARSHIP_JOBS
     end
@@ -58,14 +60,19 @@ set -gx STARSHIP_SHELL "fish"
 # Transience related functions
 function reset-transient --on-event fish_postexec
     set -g TRANSIENT 0
+    set -g RIGHT_TRANSIENT 0
 end
 
 function transient_execute
-    if commandline --is-valid
+    if commandline --paging-mode
+        commandline -f accept-autosuggestion
+        return
+    end
+    commandline --is-valid
+    if test $status != 2
         set -g TRANSIENT 1
+        set -g RIGHT_TRANSIENT 1
         commandline -f repaint
-    else
-        set -g TRANSIENT 0
     end
     commandline -f execute
 end

--- a/src/init/starship.fish
+++ b/src/init/starship.fish
@@ -11,6 +11,7 @@ function fish_prompt
     set STARSHIP_DURATION "$CMD_DURATION$cmd_duration"
     set STARSHIP_JOBS (count (jobs -p))
     if test "$TRANSIENT" = "1"
+        set -g TRANSIENT 0
         # Clear from cursor to end of screen as `commandline -f repaint` does not do this
         # See https://github.com/fish-shell/fish-shell/issues/8418
         printf \e\[0J
@@ -19,7 +20,6 @@ function fish_prompt
         else
             printf "\e[1;32m❯\e[0m "
         end
-        set -g TRANSIENT 0
     else
         ::STARSHIP:: prompt --terminal-width="$COLUMNS" --status=$STARSHIP_CMD_STATUS --pipestatus="$STARSHIP_CMD_PIPESTATUS" --keymap=$STARSHIP_KEYMAP --cmd-duration=$STARSHIP_DURATION --jobs=$STARSHIP_JOBS
     end
@@ -38,12 +38,12 @@ function fish_right_prompt
     set STARSHIP_DURATION "$CMD_DURATION$cmd_duration"
     set STARSHIP_JOBS (count (jobs -p))
     if test "$RIGHT_TRANSIENT" = "1"
+        set -g RIGHT_TRANSIENT 0
         if type -q starship_transient_rprompt_func
             starship_transient_rprompt_func
         else
             printf ""
         end
-        set -g RIGHT_TRANSIENT 0
     else
         ::STARSHIP:: prompt --right --terminal-width="$COLUMNS" --status=$STARSHIP_CMD_STATUS --pipestatus="$STARSHIP_CMD_PIPESTATUS" --keymap=$STARSHIP_KEYMAP --cmd-duration=$STARSHIP_DURATION --jobs=$STARSHIP_JOBS
     end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR fixes the problem that the transient prompt in fish does not work when pressing Enter without entering a command.
In addition, it also fixes the problem that the transient prompt is incorrectly triggered when pressing Enter to confirm an entry in Tab Completion.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Improve transient prompt in fish.

#### Screenshots (if appropriate):

Before:
<img width="650" alt="old" src="https://github.com/user-attachments/assets/4873b9c1-112c-4b10-8c2b-4cb29ccf4ef6">

After:
<img width="650" alt="new" src="https://github.com/user-attachments/assets/88782429-9627-4ff4-81b4-ab9efe800319">

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
