### PR TITLE
feat(spin): add new module for Spin

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -1719,7 +1719,7 @@
         "permanent": false,
         "style": "bold bright-purple",
         "symbol": "💫 ",
-        "version_format": "Spin ${raw}"
+        "version_format": "v${raw}"
       },
       "allOf": [
         {

--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -5979,7 +5979,7 @@
           "type": "string"
         },
         "version_format": {
-          "default": "Spin ${raw}",
+          "default": "v${raw}",
           "type": "string"
         },
         "symbol": {

--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -1704,6 +1704,29 @@
         }
       ]
     },
+    "spin": {
+      "default": {
+        "detect_extensions": [],
+        "detect_files": [
+          "spin.toml",
+          "Spin.toml"
+        ],
+        "detect_folders": [
+          ".spin"
+        ],
+        "disabled": false,
+        "format": "[$symbol($version) ]($style)",
+        "permanent": false,
+        "style": "bold bright-purple",
+        "symbol": "💫 ",
+        "version_format": "Spin ${raw}"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/SpinConfig"
+        }
+      ]
+    },
     "status": {
       "default": {
         "disabled": true,
@@ -5944,6 +5967,62 @@
         "disabled": {
           "default": false,
           "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "SpinConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "[$symbol($version) ]($style)",
+          "type": "string"
+        },
+        "version_format": {
+          "default": "Spin ${raw}",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "💫 ",
+          "type": "string"
+        },
+        "permanent": {
+          "default": false,
+          "type": "boolean"
+        },
+        "style": {
+          "default": "bold bright-purple",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "detect_extensions": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_files": {
+          "default": [
+            "spin.toml",
+            "Spin.toml"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_folders": {
+          "default": [
+            ".spin"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       },
       "additionalProperties": false

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -4263,25 +4263,25 @@ The `spin` module displays the current [Spin](https://github.com/fermyon/spin) v
 
 ### Options
 
-| Option              | Default                                | Description                                                                                                                                    |
-| ------------------- | -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| `detect_extensions` | `[]`                                   | Which extensions should trigger this module. |
-| `detect_files`      | `['Spin.toml', 'spin.toml']`           | Which filenames should trigger this module. |
-| `detect_folders`    | `['.spin']`                            | Which folders should trigger this module.|
-| `permanent`         | `false`                                | Always display the current Spin version. |
-| `symbol`            | `'💫 '`                                | The symbol used before the Spin version. |
-| `style`             | `'bold bright-purple'`                 | The style for the module. |
-| `format`            | `'[$symbol($version) ]($style)'`       | The format for the module. |
-| `version_format`    | `'Spin ${raw}'`                        | The format for the Spin version. |
-| `disabled`          | `false`                                | Disables the `spin` module. |
+| Option              | Default                          | Description                                  |
+| ------------------- | -------------------------------- | -------------------------------------------- |
+| `detect_extensions` | `[]`                             | Which extensions should trigger this module. |
+| `detect_files`      | `['Spin.toml', 'spin.toml']`     | Which filenames should trigger this module.  |
+| `detect_folders`    | `['.spin']`                      | Which folders should trigger this module.    |
+| `permanent`         | `false`                          | Always display the current Spin version.     |
+| `symbol`            | `'💫 '`                          | The symbol used before the Spin version.     |
+| `style`             | `'bold bright-purple'`           | The style for the module.                    |
+| `format`            | `'[$symbol($version) ]($style)'` | The format for the module.                   |
+| `version_format`    | `'Spin ${raw}'`                  | The format for the Spin version.             |
+| `disabled`          | `false`                          | Disables the `spin` module.                  |
 
 ### Variables
 
-| Variable    | Example      | Description                          |
-| ----------- | ------------ | ------------------------------------ |
-| version     | `2.7.0`      | The current Spin version             |
-| symbol      |              | Mirrors the value of option `symbol` |
-| style\*     |              | Mirrors the value of option `style`  |
+| Variable | Example | Description                          |
+| -------- | ------- | ------------------------------------ |
+| version  | `2.7.0` | The current Spin version             |
+| symbol   |         | Mirrors the value of option `symbol` |
+| style\*  |         | Mirrors the value of option `style`  |
 
 *: This variable can only be used as a part of a style string
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -323,6 +323,7 @@ $ruby\
 $rust\
 $scala\
 $solidity\
+$spin\
 $swift\
 $terraform\
 $typst\
@@ -4254,6 +4255,46 @@ The `spack` module shows the current [Spack](https://spack.readthedocs.io/en/lat
 
 [spack]
 format = '[$symbol$environment](dimmed blue) '
+```
+
+## Spin
+
+The `spin` module displays the current [Spin](https://github.com/fermyon/spin) version.
+
+### Options
+
+| Option              | Default                                | Description                                                                                                                                    |
+| ------------------- | -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `detect_extensions` | `[]`                                   | Which extensions should trigger this module. |
+| `detect_files`      | `['Spin.toml', 'spin.toml']`           | Which filenames should trigger this module. |
+| `detect_folders`    | `['.spin']`                            | Which folders should trigger this module.|
+| `permanent`         | `false`                                | Always display the current Spin version. |
+| `symbol`            | `'💫 '`                                | The symbol used before the Spin version. |
+| `style`             | `'bold bright-purple'`                 | The style for the module. |
+| `format`            | `'[$symbol($version) ]($style)'`       | The format for the module. |
+| `version_format`    | `'Spin ${raw}'`                        | The format for the Spin version. |
+| `disabled`          | `false`                                | Disables the `spin` module. |
+
+### Variables
+
+| Variable    | Example      | Description                          |
+| ----------- | ------------ | ------------------------------------ |
+| version     | `2.7.0`      | The current Spin version             |
+| symbol      |              | Mirrors the value of option `symbol` |
+| style\*     |              | Mirrors the value of option `style`  |
+
+*: This variable can only be used as a part of a style string
+
+### Example
+
+```toml
+# ~/.config/starship.toml
+
+[spin]
+disabled = false
+permanent = false
+style = 'bright-purple'
+format = '[$symbol($version) ]($style)'
 ```
 
 ## Status

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -4272,7 +4272,7 @@ The `spin` module displays the current [Spin](https://github.com/fermyon/spin) v
 | `symbol`            | `'💫 '`                          | The symbol used before the Spin version.     |
 | `style`             | `'bold bright-purple'`           | The style for the module.                    |
 | `format`            | `'[$symbol($version) ]($style)'` | The format for the module.                   |
-| `version_format`    | `'Spin ${raw}'`                  | The format for the Spin version.             |
+| `version_format`    | `'v${raw}'`                      | The format for the Spin version.             |
 | `disabled`          | `false`                          | Disables the `spin` module.                  |
 
 ### Variables

--- a/docs/public/presets/toml/bracketed-segments.toml
+++ b/docs/public/presets/toml/bracketed-segments.toml
@@ -163,6 +163,9 @@ format = '\[[$symbol($version)]($style)\]'
 [spack]
 format = '\[[$symbol$environment]($style)\]'
 
+[spin]
+format = '\[[$symbol($version)]($style)\]'
+
 [sudo]
 format = '\[[as $symbol]($style)\]'
 

--- a/docs/public/presets/toml/jetpack.toml
+++ b/docs/public/presets/toml/jetpack.toml
@@ -74,6 +74,7 @@ $buf\
 $conda\
 $meson\
 $spack\
+$spin\
 $memory_usage\
 $aws\
 $gcloud\
@@ -313,3 +314,6 @@ unknown_msg = '[◌](bold dimmed ellow)'
 [spack]
 symbol = "◇ "
 format = " spack [$symbol$environment]($style)"
+
+[spin]
+format = " spin [$symbol($version)]($style)"

--- a/docs/public/presets/toml/plain-text-symbols.toml
+++ b/docs/public/presets/toml/plain-text-symbols.toml
@@ -212,6 +212,9 @@ symbol = "scala "
 [spack]
 symbol = "spack "
 
+[spin]
+symbol = "spin "
+
 [solidity]
 symbol = "solidity "
 

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -84,6 +84,7 @@ pub mod shlvl;
 pub mod singularity;
 pub mod solidity;
 pub mod spack;
+pub mod spin;
 mod starship_root;
 pub mod status;
 pub mod sudo;
@@ -277,6 +278,8 @@ pub struct FullConfig<'a> {
     solidity: solidity::SolidityConfig<'a>,
     #[serde(borrow)]
     spack: spack::SpackConfig<'a>,
+    #[serde(borrow)]
+    spin: spin::SpinConfig<'a>,
     #[serde(borrow)]
     status: status::StatusConfig<'a>,
     #[serde(borrow)]

--- a/src/configs/spin.rs
+++ b/src/configs/spin.rs
@@ -23,7 +23,7 @@ impl<'a> Default for SpinConfig<'a> {
     fn default() -> Self {
         SpinConfig {
             format: "[$symbol($version) ]($style)",
-            version_format: "Spin ${raw}",
+            version_format: "v${raw}",
             symbol: "💫 ",
             permanent: false,
             style: "bold bright-purple",

--- a/src/configs/spin.rs
+++ b/src/configs/spin.rs
@@ -1,0 +1,36 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(
+    feature = "config-schema",
+    derive(schemars::JsonSchema),
+    schemars(deny_unknown_fields)
+)]
+#[serde(default)]
+pub struct SpinConfig<'a> {
+    pub format: &'a str,
+    pub version_format: &'a str,
+    pub symbol: &'a str,
+    pub permanent: bool,
+    pub style: &'a str,
+    pub disabled: bool,
+    pub detect_extensions: Vec<&'a str>,
+    pub detect_files: Vec<&'a str>,
+    pub detect_folders: Vec<&'a str>,
+}
+
+impl<'a> Default for SpinConfig<'a> {
+    fn default() -> Self {
+        SpinConfig {
+            format: "[$symbol($version) ]($style)",
+            version_format: "Spin ${raw}",
+            symbol: "💫 ",
+            permanent: false,
+            style: "bold bright-purple",
+            disabled: false,
+            detect_extensions: vec![],
+            detect_files: vec!["spin.toml", "Spin.toml"],
+            detect_folders: vec![".spin"],
+        }
+    }
+}

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -94,6 +94,7 @@ pub const PROMPT_ORDER: &[&str] = &[
     "rust",
     "scala",
     "solidity",
+    "spin",
     "swift",
     "terraform",
     "typst",

--- a/src/module.rs
+++ b/src/module.rs
@@ -89,6 +89,7 @@ pub const ALL_MODULES: &[&str] = &[
     "singularity",
     "solidity",
     "spack",
+    "spin",
     "status",
     "sudo",
     "swift",

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -81,6 +81,7 @@ mod shlvl;
 mod singularity;
 mod solidity;
 mod spack;
+mod spin;
 mod status;
 mod sudo;
 mod swift;
@@ -193,6 +194,7 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
             "singularity" => singularity::module(context),
             "solidity" => solidity::module(context),
             "spack" => spack::module(context),
+            "spin" => spin::module(context),
             "swift" => swift::module(context),
             "status" => status::module(context),
             "sudo" => sudo::module(context),
@@ -318,6 +320,7 @@ pub fn description(module: &str) -> &'static str {
         "singularity" => "The currently used Singularity image",
         "solidity" => "The current installed version of Solidity",
         "spack" => "The current spack environment, if $SPACK_ENV is set",
+        "spin" => "The current installed version of Spin",
         "status" => "The status of the last command",
         "sudo" => "The sudo credentials are currently cached",
         "swift" => "The currently installed version of Swift",

--- a/src/modules/spin.rs
+++ b/src/modules/spin.rs
@@ -9,7 +9,6 @@ use crate::{
 };
 
 use crate::utils::get_command_string_output;
-const SPIN_CANARY: &str = "canary";
 const SPIN_CANARY_IDENTIFIER: &str = "pre";
 const SPIN_BINARY: &str = "spin";
 
@@ -73,7 +72,7 @@ fn parse_spin_version(spin_version_stdout: &str) -> Option<String> {
     let input = spin_version_stdout;
     let capture = semver_regex.find(input)?.as_str();
     if input.contains(SPIN_CANARY_IDENTIFIER) {
-        Some(format!("{} ({})", capture, SPIN_CANARY))
+        Some(format!("{} ({})", capture, SPIN_CANARY_IDENTIFIER))
     } else {
         Some(capture.to_string())
     }
@@ -92,7 +91,7 @@ mod tests {
         let input = "spin 2.8.0-pre0 (3e62d2e 2024-09-04)";
         assert_eq!(
             super::parse_spin_version(input),
-            Some(String::from("2.8.0 (canary)"))
+            Some(String::from("2.8.0 (pre)"))
         );
     }
 }

--- a/src/modules/spin.rs
+++ b/src/modules/spin.rs
@@ -93,10 +93,7 @@ mod tests {
             })
             .collect();
 
-        let expected = Some(format!(
-            "{}",
-            Color::LightPurple.bold().paint("💫 v2.7.0 ")
-        ));
+        let expected = Some(format!("{}", Color::LightPurple.bold().paint("💫 v2.7.0 ")));
         assert_eq!(expected, actual);
         dir.close()
     }

--- a/src/modules/spin.rs
+++ b/src/modules/spin.rs
@@ -9,7 +9,6 @@ use crate::{
 };
 
 use crate::utils::get_command_string_output;
-const SPIN_CANARY_IDENTIFIER: &str = "pre";
 const SPIN_BINARY: &str = "spin";
 
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
@@ -68,14 +67,10 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 }
 
 fn parse_spin_version(spin_version_stdout: &str) -> Option<String> {
-    let semver_regex = Regex::new(r"\d+\.\d+\.\d+").ok()?;
+    let semver_regex = Regex::new(r"\d+\.\d+\.\d+(-[a-zA-Z0-9]+)?").ok()?;
     let input = spin_version_stdout;
     let capture = semver_regex.find(input)?.as_str();
-    if input.contains(SPIN_CANARY_IDENTIFIER) {
-        Some(format!("{} ({})", capture, SPIN_CANARY_IDENTIFIER))
-    } else {
-        Some(capture.to_string())
-    }
+    Some(capture.to_string())
 }
 
 #[cfg(test)]
@@ -117,7 +112,7 @@ mod tests {
         let input = "spin 2.8.0-pre0 (3e62d2e 2024-09-04)";
         assert_eq!(
             super::parse_spin_version(input),
-            Some(String::from("2.8.0 (pre)"))
+            Some(String::from("2.8.0-pre0"))
         );
     }
 }

--- a/src/modules/spin.rs
+++ b/src/modules/spin.rs
@@ -1,0 +1,98 @@
+use regex::Regex;
+
+use crate::{
+    config::ModuleConfig,
+    configs::spin::SpinConfig,
+    context::Context,
+    formatter::{StringFormatter, VersionFormatter},
+    module::Module,
+};
+
+use crate::utils::get_command_string_output;
+const SPIN_CANARY: &str = "canary";
+const SPIN_CANARY_IDENTIFIER: &str = "pre";
+const SPIN_BINARY: &str = "spin";
+
+pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let mut module = context.new_module("spin");
+    let config = SpinConfig::try_load(module.config);
+    if !config.permanent {
+        let is_spin_project = context
+            .try_begin_scan()?
+            .set_files(&config.detect_files)
+            .set_extensions(&config.detect_extensions)
+            .set_folders(&config.detect_folders)
+            .is_match();
+
+        if !is_spin_project {
+            return None;
+        }
+    }
+
+    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
+        formatter
+            .map_meta(|var, _| match var {
+                "symbol" => Some(config.symbol),
+                _ => None,
+            })
+            .map_style(|variable| match variable {
+                "style" => Some(Ok(config.style)),
+                _ => None,
+            })
+            .map(|variable| match variable {
+                "version" => {
+                    let spin_version_stdout =
+                        get_command_string_output(context.exec_cmd(SPIN_BINARY, &["--version"])?);
+                    let spin_version = parse_spin_version(spin_version_stdout.as_str())?;
+
+                    VersionFormatter::format_module_version(
+                        module.get_name(),
+                        &spin_version,
+                        config.version_format,
+                    )
+                    .map(Ok)
+                }
+                _ => None,
+            })
+            .parse(None, Some(context))
+    });
+
+    module.set_segments(match parsed {
+        Ok(segments) => segments,
+        Err(error) => {
+            log::warn!("Error in module `spin`:\n{}", error);
+            return None;
+        }
+    });
+
+    Some(module)
+}
+
+fn parse_spin_version(spin_version_stdout: &str) -> Option<String> {
+    let semver_regex = Regex::new(r"\d+\.\d+\.\d+").ok()?;
+    let input = spin_version_stdout;
+    let capture = semver_regex.find(input)?.as_str();
+    if input.contains(SPIN_CANARY_IDENTIFIER) {
+        Some(format!("{} ({})", capture, SPIN_CANARY))
+    } else {
+        Some(capture.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_parse_spin_version() {
+        let input = "spin 2.7.0 (a111517 2024-07-30)";
+        assert_eq!(
+            super::parse_spin_version(input),
+            Some(String::from("2.7.0"))
+        );
+
+        let input = "spin 2.8.0-pre0 (3e62d2e 2024-09-04)";
+        assert_eq!(
+            super::parse_spin_version(input),
+            Some(String::from("2.8.0 (canary)"))
+        );
+    }
+}

--- a/src/modules/spin.rs
+++ b/src/modules/spin.rs
@@ -80,6 +80,32 @@ fn parse_spin_version(spin_version_stdout: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
+    use std::io;
+
+    use crate::test::ModuleRenderer;
+    use nu_ansi_term::Color;
+
+    #[test]
+    fn test_spin_module_rendering() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+
+        let actual = ModuleRenderer::new("spin")
+            .path(dir.path())
+            .config(toml::toml! {
+               [spin]
+               permanent = true
+               disabled = false
+            })
+            .collect();
+
+        let expected = Some(format!(
+            "{}",
+            Color::LightPurple.bold().paint("💫 Spin 2.7.0 ")
+        ));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
     #[test]
     fn test_parse_spin_version() {
         let input = "spin 2.7.0 (a111517 2024-07-30)";

--- a/src/modules/spin.rs
+++ b/src/modules/spin.rs
@@ -95,7 +95,7 @@ mod tests {
 
         let expected = Some(format!(
             "{}",
-            Color::LightPurple.bold().paint("💫 Spin 2.7.0 ")
+            Color::LightPurple.bold().paint("💫 v2.7.0 ")
         ));
         assert_eq!(expected, actual);
         dir.close()

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -456,6 +456,10 @@ Version: 0.8.16+commit.07a7930e.Linux.g++"),
         "solcjs --version" => Some(CommandOutput {
             stdout: String::from("0.8.15+commit.e14f2714.Emscripten.clang"),
             stderr: String::default() }),
+        "spin --version" => Some(CommandOutput {
+            stdout: String::from("spin 2.7.0 (a111517 2024-07-30)\n"),
+            stderr: String::default(),
+        }),
         "swift --version" => Some(CommandOutput {
             stdout: String::from(
                 "\


### PR DESCRIPTION
#### Description

This PR adds a new module for [Spin](github.com/fermyon/spin), allowing Spin users to display the currently installed version of the Spin CLI in their prompt. 


#### Motivation and Context

As a developer using Spin to build WebAssembly applications, I want to display the current version of Spin as part of my prompt. This is especially useful for Spin users that leverage Spin's version manager to switch between multiple versions of Spin on their machine.


#### Screenshots (if appropriate):

<img width="460" alt="image" src="https://github.com/user-attachments/assets/a6e4bf04-9577-4e71-894e-1a6e5f4a2b5c">


#### How Has This Been Tested?

I installed Spin CLI on my machine using homebrew (`brew install fermyon/tap/spin`), and updated my `starship.toml` by adding:

```toml
[spin]
disabled = false
permanent = true
```

To display the currently installed version of Spin also outside of Spin App directories, I set the `permanent` option to `true`. 

- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:

- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
