### PR TITLE
docs(git_commit): add extra trailing space to `tag_symbol`

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1845,7 +1845,7 @@ The `git_commit` module shows the current commit hash and also the tag (if any) 
 | `only_detached`      | `true`                       | Only show git commit hash when in detached `HEAD` state                              |
 | `tag_disabled`       | `true`                       | Disables showing tag info in `git_commit` module.                                    |
 | `tag_max_candidates` | `0`                          | How many commits to consider for tag display. The default only allows exact matches. |
-| `tag_symbol`         | `' 🏷 '`                      | Tag symbol prefixing the info shown                                                  |
+| `tag_symbol`         | `' 🏷  '`                     | Tag symbol prefixing the info shown                                                  |
 | `disabled`           | `false`                      | Disables the `git_commit` module.                                                    |
 
 ### Variables


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
The [documented default](https://starship.rs/config/#options-32) for `tag_symbol` has one trailing space, but it actually has 2 trailing spaces. This removes the extra trailing space.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Removes an extra trailing space to match the documented default.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
