### PR TITLE
fix: remove double spaces in default values

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -1232,7 +1232,7 @@
         "disabled": false,
         "format": "via [$symbol($version )]($style)",
         "style": "bold blue",
-        "symbol": "🪖  ",
+        "symbol": "🪖 ",
         "version_format": "v${raw}"
       },
       "allOf": [
@@ -1307,7 +1307,7 @@
           "Ultramarine": "🔷 ",
           "Unknown": "❓ ",
           "Uos": "🐲 ",
-          "Void": "  ",
+          "Void": " ",
           "Windows": "🪟 ",
           "openEuler": "🦉 ",
           "openSUSE": "🦎 "
@@ -4935,7 +4935,7 @@
           "type": "string"
         },
         "symbol": {
-          "default": "🪖  ",
+          "default": "🪖 ",
           "type": "string"
         },
         "style": {
@@ -5054,7 +5054,7 @@
             "Ultramarine": "🔷 ",
             "Unknown": "❓ ",
             "Uos": "🐲 ",
-            "Void": "  ",
+            "Void": " ",
             "Windows": "🪟 ",
             "openEuler": "🦉 ",
             "openSUSE": "🦎 "

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -3412,7 +3412,7 @@ Ubuntu = "🎯 "
 Ultramarine = "🔷 "
 Unknown = "❓ "
 Uos = "🐲 "
-Void = "  "
+Void = " "
 Windows = "🪟 "
 ```
 

--- a/docs/public/presets/toml/nerd-font-symbols.toml
+++ b/docs/public/presets/toml/nerd-font-symbols.toml
@@ -1,5 +1,5 @@
 [aws]
-symbol = "  "
+symbol = " "
 
 [buf]
 symbol = " "

--- a/src/configs/opa.rs
+++ b/src/configs/opa.rs
@@ -23,7 +23,7 @@ impl Default for OpaConfig<'_> {
         OpaConfig {
             format: "via [$symbol($version )]($style)",
             version_format: "v${raw}",
-            symbol: "🪖  ",
+            symbol: "🪖 ",
             style: "bold blue",
             disabled: false,
             detect_extensions: vec!["rego"],

--- a/src/configs/os.rs
+++ b/src/configs/os.rs
@@ -77,7 +77,7 @@ impl Default for OSConfig<'_> {
                 Type::Ultramarine => "🔷 ",
                 Type::Unknown => "❓ ",
                 Type::Uos => "🐲 ",
-                Type::Void => "  ",
+                Type::Void => " ",
                 Type::Windows => "🪟 ",
                 // Future symbols.
                 //aosc =>       " ",

--- a/src/modules/opa.rs
+++ b/src/modules/opa.rs
@@ -90,7 +90,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("test.rego"))?.sync_all()?;
         let actual = ModuleRenderer::new("opa").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Blue.bold().paint("🪖  v0.44.0 ")));
+        let expected = Some(format!("via {}", Color::Blue.bold().paint("🪖 v0.44.0 ")));
         assert_eq!(expected, actual);
         dir.close()
     }
@@ -103,7 +103,7 @@ mod tests {
             .path(dir.path())
             .cmd("opa version", None)
             .collect();
-        let expected = Some(format!("via {}", Color::Blue.bold().paint("🪖  ")));
+        let expected = Some(format!("via {}", Color::Blue.bold().paint("🪖 ")));
         assert_eq!(expected, actual);
         dir.close()
     }

--- a/src/modules/os.rs
+++ b/src/modules/os.rs
@@ -375,7 +375,7 @@ mod tests {
             Type::Ultramarine => "🔷 ",
             Type::Unknown => "❓ ",
             Type::Uos => "🐲 ",
-            Type::Void => "  ",
+            Type::Void => " ",
             Type::Windows => "🪟 ",
             _ => "",
         };


### PR DESCRIPTION
Command run: `for file in $(rg --hidden '".  "' -l); do sed -i '/".  "/s/  ",/ ",/' $file; done`

<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->



#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Double spaces between blocks look weird and inconsistent (cuz everything else is separated by single spaces).

#### Screenshots (if appropriate):
**Before**:
- Emacs (Vterm)
![изображение](https://github.com/user-attachments/assets/06c1346e-6d42-4cb8-b7a3-a92da202f2fb)

- Alacritty
![изображение](https://github.com/user-attachments/assets/c23e5090-f645-4eec-87cb-0a91658bf13d)

**After**:
- Emacs
![изображение](https://github.com/user-attachments/assets/5654d152-9c01-4b77-b889-770a39e174b1)


- Alacritty
![изображение](https://github.com/user-attachments/assets/57fdb578-02a7-4d6a-b0ce-5677d8179233)


#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
