### PR TITLE
docs(preset/nerd-fonts): Add CMake symbol to Nerd Fonts preset

### DIFF
--- a/docs/public/presets/toml/nerd-font-symbols.toml
+++ b/docs/public/presets/toml/nerd-font-symbols.toml
@@ -7,6 +7,9 @@ symbol = " "
 [c]
 symbol = " "
 
+[cmake]
+symbol = " "
+
 [conda]
 symbol = " "
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
The CMake logo is available in Nerd Fonts, but was not being used in the given preset. I have added it here.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The given presets should be complete!

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] I have updated the documentation accordingly.
- [ x] I have updated the tests accordingly.
