### PR TITLE
feat: PowerShell Init - Combine ViModeChangeHandler

### DIFF
--- a/src/init/starship.ps1
+++ b/src/init/starship.ps1
@@ -213,10 +213,11 @@ $null = New-Module starship {
     try {
         # Combine user defined ViModeChangeHandler if it exists
         if((Get-PSReadLineOption).ViModeChangeHandler){
-            Set-PSReadLineOption -ViModeIndicator script -ViModeChangeHandler [scriptblock]::Create(
+            Set-PSReadLineOption -ViModeIndicator script -ViModeChangeHandler $([scriptblock]::Create(
                 "[Microsoft.PowerShell.PSConsoleReadLine]::InvokePrompt()" +
+                "`n" +
                 (Get-PSReadLineOption).ViModeChangeHandler.ToString()
-            )
+            ))
         } else {
             Set-PSReadLineOption -ViModeIndicator script -ViModeChangeHandler {
                 [Microsoft.PowerShell.PSConsoleReadLine]::InvokePrompt()

--- a/src/init/starship.ps1
+++ b/src/init/starship.ps1
@@ -211,8 +211,16 @@ $null = New-Module starship {
     )
 
     try {
-        Set-PSReadLineOption -ViModeIndicator script -ViModeChangeHandler {
-            [Microsoft.PowerShell.PSConsoleReadLine]::InvokePrompt()
+        # Combine user defined ViModeChangeHandler if it exists
+        if((Get-PSReadLineOption).ViModeChangeHandler){
+            Set-PSReadLineOption -ViModeIndicator script -ViModeChangeHandler [scriptblock]::Create(
+                "[Microsoft.PowerShell.PSConsoleReadLine]::InvokePrompt()" +
+                (Get-PSReadLineOption).ViModeChangeHandler.ToString()
+            )
+        } else {
+            Set-PSReadLineOption -ViModeIndicator script -ViModeChangeHandler {
+                [Microsoft.PowerShell.PSConsoleReadLine]::InvokePrompt()
+            }
         }
     } catch {}
 


### PR DESCRIPTION
If a user has defined a ViModeChangeHandler setting this would respect that as well as redraw the prompt (to allow rendering things like the character change).

#### Description
Users don't realize that the `ViModeChangeHandler` is redrawing the prompt. If the user sets their own, as show in the PSReadLine example [to change cursor type](https://learn.microsoft.com/en-us/powershell/module/psreadline/set-psreadlineoption?view=powershell-7.4#example-6-use-vimodechangehandler-to-display-vi-mode-changes), they don't realize it'll be overwritten by the `starship init powershell` call.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #6217 

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
