### PR TITLE
feat(aws): support duration for aws sso

### DIFF
--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -141,8 +141,9 @@ fn get_credentials_duration(
     {
         chrono::DateTime::parse_from_rfc3339(&expiration_date).ok()
     } else {
-        let creds = get_creds(context, aws_creds)?;
-        if let Some(section) = get_profile_creds(creds, aws_profile) {
+        if let Some(section) =
+            get_creds(context, aws_creds).and_then(|creds| get_profile_creds(creds, aws_profile))
+        {
             let expiration_keys = ["expiration", "x_security_token_expires"];
             expiration_keys
                 .iter()

--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -139,16 +139,19 @@ fn get_credentials_duration(
         .into_iter()
         .find_map(|env_var| context.get_env(env_var))
     {
+        // get expiration from environment variables
         chrono::DateTime::parse_from_rfc3339(&expiration_date).ok()
     } else if let Some(section) =
         get_creds(context, aws_creds).and_then(|creds| get_profile_creds(creds, aws_profile))
     {
+        // get expiration from credentials file
         let expiration_keys = ["expiration", "x_security_token_expires"];
         expiration_keys
             .iter()
             .find_map(|expiration_key| section.get(expiration_key))
             .and_then(|expiration| DateTime::parse_from_rfc3339(expiration).ok())
     } else {
+        // get expiration from cached SSO credentials
         let config = get_config(context, aws_config)?;
         let section = get_profile_config(config, aws_profile)?;
         let start_url = section.get("sso_start_url")?;

--- a/src/modules/pulumi.rs
+++ b/src/modules/pulumi.rs
@@ -316,7 +316,7 @@ mod tests {
     /// stack name.
     fn render_valid_paths() -> io::Result<()> {
         use io::Write;
-        let dir = tempfile::tempdir()?;
+        let (module_renderer, dir) = ModuleRenderer::new_with_home("pulumi")?;
         let root = dunce::canonicalize(dir.path())?;
         let mut yaml = File::create(root.join("Pulumi.yml"))?;
         yaml.write_all("name: starship\nruntime: nodejs\ndescription: A thing\n".as_bytes())?;
@@ -360,22 +360,20 @@ mod tests {
             ),
         )?;
         credential.sync_all()?;
-        let rendered = ModuleRenderer::new("pulumi")
+        let rendered = module_renderer
             .path(root.clone())
             .logical_path(root.clone())
             .config(toml::toml! {
                 [pulumi]
                 format = "via [$symbol($username@)$stack]($style) "
             })
-            .env("HOME", root.to_str().unwrap())
             .collect();
         let expected = format!(
             "via {} ",
             Color::Fixed(5).bold().paint(" test-user@launch")
         );
         assert_eq!(expected, rendered.expect("a result"));
-        dir.close()?;
-        Ok(())
+        dir.close()
     }
 
     #[test]
@@ -383,7 +381,7 @@ mod tests {
     /// the current API.
     fn partial_login() -> io::Result<()> {
         use io::Write;
-        let dir = tempfile::tempdir()?;
+        let (module_renderer, dir) = ModuleRenderer::new_with_home("pulumi")?;
         let root = dunce::canonicalize(dir.path())?;
         let mut yaml = File::create(root.join("Pulumi.yml"))?;
         yaml.write_all("name: starship\nruntime: nodejs\ndescription: A thing\n".as_bytes())?;
@@ -422,19 +420,17 @@ mod tests {
             ),
         )?;
         credential.sync_all()?;
-        let rendered = ModuleRenderer::new("pulumi")
+        let rendered = module_renderer
             .path(root.clone())
             .logical_path(root.clone())
             .config(toml::toml! {
                 [pulumi]
                 format = "via [$symbol($username@)$stack]($style) "
             })
-            .env("HOME", root.to_str().unwrap())
             .collect();
         let expected = format!("via {} ", Color::Fixed(5).bold().paint(" launch"));
         assert_eq!(expected, rendered.expect("a result"));
-        dir.close()?;
-        Ok(())
+        dir.close()
     }
 
     #[test]

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -65,6 +65,14 @@ impl<'a> ModuleRenderer<'a> {
         Self { name, context }
     }
 
+    /// Creates a new `ModuleRenderer` with `HOME` set to a `TempDir`
+    pub fn new_with_home(name: &'a str) -> io::Result<(Self, tempfile::TempDir)> {
+        let module_renderer = ModuleRenderer::new(name);
+        let homedir = tempfile::tempdir()?;
+        let home = dunce::canonicalize(homedir.path())?;
+        Ok((module_renderer.env("HOME", home.to_str().unwrap()), homedir))
+    }
+
     pub fn path<T>(mut self, path: T) -> Self
     where
         T: Into<PathBuf>,


### PR DESCRIPTION
#### Description

show time until expiration of credentials from `aws sso`

#### Motivation and Context

#5170 added support for showing profiles from `aws sso`
but `duration` still only works for credentials in `~/.aws/credentials`

#### Screenshots (if appropriate):

#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

`starship.toml`:
```toml
[aws]
format = '[($profile )($duration)]'
```
`~/.aws/config`:
```ini
[default]
sso_start_url = https://[redacted].awsapps.com/start
sso_region = us-east-1
```
`~/.aws/sso/cache/[redacted].json`:
```json
{"startUrl": "https://[redacted].awsapps.com/start", "region": "us-east-1", "accessToken": "[redacted]", "expiresAt": "2025-03-08T05:32:14Z", "clientId": "[redacted]", "clientSecret": "[redacted]", "registrationExpiresAt": "2025-05-29T17:37:08Z"}
```
```
$ target/debug/starship module aws
44m14s
```

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.

I don't know if there is any documentation to update. Let me know if you'd like anything reworded
Some tests assume the default config with `$duration` in the format and started failing on my machine with active SSO creds, so I made them stop showing the duration.
I didn't add a test because that would mean writing into `~/.aws/sso/cache`, which seems not ideal. Happy to do it if you prefer.