### PR TITLE
docs: $PROFILE config for PowerShell 7+

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,11 +365,19 @@ Add the following to the end of your PowerShell configuration (find it by runnin
 Invoke-Expression (&starship init powershell)
 ```
 
-If you are using PowerShell 7.0+, instead of the version(s) that ship with Windows 10/11, you can use the following instead:
+If you are using PowerShell 7.0+, instead of the version(s) that ship with Windows 10/11, you may need to use the following instead:
 
 ```powershell
 & 'C:\Program Files\starship\bin\starship.exe' init powershell | Out-String | Invoke-Expression
 ```
+
+If you do not already have a PowerShell configuration file, create one in the location you obtained, with the name shown when you ran the `$PROFILE` command. If this is the first time you are attempting to run code not signed by Microsoft, you will need to enable scripts execution. You can do this by running the following command: 
+
+`Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser -Confirm `. 
+
+or,
+
+`Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Scope CurrentUser -Confirm `.
 
 To test if Starship is working, save and close your updated profile, and run `. $PROFILE` in PowerShell. If you see your Starship prompt, you're all set! Tip: This works best if you installed Starship with the MSI installer in the default installation location. Otherwise, you may have to update the path to the `starship.exe` file.
 

--- a/README.md
+++ b/README.md
@@ -364,11 +364,12 @@ Add the following to the end of your PowerShell configuration (find it by runnin
 ```powershell
 Invoke-Expression (&starship init powershell)
 ```
-
 If you are using PowerShell 7.0+, instead of the version(s) that ship with Windows 10/11, you can use the following instead:
+
 ```powershell
 & 'C:\Program Files\starship\bin\starship.exe' init powershell | Out-String | Invoke-Expression
 ```
+
 To test if Starship is working, save and close your updated profile, and run `. $PROFILE` in PowerShell. If you see your Starship prompt, you're all set! Tip: This works best if you installed Starship with the MSI installer in the default installation location. Otherwise, you may have to update the path to the `starship.exe` file.
 
 </details>

--- a/README.md
+++ b/README.md
@@ -371,13 +371,13 @@ If you are using PowerShell 7.0+, instead of the version(s) that ship with Windo
 & 'C:\Program Files\starship\bin\starship.exe' init powershell | Out-String | Invoke-Expression
 ```
 
-If you do not already have a PowerShell configuration file, create one in the location you obtained, with the name shown when you ran the `$PROFILE` command. If this is the first time you are attempting to run code not signed by Microsoft, you will need to enable scripts execution. You can do this by running the following command: 
+If you do not already have a PowerShell configuration file, create one in the location you obtained, with the name shown when you ran the `$PROFILE` command. If this is the first time you are attempting to run code not signed by Microsoft, you will need to enable scripts execution. You can do this by running the following command:
 
-`Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser -Confirm `. 
+`Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser -Confirm`. 
 
 or,
 
-`Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Scope CurrentUser -Confirm `.
+`Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Scope CurrentUser -Confirm`.
 
 To test if Starship is working, save and close your updated profile, and run `. $PROFILE` in PowerShell. If you see your Starship prompt, you're all set! Tip: This works best if you installed Starship with the MSI installer in the default installation location. Otherwise, you may have to update the path to the `starship.exe` file.
 

--- a/README.md
+++ b/README.md
@@ -365,6 +365,17 @@ Add the following to the end of your PowerShell configuration (find it by runnin
 Invoke-Expression (&starship init powershell)
 ```
 
+If you are using PowerShell 7.0+, instead of the versions that ship with Windows 10/11, you can 
+use the following instead:
+
+```powershell
+& 'C:\Program Files\starship\bin\starship.exe' init powershell | Out-String | Invoke-Expression
+```
+To test if Starship is working, save and close your updated profile, and run `. $PROFILE` in 
+Pwershell. If you see your Starship prompt, you're all set! Tip: This works best if you installed
+Starship with the MSI installer in the default installation location. Otherwise, you may have to
+update the path to the `starship.exe` file.
+
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -365,14 +365,13 @@ Add the following to the end of your PowerShell configuration (find it by runnin
 Invoke-Expression (&starship init powershell)
 ```
 
-If you are using PowerShell 7.0+, instead of the versions that ship with Windows 10/11, you can 
+If you are using PowerShell 7.0+, instead of the version(s) that ship with Windows 10/11, you can 
 use the following instead:
-
 ```powershell
 & 'C:\Program Files\starship\bin\starship.exe' init powershell | Out-String | Invoke-Expression
 ```
 To test if Starship is working, save and close your updated profile, and run `. $PROFILE` in 
-Pwershell. If you see your Starship prompt, you're all set! Tip: This works best if you installed
+PowerShell. If you see your Starship prompt, you're all set! Tip: This works best if you installed
 Starship with the MSI installer in the default installation location. Otherwise, you may have to
 update the path to the `starship.exe` file.
 

--- a/README.md
+++ b/README.md
@@ -365,15 +365,11 @@ Add the following to the end of your PowerShell configuration (find it by runnin
 Invoke-Expression (&starship init powershell)
 ```
 
-If you are using PowerShell 7.0+, instead of the version(s) that ship with Windows 10/11, you can 
-use the following instead:
+If you are using PowerShell 7.0+, instead of the version(s) that ship with Windows 10/11, you can use the following instead:
 ```powershell
 & 'C:\Program Files\starship\bin\starship.exe' init powershell | Out-String | Invoke-Expression
 ```
-To test if Starship is working, save and close your updated profile, and run `. $PROFILE` in 
-PowerShell. If you see your Starship prompt, you're all set! Tip: This works best if you installed
-Starship with the MSI installer in the default installation location. Otherwise, you may have to
-update the path to the `starship.exe` file.
+To test if Starship is working, save and close your updated profile, and run `. $PROFILE` in PowerShell. If you see your Starship prompt, you're all set! Tip: This works best if you installed Starship with the MSI installer in the default installation location. Otherwise, you may have to update the path to the `starship.exe` file.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -373,7 +373,7 @@ If you are using PowerShell 7.0+, instead of the version(s) that ship with Windo
 
 If you do not already have a PowerShell configuration file, create one in the location you obtained, with the name shown when you ran the `$PROFILE` command. If this is the first time you are attempting to run code not signed by Microsoft, you will need to enable scripts execution. You can do this by running the following command:
 
-`Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser -Confirm`. 
+`Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser -Confirm`.
 
 or,
 

--- a/README.md
+++ b/README.md
@@ -364,6 +364,7 @@ Add the following to the end of your PowerShell configuration (find it by runnin
 ```powershell
 Invoke-Expression (&starship init powershell)
 ```
+
 If you are using PowerShell 7.0+, instead of the version(s) that ship with Windows 10/11, you can use the following instead:
 
 ```powershell

--- a/src/modules/package.rs
+++ b/src/modules/package.rs
@@ -583,7 +583,7 @@ license = "MIT"
 
     #[test]
     fn test_extract_nimble_package_version_for_non_nimble_directory() -> io::Result<()> {
-        // Only create an empty directory. There's no .nibmle file for this case.
+        // Only create an empty directory. There's no .nimble file for this case.
         let project_dir = create_project_dir()?;
 
         let starship_config = toml::toml! {


### PR DESCRIPTION
#### Description
Add the following to README.md:
![image](https://github.com/user-attachments/assets/2c903c37-c251-47b5-8f62-aa0029dc1956)

#### Motivation and Context
I was unable to get Starship to work on my machine without a lot of trouble shooting. I am using the bleeding edge of Windows 11 Pro (latest update), and the latest release of PowerShell 7, and wanted to provide a way for others to skip right to the chase if they were having a similar issue. 

I was unable to find an existing open issue, and figured I could write the narrative into the README.md myself, and help everyone out for Windows 11.

#### Screenshots (if appropriate):
This image shows the updated README.MD
![image](https://github.com/user-attachments/assets/9e4d729c-aa13-4b59-866f-64f4dcff2267)

This image shows my PowerShell prompt running the default Starship as a result of implementing the profile update outlined in my contribution.
![image](https://github.com/user-attachments/assets/eb45401a-cea2-4391-8528-ccb70eb67e18)

#### How Has This Been Tested?
Previewed the resulting update in the browser by loading the README.md file from my branch and observing the visual changes. Made some cosmetic, grammatic, and other minor revisions for style and conciseness as a result, and provided the final screenshot above.

<!--- Include details of your testing environment, tests ran to see how -->
Developed in VSCode 1.92.2, previewed in Chrome Version 128.0.6613.86 (Official Build) (64-bit)
No other code has been updated or affected.

#### Checklist:
- [X] I have updated the documentation accordingly. (The contribution is to the documentation)
- [X ] I have updated the tests accordingly. (The testing was visual, and not functionality related.
