### PR TITLE
feat: Fortran module

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -535,7 +535,6 @@
     },
     "fortran": {
       "default": {
-        "compiler": "gfortran",
         "detect_extensions": [
           "f",
           "F",
@@ -3421,10 +3420,6 @@
           "items": {
             "type": "string"
           }
-        },
-        "compiler": {
-          "default": "gfortran",
-          "type": "string"
         }
       },
       "additionalProperties": false

--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -533,6 +533,45 @@
         }
       ]
     },
+    "fortran": {
+      "default": {
+        "compiler": "gfortran",
+        "detect_extensions": [
+          "f",
+          "F",
+          "for",
+          "FOR",
+          "ftn",
+          "FTN",
+          "f77",
+          "F77",
+          "f90",
+          "F90",
+          "f95",
+          "F95",
+          "f03",
+          "F03",
+          "f08",
+          "F08",
+          "f18",
+          "F18"
+        ],
+        "detect_files": [
+          "fpm.toml"
+        ],
+        "detect_folders": [],
+        "disabled": false,
+        "format": "via [$symbol($version )]($style)",
+        "style": "bold purple",
+        "symbol": "󱈚 ",
+        "version_format": "${raw}"
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/FortranConfig"
+        }
+      ]
+    },
     "fossil_branch": {
       "default": {
         "disabled": true,
@@ -3314,6 +3353,78 @@
         "disabled": {
           "default": false,
           "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
+    "FortranConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "default": "via [$symbol($version )]($style)",
+          "type": "string"
+        },
+        "version_format": {
+          "default": "${raw}",
+          "type": "string"
+        },
+        "symbol": {
+          "default": "󱈚 ",
+          "type": "string"
+        },
+        "style": {
+          "default": "bold purple",
+          "type": "string"
+        },
+        "disabled": {
+          "default": false,
+          "type": "boolean"
+        },
+        "detect_extensions": {
+          "default": [
+            "f",
+            "F",
+            "for",
+            "FOR",
+            "ftn",
+            "FTN",
+            "f77",
+            "F77",
+            "f90",
+            "F90",
+            "f95",
+            "F95",
+            "f03",
+            "F03",
+            "f08",
+            "F08",
+            "f18",
+            "F18"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_files": {
+          "default": [
+            "fpm.toml"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_folders": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "compiler": {
+          "default": "gfortran",
+          "type": "string"
         }
       },
       "additionalProperties": false

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -295,6 +295,7 @@ $elixir\
 $elm\
 $erlang\
 $fennel\
+$fortran\
 $gleam\
 $golang\
 $guix_shell\
@@ -1629,6 +1630,33 @@ Produces a prompt that looks like:
 ```
 AA -------------------------------------------- BB -------------------------------------------- CC
 ```
+## Fortran
+
+The `fortran` module shows the current compiler version of Fortran, by default `gfortran`.
+
+### Options
+
+| Option              | Default                              | Description                                                               |
+| ------------------- | ------------------------------------ | ------------------------------------------------------------------------- |
+| `symbol`            | `' '`                               | The symbol used before displaying the version of COBOL.                   |
+| `format`            | `'via [$symbol($version )]($style)'` | The format for the module.                                                |
+| `version_format`    | `'${raw}'`                           | The version format. Available vars are `raw`, `major`, `minor`, & `patch` |
+| `style`             | `'bold purple'`                      | The style for the module.                                                 |
+| `detect_extensions` | `['f', 'F', 'for', 'FOR', 'ftn', 'FTN', 'f77', 'F77', 'f90', 'F90', 'f95', 'F95','f03', 'F03', 'f08', 'F08', 'f18', 'F18']`       | Which extensions should trigger this module.                              |
+| `detect_files`      | `['fpm.toml']`                        | Which filenames should trigger this module.                               |
+| `detect_folders`    | `[]`                                 | Which folders should trigger this module.                                 |
+| `disabled`          | `false`                              | Disables the `fortran` module.                                              |
+| `compiler`          | `'gfortran'`                         | Selects Fortran compiler |
+
+### Variables
+
+| Variable | Example    | Description                          |
+| -------- | ---------- | ------------------------------------ |
+| version  | `14.2.0`   | The version of the Fortran compiler  |
+| symbol   |            | Mirrors the value of option `symbol` |
+| style\*  |            | Mirrors the value of option `style`  |
+
+*: This variable can only be used as a part of a style string
 
 ## Fossil Branch
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1632,7 +1632,7 @@ AA -------------------------------------------- BB -----------------------------
 ```
 ## Fortran
 
-The `fortran` module shows the current compiler version of Fortran, by default `gfortran`.
+The `fortran` module shows the current compiler version of Fortran (`gfortran`).
 
 ### Options
 
@@ -1646,7 +1646,6 @@ The `fortran` module shows the current compiler version of Fortran, by default `
 | `detect_files`      | `['fpm.toml']`                        | Which filenames should trigger this module.                               |
 | `detect_folders`    | `[]`                                 | Which folders should trigger this module.                                 |
 | `disabled`          | `false`                              | Disables the `fortran` module.                                              |
-| `compiler`          | `'gfortran'`                         | Selects Fortran compiler |
 
 ### Variables
 

--- a/docs/public/presets/toml/bracketed-segments.toml
+++ b/docs/public/presets/toml/bracketed-segments.toml
@@ -49,6 +49,9 @@ format = '\[[$symbol($version)]($style)\]'
 [fennel]
 format = '\[[$symbol($version)]($style)\]'
 
+[fortran]
+format = '\[[$symbol($version)]($style)\]'
+
 [fossil_branch]
 format = '\[[$symbol$branch]($style)\]'
 

--- a/docs/public/presets/toml/jetpack.toml
+++ b/docs/public/presets/toml/jetpack.toml
@@ -39,6 +39,7 @@ $elixir\
 $elm\
 $erlang\
 $fennel\
+$fortran\
 $golang\
 $guix_shell\
 $haskell\

--- a/docs/public/presets/toml/nerd-font-symbols.toml
+++ b/docs/public/presets/toml/nerd-font-symbols.toml
@@ -40,6 +40,9 @@ symbol = " "
 [fennel]
 symbol = " "
 
+[fortran]
+symbol = "󱈚 "
+
 [fossil_branch]
 symbol = " "
 

--- a/docs/public/presets/toml/no-empty-icons.toml
+++ b/docs/public/presets/toml/no-empty-icons.toml
@@ -40,6 +40,9 @@ format = '(via [$symbol($version )]($style))'
 [fennel]
 format = '(via [$symbol($version )]($style))'
 
+[fortran]
+format = "(via [$symbol($version )]($style))"
+
 [gleam]
 format = '(via [$symbol($version )]($style))'
 

--- a/docs/public/presets/toml/no-nerd-font.toml
+++ b/docs/public/presets/toml/no-nerd-font.toml
@@ -8,6 +8,9 @@ empty_symbol = "❗ "
 [erlang]
 symbol = "ⓔ "
 
+[fortran]
+symbol = "F "
+
 [nodejs]
 symbol = "[⬢](bold green) "
 

--- a/docs/public/presets/toml/no-runtime-versions.toml
+++ b/docs/public/presets/toml/no-runtime-versions.toml
@@ -37,6 +37,9 @@ format = 'via [$symbol]($style)'
 [fennel]
 format = 'via [$symbol]($style)'
 
+[fortran]
+format = 'via [$symbol]($style)'
+
 [gleam]
 format = 'via [$symbol]($style)'
 

--- a/docs/public/presets/toml/plain-text-symbols.toml
+++ b/docs/public/presets/toml/plain-text-symbols.toml
@@ -70,6 +70,9 @@ symbol = "elm "
 [fennel]
 symbol = "fnl "
 
+[fortran]
+symbol = "fortran "
+
 [fossil_branch]
 symbol = "fossil "
 

--- a/src/configs/fortran.rs
+++ b/src/configs/fortran.rs
@@ -16,7 +16,6 @@ pub struct FortranConfig<'a> {
     pub detect_extensions: Vec<&'a str>,
     pub detect_files: Vec<&'a str>,
     pub detect_folders: Vec<&'a str>,
-    pub compiler: &'a str,
 }
 
 impl Default for FortranConfig<'_> {
@@ -33,7 +32,6 @@ impl Default for FortranConfig<'_> {
             ],
             detect_files: vec!["fpm.toml"],
             detect_folders: vec![],
-            compiler: "gfortran",
         }
     }
 }

--- a/src/configs/fortran.rs
+++ b/src/configs/fortran.rs
@@ -1,0 +1,39 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(
+    feature = "config-schema",
+    derive(schemars::JsonSchema),
+    schemars(deny_unknown_fields)
+)]
+#[serde(default)]
+pub struct FortranConfig<'a> {
+    pub format: &'a str,
+    pub version_format: &'a str,
+    pub symbol: &'a str,
+    pub style: &'a str,
+    pub disabled: bool,
+    pub detect_extensions: Vec<&'a str>,
+    pub detect_files: Vec<&'a str>,
+    pub detect_folders: Vec<&'a str>,
+    pub compiler: &'a str,
+}
+
+impl Default for FortranConfig<'_> {
+    fn default() -> Self {
+        FortranConfig {
+            format: "via [$symbol($version )]($style)",
+            version_format: "${raw}",
+            symbol: "󱈚 ",
+            style: "bold purple",
+            disabled: false,
+            detect_extensions: vec![
+                "f", "F", "for", "FOR", "ftn", "FTN", "f77", "F77", "f90", "F90", "f95", "F95",
+                "f03", "F03", "f08", "F08", "f18", "F18",
+            ],
+            detect_files: vec!["fpm.toml"],
+            detect_folders: vec![],
+            compiler: "gfortran",
+        }
+    }
+}

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -28,6 +28,7 @@ pub mod env_var;
 pub mod erlang;
 pub mod fennel;
 pub mod fill;
+pub mod fortran;
 pub mod fossil_branch;
 pub mod fossil_metrics;
 pub mod gcloud;
@@ -167,6 +168,8 @@ pub struct FullConfig<'a> {
     fennel: fennel::FennelConfig<'a>,
     #[serde(borrow)]
     fill: fill::FillConfig<'a>,
+    #[serde(borrow)]
+    fortran: fortran::FortranConfig<'a>,
     #[serde(borrow)]
     fossil_branch: fossil_branch::FossilBranchConfig<'a>,
     #[serde(borrow)]

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -65,6 +65,7 @@ pub const PROMPT_ORDER: &[&str] = &[
     "elm",
     "erlang",
     "fennel",
+    "fortran",
     "gleam",
     "golang",
     "gradle",

--- a/src/module.rs
+++ b/src/module.rs
@@ -33,6 +33,7 @@ pub const ALL_MODULES: &[&str] = &[
     "erlang",
     "fennel",
     "fill",
+    "fortran",
     "fossil_branch",
     "fossil_metrics",
     "gcloud",

--- a/src/modules/fortran.rs
+++ b/src/modules/fortran.rs
@@ -120,4 +120,18 @@ mod tests {
 
         dir.close()
     }
+
+    #[test]
+    fn folder_with_fpm_config_file() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join("fpm.toml"))?.sync_all()?;
+
+        let actual = ModuleRenderer::new("fortran").path(dir.path()).collect();
+
+        let expected = Some(format!("via {}", Color::Purple.bold().paint("󱈚 14.2.0 ")));
+
+        assert_eq!(expected, actual);
+
+        dir.close()
+    }
 }

--- a/src/modules/fortran.rs
+++ b/src/modules/fortran.rs
@@ -33,7 +33,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             })
             .map(|variable| match variable {
                 "version" => {
-                    let fortran_version = get_version(context, &config)?;
+                    let fortran_version = get_version(context)?;
                     VersionFormatter::format_module_version(
                         &module.get_name(),
                         &fortran_version,
@@ -57,11 +57,10 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     Some(module)
 }
 
-fn get_version(context: &Context, config: &FortranConfig) -> Option<String> {
+fn get_version(context: &Context) -> Option<String> {
     // first line of output like "GNU Fortran (Homebrew GCC 14.2.0_1) 14.2.0"
 
-    let version = match config.compiler {
-        "gfortran" => context
+    let version = context
             .exec_cmd("gfortran", &["--version"])?
             .stdout
             .split("\n")
@@ -69,23 +68,7 @@ fn get_version(context: &Context, config: &FortranConfig) -> Option<String> {
             .first()?
             .split_whitespace()
             .last()?
-            .to_string(),
-        "ifort" => todo!(),
-        "ifx" => todo!(),
-        "nagfor" => todo!(),
-        "pgfortran" => todo!(),
-        "ftn" => todo!(),
-        "xlf" => todo!(),
-        "ftn95" => todo!(),
-        "lf95" => todo!(),
-        _ => {
-            log::warn!(
-                "Supported compilers are 'gfortran', 'ifort', 'ifx', 'nagfor', 'pgfortran', 'ftn', 'xlf', 'ftn95' and 'lf95', found {}",
-                config.compiler
-            );
-            return None;
-        }
-    };
+            .to_string();
     Some(version)
 }
 

--- a/src/modules/fortran.rs
+++ b/src/modules/fortran.rs
@@ -1,0 +1,140 @@
+use crate::{
+    config::ModuleConfig,
+    configs::fortran::FortranConfig,
+    formatter::{StringFormatter, VersionFormatter},
+};
+
+use super::{Context, Module};
+
+pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let mut module = context.new_module("fortran");
+    let config = FortranConfig::try_load(module.config);
+
+    let is_fortran_project = context
+        .try_begin_scan()?
+        .set_files(&config.detect_files)
+        .set_extensions(&config.detect_extensions)
+        .set_folders(&config.detect_folders)
+        .is_match();
+
+    if !is_fortran_project {
+        return None;
+    }
+
+    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
+        formatter
+            .map_meta(|var, _| match var {
+                "symbol" => Some(config.symbol),
+                _ => None,
+            })
+            .map_style(|variable| match variable {
+                "style" => Some(Ok(config.style)),
+                _ => None,
+            })
+            .map(|variable| match variable {
+                "version" => {
+                    let fortran_version = get_version(context, &config)?;
+                    VersionFormatter::format_module_version(
+                        &module.get_name(),
+                        &fortran_version,
+                        config.version_format,
+                    )
+                    .map(Ok)
+                }
+                _ => None,
+            })
+            .parse(None, Some(context))
+    });
+
+    module.set_segments(match parsed {
+        Ok(segments) => segments,
+        Err(error) => {
+            log::warn!("Error in module `fortran`:\n{}", error);
+            return None;
+        }
+    });
+
+    Some(module)
+}
+
+fn get_version(context: &Context, config: &FortranConfig) -> Option<String> {
+    // first line of output like "GNU Fortran (Homebrew GCC 14.2.0_1) 14.2.0"
+
+    let version = match config.compiler {
+        "gfortran" => context
+            .exec_cmd("gfortran", &["--version"])?
+            .stdout
+            .split("\n")
+            .collect::<Vec<&str>>()
+            .first()?
+            .split_whitespace()
+            .last()?
+            .to_string(),
+        "ifort" => todo!(),
+        "ifx" => todo!(),
+        "nagfor" => todo!(),
+        "pgfortran" => todo!(),
+        "ftn" => todo!(),
+        "xlf" => todo!(),
+        "ftn95" => todo!(),
+        "lf95" => todo!(),
+        _ => {
+            log::warn!(
+                "Supported compilers are 'gfortran', 'ifort', 'ifx', 'nagfor', 'pgfortran', 'ftn', 'xlf', 'ftn95' and 'lf95', found {}",
+                config.compiler
+            );
+            return None;
+        }
+    };
+    Some(version)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs::File, io};
+
+    use nu_ansi_term::Color;
+
+    use crate::test::ModuleRenderer;
+
+    #[test]
+    fn folder_without_fortran_file() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+
+        let actual = ModuleRenderer::new("fortran").path(dir.path()).collect();
+
+        let expected = None;
+
+        assert_eq!(expected, actual);
+
+        dir.close()
+    }
+
+    #[test]
+    fn folder_with_f_fortran_file() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join("test.f"))?.sync_all()?;
+
+        let actual = ModuleRenderer::new("fortran").path(dir.path()).collect();
+
+        let expected = Some(format!("via {}", Color::Purple.bold().paint("󱈚 14.2.0 ")));
+
+        assert_eq!(expected, actual);
+
+        dir.close()
+    }
+
+    #[test]
+    fn folder_with_capital_f18_fortran_file() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join("test.F18"))?.sync_all()?;
+
+        let actual = ModuleRenderer::new("fortran").path(dir.path()).collect();
+
+        let expected = Some(format!("via {}", Color::Purple.bold().paint("󱈚 14.2.0 ")));
+
+        assert_eq!(expected, actual);
+
+        dir.close()
+    }
+}

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -25,6 +25,7 @@ mod env_var;
 mod erlang;
 mod fennel;
 mod fill;
+mod fortran;
 mod fossil_branch;
 mod fossil_metrics;
 mod gcloud;
@@ -138,6 +139,7 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
             "env_var" => env_var::module(None, context),
             "fennel" => fennel::module(context),
             "fill" => fill::module(context),
+            "fortran" => fortran::module(context),
             "fossil_branch" => fossil_branch::module(context),
             "fossil_metrics" => fossil_metrics::module(context),
             "gcloud" => gcloud::module(context),
@@ -264,6 +266,7 @@ pub fn description(module: &str) -> &'static str {
         "erlang" => "Current OTP version",
         "fennel" => "The currently installed version of Fennel",
         "fill" => "Fills the remaining space on the line with a pad string",
+        "fortran" => "The currently used version of Fortran",
         "fossil_branch" => "The active branch of the check-out in your current directory",
         "fossil_metrics" => "The currently added/deleted lines in your check-out",
         "gcloud" => "The current GCP client configuration",

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -191,6 +191,16 @@ warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.",
             ),
             stderr: String::default(),
         }),
+        "gfortran --version" => Some(CommandOutput {
+            stdout: String::from(
+                "\
+                GNU Fortran (Homebrew GCC 14.2.0_1) 14.2.0
+                Copyright (C) 2024 Free Software Foundation, Inc.
+                This is free software; see the source for copying conditions.  There is NO
+                warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.\n\n",
+            ),
+            stderr: String::default(),
+        }),
         "clang --version" => Some(CommandOutput {
             stdout: String::from(
                 "\


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
Added module for Fortran. Displays version of `gfortran`; decided against supporting multiple compilers because most alternatives are proprietary software.

#### Motivation and Context
There was no support for Fortran yet.
Closes #6680

#### Screenshots (if appropriate):
<img width="1032" alt="Screenshot 2025-04-15 at 4 30 18 PM" src="https://github.com/user-attachments/assets/f086e203-eda7-4358-8eed-efabcfcc83d6" />

#### How Has This Been Tested?
Tested on macOS by executing `starship prompt` in a directory containing Fortran files. Prompt looked correct. Tested on linux by setting up Docker container and enabling Starship in bash. Tested multiple scenarios; prompt looked correct. Also created unit tests which are all passing.
- [x] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
