### PR TITLE
Revert "perf(fish): Skip unnecessary indirection in starship init fish"

### DIFF
--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -156,7 +156,11 @@ pub fn init_stub(shell_name: &str) -> io::Result<()> {
             starship.sprint_posix()?
         ),
         "zsh" => print_script(ZSH_INIT, &starship.sprint_posix()?),
-        "fish" => print_script(FISH_INIT, &starship.sprint_posix()?),
+        "fish" => print!(
+            // Fish does process substitution with pipes and psub instead of bash syntax
+            r#"source ({} init fish --print-full-init | psub)"#,
+            starship.sprint_posix()?
+        ),
         "powershell" => print!(
             r#"Invoke-Expression (& {} init powershell --print-full-init | Out-String)"#,
             starship.sprint_pwsh()?


### PR DESCRIPTION
This reverts commit 798f64033f5348793003ddd74fa0ce1c744c300b (PR #6253).

<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

`source (starship init)` now errors (I thought I tested it, but I can reproduce it now):
```
fish: Expected end of the statement, but found end of the input
```

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #6325

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
