### PR TITLE
fix(bash): fix variable leak in Bash integration

### DIFF
--- a/src/init/starship.bash
+++ b/src/init/starship.bash
@@ -32,12 +32,12 @@ starship_preexec() {
 # Will be run before the prompt is drawn
 starship_precmd() {
     # Save the status, because commands in this pipeline will change $?
-    STARSHIP_CMD_STATUS=$? STARSHIP_PIPE_STATUS=(${PIPESTATUS[@]})
+    STARSHIP_CMD_STATUS=$? STARSHIP_PIPE_STATUS=("${PIPESTATUS[@]}")
     if [[ ${BLE_ATTACHED-} && ${#BLE_PIPESTATUS[@]} -gt 0 ]]; then
         STARSHIP_PIPE_STATUS=("${BLE_PIPESTATUS[@]}")
     fi
     if [[ -n "${BP_PIPESTATUS-}" ]] && [[ "${#BP_PIPESTATUS[@]}" -gt 0 ]]; then
-        STARSHIP_PIPE_STATUS=(${BP_PIPESTATUS[@]})
+        STARSHIP_PIPE_STATUS=("${BP_PIPESTATUS[@]}")
     fi
 
     # Due to a bug in certain Bash versions, any external process launched

--- a/src/init/starship.bash
+++ b/src/init/starship.bash
@@ -52,7 +52,7 @@ starship_precmd() {
     # Original bug: https://lists.gnu.org/archive/html/bug-bash/2022-07/msg00117.html
     jobs &>/dev/null
 
-    local NUM_JOBS=0
+    local NUM_JOBS=0 IFS=$' \t\n'
     # Evaluate the number of jobs before running the preserved prompt command, so that tools
     # like z/autojump, which background certain jobs, do not cause spurious background jobs
     # to be displayed by starship. Also avoids forking to run `wc`, slightly improving perf.

--- a/src/init/starship.bash
+++ b/src/init/starship.bash
@@ -52,7 +52,7 @@ starship_precmd() {
     # Original bug: https://lists.gnu.org/archive/html/bug-bash/2022-07/msg00117.html
     jobs &>/dev/null
 
-    local NUM_JOBS=0 IFS=$' \t\n'
+    local job NUM_JOBS=0 IFS=$' \t\n'
     # Evaluate the number of jobs before running the preserved prompt command, so that tools
     # like z/autojump, which background certain jobs, do not cause spurious background jobs
     # to be displayed by starship. Also avoids forking to run `wc`, slightly improving perf.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

This PR contains several trivial fixes to the Bash integration.

The most significant one is a fix for the variable leak. I suggest localizing the variable `job` used in the shell function `starship_precmd` (see commit 1edc7fec0075e92d943b4d91b01f632dab2dd257).

The others are protection for the custom `IFS` set by users. Commit 778694d71210acf1ed07a448ed72e5b42b5d4252 locally sets the variable `IFS` to the standard value `$' \t\n'`. Commit 8a73d3890e5310dd207f4329503f2659fb490f47 properly quotes the array expansions `${arr[@]}` as `"${arr[@]}"`.

#### Motivation and Context
> *Why is this change required?*

In the Bash integration, the variable `job` locally used in the shell function `starship_precmd` is not declared to be local. This makes the variable leak to the global context. The variable `job` is not intended to be exposed to the user. Rather, it would overwrite the global variable `job` if any is set by the user. This change is required to avoid polluting the global context and overwriting the user's variable.

As for the `IFS` issue, users are allowed to temporarily override the shell variable `IFS` to change how the word splitting happens. When `IFS` has a custom value set by the user, the word splitting of `${PIPESTATUS[@]}` and `$(jobs -p)` would end up with unexpected results. These changes are required to make the starship prompts unaffected by the custom `IFS`.

> *What problem does it solve?*

As for the variable leak issue, it solves the problem that the user's variable `job` if any would be overwritten.

As for the `IFS` issue, users can temporarily set the custom value to `IFS` to use the word splitting to split a string by a specified delimiter. For example, users may want to run the following commands:

```bash
$ old_IFS=${IFS-$' \t\n'}
$ IFS=:
$ arr=($BASHOPTS)
$ IFS=$old_IFS
```

During the above sequence of the commands, `starship_precmd` can be broken by the custom value of `IFS`. `$(jobs -p)` would not be split by newlines, so all the process IDs of jobs would be connected to produce a single word even with multiple jobs. If the custom `IFS` contains digits, `${PIPESTATUS[@]}` would also be broken by unexpected splitting and removal of numbers.

> *If it fixes an open issue, please link to the issue here.*
~~Closes #~~

There is no corresponding issue.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.

This is a fix for unexpected behaviors in the shell integration, and I haven't updated the documentation because there is no change in the expected/documented behavior.

- [ ] I have updated the tests accordingly.

The issue that this PR tries to fix is the one happening within the integration with the shell. I'm not sure how to add the tests for the integration with Bash, so now it's not included in this PR. If tests are needed, I'd appreciate it if you could lead me to the right way to add the appropriate tests.
