### PR TITLE
feat: skip installation opportunistically based on installed version

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,8 @@ use starship::*;
 #[derive(Parser, Debug)]
 #[clap(
     author=crate_authors!(),
+    // NOTE: Do not change the output format of the `-V` option,
+    // as `install.sh` uses it to determine the installed version.
     version=shadow::PKG_VERSION,
     long_version=shadow::CLAP_LONG_VERSION,
     about="The cross-shell prompt for astronauts. ☄🌌️",


### PR DESCRIPTION
#### Description
This PR aims to optimize and streamline the installation/update process carried out by `install.sh`. Specifically, the proposed changes allow installation to be skipped entirely under one of the following conditions:
1) `install.sh` is run to install or update to the latest version, but it is already installed.
2) `install.sh` is run with the [`--version`](https://github.com/starship/starship/pull/5728) option to install a specific version, but that version is already installed.

The first scenario entails resolving the `latest` release to an actual release tag, which is done cleanly by querying the relevant public API endpoint, and in a way that is compatible with not only GitHub, but other code forges alike, which plays well with the existing `--base-url` design.

Extra care has been taken to ensure the introduced changes are robust, well-documented, consistent with the existing coding style, and cross-platform compatible.

#### Motivation and Context
Closes #6696

#### Screenshots (if appropriate):

#### How Has This Been Tested?
- ShellCheck has been used for static analysis, and no errors or warnings were reported.
- Manual testing has also been conducted thoroughly, covering a wide range of use cases.
- [x] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
