### PR TITLE
perf(ancestor-scan): preallocate and reuse a single `PathBuf`

### DIFF
--- a/src/modules/hg_branch.rs
+++ b/src/modules/hg_branch.rs
@@ -32,12 +32,12 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     };
 
     let repo_root = context.begin_ancestor_scan().set_folders(&[".hg"]).scan()?;
-    let branch_name = get_hg_current_bookmark(repo_root).unwrap_or_else(|_| {
-        get_hg_branch_name(repo_root).unwrap_or_else(|_| String::from("default"))
+    let branch_name = get_hg_current_bookmark(&repo_root).unwrap_or_else(|_| {
+        get_hg_branch_name(&repo_root).unwrap_or_else(|_| String::from("default"))
     });
 
     let branch_graphemes = truncate_text(&branch_name, len, config.truncation_symbol);
-    let topic_graphemes = if let Ok(topic) = get_hg_topic_name(repo_root) {
+    let topic_graphemes = if let Ok(topic) = get_hg_topic_name(&repo_root) {
         truncate_text(&topic, len, config.truncation_symbol)
     } else {
         String::new()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

To improve performances, reuse a single allocation in `ScanAncestors::scan()`

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Testing on a fairly deep path (7 folders), this makes a `.marker` dir search go from ~1ms to ~600µs somewhat consistently. Since `starship` is run extremely often, I think any kind of perf improvement (for notably the case where there is no `.marker`) is nice.

Here it makes the code longer, and probably a little more complex, but I don't think it's hard to understand by any means, especially with the comments

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.

The tests must not be updated, else it means I broke something