### PR TITLE
fix: direnv individual message styling (#6153)

### DIFF
--- a/src/modules/direnv.rs
+++ b/src/modules/direnv.rs
@@ -40,15 +40,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter
             .map_meta(|variable, _| match variable {
-                "symbol" => Some(config.symbol),
-                "rc_path" => match state.rc_path.to_str() {
-                    None => {
-                        log::warn!("direnv rc path has non UTF-8 characters");
-
-                        None
-                    }
-                    ret => ret,
-                },
                 "allowed" => Some(match state.allowed {
                     AllowStatus::Allowed => config.allowed_msg,
                     AllowStatus::NotAllowed => config.not_allowed_msg,
@@ -62,6 +53,11 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             })
             .map_style(|variable| match variable {
                 "style" => Some(Ok(config.style)),
+                _ => None,
+            })
+            .map(|variable| match variable {
+                "symbol" => Some(Ok(Cow::from(config.symbol))),
+                "rc_path" => Some(Ok(state.rc_path.to_string_lossy())),
                 _ => None,
             })
             .parse(None, Some(context))


### PR DESCRIPTION
#### Description
permits the `direnv` module's `*_msg` segments to use the formatter:
- switches from `map` to `map_meta`
- introduces a warning if the `rc_path` isn't UTF-8 (reasonably this shouldn't be an issue?)

#### Motivation and Context
as detailed in #6153, it's nice to have colors for quick glancing, and not having the ability to format segments is an inconsistency with other modules

closes #6153

#### Screenshots (if appropriate):
using the following config:
```toml
[direnv]
disabled = false

allowed_msg = "[allowed](bold green)"
not_allowed_msg = "[not allowed](bold yellow)"
denied_msg = "[denied](bold red)"

loaded_msg = "[loaded](bold green)"
unloaded_msg = "[unloaded](bold red)"

format = "$allowed $loaded"
```
before:
![image](https://github.com/user-attachments/assets/7649263a-62cd-48de-9780-d0312844a8c5)
after:
![image](https://github.com/user-attachments/assets/89cc3f0c-d0c7-4cf4-bd30-23980ed9b92d)

#### How Has This Been Tested?
- the `msg_formatting` test in the `direnv` module passes on linux
- the above screenshots/config 

testing should be trivial on other platforms, but these changes shouldn't be platform-dependent
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
  likely not necessary, as none of the other modules mention that their variables can also be formatted strings
- [x] I have updated the tests accordingly.
