### PR TITLE
fix(directory): before_repo_root_style without repo_root_style

### DIFF
--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -107,7 +107,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     };
 
     let path_vec = match &repo.and_then(|r| r.workdir.as_ref()) {
-        Some(repo_root) => {
+        Some(repo_root) if repo_root != &&home_dir => {
             let contracted_path = contract_repo_path(display_dir, repo_root)?;
             let repo_path_vec: Vec<&str> = contracted_path.split('/').collect();
             let after_repo_root = contracted_path.replacen(repo_path_vec[0], "", 1);

--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -1830,7 +1830,7 @@ mod tests {
             "{}{} ",
             Color::White
                 .dimmed()
-                .paint(format!("{}{}", "…/", convert_path_sep(".config/"))),
+                .paint(convert_path_sep("…/.config/")),
             Color::Cyan
                 .bold()
                 .paint(convert_path_sep("nix/darwin-configurations")),

--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -1828,9 +1828,7 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "{}{} ",
-            Color::White
-                .dimmed()
-                .paint(convert_path_sep("…/.config/")),
+            Color::White.dimmed().paint(convert_path_sep("…/.config/")),
             Color::Cyan
                 .bold()
                 .paint(convert_path_sep("nix/darwin-configurations")),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This fixes the issue in the directory module where `before_repo_root_style` fails to work when `repo_root_style` is not set.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #6179

#### Screenshots (if appropriate):
Screenshot of testing after fix:

<img width="874" alt="image" src="https://github.com/user-attachments/assets/a8c74430-ce63-4bb2-9919-bfa1a2411cbc">


#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
  - Tested manually with `eval "$(cargo run init zsh)"`
  - Ensured automated tests passed.
  - I tested within the devshell created by the following `nix` flake. It should be the same environment used to build `starship` on nix, but with rustfmt installed as well.

<details><summary>flake.nix</summary>

```nix
{
  inputs = {
    utils.url = "github:numtide/flake-utils";
    nixpkgs.url = "github:NixOS/nixpkgs";
  };
  outputs =
    {
      self,
      nixpkgs,
      utils,
    }:
    utils.lib.eachDefaultSystem (
      system:
      let
        pkgs = nixpkgs.legacyPackages.${system};
      in
      {
        devShell = pkgs.mkShell {
          buildInputs = [ pkgs.rustfmt ];
          inputsFrom = [ pkgs.starship ];
        };
      }
    );
}
```

</details>

- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
