### PR TITLE
chore: fix clippy warnings for rust v1.83 & current nightly

### DIFF
--- a/src/configs/aws.rs
+++ b/src/configs/aws.rs
@@ -49,7 +49,7 @@ pub struct AwsConfig<'a> {
     pub force_display: bool,
 }
 
-impl<'a> Default for AwsConfig<'a> {
+impl Default for AwsConfig<'_> {
     fn default() -> Self {
         AwsConfig {
             format: "on [$symbol($profile )(\\($region\\) )(\\[$duration\\] )]($style)",

--- a/src/configs/azure.rs
+++ b/src/configs/azure.rs
@@ -16,7 +16,7 @@ pub struct AzureConfig<'a> {
     pub subscription_aliases: HashMap<String, &'a str>,
 }
 
-impl<'a> Default for AzureConfig<'a> {
+impl Default for AzureConfig<'_> {
     fn default() -> Self {
         AzureConfig {
             format: "on [$symbol($subscription)]($style) ",

--- a/src/configs/battery.rs
+++ b/src/configs/battery.rs
@@ -19,7 +19,7 @@ pub struct BatteryConfig<'a> {
     pub format: &'a str,
 }
 
-impl<'a> Default for BatteryConfig<'a> {
+impl Default for BatteryConfig<'_> {
     fn default() -> Self {
         BatteryConfig {
             full_symbol: "󰁹 ",
@@ -48,7 +48,7 @@ pub struct BatteryDisplayConfig<'a> {
     pub discharging_symbol: Option<&'a str>,
 }
 
-impl<'a> Default for BatteryDisplayConfig<'a> {
+impl Default for BatteryDisplayConfig<'_> {
     fn default() -> Self {
         BatteryDisplayConfig {
             threshold: 10,

--- a/src/configs/buf.rs
+++ b/src/configs/buf.rs
@@ -18,7 +18,7 @@ pub struct BufConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> Default for BufConfig<'a> {
+impl Default for BufConfig<'_> {
     fn default() -> Self {
         BufConfig {
             format: "with [$symbol($version )]($style)",

--- a/src/configs/bun.rs
+++ b/src/configs/bun.rs
@@ -18,7 +18,7 @@ pub struct BunConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> Default for BunConfig<'a> {
+impl Default for BunConfig<'_> {
     fn default() -> Self {
         BunConfig {
             format: "via [$symbol($version )]($style)",

--- a/src/configs/c.rs
+++ b/src/configs/c.rs
@@ -19,7 +19,7 @@ pub struct CConfig<'a> {
     pub commands: Vec<Vec<&'a str>>,
 }
 
-impl<'a> Default for CConfig<'a> {
+impl Default for CConfig<'_> {
     fn default() -> Self {
         CConfig {
             format: "via [$symbol($version(-$name) )]($style)",

--- a/src/configs/character.rs
+++ b/src/configs/character.rs
@@ -19,7 +19,7 @@ pub struct CharacterConfig<'a> {
     pub disabled: bool,
 }
 
-impl<'a> Default for CharacterConfig<'a> {
+impl Default for CharacterConfig<'_> {
     fn default() -> Self {
         CharacterConfig {
             format: "$symbol ",

--- a/src/configs/cmake.rs
+++ b/src/configs/cmake.rs
@@ -18,7 +18,7 @@ pub struct CMakeConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> Default for CMakeConfig<'a> {
+impl Default for CMakeConfig<'_> {
     fn default() -> Self {
         CMakeConfig {
             format: "via [$symbol($version )]($style)",

--- a/src/configs/cmd_duration.rs
+++ b/src/configs/cmd_duration.rs
@@ -20,7 +20,7 @@ pub struct CmdDurationConfig<'a> {
     pub notification_timeout: Option<u32>,
 }
 
-impl<'a> Default for CmdDurationConfig<'a> {
+impl Default for CmdDurationConfig<'_> {
     fn default() -> Self {
         CmdDurationConfig {
             min_time: 2_000,

--- a/src/configs/cobol.rs
+++ b/src/configs/cobol.rs
@@ -18,7 +18,7 @@ pub struct CobolConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> Default for CobolConfig<'a> {
+impl Default for CobolConfig<'_> {
     fn default() -> Self {
         CobolConfig {
             format: "via [$symbol($version )]($style)",

--- a/src/configs/conda.rs
+++ b/src/configs/conda.rs
@@ -16,7 +16,7 @@ pub struct CondaConfig<'a> {
     pub disabled: bool,
 }
 
-impl<'a> Default for CondaConfig<'a> {
+impl Default for CondaConfig<'_> {
     fn default() -> Self {
         CondaConfig {
             truncation_length: 1,

--- a/src/configs/container.rs
+++ b/src/configs/container.rs
@@ -14,7 +14,7 @@ pub struct ContainerConfig<'a> {
     pub disabled: bool,
 }
 
-impl<'a> Default for ContainerConfig<'a> {
+impl Default for ContainerConfig<'_> {
     fn default() -> Self {
         ContainerConfig {
             format: "[$symbol \\[$name\\]]($style) ",

--- a/src/configs/crystal.rs
+++ b/src/configs/crystal.rs
@@ -18,7 +18,7 @@ pub struct CrystalConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> Default for CrystalConfig<'a> {
+impl Default for CrystalConfig<'_> {
     fn default() -> Self {
         CrystalConfig {
             format: "via [$symbol($version )]($style)",

--- a/src/configs/custom.rs
+++ b/src/configs/custom.rs
@@ -33,7 +33,7 @@ pub struct CustomConfig<'a> {
     pub unsafe_no_escape: bool,
 }
 
-impl<'a> Default for CustomConfig<'a> {
+impl Default for CustomConfig<'_> {
     fn default() -> Self {
         CustomConfig {
             format: "[$symbol($output )]($style)",

--- a/src/configs/daml.rs
+++ b/src/configs/daml.rs
@@ -18,7 +18,7 @@ pub struct DamlConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> Default for DamlConfig<'a> {
+impl Default for DamlConfig<'_> {
     fn default() -> Self {
         DamlConfig {
             symbol: "Λ ",

--- a/src/configs/dart.rs
+++ b/src/configs/dart.rs
@@ -18,7 +18,7 @@ pub struct DartConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> Default for DartConfig<'a> {
+impl Default for DartConfig<'_> {
     fn default() -> Self {
         DartConfig {
             format: "via [$symbol($version )]($style)",

--- a/src/configs/deno.rs
+++ b/src/configs/deno.rs
@@ -18,7 +18,7 @@ pub struct DenoConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> Default for DenoConfig<'a> {
+impl Default for DenoConfig<'_> {
     fn default() -> Self {
         DenoConfig {
             format: "via [$symbol($version )]($style)",

--- a/src/configs/directory.rs
+++ b/src/configs/directory.rs
@@ -28,7 +28,7 @@ pub struct DirectoryConfig<'a> {
     pub use_os_path_sep: bool,
 }
 
-impl<'a> Default for DirectoryConfig<'a> {
+impl Default for DirectoryConfig<'_> {
     fn default() -> Self {
         DirectoryConfig {
             truncation_length: 3,

--- a/src/configs/direnv.rs
+++ b/src/configs/direnv.rs
@@ -22,7 +22,7 @@ pub struct DirenvConfig<'a> {
     pub unloaded_msg: &'a str,
 }
 
-impl<'a> Default for DirenvConfig<'a> {
+impl Default for DirenvConfig<'_> {
     fn default() -> Self {
         Self {
             format: "[$symbol$loaded/$allowed]($style) ",

--- a/src/configs/docker_context.rs
+++ b/src/configs/docker_context.rs
@@ -18,7 +18,7 @@ pub struct DockerContextConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> Default for DockerContextConfig<'a> {
+impl Default for DockerContextConfig<'_> {
     fn default() -> Self {
         DockerContextConfig {
             symbol: "🐳 ",

--- a/src/configs/dotnet.rs
+++ b/src/configs/dotnet.rs
@@ -19,7 +19,7 @@ pub struct DotnetConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> Default for DotnetConfig<'a> {
+impl Default for DotnetConfig<'_> {
     fn default() -> Self {
         DotnetConfig {
             format: "via [$symbol($version )(🎯 $tfm )]($style)",

--- a/src/configs/elixir.rs
+++ b/src/configs/elixir.rs
@@ -18,7 +18,7 @@ pub struct ElixirConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> Default for ElixirConfig<'a> {
+impl Default for ElixirConfig<'_> {
     fn default() -> Self {
         ElixirConfig {
             format: "via [$symbol($version \\(OTP $otp_version\\) )]($style)",

--- a/src/configs/elm.rs
+++ b/src/configs/elm.rs
@@ -18,7 +18,7 @@ pub struct ElmConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> Default for ElmConfig<'a> {
+impl Default for ElmConfig<'_> {
     fn default() -> Self {
         ElmConfig {
             format: "via [$symbol($version )]($style)",

--- a/src/configs/env_var.rs
+++ b/src/configs/env_var.rs
@@ -19,7 +19,7 @@ pub struct EnvVarConfig<'a> {
     pub description: &'a str,
 }
 
-impl<'a> Default for EnvVarConfig<'a> {
+impl Default for EnvVarConfig<'_> {
     fn default() -> Self {
         EnvVarConfig {
             symbol: "",

--- a/src/configs/erlang.rs
+++ b/src/configs/erlang.rs
@@ -18,7 +18,7 @@ pub struct ErlangConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> Default for ErlangConfig<'a> {
+impl Default for ErlangConfig<'_> {
     fn default() -> Self {
         ErlangConfig {
             format: "via [$symbol($version )]($style)",

--- a/src/configs/fennel.rs
+++ b/src/configs/fennel.rs
@@ -19,7 +19,7 @@ pub struct FennelConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> Default for FennelConfig<'a> {
+impl Default for FennelConfig<'_> {
     fn default() -> Self {
         FennelConfig {
             format: "via [$symbol($version )]($style)",

--- a/src/configs/fill.rs
+++ b/src/configs/fill.rs
@@ -13,7 +13,7 @@ pub struct FillConfig<'a> {
     pub disabled: bool,
 }
 
-impl<'a> Default for FillConfig<'a> {
+impl Default for FillConfig<'_> {
     fn default() -> Self {
         FillConfig {
             style: "bold black",

--- a/src/configs/fossil_branch.rs
+++ b/src/configs/fossil_branch.rs
@@ -16,7 +16,7 @@ pub struct FossilBranchConfig<'a> {
     pub disabled: bool,
 }
 
-impl<'a> Default for FossilBranchConfig<'a> {
+impl Default for FossilBranchConfig<'_> {
     fn default() -> Self {
         FossilBranchConfig {
             format: "on [$symbol$branch]($style) ",

--- a/src/configs/fossil_metrics.rs
+++ b/src/configs/fossil_metrics.rs
@@ -15,7 +15,7 @@ pub struct FossilMetricsConfig<'a> {
     pub disabled: bool,
 }
 
-impl<'a> Default for FossilMetricsConfig<'a> {
+impl Default for FossilMetricsConfig<'_> {
     fn default() -> Self {
         FossilMetricsConfig {
             format: "([+$added]($added_style) )([-$deleted]($deleted_style) )",

--- a/src/configs/gcloud.rs
+++ b/src/configs/gcloud.rs
@@ -18,7 +18,7 @@ pub struct GcloudConfig<'a> {
     pub detect_env_vars: Vec<&'a str>,
 }
 
-impl<'a> Default for GcloudConfig<'a> {
+impl Default for GcloudConfig<'_> {
     fn default() -> Self {
         GcloudConfig {
             format: "on [$symbol$account(@$domain)(\\($region\\))]($style) ",

--- a/src/configs/git_branch.rs
+++ b/src/configs/git_branch.rs
@@ -19,7 +19,7 @@ pub struct GitBranchConfig<'a> {
     pub disabled: bool,
 }
 
-impl<'a> Default for GitBranchConfig<'a> {
+impl Default for GitBranchConfig<'_> {
     fn default() -> Self {
         GitBranchConfig {
             format: "on [$symbol$branch(:$remote_branch)]($style) ",

--- a/src/configs/git_commit.rs
+++ b/src/configs/git_commit.rs
@@ -18,7 +18,7 @@ pub struct GitCommitConfig<'a> {
     pub tag_max_candidates: usize,
 }
 
-impl<'a> Default for GitCommitConfig<'a> {
+impl Default for GitCommitConfig<'_> {
     fn default() -> Self {
         GitCommitConfig {
             // be consistent with git by default, which has DEFAULT_ABBREV set to 7

--- a/src/configs/git_metrics.rs
+++ b/src/configs/git_metrics.rs
@@ -16,7 +16,7 @@ pub struct GitMetricsConfig<'a> {
     pub ignore_submodules: bool,
 }
 
-impl<'a> Default for GitMetricsConfig<'a> {
+impl Default for GitMetricsConfig<'_> {
     fn default() -> Self {
         GitMetricsConfig {
             added_style: "bold green",

--- a/src/configs/git_state.rs
+++ b/src/configs/git_state.rs
@@ -20,7 +20,7 @@ pub struct GitStateConfig<'a> {
     pub disabled: bool,
 }
 
-impl<'a> Default for GitStateConfig<'a> {
+impl Default for GitStateConfig<'_> {
     fn default() -> Self {
         GitStateConfig {
             rebase: "REBASING",

--- a/src/configs/git_status.rs
+++ b/src/configs/git_status.rs
@@ -28,7 +28,7 @@ pub struct GitStatusConfig<'a> {
     pub windows_starship: Option<&'a str>,
 }
 
-impl<'a> Default for GitStatusConfig<'a> {
+impl Default for GitStatusConfig<'_> {
     fn default() -> Self {
         GitStatusConfig {
             format: "([\\[$all_status$ahead_behind\\]]($style) )",

--- a/src/configs/gleam.rs
+++ b/src/configs/gleam.rs
@@ -18,7 +18,7 @@ pub struct GleamConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> Default for GleamConfig<'a> {
+impl Default for GleamConfig<'_> {
     fn default() -> Self {
         GleamConfig {
             format: "via [$symbol($version )]($style)",

--- a/src/configs/go.rs
+++ b/src/configs/go.rs
@@ -19,7 +19,7 @@ pub struct GoConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> Default for GoConfig<'a> {
+impl Default for GoConfig<'_> {
     fn default() -> Self {
         GoConfig {
             format: "via [$symbol($version )]($style)",

--- a/src/configs/gradle.rs
+++ b/src/configs/gradle.rs
@@ -19,7 +19,7 @@ pub struct GradleConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> Default for GradleConfig<'a> {
+impl Default for GradleConfig<'_> {
     fn default() -> Self {
         GradleConfig {
             format: "via [$symbol($version )]($style)",

--- a/src/configs/guix_shell.rs
+++ b/src/configs/guix_shell.rs
@@ -14,7 +14,7 @@ pub struct GuixShellConfig<'a> {
     pub disabled: bool,
 }
 
-impl<'a> Default for GuixShellConfig<'a> {
+impl Default for GuixShellConfig<'_> {
     fn default() -> Self {
         GuixShellConfig {
             format: "via [$symbol]($style) ",

--- a/src/configs/haskell.rs
+++ b/src/configs/haskell.rs
@@ -18,7 +18,7 @@ pub struct HaskellConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> Default for HaskellConfig<'a> {
+impl Default for HaskellConfig<'_> {
     fn default() -> Self {
         HaskellConfig {
             format: "via [$symbol($version )]($style)",

--- a/src/configs/haxe.rs
+++ b/src/configs/haxe.rs
@@ -18,7 +18,7 @@ pub struct HaxeConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> Default for HaxeConfig<'a> {
+impl Default for HaxeConfig<'_> {
     fn default() -> Self {
         HaxeConfig {
             format: "via [$symbol($version )]($style)",

--- a/src/configs/helm.rs
+++ b/src/configs/helm.rs
@@ -18,7 +18,7 @@ pub struct HelmConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> Default for HelmConfig<'a> {
+impl Default for HelmConfig<'_> {
     fn default() -> Self {
         HelmConfig {
             format: "via [$symbol($version )]($style)",

--- a/src/configs/hg_branch.rs
+++ b/src/configs/hg_branch.rs
@@ -16,7 +16,7 @@ pub struct HgBranchConfig<'a> {
     pub disabled: bool,
 }
 
-impl<'a> Default for HgBranchConfig<'a> {
+impl Default for HgBranchConfig<'_> {
     fn default() -> Self {
         HgBranchConfig {
             symbol: " ",

--- a/src/configs/hostname.rs
+++ b/src/configs/hostname.rs
@@ -19,7 +19,7 @@ pub struct HostnameConfig<'a> {
     pub aliases: IndexMap<String, &'a str>,
 }
 
-impl<'a> Default for HostnameConfig<'a> {
+impl Default for HostnameConfig<'_> {
     fn default() -> Self {
         HostnameConfig {
             ssh_only: true,

--- a/src/configs/java.rs
+++ b/src/configs/java.rs
@@ -18,7 +18,7 @@ pub struct JavaConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> Default for JavaConfig<'a> {
+impl Default for JavaConfig<'_> {
     fn default() -> Self {
         JavaConfig {
             format: "via [$symbol($version )]($style)",

--- a/src/configs/jobs.rs
+++ b/src/configs/jobs.rs
@@ -17,7 +17,7 @@ pub struct JobsConfig<'a> {
     pub disabled: bool,
 }
 
-impl<'a> Default for JobsConfig<'a> {
+impl Default for JobsConfig<'_> {
     fn default() -> Self {
         JobsConfig {
             threshold: 1,

--- a/src/configs/julia.rs
+++ b/src/configs/julia.rs
@@ -18,7 +18,7 @@ pub struct JuliaConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> Default for JuliaConfig<'a> {
+impl Default for JuliaConfig<'_> {
     fn default() -> Self {
         JuliaConfig {
             format: "via [$symbol($version )]($style)",

--- a/src/configs/kotlin.rs
+++ b/src/configs/kotlin.rs
@@ -19,7 +19,7 @@ pub struct KotlinConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> Default for KotlinConfig<'a> {
+impl Default for KotlinConfig<'_> {
     fn default() -> Self {
         KotlinConfig {
             format: "via [$symbol($version )]($style)",

--- a/src/configs/kubernetes.rs
+++ b/src/configs/kubernetes.rs
@@ -22,7 +22,7 @@ pub struct KubernetesConfig<'a> {
     pub contexts: Vec<KubernetesContextConfig<'a>>,
 }
 
-impl<'a> Default for KubernetesConfig<'a> {
+impl Default for KubernetesConfig<'_> {
     fn default() -> Self {
         KubernetesConfig {
             symbol: "☸ ",

--- a/src/configs/localip.rs
+++ b/src/configs/localip.rs
@@ -14,7 +14,7 @@ pub struct LocalipConfig<'a> {
     pub disabled: bool,
 }
 
-impl<'a> Default for LocalipConfig<'a> {
+impl Default for LocalipConfig<'_> {
     fn default() -> Self {
         LocalipConfig {
             ssh_only: true,

--- a/src/configs/lua.rs
+++ b/src/configs/lua.rs
@@ -19,7 +19,7 @@ pub struct LuaConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> Default for LuaConfig<'a> {
+impl Default for LuaConfig<'_> {
     fn default() -> Self {
         LuaConfig {
             format: "via [$symbol($version )]($style)",

--- a/src/configs/memory_usage.rs
+++ b/src/configs/memory_usage.rs
@@ -15,7 +15,7 @@ pub struct MemoryConfig<'a> {
     pub disabled: bool,
 }
 
-impl<'a> Default for MemoryConfig<'a> {
+impl Default for MemoryConfig<'_> {
     fn default() -> Self {
         MemoryConfig {
             threshold: 75,

--- a/src/configs/meson.rs
+++ b/src/configs/meson.rs
@@ -16,7 +16,7 @@ pub struct MesonConfig<'a> {
     pub disabled: bool,
 }
 
-impl<'a> Default for MesonConfig<'a> {
+impl Default for MesonConfig<'_> {
     fn default() -> Self {
         MesonConfig {
             truncation_length: u32::MAX,

--- a/src/configs/mojo.rs
+++ b/src/configs/mojo.rs
@@ -20,7 +20,7 @@ pub struct MojoConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> Default for MojoConfig<'a> {
+impl Default for MojoConfig<'_> {
     fn default() -> Self {
         MojoConfig {
             format: "with [$symbol($version )]($style)",

--- a/src/configs/nats.rs
+++ b/src/configs/nats.rs
@@ -14,7 +14,7 @@ pub struct NatsConfig<'a> {
     pub disabled: bool,
 }
 
-impl<'a> Default for NatsConfig<'a> {
+impl Default for NatsConfig<'_> {
     fn default() -> Self {
         NatsConfig {
             format: "[$symbol($name )]($style)",

--- a/src/configs/nim.rs
+++ b/src/configs/nim.rs
@@ -18,7 +18,7 @@ pub struct NimConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> Default for NimConfig<'a> {
+impl Default for NimConfig<'_> {
     fn default() -> Self {
         NimConfig {
             format: "via [$symbol($version )]($style)",

--- a/src/configs/nix_shell.rs
+++ b/src/configs/nix_shell.rs
@@ -21,7 +21,7 @@ pub struct NixShellConfig<'a> {
 /* The trailing double spaces in `symbol` are needed to work around issues with
 multiwidth emoji support in some shells. Please do not file a PR to change this
 unless you can show that your changes do not affect this workaround.  */
-impl<'a> Default for NixShellConfig<'a> {
+impl Default for NixShellConfig<'_> {
     fn default() -> Self {
         NixShellConfig {
             format: "via [$symbol$state( \\($name\\))]($style) ",

--- a/src/configs/nodejs.rs
+++ b/src/configs/nodejs.rs
@@ -19,7 +19,7 @@ pub struct NodejsConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> Default for NodejsConfig<'a> {
+impl Default for NodejsConfig<'_> {
     fn default() -> Self {
         NodejsConfig {
             format: "via [$symbol($version )]($style)",

--- a/src/configs/ocaml.rs
+++ b/src/configs/ocaml.rs
@@ -20,7 +20,7 @@ pub struct OCamlConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> Default for OCamlConfig<'a> {
+impl Default for OCamlConfig<'_> {
     fn default() -> Self {
         OCamlConfig {
             format: "via [$symbol($version )(\\($switch_indicator$switch_name\\) )]($style)",

--- a/src/configs/odin.rs
+++ b/src/configs/odin.rs
@@ -18,7 +18,7 @@ pub struct OdinConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> Default for OdinConfig<'a> {
+impl Default for OdinConfig<'_> {
     fn default() -> Self {
         OdinConfig {
             format: "via [$symbol($version )]($style)",

--- a/src/configs/opa.rs
+++ b/src/configs/opa.rs
@@ -18,7 +18,7 @@ pub struct OpaConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> Default for OpaConfig<'a> {
+impl Default for OpaConfig<'_> {
     fn default() -> Self {
         OpaConfig {
             format: "via [$symbol($version )]($style)",

--- a/src/configs/openstack.rs
+++ b/src/configs/openstack.rs
@@ -14,7 +14,7 @@ pub struct OspConfig<'a> {
     pub disabled: bool,
 }
 
-impl<'a> Default for OspConfig<'a> {
+impl Default for OspConfig<'_> {
     fn default() -> Self {
         OspConfig {
             format: "on [$symbol$cloud(\\($project\\))]($style) ",

--- a/src/configs/os.rs
+++ b/src/configs/os.rs
@@ -22,7 +22,7 @@ impl<'a> OSConfig<'a> {
     }
 }
 
-impl<'a> Default for OSConfig<'a> {
+impl Default for OSConfig<'_> {
     fn default() -> Self {
         OSConfig {
             format: "[$symbol]($style)",

--- a/src/configs/package.rs
+++ b/src/configs/package.rs
@@ -16,7 +16,7 @@ pub struct PackageConfig<'a> {
     pub version_format: &'a str,
 }
 
-impl<'a> Default for PackageConfig<'a> {
+impl Default for PackageConfig<'_> {
     fn default() -> Self {
         PackageConfig {
             format: "is [$symbol$version]($style) ",

--- a/src/configs/perl.rs
+++ b/src/configs/perl.rs
@@ -18,7 +18,7 @@ pub struct PerlConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> Default for PerlConfig<'a> {
+impl Default for PerlConfig<'_> {
     fn default() -> Self {
         PerlConfig {
             format: "via [$symbol($version )]($style)",

--- a/src/configs/php.rs
+++ b/src/configs/php.rs
@@ -18,7 +18,7 @@ pub struct PhpConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> Default for PhpConfig<'a> {
+impl Default for PhpConfig<'_> {
     fn default() -> Self {
         PhpConfig {
             format: "via [$symbol($version )]($style)",

--- a/src/configs/pijul_channel.rs
+++ b/src/configs/pijul_channel.rs
@@ -16,7 +16,7 @@ pub struct PijulConfig<'a> {
     pub disabled: bool,
 }
 
-impl<'a> Default for PijulConfig<'a> {
+impl Default for PijulConfig<'_> {
     fn default() -> Self {
         PijulConfig {
             symbol: " ",

--- a/src/configs/pulumi.rs
+++ b/src/configs/pulumi.rs
@@ -16,7 +16,7 @@ pub struct PulumiConfig<'a> {
     pub search_upwards: bool,
 }
 
-impl<'a> Default for PulumiConfig<'a> {
+impl Default for PulumiConfig<'_> {
     fn default() -> Self {
         PulumiConfig {
             format: "via [$symbol($username@)$stack]($style) ",

--- a/src/configs/purescript.rs
+++ b/src/configs/purescript.rs
@@ -18,7 +18,7 @@ pub struct PureScriptConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> Default for PureScriptConfig<'a> {
+impl Default for PureScriptConfig<'_> {
     fn default() -> Self {
         PureScriptConfig {
             format: "via [$symbol($version )]($style)",

--- a/src/configs/python.rs
+++ b/src/configs/python.rs
@@ -24,7 +24,7 @@ pub struct PythonConfig<'a> {
     pub detect_env_vars: Vec<&'a str>,
 }
 
-impl<'a> Default for PythonConfig<'a> {
+impl Default for PythonConfig<'_> {
     fn default() -> Self {
         PythonConfig {
             pyenv_version_name: false,

--- a/src/configs/quarto.rs
+++ b/src/configs/quarto.rs
@@ -18,7 +18,7 @@ pub struct QuartoConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> Default for QuartoConfig<'a> {
+impl Default for QuartoConfig<'_> {
     fn default() -> Self {
         QuartoConfig {
             format: "via [$symbol($version )]($style)",

--- a/src/configs/raku.rs
+++ b/src/configs/raku.rs
@@ -18,7 +18,7 @@ pub struct RakuConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> Default for RakuConfig<'a> {
+impl Default for RakuConfig<'_> {
     fn default() -> Self {
         RakuConfig {
             format: "via [$symbol($version-$vm_version )]($style)",

--- a/src/configs/red.rs
+++ b/src/configs/red.rs
@@ -18,7 +18,7 @@ pub struct RedConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> Default for RedConfig<'a> {
+impl Default for RedConfig<'_> {
     fn default() -> Self {
         RedConfig {
             format: "via [$symbol($version )]($style)",

--- a/src/configs/rlang.rs
+++ b/src/configs/rlang.rs
@@ -18,7 +18,7 @@ pub struct RLangConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> Default for RLangConfig<'a> {
+impl Default for RLangConfig<'_> {
     fn default() -> Self {
         RLangConfig {
             format: "via [$symbol($version )]($style)",

--- a/src/configs/ruby.rs
+++ b/src/configs/ruby.rs
@@ -19,7 +19,7 @@ pub struct RubyConfig<'a> {
     pub detect_variables: Vec<&'a str>,
 }
 
-impl<'a> Default for RubyConfig<'a> {
+impl Default for RubyConfig<'_> {
     fn default() -> Self {
         RubyConfig {
             format: "via [$symbol($version )]($style)",

--- a/src/configs/rust.rs
+++ b/src/configs/rust.rs
@@ -18,7 +18,7 @@ pub struct RustConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> Default for RustConfig<'a> {
+impl Default for RustConfig<'_> {
     fn default() -> Self {
         RustConfig {
             format: "via [$symbol($version )]($style)",

--- a/src/configs/scala.rs
+++ b/src/configs/scala.rs
@@ -18,7 +18,7 @@ pub struct ScalaConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> Default for ScalaConfig<'a> {
+impl Default for ScalaConfig<'_> {
     fn default() -> Self {
         ScalaConfig {
             format: "via [$symbol($version )]($style)",

--- a/src/configs/shell.rs
+++ b/src/configs/shell.rs
@@ -26,7 +26,7 @@ pub struct ShellConfig<'a> {
     pub disabled: bool,
 }
 
-impl<'a> Default for ShellConfig<'a> {
+impl Default for ShellConfig<'_> {
     fn default() -> Self {
         ShellConfig {
             format: "[$indicator]($style) ",

--- a/src/configs/shlvl.rs
+++ b/src/configs/shlvl.rs
@@ -17,7 +17,7 @@ pub struct ShLvlConfig<'a> {
     pub disabled: bool,
 }
 
-impl<'a> Default for ShLvlConfig<'a> {
+impl Default for ShLvlConfig<'_> {
     fn default() -> Self {
         ShLvlConfig {
             threshold: 2,

--- a/src/configs/singularity.rs
+++ b/src/configs/singularity.rs
@@ -14,7 +14,7 @@ pub struct SingularityConfig<'a> {
     pub disabled: bool,
 }
 
-impl<'a> Default for SingularityConfig<'a> {
+impl Default for SingularityConfig<'_> {
     fn default() -> Self {
         SingularityConfig {
             format: "[$symbol\\[$env\\]]($style) ",

--- a/src/configs/solidity.rs
+++ b/src/configs/solidity.rs
@@ -9,7 +9,6 @@ use crate::config::VecOr;
     schemars(deny_unknown_fields)
 )]
 #[serde(default)]
-
 pub struct SolidityConfig<'a> {
     pub format: &'a str,
     pub version_format: &'a str,
@@ -22,7 +21,7 @@ pub struct SolidityConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> Default for SolidityConfig<'a> {
+impl Default for SolidityConfig<'_> {
     fn default() -> Self {
         SolidityConfig {
             format: "via [$symbol($version)]($style)",

--- a/src/configs/spack.rs
+++ b/src/configs/spack.rs
@@ -15,7 +15,7 @@ pub struct SpackConfig<'a> {
     pub disabled: bool,
 }
 
-impl<'a> Default for SpackConfig<'a> {
+impl Default for SpackConfig<'_> {
     fn default() -> Self {
         SpackConfig {
             truncation_length: 1,

--- a/src/configs/status.rs
+++ b/src/configs/status.rs
@@ -26,7 +26,7 @@ pub struct StatusConfig<'a> {
     pub disabled: bool,
 }
 
-impl<'a> Default for StatusConfig<'a> {
+impl Default for StatusConfig<'_> {
     fn default() -> Self {
         StatusConfig {
             format: "[$symbol$status]($style) ",

--- a/src/configs/sudo.rs
+++ b/src/configs/sudo.rs
@@ -15,7 +15,7 @@ pub struct SudoConfig<'a> {
     pub disabled: bool,
 }
 
-impl<'a> Default for SudoConfig<'a> {
+impl Default for SudoConfig<'_> {
     fn default() -> Self {
         SudoConfig {
             format: "[as $symbol]($style)",

--- a/src/configs/swift.rs
+++ b/src/configs/swift.rs
@@ -18,7 +18,7 @@ pub struct SwiftConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> Default for SwiftConfig<'a> {
+impl Default for SwiftConfig<'_> {
     fn default() -> Self {
         SwiftConfig {
             format: "via [$symbol($version )]($style)",

--- a/src/configs/terraform.rs
+++ b/src/configs/terraform.rs
@@ -18,7 +18,7 @@ pub struct TerraformConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> Default for TerraformConfig<'a> {
+impl Default for TerraformConfig<'_> {
     fn default() -> Self {
         TerraformConfig {
             format: "via [$symbol$workspace]($style) ",

--- a/src/configs/time.rs
+++ b/src/configs/time.rs
@@ -18,7 +18,7 @@ pub struct TimeConfig<'a> {
     pub time_range: &'a str,
 }
 
-impl<'a> Default for TimeConfig<'a> {
+impl Default for TimeConfig<'_> {
     fn default() -> Self {
         TimeConfig {
             format: "at [$time]($style) ",

--- a/src/configs/typst.rs
+++ b/src/configs/typst.rs
@@ -18,7 +18,7 @@ pub struct TypstConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> Default for TypstConfig<'a> {
+impl Default for TypstConfig<'_> {
     fn default() -> Self {
         TypstConfig {
             format: "via [$symbol($version )]($style)",

--- a/src/configs/username.rs
+++ b/src/configs/username.rs
@@ -18,7 +18,7 @@ pub struct UsernameConfig<'a> {
     pub aliases: IndexMap<String, &'a str>,
 }
 
-impl<'a> Default for UsernameConfig<'a> {
+impl Default for UsernameConfig<'_> {
     fn default() -> Self {
         UsernameConfig {
             detect_env_vars: vec![],

--- a/src/configs/v.rs
+++ b/src/configs/v.rs
@@ -18,7 +18,7 @@ pub struct VConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> Default for VConfig<'a> {
+impl Default for VConfig<'_> {
     fn default() -> Self {
         VConfig {
             format: "via [$symbol($version )]($style)",

--- a/src/configs/vagrant.rs
+++ b/src/configs/vagrant.rs
@@ -18,7 +18,7 @@ pub struct VagrantConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> Default for VagrantConfig<'a> {
+impl Default for VagrantConfig<'_> {
     fn default() -> Self {
         VagrantConfig {
             format: "via [$symbol($version )]($style)",

--- a/src/configs/vcsh.rs
+++ b/src/configs/vcsh.rs
@@ -14,7 +14,7 @@ pub struct VcshConfig<'a> {
     pub disabled: bool,
 }
 
-impl<'a> Default for VcshConfig<'a> {
+impl Default for VcshConfig<'_> {
     fn default() -> Self {
         VcshConfig {
             symbol: "",

--- a/src/configs/zig.rs
+++ b/src/configs/zig.rs
@@ -18,7 +18,7 @@ pub struct ZigConfig<'a> {
     pub detect_folders: Vec<&'a str>,
 }
 
-impl<'a> Default for ZigConfig<'a> {
+impl Default for ZigConfig<'_> {
     fn default() -> Self {
         ZigConfig {
             format: "via [$symbol($version )]($style)",

--- a/src/context.rs
+++ b/src/context.rs
@@ -134,7 +134,7 @@ impl<'a> Context<'a> {
         if properties
             .pipestatus
             .as_deref()
-            .map_or(false, |p| p.len() == 1 && p[0].is_empty())
+            .is_some_and(|p| p.len() == 1 && p[0].is_empty())
         {
             properties.pipestatus = None;
         }

--- a/src/context_env.rs
+++ b/src/context_env.rs
@@ -14,6 +14,7 @@ pub struct Env<'a> {
     _marker: std::marker::PhantomData<&'a ()>,
 }
 
+#[cfg_attr(not(test), allow(clippy::needless_lifetimes))]
 impl<'a> Env<'a> {
     // Retrieves a environment variable from the os or from a table if in testing mode
     #[cfg(test)]

--- a/src/formatter/string_formatter.rs
+++ b/src/formatter/string_formatter.rs
@@ -352,13 +352,13 @@ impl<'a> StringFormatter<'a> {
                                     variables
                                         .get(var.as_ref())
                                         // false if can't find the variable in format string
-                                        .map_or(false, |map_result| {
+                                        .is_some_and(|map_result| {
                                             let map_result = map_result.as_ref();
                                             map_result
                                                 .and_then(|result| result.as_ref().ok())
                                                 // false if the variable is None or Err, or a meta variable
                                                 // that shouldn't show
-                                                .map_or(false, |result| match result {
+                                                .is_some_and(|result| match result {
                                                     // If the variable is a meta variable, also
                                                     // check the format string inside it.
                                                     VariableValue::Meta(meta_elements) => {

--- a/src/formatter/string_formatter.rs
+++ b/src/formatter/string_formatter.rs
@@ -20,7 +20,7 @@ enum VariableValue<'a> {
     Meta(Vec<FormatElement<'a>>),
 }
 
-impl<'a> Default for VariableValue<'a> {
+impl Default for VariableValue<'_> {
     fn default() -> Self {
         VariableValue::Plain(Cow::Borrowed(""))
     }
@@ -407,13 +407,13 @@ impl<'a> StringFormatter<'a> {
     }
 }
 
-impl<'a> VariableHolder<String> for StringFormatter<'a> {
+impl VariableHolder<String> for StringFormatter<'_> {
     fn get_variables(&self) -> BTreeSet<String> {
         self.variables.keys().cloned().collect()
     }
 }
 
-impl<'a> StyleVariableHolder<String> for StringFormatter<'a> {
+impl StyleVariableHolder<String> for StringFormatter<'_> {
     fn get_style_variables(&self) -> BTreeSet<String> {
         self.style_variables.keys().cloned().collect()
     }

--- a/src/module.rs
+++ b/src/module.rs
@@ -177,7 +177,7 @@ impl<'a> Module<'a> {
     }
 }
 
-impl<'a> fmt::Display for Module<'a> {
+impl fmt::Display for Module<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let ansi_strings = self.ansi_strings();
         write!(f, "{}", AnsiStrings(&ansi_strings))

--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -340,7 +340,7 @@ fn to_fish_style(pwd_dir_length: usize, dir_string: &str, truncated_dir_string: 
 
 /// Convert the path separators in `path` to the OS specific path separators.
 fn convert_path_sep(path: &str) -> String {
-    return PathBuf::from_slash(path).to_string_lossy().into_owned();
+    PathBuf::from_slash(path).to_string_lossy().into_owned()
 }
 
 /// Get the path before the git repo root by trim the most right repo name.

--- a/src/modules/dotnet.rs
+++ b/src/modules/dotnet.rs
@@ -17,7 +17,6 @@ const GLOBAL_JSON_FILE: &str = "global.json";
 const PROJECT_JSON_FILE: &str = "project.json";
 
 /// A module which shows the latest (or pinned) version of the dotnet SDK
-
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let mut module = context.new_module("dotnet");
     let config = DotnetConfig::try_load(module.config);

--- a/src/modules/dotnet.rs
+++ b/src/modules/dotnet.rs
@@ -180,7 +180,7 @@ fn estimate_dotnet_version(
 ///     - The root of the git repository
 ///       (If there is one)
 fn try_find_nearby_global_json(current_dir: &Path, repo_root: Option<&Path>) -> Option<String> {
-    let current_dir_is_repo_root = repo_root.map_or(false, |r| r == current_dir);
+    let current_dir_is_repo_root = repo_root == Some(current_dir);
     let parent_dir = if current_dir_is_repo_root {
         // Don't scan the parent directory if it's above the root of a git repository
         None

--- a/src/modules/kubernetes.rs
+++ b/src/modules/kubernetes.rs
@@ -156,7 +156,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     .any(|v| !v.is_empty());
 
     let is_kube_project = have_scan_config.then(|| {
-        context.try_begin_scan().map_or(false, |scanner| {
+        context.try_begin_scan().is_some_and(|scanner| {
             scanner
                 .set_files(&config.detect_files)
                 .set_folders(&config.detect_folders)

--- a/src/modules/rust.rs
+++ b/src/modules/rust.rs
@@ -332,7 +332,7 @@ fn find_rust_toolchain_file(context: &Context) -> Option<String> {
 
     if context
         .dir_contents()
-        .map_or(false, |dir| dir.has_file("rust-toolchain"))
+        .is_ok_and(|dir| dir.has_file("rust-toolchain"))
     {
         if let Some(toolchain) = read_channel(Path::new("rust-toolchain"), false) {
             return Some(toolchain);
@@ -341,7 +341,7 @@ fn find_rust_toolchain_file(context: &Context) -> Option<String> {
 
     if context
         .dir_contents()
-        .map_or(false, |dir| dir.has_file("rust-toolchain.toml"))
+        .is_ok_and(|dir| dir.has_file("rust-toolchain.toml"))
     {
         if let Some(toolchain) = read_channel(Path::new("rust-toolchain.toml"), true) {
             return Some(toolchain);

--- a/src/modules/solidity.rs
+++ b/src/modules/solidity.rs
@@ -77,7 +77,6 @@ fn parse_solidity_version(version: &str) -> Option<String> {
 }
 
 #[cfg(test)]
-
 mod tests {
     use super::*;
     use crate::test::ModuleRenderer;

--- a/src/print.rs
+++ b/src/print.rs
@@ -22,7 +22,7 @@ use crate::utils::wrap_colorseq_for_shell;
 
 pub struct Grapheme<'a>(pub &'a str);
 
-impl<'a> Grapheme<'a> {
+impl Grapheme<'_> {
     pub fn width(&self) -> usize {
         self.0
             .chars()

--- a/src/serde_utils.rs
+++ b/src/serde_utils.rs
@@ -176,9 +176,7 @@ impl<'de> Deserializer<'de> for ValueDeserializer<'de> {
             .info
             .filter(|StructInfo { name, .. }| name == &"StarshipRootConfig")
             .and(self.current_key)
-            .map_or(false, |key| {
-                ALL_MODULES.contains(&key) || key == "custom" || key == "env_var"
-            })
+            .is_some_and(|key| ALL_MODULES.contains(&key) || key == "custom" || key == "env_var")
         {
             return visitor.visit_none();
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR fixes the additional clippy warnings that will get released alongside rust 1.83 due to release on Thursday and the current rust nightly.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
