### PR TITLE
feat(fish): support async prompt

### DIFF
--- a/src/init/starship.fish
+++ b/src/init/starship.fish
@@ -1,31 +1,54 @@
 function fish_prompt
-    switch "$fish_key_bindings"
-        case fish_hybrid_key_bindings fish_vi_key_bindings
-            set STARSHIP_KEYMAP "$fish_bind_mode"
-        case '*'
-            set STARSHIP_KEYMAP insert
-    end
-    set STARSHIP_CMD_PIPESTATUS $pipestatus
-    set STARSHIP_CMD_STATUS $status
-    # Account for changes in variable name between v2.7 and v3.0
-    set STARSHIP_DURATION "$CMD_DURATION$cmd_duration"
-    set STARSHIP_JOBS (count (jobs -p))
     if test "$TRANSIENT" = "1"
         set -g TRANSIENT 0
         # Clear from cursor to end of screen as `commandline -f repaint` does not do this
         # See https://github.com/fish-shell/fish-shell/issues/8418
         printf \e\[0J
-        if type -q starship_transient_prompt_func
-            starship_transient_prompt_func
-        else
-            printf "\e[1;32m❯\e[0m "
-        end
+        __starship_transient_prompt_func
+    else if test -e $FISH_PROMPT_TEMP_FILE
+        cat $FISH_PROMPT_TEMP_FILE
     else
-        ::STARSHIP:: prompt --terminal-width="$COLUMNS" --status=$STARSHIP_CMD_STATUS --pipestatus="$STARSHIP_CMD_PIPESTATUS" --keymap=$STARSHIP_KEYMAP --cmd-duration=$STARSHIP_DURATION --jobs=$STARSHIP_JOBS
+        __starship_transient_prompt_func
     end
 end
 
 function fish_right_prompt
+    if test "$RIGHT_TRANSIENT" = "1"
+        set -g RIGHT_TRANSIENT 0
+        __starship_transient_rprompt_func
+    else if test -e $FISH_RIGHT_PROMPT_TEMP_FILE
+        cat $FISH_RIGHT_PROMPT_TEMP_FILE
+    else
+        __starship_transient_rprompt_func
+    end
+end
+
+function __starship_transient_prompt_func
+    if type -q starship_transient_prompt_func
+        starship_transient_prompt_func
+    else
+        printf "\e[1;32m❯\e[0m "
+    end
+end
+
+function __starship_transient_rprompt_func
+    if type -q starship_transient_rprompt_func
+        starship_transient_rprompt_func
+    else
+        printf ""
+    end
+end
+
+# Get the the temp directory to store async prompt
+set -g ASYNC_PROMPT_TEMP_DIR (command mktemp -d)
+set -g FISH_PROMPT_TEMP_FILE $ASYNC_PROMPT_TEMP_DIR'/'$fish_pid'_fish_prompt'
+set -g FISH_RIGHT_PROMPT_TEMP_FILE $ASYNC_PROMPT_TEMP_DIR'/'$fish_pid'_fish_right_prompt'
+
+# Set the async prompt signal
+set -g ASYNC_PROMPT_SIGNAL SIGUSR1
+
+# Generate prompt in other job
+function __async_prompt_fire --on-event fish_prompt
     switch "$fish_key_bindings"
         case fish_hybrid_key_bindings fish_vi_key_bindings
             set STARSHIP_KEYMAP "$fish_bind_mode"
@@ -37,16 +60,22 @@ function fish_right_prompt
     # Account for changes in variable name between v2.7 and v3.0
     set STARSHIP_DURATION "$CMD_DURATION$cmd_duration"
     set STARSHIP_JOBS (count (jobs -p))
-    if test "$RIGHT_TRANSIENT" = "1"
-        set -g RIGHT_TRANSIENT 0
-        if type -q starship_transient_rprompt_func
-            starship_transient_rprompt_func
-        else
-            printf ""
-        end
-    else
-        ::STARSHIP:: prompt --right --terminal-width="$COLUMNS" --status=$STARSHIP_CMD_STATUS --pipestatus="$STARSHIP_CMD_PIPESTATUS" --keymap=$STARSHIP_KEYMAP --cmd-duration=$STARSHIP_DURATION --jobs=$STARSHIP_JOBS
-    end
+    fish -c '
+    ::STARSHIP:: prompt --terminal-width="'$COLUMNS'" --status='$STARSHIP_CMD_STATUS' --pipestatus="'$STARSHIP_CMD_PIPESTATUS'" --keymap='$STARSHIP_KEYMAP' --cmd-duration='$STARSHIP_DURATION' --jobs='$STARSHIP_JOBS' > '$FISH_PROMPT_TEMP_FILE'
+    ::STARSHIP:: prompt --right --terminal-width="'$COLUMNS'" --status='$STARSHIP_CMD_STATUS' --pipestatus="'$STARSHIP_CMD_PIPESTATUS'" --keymap='$STARSHIP_KEYMAP' --cmd-duration='$STARSHIP_DURATION' --jobs='$STARSHIP_JOBS' > '$FISH_RIGHT_PROMPT_TEMP_FILE'
+    kill -s "'$ASYNC_PROMPT_SIGNAL'" '$fish_pid &
+    disown
+end
+
+# Repaint the prompt when ASYNC_PROMPT_SIGNAL received
+function __async_prompt_repaint_prompt --on-signal "$ASYNC_PROMPT_SIGNAL"
+    commandline -f repaint
+end
+
+# Remove the temp file to store async prompt when fish exit
+function __async_prompt_cleanup --on-event fish_exit
+    rm -f $FISH_PROMPT_TEMP_FILE
+    rm -f $FISH_RIGHT_PROMPT_TEMP_FILE
 end
 
 # Disable virtualenv prompt, it breaks starship

--- a/src/init/starship.fish
+++ b/src/init/starship.fish
@@ -19,6 +19,7 @@ function fish_prompt
         else
             printf "\e[1;32m❯\e[0m "
         end
+        set -g TRANSIENT 0
     else
         ::STARSHIP:: prompt --terminal-width="$COLUMNS" --status=$STARSHIP_CMD_STATUS --pipestatus="$STARSHIP_CMD_PIPESTATUS" --keymap=$STARSHIP_KEYMAP --cmd-duration=$STARSHIP_DURATION --jobs=$STARSHIP_JOBS
     end
@@ -36,12 +37,13 @@ function fish_right_prompt
     # Account for changes in variable name between v2.7 and v3.0
     set STARSHIP_DURATION "$CMD_DURATION$cmd_duration"
     set STARSHIP_JOBS (count (jobs -p))
-    if test "$TRANSIENT" = "1"
+    if test "$RIGHT_TRANSIENT" = "1"
         if type -q starship_transient_rprompt_func
             starship_transient_rprompt_func
         else
             printf ""
         end
+        set -g RIGHT_TRANSIENT 0
     else
         ::STARSHIP:: prompt --right --terminal-width="$COLUMNS" --status=$STARSHIP_CMD_STATUS --pipestatus="$STARSHIP_CMD_PIPESTATUS" --keymap=$STARSHIP_KEYMAP --cmd-duration=$STARSHIP_DURATION --jobs=$STARSHIP_JOBS
     end
@@ -58,14 +60,19 @@ set -gx STARSHIP_SHELL "fish"
 # Transience related functions
 function reset-transient --on-event fish_postexec
     set -g TRANSIENT 0
+    set -g RIGHT_TRANSIENT 0
 end
 
 function transient_execute
-    if commandline --is-valid
+    if commandline --paging-mode
+        commandline -f accept-autosuggestion
+        return
+    end
+    commandline --is-valid
+    if test $status != 2
         set -g TRANSIENT 1
+        set -g RIGHT_TRANSIENT 1
         commandline -f repaint
-    else
-        set -g TRANSIENT 0
     end
     commandline -f execute
 end

--- a/src/init/starship.fish
+++ b/src/init/starship.fish
@@ -11,6 +11,7 @@ function fish_prompt
     set STARSHIP_DURATION "$CMD_DURATION$cmd_duration"
     set STARSHIP_JOBS (count (jobs -p))
     if test "$TRANSIENT" = "1"
+        set -g TRANSIENT 0
         # Clear from cursor to end of screen as `commandline -f repaint` does not do this
         # See https://github.com/fish-shell/fish-shell/issues/8418
         printf \e\[0J
@@ -19,7 +20,6 @@ function fish_prompt
         else
             printf "\e[1;32m❯\e[0m "
         end
-        set -g TRANSIENT 0
     else
         ::STARSHIP:: prompt --terminal-width="$COLUMNS" --status=$STARSHIP_CMD_STATUS --pipestatus="$STARSHIP_CMD_PIPESTATUS" --keymap=$STARSHIP_KEYMAP --cmd-duration=$STARSHIP_DURATION --jobs=$STARSHIP_JOBS
     end
@@ -38,12 +38,12 @@ function fish_right_prompt
     set STARSHIP_DURATION "$CMD_DURATION$cmd_duration"
     set STARSHIP_JOBS (count (jobs -p))
     if test "$RIGHT_TRANSIENT" = "1"
+        set -g RIGHT_TRANSIENT 0
         if type -q starship_transient_rprompt_func
             starship_transient_rprompt_func
         else
             printf ""
         end
-        set -g RIGHT_TRANSIENT 0
     else
         ::STARSHIP:: prompt --right --terminal-width="$COLUMNS" --status=$STARSHIP_CMD_STATUS --pipestatus="$STARSHIP_CMD_PIPESTATUS" --keymap=$STARSHIP_KEYMAP --cmd-duration=$STARSHIP_DURATION --jobs=$STARSHIP_JOBS
     end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR makes prompt load asynchronously in fish.

The idea comes from [fish-async-prompt](https://github.com/acomagu/fish-async-prompt), which basically runs starship in a new fish process and notifies fish to update prompt by sending a signal after loading is complete.

This makes starship very fast in fish. The difference is noticeable, especially in large git repositories. With async prompt enabled, the delay is almost unnoticeable.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Try to make prompt load asynchronously in fish. 

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
