### PR TITLE
fix(preset/pure): only enable python module if venv is active

### DIFF
--- a/docs/public/presets/toml/pure-preset.toml
+++ b/docs/public/presets/toml/pure-preset.toml
@@ -44,3 +44,5 @@ style = "yellow"
 [python]
 format = "[$virtualenv]($style) "
 style = "bright-black"
+detect_extensions = []
+detect_files = []


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
~This PR, inspired by the `no-empty-icons` preset, wraps the venv name and the trailing whitespace in a *conditional* format string. So if the venv name is not available (i.e empty, due to inactive venv), the trailing whitespace will not be either.~

This PR makes it so that the python module is enabled only when a venv is active. All file [& extension] based detection has been disabled.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When a python module is detected (due to the presence of `.py` or `.ipynb` file(s)) but a venv is not active, only the trailing whitespace is displayed and since, in pure, it is placed before the prompt character, this leads to indentation of the prompt character by a single whitespace.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**
