### PR TITLE
feat(bun): Detect bun using new text-format lockfile

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -87,6 +87,7 @@
       "default": {
         "detect_extensions": [],
         "detect_files": [
+          "bun.lock",
           "bun.lockb",
           "bunfig.toml"
         ],
@@ -2222,6 +2223,7 @@
         },
         "detect_files": {
           "default": [
+            "bun.lock",
             "bun.lockb",
             "bunfig.toml"
           ],

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -618,21 +618,22 @@ symbol = '🦬 '
 The `bun` module shows the currently installed version of the [bun](https://bun.sh) JavaScript runtime.
 By default the module will be shown if any of the following conditions are met:
 
+- The current directory contains a `bun.lock` file
 - The current directory contains a `bun.lockb` file
 - The current directory contains a `bunfig.toml` file
 
 ### Options
 
-| Option              | Default                              | Description                                                               |
-| ------------------- | ------------------------------------ | ------------------------------------------------------------------------- |
-| `format`            | `'via [$symbol($version )]($style)'` | The format for the module.                                                |
-| `version_format`    | `'v${raw}'`                          | The version format. Available vars are `raw`, `major`, `minor`, & `patch` |
-| `symbol`            | `'🥟 '`                              | A format string representing the symbol of Bun.                           |
-| `detect_extensions` | `[]`                                 | Which extensions should trigger this module.                              |
-| `detect_files`      | `['bun.lockb', 'bunfig.toml']`       | Which filenames should trigger this module.                               |
-| `detect_folders`    | `[]`                                 | Which folders should trigger this module.                                 |
-| `style`             | `'bold red'`                         | The style for the module.                                                 |
-| `disabled`          | `false`                              | Disables the `bun` module.                                                |
+| Option              | Default                                    | Description                                                               |
+| ------------------- | ------------------------------------------ | ------------------------------------------------------------------------- |
+| `format`            | `'via [$symbol($version )]($style)'`       | The format for the module.                                                |
+| `version_format`    | `'v${raw}'`                                | The version format. Available vars are `raw`, `major`, `minor`, & `patch` |
+| `symbol`            | `'🥟 '`                                    | A format string representing the symbol of Bun.                           |
+| `detect_extensions` | `[]`                                       | Which extensions should trigger this module.                              |
+| `detect_files`      | `['bun.lock', 'bun.lockb', 'bunfig.toml']` | Which filenames should trigger this module.                               |
+| `detect_folders`    | `[]`                                       | Which folders should trigger this module.                                 |
+| `style`             | `'bold red'`                               | The style for the module.                                                 |
+| `disabled`          | `false`                                    | Disables the `bun` module.                                                |
 
 ### Variables
 

--- a/src/configs/bun.rs
+++ b/src/configs/bun.rs
@@ -27,7 +27,7 @@ impl<'a> Default for BunConfig<'a> {
             style: "bold red",
             disabled: false,
             detect_extensions: vec![],
-            detect_files: vec!["bun.lockb", "bunfig.toml"],
+            detect_files: vec!["bun.lock", "bun.lockb", "bunfig.toml"],
             detect_folders: vec![],
         }
     }

--- a/src/modules/bun.rs
+++ b/src/modules/bun.rs
@@ -95,9 +95,32 @@ mod tests {
     }
 
     #[test]
+    fn folder_with_bun_file_text_lockfile() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join("bun.lock"))?.sync_all()?;
+        let actual = ModuleRenderer::new("bun").path(dir.path()).collect();
+        let expected = Some(format!("via {}", Color::Red.bold().paint("🥟 v0.1.4 ")));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
     fn no_bun_installed() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("bun.lockb"))?.sync_all()?;
+        let actual = ModuleRenderer::new("bun")
+            .path(dir.path())
+            .cmd("bun --version", None)
+            .collect();
+        let expected = Some(format!("via {}", Color::Red.bold().paint("🥟 ")));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn no_bun_installed_text_lockfile() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join("bun.lock"))?.sync_all()?;
         let actual = ModuleRenderer::new("bun")
             .path(dir.path())
             .cmd("bun --version", None)


### PR DESCRIPTION
#### Description

Bun version 1.1.39 introduced a new plaintext lockfile. Currently it is opt-in only, but it will become the default in bun version 1.2.

The new filename is `bun.lock`, instead of `bun.lockb`. Either of these should cause Starship to detect bun.

#### Motivation and Context

Currently, a project that has opted in to the new lockfile format is not detected as a bun project.

#### How Has This Been Tested?

Tests have been updated and run, as well as manual visual verification on Windows.

- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
