### PR TITLE
fix(status): add trailing space to `pipestatus_format`

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -1715,7 +1715,7 @@
         "not_executable_symbol": "🚫",
         "not_found_symbol": "🔍",
         "pipestatus": false,
-        "pipestatus_format": "\\[$pipestatus\\] => [$symbol$common_meaning$signal_name$maybe_int]($style)",
+        "pipestatus_format": "\\[$pipestatus\\] => [$symbol$common_meaning$signal_name$maybe_int]($style) ",
         "pipestatus_separator": "|",
         "recognize_signal_code": true,
         "sigint_symbol": "🧱",
@@ -6006,7 +6006,7 @@
           "type": "string"
         },
         "pipestatus_format": {
-          "default": "\\[$pipestatus\\] => [$symbol$common_meaning$signal_name$maybe_int]($style)",
+          "default": "\\[$pipestatus\\] => [$symbol$common_meaning$signal_name$maybe_int]($style) ",
           "type": "string"
         },
         "pipestatus_segment_format": {

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -4272,23 +4272,23 @@ To enable it, set `disabled` to `false` in your configuration file.
 
 ### Options
 
-| Option                      | Default                                                                       | Description                                                           |
-| --------------------------- | ----------------------------------------------------------------------------- | --------------------------------------------------------------------- |
-| `format`                    | `'[$symbol$status]($style) '`                                                 | The format of the module                                              |
-| `symbol`                    | `'❌'`                                                                        | The symbol displayed on program error                                 |
-| `success_symbol`            | `''`                                                                          | The symbol displayed on program success                               |
-| `not_executable_symbol`     | `'🚫'`                                                                        | The symbol displayed when file isn't executable                       |
-| `not_found_symbol`          | `'🔍'`                                                                        | The symbol displayed when the command can't be found                  |
-| `sigint_symbol`             | `'🧱'`                                                                        | The symbol displayed on SIGINT (Ctrl + c)                             |
-| `signal_symbol`             | `'⚡'`                                                                        | The symbol displayed on any signal                                    |
-| `style`                     | `'bold red'`                                                                  | The style for the module.                                             |
-| `recognize_signal_code`     | `true`                                                                        | Enable signal mapping from exit code                                  |
-| `map_symbol`                | `false`                                                                       | Enable symbols mapping from exit code                                 |
-| `pipestatus`                | `false`                                                                       | Enable pipestatus reporting                                           |
-| `pipestatus_separator`      | <code>&vert;</code>                                                           | The symbol used to separate pipestatus segments (supports formatting) |
-| `pipestatus_format`         | `'\[$pipestatus\] => [$symbol$common_meaning$signal_name$maybe_int]($style)'` | The format of the module when the command is a pipeline               |
-| `pipestatus_segment_format` |                                                                               | When specified, replaces `format` when formatting pipestatus segments |
-| `disabled`                  | `true`                                                                        | Disables the `status` module.                                         |
+| Option                      | Default                                                                        | Description                                                           |
+| --------------------------- | ------------------------------------------------------------------------------ | --------------------------------------------------------------------- |
+| `format`                    | `'[$symbol$status]($style) '`                                                  | The format of the module                                              |
+| `symbol`                    | `'❌'`                                                                         | The symbol displayed on program error                                 |
+| `success_symbol`            | `''`                                                                           | The symbol displayed on program success                               |
+| `not_executable_symbol`     | `'🚫'`                                                                         | The symbol displayed when file isn't executable                       |
+| `not_found_symbol`          | `'🔍'`                                                                         | The symbol displayed when the command can't be found                  |
+| `sigint_symbol`             | `'🧱'`                                                                         | The symbol displayed on SIGINT (Ctrl + c)                             |
+| `signal_symbol`             | `'⚡'`                                                                         | The symbol displayed on any signal                                    |
+| `style`                     | `'bold red'`                                                                   | The style for the module.                                             |
+| `recognize_signal_code`     | `true`                                                                         | Enable signal mapping from exit code                                  |
+| `map_symbol`                | `false`                                                                        | Enable symbols mapping from exit code                                 |
+| `pipestatus`                | `false`                                                                        | Enable pipestatus reporting                                           |
+| `pipestatus_separator`      | <code>&vert;</code>                                                            | The symbol used to separate pipestatus segments (supports formatting) |
+| `pipestatus_format`         | `'\[$pipestatus\] => [$symbol$common_meaning$signal_name$maybe_int]($style) '` | The format of the module when the command is a pipeline               |
+| `pipestatus_segment_format` |                                                                                | When specified, replaces `format` when formatting pipestatus segments |
+| `disabled`                  | `true`                                                                         | Disables the `status` module.                                         |
 
 ### Variables
 

--- a/src/configs/status.rs
+++ b/src/configs/status.rs
@@ -42,7 +42,7 @@ impl<'a> Default for StatusConfig<'a> {
             pipestatus: false,
             pipestatus_separator: "|",
             pipestatus_format:
-                "\\[$pipestatus\\] => [$symbol$common_meaning$signal_name$maybe_int]($style)",
+                "\\[$pipestatus\\] => [$symbol$common_meaning$signal_name$maybe_int]($style) ",
             pipestatus_segment_format: None,
             disabled: true,
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

Forgotten space in the default format of the `status` module

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #6401

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
