### PR TITLE
chore: fix hindi truncation tests and bump deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1658,7 +1658,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a45489186a6123c128fdf6016183fcfab7113e1820eb813127e036e287233fb"
 dependencies = [
  "jiff-tzdb-platform",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2305,9 +2305,9 @@ dependencies = [
 
 [[package]]
 name = "process_control"
-version = "4.2.2"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17139892be8ee0f51485168e9bd626db6e7d1941d738d183e70e26017f573db0"
+checksum = "f32c4eb5a227708adf07971a8b0da3d7c8f7fb3e54de64aaaedc9bef72f70b62"
 dependencies = [
  "libc",
  "signal-hook 0.3.17",
@@ -3192,9 +3192,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"
@@ -3377,7 +3377,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ os_info = "3.8.2"
 path-slash = "0.2.1"
 pest = "2.7.12"
 pest_derive = "2.7.12"
+process_control = "5.0.0"
 quick-xml = "0.36.1"
 rand = "0.8.5"
 rayon = "1.10.0"
@@ -82,14 +83,12 @@ systemstat = "=0.2.3"
 terminal_size = "0.3.0"
 toml = { version = "0.8.19", features = ["preserve_order"] }
 toml_edit = "0.22.21"
-unicode-segmentation = "1.11.0"
+unicode-segmentation = "1.12.0"
 unicode-width = "0.1.13"
 urlencoding = "2.1.3"
 versions = "6.3.2"
 which = "6.0.3"
 yaml-rust2 = "0.8.1"
-
-process_control = { version = "4.2.2", features = ["crossbeam-channel"] }
 
 guess_host_triple = "0.1.4"
 home = "0.5.9"

--- a/src/modules/git_branch.rs
+++ b/src/modules/git_branch.rs
@@ -204,12 +204,12 @@ mod tests {
 
     #[test]
     fn test_hindi_truncation() -> io::Result<()> {
-        test_truncate_length("नमस्ते", 3, "नमस्", "…")
+        test_truncate_length("नमस्ते", 2, "नम", "…")
     }
 
     #[test]
     fn test_hindi_truncation2() -> io::Result<()> {
-        test_truncate_length("नमस्त", 3, "नमस्", "…")
+        test_truncate_length("नमस्त", 2, "नम", "…")
     }
 
     #[test]

--- a/src/modules/utils/truncate.rs
+++ b/src/modules/utils/truncate.rs
@@ -81,12 +81,12 @@ mod tests {
 
     #[test]
     fn test_hindi_truncation() {
-        test_truncate_length("नमस्ते", 3, "नमस्", "…")
+        test_truncate_length("नमस्ते", 2, "नम", "…")
     }
 
     #[test]
     fn test_hindi_truncation2() {
-        test_truncate_length("नमस्त", 3, "नमस्", "…")
+        test_truncate_length("नमस्त", 2, "नम", "…")
     }
 
     #[test]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

The `unicode-segmentation` update appears to segment the text differently (into three characters). The tests are fixed by truncating one character more.

The `process-control` update from #6260 which also requires manual intervention.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
