### PR TITLE
fix(pixi): Don't trigger pixi module by `.pixi` directory

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -65,7 +65,11 @@
     "buf": {
       "default": {
         "detect_extensions": [],
-        "detect_files": ["buf.yaml", "buf.gen.yaml", "buf.work.yaml"],
+        "detect_files": [
+          "buf.yaml",
+          "buf.gen.yaml",
+          "buf.work.yaml"
+        ],
         "detect_folders": [],
         "disabled": false,
         "format": "with [$symbol($version )]($style)",
@@ -82,7 +86,11 @@
     "bun": {
       "default": {
         "detect_extensions": [],
-        "detect_files": ["bun.lock", "bun.lockb", "bunfig.toml"],
+        "detect_files": [
+          "bun.lock",
+          "bun.lockb",
+          "bunfig.toml"
+        ],
         "detect_folders": [],
         "disabled": false,
         "format": "via [$symbol($version )]($style)",
@@ -99,11 +107,23 @@
     "c": {
       "default": {
         "commands": [
-          ["cc", "--version"],
-          ["gcc", "--version"],
-          ["clang", "--version"]
+          [
+            "cc",
+            "--version"
+          ],
+          [
+            "gcc",
+            "--version"
+          ],
+          [
+            "clang",
+            "--version"
+          ]
         ],
-        "detect_extensions": ["c", "h"],
+        "detect_extensions": [
+          "c",
+          "h"
+        ],
         "detect_files": [],
         "detect_folders": [],
         "disabled": false,
@@ -138,7 +158,10 @@
     "cmake": {
       "default": {
         "detect_extensions": [],
-        "detect_files": ["CMakeLists.txt", "CMakeCache.txt"],
+        "detect_files": [
+          "CMakeLists.txt",
+          "CMakeCache.txt"
+        ],
         "detect_folders": [],
         "disabled": false,
         "format": "via [$symbol($version )]($style)",
@@ -170,7 +193,12 @@
     },
     "cobol": {
       "default": {
-        "detect_extensions": ["cbl", "cob", "CBL", "COB"],
+        "detect_extensions": [
+          "cbl",
+          "cob",
+          "CBL",
+          "COB"
+        ],
         "detect_files": [],
         "detect_folders": [],
         "disabled": false,
@@ -187,10 +215,12 @@
     },
     "conda": {
       "default": {
+        "detect_env_vars": [
+          "!PIXI_ENVIRONMENT_NAME"
+        ],
         "disabled": false,
         "format": "via [$symbol$environment]($style) ",
         "ignore_base": true,
-        "ignore_pixi_envs": true,
         "style": "green bold",
         "symbol": "🅒 ",
         "truncation_length": 1
@@ -257,8 +287,12 @@
     },
     "crystal": {
       "default": {
-        "detect_extensions": ["cr"],
-        "detect_files": ["shard.yml"],
+        "detect_extensions": [
+          "cr"
+        ],
+        "detect_files": [
+          "shard.yml"
+        ],
         "detect_folders": [],
         "disabled": false,
         "format": "via [$symbol($version )]($style)",
@@ -275,7 +309,9 @@
     "daml": {
       "default": {
         "detect_extensions": [],
-        "detect_files": ["daml.yaml"],
+        "detect_files": [
+          "daml.yaml"
+        ],
         "detect_folders": [],
         "disabled": false,
         "format": "via [$symbol($version )]($style)",
@@ -291,9 +327,17 @@
     },
     "dart": {
       "default": {
-        "detect_extensions": ["dart"],
-        "detect_files": ["pubspec.yaml", "pubspec.yml", "pubspec.lock"],
-        "detect_folders": [".dart_tool"],
+        "detect_extensions": [
+          "dart"
+        ],
+        "detect_files": [
+          "pubspec.yaml",
+          "pubspec.yml",
+          "pubspec.lock"
+        ],
+        "detect_folders": [
+          ".dart_tool"
+        ],
         "disabled": false,
         "format": "via [$symbol($version )]($style)",
         "style": "bold blue",
@@ -360,9 +404,13 @@
       "default": {
         "allowed_msg": "allowed",
         "denied_msg": "denied",
-        "detect_env_vars": ["DIRENV_FILE"],
+        "detect_env_vars": [
+          "DIRENV_FILE"
+        ],
         "detect_extensions": [],
-        "detect_files": [".envrc"],
+        "detect_files": [
+          ".envrc"
+        ],
         "detect_folders": [],
         "disabled": true,
         "format": "[$symbol$loaded/$allowed]($style) ",
@@ -401,7 +449,11 @@
     },
     "dotnet": {
       "default": {
-        "detect_extensions": ["csproj", "fsproj", "xproj"],
+        "detect_extensions": [
+          "csproj",
+          "fsproj",
+          "xproj"
+        ],
         "detect_files": [
           "global.json",
           "project.json",
@@ -426,7 +478,9 @@
     "elixir": {
       "default": {
         "detect_extensions": [],
-        "detect_files": ["mix.exs"],
+        "detect_files": [
+          "mix.exs"
+        ],
         "detect_folders": [],
         "disabled": false,
         "format": "via [$symbol($version \\(OTP $otp_version\\) )]($style)",
@@ -442,9 +496,17 @@
     },
     "elm": {
       "default": {
-        "detect_extensions": ["elm"],
-        "detect_files": ["elm.json", "elm-package.json", ".elm-version"],
-        "detect_folders": ["elm-stuff"],
+        "detect_extensions": [
+          "elm"
+        ],
+        "detect_files": [
+          "elm.json",
+          "elm-package.json",
+          ".elm-version"
+        ],
+        "detect_folders": [
+          "elm-stuff"
+        ],
         "disabled": false,
         "format": "via [$symbol($version )]($style)",
         "style": "cyan bold",
@@ -467,7 +529,10 @@
     "erlang": {
       "default": {
         "detect_extensions": [],
-        "detect_files": ["rebar.config", "erlang.mk"],
+        "detect_files": [
+          "rebar.config",
+          "erlang.mk"
+        ],
         "detect_folders": [],
         "disabled": false,
         "format": "via [$symbol($version )]($style)",
@@ -483,7 +548,9 @@
     },
     "fennel": {
       "default": {
-        "detect_extensions": ["fnl"],
+        "detect_extensions": [
+          "fnl"
+        ],
         "detect_files": [],
         "detect_folders": [],
         "disabled": true,
@@ -652,8 +719,12 @@
     },
     "gleam": {
       "default": {
-        "detect_extensions": ["gleam"],
-        "detect_files": ["gleam.toml"],
+        "detect_extensions": [
+          "gleam"
+        ],
+        "detect_files": [
+          "gleam.toml"
+        ],
         "detect_folders": [],
         "disabled": false,
         "format": "via [$symbol($version )]($style)",
@@ -669,7 +740,9 @@
     },
     "golang": {
       "default": {
-        "detect_extensions": ["go"],
+        "detect_extensions": [
+          "go"
+        ],
         "detect_files": [
           "go.mod",
           "go.sum",
@@ -679,7 +752,9 @@
           "Gopkg.lock",
           ".go-version"
         ],
-        "detect_folders": ["Godeps"],
+        "detect_folders": [
+          "Godeps"
+        ],
         "disabled": false,
         "format": "via [$symbol($version )]($style)",
         "not_capable_style": "bold red",
@@ -695,9 +770,14 @@
     },
     "gradle": {
       "default": {
-        "detect_extensions": ["gradle", "gradle.kts"],
+        "detect_extensions": [
+          "gradle",
+          "gradle.kts"
+        ],
         "detect_files": [],
-        "detect_folders": ["gradle"],
+        "detect_folders": [
+          "gradle"
+        ],
         "disabled": false,
         "format": "via [$symbol($version )]($style)",
         "recursive": false,
@@ -726,8 +806,15 @@
     },
     "haskell": {
       "default": {
-        "detect_extensions": ["hs", "cabal", "hs-boot"],
-        "detect_files": ["stack.yaml", "cabal.project"],
+        "detect_extensions": [
+          "hs",
+          "cabal",
+          "hs-boot"
+        ],
+        "detect_files": [
+          "stack.yaml",
+          "cabal.project"
+        ],
         "detect_folders": [],
         "disabled": false,
         "format": "via [$symbol($version )]($style)",
@@ -743,9 +830,19 @@
     },
     "haxe": {
       "default": {
-        "detect_extensions": ["hx", "hxml"],
-        "detect_files": ["haxelib.json", "hxformat.json", ".haxerc"],
-        "detect_folders": [".haxelib", "haxe_libraries"],
+        "detect_extensions": [
+          "hx",
+          "hxml"
+        ],
+        "detect_files": [
+          "haxelib.json",
+          "hxformat.json",
+          ".haxerc"
+        ],
+        "detect_folders": [
+          ".haxelib",
+          "haxe_libraries"
+        ],
         "disabled": false,
         "format": "via [$symbol($version )]($style)",
         "style": "bold fg:202",
@@ -761,7 +858,10 @@
     "helm": {
       "default": {
         "detect_extensions": [],
-        "detect_files": ["helmfile.yaml", "Chart.yaml"],
+        "detect_files": [
+          "helmfile.yaml",
+          "Chart.yaml"
+        ],
         "detect_folders": [],
         "disabled": false,
         "format": "via [$symbol($version )]($style)",
@@ -809,7 +909,14 @@
     },
     "java": {
       "default": {
-        "detect_extensions": ["java", "class", "jar", "gradle", "clj", "cljc"],
+        "detect_extensions": [
+          "java",
+          "class",
+          "jar",
+          "gradle",
+          "clj",
+          "cljc"
+        ],
         "detect_files": [
           "pom.xml",
           "build.gradle.kts",
@@ -851,8 +958,13 @@
     },
     "julia": {
       "default": {
-        "detect_extensions": ["jl"],
-        "detect_files": ["Project.toml", "Manifest.toml"],
+        "detect_extensions": [
+          "jl"
+        ],
+        "detect_files": [
+          "Project.toml",
+          "Manifest.toml"
+        ],
         "detect_folders": [],
         "disabled": false,
         "format": "via [$symbol($version )]($style)",
@@ -868,7 +980,10 @@
     },
     "kotlin": {
       "default": {
-        "detect_extensions": ["kt", "kts"],
+        "detect_extensions": [
+          "kt",
+          "kts"
+        ],
         "detect_files": [],
         "detect_folders": [],
         "disabled": false,
@@ -929,9 +1044,15 @@
     },
     "lua": {
       "default": {
-        "detect_extensions": ["lua"],
-        "detect_files": [".lua-version"],
-        "detect_folders": ["lua"],
+        "detect_extensions": [
+          "lua"
+        ],
+        "detect_files": [
+          ".lua-version"
+        ],
+        "detect_folders": [
+          "lua"
+        ],
         "disabled": false,
         "format": "via [$symbol($version )]($style)",
         "lua_binary": "lua",
@@ -1001,7 +1122,10 @@
     },
     "mojo": {
       "default": {
-        "detect_extensions": ["mojo", "🔥"],
+        "detect_extensions": [
+          "mojo",
+          "🔥"
+        ],
         "detect_files": [],
         "detect_folders": [],
         "disabled": false,
@@ -1043,8 +1167,14 @@
     },
     "nim": {
       "default": {
-        "detect_extensions": ["nim", "nims", "nimble"],
-        "detect_files": ["nim.cfg"],
+        "detect_extensions": [
+          "nim",
+          "nims",
+          "nimble"
+        ],
+        "detect_files": [
+          "nim.cfg"
+        ],
         "detect_folders": [],
         "disabled": false,
         "format": "via [$symbol($version )]($style)",
@@ -1077,7 +1207,14 @@
     },
     "nodejs": {
       "default": {
-        "detect_extensions": ["js", "mjs", "cjs", "ts", "mts", "cts"],
+        "detect_extensions": [
+          "js",
+          "mjs",
+          "cjs",
+          "ts",
+          "mts",
+          "cts"
+        ],
         "detect_files": [
           "package.json",
           ".node-version",
@@ -1086,7 +1223,9 @@
           "!bun.lock",
           "!bun.lockb"
         ],
-        "detect_folders": ["node_modules"],
+        "detect_folders": [
+          "node_modules"
+        ],
         "disabled": false,
         "format": "via [$symbol($version )]($style)",
         "not_capable_style": "bold red",
@@ -1102,7 +1241,13 @@
     },
     "ocaml": {
       "default": {
-        "detect_extensions": ["opam", "ml", "mli", "re", "rei"],
+        "detect_extensions": [
+          "opam",
+          "ml",
+          "mli",
+          "re",
+          "rei"
+        ],
         "detect_files": [
           "dune",
           "dune-project",
@@ -1110,7 +1255,10 @@
           "jbuild-ignore",
           ".merlin"
         ],
-        "detect_folders": ["_opam", "esy.lock"],
+        "detect_folders": [
+          "_opam",
+          "esy.lock"
+        ],
         "disabled": false,
         "format": "via [$symbol($version )(\\($switch_indicator$switch_name\\) )]($style)",
         "global_switch_indicator": "",
@@ -1127,7 +1275,9 @@
     },
     "odin": {
       "default": {
-        "detect_extensions": ["odin"],
+        "detect_extensions": [
+          "odin"
+        ],
         "detect_files": [],
         "detect_folders": [],
         "disabled": false,
@@ -1144,7 +1294,9 @@
     },
     "opa": {
       "default": {
-        "detect_extensions": ["rego"],
+        "detect_extensions": [
+          "rego"
+        ],
         "detect_files": [],
         "detect_folders": [],
         "disabled": false,
@@ -1254,7 +1406,11 @@
     },
     "perl": {
       "default": {
-        "detect_extensions": ["pl", "pm", "pod"],
+        "detect_extensions": [
+          "pl",
+          "pm",
+          "pod"
+        ],
         "detect_files": [
           "Makefile.PL",
           "Build.PL",
@@ -1279,8 +1435,13 @@
     },
     "php": {
       "default": {
-        "detect_extensions": ["php"],
-        "detect_files": ["composer.json", ".php-version"],
+        "detect_extensions": [
+          "php"
+        ],
+        "detect_files": [
+          "composer.json",
+          ".php-version"
+        ],
         "detect_folders": [],
         "disabled": false,
         "format": "via [$symbol($version )]($style)",
@@ -1311,13 +1472,20 @@
     },
     "pixi": {
       "default": {
-        "detect_files": ["pixi.toml", "pixi.lock"],
+        "detect_extensions": [],
+        "detect_files": [
+          "pixi.toml",
+          "pixi.lock"
+        ],
+        "detect_folders": [],
         "disabled": false,
         "format": "via [$symbol($version )(\\($environment\\) )]($style)",
-        "pixi_binary": ["pixi"],
+        "pixi_binary": [
+          "pixi"
+        ],
         "show_default_environment": true,
         "style": "yellow bold",
-        "symbol": "📦 ",
+        "symbol": "🧚 ",
         "version_format": "v${raw}"
       },
       "allOf": [
@@ -1343,8 +1511,14 @@
     },
     "purescript": {
       "default": {
-        "detect_extensions": ["purs"],
-        "detect_files": ["spago.dhall", "spago.yaml", "spago.lock"],
+        "detect_extensions": [
+          "purs"
+        ],
+        "detect_files": [
+          "spago.dhall",
+          "spago.yaml",
+          "spago.lock"
+        ],
         "detect_folders": [],
         "disabled": false,
         "format": "via [$symbol($version )]($style)",
@@ -1360,8 +1534,13 @@
     },
     "python": {
       "default": {
-        "detect_env_vars": ["VIRTUAL_ENV"],
-        "detect_extensions": ["py", "ipynb"],
+        "detect_env_vars": [
+          "VIRTUAL_ENV"
+        ],
+        "detect_extensions": [
+          "py",
+          "ipynb"
+        ],
         "detect_files": [
           "requirements.txt",
           ".python-version",
@@ -1376,7 +1555,17 @@
         "format": "via [${symbol}${pyenv_prefix}(${version} )(\\($virtualenv\\) )]($style)",
         "pyenv_prefix": "pyenv ",
         "pyenv_version_name": false,
-        "python_binary": [["python"], ["python3"], ["python2"]],
+        "python_binary": [
+          [
+            "python"
+          ],
+          [
+            "python3"
+          ],
+          [
+            "python2"
+          ]
+        ],
         "style": "yellow bold",
         "symbol": "🐍 ",
         "version_format": "v${raw}"
@@ -1389,8 +1578,12 @@
     },
     "quarto": {
       "default": {
-        "detect_extensions": ["qmd"],
-        "detect_files": ["_quarto.yml"],
+        "detect_extensions": [
+          "qmd"
+        ],
+        "detect_files": [
+          "_quarto.yml"
+        ],
         "detect_folders": [],
         "disabled": false,
         "format": "via [$symbol($version )]($style)",
@@ -1406,8 +1599,16 @@
     },
     "raku": {
       "default": {
-        "detect_extensions": ["p6", "pm6", "pod6", "raku", "rakumod"],
-        "detect_files": ["META6.json"],
+        "detect_extensions": [
+          "p6",
+          "pm6",
+          "pod6",
+          "raku",
+          "rakumod"
+        ],
+        "detect_files": [
+          "META6.json"
+        ],
         "detect_folders": [],
         "disabled": false,
         "format": "via [$symbol($version-$vm_version )]($style)",
@@ -1423,7 +1624,10 @@
     },
     "red": {
       "default": {
-        "detect_extensions": ["red", "reds"],
+        "detect_extensions": [
+          "red",
+          "reds"
+        ],
         "detect_files": [],
         "detect_folders": [],
         "disabled": false,
@@ -1440,9 +1644,19 @@
     },
     "rlang": {
       "default": {
-        "detect_extensions": ["R", "Rd", "Rmd", "Rproj", "Rsx"],
-        "detect_files": ["DESCRIPTION"],
-        "detect_folders": [".Rproj.user"],
+        "detect_extensions": [
+          "R",
+          "Rd",
+          "Rmd",
+          "Rproj",
+          "Rsx"
+        ],
+        "detect_files": [
+          "DESCRIPTION"
+        ],
+        "detect_folders": [
+          ".Rproj.user"
+        ],
         "disabled": false,
         "format": "via [$symbol($version )]($style)",
         "style": "blue bold",
@@ -1457,10 +1671,18 @@
     },
     "ruby": {
       "default": {
-        "detect_extensions": ["rb"],
-        "detect_files": ["Gemfile", ".ruby-version"],
+        "detect_extensions": [
+          "rb"
+        ],
+        "detect_files": [
+          "Gemfile",
+          ".ruby-version"
+        ],
         "detect_folders": [],
-        "detect_variables": ["RUBY_VERSION", "RBENV_VERSION"],
+        "detect_variables": [
+          "RUBY_VERSION",
+          "RBENV_VERSION"
+        ],
         "disabled": false,
         "format": "via [$symbol($version )]($style)",
         "style": "bold red",
@@ -1475,8 +1697,12 @@
     },
     "rust": {
       "default": {
-        "detect_extensions": ["rs"],
-        "detect_files": ["Cargo.toml"],
+        "detect_extensions": [
+          "rs"
+        ],
+        "detect_files": [
+          "Cargo.toml"
+        ],
         "detect_folders": [],
         "disabled": false,
         "format": "via [$symbol($version )]($style)",
@@ -1492,9 +1718,18 @@
     },
     "scala": {
       "default": {
-        "detect_extensions": ["sbt", "scala"],
-        "detect_files": [".scalaenv", ".sbtenv", "build.sbt"],
-        "detect_folders": [".metals"],
+        "detect_extensions": [
+          "sbt",
+          "scala"
+        ],
+        "detect_files": [
+          ".scalaenv",
+          ".sbtenv",
+          "build.sbt"
+        ],
+        "detect_folders": [
+          ".metals"
+        ],
         "disabled": false,
         "format": "via [$symbol($version )]($style)",
         "style": "red bold",
@@ -1561,8 +1796,12 @@
     },
     "solidity": {
       "default": {
-        "compiler": ["solc"],
-        "detect_extensions": ["sol"],
+        "compiler": [
+          "solc"
+        ],
+        "detect_extensions": [
+          "sol"
+        ],
         "detect_files": [],
         "detect_folders": [],
         "disabled": false,
@@ -1630,8 +1869,12 @@
     },
     "swift": {
       "default": {
-        "detect_extensions": ["swift"],
-        "detect_files": ["Package.swift"],
+        "detect_extensions": [
+          "swift"
+        ],
+        "detect_files": [
+          "Package.swift"
+        ],
         "detect_folders": [],
         "disabled": false,
         "format": "via [$symbol($version )]($style)",
@@ -1647,9 +1890,15 @@
     },
     "terraform": {
       "default": {
-        "detect_extensions": ["tf", "tfplan", "tfstate"],
+        "detect_extensions": [
+          "tf",
+          "tfplan",
+          "tfstate"
+        ],
         "detect_files": [],
-        "detect_folders": [".terraform"],
+        "detect_folders": [
+          ".terraform"
+        ],
         "disabled": false,
         "format": "via [$symbol$workspace]($style) ",
         "style": "bold 105",
@@ -1679,8 +1928,12 @@
     },
     "typst": {
       "default": {
-        "detect_extensions": ["typ"],
-        "detect_files": ["template.typ"],
+        "detect_extensions": [
+          "typ"
+        ],
+        "detect_files": [
+          "template.typ"
+        ],
         "detect_folders": [],
         "disabled": false,
         "format": "via [$symbol($version )]($style)",
@@ -1713,7 +1966,9 @@
     "vagrant": {
       "default": {
         "detect_extensions": [],
-        "detect_files": ["Vagrantfile"],
+        "detect_files": [
+          "Vagrantfile"
+        ],
         "detect_folders": [],
         "disabled": false,
         "format": "via [$symbol($version )]($style)",
@@ -1742,8 +1997,14 @@
     },
     "vlang": {
       "default": {
-        "detect_extensions": ["v"],
-        "detect_files": ["v.mod", "vpkg.json", ".vpkg-lock.json"],
+        "detect_extensions": [
+          "v"
+        ],
+        "detect_files": [
+          "v.mod",
+          "vpkg.json",
+          ".vpkg-lock.json"
+        ],
         "detect_folders": [],
         "disabled": false,
         "format": "via [$symbol($version )]($style)",
@@ -1759,7 +2020,9 @@
     },
     "zig": {
       "default": {
-        "detect_extensions": ["zig"],
+        "detect_extensions": [
+          "zig"
+        ],
         "detect_files": [],
         "detect_folders": [],
         "disabled": false,
@@ -1814,7 +2077,10 @@
       "type": "boolean"
     },
     "palette": {
-      "type": ["string", "null"]
+      "type": [
+        "string",
+        "null"
+      ]
     },
     "palettes": {
       "default": {},
@@ -1981,11 +2247,17 @@
         },
         "charging_symbol": {
           "default": null,
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "discharging_symbol": {
           "default": null,
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "additionalProperties": false
@@ -2021,7 +2293,11 @@
           }
         },
         "detect_files": {
-          "default": ["buf.yaml", "buf.gen.yaml", "buf.work.yaml"],
+          "default": [
+            "buf.yaml",
+            "buf.gen.yaml",
+            "buf.work.yaml"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -2068,7 +2344,11 @@
           }
         },
         "detect_files": {
-          "default": ["bun.lock", "bun.lockb", "bunfig.toml"],
+          "default": [
+            "bun.lock",
+            "bun.lockb",
+            "bunfig.toml"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -2108,7 +2388,10 @@
           "type": "boolean"
         },
         "detect_extensions": {
-          "default": ["c", "h"],
+          "default": [
+            "c",
+            "h"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -2130,9 +2413,18 @@
         },
         "commands": {
           "default": [
-            ["cc", "--version"],
-            ["gcc", "--version"],
-            ["clang", "--version"]
+            [
+              "cc",
+              "--version"
+            ],
+            [
+              "gcc",
+              "--version"
+            ],
+            [
+              "clang",
+              "--version"
+            ]
           ],
           "type": "array",
           "items": {
@@ -2214,7 +2506,10 @@
           }
         },
         "detect_files": {
-          "default": ["CMakeLists.txt", "CMakeCache.txt"],
+          "default": [
+            "CMakeLists.txt",
+            "CMakeCache.txt"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -2264,7 +2559,10 @@
           "format": "int64"
         },
         "notification_timeout": {
-          "type": ["integer", "null"],
+          "type": [
+            "integer",
+            "null"
+          ],
           "format": "uint32",
           "minimum": 0.0
         }
@@ -2295,7 +2593,12 @@
           "type": "boolean"
         },
         "detect_extensions": {
-          "default": ["cbl", "cob", "CBL", "COB"],
+          "default": [
+            "cbl",
+            "cob",
+            "CBL",
+            "COB"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -2343,9 +2646,14 @@
           "default": true,
           "type": "boolean"
         },
-        "ignore_pixi_envs": {
-          "default": true,
-          "type": "boolean"
+        "detect_env_vars": {
+          "default": [
+            "!PIXI_ENVIRONMENT_NAME"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         },
         "disabled": {
           "default": false,
@@ -2480,14 +2788,18 @@
           "type": "boolean"
         },
         "detect_extensions": {
-          "default": ["cr"],
+          "default": [
+            "cr"
+          ],
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "detect_files": {
-          "default": ["shard.yml"],
+          "default": [
+            "shard.yml"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -2534,7 +2846,9 @@
           }
         },
         "detect_files": {
-          "default": ["daml.yaml"],
+          "default": [
+            "daml.yaml"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -2574,21 +2888,29 @@
           "type": "boolean"
         },
         "detect_extensions": {
-          "default": ["dart"],
+          "default": [
+            "dart"
+          ],
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "detect_files": {
-          "default": ["pubspec.yaml", "pubspec.yml", "pubspec.lock"],
+          "default": [
+            "pubspec.yaml",
+            "pubspec.yml",
+            "pubspec.lock"
+          ],
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "detect_folders": {
-          "default": [".dart_tool"],
+          "default": [
+            ".dart_tool"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -2694,11 +3016,17 @@
         },
         "repo_root_style": {
           "default": null,
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "before_repo_root_style": {
           "default": null,
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "disabled": {
           "default": false,
@@ -2754,14 +3082,18 @@
           }
         },
         "detect_env_vars": {
-          "default": ["DIRENV_FILE"],
+          "default": [
+            "DIRENV_FILE"
+          ],
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "detect_files": {
-          "default": [".envrc"],
+          "default": [
+            ".envrc"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -2876,7 +3208,11 @@
           "type": "boolean"
         },
         "detect_extensions": {
-          "default": ["csproj", "fsproj", "xproj"],
+          "default": [
+            "csproj",
+            "fsproj",
+            "xproj"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -2936,7 +3272,9 @@
           }
         },
         "detect_files": {
-          "default": ["mix.exs"],
+          "default": [
+            "mix.exs"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -2976,21 +3314,29 @@
           "type": "boolean"
         },
         "detect_extensions": {
-          "default": ["elm"],
+          "default": [
+            "elm"
+          ],
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "detect_files": {
-          "default": ["elm.json", "elm-package.json", ".elm-version"],
+          "default": [
+            "elm.json",
+            "elm-package.json",
+            ".elm-version"
+          ],
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "detect_folders": {
-          "default": ["elm-stuff"],
+          "default": [
+            "elm-stuff"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -3011,10 +3357,16 @@
           "type": "string"
         },
         "variable": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "default": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "format": {
           "default": "with [$env_value]($style) ",
@@ -3062,7 +3414,10 @@
           }
         },
         "detect_files": {
-          "default": ["rebar.config", "erlang.mk"],
+          "default": [
+            "rebar.config",
+            "erlang.mk"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -3102,7 +3457,9 @@
           "type": "boolean"
         },
         "detect_extensions": {
-          "default": ["fnl"],
+          "default": [
+            "fnl"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -3479,7 +3836,10 @@
           "type": "boolean"
         },
         "windows_starship": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "additionalProperties": false
@@ -3508,14 +3868,18 @@
           "type": "boolean"
         },
         "detect_extensions": {
-          "default": ["gleam"],
+          "default": [
+            "gleam"
+          ],
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "detect_files": {
-          "default": ["gleam.toml"],
+          "default": [
+            "gleam.toml"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -3559,7 +3923,9 @@
           "type": "string"
         },
         "detect_extensions": {
-          "default": ["go"],
+          "default": [
+            "go"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -3581,7 +3947,9 @@
           }
         },
         "detect_folders": {
-          "default": ["Godeps"],
+          "default": [
+            "Godeps"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -3618,7 +3986,10 @@
           "type": "boolean"
         },
         "detect_extensions": {
-          "default": ["gradle", "gradle.kts"],
+          "default": [
+            "gradle",
+            "gradle.kts"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -3632,7 +4003,9 @@
           }
         },
         "detect_folders": {
-          "default": ["gradle"],
+          "default": [
+            "gradle"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -3687,14 +4060,21 @@
           "type": "boolean"
         },
         "detect_extensions": {
-          "default": ["hs", "cabal", "hs-boot"],
+          "default": [
+            "hs",
+            "cabal",
+            "hs-boot"
+          ],
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "detect_files": {
-          "default": ["stack.yaml", "cabal.project"],
+          "default": [
+            "stack.yaml",
+            "cabal.project"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -3734,21 +4114,31 @@
           "type": "boolean"
         },
         "detect_extensions": {
-          "default": ["hx", "hxml"],
+          "default": [
+            "hx",
+            "hxml"
+          ],
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "detect_files": {
-          "default": ["haxelib.json", "hxformat.json", ".haxerc"],
+          "default": [
+            "haxelib.json",
+            "hxformat.json",
+            ".haxerc"
+          ],
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "detect_folders": {
-          "default": [".haxelib", "haxe_libraries"],
+          "default": [
+            ".haxelib",
+            "haxe_libraries"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -3788,7 +4178,10 @@
           }
         },
         "detect_files": {
-          "default": ["helmfile.yaml", "Chart.yaml"],
+          "default": [
+            "helmfile.yaml",
+            "Chart.yaml"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -3903,7 +4296,14 @@
           "type": "string"
         },
         "detect_extensions": {
-          "default": ["java", "class", "jar", "gradle", "clj", "cljc"],
+          "default": [
+            "java",
+            "class",
+            "jar",
+            "gradle",
+            "clj",
+            "cljc"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -3996,14 +4396,19 @@
           "type": "boolean"
         },
         "detect_extensions": {
-          "default": ["jl"],
+          "default": [
+            "jl"
+          ],
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "detect_files": {
-          "default": ["Project.toml", "Manifest.toml"],
+          "default": [
+            "Project.toml",
+            "Manifest.toml"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -4047,7 +4452,10 @@
           "type": "boolean"
         },
         "detect_extensions": {
-          "default": ["kt", "kts"],
+          "default": [
+            "kt",
+            "kts"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -4150,23 +4558,38 @@
         },
         "user_pattern": {
           "default": null,
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "symbol": {
           "default": null,
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "style": {
           "default": null,
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "context_alias": {
           "default": null,
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "user_alias": {
           "default": null,
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         }
       },
       "additionalProperties": false
@@ -4231,21 +4654,27 @@
           "type": "boolean"
         },
         "detect_extensions": {
-          "default": ["lua"],
+          "default": [
+            "lua"
+          ],
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "detect_files": {
-          "default": [".lua-version"],
+          "default": [
+            ".lua-version"
+          ],
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "detect_folders": {
-          "default": ["lua"],
+          "default": [
+            "lua"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -4391,7 +4820,10 @@
           "type": "boolean"
         },
         "detect_extensions": {
-          "default": ["mojo", "🔥"],
+          "default": [
+            "mojo",
+            "🔥"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -4482,14 +4914,20 @@
           "type": "boolean"
         },
         "detect_extensions": {
-          "default": ["nim", "nims", "nimble"],
+          "default": [
+            "nim",
+            "nims",
+            "nimble"
+          ],
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "detect_files": {
-          "default": ["nim.cfg"],
+          "default": [
+            "nim.cfg"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -4571,7 +5009,14 @@
           "type": "string"
         },
         "detect_extensions": {
-          "default": ["js", "mjs", "cjs", "ts", "mts", "cts"],
+          "default": [
+            "js",
+            "mjs",
+            "cjs",
+            "ts",
+            "mts",
+            "cts"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -4592,7 +5037,9 @@
           }
         },
         "detect_folders": {
-          "default": ["node_modules"],
+          "default": [
+            "node_modules"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -4633,7 +5080,13 @@
           "type": "boolean"
         },
         "detect_extensions": {
-          "default": ["opam", "ml", "mli", "re", "rei"],
+          "default": [
+            "opam",
+            "ml",
+            "mli",
+            "re",
+            "rei"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -4653,7 +5106,10 @@
           }
         },
         "detect_folders": {
-          "default": ["_opam", "esy.lock"],
+          "default": [
+            "_opam",
+            "esy.lock"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -4686,7 +5142,9 @@
           "type": "boolean"
         },
         "detect_extensions": {
-          "default": ["odin"],
+          "default": [
+            "odin"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -4733,7 +5191,9 @@
           "type": "boolean"
         },
         "detect_extensions": {
-          "default": ["rego"],
+          "default": [
+            "rego"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -4909,7 +5369,11 @@
           "type": "boolean"
         },
         "detect_extensions": {
-          "default": ["pl", "pm", "pod"],
+          "default": [
+            "pl",
+            "pm",
+            "pod"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -4964,14 +5428,19 @@
           "type": "boolean"
         },
         "detect_extensions": {
-          "default": ["php"],
+          "default": [
+            "php"
+          ],
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "detect_files": {
-          "default": ["composer.json", ".php-version"],
+          "default": [
+            "composer.json",
+            ".php-version"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -5022,7 +5491,9 @@
       "type": "object",
       "properties": {
         "pixi_binary": {
-          "default": ["pixi"],
+          "default": [
+            "pixi"
+          ],
           "allOf": [
             {
               "$ref": "#/definitions/Either_for_String_and_Array_of_String"
@@ -5042,7 +5513,7 @@
           "type": "string"
         },
         "symbol": {
-          "default": "📦 ",
+          "default": "🧚 ",
           "type": "string"
         },
         "style": {
@@ -5053,8 +5524,25 @@
           "default": false,
           "type": "boolean"
         },
+        "detect_extensions": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "detect_files": {
-          "default": ["pixi.toml", "pixi.lock"],
+          "default": [
+            "pixi.toml",
+            "pixi.lock"
+          ],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "detect_folders": {
+          "default": [],
           "type": "array",
           "items": {
             "type": "string"
@@ -5130,14 +5618,20 @@
           "type": "boolean"
         },
         "detect_extensions": {
-          "default": ["purs"],
+          "default": [
+            "purs"
+          ],
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "detect_files": {
-          "default": ["spago.dhall", "spago.yaml", "spago.lock"],
+          "default": [
+            "spago.dhall",
+            "spago.yaml",
+            "spago.lock"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -5165,7 +5659,17 @@
           "type": "string"
         },
         "python_binary": {
-          "default": [["python"], ["python3"], ["python2"]],
+          "default": [
+            [
+              "python"
+            ],
+            [
+              "python3"
+            ],
+            [
+              "python2"
+            ]
+          ],
           "allOf": [
             {
               "$ref": "#/definitions/Either_for_Either_for_String_and_Array_of_String_and_Array_of_Either_for_String_and_Array_of_String"
@@ -5193,7 +5697,10 @@
           "type": "boolean"
         },
         "detect_extensions": {
-          "default": ["py", "ipynb"],
+          "default": [
+            "py",
+            "ipynb"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -5222,7 +5729,9 @@
           }
         },
         "detect_env_vars": {
-          "default": ["VIRTUAL_ENV"],
+          "default": [
+            "VIRTUAL_ENV"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -5240,19 +5749,6 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/Either_for_String_and_Array_of_String"
-          }
-        }
-      ]
-    },
-    "Either_for_String_and_Array_of_String": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "array",
-          "items": {
-            "type": "string"
           }
         }
       ]
@@ -5281,14 +5777,18 @@
           "type": "boolean"
         },
         "detect_extensions": {
-          "default": ["qmd"],
+          "default": [
+            "qmd"
+          ],
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "detect_files": {
-          "default": ["_quarto.yml"],
+          "default": [
+            "_quarto.yml"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -5328,14 +5828,22 @@
           "type": "boolean"
         },
         "detect_extensions": {
-          "default": ["p6", "pm6", "pod6", "raku", "rakumod"],
+          "default": [
+            "p6",
+            "pm6",
+            "pod6",
+            "raku",
+            "rakumod"
+          ],
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "detect_files": {
-          "default": ["META6.json"],
+          "default": [
+            "META6.json"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -5375,7 +5883,10 @@
           "type": "boolean"
         },
         "detect_extensions": {
-          "default": ["red", "reds"],
+          "default": [
+            "red",
+            "reds"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -5422,21 +5933,31 @@
           "type": "boolean"
         },
         "detect_extensions": {
-          "default": ["R", "Rd", "Rmd", "Rproj", "Rsx"],
+          "default": [
+            "R",
+            "Rd",
+            "Rmd",
+            "Rproj",
+            "Rsx"
+          ],
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "detect_files": {
-          "default": ["DESCRIPTION"],
+          "default": [
+            "DESCRIPTION"
+          ],
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "detect_folders": {
-          "default": [".Rproj.user"],
+          "default": [
+            ".Rproj.user"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -5469,14 +5990,19 @@
           "type": "boolean"
         },
         "detect_extensions": {
-          "default": ["rb"],
+          "default": [
+            "rb"
+          ],
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "detect_files": {
-          "default": ["Gemfile", ".ruby-version"],
+          "default": [
+            "Gemfile",
+            ".ruby-version"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -5490,7 +6016,10 @@
           }
         },
         "detect_variables": {
-          "default": ["RUBY_VERSION", "RBENV_VERSION"],
+          "default": [
+            "RUBY_VERSION",
+            "RBENV_VERSION"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -5523,14 +6052,18 @@
           "type": "boolean"
         },
         "detect_extensions": {
-          "default": ["rs"],
+          "default": [
+            "rs"
+          ],
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "detect_files": {
-          "default": ["Cargo.toml"],
+          "default": [
+            "Cargo.toml"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -5570,21 +6103,30 @@
           "type": "string"
         },
         "detect_extensions": {
-          "default": ["sbt", "scala"],
+          "default": [
+            "sbt",
+            "scala"
+          ],
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "detect_files": {
-          "default": [".scalaenv", ".sbtenv", "build.sbt"],
+          "default": [
+            ".scalaenv",
+            ".sbtenv",
+            "build.sbt"
+          ],
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "detect_folders": {
-          "default": [".metals"],
+          "default": [
+            ".metals"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -5617,7 +6159,10 @@
           "type": "string"
         },
         "pwsh_indicator": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "ion_indicator": {
           "default": "ion",
@@ -5741,7 +6286,9 @@
           "type": "string"
         },
         "compiler": {
-          "default": ["solc"],
+          "default": [
+            "solc"
+          ],
           "allOf": [
             {
               "$ref": "#/definitions/Either_for_String_and_Array_of_String"
@@ -5749,7 +6296,9 @@
           ]
         },
         "detect_extensions": {
-          "default": ["sol"],
+          "default": [
+            "sol"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -5836,10 +6385,16 @@
           "type": "string"
         },
         "success_style": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "failure_style": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "map_symbol": {
           "default": false,
@@ -5862,7 +6417,10 @@
           "type": "string"
         },
         "pipestatus_segment_format": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "disabled": {
           "default": true,
@@ -5921,14 +6479,18 @@
           "type": "boolean"
         },
         "detect_extensions": {
-          "default": ["swift"],
+          "default": [
+            "swift"
+          ],
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "detect_files": {
-          "default": ["Package.swift"],
+          "default": [
+            "Package.swift"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -5968,7 +6530,11 @@
           "type": "boolean"
         },
         "detect_extensions": {
-          "default": ["tf", "tfplan", "tfstate"],
+          "default": [
+            "tf",
+            "tfplan",
+            "tfstate"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -5982,7 +6548,9 @@
           }
         },
         "detect_folders": {
-          "default": [".terraform"],
+          "default": [
+            ".terraform"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -6007,7 +6575,10 @@
           "type": "boolean"
         },
         "time_format": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "disabled": {
           "default": true,
@@ -6048,14 +6619,18 @@
           "type": "boolean"
         },
         "detect_extensions": {
-          "default": ["typ"],
+          "default": [
+            "typ"
+          ],
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "detect_files": {
-          "default": ["template.typ"],
+          "default": [
+            "template.typ"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -6142,7 +6717,9 @@
           }
         },
         "detect_files": {
-          "default": ["Vagrantfile"],
+          "default": [
+            "Vagrantfile"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -6204,14 +6781,20 @@
           "type": "boolean"
         },
         "detect_extensions": {
-          "default": ["v"],
+          "default": [
+            "v"
+          ],
           "type": "array",
           "items": {
             "type": "string"
           }
         },
         "detect_files": {
-          "default": ["v.mod", "vpkg.json", ".vpkg-lock.json"],
+          "default": [
+            "v.mod",
+            "vpkg.json",
+            ".vpkg-lock.json"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -6251,7 +6834,9 @@
           "type": "boolean"
         },
         "detect_extensions": {
-          "default": ["zig"],
+          "default": [
+            "zig"
+          ],
           "type": "array",
           "items": {
             "type": "string"
@@ -6343,10 +6928,16 @@
           }
         },
         "os": {
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "use_stdin": {
-          "type": ["boolean", "null"]
+          "type": [
+            "boolean",
+            "null"
+          ]
         },
         "ignore_timeout": {
           "default": false,

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -3710,7 +3710,7 @@ This does not suppress pixi's own prompt modifier, you may want to run `pixi con
 | `pixi_binary`              | `['pixi']`                                              | Configures the pixi binary that Starship should execute when getting the version. |
 | `detect_extensions`        | `[]`                                                    | Which extensions should trigger this module.                                      |
 | `detect_files`             | `['pixi.toml']`                                         | Which filenames should trigger this module.                                       |
-| `detect_folders`           | `['.pixi']`                                             | Which folders should trigger this module.                                         |
+| `detect_folders`           | `[]`                                                    | Which folders should trigger this module.                                         |
 | `disabled`                 | `false`                                                 | Disables the `pixi` module.                                                       |
 
 ### Variables

--- a/src/configs/pixi.rs
+++ b/src/configs/pixi.rs
@@ -34,7 +34,7 @@ impl Default for PixiConfig<'_> {
             disabled: false,
             detect_extensions: vec![],
             detect_files: vec!["pixi.toml", "pixi.lock"],
-            detect_folders: vec![".pixi"],
+            detect_folders: vec![],
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description

follow-up of #6335.

I just noticed that this also triggers in `~` because there is a `.pixi` directory present as well but isn't a pixi project.

This directory is a special case that contains configuration files of pixi, the module shouldn't be triggered in `~`.
Since all pixi projects contain a `pixi.lock` anyway, removing this shouldn't produce any new issues.

Closes #6707

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
