### PR TITLE
docs(preset/nerd-fonts): add bun and deno to nerd-font-symbols preset

### DIFF
--- a/docs/public/presets/toml/nerd-font-symbols.toml
+++ b/docs/public/presets/toml/nerd-font-symbols.toml
@@ -4,6 +4,9 @@ symbol = "  "
 [buf]
 symbol = " "
 
+[bun]
+symbol = " "
+
 [c]
 symbol = " "
 
@@ -18,6 +21,9 @@ symbol = " "
 
 [dart]
 symbol = " "
+
+[deno]
+symbol = " "
 
 [directory]
 read_only = " 󰌾"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
I've added `bun` and `deno` symbols to nerd-font-symbols preset.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I found that Bun and Deno symbols are available in Nerd Fonts, but they were missing from the preset.

#### Screenshots (if appropriate):

N/A


#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly. ← Not applicable in this case
