### PR TITLE
Develop seperator

### DIFF
--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -79,6 +79,7 @@ pub mod rlang;
 pub mod ruby;
 pub mod rust;
 pub mod scala;
+pub mod separator;
 pub mod shell;
 pub mod shlvl;
 pub mod singularity;

--- a/src/configs/separator.rs
+++ b/src/configs/separator.rs
@@ -1,0 +1,25 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(
+    feature = "config-schema",
+    derive(schemars::JsonSchema),
+    schemars(deny_unknown_fields)
+)]
+#[serde(default)]
+#[derive(Debug)]
+pub struct SeperatorConfig {
+    pub symbol: String,
+    pub color: String,
+    pub disabled: bool,
+}
+
+impl Default for SeperatorConfig {
+    fn default() -> Self {
+        SeperatorConfig {
+            symbol: "▄".to_string(),
+            color: "blue".to_string(),
+            disabled: false,
+        }
+    }
+}

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -107,6 +107,7 @@ pub const PROMPT_ORDER: &[&str] = &[
     "conda",
     "meson",
     "spack",
+    "seperator",
     "memory_usage",
     "aws",
     "gcloud",

--- a/src/module.rs
+++ b/src/module.rs
@@ -84,6 +84,7 @@ pub const ALL_MODULES: &[&str] = &[
     "ruby",
     "rust",
     "scala",
+    "separator",
     "shell",
     "shlvl",
     "singularity",

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -95,6 +95,7 @@ mod zig;
 
 #[cfg(feature = "battery")]
 mod battery;
+pub mod separator;
 mod typst;
 
 #[cfg(feature = "battery")]
@@ -188,6 +189,7 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
             "ruby" => ruby::module(context),
             "rust" => rust::module(context),
             "scala" => scala::module(context),
+            "separator" => separator::module(context),
             "shell" => shell::module(context),
             "shlvl" => shlvl::module(context),
             "singularity" => singularity::module(context),
@@ -313,6 +315,7 @@ pub fn description(module: &str) -> &'static str {
         "ruby" => "The currently installed version of Ruby",
         "rust" => "The currently installed version of Rust",
         "scala" => "The currently installed version of Scala",
+        "separator" => "The symbol and style used to separate modules",
         "shell" => "The currently used shell indicator",
         "shlvl" => "The current value of SHLVL",
         "singularity" => "The currently used Singularity image",

--- a/src/modules/separator.rs
+++ b/src/modules/separator.rs
@@ -1,0 +1,297 @@
+use super::{Context, Module, ModuleConfig};
+use crate::{configs::separator::SeperatorConfig, segment::Segment};
+use nu_ansi_term::{Color, Style};
+
+#[derive(Debug, Clone, Copy)]
+enum TermColor {
+    Standard(Color),
+    Bright(Color),
+}
+
+impl From<&str> for TermColor {
+    fn from(color: &str) -> Self {
+        match color {
+            // Standard colors
+            "black" => TermColor::Standard(Color::Black),
+            "red" => TermColor::Standard(Color::Red),
+            "green" => TermColor::Standard(Color::Green),
+            "yellow" => TermColor::Standard(Color::Yellow),
+            "blue" => TermColor::Standard(Color::Blue),
+            "purple" => TermColor::Standard(Color::Purple),
+            "cyan" => TermColor::Standard(Color::Cyan),
+            "white" => TermColor::Standard(Color::White),
+            // Bright colors
+            "bright-black" => TermColor::Bright(Color::DarkGray),
+            "bright-red" => TermColor::Bright(Color::LightRed),
+            "bright-green" => TermColor::Bright(Color::LightGreen),
+            "bright-yellow" => TermColor::Bright(Color::LightYellow),
+            "bright-blue" => TermColor::Bright(Color::LightBlue),
+            "bright-purple" => TermColor::Bright(Color::LightPurple),
+            "bright-cyan" => TermColor::Bright(Color::LightCyan),
+            "bright-white" => TermColor::Bright(Color::LightGray),
+            // Default fallback
+            _ => TermColor::Standard(Color::Green),
+        }
+    }
+}
+
+impl From<TermColor> for Color {
+    fn from(term_color: TermColor) -> Self {
+        match term_color {
+            TermColor::Standard(c) | TermColor::Bright(c) => c,
+        }
+    }
+}
+
+pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let config = SeperatorConfig::try_load(context.new_module("separator").config);
+
+    // Early return if disabled or no command duration
+    if config.disabled || context.get_cmd_duration().is_none() {
+        return None;
+    }
+
+    let style = Style::new().fg(Color::from(TermColor::from(config.color.as_str())));
+    let separator = config.symbol.repeat(context.width);
+
+    let mut module = context.new_module("separator");
+    module.set_segments(vec![Segment::fill(Some(style.into()), separator)]);
+    Some(module)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::ModuleRenderer;
+    use nu_ansi_term::Color;
+
+    fn get_terminal_width() -> usize {
+        if let Some((width, _)) = terminal_size::terminal_size() {
+            width.0 as usize
+        } else {
+            80
+        }
+    }
+    #[test]
+    fn test_separator_after_command() {
+        let actual = ModuleRenderer::new("separator")
+            .config(toml::toml! {
+                [separator]
+                disabled = false
+                symbol = "-"
+                color = "green"
+            })
+            .cmd("echo 'test'", None) // Simulates running a command
+            .cmd_duration(1500) // Command took 1500ms
+            .collect();
+
+        let expected = Some(format!(
+            "{}",
+            Color::Green.paint("-".repeat(get_terminal_width()))
+        ));
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_separator_multiple_commands() {
+        let actual = ModuleRenderer::new("separator")
+            .config(toml::toml! {
+                [separator]
+                disabled = false
+                symbol = "*"
+                color = "blue"
+            })
+            .cmd("ls", None) // First command
+            .cmd_duration(500) // First command duration
+            .cmd("pwd", None) // Second command
+            .cmd_duration(200) // Second command duration
+            .collect();
+
+        let expected = Some(format!(
+            "{}",
+            Color::Blue.paint("*".repeat(get_terminal_width()))
+        ));
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_separator_zero_duration() {
+        let actual = ModuleRenderer::new("separator")
+            .config(toml::toml! {
+                [separator]
+                disabled = false
+                symbol = "-"
+                color = "red"
+            })
+            .cmd("echo 'quick'", None)
+            .cmd_duration(0) // Command completed instantly
+            .collect();
+        log::info!("actual: {:?}", actual);
+        let expected = Some(format!(
+            "{}",
+            Color::Red.paint("-".repeat(get_terminal_width()))
+        ));
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_separator_long_command() {
+        let actual = ModuleRenderer::new("separator")
+            .config(toml::toml! {
+                [separator]
+                disabled = false
+                symbol = "="
+                color = "purple"
+            })
+            .cmd("sleep 2 && echo 'done'", None) // Long running command
+            .cmd_duration(2000) // 2 second duration
+            .collect();
+
+        let expected = Some(format!(
+            "{}",
+            Color::Purple.paint("=".repeat(get_terminal_width()))
+        ));
+        assert_eq!(actual, expected);
+    }
+    #[test]
+    fn test_disabled_module() {
+        let actual = ModuleRenderer::new("separator")
+            .config(toml::toml! {
+                [separator]
+                disabled = true
+            })
+            .cmd_duration(500)
+            .collect();
+
+        assert_eq!(actual, None);
+    }
+
+    #[test]
+    fn test_no_cmd_duration() {
+        let actual = ModuleRenderer::new("separator")
+            .config(toml::toml! {
+                [separator]
+                disabled = false
+            })
+            .collect();
+
+        assert_eq!(actual, None);
+    }
+
+    #[test]
+    fn test_default_config() {
+        let width = get_terminal_width();
+        let actual = ModuleRenderer::new("separator")
+            .config(toml::toml! {
+                [separator]
+                disabled = false
+                symbol = "-"
+                color = "green"
+            })
+            .cmd_duration(500)
+            .collect();
+
+        // Default terminal width is usually 80 characters
+        let expected = Some(format!("{}", Color::Green.paint("-".repeat(width))));
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_custom_color() {
+        let width = get_terminal_width();
+        let actual = ModuleRenderer::new("separator")
+            .config(toml::toml! {
+                [separator]
+                disabled = false
+                symbol = "="
+                color = "red"
+            })
+            .cmd_duration(500)
+            .collect();
+
+        let expected = Some(format!("{}", Color::Red.paint("=".repeat(width))));
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_custom_symbol() {
+        let actual = ModuleRenderer::new("separator")
+            .config(toml::toml! {
+                [separator]
+                disabled = false
+                symbol = "*"
+                color = "blue"
+            })
+            .cmd_duration(500)
+            .collect();
+
+        let expected = Some(format!("{}", Color::Blue.paint("*".repeat(80))));
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_custom_width() {
+        let actual = ModuleRenderer::new("separator")
+            .config(toml::toml! {
+                [separator]
+                disabled = false
+                symbol = "-"
+                color = "green"
+            })
+            .cmd_duration(500)
+            .env("COLUMNS", "40") // Set custom terminal width
+            .collect();
+
+        let expected = Some(format!("{}", Color::Green.paint("-".repeat(40))));
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_bright_colors() {
+        let actual = ModuleRenderer::new("separator")
+            .config(toml::toml! {
+                [separator]
+                disabled = false
+                symbol = "-"
+                color = "bright-red"
+            })
+            .cmd_duration(500)
+            .collect();
+
+        let expected = Some(format!("{}", Color::LightRed.paint("-".repeat(80))));
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_invalid_color() {
+        let actual = ModuleRenderer::new("separator")
+            .config(toml::toml! {
+                [separator]
+                disabled = false
+                symbol = "-"
+                color = "invalid-color"
+            })
+            .cmd_duration(500)
+            .collect();
+
+        // Should default to green when color is invalid
+        let expected = Some(format!("{}", Color::Green.paint("-".repeat(80))));
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_empty_symbol() {
+        let actual = ModuleRenderer::new("separator")
+            .config(toml::toml! {
+                [separator]
+                disabled = false
+                symbol = ""
+                color = "green"
+            })
+            .cmd_duration(500)
+            .collect();
+
+        // Empty symbol should result in empty string repeated
+        let expected = Some(format!("{}", Color::Green.paint("")));
+        assert_eq!(actual, expected);
+    }
+}


### PR DESCRIPTION
This pull request introduces a new `separator` module to the project. The changes include adding the module's configuration, defining its behavior, and incorporating it into the overall project structure.

### Addition of the `separator` module:

* [`src/configs/mod.rs`](diffhunk://#diff-a3b98735c2fee01e1efeac6f98f3dacd318d47e8bfa19e1a16e5cb07b47367eeR82): Added the `separator` module to the list of public modules.
* [`src/configs/separator.rs`](diffhunk://#diff-7afd0ef0bc4f705e5b0d35449e912caca719f649dbbd2ba0fff3c6d70c6b124eR1-R25): Defined the `SeperatorConfig` struct with `symbol`, `color`, and `disabled` fields, including default values and serialization/deserialization support.
* [`src/configs/starship_root.rs`](diffhunk://#diff-c6e4e78578c4c643a496a966ba62ac21c625c0d48f1def2426acc1f7c1153141R110): Included `separator` in the `PROMPT_ORDER` constant to determine its position in the prompt.
* [`src/module.rs`](diffhunk://#diff-e59e07343e640ea0d934ecf5a9b628fbc00f63eec5c2daea6297646ef68c7fbeR87): Added `separator` to the `ALL_MODULES` constant, making it a recognized module in the system.
* `src/modules/mod.rs`: 
  - Added the `separator` module to the list of public modules.
  - Integrated the `separator` module into the `handle` and `description` functions to handle its initialization and provide a description. [[1]](diffhunk://#diff-90d2c2330dd750ac18b6a3a2b13fcb041216ac7e0efef9a2ff729ebf2184f686R192) [[2]](diffhunk://#diff-90d2c2330dd750ac18b6a3a2b13fcb041216ac7e0efef9a2ff729ebf2184f686R318)
  
### Implementation of the `separator` module:

* [`src/modules/separator.rs`](diffhunk://#diff-5a3a298b154312ec63d86d8ca57e0586b36baaf8bbb4740478afafd1c8cd9ac0R1-R297): Implemented the `separator` module, including the configuration loading, module creation, and tests to validate its functionality. The module displays a separator symbol with the specified color and repeats it based on the terminal width.