### PR TITLE
fix(fish): use correct input function in transient execute

### DIFF
--- a/src/init/starship.fish
+++ b/src/init/starship.fish
@@ -64,12 +64,7 @@ function reset-transient --on-event fish_postexec
 end
 
 function transient_execute
-    if commandline --paging-mode
-        commandline -f accept-autosuggestion
-        return
-    end
-    commandline --is-valid
-    if test $status != 2
+    if commandline --is-valid || test -z "$(commandline)" && not commandline --paging-mode
         set -g TRANSIENT 1
         set -g RIGHT_TRANSIENT 1
         commandline -f repaint


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

#6107 (unreleased) introduced a bug that mistakenly make `Enter` `accept-autosuggestion` when pager is open:

https://github.com/user-attachments/assets/fdd3b897-4421-4916-957c-0d05bafa87a6

This pull request uses the check from tide's transient prompt implementation, which in essence falls back to `execute` to only accept the selection in pager:

https://github.com/IlanCosman/tide/blob/44c521ab292f0eb659a9e2e1b6f83f5f0595fcbd/functions/fish_prompt.fish#L154-L164

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
