### PR TITLE
docs: fix typo in comment of git_commit module

### DIFF
--- a/src/modules/git_commit.rs
+++ b/src/modules/git_commit.rs
@@ -365,7 +365,7 @@ mod tests {
             .current_dir(repo_dir.path())
             .output()?;
 
-        // Annotaged tags are preferred over lightweight tags
+        // Annotated tags are preferred over lightweight tags
         create_command("git")?
             .args(["tag", "l0"])
             .env("GIT_COMMITTER_DATE", "2022-01-01 00:00:02 +0000")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
This fixes a typo in a comment in the `git_commit` module. 

#### Motivation and Context
This typo causes CI failures in other PRs that have nothing to do with it.

#### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/6086e674-3d61-45f9-8ee9-6da11eadabc7)

#### How Has This Been Tested?
N/A

#### Checklist:
N/A