### PR TITLE
fix: add "v" prefix to the version in the download URL when the version flag is specified

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -531,7 +531,7 @@ if [ "${PLATFORM}" = "pc-windows-msvc" ]; then
 fi
 
 if [ "${VERSION}" != "latest" ]; then
-  URL="${BASE_URL}/download/${VERSION}/starship-${TARGET}.${EXT}"
+  URL="${BASE_URL}/download/v${VERSION}/starship-${TARGET}.${EXT}"
 else
   URL="${BASE_URL}/latest/download/starship-${TARGET}.${EXT}"
 fi


### PR DESCRIPTION
#### Description

This fixes the ability to install with a custom version which currently fails:

```console
❯ curl https://starship.rs/install.sh | sh -s -- --version 1.19.0
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 14280    0 14280    0     0  19102      0 --:--:-- --:--:-- --:--:-- 19193

  Configuration
> Bin directory: /usr/local/bin
> Platform:      apple-darwin
> Arch:          aarch64

> Tarball URL: https://github.com/starship/starship/releases/download/1.19.0/starship-aarch64-apple-darwin.tar.gz
? Install Starship 1.19.0 to /usr/local/bin? [y/N] y
! Escalated permissions are required to install to /usr/local/bin
Password:
> Installing Starship as root, please wait…
x Command failed (exit code 22): curl --fail --silent --location --output 

> This is likely due to Starship not yet supporting your configuration.
> If you would like to see a build for your configuration,
> please create an issue requesting a build for aarch64-apple-darwin:
> https://github.com/starship/starship/issues/new/
```

 
When specifying a custom version the correct URL have the version number prefixed with a "v". The command above currently uses the URL:

https://github.com/starship/starship/releases/download/1.19.0/starship-aarch64-apple-darwin.tar.gz

When it should be using the URL:

https://github.com/starship/starship/releases/download/v1.19.0/starship-aarch64-apple-darwin.tar.gz

#### How Has This Been Tested?

I made the changes to the script in this PR locally, and was able to successfully install the specified version using the same command.

- [X] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
