### PR TITLE
docs(config): fix typos

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1173,7 +1173,7 @@ it would have been `nixpkgs/pkgs`.
 | `use_logical_path`          | `true`  | If `true` render the logical path sourced from the shell via `PWD` or `--logical-path`. If `false` instead render the physical filesystem path with symlinks resolved. |
 
 `substitutions` allows you to define arbitrary replacements for literal strings that occur in the path, for example long network
-prefixes or development directories (i.e. Java). Note that this will disable the fish style PWD.
+prefixes or development directories of Java. Note that this will disable the fish style PWD.
 
 ```toml
 [directory.substitutions]
@@ -1982,7 +1982,7 @@ You can disable the module or use the `windows_starship` option to use a Windows
 | `staged`            | `'+'`                                         | The format of `staged`                                                                                      |
 | `renamed`           | `'»'`                                         | The format of `renamed`                                                                                     |
 | `deleted`           | `'✘'`                                         | The format of `deleted`                                                                                     |
-| `typechanged`       | `""`                                          | The format of `typechange`                                                                                  |
+| `typechanged`       | `""`                                          | The format of `typechanged`                                                                                 |
 | `style`             | `'bold red'`                                  | The style for the module.                                                                                   |
 | `ignore_submodules` | `false`                                       | Ignore changes to submodules.                                                                               |
 | `disabled`          | `false`                                       | Disables the `git_status` module.                                                                           |
@@ -2003,7 +2003,7 @@ The following variables can be used in `format`:
 | `staged`       | Displays `staged` when a new file has been added to the staging area.                                         |
 | `renamed`      | Displays `renamed` when a renamed file has been added to the staging area.                                    |
 | `deleted`      | Displays `deleted` when a file's deletion has been added to the staging area.                                 |
-| `typechanged`  | Displays `typechange` when a file's type has been changed in the staging area.                                |
+| `typechanged`  | Displays `typechanged` when a file's type has been changed in the staging area.                               |
 | style\*        | Mirrors the value of option `style`                                                                           |
 
 *: This variable can only be used as a part of a style string


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

This PR fixes two types of typos:

(1) One is a rather trivial one. In the description of the option and variable `typechanged` for the `git_status` module, `typechange` appears. These are oversights of the modification `typechange{ => d}` after [a comment](https://github.com/starship/starship/pull/4829#discussion_r1084307216) in [#4829](https://github.com/starship/starship/pull/4829).

(2) The other is a (seemingly) incorrect usage of "i.e.". "i.e." is used to rephrase the previous grammatical element, but in the following part (**boldfaced by me**), there doesn't seem to be something equivalent to "Java" in preceding texts.

> `substitutions` allows you to define arbitrary replacements for literal strings that occur in the path, for example long network
prefixes or development directories **(i.e. Java)**.

Directories are not Java, paths are not Java, and literal strings are not Java in general. In the next paragraph, there is an example for the development directories of Java. I guess it was intended to be "*e.g. of Java*" instead of "i.e. Java", but "e.g." is redundant because this clause is already inside "for example". Here, I suggest replacing "development directories (i.e. Java)" with "development directories of Java".

#### Motivation and Context

> *Why is this change required?*

This change is required because the typos would affect the readability of the document.

> *What problem does it solve?*

This solves the problem of the documentation.

> *If it fixes an open issue, please link to the issue here.*

~~Closes #~~

There is no associated issue.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
> *Please describe in detail how you tested your changes.*

I have checked the appearance of the document in a Markdown viewer ([Markdown Viewer 5.3](https://chromewebstore.google.com/detail/markdown-viewer/ckkdlimhmcjmikdlpkmbgfkaikojcbjk?pli=1)).

<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.

Technically the main part of this PR is the documentation change. I haven't documented the documentation change because I don't expect documentation for documentation. However, if there is any documentation for the documentation change (such as ChangeLog for documentation?), please let me know about it. I'll happily update it.

- [ ] I have updated the tests accordingly.

I haven't updated the tests because this is a documentation change. If any tests need to be added for documentation (such as a spellcheck configuration?), please let me know.
