### PR TITLE
fix(preset): add missing rlang to plain-text-symbols preset

### DIFF
--- a/docs/public/presets/toml/plain-text-symbols.toml
+++ b/docs/public/presets/toml/plain-text-symbols.toml
@@ -203,6 +203,9 @@ symbol = "quarto "
 [raku]
 symbol = "raku "
 
+[rlang]
+symbol = "r "
+
 [ruby]
 symbol = "rb "
 


### PR DESCRIPTION
R language configuration is missing in the `plain-text-symbols` preset, so I added it.