### PR TITLE
docs(preset): add `git_commit` tag symbol to Nerd Font Symbols preset

### DIFF
--- a/docs/public/presets/toml/nerd-font-symbols.toml
+++ b/docs/public/presets/toml/nerd-font-symbols.toml
@@ -37,6 +37,9 @@ symbol = " "
 [git_branch]
 symbol = " "
 
+[git_commit]
+tag_symbol = '  '
+
 [golang]
 symbol = " "
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
The Nerd Font Symbols preset is missing a Nerd Font icon for the `git_commit` module `tag_symbol`. This PR sets it to the Octicon `tag` icon.

n.b. This PR incorporates the fix from https://github.com/starship/starship/pull/6186 (i.e. there is only 1 trailing space after the icon, instead of the current 2).

#### Motivation and Context
Makes the Nerd Font Symbols preset do what it's supposed to.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
