### PR TITLE
docs: Add example configuration for transient prompt in Nushell

### DIFF
--- a/docs/advanced-config/README.md
+++ b/docs/advanced-config/README.md
@@ -141,6 +141,25 @@ bleopt prompt_ps1_final='$(starship module character)'
 bleopt prompt_rps1_final='$(starship module time)'
 ```
 
+## TransientPrompt and TransientRightPrompt in Nushell
+
+Nushell allows enabling transient prompt by configuring enviromental variables
+inside of the `~/.config/nushell/env.nu` file. Transient prompt is
+automatically enabled when variable `TRANSIENT_PROMPT_COMMAND` is set. This
+variable controls what the left side of the input will be replaced with, valid
+values can be `""`, `"❯"` or a command prefixed with `^`. Similarly, variable
+`TRANSIENT_PROMPT_COMMAND_RIGHT` controls what the right side of the input will
+be replaced with. Example configuration for Starship prompt can be seen bellow.
+
+```sh
+$env.TRANSIENT_PROMPT_COMMAND = ^starship module character
+$env.TRANSIENT_PROMPT_INDICATOR = ""
+$env.TRANSIENT_PROMPT_INDICATOR_VI_INSERT = ""
+$env.TRANSIENT_PROMPT_INDICATOR_VI_NORMAL = ""
+$env.TRANSIENT_PROMPT_MULTILINE_INDICATOR = ""
+$env.TRANSIENT_PROMPT_COMMAND_RIGHT = ^starship module time
+```
+
 ## Custom pre-prompt and pre-execution Commands in Cmd
 
 Clink provides extremely flexible APIs to run pre-prompt and pre-exec commands


### PR DESCRIPTION
#### Description
This PR adds example code into documentation for using Starship transient prompt in Nushell. The support for transient prompts was added to Nushell in this PR https://github.com/nushell/nushell/pull/10391 .

#### Motivation and Context
Closes #5555 
Relevant to #888 

#### Screenshot
Screenshot showcasing two line transient prompt in nushell:
![image](https://github.com/user-attachments/assets/90f88958-00bf-4eb7-9c4b-2cfe729fa028)

#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

I have been using this for the past month without any issues.  The example code is very simple, but would be good if other Nushell users would test it too.

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
