### PR TITLE
feat(nodejs): disable if bun project files detected

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -1135,7 +1135,10 @@
         "detect_files": [
           "package.json",
           ".node-version",
-          ".nvmrc"
+          ".nvmrc",
+          "!bunfig.toml",
+          "!bun.lock",
+          "!bun.lockb"
         ],
         "detect_folders": [
           "node_modules"
@@ -4737,7 +4740,10 @@
           "default": [
             "package.json",
             ".node-version",
-            ".nvmrc"
+            ".nvmrc",
+            "!bunfig.toml",
+            "!bun.lock",
+            "!bun.lockb"
           ],
           "type": "array",
           "items": {

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -645,7 +645,7 @@ By default the module will be shown if any of the following conditions are met:
 
 *: This variable can only be used as a part of a style string
 
-### Examples
+### Example
 
 #### Customize the format
 
@@ -654,15 +654,6 @@ By default the module will be shown if any of the following conditions are met:
 
 [bun]
 format = 'via [🍔 $version](bold green) '
-```
-
-#### Replace Node.js
-
-You can override the `detect_files` property of [the nodejs module](#nodejs) in your config so as to only show the bun runtime:
-
-```toml
-[nodejs]
-detect_files = ['package.json', '.node-version', '!bunfig.toml', '!bun.lockb']
 ```
 
 ## C
@@ -3107,6 +3098,8 @@ By default the module will be shown if any of the following conditions are met:
 - The current directory contains a `node_modules` directory
 - The current directory contains a file with the `.js`, `.mjs` or `.cjs` extension
 - The current directory contains a file with the `.ts`, `.mts` or `.cts` extension
+
+Additionally, the module will be hidden by default if the directory contains a `bunfig.toml`, `bun.lock`, or `bun.lockb` file, overriding the above conditions.
 
 ### Options
 

--- a/src/configs/nodejs.rs
+++ b/src/configs/nodejs.rs
@@ -29,7 +29,14 @@ impl Default for NodejsConfig<'_> {
             disabled: false,
             not_capable_style: "bold red",
             detect_extensions: vec!["js", "mjs", "cjs", "ts", "mts", "cts"],
-            detect_files: vec!["package.json", ".node-version", ".nvmrc"],
+            detect_files: vec![
+                "package.json",
+                ".node-version",
+                ".nvmrc",
+                "!bunfig.toml",
+                "!bun.lock",
+                "!bun.lockb",
+            ],
             detect_folders: vec!["node_modules"],
         }
     }


### PR DESCRIPTION
#### Description

Hide the Node.js prompt by default if Bun project files are detected.

#### Motivation and Context

The current default prompt shows both the Node.js and Bun prompts in Bun projects, because both runtimes use `package.json` to specify dependencies. However, in Bun projects, this file doesn't actually indicate that Node.js is used. This is a common enough use case that it was added to the docs in #5834.

It was suggested that this should be the default behavior in #4298 but was never implemented.

Closes #5805

#### How Has This Been Tested?

I have not tested this but have tested the equivalent behavior via config file

