### PR TITLE
feat: add network namespace module

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -1082,6 +1082,19 @@
         }
       ]
     },
+    "netns": {
+      "default": {
+        "disabled": false,
+        "format": "[$symbol \\[$name\\]]($style) ",
+        "style": "blue bold dimmed",
+        "symbol": "🛜"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/NetnsConfig"
+        }
+      ]
+    },
     "nim": {
       "default": {
         "detect_extensions": [
@@ -4596,6 +4609,28 @@
         },
         "disabled": {
           "default": true,
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "NetnsConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "[$symbol \\[$name\\]]($style) ",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "🛜",
+          "type": "string"
+        },
+        "style": {
+          "default": "blue bold dimmed",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
           "type": "boolean"
         }
       },

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -353,6 +353,7 @@ $time\
 $status\
 $os\
 $container\
+$netns\
 $shell\
 $character"""
 ```
@@ -3009,6 +3010,38 @@ The `nats` module shows the name of the current [NATS](https://nats.io) context.
 [nats]
 format = '[$symbol]($style)'
 style = 'bold purple'
+```
+
+## Network Namespace
+
+The `netns` module shows the current network namespace.
+This uses `ip netns identify` to get the network namespace, so only network namespaces mounted at `/var/run/netns` will be detected.
+
+### Options
+
+| Option     | Default                         | Description                                                       |
+| ---------- | ------------------------------- | ----------------------------------------------------------------- |
+| `format`   | `'[$symbol \[$name\]]($style)'` | The format for the module.                                        |
+| `symbol`   | `'🛜 '`                         | The symbol used before the network namespace (defaults to empty). |
+| `style`    | `'blue bold dimmed'`            | The style for the module.                                         |
+| `disabled` | `false`                         | Disables the `netns` module.                                      |
+
+### Variables
+
+| Variable | Example    | Description                               |
+| -------- | ---------- | ----------------------------------------- |
+| name     | `my-netns` | The name of the current network namespace |
+| symbol   |            | Mirrors the value of option `symbol`      |
+| style\*  |            | Mirrors the value of option `style`       |
+
+### Example
+
+```toml
+# ~/.config/starship.toml
+
+[netns]
+style = 'bold yellow'
+symbol = '🌐 '
 ```
 
 ## Nim

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -57,6 +57,7 @@ pub mod memory_usage;
 pub mod meson;
 pub mod mojo;
 pub mod nats;
+pub mod netns;
 pub mod nim;
 pub mod nix_shell;
 pub mod nodejs;
@@ -223,6 +224,8 @@ pub struct FullConfig<'a> {
     mojo: mojo::MojoConfig<'a>,
     #[serde(borrow)]
     nats: nats::NatsConfig<'a>,
+    #[serde(borrow)]
+    netns: netns::NetnsConfig<'a>,
     #[serde(borrow)]
     nim: nim::NimConfig<'a>,
     #[serde(borrow)]

--- a/src/configs/netns.rs
+++ b/src/configs/netns.rs
@@ -18,7 +18,7 @@ impl Default for NetnsConfig<'_> {
     fn default() -> Self {
         NetnsConfig {
             format: "[$symbol \\[$name\\]]($style) ",
-            symbol: "️🛜",
+            symbol: "🛜",
             style: "blue bold dimmed",
             disabled: false,
         }

--- a/src/configs/netns.rs
+++ b/src/configs/netns.rs
@@ -1,0 +1,26 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(
+    feature = "config-schema",
+    derive(schemars::JsonSchema),
+    schemars(deny_unknown_fields)
+)]
+#[serde(default)]
+pub struct NetnsConfig<'a> {
+    pub format: &'a str,
+    pub symbol: &'a str,
+    pub style: &'a str,
+    pub disabled: bool,
+}
+
+impl Default for NetnsConfig<'_> {
+    fn default() -> Self {
+        NetnsConfig {
+            format: "[$symbol \\[$name\\]]($style) ",
+            symbol: "️🛜",
+            style: "blue bold dimmed",
+            disabled: false,
+        }
+    }
+}

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -125,6 +125,7 @@ pub const PROMPT_ORDER: &[&str] = &[
     "time",
     "status",
     "container",
+    "netns",
     "os",
     "shell",
     "character",

--- a/src/module.rs
+++ b/src/module.rs
@@ -62,6 +62,7 @@ pub const ALL_MODULES: &[&str] = &[
     "meson",
     "mojo",
     "nats",
+    "netns",
     "nim",
     "nix_shell",
     "nodejs",

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -54,6 +54,7 @@ mod memory_usage;
 mod meson;
 mod mojo;
 mod nats;
+mod netns;
 mod nim;
 mod nix_shell;
 mod nodejs;
@@ -166,6 +167,7 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
             "meson" => meson::module(context),
             "mojo" => mojo::module(context),
             "nats" => nats::module(context),
+            "netns" => netns::module(context),
             "nim" => nim::module(context),
             "nix_shell" => nix_shell::module(context),
             "nodejs" => nodejs::module(context),
@@ -291,6 +293,7 @@ pub fn description(module: &str) -> &'static str {
         }
         "mojo" => "The currently installed version of Mojo",
         "nats" => "The current NATS context",
+        "netns" => "The current network namespace",
         "nim" => "The currently installed version of Nim",
         "nix_shell" => "The nix-shell environment",
         "nodejs" => "The currently installed version of NodeJS",

--- a/src/modules/netns.rs
+++ b/src/modules/netns.rs
@@ -1,0 +1,11 @@
+use super::{Context, Module};
+
+#[cfg(not(target_os = "linux"))]
+pub fn module<'a>(_context: &'a Context) -> Option<Module<'a>> {
+    None
+}
+
+#[cfg(target_os = "linux")]
+pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    None
+}

--- a/src/modules/netns.rs
+++ b/src/modules/netns.rs
@@ -7,5 +7,14 @@ pub fn module<'a>(_context: &'a Context) -> Option<Module<'a>> {
 
 #[cfg(target_os = "linux")]
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
-    None
+    use crate::{config::ModuleConfig, configs::netns::NetnsConfig};
+
+    let module = context.new_module("netns");
+    let config = NetnsConfig::try_load(module.config);
+
+    if config.disabled {
+        return None;
+    }
+
+    Some(module)
 }

--- a/src/modules/netns.rs
+++ b/src/modules/netns.rs
@@ -7,14 +7,48 @@ pub fn module<'a>(_context: &'a Context) -> Option<Module<'a>> {
 
 #[cfg(target_os = "linux")]
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
-    use crate::{config::ModuleConfig, configs::netns::NetnsConfig};
+    use crate::{config::ModuleConfig, configs::netns::NetnsConfig, formatter::StringFormatter};
 
-    let module = context.new_module("netns");
+    fn netns_name(context: &Context) -> Option<String> {
+        context
+            .exec_cmd("ip", &["netns", "identify"])
+            .map(|output| output.stdout.trim().to_string())
+            .filter(|name| !name.is_empty())
+    }
+
+    let mut module = context.new_module("netns");
     let config = NetnsConfig::try_load(module.config);
 
     if config.disabled {
         return None;
     }
+
+    let netns_name = netns_name(context)?;
+
+    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
+        formatter
+            .map_meta(|variable, _| match variable {
+                "symbol" => Some(config.symbol),
+                _ => None,
+            })
+            .map_style(|variable| match variable {
+                "style" => Some(Ok(config.style)),
+                _ => None,
+            })
+            .map(|variable| match variable {
+                "name" => Some(Ok(&netns_name)),
+                _ => None,
+            })
+            .parse(None, Some(context))
+    });
+
+    module.set_segments(match parsed {
+        Ok(segments) => segments,
+        Err(error) => {
+            log::warn!("Error in module `netns`: \n{}", error);
+            return None;
+        }
+    });
 
     Some(module)
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description

This module displays the name of the current [Linux network namespace](https://www.man7.org/linux/man-pages/man7/network_namespaces.7.html), if it's not the default one. This is in a similar vein to the container module.

#### Motivation and Context

Useful for people who develop on or administrate systems that use multiple network namespaces.

Closes #5541.

#### Screenshots (if appropriate):

#### How Has This Been Tested?

In addition to the unit tests, I ran `cargo run -- module netns` from within a netns created using `ip-netns`, as well as the default namespace. In both cases, the output is correct.

- [ ] I have tested using **MacOS**
- [X] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have updated the documentation accordingly.
- [X] I have updated the tests accordingly.
