### PR TITLE
fix(git_status): read proper name for core.fsmonitor flag

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -345,7 +345,7 @@ impl<'a> Context<'a> {
 
                 let fs_monitor_value_is_true = repository
                     .config_snapshot()
-                    .boolean("core.fs_monitor")
+                    .boolean("core.fsmonitor")
                     .unwrap_or(false);
 
                 Ok(Repo {


### PR DESCRIPTION
## Context

It seems like this is referencing the wrong config value, so it is unsetting the config value when running git statuses

#### Description
`core.fs_monitor` is not a valid config value, the proper name is `core.fsmonitor`

#### Motivation and Context

This should help speed up git status by using the `core.fsmonitor` git config

#### Screenshots (if appropriate):

See the git status is overriding the `core.fsmonitor` to empty

<img width="1131" alt="image" src="https://github.com/user-attachments/assets/a08641b6-61d6-4ca0-9050-103e89f70512">
