### PR TITLE
fix(fossil_metrics): Add -i flag to the fossil_metrics module's command

### DIFF
--- a/src/modules/fossil_metrics.rs
+++ b/src/modules/fossil_metrics.rs
@@ -28,7 +28,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         .set_files(&[checkout_db])
         .scan()?;
 
-    // Read the total number of added and deleted lines from "fossil diff --numstat"
+    // Read the total number of added and deleted lines from "fossil diff -i --numstat"
     let output = context
         .exec_cmd("fossil", &["diff", "-i", "--numstat"])?
         .stdout;
@@ -60,7 +60,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     Some(module)
 }
 
-/// Represents the parsed output from a Fossil diff with the --numstat option enabled.
+/// Represents the parsed output from a Fossil diff with the -i --numstat option enabled.
 #[derive(Debug, PartialEq)]
 struct FossilDiff<'a> {
     added: &'a str,
@@ -68,7 +68,7 @@ struct FossilDiff<'a> {
 }
 
 impl<'a> FossilDiff<'a> {
-    /// Parses the output of `fossil diff --numstat` as a `FossilDiff` struct.
+    /// Parses the output of `fossil diff -i --numstat` as a `FossilDiff` struct.
     pub fn parse(diff_numstat: &'a str, only_nonzero_diffs: bool) -> Self {
         // Fossil formats the last line of the output as "%10d %10d TOTAL over %d changed files\n"
         // where the 1st and 2nd placeholders are the number of added and deleted lines respectively

--- a/src/modules/fossil_metrics.rs
+++ b/src/modules/fossil_metrics.rs
@@ -29,7 +29,9 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         .scan()?;
 
     // Read the total number of added and deleted lines from "fossil diff --numstat"
-    let output = context.exec_cmd("fossil", &["diff", "--numstat"])?.stdout;
+    let output = context
+        .exec_cmd("fossil", &["diff", "-i", "--numstat"])?
+        .stdout;
     let stats = FossilDiff::parse(&output, config.only_nonzero_diffs);
 
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -257,7 +257,7 @@ Elixir 1.10 (compiled with Erlang/OTP 22)\n",
             stdout: String::default(),
             stderr: String::default(),
         }),
-        "fossil diff --numstat" => Some(CommandOutput{
+        "fossil diff -i --numstat" => Some(CommandOutput{
             stdout: String::from("\
          3          2 README.md
          3          2 TOTAL over 1 changed files"),


### PR DESCRIPTION
 #6448
This pull request includes a small change to the `src/modules/fossil_metrics.rs` file. The change modifies the `exec_cmd` call to include the `-i` flag when running the `fossil diff` command.

* [`src/modules/fossil_metrics.rs`](diffhunk://#diff-f2faf7236fc5096af8b85713a599931dff87898e5ff07b1cd0363ef0b08d2171L32-R34): Updated the `exec_cmd` call to include the `-i` flag for the `fossil diff` command to improve the diff output.