### PR TITLE
refactor: bump msrv to remove once-cell, improve logger test & handle clippy warnings

### DIFF
--- a/.dprint.json
+++ b/.dprint.json
@@ -28,6 +28,6 @@
     "https://github.com/dprint/dprint-plugin-typescript/releases/download/0.93.0/plugin.wasm",
     "https://github.com/dprint/dprint-plugin-json/releases/download/0.19.3/plugin.wasm",
     "https://github.com/dprint/dprint-plugin-markdown/releases/download/0.17.8/plugin.wasm",
-    "https://github.com/dprint/dprint-plugin-toml/releases/download/0.6.2/plugin.wasm"
+    "https://github.com/dprint/dprint-plugin-toml/releases/download/0.6.3/plugin.wasm"
   ]
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2773,7 +2773,6 @@ dependencies = [
  "nix",
  "notify-rust",
  "nu-ansi-term",
- "once_cell",
  "open",
  "os_info",
  "path-slash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ license = "ISC"
 readme = "README.md"
 repository = "https://github.com/starship/starship"
 # Note: MSRV is only intended as a hint, and only the latest version is officially supported in starship.
-rust-version = "1.74"
+rust-version = "1.80"
 description = """
 The minimal, blazing-fast, and infinitely customizable prompt for any shell! ☄🌌️
 """
@@ -57,7 +57,6 @@ log = { version = "0.4.22", features = ["std"] }
 # see: https://github.com/NixOS/nixpkgs/issues/160876
 notify-rust = { version = "4.11.3", optional = true }
 nu-ansi-term = "0.50.1"
-once_cell = "1.20.2"
 open = "5.3.0"
 # update os module config and tests when upgrading os_info
 os_info = "3.8.2"

--- a/deny.toml
+++ b/deny.toml
@@ -4,8 +4,6 @@ version = 2
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
-
-
   # { id = "RUSTSEC-0000-0000",  reason = "" },
 ]
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -12,7 +12,6 @@ use gix::{
     sec::{self as git_sec, trust::DefaultForLevel},
     state as git_state, Repository, ThreadSafeRepository,
 };
-use once_cell::sync::OnceCell;
 #[cfg(test)]
 use std::collections::HashMap;
 use std::collections::HashSet;
@@ -25,6 +24,7 @@ use std::num::ParseIntError;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::string::String;
+use std::sync::OnceLock;
 use std::time::{Duration, Instant};
 use terminal_size::terminal_size;
 
@@ -44,13 +44,13 @@ pub struct Context<'a> {
     pub logical_dir: PathBuf,
 
     /// A struct containing directory contents in a lookup-optimized format.
-    dir_contents: OnceCell<DirContents>,
+    dir_contents: OnceLock<Result<DirContents, std::io::Error>>,
 
     /// Properties to provide to modules.
     pub properties: Properties,
 
     /// Private field to store Git information for modules who need it
-    repo: OnceCell<Repo>,
+    repo: OnceLock<Result<Repo, Box<gix::discover::Error>>>,
 
     /// The shell the user is assumed to be running
     pub shell: Shell,
@@ -166,8 +166,8 @@ impl<'a> Context<'a> {
             properties,
             current_dir,
             logical_dir,
-            dir_contents: OnceCell::new(),
-            repo: OnceCell::new(),
+            dir_contents: OnceLock::new(),
+            repo: OnceLock::new(),
             shell,
             target,
             width,
@@ -286,9 +286,9 @@ impl<'a> Context<'a> {
     }
 
     /// Will lazily get repo root and branch when a module requests it.
-    pub fn get_repo(&self) -> Result<&Repo, Box<gix::discover::Error>> {
+    pub fn get_repo(&self) -> Result<&Repo, &gix::discover::Error> {
         self.repo
-            .get_or_try_init(|| -> Result<Repo, Box<gix::discover::Error>> {
+            .get_or_init(|| -> Result<Repo, Box<gix::discover::Error>> {
                 // custom open options
                 let mut git_open_opts_map =
                     git_sec::trust::Mapping::<gix::open::Options>::default();
@@ -359,17 +359,21 @@ impl<'a> Context<'a> {
                     kind: repository.kind(),
                 })
             })
+            .as_ref()
+            .map_err(|e| e.as_ref())
     }
 
-    pub fn dir_contents(&self) -> Result<&DirContents, std::io::Error> {
-        self.dir_contents.get_or_try_init(|| {
-            let timeout = self.root_config.scan_timeout;
-            DirContents::from_path_with_timeout(
-                &self.current_dir,
-                Duration::from_millis(timeout),
-                self.root_config.follow_symlinks,
-            )
-        })
+    pub fn dir_contents(&self) -> Result<&DirContents, &std::io::Error> {
+        self.dir_contents
+            .get_or_init(|| {
+                let timeout = self.root_config.scan_timeout;
+                DirContents::from_path_with_timeout(
+                    &self.current_dir,
+                    Duration::from_millis(timeout),
+                    self.root_config.follow_symlinks,
+                )
+            })
+            .as_ref()
     }
 
     fn get_shell() -> Shell {

--- a/src/context.rs
+++ b/src/context.rs
@@ -360,7 +360,7 @@ impl<'a> Context<'a> {
                 })
             })
             .as_ref()
-            .map_err(|e| e.as_ref())
+            .map_err(std::convert::AsRef::as_ref)
     }
 
     pub fn dir_contents(&self) -> Result<&DirContents, &std::io::Error> {

--- a/src/formatter/string_formatter.rs
+++ b/src/formatter/string_formatter.rs
@@ -303,10 +303,6 @@ impl<'a> StringFormatter<'a> {
                             ),
                         )),
                         FormatElement::TextGroup(textgroup) => {
-                            let textgroup = TextGroup {
-                                format: textgroup.format,
-                                style: textgroup.style,
-                            };
                             parse_textgroup(textgroup, variables, style_variables, context)
                         }
                         FormatElement::Variable(name) => variables

--- a/src/formatter/version.rs
+++ b/src/formatter/version.rs
@@ -1,8 +1,8 @@
 use super::string_formatter::StringFormatterError;
 use super::StringFormatter;
 use crate::segment;
-use once_cell::sync::Lazy;
 use std::ops::Deref;
+use std::sync::LazyLock;
 use versions::Versioning;
 
 pub struct VersionFormatter<'a> {
@@ -30,7 +30,7 @@ impl<'a> VersionFormatter<'a> {
 
     /// Formats a version structure into a readable string
     pub fn format(self, version: &'a str) -> Result<String, StringFormatterError> {
-        let parsed = Lazy::new(|| Versioning::new(version));
+        let parsed = LazyLock::new(|| Versioning::new(version));
         let formatted = self
             .formatter
             .map(|variable| match variable {

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -246,7 +246,9 @@ mod test {
     use super::*;
     use crate::utils::read_file;
     use log::Log;
+    use std::fs::{File, FileTimes};
     use std::io;
+    use std::time::SystemTime;
 
     #[test]
     fn test_log_to_file() -> io::Result<()> {
@@ -353,11 +355,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(unix)]
     fn test_cleanup() -> io::Result<()> {
-        use nix::sys::{stat::utimes, time::TimeVal};
-        use std::fs::File;
-
         let log_dir = tempfile::tempdir()?;
 
         // Should not be deleted
@@ -379,6 +377,10 @@ mod test {
         }
         fs::create_dir(&directory)?;
 
+        let times = FileTimes::new()
+            .set_accessed(SystemTime::UNIX_EPOCH)
+            .set_modified(SystemTime::UNIX_EPOCH);
+
         // Set all files except the new file to be older than 24 hours
         for file in &[
             &non_matching_file,
@@ -386,10 +388,19 @@ mod test {
             &old_file,
             &directory,
         ] {
-            utimes(file.as_path(), &TimeVal::new(0, 0), &TimeVal::new(0, 0))?;
-            if let Ok(f) = File::open(file) {
-                f.sync_all()?;
-            }
+            let Ok(f) = File::open(file) else {
+                panic!("Unable to open file {file:?}!")
+            };
+
+            match f.set_times(times) {
+                Err(err) if err.kind() == io::ErrorKind::PermissionDenied => {
+                    // Ignore permission errors (e.g. on Windows)
+                    eprintln!("Unable to set file times for {file:?}: {err:?}");
+                    return Ok(());
+                }
+                other => other,
+            }?;
+            f.sync_all()?;
         }
 
         cleanup_log_files(log_dir.path());

--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 
 use chrono::DateTime;
 use ini::Ini;
-use once_cell::unsync::OnceCell;
+use std::cell::OnceCell;
 
 use super::{Context, Module, ModuleConfig};
 

--- a/src/modules/c.rs
+++ b/src/modules/c.rs
@@ -4,10 +4,10 @@ use crate::configs::c::CConfig;
 use crate::formatter::StringFormatter;
 use crate::formatter::VersionFormatter;
 
-use once_cell::sync::Lazy;
 use semver::Version;
 use std::borrow::Cow;
 use std::ops::Deref;
+use std::sync::LazyLock;
 
 /// Creates a module with the current C compiler and version
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
@@ -25,7 +25,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     }
 
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
-        let c_compiler_info = Lazy::new(|| context.exec_cmds_return_first(config.commands));
+        let c_compiler_info = LazyLock::new(|| context.exec_cmds_return_first(config.commands));
 
         formatter
             .map_meta(|var, _| match var {

--- a/src/modules/dotnet.rs
+++ b/src/modules/dotnet.rs
@@ -254,7 +254,7 @@ fn get_pinned_sdk_version(json: &str) -> Option<String> {
     }
 }
 
-fn get_local_dotnet_files(context: &Context) -> Result<Vec<DotNetFile>, std::io::Error> {
+fn get_local_dotnet_files<'a>(context: &'a Context) -> Result<Vec<DotNetFile>, &'a std::io::Error> {
     Ok(context
         .dir_contents()?
         .files()

--- a/src/modules/elixir.rs
+++ b/src/modules/elixir.rs
@@ -4,8 +4,8 @@ use crate::configs::elixir::ElixirConfig;
 use crate::formatter::StringFormatter;
 
 use crate::formatter::VersionFormatter;
-use once_cell::sync::Lazy;
 use std::ops::Deref;
+use std::sync::LazyLock;
 
 /// Create a module with the current Elixir version
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
@@ -23,7 +23,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         return None;
     }
 
-    let versions = Lazy::new(|| get_elixir_version(context));
+    let versions = LazyLock::new(|| get_elixir_version(context));
 
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter

--- a/src/modules/gcloud.rs
+++ b/src/modules/gcloud.rs
@@ -1,8 +1,8 @@
 use ini::Ini;
-use once_cell::sync::{Lazy, OnceCell};
 use std::borrow::Cow;
 use std::path::Path;
 use std::path::PathBuf;
+use std::sync::{LazyLock, OnceLock};
 
 use super::{Context, Module, ModuleConfig};
 
@@ -15,7 +15,7 @@ type Account<'a> = (&'a str, Option<&'a str>);
 struct GcloudContext {
     config_name: String,
     config_path: PathBuf,
-    config: OnceCell<Option<Ini>>,
+    config: OnceLock<Option<Ini>>,
 }
 
 impl<'a> GcloudContext {
@@ -94,7 +94,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         return None;
     }
     let gcloud_context = GcloudContext::new(&config_name, &config_path);
-    let account: Lazy<Option<Account<'_>>, _> = Lazy::new(|| gcloud_context.get_account());
+    let account: LazyLock<Option<Account<'_>>, _> = LazyLock::new(|| gcloud_context.get_account());
 
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter

--- a/src/modules/git_status.rs
+++ b/src/modules/git_status.rs
@@ -1,5 +1,5 @@
-use once_cell::sync::OnceCell;
 use regex::Regex;
+use std::sync::OnceLock;
 
 use super::{Context, Module, ModuleConfig};
 
@@ -135,8 +135,8 @@ struct GitStatusInfo<'a> {
     context: &'a Context<'a>,
     repo: &'a context::Repo,
     config: GitStatusConfig<'a>,
-    repo_status: OnceCell<Option<RepoStatus>>,
-    stashed_count: OnceCell<Option<usize>>,
+    repo_status: OnceLock<Option<RepoStatus>>,
+    stashed_count: OnceLock<Option<usize>>,
 }
 
 impl<'a> GitStatusInfo<'a> {
@@ -149,8 +149,8 @@ impl<'a> GitStatusInfo<'a> {
             context,
             repo,
             config,
-            repo_status: OnceCell::new(),
-            stashed_count: OnceCell::new(),
+            repo_status: OnceLock::new(),
+            stashed_count: OnceLock::new(),
         }
     }
 

--- a/src/modules/golang.rs
+++ b/src/modules/golang.rs
@@ -4,11 +4,11 @@ use crate::configs::go::GoConfig;
 use crate::formatter::StringFormatter;
 use crate::formatter::VersionFormatter;
 
-use once_cell::sync::Lazy;
 use regex::Regex;
 use semver::Version;
 use semver::VersionReq;
 use std::ops::Deref;
+use std::sync::LazyLock;
 
 /// Creates a module with the current Go version
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
@@ -26,8 +26,8 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     }
 
     let golang_version =
-        Lazy::new(|| parse_go_version(&context.exec_cmd("go", &["version"])?.stdout));
-    let mod_version = Lazy::new(|| get_go_mod_version(context));
+        LazyLock::new(|| parse_go_version(&context.exec_cmd("go", &["version"])?.stdout));
+    let mod_version = LazyLock::new(|| get_go_mod_version(context));
 
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter

--- a/src/modules/hostname.rs
+++ b/src/modules/hostname.rs
@@ -275,10 +275,7 @@ mod tests {
         toml_config["hostname"]["aliases"]
             .as_table_mut()
             .unwrap()
-            .insert(
-                hostname.clone(),
-                toml::Value::String("homeworld".to_string()),
-            );
+            .insert(hostname, toml::Value::String("homeworld".to_string()));
         let actual = ModuleRenderer::new("hostname")
             .config(toml_config)
             .collect();

--- a/src/modules/mojo.rs
+++ b/src/modules/mojo.rs
@@ -3,8 +3,8 @@ use super::{Context, Module, ModuleConfig};
 use crate::configs::mojo::MojoConfig;
 use crate::formatter::StringFormatter;
 
-use once_cell::sync::Lazy;
 use std::ops::Deref;
+use std::sync::LazyLock;
 
 /// Creates a module with the current Mojo version
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
@@ -22,7 +22,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         return None;
     }
 
-    let version_hash = Lazy::new(|| get_mojo_version(context));
+    let version_hash = LazyLock::new(|| get_mojo_version(context));
 
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter

--- a/src/modules/mojo.rs
+++ b/src/modules/mojo.rs
@@ -3,7 +3,6 @@ use super::{Context, Module, ModuleConfig};
 use crate::configs::mojo::MojoConfig;
 use crate::formatter::StringFormatter;
 
-use std::ops::Deref;
 use std::sync::LazyLock;
 
 /// Creates a module with the current Mojo version
@@ -35,11 +34,11 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 _ => None,
             })
             .map(|variable| match variable {
-                "version" => match version_hash.deref() {
+                "version" => match &*version_hash {
                     Some((version, _)) => Some(Ok(version)),
                     _ => None,
                 },
-                "hash" => match version_hash.deref() {
+                "hash" => match &*version_hash {
                     Some((_, Some(hash))) => Some(Ok(hash)),
                     _ => None,
                 },

--- a/src/modules/nodejs.rs
+++ b/src/modules/nodejs.rs
@@ -3,12 +3,12 @@ use super::{Context, Module, ModuleConfig};
 use crate::configs::nodejs::NodejsConfig;
 use crate::formatter::{StringFormatter, VersionFormatter};
 
-use once_cell::sync::Lazy;
 use regex::Regex;
 use semver::Version;
 use semver::VersionReq;
 use serde_json as json;
 use std::ops::Deref;
+use std::sync::LazyLock;
 
 /// Creates a module with the current Node.js version
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
@@ -30,12 +30,12 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         return None;
     }
 
-    let nodejs_version = Lazy::new(|| {
+    let nodejs_version = LazyLock::new(|| {
         context
             .exec_cmd("node", &["--version"])
             .map(|cmd| cmd.stdout)
     });
-    let engines_version = Lazy::new(|| get_engines_version(context));
+    let engines_version = LazyLock::new(|| get_engines_version(context));
 
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter

--- a/src/modules/ocaml.rs
+++ b/src/modules/ocaml.rs
@@ -1,7 +1,7 @@
 use super::{Context, Module, ModuleConfig};
-use once_cell::sync::Lazy;
 use std::ops::Deref;
 use std::path::Path;
+use std::sync::LazyLock;
 
 use crate::configs::ocaml::OCamlConfig;
 use crate::formatter::StringFormatter;
@@ -29,7 +29,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         return None;
     }
 
-    let opam_switch: Lazy<Option<OpamSwitch>, _> = Lazy::new(|| get_opam_switch(context));
+    let opam_switch: LazyLock<Option<OpamSwitch>, _> = LazyLock::new(|| get_opam_switch(context));
 
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter

--- a/src/modules/raku.rs
+++ b/src/modules/raku.rs
@@ -3,8 +3,8 @@ use super::{Context, Module, ModuleConfig};
 use crate::configs::raku::RakuConfig;
 use crate::formatter::StringFormatter;
 use crate::formatter::VersionFormatter;
-use once_cell::sync::Lazy;
 use std::ops::Deref;
+use std::sync::LazyLock;
 
 /// Creates a module with the current raku version
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
@@ -21,7 +21,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         return None;
     }
 
-    let versions = Lazy::new(|| get_raku_version(context));
+    let versions = LazyLock::new(|| get_raku_version(context));
 
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -5,18 +5,18 @@ use crate::{
     utils::{create_command, CommandOutput},
 };
 use log::{Level, LevelFilter};
-use once_cell::sync::Lazy;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
 use std::sync::Once;
 use tempfile::TempDir;
 
-static FIXTURE_DIR: Lazy<PathBuf> =
-    Lazy::new(|| PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/test/fixtures/"));
+static FIXTURE_DIR: LazyLock<PathBuf> =
+    LazyLock::new(|| PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/test/fixtures/"));
 
-static GIT_FIXTURE: Lazy<PathBuf> = Lazy::new(|| FIXTURE_DIR.join("git-repo.bundle"));
-static HG_FIXTURE: Lazy<PathBuf> = Lazy::new(|| FIXTURE_DIR.join("hg-repo.bundle"));
+static GIT_FIXTURE: LazyLock<PathBuf> = LazyLock::new(|| FIXTURE_DIR.join("git-repo.bundle"));
+static HG_FIXTURE: LazyLock<PathBuf> = LazyLock::new(|| FIXTURE_DIR.join("hg-repo.bundle"));
 
 static LOGGER: Once = Once::new();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR bumps the MSRV to 1.80. This enables replacing `once_cell` with std-provided `LazyLock` and `OnceLock`. The std version does not provide `get_or_try_init yet ` so I switched relevant code to store `Result<_, _>`instead. This might be the better anyway because the documentation sounds like any errors would not be cached.

I also made the `test_cleanup` for the logger target-agnostic, but it still does not run as-is on Windows due to requiring elevated permissions to change file dates.

I also fixed a few clippy warnings to get ahead of the upcoming rust v1.82 release.

Edit: also handled the recent dprint TOML-formatter upgrade.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
