### PR TITLE
fix(python): improve parsing of `pyvenv.cfg` files

### DIFF
--- a/src/modules/python.rs
+++ b/src/modules/python.rs
@@ -1,5 +1,4 @@
 use ini::Ini;
-use std::io::Read;
 use std::path::Path;
 
 use super::{Context, Module, ModuleConfig};
@@ -124,19 +123,11 @@ fn get_python_virtual_env(context: &Context) -> Option<String> {
 }
 
 fn get_prompt_from_venv(venv_path: &Path) -> Option<String> {
-    let mut buf = String::new();
-    if std::fs::File::open(venv_path.join("pyvenv.cfg"))
-        .ok()?
-        .read_to_string(&mut buf)
-        .is_err()
-    {
-        return None;
-    }
-    Ini::load_from_str(buf.replace("\\", "/").as_str())
+    Ini::load_from_file_noescape(venv_path.join("pyvenv.cfg"))
         .ok()?
         .general_section()
         .get("prompt")
-        .map(|prompt| String::from(prompt.trim_matches(&['(', ')'] as &[_])))
+        .map(|prompt| String::from(prompt.replace("\\", "/").trim_matches(&['(', ')'] as &[_])))
 }
 
 #[cfg(test)]

--- a/src/modules/python.rs
+++ b/src/modules/python.rs
@@ -1,4 +1,5 @@
 use ini::Ini;
+use std::io::Read;
 use std::path::Path;
 
 use super::{Context, Module, ModuleConfig};
@@ -121,8 +122,16 @@ fn get_python_virtual_env(context: &Context) -> Option<String> {
         })
     })
 }
+
 fn get_prompt_from_venv(venv_path: &Path) -> Option<String> {
-    Ini::load_from_file(venv_path.join("pyvenv.cfg"))
+    let mut buf = String::new();
+    if let Err(_) = std::fs::File::open(venv_path.join("pyvenv.cfg"))
+        .ok()?
+        .read_to_string(&mut buf)
+    {
+        return None;
+    }
+    Ini::load_from_str(buf.replace("\\", "/").as_str())
         .ok()?
         .general_section()
         .get("prompt")
@@ -418,6 +427,33 @@ prompt = '(foo)'
         let expected = Some(format!(
             "via {}",
             Color::Yellow.bold().paint("🐍 v3.8.0 (foo) ")
+        ));
+
+        assert_eq!(actual, expected);
+        dir.close()
+    }
+
+    #[test]
+    fn with_active_venv_and_line_break_like_prompt() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        create_dir_all(dir.path().join("my_venv"))?;
+        let mut venv_cfg = File::create(dir.path().join("my_venv").join("pyvenv.cfg"))?;
+        venv_cfg.write_all(
+            br"
+home = something
+prompt = foo\nbar
+        ",
+        )?;
+        venv_cfg.sync_all()?;
+
+        let actual = ModuleRenderer::new("python")
+            .path(dir.path())
+            .env("VIRTUAL_ENV", dir.path().join("my_venv").to_str().unwrap())
+            .collect();
+
+        let expected = Some(format!(
+            "via {}",
+            Color::Yellow.bold().paint("🐍 v3.8.0 (foo/nbar) ")
         ));
 
         assert_eq!(actual, expected);

--- a/src/modules/python.rs
+++ b/src/modules/python.rs
@@ -125,9 +125,10 @@ fn get_python_virtual_env(context: &Context) -> Option<String> {
 
 fn get_prompt_from_venv(venv_path: &Path) -> Option<String> {
     let mut buf = String::new();
-    if let Err(_) = std::fs::File::open(venv_path.join("pyvenv.cfg"))
+    if std::fs::File::open(venv_path.join("pyvenv.cfg"))
         .ok()?
         .read_to_string(&mut buf)
+        .is_err()
     {
         return None;
     }

--- a/src/modules/python.rs
+++ b/src/modules/python.rs
@@ -127,7 +127,7 @@ fn get_prompt_from_venv(venv_path: &Path) -> Option<String> {
         .ok()?
         .general_section()
         .get("prompt")
-        .map(|prompt| String::from(prompt.replace("\\", "/").trim_matches(&['(', ')'] as &[_])))
+        .map(|prompt| String::from(prompt.trim_matches(&['(', ')'] as &[_])))
 }
 
 #[cfg(test)]
@@ -445,7 +445,7 @@ prompt = foo\nbar
 
         let expected = Some(format!(
             "via {}",
-            Color::Yellow.bold().paint("🐍 v3.8.0 (foo/nbar) ")
+            Color::Yellow.bold().paint(r"🐍 v3.8.0 (foo\nbar) ")
         ));
 
         assert_eq!(actual, expected);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Some python virtual environments have `prompt` set to a path, which in Windows would include the `\` symbol here. We will accidentally escape something like `\n` to a line break here, and similarly symbols like `\r` will be converted. I got around this by rewriting `\` to `\\` before parsing the `pyvenv.cfg` file.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #6125

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
