### PR TITLE
feat(battery): Use best match instead of first match for `battery.display` threshold

### DIFF
--- a/src/modules/battery.rs
+++ b/src/modules/battery.rs
@@ -445,26 +445,32 @@ mod tests {
         });
 
         // Larger threshold first
-        let actual = ModuleRenderer::new("battery").config(toml::toml! {
-            [[battery.display]]
-            threshold = 100
-            style = "red"
-            [[battery.display]]
-            threshold = 60
-            style = "green bold"
-        }).battery_info_provider(&mock).collect();
+        let actual = ModuleRenderer::new("battery")
+            .config(toml::toml! {
+                [[battery.display]]
+                threshold = 100
+                style = "red"
+                [[battery.display]]
+                threshold = 60
+                style = "green bold"
+            })
+            .battery_info_provider(&mock)
+            .collect();
         let expected = Some(format!("{} ", Color::Green.bold().paint("󰂃 50%")));
         assert_eq!(expected, actual);
 
         // Smaller threshold first
-        let actual = ModuleRenderer::new("battery").config(toml::toml! {
-            [[battery.display]]
-            threshold = 60
-            style = "green bold"
-            [[battery.display]]
-            threshold = 100
-            style = "red"
-        }).battery_info_provider(&mock).collect();
+        let actual = ModuleRenderer::new("battery")
+            .config(toml::toml! {
+                [[battery.display]]
+                threshold = 60
+                style = "green bold"
+                [[battery.display]]
+                threshold = 100
+                style = "red"
+            })
+            .battery_info_provider(&mock)
+            .collect();
         let expected = Some(format!("{} ", Color::Green.bold().paint("󰂃 50%")));
         assert_eq!(expected, actual);
     }

--- a/src/modules/battery.rs
+++ b/src/modules/battery.rs
@@ -17,28 +17,11 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     // Parse config under `display`.
     // Select the style that is most minimally greater than the current battery percentage.
     // If no such style exists do not display battery module.
-    let mut closest_style = None;
-    for display_style in &config.display {
-        // Skip style if its threshold is lower than the current battery percentage.
-        if percentage > display_style.threshold as f32 {
-            continue;
-        }
-        // Unwrap the `Option`
-        let Some(closest_so_far) = closest_style else {
-            // If `closest_style` is `None` then this is the first valid style
-            // encountered, so save it and continue to the next loop iteration.
-            closest_style = Some(display_style);
-            continue;
-        };
-        // If this style's threshold is less than the previous closest so far,
-        // save it and continue to the next loop iteration
-        if display_style.threshold < closest_so_far.threshold {
-            closest_style = Some(display_style);
-            continue;
-        }
-    }
-    let display_style = closest_style?;
-    //let display_style = config.display.iter().find(|display_style| percentage <= display_style.threshold as f32)?;
+    let display_style = config
+        .display
+        .iter()
+        .filter(|display_style| percentage <= display_style.threshold as f32)
+        .min_by_key(|display_style| display_style.threshold)?;
 
     // Parse the format string and build the module
     match StringFormatter::new(config.format) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Previously the selection code for `battery.display` styles simply filtered for the first style found within the config with a threshold larger than the current battery percentage. If the config defined multiple display thresholds that were above the battery percentage it would only select the first one that was encountered rather than the one that was closest to the current battery percentage.

<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

### Description
<!--- Describe your changes in detail -->

If the battery percentage is currently 50% and I had defined in my config something akin to the following:

```toml
[[battery.display]]
threshold = 100
style = "red"

[[battery.display]]
threshold = 60
style = "green bold"
```

Starship would output the battery module in red, even though the 60% entry is closer to the 50% battery charge. And if the entries were reversed within the config:

```toml
[[battery.display]]
threshold = 60
style = "green bold"

[[battery.display]]
threshold = 100
style = "red"
```

Starship would then output the battery module in green.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
As I was spending my afternoon customizing my prompt config, I added `battery.display` entries for every 10% threshold. I happened to write it from 100% down to 10% (5% actually but that's irrelevant). My laptop was somewhere in the 50-60% range but it was still printing the style I set for 100% rather than the 60% threshold I expected it to print. Not a huge issue as it still accurately displayed the battery percentage regardless of the symbol and style I had set, but my curiosity got the better of me and I dug into the code and found that the module using the simple find call rather than ensuring it chose the closest threshold that was still above the current battery percentage.

#### Implementation Details

The change I've made has transformed the `config.display.iter.find(...)` call into a for-loop that tracks the closest matching entry so far. It could be rewritten to a `config.display.iter.fold(...)` chain, however I find that version of the code to be more convoluted as the accumulation value and closure tend to obscure the larger picture to my eyes, and the more explicit separation of processes and clearer (imo) variable names makes it easier to read/comprehend. Regardless I'd be happy to convert it to a `.fold(...)` version if others think that is clearer/more concise.
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
This PR adds a test within `src/modules/battery.rs` to ensure the new parsing operates as expected, accomplished by using the contrived example config above: containing two `battery.display` entries, one with a threshold at 100% & the other at 60%, with a mock battery set at 50% charge. This config is first processed with the 100% threshold defined above the 60% threshold, and then again with the 60% threshold defined above the 100% threshold. To ensure the entries are parsed correctly each entry is given a different style, so the expected value that is compared against has the same style as the 60% threshold entry for both test cases.
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
    - I'm not sure if it should be updated or not, the order-dependency on the user configuration was not documented in the current documentation, and I don't think the order-dependency was necessarily intended by the original author.
- [x] I have updated the tests accordingly.
