### PR TITLE
feat: adding time to duration

### DIFF
--- a/src/configs/cmd_duration.rs
+++ b/src/configs/cmd_duration.rs
@@ -16,6 +16,7 @@ pub struct CmdDurationConfig<'a> {
     pub show_notifications: bool,
     pub min_time_to_notify: i64,
     pub show_time_end: bool,
+    pub show_full_time_min_seconds: u64,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub notification_timeout: Option<u32>,
@@ -33,6 +34,7 @@ impl Default for CmdDurationConfig<'_> {
             min_time_to_notify: 45_000,
             notification_timeout: None,
             show_time_end: false,
+            show_full_time_min_seconds: 43200, // 12 hours
         }
     }
 }

--- a/src/configs/cmd_duration.rs
+++ b/src/configs/cmd_duration.rs
@@ -15,6 +15,7 @@ pub struct CmdDurationConfig<'a> {
     pub disabled: bool,
     pub show_notifications: bool,
     pub min_time_to_notify: i64,
+    pub show_time_end: bool,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub notification_timeout: Option<u32>,
@@ -31,6 +32,7 @@ impl Default for CmdDurationConfig<'_> {
             show_notifications: false,
             min_time_to_notify: 45_000,
             notification_timeout: None,
+            show_time_end: false,
         }
     }
 }

--- a/src/modules/cmd_duration.rs
+++ b/src/modules/cmd_duration.rs
@@ -31,9 +31,9 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let duration_str = render_time(elapsed, config.show_milliseconds);
     let formatted = if config.show_time_end {
         let time_end = if elapsed >= config.show_full_time_min_seconds as u128 * 1000 {
-                Local::now().format("%Y-%m-%d %H:%M:%S").to_string()
-            } else {
-                Local::now().format("%H:%M:%S").to_string()
+            Local::now().format("%Y-%m-%d %H:%M:%S").to_string()
+        } else {
+            Local::now().format("%H:%M:%S").to_string()
         };
         format!("{duration_str} ending {time_end}")
     } else {

--- a/src/modules/cmd_duration.rs
+++ b/src/modules/cmd_duration.rs
@@ -30,8 +30,12 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
     let duration_str = render_time(elapsed, config.show_milliseconds);
     let formatted = if config.show_time_end {
-        let time_end = Local::now().format("ending %H:%M:%S").to_string();
-        format!("{duration_str} {time_end}")
+        let time_end = if elapsed >= config.show_full_time_min_seconds as u128 * 1000 {
+                Local::now().format("%Y-%m-%d %H:%M:%S").to_string()
+            } else {
+                Local::now().format("%H:%M:%S").to_string()
+        };
+        format!("{duration_str} ending {time_end}")
     } else {
         duration_str
     };

--- a/src/modules/cmd_duration.rs
+++ b/src/modules/cmd_duration.rs
@@ -3,6 +3,7 @@ use super::{Context, Module, ModuleConfig};
 use crate::configs::cmd_duration::CmdDurationConfig;
 use crate::formatter::StringFormatter;
 use crate::utils::render_time;
+use chrono::Local;
 
 /// Outputs the time it took the last command to execute
 ///
@@ -27,6 +28,14 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         return None;
     }
 
+    let duration_str = render_time(elapsed, config.show_milliseconds);
+    let formatted = if config.show_time_end {
+        let time_end = Local::now().format("ending %H:%M:%S").to_string();
+        format!("{duration_str} {time_end}")
+    } else {
+        duration_str
+    };
+
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter
             .map_style(|variable| match variable {
@@ -34,7 +43,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 _ => None,
             })
             .map(|variable| match variable {
-                "duration" => Some(Ok(render_time(elapsed, config.show_milliseconds))),
+                "duration" => Some(Ok(formatted.clone())),
                 _ => None,
             })
             .parse(None, Some(context))


### PR DESCRIPTION
When `show_time_end` config is `true` in [cmd_duration] the end time is also shown after duration `took 3s ending 18:03:31`.

#### Description
Modified {modules,config}/cmd_duration.rs, using localtime via Chrono

#### Motivation and Context
Personal need to have also time ending (not only duration) shown for long processes (e.g. builds)

#### How Has This Been Tested?

Manual test, via `test`. Minor modification.

- [ ] I have tested using **MacOS**
- [ x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
