### PR TITLE
fix: consider text-only meta variables in conditionals set if non-empty

### DIFF
--- a/src/formatter/string_formatter.rs
+++ b/src/formatter/string_formatter.rs
@@ -364,7 +364,7 @@ impl<'a> StringFormatter<'a> {
                                                     VariableValue::Meta(meta_elements) => {
                                                         let meta_variables =
                                                             clone_without_meta(variables);
-                                                        should_show_elements(
+                                                        should_show_meta_var(
                                                             meta_elements,
                                                             &meta_variables,
                                                         )
@@ -381,6 +381,45 @@ impl<'a> StringFormatter<'a> {
                                                 })
                                         })
                                 })
+                            }
+
+                            // Check if a single format element should be shown.
+                            fn should_show_format_element<'a>(
+                                format_element: &FormatElement,
+                                variables: &'a VariableMapType<'a>,
+                            ) -> bool {
+                                match format_element {
+                                    // Should not usually happen, but if it does, check if the variable
+                                    // is set using `should_show_elements`.
+                                    FormatElement::Variable(_) => {
+                                        should_show_elements(&[format_element.clone()], variables)
+                                    }
+                                    FormatElement::Conditional(format) => {
+                                        should_show_elements(format, variables)
+                                    }
+                                    FormatElement::TextGroup(textgroup) => textgroup
+                                        .format
+                                        .iter()
+                                        .any(|f| should_show_format_element(f, variables)),
+                                    FormatElement::Text(t) => !t.is_empty(),
+                                }
+                            }
+
+                            // If metavariables contain a variable they are treated set if one of them
+                            // is not empty.
+                            // If metavariables contain only text, they are also treated as set if the
+                            // string is not empty.
+                            fn should_show_meta_var<'a>(
+                                format_elements: &[FormatElement],
+                                variables: &'a VariableMapType<'a>,
+                            ) -> bool {
+                                if !format_elements.get_variables().is_empty() {
+                                    return should_show_elements(format_elements, variables);
+                                }
+
+                                format_elements
+                                    .iter()
+                                    .any(|f| should_show_format_element(f, variables))
                             }
 
                             let should_show: bool = should_show_elements(&format, variables);
@@ -754,6 +793,42 @@ mod tests {
         let result = formatter.parse(None, None).unwrap();
         let mut result_iter = result.iter();
         match_next!(result_iter, " ", None);
+    }
+
+    #[test]
+    fn test_conditional_meta_variable_empty_string() {
+        const FORMAT_STR: &str = r"($colored $uncolored)";
+
+        let formatter = StringFormatter::new(FORMAT_STR)
+            .unwrap()
+            .map_meta(|var, _| match var {
+                "colored" => Some("[](green)"),
+                "uncolored" => Some(""),
+                _ => None,
+            });
+        let result = formatter.parse(None, None).unwrap();
+
+        let mut result_iter = result.iter();
+        assert!(result_iter.next().is_none());
+    }
+
+    #[test]
+    fn test_conditional_meta_variable_string() {
+        const FORMAT_STR: &str = r"($colored $uncolored)";
+
+        let formatter = StringFormatter::new(FORMAT_STR)
+            .unwrap()
+            .map_meta(|var, _| match var {
+                "colored" => Some("[green](green)"),
+                "uncolored" => Some("text"),
+                _ => None,
+            });
+        let result = formatter.parse(None, None).unwrap();
+        let mut result_iter = result.iter();
+        match_next!(result_iter, "green", Some(Color::Green.normal()));
+        match_next!(result_iter, " ", None);
+        match_next!(result_iter, "text", None);
+        assert!(result_iter.next().is_none());
     }
 
     #[test]

--- a/src/modules/shell.rs
+++ b/src/modules/shell.rs
@@ -414,7 +414,7 @@ mod tests {
             .shell(Shell::Fish)
             .config(toml::toml! {
                 [shell]
-                bash_indicator = "B"
+                fish_indicator = ""
                 format = "($indicator )"
                 disabled = false
             })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Meta variables were only considered set if they contained another variable, and it was set, just like conditionals themselves. This caused issues with the way the shell module was working, and the behaviour was non-obvious because explicitly set values were not considered set.

Detailed descriptions of the issue are also available in the linked issues.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #3409
Closes #5295
Closes #5885
Closes #6546

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
