### PR TITLE
fix: get php version in windows

### DIFF
--- a/src/modules/php.rs
+++ b/src/modules/php.rs
@@ -35,7 +35,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                         "php",
                         &[
                             "-nr",
-                            "echo PHP_MAJOR_VERSION.\".\".PHP_MINOR_VERSION.\".\".PHP_RELEASE_VERSION;",
+                            "echo PHP_MAJOR_VERSION.'.'.PHP_MINOR_VERSION.'.'.PHP_RELEASE_VERSION;",
                         ],
                     )?.stdout;
                     VersionFormatter::format_module_version(module.get_name(), &php_version, config.version_format).map(Ok)


### PR DESCRIPTION
This will resolve this issue below:

```log
[TRACE] - (starship::context): Executing command "php" with args ["-nr", "echo PHP_MAJOR_VERSION.\".\".PHP_MINOR_VERSION.\".\".PHP_RELEASE_VERSION;"] from context
[TRACE] - (starship::utils): Creating Command for binary "php"
[TRACE] - (starship::utils): Using "C:\\Users\\Aminul\\.config\\herd\\bin\\php.bat" as "php"
[TRACE] - (starship::utils): stdout: "\nParse error: syntax error, unexpected end of file, expecting variable (T_VARIABLE) or ${ (T_DOLLAR_OPEN_CURLY_BRACES) or {$ (T_CURLY_OPEN) in Command line code on line 1\n", stderr: "", exit code: "Some(254)", took 42.1362ms

```