### PR TITLE
chore: bump deps and address clippy warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,9 +149,9 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8828ec6e544c02b0d6691d21ed9f9218d0384a82542855073c2a3f58304aaf0"
+checksum = "d7ebdfa2ebdab6b1760375fa7d6f382b9f486eac35fc994625a00e89280bdbb7"
 dependencies = [
  "async-task",
  "concurrent-queue",
@@ -229,14 +229,14 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.72",
 ]
 
 [[package]]
 name = "async-signal"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "794f185324c2f00e771cd9f1ae8b5ac68be2ca7abb129a87afd6e86d228bc54d"
+checksum = "dfb3634b73397aa844481f814fad23bbf07fdb0eabec10f2eb95e58944b1ec32"
 dependencies = [
  "async-io",
  "async-lock",
@@ -264,7 +264,7 @@ checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -359,9 +359,9 @@ checksum = "a3e368af43e418a04d52505cf3dbc23dda4e3407ae2fa99fd0e4f308ce546acc"
 
 [[package]]
 name = "cc"
-version = "1.0.105"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5208975e568d83b6b05cc0a063c8e7e9acc2b43bee6da15616a5b73e109d7437"
+checksum = "2aba8f4e9906c7ce3c73463f62a7f0c65183ada1a2d47e397cc8810827f9694f"
 
 [[package]]
 name = "cfg-if"
@@ -397,9 +397,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.9"
+version = "4.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64acc1846d54c1fe936a78dc189c34e28d3f5afc348403f28ecf53660b9b8462"
+checksum = "8f6b81fb3c84f5563d509c59b5a48d935f689e993afa90fe39047f05adef9142"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -407,9 +407,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.9"
+version = "4.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb8393d67ba2e7bfaf28a23458e4e2b543cc73a99595511eb207fdb8aede942"
+checksum = "5ca6706fd5224857d9ac5eb9355f6683563cc0541c7cd9d014043b57cbec78ac"
 dependencies = [
  "anstream",
  "anstyle",
@@ -421,9 +421,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.8"
+version = "4.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b4be9c4c4b1f30b78d8a750e0822b6a6102d97e62061c583a6c1dea2dfb33ae"
+checksum = "faa2032320fd6f50d22af510d204b2994eef49600dfbd0e771a166213844e4cd"
 dependencies = [
  "clap",
 ]
@@ -437,7 +437,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -792,7 +792,7 @@ checksum = "de0d48a183585823424a4ce1aa132d174a6a81bd540895822eb4c8373a8e49e8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1056,7 +1056,7 @@ dependencies = [
  "gix-utils",
  "itoa",
  "thiserror",
- "winnow 0.6.13",
+ "winnow 0.6.15",
 ]
 
 [[package]]
@@ -1109,7 +1109,7 @@ dependencies = [
  "smallvec",
  "thiserror",
  "unicode-bom",
- "winnow 0.6.13",
+ "winnow 0.6.15",
 ]
 
 [[package]]
@@ -1279,7 +1279,7 @@ checksum = "999ce923619f88194171a67fb3e6d613653b8d4d6078b529b15a765da0edcc17"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -1298,7 +1298,7 @@ dependencies = [
  "itoa",
  "smallvec",
  "thiserror",
- "winnow 0.6.13",
+ "winnow 0.6.15",
 ]
 
 [[package]]
@@ -1382,7 +1382,7 @@ dependencies = [
  "gix-validate",
  "memmap2",
  "thiserror",
- "winnow 0.6.13",
+ "winnow 0.6.15",
 ]
 
 [[package]]
@@ -1444,9 +1444,9 @@ dependencies = [
 
 [[package]]
 name = "gix-tempfile"
-version = "14.0.0"
+version = "14.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3b0e276cd08eb2a22e9f286a4f13a222a01be2defafa8621367515375644b99"
+checksum = "006acf5a613e0b5cf095d8e4b3f48c12a60d9062aa2b2dd105afaf8344a5600c"
 dependencies = [
  "gix-fs",
  "libc",
@@ -1845,14 +1845,13 @@ dependencies = [
 
 [[package]]
 name = "mockall"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43766c2b5203b10de348ffe19f7e54564b64f3d6018ff7648d1e2d6d3a0f0a48"
+checksum = "d4c28b3fb6d753d28c20e826cd46ee611fda1cf3cde03a443a974043247c065a"
 dependencies = [
  "cfg-if",
  "downcast",
  "fragile",
- "lazy_static",
  "mockall_derive",
  "predicates",
  "predicates-tree",
@@ -1860,14 +1859,14 @@ dependencies = [
 
 [[package]]
 name = "mockall_derive"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af7cbce79ec385a1d4f54baa90a76401eb15d9cab93685f62e7e9f942aa00ae2"
+checksum = "341014e7f530314e9a1fdbc7400b244efea7122662c96bfa248c31da5bfb2020"
 dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2094,7 +2093,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.2",
+ "redox_syscall 0.5.3",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -2158,7 +2157,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2337,6 +2336,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96a05e2e8efddfa51a84ca47cec303fac86c8541b686d37cac5efc0e094417bc"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2406,9 +2414,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
+checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -2515,7 +2523,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.69",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2565,7 +2573,7 @@ checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2576,7 +2584,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2598,7 +2606,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -2633,9 +2641,9 @@ dependencies = [
 
 [[package]]
 name = "sha1_smol"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
 name = "sha2"
@@ -2663,9 +2671,9 @@ dependencies = [
 
 [[package]]
 name = "shadow-rs"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a600f795d0894cda22235b44eea4b85c2a35b405f65523645ac8e35b306817a"
+checksum = "d253e54681d4be0161e965db57974ae642a0b6aaeb18a999424c4dab062be8c5"
 dependencies = [
  "const_format",
  "is_debug",
@@ -2756,7 +2764,7 @@ dependencies = [
  "indexmap 2.2.6",
  "log",
  "mockall",
- "nix 0.28.0",
+ "nix 0.29.0",
  "notify-rust",
  "nu-ansi-term",
  "once_cell",
@@ -2766,7 +2774,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "process_control",
- "quick-xml",
+ "quick-xml 0.36.1",
  "rand",
  "rayon",
  "regex",
@@ -2790,7 +2798,7 @@ dependencies = [
  "urlencoding",
  "versions",
  "which",
- "windows",
+ "windows 0.58.0",
  "winres",
  "yaml-rust2",
 ]
@@ -2837,9 +2845,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.69"
+version = "2.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201fcda3845c23e8212cd466bfebf0bd20694490fc0356ae8e428e0824a915a6"
+checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2866,8 +2874,8 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f89f5fb70d6f62381f5d9b2ba9008196150b40b75f3068eb24faeddf1c686871"
 dependencies = [
- "quick-xml",
- "windows",
+ "quick-xml 0.31.0",
+ "windows 0.56.0",
  "windows-version",
 ]
 
@@ -2955,22 +2963,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -3017,9 +3025,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6b6a2fb3a985e99cebfaefa9faa3024743da73304ca1c683a36429613d3d22"
+checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3082,7 +3090,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.13",
+ "winnow 0.6.15",
 ]
 
 [[package]]
@@ -3104,7 +3112,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -3309,7 +3317,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.72",
  "wasm-bindgen-shared",
 ]
 
@@ -3331,7 +3339,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.72",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3396,6 +3404,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core 0.58.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3410,9 +3428,22 @@ version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4698e52ed2d08f8658ab0c39512a7c00ee5fe2688c65f8c0a4f06750d729f2a6"
 dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-result",
+ "windows-implement 0.56.0",
+ "windows-interface 0.56.0",
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings",
  "windows-targets 0.52.6",
 ]
 
@@ -3424,7 +3455,18 @@ checksum = "f6fc35f58ecd95a9b71c4f2329b911016e6bec66b3f2e6a4aad86bd2e99e2f9b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.72",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -3435,7 +3477,18 @@ checksum = "08990546bf4edef8f431fa6326e032865f27138718c587dc21bc0265bbcb57cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.72",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -3444,6 +3497,25 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
 dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result 0.2.0",
  "windows-targets 0.52.6",
 ]
 
@@ -3606,9 +3678,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.13"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59b5e5f6c299a3c7890b876a2a587f3115162487e704907d9b6cd29473052ba1"
+checksum = "557404e450152cd6795bb558bca69e43c585055f4606e3bcae5894fc6dac9ba0"
 dependencies = [
  "memchr",
 ]
@@ -3651,9 +3723,9 @@ dependencies = [
 
 [[package]]
 name = "zbus"
-version = "4.3.1"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "851238c133804e0aa888edf4a0229481c753544ca12a60fd1c3230c8a500fe40"
+checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
 dependencies = [
  "async-broadcast",
  "async-executor",
@@ -3689,14 +3761,14 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "4.3.1"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d5a3f12c20bd473be3194af6b49d50d7bb804ef3192dc70eddedb26b85d9da7"
+checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.72",
  "zvariant_utils",
 ]
 
@@ -3728,14 +3800,14 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.72",
 ]
 
 [[package]]
 name = "zvariant"
-version = "4.1.2"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1724a2b330760dc7d2a8402d841119dc869ef120b139d29862d6980e9c75bfc9"
+checksum = "2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe"
 dependencies = [
  "endi",
  "enumflags2",
@@ -3746,24 +3818,24 @@ dependencies = [
 
 [[package]]
 name = "zvariant_derive"
-version = "4.1.2"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55025a7a518ad14518fb243559c058a2e5b848b015e31f1d90414f36e3317859"
+checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.72",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_utils"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc242db087efc22bd9ade7aa7809e4ba828132edc312871584a6b4391bdf8786"
+checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.69",
+ "syn 2.0.72",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ license = "ISC"
 readme = "README.md"
 repository = "https://github.com/starship/starship"
 # Note: MSRV is only intended as a hint, and only the latest version is officially supported in starship.
-rust-version = "1.71"
+rust-version = "1.74"
 description = """
 The minimal, blazing-fast, and infinitely customizable prompt for any shell! ☄🌌️
 """
@@ -43,8 +43,8 @@ gix-faster = ["gix-features/zlib-stock", "gix/fast-sha1"]
 
 [dependencies]
 chrono = { version = "0.4.38", default-features = false, features = ["clock", "std", "wasmbind"] }
-clap = { version = "4.5.9", features = ["derive", "cargo", "unicode"] }
-clap_complete = "4.5.8"
+clap = { version = "4.5.10", features = ["derive", "cargo", "unicode"] }
+clap_complete = "4.5.9"
 dirs = "5.0.1"
 dunce = "1.0.4"
 gethostname = "0.5.0"
@@ -64,7 +64,7 @@ os_info = "3.8.2"
 path-slash = "0.2.1"
 pest = "2.7.11"
 pest_derive = "2.7.11"
-quick-xml = "0.31.0"
+quick-xml = "0.36.1"
 rand = "0.8.5"
 rayon = "1.10.0"
 regex = { version = "1.10.5", default-features = false, features = ["perf", "std", "unicode-perl"] }
@@ -73,7 +73,7 @@ semver = "1.0.23"
 serde = { version = "1.0.204", features = ["derive"] }
 serde_json = "1.0.120"
 sha1 = "0.10.6"
-shadow-rs = { version = "0.29.0", default-features = false }
+shadow-rs = { version = "0.30.0", default-features = false }
 # battery is optional (on by default) because the crate doesn't currently build for Termux
 # see: https://github.com/svartalf/rust-battery/issues/33
 starship-battery = { version = "0.8.3", optional = true }
@@ -104,7 +104,7 @@ features = ["preserve_order", "indexmap2"]
 deelevate = "0.2.0"
 
 [target.'cfg(windows)'.dependencies.windows]
-version = "0.56.0"
+version = "0.58.0"
 features = [
   "Win32_Foundation",
   "Win32_UI_Shell",
@@ -114,17 +114,17 @@ features = [
 ]
 
 [target.'cfg(not(windows))'.dependencies]
-nix = { version = "0.28.0", default-features = false, features = ["feature", "fs", "user"] }
+nix = { version = "0.29.0", default-features = false, features = ["feature", "fs", "user"] }
 
 [build-dependencies]
-shadow-rs = { version = "0.29.0", default-features = false }
+shadow-rs = { version = "0.30.0", default-features = false }
 dunce = "1.0.4"
 
 [target.'cfg(windows)'.build-dependencies]
 winres = "0.1.12"
 
 [dev-dependencies]
-mockall = "0.12.1"
+mockall = "0.13.0"
 tempfile = "3.10.1"
 
 [profile.release]

--- a/src/bug_report.rs
+++ b/src/bug_report.rs
@@ -62,6 +62,7 @@ struct Environment {
 }
 
 fn get_pkg_branch_tag() -> &'static str {
+    #[allow(clippy::const_is_empty)]
     if !shadow::TAG.is_empty() {
         return shadow::TAG;
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -313,7 +313,7 @@ impl Style {
     where
         F: FnOnce(&nu_ansi_term::Style) -> nu_ansi_term::Style,
     {
-        Style {
+        Self {
             style: f(&self.style),
             ..*self
         }
@@ -336,7 +336,7 @@ impl Style {
 
 impl From<nu_ansi_term::Style> for Style {
     fn from(value: nu_ansi_term::Style) -> Self {
-        Style {
+        Self {
             style: value,
             ..Default::default()
         }
@@ -345,7 +345,7 @@ impl From<nu_ansi_term::Style> for Style {
 
 impl From<nu_ansi_term::Color> for Style {
     fn from(value: nu_ansi_term::Color) -> Self {
-        Style {
+        Self {
             style: value.into(),
             ..Default::default()
         }
@@ -361,8 +361,8 @@ impl From<nu_ansi_term::Color> for Style {
  - 'italic'
  - 'inverted'
  - 'blink'
- - 'prev_fg'        (specifies the color should be the previous foreground color)
- - 'prev_bg'        (specifies the color should be the previous background color)
+ - '`prev_fg`'        (specifies the color should be the previous foreground color)
+ - '`prev_bg`'        (specifies the color should be the previous background color)
  - '<color>'       (see the `parse_color_string` doc for valid color strings)
 */
 pub fn parse_style_string(style_string: &str, context: Option<&Context>) -> Option<Style> {
@@ -382,14 +382,14 @@ pub fn parse_style_string(style_string: &str, context: Option<&Context>) -> Opti
             };
 
             match token.as_str() {
-                "underline" => Some(style.map_style(|s| s.underline())),
-                "bold" => Some(style.map_style(|s| s.bold())),
-                "italic" => Some(style.map_style(|s| s.italic())),
-                "dimmed" => Some(style.map_style(|s| s.dimmed())),
-                "inverted" => Some(style.map_style(|s| s.reverse())),
-                "blink" => Some(style.map_style(|s| s.blink())),
-                "hidden" => Some(style.map_style(|s| s.hidden())),
-                "strikethrough" => Some(style.map_style(|s| s.strikethrough())),
+                "underline" => Some(style.map_style(nu_ansi_term::Style::underline)),
+                "bold" => Some(style.map_style(nu_ansi_term::Style::bold)),
+                "italic" => Some(style.map_style(nu_ansi_term::Style::italic)),
+                "dimmed" => Some(style.map_style(nu_ansi_term::Style::dimmed)),
+                "inverted" => Some(style.map_style(nu_ansi_term::Style::reverse)),
+                "blink" => Some(style.map_style(nu_ansi_term::Style::blink)),
+                "hidden" => Some(style.map_style(nu_ansi_term::Style::hidden)),
+                "strikethrough" => Some(style.map_style(nu_ansi_term::Style::strikethrough)),
 
                 "prev_fg" if col_fg => Some(style.fg(PrevColor::Fg)),
                 "prev_fg" => Some(style.bg(PrevColor::Fg)),

--- a/src/formatter/string_formatter.rs
+++ b/src/formatter/string_formatter.rs
@@ -102,11 +102,11 @@ impl<'a> StringFormatter<'a> {
     /// parameter and returns the one of the following values:
     ///
     /// - `None`: This variable will be reserved for further mappers. If it is `None` when
-    /// `self.parse()` is called, it will be dropped.
+    ///   `self.parse()` is called, it will be dropped.
     ///
     /// - `Some(Err(StringFormatterError))`: This variable will throws `StringFormatterError` when
-    /// `self.parse()` is called. Return this if some fatal error occurred and the format string
-    /// should not be rendered.
+    ///   `self.parse()` is called. Return this if some fatal error occurred and the format string
+    ///   should not be rendered.
     ///
     /// - `Some(Ok(_))`: The value of this variable will be displayed in the format string.
     ///
@@ -222,7 +222,7 @@ impl<'a> StringFormatter<'a> {
             .par_iter_mut()
             .filter(|(_, value)| value.is_none())
             .for_each(|(key, value)| {
-                *value = mapper(key).map(|var| var.map(std::convert::Into::into));
+                *value = mapper(key).map(|var| var.map(Into::into));
             });
         self
     }
@@ -486,7 +486,7 @@ mod tests {
         let style = Some(Color::Red.bold());
 
         let formatter = StringFormatter::new(FORMAT_STR).unwrap().map(empty_mapper);
-        let result = formatter.parse(style.map(|s| s.into()), None).unwrap();
+        let result = formatter.parse(style.map(Into::into), None).unwrap();
         let mut result_iter = result.iter();
         match_next!(result_iter, "text", style);
     }
@@ -561,9 +561,7 @@ mod tests {
         let inner_style = Some(Color::Blue.normal());
 
         let formatter = StringFormatter::new(FORMAT_STR).unwrap().map(empty_mapper);
-        let result = formatter
-            .parse(outer_style.map(|s| s.into()), None)
-            .unwrap();
+        let result = formatter.parse(outer_style.map(Into::into), None).unwrap();
         let mut result_iter = result.iter();
         match_next!(result_iter, "outer ", outer_style);
         match_next!(result_iter, "middle ", middle_style);
@@ -619,9 +617,9 @@ mod tests {
 
         let mut segments: Vec<Segment> = Vec::new();
         segments.extend(Segment::from_text(None, "styless"));
-        segments.extend(Segment::from_text(styled_style.map(|s| s.into()), "styled"));
+        segments.extend(Segment::from_text(styled_style.map(Into::into), "styled"));
         segments.extend(Segment::from_text(
-            styled_no_modifier_style.map(|s| s.into()),
+            styled_no_modifier_style.map(Into::into),
             "styled_no_modifier",
         ));
 

--- a/src/module.rs
+++ b/src/module.rs
@@ -222,8 +222,10 @@ where
         chunks
             .into_iter()
             .flat_map(|(strs, fill)| {
-                let fill_string =
-                    fill.ansi_string(fill_size, strs.last().map(|segment| segment.style_ref()));
+                let fill_string = fill.ansi_string(
+                    fill_size,
+                    strs.last().map(nu_ansi_term::AnsiGenericString::style_ref),
+                );
                 strs.into_iter().chain(std::iter::once(fill_string))
             })
             .chain(current)

--- a/src/modules/dotnet.rs
+++ b/src/modules/dotnet.rs
@@ -99,7 +99,7 @@ fn find_current_tfm(files: &[DotNetFile]) -> Option<String> {
 fn get_tfm_from_project_file(path: &Path) -> Option<String> {
     let project_file = utils::read_file(path).ok()?;
     let mut reader = Reader::from_str(&project_file);
-    reader.trim_text(true);
+    reader.config_mut().trim_text(true);
 
     let mut in_tfm = false;
     let mut buf = Vec::new();

--- a/src/modules/kubernetes.rs
+++ b/src/modules/kubernetes.rs
@@ -115,7 +115,7 @@ impl DataValue for JsonValue {
 impl DataValue for Yaml {
     fn get(&self, key: &str) -> Option<&Self> {
         match self {
-            Yaml::Hash(map) => map.get(&Yaml::String(key.to_string())),
+            Self::Hash(map) => map.get(&Self::String(key.to_string())),
             _ => None,
         }
     }
@@ -126,7 +126,7 @@ impl DataValue for Yaml {
 
     fn as_array(&self) -> Option<Vec<&Self>> {
         match self {
-            Yaml::Array(arr) => Some(arr.iter().collect()),
+            Self::Array(arr) => Some(arr.iter().collect()),
             _ => None,
         }
     }
@@ -1567,7 +1567,7 @@ users: []
         let actual = results.first().unwrap();
         match actual {
             Document::Json(..) => {}
-            _ => panic!("Expected Document::Json, got {:?}", actual),
+            _ => panic!("Expected Document::Json, got {actual:?}"),
         }
         Ok(())
     }
@@ -1598,7 +1598,7 @@ users: []
         let actual = results.first().unwrap();
         match actual {
             Document::Yaml(..) => {}
-            _ => panic!("Expected Document::Yaml, got {:?}", actual),
+            _ => panic!("Expected Document::Yaml, got {actual:?}"),
         }
         Ok(())
     }

--- a/src/modules/package.rs
+++ b/src/modules/package.rs
@@ -152,7 +152,7 @@ fn get_mix_version(context: &Context, config: &PackageConfig) -> Option<String> 
 fn get_maven_version(context: &Context, config: &PackageConfig) -> Option<String> {
     let file_contents = context.read_file_from_pwd("pom.xml")?;
     let mut reader = QXReader::from_str(&file_contents);
-    reader.trim_text(true);
+    reader.config_mut().trim_text(true);
 
     let mut buf = vec![];
     let mut in_ver = false;

--- a/src/modules/utils/directory_nix.rs
+++ b/src/modules/utils/directory_nix.rs
@@ -10,8 +10,8 @@ use std::path::Path;
 /// It extracts Unix access rights from the directory and checks whether
 /// 1) the current user is the owner of the directory and whether it has the write access
 /// 2) the current user's primary group is the directory group owner whether if it has write access
-/// 2a) (not implemented on macOS) one of the supplementary groups of the current user is the
-/// directory group owner and whether it has write access
+///    2a) (not implemented on macOS) one of the supplementary groups of the current user is the
+///        directory group owner and whether it has write access
 /// 3) 'others' part of the access mask has the write access
 #[allow(clippy::useless_conversion)] // On some platforms it is not u32
 pub fn is_write_allowed(folder_path: &Path) -> Result<bool, String> {

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -130,8 +130,8 @@ impl Segment {
 
     pub fn style(&self) -> Option<AnsiStyle> {
         match self {
-            Self::Fill(fs) => fs.style.map(|cs| cs.to_ansi_style(None).to_owned()),
-            Self::Text(ts) => ts.style.map(|cs| cs.to_ansi_style(None).to_owned()),
+            Self::Fill(fs) => fs.style.map(|cs| cs.to_ansi_style(None)),
+            Self::Text(ts) => ts.style.map(|cs| cs.to_ansi_style(None)),
             Self::LineTerm => None,
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR bumps dependencies that renovate failed to update recently (though that issue should be fixed soon) and addresses upcoming rust beta clippy warnings and some more from the nightly version. The quick-xml update also required two single-line changes. I also bumped the MSRV to match the decencies.

The gix issue that was triggering the audit warning was already fixed by c3c640081d0d631a3d83231de32a77275fa4e7cd.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
