### PR TITLE
docs(config): correct `Dart` to `Deno` in docs/ja-JP/config/#deno

### DIFF
--- a/docs/ja-JP/config/README.md
+++ b/docs/ja-JP/config/README.md
@@ -1058,7 +1058,7 @@ format = 'via [🔰 $version](bold red) '
 | ------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------ |
 | `format`            | `'via [$symbol($version )]($style)'`                                    | module のフォーマットです。                                      |
 | `version_format`    | `'v${raw}'`                                                             | バージョンのフォーマット。 使用可能な変数は`raw`、`major`、`minor`と`patch`です。 |
-| `symbol`            | `'🦕 '`                                                                  | Dart のシンボルを表すフォーマット文字列                                 |
+| `symbol`            | `'🦕 '`                                                                  | Deno のシンボルを表すフォーマット文字列                                 |
 | `detect_extensions` | `[]`                                                                    | どの拡張子がこのモジュールをアクティブにするか                                |
 | `detect_files`      | `['deno.json', 'deno.jsonc', 'mod.ts', 'mod.js', 'deps.ts', 'deps.js']` | どのファイル名がこのモジュールをアクティブにするか                              |
 | `detect_folders`    | `[]`                                                                    | どのフォルダーがこのモジュールをアクティブにするか                              |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
As the title says, this PR just replaces `Dart` with `Deno` in the `Deno` section of docs/ja-JP/config.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
