### PR TITLE
feat(git_commit): add a option to toggle hash in git_commit

### DIFF
--- a/src/modules/git_commit.rs
+++ b/src/modules/git_commit.rs
@@ -17,7 +17,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let git_head = git_repo.head().ok()?;
 
     let is_detached = git_head.is_detached();
-    if config.only_detached && !is_detached {
+    if config.tag_disabled && config.only_detached && !is_detached {
         return None;
     }
 
@@ -28,7 +28,12 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 _ => None,
             })
             .map(|variable| match variable {
-                "hash" => Some(Ok(git_hash(context.get_repo().ok()?, &config)?)),
+                "hash" if config.only_detached && is_detached => {
+                    Some(Ok(git_hash(context.get_repo().ok()?, &config)?))
+                }
+                "hash" if !config.only_detached => {
+                    Some(Ok(git_hash(context.get_repo().ok()?, &config)?))
+                }
                 "tag" if !config.tag_disabled => Some(Ok(format!(
                     "{}{}",
                     config.tag_symbol,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Added a configuration option to toggle the commit hash in the *git_commit* module.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


#### Screenshots (if appropriate):
![screenshot-Tue-2024-09--03-20-59-31](https://github.com/user-attachments/assets/354a1809-988d-4284-9767-c3eba6b7e71c)
![screenshot-Tue-2024-09--03-20-59-53](https://github.com/user-attachments/assets/92a50d7f-055a-470a-a009-8589ad125d84)



#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
