### PR TITLE
docs: Add Fedora, CENTOS & EPEL in install docs & remove Cent OS 7+

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,9 +228,8 @@ Alternatively, install Starship using any of the following package managers:
 | _Any_              | [Linuxbrew]             | `brew install starship`                                       |
 | Alpine Linux 3.13+ | [Alpine Linux Packages] | `apk add starship`                                            |
 | Arch Linux         | [Arch Linux Extra]      | `pacman -S starship`                                          |
-| CentOS 7+          | [Copr]                  | `dnf copr enable atim/starship` <br /> `dnf install starship` |
 | Debian 13+         | [Debian Main]           | `apt install starship`                                        |
-| Fedora Linux          | [Copr]                  | `dnf copr enable atim/starship` <br /> `dnf install starship` |
+| Fedora Linux/CentOS/EPEL         | [Copr]                  | `dnf copr enable atim/starship` <br /> `dnf install starship` |
 | Gentoo             | [Gentoo Packages]       | `emerge app-shells/starship`                                  |
 | Manjaro            |                         | `pacman -S starship`                                          |
 | NixOS              | [nixpkgs]               | `nix-env -iA nixpkgs.starship`                                |

--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ Alternatively, install Starship using any of the following package managers:
 | Arch Linux         | [Arch Linux Extra]      | `pacman -S starship`                                          |
 | CentOS 7+          | [Copr]                  | `dnf copr enable atim/starship` <br /> `dnf install starship` |
 | Debian 13+         | [Debian Main]           | `apt install starship`                                        |
+| Fedora Linux          | [Copr]                  | `dnf copr enable atim/starship` <br /> `dnf install starship` |
 | Gentoo             | [Gentoo Packages]       | `emerge app-shells/starship`                                  |
 | Manjaro            |                         | `pacman -S starship`                                          |
 | NixOS              | [nixpkgs]               | `nix-env -iA nixpkgs.starship`                                |


### PR DESCRIPTION

#### Description
Added Install instructions for Fedora, CENTOS & EPEL with [Copr](https://copr.fedorainfracloud.org/coprs/atim/starship) package in docs. For some reason, there was the same Copr documentation for CentOS 7+ which has been in EOL for a while & not fedora.

#### Checklist:
- [x] I have updated the documentation accordingly.

