### PR TITLE
fix(username): avoid using `whoami` on android

### DIFF
--- a/src/modules/username.rs
+++ b/src/modules/username.rs
@@ -19,13 +19,13 @@ const USERNAME_ENV_VAR: &str = "USERNAME";
 /// Does not display the username:
 ///     - If the option `username.detect_env_vars` is set with a negated environment variable [A]
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
-    #[cfg(not(test))]
+    #[cfg(not(any(test, target_os = "android")))]
     let mut username = whoami::fallible::username()
         .inspect_err(|e| log::debug!("Failed to get username {e:?}"))
         .ok()
         .or_else(|| context.get_env(USERNAME_ENV_VAR))?;
 
-    #[cfg(test)]
+    #[cfg(any(test, target_os = "android"))]
     let mut username = context.get_env(USERNAME_ENV_VAR)?;
 
     let mut module = context.new_module("username");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

The crate does not officially support android yet and returns unexpected username values in Termux environments. I assume that the `whoami` hostname is fine, since the implementation should mostly match the previous `gethostname ` crate.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #6340

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
