### PR TITLE
fix: indentation issue in pure-preset.toml

### DIFF
--- a/docs/public/presets/toml/pure-preset.toml
+++ b/docs/public/presets/toml/pure-preset.toml
@@ -6,12 +6,13 @@ $git_branch\
 $git_state\
 $git_status\
 $cmd_duration\
-$line_break\
 $python\
+$line_break\
 $character"""
 
 [directory]
 style = "blue"
+format = "[$path ]($style)"
 
 [character]
 success_symbol = "[❯](purple)"


### PR DESCRIPTION
Fix wrong indentation when open new terminal window in `~` dir

Before:
<img width="277" alt="image" src="https://github.com/user-attachments/assets/c6a06de3-dff8-4114-9f24-2c005785098d" />
After:
<img width="406" alt="image" src="https://github.com/user-attachments/assets/98abe508-2f52-4b10-b4c7-cf7725d15055" />
