### PR TITLE
fix(battery): prefer charge ratio over current capacity

### DIFF
--- a/src/modules/battery.rs
+++ b/src/modules/battery.rs
@@ -132,9 +132,12 @@ impl BatteryInfoProvider for BatteryInfoProviderImpl {
                 .filter_map(|battery| match battery {
                     Ok(battery) => {
                         log::debug!("Battery found: {:?}", battery);
+
+                        let charge_rate = battery.state_of_charge().value;
+                        let energy_full = battery.energy_full().value;
                         Some(BatteryInfo {
-                            energy: battery.energy().value,
-                            energy_full: battery.energy_full().value,
+                            energy: charge_rate * energy_full,
+                            energy_full,
                             state: battery.state(),
                         })
                     }

--- a/typos.toml
+++ b/typos.toml
@@ -6,6 +6,7 @@ edn = "edn"
 esy = "esy"
 numver = "numver"
 afe = "afe"
+typ = "typ"
 extentions = "extentions" # TODO: should be extensions
 worl = "worl" # typo on purpose
 [files]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
For calculating the current battery charge percentage, starship divides the current capacity with the fully charged capacity. Some operating systems have APIs that instead return a percentage directly, which is expected to be more accurate. `starship-battery` has an API for this as `state_of_charge()`, which this PR switches to instead.
To still allow merging of multiple batteries, I've kept the internal struct with `energy` and `energy_full`, but set `energy` to the product of the current rate of charge and the full battery capacity.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Once https://github.com/starship/rust-battery/pull/85 is merged should close https://github.com/starship/starship/issues/5212

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
