### PR TITLE
feat(container): identify systemd-nspawn environment

### DIFF
--- a/src/modules/container.rs
+++ b/src/modules/container.rs
@@ -21,19 +21,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             return Some("OpenVZ".into());
         }
 
-        if context_path(context, "/run/host/container-manager").exists() {
-            // systemd-nspawn
-            if read_file("/run/host/container-manager")
-                .map(|c| c.contains("systemd-nspawn"))
-                .unwrap_or_default()
-            {
-                return Some("nspawn".into());
-            }
-
-            // OCI
-            return Some("OCI".into());
-        }
-
         let container_env_path = context_path(context, "/run/.containerenv");
 
         if container_env_path.exists() {
@@ -75,6 +62,11 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         if context_path(context, "/.dockerenv").exists() {
             // docker
             return Some("Docker".into());
+        }
+
+        if context_path(context, "/run/host/container-manager").exists() {
+            // OCI
+            return Some("OCI".into());
         }
 
         None

--- a/src/modules/container.rs
+++ b/src/modules/container.rs
@@ -22,6 +22,14 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         }
 
         if context_path(context, "/run/host/container-manager").exists() {
+            // systemd-nspawn
+            if read_file("/run/host/container-manager")
+                .map(|c| c.contains("systemd-nspawn"))
+                .unwrap_or_default()
+            {
+                return Some("nspawn".into());
+            }
+
             // OCI
             return Some("OCI".into());
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR implements support for identifying `systemd-nspawn` based environments. This change was initially implemented in #5943 but since that PR can't be merged due to failing tests i have decided to create a new PR to address the issue.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #5937 
Closes #5943

A `systemd-nspawn` container gets wrongly detected as `OCI`.

#### Screenshots (if appropriate):

The following screenshots were taken inside a [NixOS](https://nixos.org/) machine. The [`nixos-container`](https://wiki.nixos.org/wiki/NixOS_Containers) command is just a wrapper around `systemd-nspawn` to make using it easier.

Before
![image](https://github.com/user-attachments/assets/e4419ceb-aba7-459a-becb-60ebd0c0e6fa)

After
![image](https://github.com/user-attachments/assets/acad16e6-b9fe-4f80-aefb-cb6f7ddfcfac)


#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
