### PR TITLE
test(username): Default to `false` for `is_root_user()` regardless of the OS

### DIFF
--- a/src/modules/username.rs
+++ b/src/modules/username.rs
@@ -109,12 +109,12 @@ fn is_root_user() -> bool {
     )
 }
 
-#[cfg(all(target_os = "windows", test))]
+#[cfg(test)]
 fn is_root_user() -> bool {
     false
 }
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(all(not(target_os = "windows"), not(test)))]
 fn is_root_user() -> bool {
     nix::unistd::geteuid() == nix::unistd::ROOT
 }


### PR DESCRIPTION
#### Description
Makes `is_root()` default to `false` for tests on all OSes instead of just Windows

#### Motivation and Context
First contribution with a tiny fix. Note that the [comment from davidkna](https://github.com/starship/starship/issues/6330#issuecomment-2423931927) was ignored, as running `cargo test` with elevated privileges (tested via `sudo -E cargo test`) does change the username to `root`, and also technically the name of the superuser can be changed, which is an edge case
Closes #6330

#### How Has This Been Tested?
- [x] I have tested using **Linux**
- [ ] I have tested using **MacOS**
Testing on Windows is irrelevant

#### Checklist:
Updating documentation and tests seems irrelevant
