### PR TITLE
feat(unity): add unity module

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -1798,6 +1798,20 @@
         }
       ]
     },
+    "unity": {
+      "default": {
+        "disabled": false,
+        "format": "via [$symbol$version ]($style)",
+        "style": "bold blue",
+        "symbol": "🎮 ",
+        "version_format": "v${raw}"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/UnityConfig"
+        }
+      ]
+    },
     "username": {
       "default": {
         "aliases": {},
@@ -6144,6 +6158,32 @@
           "items": {
             "type": "string"
           }
+        }
+      },
+      "additionalProperties": false
+    },
+    "UnityConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "via [$symbol$version ]($style)",
+          "type": "string"
+        },
+        "version_format": {
+          "default": "v${raw}",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "🎮 ",
+          "type": "string"
+        },
+        "style": {
+          "default": "bold blue",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
         }
       },
       "additionalProperties": false

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -290,6 +290,7 @@ $cobol\
 $daml\
 $dart\
 $deno\
+$unity\
 $dotnet\
 $elixir\
 $elm\
@@ -4507,6 +4508,33 @@ By default, the module will be shown if any of the following conditions are met:
 | typst_version | `default` | The current Typst version                       |
 | symbol        |           | Mirrors the value of option `symbol`            |
 | style\*       |           | Mirrors the value of option `style`             |
+
+*: This variable can only be used as a part of a style string
+
+## Unity
+
+The `unity` module shows the currently installed version of [Unity](https://unity.com).
+By default the module will be shown if any of the following conditions are met:
+
+- The current directory contains both `ProjectSettings` and `Assets` directories.
+
+### Options
+
+| Option           | Default                           | Description                                                               |
+| ---------------- | --------------------------------- | ------------------------------------------------------------------------- |
+| `format`         | `'via [$symbol$version]($style)'` | The format for the module unity.                                          |
+| `version_format` | `'v${raw}'`                       | The version format. Available vars are `raw`, `major`, `minor`, & `patch` |
+| `symbol`         | `'🎮 '`                           | The symbol used before displaying the version of Unity.                   |
+| `style`          | `'bold blue'`                     | The style for the module.                                                 |
+| `disabled`       | `false`                           | Disables the `unity` module.                                              |
+
+### Variables
+
+| Variable | Example         | Description                          |
+| -------- | --------------- | ------------------------------------ |
+| version  | `v2022.30.12f3` | The version of `unity`               |
+| symbol   |                 | Mirrors the value of option `symbol` |
+| style\*  |                 | Mirrors the value of option `style`  |
 
 *: This variable can only be used as a part of a style string
 

--- a/docs/public/presets/toml/bracketed-segments.toml
+++ b/docs/public/presets/toml/bracketed-segments.toml
@@ -175,6 +175,9 @@ format = '\[[$symbol$workspace]($style)\]'
 [time]
 format = '\[[$time]($style)\]'
 
+[unity]
+format = '\[[$symbol$version ]($style)\]'
+
 [username]
 format = '\[[$user]($style)\]'
 

--- a/docs/public/presets/toml/nerd-font-symbols.toml
+++ b/docs/public/presets/toml/nerd-font-symbols.toml
@@ -160,5 +160,8 @@ symbol = " "
 [swift]
 symbol = " "
 
+[unity]
+symbol = "󰚯 "
+
 [zig]
 symbol = " "

--- a/docs/public/presets/toml/no-runtime-versions.toml
+++ b/docs/public/presets/toml/no-runtime-versions.toml
@@ -127,5 +127,8 @@ format = 'via [$symbol]($style)'
 [vlang]
 format = 'via [$symbol]($style)'
 
+[unity]
+format = 'via [$symbol]($style)'
+
 [zig]
 format = 'via [$symbol]($style)'

--- a/docs/public/presets/toml/plain-text-symbols.toml
+++ b/docs/public/presets/toml/plain-text-symbols.toml
@@ -230,5 +230,8 @@ symbol = "typst "
 [terraform]
 symbol = "terraform "
 
+[unity]
+symbol = "unity "
+
 [zig]
 symbol = "zig "

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -90,6 +90,7 @@ pub mod swift;
 pub mod terraform;
 pub mod time;
 pub mod typst;
+pub mod unity;
 pub mod username;
 pub mod v;
 pub mod vagrant;
@@ -286,6 +287,8 @@ pub struct FullConfig<'a> {
     time: time::TimeConfig<'a>,
     #[serde(borrow)]
     typst: typst::TypstConfig<'a>,
+    #[serde(borrow)]
+    unity: unity::UnityConfig<'a>,
     #[serde(borrow)]
     username: username::UsernameConfig<'a>,
     #[serde(borrow)]

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -60,6 +60,7 @@ pub const PROMPT_ORDER: &[&str] = &[
     "daml",
     "dart",
     "deno",
+    "unity",
     "dotnet",
     "elixir",
     "elm",

--- a/src/configs/unity.rs
+++ b/src/configs/unity.rs
@@ -1,0 +1,28 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(
+    feature = "config-schema",
+    derive(schemars::JsonSchema),
+    schemars(deny_unknown_fields)
+)]
+#[serde(default)]
+pub struct UnityConfig<'a> {
+    pub format: &'a str,
+    pub version_format: &'a str,
+    pub symbol: &'a str,
+    pub style: &'a str,
+    pub disabled: bool,
+}
+
+impl<'a> Default for UnityConfig<'a> {
+    fn default() -> Self {
+        UnityConfig {
+            format: "via [$symbol$version ]($style)",
+            version_format: "v${raw}",
+            symbol: "🎮 ",
+            style: "bold blue",
+            disabled: false,
+        }
+    }
+}

--- a/src/module.rs
+++ b/src/module.rs
@@ -94,6 +94,7 @@ pub const ALL_MODULES: &[&str] = &[
     "terraform",
     "time",
     "typst",
+    "unity",
     "username",
     "vagrant",
     "vcsh",

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -85,6 +85,7 @@ mod sudo;
 mod swift;
 mod terraform;
 mod time;
+mod unity;
 mod username;
 mod utils;
 mod vagrant;
@@ -198,6 +199,7 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
             "time" => time::module(context),
             "typst" => typst::module(context),
             "crystal" => crystal::module(context),
+            "unity" => unity::module(context),
             "username" => username::module(context),
             "vlang" => vlang::module(context),
             "vagrant" => vagrant::module(context),
@@ -321,6 +323,7 @@ pub fn description(module: &str) -> &'static str {
         "terraform" => "The currently selected terraform workspace and version",
         "time" => "The current local time",
         "typst" => "The current installed version of typst",
+        "unity" => "The version of Unity of the project in the current directory",
         "username" => "The active user's username",
         "vagrant" => "The currently installed version of Vagrant",
         "vcsh" => "The currently active VCSH repository",

--- a/src/modules/unity.rs
+++ b/src/modules/unity.rs
@@ -1,0 +1,131 @@
+use super::{Context, Module, ModuleConfig};
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
+use yaml_rust2::YamlLoader;
+
+use crate::configs::unity::UnityConfig;
+use crate::formatter::string_formatter::StringFormatterError;
+use crate::formatter::StringFormatter;
+use crate::formatter::VersionFormatter;
+
+/// Creates a module with the current Unity version and platform
+pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let mut module = context.new_module("unity");
+    let config = UnityConfig::try_load(module.config);
+
+    let is_unity_project = context
+        .dir_contents()
+        .map(|c| c.has_folder("Assets") && c.has_folder("ProjectSettings"))
+        .ok()?;
+
+    let version_file_path = Path::new(&context.logical_dir)
+        .join("ProjectSettings")
+        .join("ProjectVersion.txt");
+
+    if !is_unity_project || !&version_file_path.exists() {
+        return None;
+    }
+
+    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
+        formatter
+            .map_meta(|variable, _| match variable {
+                "symbol" => Some(config.symbol),
+                _ => None,
+            })
+            .map_style(|variable| match variable {
+                "style" => Some(Ok(config.style)),
+                _ => None,
+            })
+            .map(|variable| match variable {
+                "version" => {
+                    let mut file = File::open(&version_file_path).ok()?;
+                    let mut contents = String::new();
+                    file.read_to_string(&mut contents).ok()?;
+
+                    let yaml = YamlLoader::load_from_str(&contents).ok()?;
+                    let yaml = &yaml[0]["m_EditorVersion"];
+
+                    if let Some(m_editor_version) = yaml.as_str() {
+                        Some(Ok(VersionFormatter::format_module_version(
+                            module.get_name(),
+                            m_editor_version.trim(),
+                            config.version_format,
+                        )
+                        .unwrap()))
+                    } else {
+                        Some(Err(StringFormatterError::Custom(String::from(
+                            "Could not find Unity version.",
+                        ))))
+                    }
+                }
+                _ => None,
+            })
+            .parse(None, Some(context))
+    });
+
+    module.set_segments(match parsed {
+        Ok(segments) => segments,
+        Err(error) => {
+            log::warn!("Error in module `unity`:\n{}", error);
+            return None;
+        }
+    });
+
+    Some(module)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::ModuleRenderer;
+    use nu_ansi_term::Color;
+    use std::fs::File;
+    use std::io;
+    use std::io::Write;
+
+    #[test]
+    fn folder_without_unity() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join("unity.txt"))?.sync_all()?;
+        let actual = ModuleRenderer::new("unity").path(dir.path()).collect();
+        let expected = None;
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn folder_with_unity() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+
+        std::fs::create_dir(dir.path().join("Assets"))?;
+        let ps_path = dir.path().join("ProjectSettings");
+        std::fs::create_dir(&ps_path)?;
+
+        let mut pv_file = File::create(ps_path.join("ProjectVersion.txt"))?;
+        pv_file.write_all(b"m_EditorVersion: 2022.3.30f1\n")?;
+        pv_file.write_all(b"m_EditorVersionWithRevision: 2022.3.30f1 (70558241b701)")?;
+        pv_file.sync_all()?;
+
+        let actual = ModuleRenderer::new("unity").path(dir.path()).collect();
+        let expected = Some(format!(
+            "via {}",
+            Color::Blue.bold().paint("🎮 v2022.3.30f1 ")
+        ));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn folder_without_version() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+
+        std::fs::create_dir(dir.path().join("Assets"))?;
+        let ps_path = dir.path().join("ProjectSettings");
+        std::fs::create_dir(ps_path)?;
+
+        let actual = ModuleRenderer::new("unity").path(dir.path()).collect();
+        let expected = None;
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+}


### PR DESCRIPTION
#### Description
Adds support for Unity game engine - shows the version of Unity used by the project in the current directory.

#### Motivation and Context
I use Unity and Starship daily, and this was a good opportunity to learn Rust. This is my first real Rust project so any advice is appreciated.

#### Screenshots (if appropriate):
<img width="577" alt="image" src="https://github.com/user-attachments/assets/1dc8dc08-c20b-4712-8e54-ab27da7cab29">

#### How Has This Been Tested?
Included tests pass and I ran Starship from Unity projects with:
`cargo run --manifest-path "/Users/mihakrajnc/Dev/Projects/starship/Cargo.toml" prompt`
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
