### PR TITLE
fix(fish): restore support for fish <v3.4.0

### DIFF
--- a/src/init/starship.fish
+++ b/src/init/starship.fish
@@ -64,7 +64,7 @@ function reset-transient --on-event fish_postexec
 end
 
 function transient_execute
-    if commandline --is-valid || test -z "$(commandline)" && not commandline --paging-mode
+    if commandline --is-valid || test -z (commandline | string collect) && not commandline --paging-mode
         set -g TRANSIENT 1
         set -g RIGHT_TRANSIENT 1
         commandline -f repaint


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
The `"$()"`-syntax used in #6265 was [only added in fish v3.4.0](https://fishshell.com/docs/3.4/relnotes.html#notable-improvements-and-fixes). This PR restores support for previous versions of fish by using the previous syntax mentioned in the release notes.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #6336

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
