### PR TITLE
docs(config): custom shell is used for when command

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -4808,7 +4808,7 @@ Format strings can also contain shell specific prompt sequences, e.g.
 | Option              | Default                         | Description                                                                                                                                                                                                                                                                                   |
 | ------------------- | ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `command`           | `''`                            | The command whose output should be printed. The command will be passed on stdin to the shell.                                                                                                                                                                                                 |
-| `when`              | `false`                         | Either a boolean value (`true` or `false`, without quotes) or a string shell command used as a condition to show the module. In case of a string, the module will be shown if the command returns a `0` status code.                                                                          |
+| `when`              | `false`                         | Either a boolean value (`true` or `false`, without quotes) or a string shell command used as a condition to show the module. In case of a string, the module will be shown if the `shell` returns a `0` status code from executing it.                                                        |
 | `require_repo`      | `false`                         | If `true`, the module will only be shown in paths containing a (git) repository. This option alone is not sufficient display condition in absence of other options.                                                                                                                           |
 | `shell`             |                                 | [See below](#custom-command-shell)                                                                                                                                                                                                                                                            |
 | `description`       | `'<custom module>'`             | The description of the module that is shown when running `starship explain`.                                                                                                                                                                                                                  |
@@ -4828,7 +4828,7 @@ Format strings can also contain shell specific prompt sequences, e.g.
 
 | Variable | Description                            |
 | -------- | -------------------------------------- |
-| output   | The output of shell command in `shell` |
+| output   | The output of `command` run in `shell` |
 | symbol   | Mirrors the value of option `symbol`   |
 | style\*  | Mirrors the value of option `style`    |
 
@@ -4843,7 +4843,7 @@ Format strings can also contain shell specific prompt sequences, e.g.
 
 If unset, it will fallback to STARSHIP_SHELL and then to 'sh' on Linux, and 'cmd /C' on Windows.
 
-The `command` will be passed in on stdin.
+The `command` (and `when`, if applicable) will be passed in on stdin.
 
 If `shell` is not given or only contains one element and Starship detects PowerShell will be used,
 the following arguments will automatically be added: `-NoProfile -Command -`.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
Clarify in Custom Command's documentation that the same `shell` is used for both the `command` and the `when` test.

#### Motivation and Context

It's plausible that `when` could either use `STARSHIP_SHELL` or the custom `shell`. So it should be disambiguated.

#### How Has This Been Tested?

Not applicable.

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] _(not applicable)_ I have updated the tests accordingly.
