### PR TITLE
feat(package): fix cargo workspace version

### DIFF
--- a/src/modules/package.rs
+++ b/src/modules/package.rs
@@ -257,19 +257,25 @@ fn get_cargo_version(context: &Context, config: &PackageConfig) -> Option<String
         // workspace version string (`package.version.workspace = true`)
         // need to read the Cargo.toml file from the workspace root
         let mut version = None;
-        // discover the workspace root
-        for path in context.current_dir.ancestors().skip(1) {
-            // Assume the workspace root is the first ancestor that contains a Cargo.toml file
-            if let Ok(mut file) = fs::File::open(path.join("Cargo.toml")) {
-                file.read_to_string(&mut file_contents).ok()?;
-                cargo_toml = toml::from_str(&file_contents).ok()?;
-                // Read workspace.package.version
-                version = cargo_toml
-                    .get("workspace")?
-                    .get("package")?
-                    .get("version")?
-                    .as_str();
-                break;
+        if let Some(workspace) = cargo_toml.get("workspace") {
+            // current Cargo.toml file is also the workspace root
+            version = workspace.get("package")?.get("version")?.as_str();
+        } else {
+            // discover the workspace root
+            for path in context.current_dir.ancestors().skip(1) {
+                // Assume the workspace root is the first ancestor that contains a Cargo.toml file
+                if let Ok(mut file) = fs::File::open(path.join("Cargo.toml")) {
+                    file_contents.clear(); // clear the buffer for reading new Cargo.toml
+                    file.read_to_string(&mut file_contents).ok()?;
+                    cargo_toml = toml::from_str(&file_contents).ok()?;
+                    // Read workspace.package.version
+                    version = cargo_toml
+                        .get("workspace")?
+                        .get("package")?
+                        .get("version")?
+                        .as_str();
+                    break;
+                }
             }
         }
         version?
@@ -430,11 +436,33 @@ mod tests {
     }
 
     #[test]
+    fn test_extract_cargo_version_ws_single() -> io::Result<()> {
+        let config_name = "Cargo.toml";
+        let config_content = toml::toml! {
+            [workspace.package]
+            version = "0.1.0"
+            [package]
+            name = "starship"
+            version.workspace = true
+        }
+        .to_string();
+
+        let project_dir = create_project_dir()?;
+        fill_config(&project_dir, config_name, Some(&config_content))?;
+        expect_output(&project_dir, Some("v0.1.0"), None);
+        project_dir.close()
+    }
+
+    #[test]
     fn test_extract_cargo_version_ws() -> io::Result<()> {
         let ws_config_name = "Cargo.toml";
         let ws_config_content = toml::toml! {
             [workspace.package]
             version = "0.1.0"
+
+            [package]
+            name = "root-crate"
+            version.workspace = true
         }
         .to_string();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
https://github.com/starship/starship/pull/4161 supported cargo workspace versions, but remaining two  bugs:
+ When root `Cargo.toml` define both `[workspace]` and one workspace package, the version fetching is failed.
+ When recursively search workspace root, they forget to clear the old `file_contents` (read buffer). Then multiple `Cargo.toml` contents will merge together, toml can not read it when those `Cargo.toml` have same field (conflict field error).

Those issues are also reported by https://github.com/starship/starship/issues/3928#issuecomment-2322970423

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Same to [Description](#Description)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
