### PR TITLE
Fix when starship would dissapear while having installed bash-preexec and bashrc was reloaded (and PS1 was set beforehand)

### DIFF
--- a/src/init/starship.bash
+++ b/src/init/starship.bash
@@ -92,8 +92,7 @@ if [[ ${BLE_VERSION-} && _ble_version -ge 400 ]]; then
     blehook PRECMD!='starship_precmd'
 # If the user appears to be using https://github.com/rcaloras/bash-preexec,
 # then hook our functions into their framework.
-elif [[ -n "${bash_preexec_imported:-}" || -n "${__bp_imported:-}" || -n "${preexec_functions-}" || -n "${precmd_functions-}" ]]; then
-    # bash-preexec needs a single function--wrap the args into a closure and pass
+elif [[ -n "${bash_preexec_imported:-}" || -n "${__bp_imported:-}" || -n "${preexec_functions-}" || -n "${precmd_functions-}" ]] && ! ([[ "${preexec_functions[@]}" =~ "starship_preexec_all" ]] || [[ "${precmd_functions[@]}" =~ "starship_precmd" ]]); then    # bash-preexec needs a single function--wrap the args into a closure and pass
     starship_preexec_all(){ starship_preexec "$_"; }
     preexec_functions+=(starship_preexec_all)
     precmd_functions+=(starship_precmd)


### PR DESCRIPTION
#### Description

In certain scenarios, when PS1 is being set and bash-preexec is installed, when ~/.bashrc is reloaded starship prompt would dissapear. This was because starship.bash did not check whether starship_preexec_all / starship_precmd where already loaded by bash-preexec and would constantly rerun the block of code where it would add said functions to `preexec_functions / precmd_functions`

Issue reference: [#6702](https://github.com/starship/starship/issues/6702)

#### How Has This Been Tested?
I have put the output of `starship init bash --print-full-init` in a file and sourced it before and after sourcing [bash-preexec.sh](https://github.com/rcaloras/bash-preexec) while having set PS1 beforehand.

Before this edit - starship dissapeared when resourcing - `source ~/.bashrc`
After this edit: issue gone

Testing environment referenced in issue.

- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.