### PR TITLE
chore: fix typo in comment to make spell-check pass

### DIFF
--- a/src/modules/package.rs
+++ b/src/modules/package.rs
@@ -583,7 +583,7 @@ license = "MIT"
 
     #[test]
     fn test_extract_nimble_package_version_for_non_nimble_directory() -> io::Result<()> {
-        // Only create an empty directory. There's no .nibmle file for this case.
+        // Only create an empty directory. There's no .nimble file for this case.
         let project_dir = create_project_dir()?;
 
         let starship_config = toml::toml! {


### PR DESCRIPTION
#### Description

This PR fixes a typo to make the spell-checker pass again. 

#### Motivation and Context

spell-check CI runs were failing due to this typo.

#### Screenshots (if appropriate):

#### How Has This Been Tested?

- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:

- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
