### PR TITLE
fix(preset): fix typo in Open Policy Agent module format string

### DIFF
--- a/docs/public/presets/toml/no-empty-icons.toml
+++ b/docs/public/presets/toml/no-empty-icons.toml
@@ -74,7 +74,7 @@ format = '(via [$symbol($version )]($style))'
 format = '(via [$symbol($version )(\($switch_indicator$switch_name\) )]($style))'
 
 [opa]
-format = '(via [$symbol($version ]($style))"'
+format = '(via [$symbol($version )]($style))'
 [package]
 format = '(is [$symbol$version]($style) )'
 

--- a/docs/public/presets/toml/no-empty-icons.toml
+++ b/docs/public/presets/toml/no-empty-icons.toml
@@ -74,7 +74,7 @@ format = '(via [$symbol($version )]($style))'
 format = '(via [$symbol($version )(\($switch_indicator$switch_name\) )]($style))'
 
 [opa]
-format = '(via [$symbo($version ]($style))"'
+format = '(via [$symbol($version ]($style))"'
 [package]
 format = '(is [$symbol$version]($style) )'
 


### PR DESCRIPTION
#### Description
Fix Open Policy Agent module typos in the No Empty Icons preset

#### Motivation and Context

#### Screenshots (if appropriate):

#### How Has This Been Tested?
👀
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
