### PR TITLE
fix(docker_context): Ignore Docker Desktop "desktop-linux" context.

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1267,7 +1267,7 @@ disabled = false
 
 The `docker_context` module shows the currently active
 [Docker context](https://docs.docker.com/engine/context/working-with-contexts/)
-if it's not set to `default` or if the `DOCKER_MACHINE_NAME`, `DOCKER_HOST` or
+if it's not set to `default` or `desktop-linux`, or if the `DOCKER_MACHINE_NAME`, `DOCKER_HOST` or
 `DOCKER_CONTEXT` environment variables are set (as they are meant to override
 the context in use).
 


### PR DESCRIPTION
#### Description
Docker Desktop uses `desktop-linux` instead of `default` as the default context since version 3.5.
This filters `desktop-linux` in the same way as "default".

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #6170

#### Screenshots (if appropriate):

#### How Has This Been Tested?
Using Docker Desktop on Linux. Before this change my prompt included "via 🐳 desktop-linux". After this change, it does not show the default context.

- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
