### PR TITLE
fix(init): eliminate a potential recursive definition

### DIFF
--- a/src/init/starship.zsh
+++ b/src/init/starship.zsh
@@ -69,10 +69,17 @@ starship_zle-keymap-select() {
     zle reset-prompt
 }
 
-## Check for existing keymap-select widget.
+# Check for existing keymap-select widget.
 if [[ -v widgets[zle-keymap-select] ]]; then
     # zle-keymap-select is a special widget so it'll be "user:fnName" or nothing. Let's get fnName only.
     __starship_preserved_zle_keymap_select=${widgets[zle-keymap-select]#user:}
+fi
+
+# Check for redefinition of zle-keymap-select and starship_zle-keymap-select-wrapped.
+if [[ -n ${__starship_preserved_zle_keymap_select:-} ]] && \
+   [[ $__starship_preserved_zle_keymap_select == "starship_zle-keymap-select" || \
+      $__starship_preserved_zle_keymap_select == "starship_zle-keymap-select-wrapped" ]]; then
+    __starship_preserved_zle_keymap_select=""
 fi
 
 if [[ -z ${__starship_preserved_zle_keymap_select:-} ]]; then
@@ -83,8 +90,9 @@ else
         $__starship_preserved_zle_keymap_select "$@";
         starship_zle-keymap-select "$@";
     }
-    zle -N zle-keymap-select starship_zle-keymap-select-wrapped;
+    zle -N zle-keymap-select starship_zle-keymap-select-wrapped
 fi
+
 
 export STARSHIP_SHELL="zsh"
 

--- a/src/init/starship.zsh
+++ b/src/init/starship.zsh
@@ -90,9 +90,8 @@ else
         $__starship_preserved_zle_keymap_select "$@";
         starship_zle-keymap-select "$@";
     }
-    zle -N zle-keymap-select starship_zle-keymap-select-wrapped
+    zle -N zle-keymap-select starship_zle-keymap-select-wrapped;
 fi
-
 
 export STARSHIP_SHELL="zsh"
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

This PR will eliminate a potential recursive definition. It will benefit users who want to use vi mode in zsh.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #3418 
Closes #5522 

Current `src/init/starship.zsh` has a potential risk to cause recursive definition of `starship_zle-keymap-select-wrapped` when user set vi mode.

for example:

use this minimal zshrc:
```zsh
bindkey -v
eval "$(starship init zsh)"
``` 
then start a terminal, type `source ~/.zshrc` **twice**
```zsh
~
❯ source ~/.zshrc
~
❯ source ~/.zshrc
```
press ESC to trigger vi normal mode, error message show bellow:
```zsh
~ 
❯ 
starship_zle-keymap-select-wrapped:1: maximum nested function level reached; increase FUNCNEST?
~ 
❯ 
```

check `starship_zle-keymap-select-wrapped` and `__starship_preserved_zle_keymap_select`
```zsh
~
❯ which starship_zle-keymap-select-wrapped
starship_zle-keymap-select-wrapped () {
	$__starship_preserved_zle_keymap_select "$@"
	starship_zle-keymap-select "$@"
}
~
❯ echo $__starship_preserved_zle_keymap_select
starship_zle-keymap-select-wrapped
```
see a recursive definition

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

I use this minimal zshrc:
```zsh
bindkey -v
eval "$(~/github-project/starship/target/debug/starship init zsh)"
```
`~/github-project/starship/target/debug/starship` is the binary which I build.

repeat the operations, vi mode works well and no error is reported. 

and user defined action works as well:
```zsh
bindkey -v
function myfoo() {
        echo "\nhello world\n"
}
zle -N zle-keymap-select myfoo; # print "hello world" every time swtich the vi mode
eval "$(~/github-project/starship/target/debug/starship init zsh)"
```

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
