### PR TITLE
feat(python): detect pyenv shell outside the python source tree

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -1409,6 +1409,7 @@
           "__init__.py"
         ],
         "detect_folders": [],
+        "detect_pyenv_shell": false,
         "disabled": false,
         "format": "via [${symbol}${pyenv_prefix}(${version} )(\\($virtualenv\\) )]($style)",
         "pyenv_prefix": "pyenv ",
@@ -5258,6 +5259,10 @@
           "items": {
             "type": "string"
           }
+        },
+        "detect_pyenv_shell": {
+          "default": false,
+          "type": "boolean"
         }
       },
       "additionalProperties": false

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -3672,6 +3672,7 @@ By default, the module will be shown if any of the following conditions are met:
 | `detect_extensions`  | `['py']`                                                                                                     | Which extensions should trigger this module                                            |
 | `detect_files`       | `['.python-version', 'Pipfile', '__init__.py', 'pyproject.toml', 'requirements.txt', 'setup.py', 'tox.ini']` | Which filenames should trigger this module                                             |
 | `detect_folders`     | `[]`                                                                                                         | Which folders should trigger this module                                               |
+| `detect_pyenv_shell` | `false`                                                                                                      | Detect the `PYENV_SHELL` environment variable.                                         |
 | `disabled`           | `false`                                                                                                      | Disables the `python` module.                                                          |
 
 ::: tip

--- a/src/configs/python.rs
+++ b/src/configs/python.rs
@@ -21,6 +21,7 @@ pub struct PythonConfig<'a> {
     pub detect_extensions: Vec<&'a str>,
     pub detect_files: Vec<&'a str>,
     pub detect_folders: Vec<&'a str>,
+    pub detect_pyenv_shell: bool,
 }
 
 impl<'a> Default for PythonConfig<'a> {
@@ -45,6 +46,7 @@ impl<'a> Default for PythonConfig<'a> {
                 "__init__.py",
             ],
             detect_folders: vec![],
+            detect_pyenv_shell: false,
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
This feature adds a new boolean setting for the `python` module `detect_pyenv_shell`.
When enabled, the currently selected via the `pyenv shell` command version is displayed even outside the python source tree.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #6197

#### Screenshots (if appropriate):
![Screenshot_20240817_111415](https://github.com/user-attachments/assets/a3ac2bc3-507f-45cb-85c8-5985b2c7acfd)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
