### PR TITLE
feat(directory): Fallback to original string when contract failed

### DIFF
--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -103,7 +103,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         String::new()
     };
 
-    // the usage of 2 takes in the following is to avoid borrowing issues. They would never overlaps, so the ? are safe
+    // the usage of 2 takes in the following is to avoid borrowing issues. They would never overlaps, so the unwrap is safe
     let mut maybe_prefix = Some(prefix);
     let path_vec = repo
         .and_then(|r| r.workdir.as_ref())
@@ -129,11 +129,16 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             }
             None
         })
-        .unwrap_or([
-            String::new(),
-            String::new(),
-            maybe_prefix.take()? + dir_string.as_str(),
-        ]);
+        .unwrap_or_else(|| {
+            [
+                String::new(),
+                String::new(),
+                maybe_prefix
+                    .take()
+                    .expect("the previous take should not have happened")
+                    + dir_string.as_str(),
+            ]
+        });
 
     let path_vec = if config.use_os_path_sep {
         path_vec.map(|i| convert_path_sep(&i))

--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -108,23 +108,23 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let path_vec = repo
         .and_then(|r| r.workdir.as_ref())
         .and_then(|repo_root| {
-            if config.repo_root_style.is_some() {
-                if let Some(contracted_path) = contract_repo_path(display_dir, repo_root) {
-                    let repo_path_vec: Vec<&str> = contracted_path.split('/').collect();
-                    let after_repo_root = contracted_path.replacen(repo_path_vec[0], "", 1);
-                    let num_segments_after_root = after_repo_root.split('/').count();
+            if config.repo_root_style.is_some()
+                && let Some(contracted_path) = contract_repo_path(display_dir, repo_root)
+            {
+                let repo_path_vec: Vec<&str> = contracted_path.split('/').collect();
+                let after_repo_root = contracted_path.replacen(repo_path_vec[0], "", 1);
+                let num_segments_after_root = after_repo_root.split('/').count();
 
-                    if config.truncation_length == 0
-                        || ((num_segments_after_root - 1) as i64) < config.truncation_length
-                    {
-                        let root = repo_path_vec[0];
-                        let before = before_root_dir(&dir_string, &contracted_path);
-                        return Some([
-                            maybe_prefix.take()? + before,
-                            root.to_string(),
-                            after_repo_root,
-                        ]);
-                    }
+                if config.truncation_length == 0
+                    || ((num_segments_after_root - 1) as i64) < config.truncation_length
+                {
+                    let root = repo_path_vec[0];
+                    let before = before_root_dir(&dir_string, &contracted_path);
+                    return Some([
+                        maybe_prefix.take()? + before,
+                        root.to_string(),
+                        after_repo_root,
+                    ]);
                 }
             }
             None


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

There was a bug where `[directory]` produced an empty directory string when `contract_repo_path` failed.

This changes fixes it. The changes involves avoiding the `?` at: (current behaviour will made it returns none, i.e. empty string)
```rs
let contracted_path = contract_repo_path(display_dir, repo_root)?;
```
The original approach also has multiple code path that leads to the default
```rs
[String::new(), String::new(), prefix + dir_string.as_str()]
```
and this implementation centralises it to only provides default value at the very end.

#### Motivation and Context


**Minimum reproducible config:**
```toml
[directory]
repo_root_style = ""
truncate_to_repo = true
```
Currently, `[directory]` can shorten path to repo root. When user is using custom `repo_root_style` style, and when the path contract fails (e.g. using a symlink to a subdirectory of a repo), the current behaviour produces an empty "shorten" string.

Creating a test scenario:
```sh
# make an empty test repo
$ mkdir my_repo && cd my_repo && git init && mkdir subdir && cd ..
# link to repo root
$ ln -s my_repo link_to_repo     
# link to repo root subdir
$ ln -s my_repo/subdir link_to_repo_subdir    
```
Current behaviour:
```sh
$ cd link_to_repo
$ starship prompt

link_to_repo on  master         # <=== This is correct
$ cd ../link_to_repo_subdir
$ starship prompt

on  master                      # <=== This is an EMPTY "shorten" path
```

New behaviour (falling back to un-shorten path, instead of unwrapping empty option):
```sh
$ cd ../link_to_repo_subdir

git-repos/other_folders/link_to_repo_subdir on  master         # <=== This is the original un-shorten path
```

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
