### PR TITLE
fix(fish): add missing arguments for fish transient prompt functions

### DIFF
--- a/src/init/starship.fish
+++ b/src/init/starship.fish
@@ -16,7 +16,7 @@ function fish_prompt
         # See https://github.com/fish-shell/fish-shell/issues/8418
         printf \e\[0J
         if type -q starship_transient_prompt_func
-            starship_transient_prompt_func
+            starship_transient_prompt_func --terminal-width="$COLUMNS" --status=$STARSHIP_CMD_STATUS --pipestatus="$STARSHIP_CMD_PIPESTATUS" --keymap=$STARSHIP_KEYMAP --cmd-duration=$STARSHIP_DURATION --jobs=$STARSHIP_JOBS
         else
             printf "\e[1;32m❯\e[0m "
         end
@@ -40,7 +40,7 @@ function fish_right_prompt
     if test "$RIGHT_TRANSIENT" = "1"
         set -g RIGHT_TRANSIENT 0
         if type -q starship_transient_rprompt_func
-            starship_transient_rprompt_func
+            starship_transient_rprompt_func --terminal-width="$COLUMNS" --status=$STARSHIP_CMD_STATUS --pipestatus="$STARSHIP_CMD_PIPESTATUS" --keymap=$STARSHIP_KEYMAP --cmd-duration=$STARSHIP_DURATION --jobs=$STARSHIP_JOBS
         else
             printf ""
         end


### PR DESCRIPTION
#### Description
Fixed an issue where required arguments were not passed when calling `starship_transient_prompt_func` and `starship_transient_rprompt_func`. This caused some modules such as `cmd_duration` and `status` not to work correctly in the transient prompt in fish.

#### Motivation and Context
Closes #6180 

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [X] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have updated the documentation accordingly. (_not absolutely required_)
- [x] I have updated the tests accordingly. (_not absolutely required_)
