### PR TITLE
docs(security): add initial security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,29 @@
+# Security Reporting
+
+If you wish to report a security vulnerability privately, we appreciate your diligence. Please follow the guidelines below to submit your report.
+
+## Reporting
+
+To report a security vulnerability, please provide the following information:
+
+1. **PUBLIC**
+   - Indicate whether this vulnerability has already been publicly discussed or disclosed.
+   - If so, provide relevant links.
+
+2. **DESCRIPTION**
+   - Provide a detailed description of the security vulnerability.
+   - Include as much information as possible to help us understand and address the issue.
+
+Report this, along with any additional relevant details in [GitHub Advisory](https://github.com/starship/starship/security/advisories/new).
+
+## Confidentiality
+
+We kindly ask you to keep the report confidential until a public announcement is made.
+
+## Notes
+
+- Vulnerabilities will be handled on a best-effort basis.
+- You will be notified, via your GitHub Advisory report, about eventual patches.
+- We will respond within a few weeks to confirm whether your report has been accepted or rejected.
+
+Thank you for helping to improve the security of Starship!


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
This PR adds a SECURITY.md file, battle tested in other projects and orgs, (the construct is CCO ie public domain, for example from here https://raw.githubusercontent.com/itiquette/git-provider-sync/refs/heads/main/SECURITY.md so just reuse)


NOTE: there is a <...> in the text, where the preferred channel for reporting should be added I left that for you, (or tell me what to add there, and I'll rebase with that).

NOTE: I had this in multiple orgs and projects over the years. Once I had a report, so I dont think you should be worry about getting to much reports from this, this is at least my experience.

#### Motivation and Context

A SECURITY.md would help anyone assessing the project for use, give a hint of how it handles critical no public security issues, and give anyone a clear instruction on how to report them non public.

**IE, for someone thinking about using starship in an organisation or privately it would give an extra trust factor.**

This policy basically  says "send your findings, and we will see if we handle them, we will notify you".

Besides, being a good FOSS practice, makes the project look more professional and it is heavily supported by GitHub https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file etc as one of the community health files, so it will pop up automatically in the ui for the end user. 



#### Screenshots (if appropriate):

Examples from the github UI (when added):

Security Tab in project front will be added automatically
![Skärmbild från 2025-05-11 05-57-27](https://github.com/user-attachments/assets/db47a7d5-1c70-400c-bbca-46f8949995b8)


Security Policy in the top right corner of UI will be added automatically

![Skärmbild från 2025-05-11 05-58-05](https://github.com/user-attachments/assets/85afc0d8-df10-4091-bfec-612560f72bf3)

Security Policy under Security Overview for the project will have the Security Policy green and enabled.
![Skärmbild från 2025-05-11 05-58-23](https://github.com/user-attachments/assets/3162ee7d-7990-4029-9186-0e2d0538d64b)

#### How Has This Been Tested?
In the GitHub UI!! It is just a communityhealth file. And linted by a markdownlinter.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [N/A] I have updated the tests accordingly.
