### PR TITLE
feat: ignore configured commands for cmd_duration notify

### DIFF
--- a/src/configs/cmd_duration.rs
+++ b/src/configs/cmd_duration.rs
@@ -15,6 +15,7 @@ pub struct CmdDurationConfig<'a> {
     pub disabled: bool,
     pub show_notifications: bool,
     pub min_time_to_notify: i64,
+    pub notify_ignore_commands: Vec<&'a str>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub notification_timeout: Option<u32>,
@@ -31,6 +32,7 @@ impl<'a> Default for CmdDurationConfig<'a> {
             show_notifications: false,
             min_time_to_notify: 45_000,
             notification_timeout: None,
+            notify_ignore_commands: vec![],
         }
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -860,6 +860,9 @@ pub struct Properties {
     /// The execution duration of the last command, in milliseconds
     #[clap(short = 'd', long)]
     pub cmd_duration: Option<String>,
+    /// The last command
+    #[clap(short = 'c', long)]
+    pub cmd: Option<String>,
     /// The keymap of fish/zsh/cmd
     #[clap(short = 'k', long, default_value = "viins")]
     pub keymap: String,
@@ -879,6 +882,7 @@ impl Default for Properties {
             cmd_duration: None,
             keymap: "viins".to_string(),
             jobs: 0,
+            cmd: None,
         }
     }
 }

--- a/src/init/starship.nu
+++ b/src/init/starship.nu
@@ -2,37 +2,53 @@
 # - overlay which can be loaded with `overlay use starship.nu`
 # - module which can be used with `use starship.nu`
 # - script which can be used with `source starship.nu`
-export-env { $env.STARSHIP_SHELL = "nu"; load-env {
-    STARSHIP_SESSION_KEY: (random chars -l 16)
-    PROMPT_MULTILINE_INDICATOR: (
-        ^::STARSHIP:: prompt --continuation
-    )
+export-env {
+    $env.STARSHIP_SHELL = "nu"
 
-    # Does not play well with default character module.
-    # TODO: Also Use starship vi mode indicators?
-    PROMPT_INDICATOR: ""
-
-    PROMPT_COMMAND: {||
-        # jobs are not supported
-        (
-            ^::STARSHIP:: prompt
-                --cmd-duration $env.CMD_DURATION_MS
-                $"--status=($env.LAST_EXIT_CODE)"
-                --terminal-width (term size).columns
-        )
+    $env.config.hooks.pre_execution ++= {||
+        let cmd = commandline | parse --regex '\s*(:?sudo\s+)?(?<cmd>\w+).*' | get cmd
+        if ($cmd | is-not-empty) {
+            export-env {
+                $env.LAST_CMD = $cmd | first
+            }
+        }
     }
 
-    config: ($env.config? | default {} | merge {
-        render_right_prompt_on_last_line: true
-    })
-
-    PROMPT_COMMAND_RIGHT: {||
-        (
-            ^::STARSHIP:: prompt
-                --right
-                --cmd-duration $env.CMD_DURATION_MS
-                $"--status=($env.LAST_EXIT_CODE)"
-                --terminal-width (term size).columns
+    load-env {
+        STARSHIP_SESSION_KEY: (random chars -l 16)
+        PROMPT_MULTILINE_INDICATOR: (
+            ^::STARSHIP:: prompt --continuation
         )
+
+        # Does not play well with default character module.
+        # TODO: Also Use starship vi mode indicators?
+        PROMPT_INDICATOR: ""
+
+        PROMPT_COMMAND: {||
+            # jobs are not supported
+            (
+                ^::STARSHIP:: prompt
+                    --cmd-duration $env.CMD_DURATION_MS
+                    --cmd ($env | default '' LAST_CMD | get LAST_CMD)
+                    $"--status=($env.LAST_EXIT_CODE)"
+                    --terminal-width (term size).columns
+            )
+        }
+
+        config: ($env.config? | default {} | merge {
+            render_right_prompt_on_last_line: true
+        })
+
+        PROMPT_COMMAND_RIGHT: {||
+            (
+                ^::STARSHIP:: prompt
+                    --right
+                    --cmd-duration $env.CMD_DURATION_MS
+                    --cmd ($env | default '' LAST_CMD | get LAST_CMD)
+                    $"--status=($env.LAST_EXIT_CODE)"
+                    --terminal-width (term size).columns
+            )
+        }
     }
-}}
+}
+

--- a/src/modules/cmd_duration.rs
+++ b/src/modules/cmd_duration.rs
@@ -83,6 +83,12 @@ fn undistract_me<'a>(
             };
         }
 
+        if let Some(cmd) = context.properties.cmd.as_deref() {
+            if config.notify_ignore_commands.contains(&cmd) {
+                return module;
+            }
+        }
+
         let body = format!(
             "Command execution {}",
             unstyle(&AnsiStrings(&module.ansi_strings()))


### PR DESCRIPTION
WIP!  I've implemented this because I was wanting this feature for a while, then I discovered it was already a popular request (#1933), so I attempted to implement it.  No tests or documentation updates yet, as the api is likely to change as this is reviewed and discussed.

#### Description

Add a `notify_ignore_commands` option to the `cmd_duration` module, and configuration for nushell support.

For example, this provides support for enabling notifications for long running commands, while ignoring a configurable list of long running commands:

```
[cmd_duration]
show_notifications = true
min_time_to_notify = 5_000
notify_ignore_commands = ["vim", "mpv", "mutt"]
```

This is useful to avoid many false positives for this notification when exiting editors, etc.

I use nushell, so have included an initial nushell configuration for getting the last run command.  This may not be possible for all shells.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #1933

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
