### PR TITLE
fix: use `whoami` for user/hostname queries again

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -971,16 +971,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gethostname"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc3655aa6818d65bc620d6911f05aa7b6aeb596291e1e9f79e52df85583d1e30"
-dependencies = [
- "rustix",
- "windows-targets 0.52.6",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2762,7 +2752,6 @@ dependencies = [
  "deelevate",
  "dirs 5.0.1",
  "dunce",
- "gethostname",
  "gix",
  "gix-features",
  "guess_host_triple",
@@ -2804,6 +2793,7 @@ dependencies = [
  "urlencoding",
  "versions",
  "which",
+ "whoami",
  "windows 0.58.0",
  "winres",
  "yaml-rust2",
@@ -3294,6 +3284,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3358,6 +3354,16 @@ dependencies = [
  "home",
  "rustix",
  "winsafe",
+]
+
+[[package]]
+name = "whoami"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "372d5b87f58ec45c384ba03563b03544dc5fadc3983e434b286913f5b4a9bb6d"
+dependencies = [
+ "redox_syscall",
+ "wasite",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ license = "ISC"
 readme = "README.md"
 repository = "https://github.com/starship/starship"
 # Note: MSRV is only intended as a hint, and only the latest version is officially supported in starship.
-rust-version = "1.74"
+rust-version = "1.76"
 description = """
 The minimal, blazing-fast, and infinitely customizable prompt for any shell! ☄🌌️
 """
@@ -47,7 +47,6 @@ clap = { version = "4.5.20", features = ["derive", "cargo", "unicode"] }
 clap_complete = "4.5.33"
 dirs = "5.0.1"
 dunce = "1.0.5"
-gethostname = "0.5.0"
 # default feature restriction addresses https://github.com/starship/starship/issues/4251
 gix = { version = "0.66.0", default-features = false, features = ["max-performance-safe", "revision"] }
 gix-features = { version = "0.38.2", optional = true }
@@ -88,6 +87,7 @@ unicode-width = "0.2.0"
 urlencoding = "2.1.3"
 versions = "6.3.2"
 which = "6.0.3"
+whoami = { version = "1.5.2", default-features = false }
 yaml-rust2 = "0.9.0"
 
 guess_host_triple = "0.1.4"

--- a/src/modules/username.rs
+++ b/src/modules/username.rs
@@ -19,6 +19,13 @@ const USERNAME_ENV_VAR: &str = "USERNAME";
 /// Does not display the username:
 ///     - If the option `username.detect_env_vars` is set with a negated environment variable [A]
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    #[cfg(not(test))]
+    let mut username = whoami::fallible::username()
+        .inspect_err(|e| log::debug!("Failed to get username {e:?}"))
+        .ok()
+        .or_else(|| context.get_env(USERNAME_ENV_VAR))?;
+
+    #[cfg(test)]
     let mut username = context.get_env(USERNAME_ENV_VAR)?;
 
     let mut module = context.new_module("username");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This should allow reading the username even if the environment variable is unset.

This was reverted previously in #5669, but with the fallible API introduced in 1.5.0, we can now fall back to reading env variables for the username if the crate fails to read it (https://github.com/starship/starship/issues/5587) and no longer changes hostname-casing with the fallible API (https://github.com/starship/starship/issues/5666).

I also bumped the MSRV to simplify error handling via `inspect_err`.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
May resolve

#6193

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
