### PR TITLE
revert: Remove specialized whoami hostname function choice for windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3794,9 +3794,9 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "1.5.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "372d5b87f58ec45c384ba03563b03544dc5fadc3983e434b286913f5b4a9bb6d"
+checksum = "6994d13118ab492c3c80c1f81928718159254c53c472bf9ce36f8dae4add02a7"
 dependencies = [
  "redox_syscall",
  "wasite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ unicode-width = "0.2.0"
 urlencoding = "2.1.3"
 versions = "7.0.0"
 which = "7.0.2"
-whoami = { version = "1.5.2", default-features = false }
+whoami = { version = "1.6.0", default-features = false }
 yaml-rust2 = "0.10.0"
 
 guess_host_triple = "0.1.4"

--- a/src/modules/hostname.rs
+++ b/src/modules/hostname.rs
@@ -4,14 +4,7 @@ use crate::config::ModuleConfig;
 use crate::configs::hostname::HostnameConfig;
 use crate::formatter::StringFormatter;
 
-#[cfg(not(windows))]
 use whoami::fallible::hostname;
-// On Windows, whoami::hostname() returns the NetBIOS name,
-// but we prefer the "hostname" returned by whoami::devicname()
-// which does a better job of preserving case and returns the
-// DNS name.
-#[cfg(windows)]
-use whoami::fallible::devicename as hostname;
 
 /// Creates a module with the system hostname
 ///


### PR DESCRIPTION
#### Description

Updates whoami to 1.6.0, which removes the need for an instance of conditional compilation for windows which is reverted in this PR.  The `hostname()` function now returns the `PhysicalDnsHostname` instead of the `NetBIOS` name, while `devicename()` (no longer used) currently returns `DnsHostname` (but may change in a future release).

#### Motivation and Context

Original issue: https://github.com/starship/starship/issues/6411

PR introducing change: https://github.com/starship/starship/pull/6343

Commit in whoami changing behavior: https://github.com/ardaku/whoami/commit/d9df51768d6b4b0d5fb611722bc72bdedb5fb936

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
