### PR TITLE
docs(preset/gruvbox-rainbow): add Pop_OS icon to os module

### DIFF
--- a/docs/public/presets/toml/gruvbox-rainbow.toml
+++ b/docs/public/presets/toml/gruvbox-rainbow.toml
@@ -66,6 +66,7 @@ CentOS = ""
 Debian = "󰣚"
 Redhat = "󱄛"
 RedHatEnterprise = "󱄛"
+Pop = ""
 
 [username]
 show_always = true


### PR DESCRIPTION
style
Included the Pop!_OS nerdfont symbol for the Gruvbox-rainbow preset under [os.symbols]

#### Description
This will  show the nerdfont Pop!_OS symbol on the terminal for people using Pop!_OS 

#### Motivation and Context
I'm currently using a system76 laptop with Pop!_OS running on it.  I found your project and enjoyed trying out all the different presets. I was testing out the gruvbox rainbow preset and noticed the os symbol was a lollipop and thought including the Pop!_OS nerdfont symbol would be enjoyed by other Pop!_OS users. 
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
I ran starship on the GNOME Terminal, within Pop!_OS using the Gruvbox Rainbow Preset.

- [ ] I have tested using **MacOS**
- [ x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
