### PR TITLE
docs: fix `pixi` command to change ps1.

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -945,7 +945,7 @@ The `conda` module shows the current [Conda](https://docs.conda.io/en/latest/) e
 ::: tip
 
 This does not suppress conda's own prompt modifier, you may want to run `conda config --set changeps1 False`.
-If you use [pixi](https://pixi.sh), you can disable pixi's prompt modifier by running `pixi config set change-ps1 false`.
+If you use [pixi](https://pixi.sh), you can disable pixi's prompt modifier by running `pixi config set shell.change-ps1 false`.
 
 :::
 
@@ -3694,7 +3694,7 @@ The `pixi` module shows the installed [pixi](https://pixi.sh) version as well as
 
 ::: tip
 
-This does not suppress pixi's own prompt modifier, you may want to run `pixi config set change-ps1 false`.
+This does not suppress pixi's own prompt modifier, you may want to run `pixi config set shell.change-ps1 false`.
 
 :::
 


### PR DESCRIPTION
#### Description
Hello there,

I've fixed the `pixi` command to update ps1 in the docs.
More precisely: `pixi config set change-ps1 false` → `pixi config set shell.change-ps1 false`.

#### Motivation and Context
`pixi config set change-ps1 false` is now deprecated.

#### How Has This Been Tested?
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
