### PR TITLE
feat: add support for `$XDG_CONFIG_HOME` & convention-compliant config file location

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -58,7 +58,7 @@ assignees: ''
 ```
 
 #### Starship Configuration
-<!-- Can be found in  ~/.config/starship.toml -->
+<!-- Can be found in  ~/.config/starship/config.toml -->
 
 ```toml
 # Your configuration here

--- a/docs/advanced-config/README.md
+++ b/docs/advanced-config/README.md
@@ -1,7 +1,7 @@
 # Advanced Configuration
 
 While Starship is a versatile shell, sometimes you need to do more than edit
-`starship.toml` to get it to do certain things. This page details some of the more
+`config.toml` to get it to do certain things. This page details some of the more
 advanced configuration techniques used in starship.
 
 > [!WARNING]
@@ -300,7 +300,7 @@ Note: The [Ble.sh](https://github.com/akinomyoga/ble.sh) framework v0.4 or highe
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 # A minimal left prompt
 format = """$character"""
@@ -332,7 +332,7 @@ Note: Continuation prompts are only available in the following shells:
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 # A continuation prompt that displays two filled-in arrows
 continuation_prompt = '▶▶ '

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1,9 +1,9 @@
 # Configuration
 
-To get started configuring starship, create the following file: `~/.config/starship.toml`.
+To get started configuring starship, create the following file: `~/.config/starship/config.toml`.
 
 ```sh
-mkdir -p ~/.config && touch ~/.config/starship.toml
+mkdir -p ~/.config/starship && touch ~/.config/starship/config.toml
 ```
 
 All configuration for starship is done in this [TOML](https://github.com/toml-lang/toml) file:
@@ -29,20 +29,25 @@ disabled = true
 You can change default configuration file location with `STARSHIP_CONFIG` environment variable:
 
 ```sh
-export STARSHIP_CONFIG=~/example/non/default/path/starship.toml
+export STARSHIP_CONFIG=~/example/non/default/path/config.toml
 ```
 
 Equivalently in PowerShell (Windows) would be adding this line to your `$PROFILE`:
 
 ```powershell
-$ENV:STARSHIP_CONFIG = "$HOME\example\non\default\path\starship.toml"
+$ENV:STARSHIP_CONFIG = "$HOME\example\non\default\path\config.toml"
 ```
 
 Or for Cmd (Windows) would be adding this line to your `starship.lua`:
 
 ```lua
-os.setenv('STARSHIP_CONFIG', 'C:\\Users\\user\\example\\non\\default\\path\\starship.toml')
+os.setenv('STARSHIP_CONFIG', 'C:\\Users\\user\\example\\non\\default\\path\\config.toml')
 ```
+
+You can also change default configuration directory location `~/.cache` with `XDG_CONFIG_HOME` environment variable.
+
+> [!NOTE]
+> The previous default configuration file location `~/.config/starship.toml` has been deprecated.
 
 ### Logging
 
@@ -228,7 +233,7 @@ This is the list of prompt-wide configuration options.
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 # Use custom format
 format = '''
@@ -421,7 +426,7 @@ is read from the `AWS_SSO_PROFILE` env var.
 #### Display everything
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [aws]
 format = 'on [$symbol($profile )(\($region\) )]($style)'
@@ -437,7 +442,7 @@ CompanyGroupFrobozzOnCallAccess = 'Frobozz'
 #### Display region
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [aws]
 format = 'on [$symbol$region]($style) '
@@ -451,7 +456,7 @@ us-east-1 = 'va'
 #### Display profile
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [aws]
 format = 'on [$symbol$profile]($style) '
@@ -484,7 +489,7 @@ The `azure` module shows the current Azure Subscription. This is based on showin
 #### Display Subscription Name
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [azure]
 disabled = false
@@ -496,7 +501,7 @@ style = 'blue bold'
 #### Display Username
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [azure]
 disabled = false
@@ -508,7 +513,7 @@ style = "blue bold"
 #### Display Subscription Name Alias
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [azure.subscription_aliases]
 very-long-subscription-name = 'vlsn'
@@ -535,7 +540,7 @@ The module is only visible when the device's battery is below 10%.
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [battery]
 full_symbol = '🔋 '
@@ -612,7 +617,7 @@ The `buf` module shows the currently installed version of [Buf](https://buf.buil
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [buf]
 symbol = '🦬 '
@@ -655,7 +660,7 @@ By default the module will be shown if any of the following conditions are met:
 #### Customize the format
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [bun]
 format = 'via [🍔 $version](bold green) '
@@ -701,7 +706,7 @@ If a C compiler is not supported by this module, you can request it by [raising 
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [c]
 format = 'via [$name $version]($style)'
@@ -800,7 +805,7 @@ look at [this example](#with-custom-error-shape).
 #### With custom error shape
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [character]
 success_symbol = '[➜](bold green) '
@@ -810,7 +815,7 @@ error_symbol = '[✗](bold red) '
 #### Without custom error shape
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [character]
 success_symbol = '[➜](bold green) '
@@ -820,7 +825,7 @@ error_symbol = '[➜](bold red) '
 #### With custom vim shape
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [character]
 vimcmd_symbol = '[V](bold green) '
@@ -930,7 +935,7 @@ running `eval $(starship init $0)`, and then proceed as normal.
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [cmd_duration]
 min_time = 500
@@ -970,7 +975,7 @@ The `conda` module shows the current [Conda](https://docs.conda.io/en/latest/) e
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [conda]
 format = '[$symbol$environment](dimmed green) '
@@ -1002,7 +1007,7 @@ The `container` module displays a symbol and container name, if inside a contain
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [container]
 format = '[$symbol \[$name\]]($style) '
@@ -1042,7 +1047,7 @@ By default the module will be shown if any of the following conditions are met:
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [crystal]
 format = 'via [✨ $version](bold blue) '
@@ -1084,7 +1089,7 @@ By default the module will be shown if any of the following conditions are met:
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [daml]
 format = 'via [D $version](bold bright-green) '
@@ -1125,7 +1130,7 @@ By default the module will be shown if any of the following conditions are met:
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [dart]
 format = 'via [🔰 $version](bold red) '
@@ -1162,7 +1167,7 @@ By default the module will be shown if any of the following conditions are met:
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [deno]
 format = 'via [🦕 $version](green bold) '
@@ -1253,7 +1258,7 @@ Let us consider the path `/path/to/home/git_repo/src/lib`
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [directory]
 truncation_length = 8
@@ -1301,7 +1306,7 @@ The `direnv` module shows the status of the current rc file if one is present. T
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [direnv]
 disabled = false
@@ -1341,7 +1346,7 @@ the context in use).
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [docker_context]
 format = 'via [🐋 $context](blue bold)'
@@ -1404,7 +1409,7 @@ when there is a `.csproj` file in the current directory.
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [dotnet]
 symbol = '🥅 '
@@ -1446,7 +1451,7 @@ By default the module will be shown if any of the following conditions are met:
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [elixir]
 symbol = '🔮 '
@@ -1489,7 +1494,7 @@ By default the module will be shown if any of the following conditions are met:
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [elm]
 format = 'via [ $version](cyan bold) '
@@ -1515,7 +1520,7 @@ The module will be shown only if any of the following conditions are met:
 > Example: following configuration will display value of USER environment variable
 >
 > ```toml
-> # ~/.config/starship.toml
+> # ~/.config/starship/config.toml
 >
 > [env_var.USER]
 > default = 'unknown user'
@@ -1545,7 +1550,7 @@ The module will be shown only if any of the following conditions are met:
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [env_var]
 variable = 'SHELL'
@@ -1555,7 +1560,7 @@ default = 'unknown shell'
 Displaying multiple environmental variables:
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [env_var.SHELL]
 variable = 'SHELL'
@@ -1598,7 +1603,7 @@ By default the module will be shown if any of the following conditions are met:
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [erlang]
 format = 'via [e $version](bold red) '
@@ -1637,7 +1642,7 @@ By default the module will be shown if any of the following conditions are met:
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [fennel]
 symbol = '⫰ '
@@ -1660,7 +1665,7 @@ other modules.
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 format = 'AA $fill BB $fill CC'
 
 [fill]
@@ -1743,7 +1748,7 @@ The `fossil_branch` module shows the name of the active branch of the check-out 
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [fossil_branch]
 symbol = '🦎 '
@@ -1783,7 +1788,7 @@ The `fossil_metrics` module will show the number of added and deleted lines in t
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [fossil_metrics]
 added_style = 'bold blue'
@@ -1830,7 +1835,7 @@ environment variables has been set.
 #### Display account and project
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [gcloud]
 format = 'on [$symbol$account(@$domain)(\($project\))]($style) '
@@ -1839,7 +1844,7 @@ format = 'on [$symbol$account(@$domain)(\($project\))]($style) '
 #### Display active config name only
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [gcloud]
 format = '[$symbol$active]($style) '
@@ -1849,7 +1854,7 @@ style = 'bold yellow'
 #### Display account and aliased region
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [gcloud]
 symbol = '️🇬️ '
@@ -1861,7 +1866,7 @@ asia-northeast1 = 'an1'
 #### Display account and aliased project
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [gcloud]
 format = 'on [$symbol$account(@$domain)(\($project\))]($style) '
@@ -1903,7 +1908,7 @@ The `git_branch` module shows the active branch of the repo in your current dire
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [git_branch]
 symbol = '🌱 '
@@ -1942,7 +1947,7 @@ The `git_commit` module shows the current commit hash and also the tag (if any) 
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [git_commit]
 commit_hash_length = 4
@@ -1985,7 +1990,7 @@ that information will be shown too.
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [git_state]
 format = '[\($state( $progress_current of $progress_total)\)]($style) '
@@ -2026,7 +2031,7 @@ the current git repository.
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [git_metrics]
 added_style = 'bold blue'
@@ -2101,7 +2106,7 @@ The following variables can be used in `conflicted`, `ahead`, `behind`, `untrack
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [git_status]
 conflicted = '🏳'
@@ -2120,7 +2125,7 @@ deleted = '🗑'
 Show ahead/behind count of the branch being tracked
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [git_status]
 ahead = '⇡${count}'
@@ -2131,7 +2136,7 @@ behind = '⇣${count}'
 Use Windows Starship executable on Windows paths in WSL
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [git_status]
 windows_starship = '/mnt/c/Users/username/scoop/apps/starship/current/starship.exe'
@@ -2170,7 +2175,7 @@ By default the module will be shown if any of the following conditions are met:
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [gleam]
 format = 'via [⭐ $version](bold red) '
@@ -2219,7 +2224,7 @@ By default the module will be shown if any of the following conditions are met:
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [golang]
 format = 'via [🏎💨 $version](bold cyan) '
@@ -2228,7 +2233,7 @@ format = 'via [🏎💨 $version](bold cyan) '
 ### Using `mod_version`
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [golang]
 format = 'via [$symbol($version )($mod_version )]($style)'
@@ -2260,7 +2265,7 @@ The module will be shown when inside a guix-shell environment.
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [guix_shell]
 disabled = true
@@ -2371,7 +2376,7 @@ By default the module will be shown if any of the following conditions are met:
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [haxe]
 format = "via [⌘ $version](bold fg:202) "
@@ -2411,7 +2416,7 @@ By default the module will be shown if any of the following conditions are met:
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [helm]
 format = 'via [⎈ $version](bold white) '
@@ -2449,7 +2454,7 @@ The `hostname` module shows the system hostname.
 #### Always show the hostname
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [hostname]
 ssh_only = false
@@ -2461,7 +2466,7 @@ disabled = false
 #### Hide the hostname in remote tmux sessions
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [hostname]
 ssh_only = false
@@ -2472,7 +2477,7 @@ disabled = false
 #### Replace the hostname with a nickname
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 [hostname]
 aliases = { "Max's MacBook Pro" = "home" }
 ```
@@ -2511,7 +2516,7 @@ By default the module will be shown if any of the following conditions are met:
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [java]
 symbol = '🌟 '
@@ -2570,7 +2575,7 @@ The default functionality is:
 ### Examples
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [jobs]
 symbol = '+ '
@@ -2621,7 +2626,7 @@ By default the module will be shown if any of the following conditions are met:
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [julia]
 symbol = '∴ '
@@ -2661,14 +2666,14 @@ By default the module will be shown if any of the following conditions are met:
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [kotlin]
 symbol = '🅺 '
 ```
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [kotlin]
 # Uses the Kotlin Compiler binary to get the installed version
@@ -2748,7 +2753,7 @@ regular expressions may contain capture groups, which can be referenced in the c
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [kubernetes]
 format = 'on [⛵ ($user on )($cluster in )$context \($namespace\)](dimmed green) '
@@ -2761,7 +2766,7 @@ contexts = [
 Only show the module in directories that contain a `k8s` file.
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [kubernetes]
 disabled = false
@@ -2774,7 +2779,7 @@ The `contexts` configuration option is used to customise what the current Kubern
 like (style and symbol) if the name matches the defined regular expression.
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [[kubernetes.contexts]]
 # "bold red" style + default symbol when Kubernetes current context name equals "production" *and* the current user
@@ -2814,7 +2819,7 @@ The `line_break` module separates the prompt into two lines.
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [line_break]
 disabled = true
@@ -2849,7 +2854,7 @@ The `localip` module shows the IPv4 address of the primary network interface.
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [localip]
 ssh_only = false
@@ -2893,7 +2898,7 @@ By default the module will be shown if any of the following conditions are met:
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [lua]
 format = 'via [🌕 $version](bold blue) '
@@ -2936,7 +2941,7 @@ By default the swap usage is displayed if the total system swap is non-zero.
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [memory_usage]
 disabled = false
@@ -2975,7 +2980,7 @@ By default the Meson project name is displayed, if `$MESON_DEVENV` is set.
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [meson]
 disabled = false
@@ -3017,7 +3022,7 @@ The `hg_branch` module shows the active branch and topic of the repo in your cur
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [hg_branch]
 format = 'on [🌱 $branch](bold purple)'
@@ -3129,7 +3134,7 @@ The `mojo` module shows the current version of [Mojo programming language](https
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [mojo]
 format = 'via [mojo ($version )($hash )]($style)'
@@ -3189,7 +3194,7 @@ This uses `ip netns identify` to get the network namespace, so only network name
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [netns]
 style = 'bold yellow'
@@ -3232,7 +3237,7 @@ By default the module will be shown if any of the following conditions are met:
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [nim]
 style = 'yellow'
@@ -3271,7 +3276,7 @@ The module will be shown when inside a nix-shell environment.
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [nix_shell]
 disabled = true
@@ -3323,7 +3328,7 @@ Additionally, the module will be hidden by default if the directory contains a `
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [nodejs]
 format = 'via [🤖 $version](bold green) '
@@ -3371,7 +3376,7 @@ By default the module will be shown if any of the following conditions are met:
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [ocaml]
 format = 'via [🐪 $version]($style) '
@@ -3407,7 +3412,7 @@ The `odin` module shows the currently installed version of [Odin](https://odin-l
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [odin]
 format = 'via [󰹩 ($version )]($style)'
@@ -3445,7 +3450,7 @@ By default the module will be shown if the current directory contains a `.rego` 
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [opa]
 format = 'via [⛑️  $version](bold red) '
@@ -3481,7 +3486,7 @@ to fetch the current project in use.
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [openstack]
 format = 'on [$symbol$cloud(\($project\))]($style) '
@@ -3589,7 +3594,7 @@ Windows = "🪟 "
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [os]
 format = "on [($name )]($style)"
@@ -3657,7 +3662,7 @@ package, and shows its current version. The module currently supports `npm`, `ni
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [package]
 format = 'via [🎁 $version](208 bold) '
@@ -3698,7 +3703,7 @@ By default the module will be shown if any of the following conditions are met:
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [perl]
 format = 'via [🦪 $version]($style) '
@@ -3739,7 +3744,7 @@ By default the module will be shown if any of the following conditions are met:
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [php]
 format = 'via [🔹 $version](147 bold) '
@@ -3845,7 +3850,7 @@ By default the module will be shown if any of the following conditions are met:
 #### With Pulumi Version
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [pulumi]
 format = '[🛥 ($version )$stack]($style) '
@@ -3854,7 +3859,7 @@ format = '[🛥 ($version )$stack]($style) '
 #### Without Pulumi version
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 [pulumi]
 symbol = '🛥 '
 format = '[$symbol$stack]($style) '
@@ -3896,7 +3901,7 @@ By default the module will be shown if any of the following conditions are met:
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [purescript]
 format = 'via [$symbol$version](bold white)'
@@ -3967,7 +3972,7 @@ By default, the module will be shown if any of the following conditions are met:
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [python]
 symbol = '👾 '
@@ -3975,7 +3980,7 @@ pyenv_version_name = true
 ```
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [python]
 # Only use the `python3` binary to get the version.
@@ -3983,7 +3988,7 @@ python_binary = 'python3'
 ```
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [python]
 # Don't trigger for files with the py extension
@@ -4059,7 +4064,7 @@ any of the following conditions are met:
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [rlang]
 format = 'with [📐 $version](blue bold) '
@@ -4098,7 +4103,7 @@ By default the module will be shown if any of the following conditions are met:
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [raku]
 format = 'via [🦪 $version]($style) '
@@ -4137,7 +4142,7 @@ The module will be shown if any of the following conditions are met:
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [red]
 symbol = '🔴 '
@@ -4183,7 +4188,7 @@ Starship gets the current Ruby version by running `ruby -v`.
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [ruby]
 symbol = '🔺 '
@@ -4225,7 +4230,7 @@ The module will be shown if any of the following conditions are met:
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [rust]
 format = 'via [⚙️ $version](red bold)'
@@ -4266,7 +4271,7 @@ By default the module will be shown if any of the following conditions are met:
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [scala]
 symbol = '🌟 '
@@ -4312,7 +4317,7 @@ The `shell` module shows an indicator for currently used shell.
 ### Examples
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [shell]
 fish_indicator = '󰈺 '
@@ -4356,7 +4361,7 @@ set to a number and meets or exceeds the specified threshold.
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [shlvl]
 disabled = false
@@ -4369,7 +4374,7 @@ prompt like `❯❯❯` where last character is colored appropriately for return
 status code and preceding characters are provided by `shlvl`.
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [shlvl]
 disabled = false
@@ -4406,7 +4411,7 @@ and `$SINGULARITY_NAME` is set.
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [singularity]
 format = '[📦 \[$env\]]($style) '
@@ -4446,7 +4451,7 @@ The module will be shown if any of the following conditions are met:
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 [solidity]
 format = "via [S $version](blue bold)"
 ```
@@ -4478,7 +4483,7 @@ The `spack` module shows the current [Spack](https://spack.readthedocs.io/en/lat
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [spack]
 format = '[$symbol$environment](dimmed blue) '
@@ -4536,7 +4541,7 @@ The status code will cast to a signed 32-bit integer.
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [status]
 style = 'bg:blue'
@@ -4578,7 +4583,7 @@ The module will only be shown if credentials are cached.
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [sudo]
 style = 'bold green'
@@ -4629,7 +4634,7 @@ The module will be shown if any of the following conditions are met:
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [swift]
 format = 'via [🏎  $version](red bold)'
@@ -4679,7 +4684,7 @@ By default the module will be shown if any of the following conditions are met:
 #### With Terraform Version
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [terraform]
 format = 'via [$symbol$version $workspace]($style) '
@@ -4688,7 +4693,7 @@ format = 'via [$symbol$version $workspace]($style) '
 #### Without Terraform version
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [terraform]
 format = 'via [$symbol$workspace]($style) '
@@ -4730,7 +4735,7 @@ Manually setting `time_format` will override the `use_12hr` setting.
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [time]
 disabled = false
@@ -4813,7 +4818,7 @@ The module will be shown if any of the following conditions are met:
 #### Always show the username
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [username]
 style_user = 'white bold'
@@ -4857,7 +4862,7 @@ By default the module will be shown if any of the following conditions are met:
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [vagrant]
 format = 'via [⍱ $version](bold white) '
@@ -4895,7 +4900,7 @@ By default the module will be shown if any of the following conditions are met:
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 [vlang]
 format = 'via [V $version](blue bold) '
 ```
@@ -4927,7 +4932,7 @@ The module will be shown only if a repository is currently in use.
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [vcsh]
 format = '[🆅 $repo](bold blue) '
@@ -4996,7 +5001,7 @@ The module will be shown if any of the following conditions are met:
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [zig]
 symbol = '⚡️ '
@@ -5118,7 +5123,7 @@ shell = ['pwsh', '-Command', '-']
 ### Example
 
 ```toml
-# ~/.config/starship.toml
+# ~/.config/starship/config.toml
 
 [custom.foo]
 command = 'echo foo' # shows output of command

--- a/docs/installing/README.md
+++ b/docs/installing/README.md
@@ -61,7 +61,7 @@ Enable the `programs.starship` module in your `home.nix` file, and add your sett
 {
   programs.starship = {
     enable = true;
-    # Configuration written to ~/.config/starship.toml
+    # Configuration written to ~/.config/starship/config.toml
     settings = {
       # add_newline = false;
 

--- a/docs/presets/bracketed-segments.md
+++ b/docs/presets/bracketed-segments.md
@@ -10,7 +10,7 @@ in brackets instead of using the default Starship wording ("via", "on", etc.).
 ### Configuration
 
 ```sh
-starship preset bracketed-segments -o ~/.config/starship.toml
+starship preset bracketed-segments -o ~/.config/starship/config.toml
 ```
 
 [Click to download TOML](/presets/toml/bracketed-segments.toml){download}

--- a/docs/presets/catppuccin-powerline.md
+++ b/docs/presets/catppuccin-powerline.md
@@ -13,7 +13,7 @@ This preset is a minimally modified version of [Gruvbox Rainbow](./gruvbox-rainb
 ### Configuration
 
 ```sh
-starship preset catppuccin-powerline -o ~/.config/starship.toml
+starship preset catppuccin-powerline -o ~/.config/starship/config.toml
 ```
 
 By default this preset uses the Mocha flavour of Catppucin, but you can specify any of the flavours by modifying the value of `palette`:

--- a/docs/presets/gruvbox-rainbow.md
+++ b/docs/presets/gruvbox-rainbow.md
@@ -13,7 +13,7 @@ This preset is heavily inspired by [Pastel Powerline](./pastel-powerline.md), an
 ### Configuration
 
 ```sh
-starship preset gruvbox-rainbow -o ~/.config/starship.toml
+starship preset gruvbox-rainbow -o ~/.config/starship/config.toml
 ```
 
 [Click to download TOML](/presets/toml/gruvbox-rainbow.toml){download}

--- a/docs/presets/jetpack.md
+++ b/docs/presets/jetpack.md
@@ -16,7 +16,7 @@ This is a pseudo minimalist preset inspired by the [geometry](https://github.com
 ### Configuration
 
 ```sh
-starship preset jetpack -o ~/.config/starship.toml
+starship preset jetpack -o ~/.config/starship/config.toml
 ```
 
 [Click to download TOML](/presets/toml/jetpack.toml){download}

--- a/docs/presets/nerd-font.md
+++ b/docs/presets/nerd-font.md
@@ -13,7 +13,7 @@ This preset changes the symbols for each module to use Nerd Font symbols.
 ### Configuration
 
 ```sh
-starship preset nerd-font-symbols -o ~/.config/starship.toml
+starship preset nerd-font-symbols -o ~/.config/starship/config.toml
 ```
 
 [Click to download TOML](/presets/toml/nerd-font-symbols.toml){download}

--- a/docs/presets/no-empty-icons.md
+++ b/docs/presets/no-empty-icons.md
@@ -9,7 +9,7 @@ If toolset files are identified the toolset icon is displayed. If the toolset is
 ### Configuration
 
 ```sh
-starship preset no-empty-icons -o ~/.config/starship.toml
+starship preset no-empty-icons -o ~/.config/starship/config.toml
 ```
 
 [Click to download TOML](/presets/toml/no-empty-icons.toml){download}

--- a/docs/presets/no-nerd-font.md
+++ b/docs/presets/no-nerd-font.md
@@ -12,7 +12,7 @@ This preset will become the default preset in a future release of starship.
 ### Configuration
 
 ```sh
-starship preset no-nerd-font -o ~/.config/starship.toml
+starship preset no-nerd-font -o ~/.config/starship/config.toml
 ```
 
 [Click to download TOML](/presets/toml/no-nerd-font.toml){download}

--- a/docs/presets/no-runtimes.md
+++ b/docs/presets/no-runtimes.md
@@ -9,7 +9,7 @@ This preset hides the version of language runtimes. If you work in containers or
 ### Configuration
 
 ```sh
-starship preset no-runtime-versions -o ~/.config/starship.toml
+starship preset no-runtime-versions -o ~/.config/starship/config.toml
 ```
 
 [Click to download TOML](/presets/toml/no-runtime-versions.toml){download}

--- a/docs/presets/pastel-powerline.md
+++ b/docs/presets/pastel-powerline.md
@@ -14,7 +14,7 @@ It also shows how path substitution works in starship.
 ### Configuration
 
 ```sh
-starship preset pastel-powerline -o ~/.config/starship.toml
+starship preset pastel-powerline -o ~/.config/starship/config.toml
 ```
 
 [Click to download TOML](/presets/toml/pastel-powerline.toml){download}

--- a/docs/presets/plain-text.md
+++ b/docs/presets/plain-text.md
@@ -10,7 +10,7 @@ don't have access to Unicode.
 ### Configuration
 
 ```sh
-starship preset plain-text-symbols -o ~/.config/starship.toml
+starship preset plain-text-symbols -o ~/.config/starship/config.toml
 ```
 
 [Click to download TOML](/presets/toml/plain-text-symbols.toml){download}

--- a/docs/presets/pure-preset.md
+++ b/docs/presets/pure-preset.md
@@ -9,7 +9,7 @@ This preset emulates the look and behavior of [Pure](https://github.com/sindreso
 ### Configuration
 
 ```sh
-starship preset pure-preset -o ~/.config/starship.toml
+starship preset pure-preset -o ~/.config/starship/config.toml
 ```
 
 [Click to download TOML](/presets/toml/pure-preset.toml){download}

--- a/docs/presets/tokyo-night.md
+++ b/docs/presets/tokyo-night.md
@@ -13,7 +13,7 @@ This preset is inspired by [tokyo-night-vscode-theme](https://github.com/enkia/t
 ### Configuration
 
 ```sh
-starship preset tokyo-night -o ~/.config/starship.toml
+starship preset tokyo-night -o ~/.config/starship/config.toml
 ```
 
 [Click to download TOML](/presets/toml/tokyo-night.toml){download}

--- a/src/bug_report.rs
+++ b/src/bug_report.rs
@@ -241,7 +241,7 @@ fn get_starship_config() -> String {
         .ok()
         .or_else(|| {
             utils::home_dir().map(|mut home_dir| {
-                home_dir.push(".config/starship.toml");
+                home_dir.push(".config/starship/config.toml");
                 home_dir
             })
         })

--- a/src/context.rs
+++ b/src/context.rs
@@ -34,7 +34,7 @@ use terminal_size::terminal_size;
 /// The data contained within Context will be relevant to this particular rendering
 /// of the prompt.
 pub struct Context<'a> {
-    /// The deserialized configuration map from the user's `starship.toml` file.
+    /// The deserialized configuration map from the user's `config.toml` file.
     pub config: StarshipConfig,
 
     /// The current working directory that starship is being called in.
@@ -1354,6 +1354,23 @@ mod tests {
         });
 
         assert_ne!(context.config.config, mod_context.config.config);
+    }
+
+    #[test]
+    fn migrate_deprecated_starship_toml_test() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let dir_path = dir.path();
+        let config_dir = dir_path.join(".config");
+        let deprecated_starship_toml = config_dir.join("starship.toml");
+        let mut env = Env::default();
+
+        fs::create_dir(&config_dir)?;
+        fs::File::create(&deprecated_starship_toml)?;
+        env.insert("HOME", dir_path.to_string_lossy().to_string());
+
+        let _ = get_config_path_os(&env);
+        assert!(!deprecated_starship_toml.exists());
+        dir.close()
     }
 
     #[cfg(windows)]

--- a/src/modules/fossil_branch.rs
+++ b/src/modules/fossil_branch.rs
@@ -12,7 +12,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let config = FossilBranchConfig::try_load(module.config);
 
     // As we default to disabled=true, we have to check here after loading our config module,
-    // before it was only checking against whatever is in the config starship.toml
+    // before it was only checking against whatever is in the config.toml
     if config.disabled {
         return None;
     }

--- a/src/modules/fossil_metrics.rs
+++ b/src/modules/fossil_metrics.rs
@@ -12,7 +12,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let config = FossilMetricsConfig::try_load(module.config);
 
     // As we default to disabled=true, we have to check here after loading our config module,
-    // before it was only checking against whatever is in the config starship.toml
+    // before it was only checking against whatever is in the config.toml
     if config.disabled {
         return None;
     }

--- a/src/modules/git_metrics.rs
+++ b/src/modules/git_metrics.rs
@@ -18,7 +18,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let config: GitMetricsConfig = GitMetricsConfig::try_load(module.config);
 
     // As we default to disabled=true, we have to check here after loading our config module,
-    // before it was only checking against whatever is in the config starship.toml
+    // before it was only checking against whatever is in the config.toml
     if config.disabled {
         return None;
     }

--- a/src/modules/hg_branch.rs
+++ b/src/modules/hg_branch.rs
@@ -16,7 +16,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let config: HgBranchConfig = HgBranchConfig::try_load(module.config);
 
     // As we default to disabled=true, we have to check here after loading our config module,
-    // before it was only checking against whatever is in the config starship.toml
+    // before it was only checking against whatever is in the config.toml
     if config.disabled {
         return None;
     }

--- a/src/modules/hg_state.rs
+++ b/src/modules/hg_state.rs
@@ -14,7 +14,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let config: HgStateConfig = HgStateConfig::try_load(module.config);
 
     // As we default to disabled=true, we have to check here after loading our config module,
-    // before it was only checking against whatever is in the config starship.toml
+    // before it was only checking against whatever is in the config.toml
     if config.disabled {
         return None;
     }

--- a/src/modules/kubernetes.rs
+++ b/src/modules/kubernetes.rs
@@ -137,7 +137,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let config: KubernetesConfig = KubernetesConfig::try_load(module.config);
 
     // As we default to disabled=true, we have to check here after loading our config module,
-    // before it was only checking against whatever is in the config starship.toml
+    // before it was only checking against whatever is in the config.toml
     if config.disabled {
         return None;
     }

--- a/src/modules/localip.rs
+++ b/src/modules/localip.rs
@@ -31,7 +31,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let config: LocalipConfig = LocalipConfig::try_load(module.config);
 
     // As we default to disabled=true, we have to check here after loading our config module,
-    // before it was only checking against whatever is in the config starship.toml
+    // before it was only checking against whatever is in the config.toml
     if config.disabled {
         return None;
     }

--- a/src/modules/memory_usage.rs
+++ b/src/modules/memory_usage.rs
@@ -47,7 +47,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let config = MemoryConfig::try_load(module.config);
 
     // As we default to disabled=true, we have to check here after loading our config module,
-    // before it was only checking against whatever is in the config starship.toml
+    // before it was only checking against whatever is in the config.toml
     if config.disabled {
         return None;
     }

--- a/src/modules/shlvl.rs
+++ b/src/modules/shlvl.rs
@@ -18,7 +18,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let config: ShLvlConfig = ShLvlConfig::try_load(module.config);
 
     // As we default to disabled=true, we have to check here after loading our config module,
-    // before it was only checking against whatever is in the config starship.toml
+    // before it was only checking against whatever is in the config.toml
     if config.disabled || shlvl < config.threshold {
         return None;
     }

--- a/src/modules/status.rs
+++ b/src/modules/status.rs
@@ -23,7 +23,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let config = StatusConfig::try_load(module.config);
 
     // As we default to disabled=true, we have to check here after loading our config module,
-    // before it was only checking against whatever is in the config starship.toml
+    // before it was only checking against whatever is in the config.toml
     if config.disabled {
         return None;
     }

--- a/src/modules/time.rs
+++ b/src/modules/time.rs
@@ -10,7 +10,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let config: TimeConfig = TimeConfig::try_load(module.config);
 
     // As we default to disabled=true, we have to check here after loading our config module,
-    // before it was only checking against whatever is in the config starship.toml
+    // before it was only checking against whatever is in the config.toml
     if config.disabled {
         return None;
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,5 @@
 use process_control::{ChildExt, Control};
+use std::env::var_os;
 use std::ffi::OsStr;
 use std::fmt::Debug;
 use std::fs::read_to_string;
@@ -737,6 +738,14 @@ pub fn render_time(raw_millis: u128, show_millis: bool) -> String {
 
 pub fn home_dir() -> Option<PathBuf> {
     dirs::home_dir()
+}
+
+pub fn config_home_dir() -> Option<PathBuf> {
+    if let Some(xdg_config_home) = var_os("XDG_CONFIG_HOME") {
+        Some(PathBuf::from(xdg_config_home))
+    } else {
+        Some(home_dir()?.join(".config"))
+    }
 }
 
 const HEXTABLE: &[char] = &[


### PR DESCRIPTION
#### Description
<!--- Describe your changes in detail -->
Based on [#5282(comment)](https://github.com/starship/starship/pull/5282#issuecomment-2819298160)

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes [#896](https://github.com/starship/starship/issues/896) (TBF it asks for _platform-specific_ locations. But the suggested location for macOS [and Windows(?)] is meant for applications, not users. The convention for Linux and macOS is same here which is `$XDG_CONFIG_HOME` defaulting to `~/.config`.)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
