### PR TITLE
feat: Change java model default symbol to nerd-font

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2417,7 +2417,7 @@ By default the module will be shown if any of the following conditions are met:
 | `detect_extensions` | `['java', 'class', 'gradle', 'jar', 'cljs', 'cljc']`                                                                  | Which extensions should trigger this module.                              |
 | `detect_files`      | `['pom.xml', 'build.gradle.kts', 'build.sbt', '.java-version', 'deps.edn', 'project.clj', 'build.boot', '.sdkmanrc']` | Which filenames should trigger this module.                               |
 | `detect_folders`    | `[]`                                                                                                                  | Which folders should trigger this modules.                                |
-| `symbol`            | `'☕ '`                                                                                                               | A format string representing the symbol of Java                           |
+| `symbol`            | `' '`                                                                                                                | A format string representing the symbol of Java                           |
 | `style`             | `'red dimmed'`                                                                                                        | The style for the module.                                                 |
 | `disabled`          | `false`                                                                                                               | Disables the `java` module.                                               |
 

--- a/src/configs/java.rs
+++ b/src/configs/java.rs
@@ -25,7 +25,7 @@ impl Default for JavaConfig<'_> {
             version_format: "v${raw}",
             disabled: false,
             style: "red dimmed",
-            symbol: "☕ ",
+            symbol: " ",
             detect_extensions: vec!["java", "class", "jar", "gradle", "clj", "cljc"],
             detect_files: vec![
                 "pom.xml",

--- a/src/modules/java.rs
+++ b/src/modules/java.rs
@@ -181,7 +181,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("Main.java"))?.sync_all()?;
         let actual = ModuleRenderer::new("java").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Red.dimmed().paint("☕ v13.0.2 ")));
+        let expected = Some(format!("via {}", Color::Red.dimmed().paint(" v13.0.2 ")));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -194,7 +194,7 @@ mod tests {
             stdout: "OpenJDK 64-Bit Server VM (16+14) for bsd-aarch64 JRE (16+14), built on Jan 17 2021 07:19:47 by \"brew\" with clang Apple LLVM 12.0.0 (clang-1200.0.32.28)\n".to_owned(),
             stderr: String::new()
         })).path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Red.dimmed().paint("☕ v16 ")));
+        let expected = Some(format!("via {}", Color::Red.dimmed().paint(" v16 ")));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -207,7 +207,7 @@ mod tests {
             .cmd("java -Xinternalversion", None)
             .path(dir.path())
             .collect();
-        let expected = Some(format!("via {}", Color::Red.dimmed().paint("☕ ")));
+        let expected = Some(format!("via {}", Color::Red.dimmed().paint(" ")));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -217,7 +217,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("Main.class"))?.sync_all()?;
         let actual = ModuleRenderer::new("java").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Red.dimmed().paint("☕ v13.0.2 ")));
+        let expected = Some(format!("via {}", Color::Red.dimmed().paint(" v13.0.2 ")));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -227,7 +227,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("build.gradle"))?.sync_all()?;
         let actual = ModuleRenderer::new("java").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Red.dimmed().paint("☕ v13.0.2 ")));
+        let expected = Some(format!("via {}", Color::Red.dimmed().paint(" v13.0.2 ")));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -237,7 +237,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("test.jar"))?.sync_all()?;
         let actual = ModuleRenderer::new("java").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Red.dimmed().paint("☕ v13.0.2 ")));
+        let expected = Some(format!("via {}", Color::Red.dimmed().paint(" v13.0.2 ")));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -247,7 +247,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("pom.xml"))?.sync_all()?;
         let actual = ModuleRenderer::new("java").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Red.dimmed().paint("☕ v13.0.2 ")));
+        let expected = Some(format!("via {}", Color::Red.dimmed().paint(" v13.0.2 ")));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -257,7 +257,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join(".sdkmanrc"))?.sync_all()?;
         let actual = ModuleRenderer::new("java").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Red.dimmed().paint("☕ v13.0.2 ")));
+        let expected = Some(format!("via {}", Color::Red.dimmed().paint(" v13.0.2 ")));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -267,7 +267,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("build.gradle.kts"))?.sync_all()?;
         let actual = ModuleRenderer::new("java").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Red.dimmed().paint("☕ v13.0.2 ")));
+        let expected = Some(format!("via {}", Color::Red.dimmed().paint(" v13.0.2 ")));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -277,7 +277,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("build.gradle.kts"))?.sync_all()?;
         let actual = ModuleRenderer::new("java").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Red.dimmed().paint("☕ v13.0.2 ")));
+        let expected = Some(format!("via {}", Color::Red.dimmed().paint(" v13.0.2 ")));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -287,7 +287,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join(".java-version"))?.sync_all()?;
         let actual = ModuleRenderer::new("java").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Red.dimmed().paint("☕ v13.0.2 ")));
+        let expected = Some(format!("via {}", Color::Red.dimmed().paint(" v13.0.2 ")));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -308,7 +308,7 @@ mod tests {
             }))
             .path(dir.path())
             .collect();
-        let expected = Some(format!("via {}", Color::Red.dimmed().paint("☕ v11.0.4 ")));
+        let expected = Some(format!("via {}", Color::Red.dimmed().paint(" v11.0.4 ")));
         assert_eq!(expected, actual);
         dir.close()
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->
The original symbol is not nerd-font icon, therefore the display of the Java module is different from that of other modules. To avoid this problem, we can replace the symbol with nerd-font icon.

#### Description
<!--- Describe your changes in detail -->
Change model `java`'s default config, replace the original symbol with nerd-font.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Many other model has a default nerd-font symbol, they looks beautiful, so I think `java` model can do the same thing.

#### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/bb5e2007-5331-4408-ab06-5b7e0bc75438)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
