### PR TITLE
style: use inline format args (clippy::uninlined_format_args)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -32,7 +32,7 @@ where
         match Self::from_config(config) {
             Ok(config) => config,
             Err(e) => {
-                log::warn!("Failed to load config value: {}", e);
+                log::warn!("Failed to load config value: {e}");
                 Self::default()
             }
         }
@@ -54,7 +54,7 @@ impl<'a, T: Deserialize<'a> + Default> ModuleConfig<'a, ValueError> for T {
             // If the error is an unrecognized key, print a warning and run
             // deserialize ignoring that error. Otherwise, just return the error
             if err.to_string().contains("Unknown key") {
-                log::warn!("{}", err);
+                log::warn!("{err}");
                 let deserializer2 = ValueDeserializer::new(config).with_allow_unknown_keys();
                 T::deserialize(deserializer2)
             } else {
@@ -141,7 +141,7 @@ impl StarshipConfig {
                 Some(parsed)
             }
             Err(error) => {
-                log::error!("Unable to parse the config file: {}", error);
+                log::error!("Unable to parse the config file: {error}");
                 None
             }
         }
@@ -445,36 +445,29 @@ fn parse_color_string(
     palette: Option<&Palette>,
 ) -> Option<nu_ansi_term::Color> {
     // Parse RGB hex values
-    log::trace!("Parsing color_string: {}", color_string);
+    log::trace!("Parsing color_string: {color_string}");
     if color_string.starts_with('#') {
-        log::trace!(
-            "Attempting to read hexadecimal color string: {}",
-            color_string
-        );
+        log::trace!("Attempting to read hexadecimal color string: {color_string}");
         if color_string.len() != 7 {
-            log::debug!("Could not parse hexadecimal string: {}", color_string);
+            log::debug!("Could not parse hexadecimal string: {color_string}");
             return None;
         }
         let r: u8 = u8::from_str_radix(&color_string[1..3], 16).ok()?;
         let g: u8 = u8::from_str_radix(&color_string[3..5], 16).ok()?;
         let b: u8 = u8::from_str_radix(&color_string[5..7], 16).ok()?;
-        log::trace!("Read RGB color string: {},{},{}", r, g, b);
+        log::trace!("Read RGB color string: {r},{g},{b}");
         return Some(Color::Rgb(r, g, b));
     }
 
     // Parse a u8 (ansi color)
     if let Result::Ok(ansi_color_num) = color_string.parse::<u8>() {
-        log::trace!("Read ANSI color string: {}", ansi_color_num);
+        log::trace!("Read ANSI color string: {ansi_color_num}");
         return Some(Color::Fixed(ansi_color_num));
     }
 
     // Check palette for a matching user-defined color
     if let Some(palette_color) = palette.as_ref().and_then(|x| x.get(color_string)) {
-        log::trace!(
-            "Read user-defined color string: {} defined as {}",
-            color_string,
-            palette_color
-        );
+        log::trace!("Read user-defined color string: {color_string} defined as {palette_color}");
         return parse_color_string(palette_color, None);
     }
 
@@ -501,9 +494,9 @@ fn parse_color_string(
     };
 
     if predefined_color.is_some() {
-        log::trace!("Read predefined color: {}", color_string);
+        log::trace!("Read predefined color: {color_string}");
     } else {
-        log::debug!("Could not parse color in string: {}", color_string);
+        log::debug!("Could not parse color in string: {color_string}");
     }
     predefined_color
 }
@@ -515,9 +508,9 @@ fn get_palette<'a>(
     if let Some(palette_name) = palette_name {
         let palette = palettes.get(palette_name);
         if palette.is_some() {
-            log::trace!("Found color palette: {}", palette_name);
+            log::trace!("Found color palette: {palette_name}");
         } else {
-            log::warn!("Could not find color palette: {}", palette_name);
+            log::warn!("Could not find color palette: {palette_name}");
         }
         palette
     } else {

--- a/src/context.rs
+++ b/src/context.rs
@@ -411,11 +411,7 @@ impl<'a> Context<'a> {
         cmd: T,
         args: &[U],
     ) -> Option<CommandOutput> {
-        log::trace!(
-            "Executing command {:?} with args {:?} from context",
-            cmd,
-            args
-        );
+        log::trace!("Executing command {cmd:?} with args {args:?} from context");
         #[cfg(test)]
         {
             let command = crate::utils::display_command(&cmd, args);
@@ -698,7 +694,7 @@ impl Repo {
         }
 
         command.args(git_args);
-        log::trace!("Executing git command: {:?}", command);
+        log::trace!("Executing git command: {command:?}");
 
         exec_timeout(
             &mut command,

--- a/src/formatter/version.rs
+++ b/src/formatter/version.rs
@@ -70,7 +70,7 @@ impl<'a> VersionFormatter<'a> {
         match VersionFormatter::format_version(version, version_format) {
             Ok(formatted) => Some(formatted),
             Err(error) => {
-                log::warn!("Error formatting `{}` version:\n{}", module_name, error);
+                log::warn!("Error formatting `{module_name}` version:\n{error}");
                 Some(format!("v{version}"))
             }
         }

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -65,7 +65,7 @@ impl StarshipPath {
             Ok(output) => output,
             Err(e) => {
                 if e.kind() != io::ErrorKind::NotFound {
-                    log::warn!("Failed to convert \"{}\" to unix path:\n{:?}", str_path, e);
+                    log::warn!("Failed to convert \"{str_path}\" to unix path:\n{e:?}");
                 }
                 // Failed to execute cygpath.exe means there're not inside cygwin environment,return directly.
                 return self.sprint();
@@ -83,7 +83,7 @@ impl StarshipPath {
                 str_path
             }
             Err(e) => {
-                log::warn!("Failed to convert \"{}\" to unix path:\n{}", str_path, e);
+                log::warn!("Failed to convert \"{str_path}\" to unix path:\n{e}");
                 str_path
             }
         };
@@ -95,7 +95,7 @@ impl StarshipPath {
 init code. The stub produces the main init script, then evaluates it with
 `source` and process substitution */
 pub fn init_stub(shell_name: &str) -> io::Result<()> {
-    log::debug!("Shell name: {}", shell_name);
+    log::debug!("Shell name: {shell_name}");
 
     let shell_basename = Path::new(shell_name)
         .file_stem()

--- a/src/main.rs
+++ b/src/main.rs
@@ -191,7 +191,7 @@ fn main() {
             std::process::exit(exit_code);
         }
     };
-    log::trace!("Parsed arguments: {:#?}", args);
+    log::trace!("Parsed arguments: {args:#?}");
 
     match args.command {
         Commands::Init {

--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -293,7 +293,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `aws`: \n{}", error);
+            log::warn!("Error in module `aws`: \n{error}");
             return None;
         }
     });

--- a/src/modules/azure.rs
+++ b/src/modules/azure.rs
@@ -70,7 +70,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `azure`:\n{}", error);
+            log::warn!("Error in module `azure`:\n{error}");
             return None;
         }
     });

--- a/src/modules/battery.rs
+++ b/src/modules/battery.rs
@@ -56,13 +56,13 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                     Some(module)
                 }
                 Err(e) => {
-                    log::warn!("Cannot parse `battery.format`: {}", e);
+                    log::warn!("Cannot parse `battery.format`: {e}");
                     None
                 }
             }
         }
         Err(e) => {
-            log::warn!("Cannot load `battery.format`: {}", e);
+            log::warn!("Cannot load `battery.format`: {e}");
             None
         }
     }
@@ -75,7 +75,7 @@ fn get_battery_status(context: &Context) -> Option<BatteryStatus> {
             percentage: battery_info.energy / battery_info.energy_full * 100.0,
             state: battery_info.state,
         };
-        log::debug!("Battery status: {:?}", battery);
+        log::debug!("Battery status: {battery:?}");
         Some(battery)
     } else {
         None
@@ -131,7 +131,7 @@ impl BatteryInfoProvider for BatteryInfoProviderImpl {
             batteries
                 .filter_map(|battery| match battery {
                     Ok(battery) => {
-                        log::debug!("Battery found: {:?}", battery);
+                        log::debug!("Battery found: {battery:?}");
 
                         let charge_rate = battery.state_of_charge().value;
                         let energy_full = battery.energy_full().value;

--- a/src/modules/buf.rs
+++ b/src/modules/buf.rs
@@ -47,7 +47,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `buf`:\n{}", error);
+            log::warn!("Error in module `buf`:\n{error}");
             return None;
         }
     });

--- a/src/modules/bun.rs
+++ b/src/modules/bun.rs
@@ -49,7 +49,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `bun`:\n{}", error);
+            log::warn!("Error in module `bun`:\n{error}");
             return None;
         }
     });

--- a/src/modules/cc.rs
+++ b/src/modules/cc.rs
@@ -100,7 +100,7 @@ fn create_module<'a, T>(
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `cc` for `lang: {}` :\n{}", lang, error);
+            log::warn!("Error in module `cc` for `lang: {lang}` :\n{error}");
             return None;
         }
     });

--- a/src/modules/character.rs
+++ b/src/modules/character.rs
@@ -70,7 +70,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `character`:\n{}", error);
+            log::warn!("Error in module `character`:\n{error}");
             return None;
         }
     });

--- a/src/modules/cmake.rs
+++ b/src/modules/cmake.rs
@@ -49,7 +49,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `cmake`: \n{}", error);
+            log::warn!("Error in module `cmake`: \n{error}");
             return None;
         }
     });

--- a/src/modules/cmd_duration.rs
+++ b/src/modules/cmd_duration.rs
@@ -43,7 +43,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `cmd_duration`: \n{}", error);
+            log::warn!("Error in module `cmd_duration`: \n{error}");
             return None;
         }
     });
@@ -101,7 +101,7 @@ fn undistract_me<'a>(
             .timeout(timeout);
 
         if let Err(err) = notification.show() {
-            log::trace!("Cannot show notification: {}", err);
+            log::trace!("Cannot show notification: {err}");
         }
     }
 

--- a/src/modules/cobol.rs
+++ b/src/modules/cobol.rs
@@ -49,7 +49,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `cobol`:\n{}", error);
+            log::warn!("Error in module `cobol`:\n{error}");
             return None;
         }
     });

--- a/src/modules/conda.rs
+++ b/src/modules/conda.rs
@@ -46,7 +46,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `conda`:\n{}", error);
+            log::warn!("Error in module `conda`:\n{error}");
             return None;
         }
     });

--- a/src/modules/container.rs
+++ b/src/modules/container.rs
@@ -101,7 +101,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `container`: \n{}", error);
+            log::warn!("Error in module `container`: \n{error}");
             return None;
         }
     });

--- a/src/modules/crystal.rs
+++ b/src/modules/crystal.rs
@@ -50,7 +50,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `crystal`:\n{}", error);
+            log::warn!("Error in module `crystal`:\n{error}");
             return None;
         }
     });

--- a/src/modules/custom.rs
+++ b/src/modules/custom.rs
@@ -96,7 +96,7 @@ pub fn module<'a>(name: &str, context: &'a Context) -> Option<Module<'a>> {
     match parsed {
         Ok(segments) => module.set_segments(segments),
         Err(error) => {
-            log::warn!("Error in module `custom.{}`:\n{}", name, error);
+            log::warn!("Error in module `custom.{name}`:\n{error}");
         }
     };
     Some(module)
@@ -157,8 +157,7 @@ fn shell_command(cmd: &str, config: &CustomConfig, context: &Context) -> Option<
         // Don't attempt to use fallback shell if the user specified a shell
         Err(error) if !shell_args.is_empty() => {
             log::debug!(
-                "Error creating command with STARSHIP_SHELL, falling back to fallback shell: {}",
-                error
+                "Error creating command with STARSHIP_SHELL, falling back to fallback shell: {error}"
             );
 
             // Skip `handle_shell` and just set the shell and command
@@ -194,8 +193,7 @@ fn shell_command(cmd: &str, config: &CustomConfig, context: &Context) -> Option<
         Ok(child) => child,
         Err(error) => {
             log::debug!(
-                "Failed to run command with given shell or STARSHIP_SHELL env variable:: {}",
-                error
+                "Failed to run command with given shell or STARSHIP_SHELL env variable:: {error}"
             );
             return None;
         }
@@ -227,7 +225,7 @@ fn shell_command(cmd: &str, config: &CustomConfig, context: &Context) -> Option<
 
 /// Execute the given command capturing all output, and return whether it return 0
 fn exec_when(cmd: &str, config: &CustomConfig, context: &Context) -> bool {
-    log::trace!("Running '{}'", cmd);
+    log::trace!("Running '{cmd}'");
 
     if let Some(output) = shell_command(cmd, config, context) {
         if !output.status.success() {

--- a/src/modules/daml.rs
+++ b/src/modules/daml.rs
@@ -50,7 +50,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `daml`:\n{}", error);
+            log::warn!("Error in module `daml`:\n{error}");
             return None;
         }
     });

--- a/src/modules/dart.rs
+++ b/src/modules/dart.rs
@@ -50,7 +50,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `dart`:\n{}", error);
+            log::warn!("Error in module `dart`:\n{error}");
             return None;
         }
     });

--- a/src/modules/deno.rs
+++ b/src/modules/deno.rs
@@ -48,7 +48,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `deno`:\n{}", error);
+            log::warn!("Error in module `deno`:\n{error}");
             return None;
         }
     });

--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -165,7 +165,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `directory`:\n{}", error);
+            log::warn!("Error in module `directory`:\n{error}");
             return None;
         }
     });
@@ -195,11 +195,7 @@ fn is_readonly_dir(path: &Path) -> bool {
     match directory_utils::is_write_allowed(path) {
         Ok(res) => !res,
         Err(e) => {
-            log::debug!(
-                "Failed to determine read only status of directory '{:?}': {}",
-                path,
-                e
-            );
+            log::debug!("Failed to determine read only status of directory '{path:?}': {e}");
             false
         }
     }

--- a/src/modules/docker_context.rs
+++ b/src/modules/docker_context.rs
@@ -82,7 +82,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `docker_context`:\n{}", error);
+            log::warn!("Error in module `docker_context`:\n{error}");
             return None;
         }
     });

--- a/src/modules/dotnet.rs
+++ b/src/modules/dotnet.rs
@@ -79,7 +79,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `dotnet`:\n{}", error);
+            log::warn!("Error in module `dotnet`:\n{error}");
             return None;
         }
     });

--- a/src/modules/elixir.rs
+++ b/src/modules/elixir.rs
@@ -61,7 +61,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `elixir`:\n{}", error);
+            log::warn!("Error in module `elixir`:\n{error}");
             return None;
         }
     });

--- a/src/modules/elm.rs
+++ b/src/modules/elm.rs
@@ -48,7 +48,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `elm`:\n{}", error);
+            log::warn!("Error in module `elm`:\n{error}");
             return None;
         }
     });

--- a/src/modules/env_var.rs
+++ b/src/modules/env_var.rs
@@ -61,7 +61,7 @@ pub fn module<'a>(name: Option<&str>, context: &'a Context) -> Option<Module<'a>
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `env_var`:\n{}", error);
+            log::warn!("Error in module `env_var`:\n{error}");
             return None;
         }
     });

--- a/src/modules/erlang.rs
+++ b/src/modules/erlang.rs
@@ -48,7 +48,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `erlang`:\n{}", error);
+            log::warn!("Error in module `erlang`:\n{error}");
             return None;
         }
     });

--- a/src/modules/fennel.rs
+++ b/src/modules/fennel.rs
@@ -49,7 +49,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `fennel`:\n{}", error);
+            log::warn!("Error in module `fennel`:\n{error}");
             return None;
         }
     });

--- a/src/modules/fossil_branch.rs
+++ b/src/modules/fossil_branch.rs
@@ -63,7 +63,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `fossil_branch`:\n{}", error);
+            log::warn!("Error in module `fossil_branch`:\n{error}");
             return None;
         }
     });

--- a/src/modules/fossil_metrics.rs
+++ b/src/modules/fossil_metrics.rs
@@ -52,7 +52,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `fossil_metrics`:\n{}", error);
+            log::warn!("Error in module `fossil_metrics`:\n{error}");
             return None;
         }
     });

--- a/src/modules/gcloud.rs
+++ b/src/modules/gcloud.rs
@@ -141,7 +141,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::error!("Error in module `gcloud`: \n{}", error);
+            log::error!("Error in module `gcloud`: \n{error}");
             return None;
         }
     });

--- a/src/modules/git_branch.rs
+++ b/src/modules/git_branch.rs
@@ -104,7 +104,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `git_branch`: \n{}", error);
+            log::warn!("Error in module `git_branch`: \n{error}");
             return None;
         }
     });

--- a/src/modules/git_commit.rs
+++ b/src/modules/git_commit.rs
@@ -42,7 +42,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `git_commit`:\n{}", error);
+            log::warn!("Error in module `git_commit`:\n{error}");
             return None;
         }
     });

--- a/src/modules/git_metrics.rs
+++ b/src/modules/git_metrics.rs
@@ -264,7 +264,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `git_metrics`:\n{}", error);
+            log::warn!("Error in module `git_metrics`:\n{error}");
             return None;
         }
     });

--- a/src/modules/git_state.rs
+++ b/src/modules/git_state.rs
@@ -39,7 +39,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `git_state`:\n{}", error);
+            log::warn!("Error in module `git_state`:\n{error}");
             return None;
         }
     });

--- a/src/modules/git_status.rs
+++ b/src/modules/git_status.rs
@@ -123,7 +123,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             }
         }
         Err(error) => {
-            log::warn!("Error in module `git_status`:\n{}", error);
+            log::warn!("Error in module `git_status`:\n{error}");
             return None;
         }
     });
@@ -676,7 +676,7 @@ fn git_status_wsl(context: &Context, conf: &GitStatusConfig) -> Option<String> {
                 log::Level::Error
             };
 
-            log::log!(level, "Failed to get Windows path:\n{:?}", e);
+            log::log!(level, "Failed to get Windows path:\n{e:?}");
 
             return None;
         }
@@ -685,13 +685,13 @@ fn git_status_wsl(context: &Context, conf: &GitStatusConfig) -> Option<String> {
     let winpath = match std::str::from_utf8(&winpath.stdout) {
         Ok(r) => r.trim_end(),
         Err(e) => {
-            log::error!("Failed to parse Windows path:\n{:?}", e);
+            log::error!("Failed to parse Windows path:\n{e:?}");
 
             return None;
         }
     };
 
-    log::trace!("Windows path: {}", winpath);
+    log::trace!("Windows path: {winpath}");
 
     // In Windows or Linux dir?
     if winpath.starts_with(r"\\wsl") {
@@ -723,7 +723,7 @@ fn git_status_wsl(context: &Context, conf: &GitStatusConfig) -> Option<String> {
     let out = match exe {
         Ok(r) => r,
         Err(e) => {
-            log::error!("Failed to run Git Status module on Windows:\n{}", e);
+            log::error!("Failed to run Git Status module on Windows:\n{e}");
 
             return None;
         }
@@ -732,10 +732,7 @@ fn git_status_wsl(context: &Context, conf: &GitStatusConfig) -> Option<String> {
     match String::from_utf8(out.stdout) {
         Ok(r) => Some(r),
         Err(e) => {
-            log::error!(
-                "Failed to parse Windows Git Status module status output:\n{}",
-                e
-            );
+            log::error!("Failed to parse Windows Git Status module status output:\n{e}");
 
             None
         }

--- a/src/modules/gleam.rs
+++ b/src/modules/gleam.rs
@@ -49,7 +49,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `gleam`:\n{}", error);
+            log::warn!("Error in module `gleam`:\n{error}");
             return None;
         }
     });

--- a/src/modules/golang.rs
+++ b/src/modules/golang.rs
@@ -74,7 +74,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `golang`:\n{}", error);
+            log::warn!("Error in module `golang`:\n{error}");
             return None;
         }
     });

--- a/src/modules/gradle.rs
+++ b/src/modules/gradle.rs
@@ -52,7 +52,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `gradle`:\n{}", error);
+            log::warn!("Error in module `gradle`:\n{error}");
             return None;
         }
     });

--- a/src/modules/guix_shell.rs
+++ b/src/modules/guix_shell.rs
@@ -33,7 +33,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `guix_shell`:\n{}", error);
+            log::warn!("Error in module `guix_shell`:\n{error}");
             return None;
         }
     });

--- a/src/modules/haskell.rs
+++ b/src/modules/haskell.rs
@@ -41,7 +41,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `haskell`:\n{}", error);
+            log::warn!("Error in module `haskell`:\n{error}");
             return None;
         }
     });

--- a/src/modules/haxe.rs
+++ b/src/modules/haxe.rs
@@ -52,7 +52,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `haxe`:\n{}", error);
+            log::warn!("Error in module `haxe`:\n{error}");
             return None;
         }
     });

--- a/src/modules/helm.rs
+++ b/src/modules/helm.rs
@@ -52,7 +52,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `helm`:\n{}", error);
+            log::warn!("Error in module `helm`:\n{error}");
             return None;
         }
     });

--- a/src/modules/hg_branch.rs
+++ b/src/modules/hg_branch.rs
@@ -64,7 +64,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `hg_branch`:\n{}", error);
+            log::warn!("Error in module `hg_branch`:\n{error}");
             return None;
         }
     });

--- a/src/modules/hostname.rs
+++ b/src/modules/hostname.rs
@@ -70,7 +70,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `hostname`:\n{}", error);
+            log::warn!("Error in module `hostname`:\n{error}");
             return None;
         }
     });

--- a/src/modules/java.rs
+++ b/src/modules/java.rs
@@ -52,7 +52,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `java`:\n{}", error);
+            log::warn!("Error in module `java`:\n{error}");
             return None;
         }
     });

--- a/src/modules/jobs.rs
+++ b/src/modules/jobs.rs
@@ -91,7 +91,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `jobs`:\n{}", error);
+            log::warn!("Error in module `jobs`:\n{error}");
             return None;
         }
     });

--- a/src/modules/julia.rs
+++ b/src/modules/julia.rs
@@ -49,7 +49,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `julia`:\n{}", error);
+            log::warn!("Error in module `julia`:\n{error}");
             return None;
         }
     });

--- a/src/modules/kotlin.rs
+++ b/src/modules/kotlin.rs
@@ -52,7 +52,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `kotlin`:\n{}", error);
+            log::warn!("Error in module `kotlin`:\n{error}");
             return None;
         }
     });

--- a/src/modules/kubernetes.rs
+++ b/src/modules/kubernetes.rs
@@ -272,7 +272,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `kubernetes`: \n{}", error);
+            log::warn!("Error in module `kubernetes`: \n{error}");
             return None;
         }
     });

--- a/src/modules/localip.rs
+++ b/src/modules/localip.rs
@@ -70,7 +70,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `localip`:\n{}", error);
+            log::warn!("Error in module `localip`:\n{error}");
             return None;
         }
     });

--- a/src/modules/lua.rs
+++ b/src/modules/lua.rs
@@ -51,7 +51,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `lua`:\n{}", error);
+            log::warn!("Error in module `lua`:\n{error}");
             return None;
         }
     });

--- a/src/modules/memory_usage.rs
+++ b/src/modules/memory_usage.rs
@@ -62,13 +62,12 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         Ok((mem, _)) => (mem, None),
         Err(e) => {
             log::debug!(
-                "Failed to retrieve both memory and swap, falling back to memory only: {}",
-                e
+                "Failed to retrieve both memory and swap, falling back to memory only: {e}"
             );
             let mem = match system.memory() {
                 Ok(mem) => mem,
                 Err(e) => {
-                    log::warn!("Failed to retrieve memory: {}", e);
+                    log::warn!("Failed to retrieve memory: {e}");
                     return None;
                 }
             };
@@ -112,7 +111,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `memory_usage`:\n{}", error);
+            log::warn!("Error in module `memory_usage`:\n{error}");
             return None;
         }
     });

--- a/src/modules/meson.rs
+++ b/src/modules/meson.rs
@@ -43,7 +43,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `meson`:\n{}", error);
+            log::warn!("Error in module `meson`:\n{error}");
             return None;
         }
     });

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -231,7 +231,7 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
     };
 
     let elapsed = start.elapsed();
-    log::trace!("Took {:?} to compute module {:?}", elapsed, module);
+    log::trace!("Took {elapsed:?} to compute module {module:?}");
     if elapsed.as_millis() >= 1 {
         // If we take less than 1ms to compute a None, then we will not return a module at all
         // if we have a module: default duration is 0 so no need to change it

--- a/src/modules/mojo.rs
+++ b/src/modules/mojo.rs
@@ -50,7 +50,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `mojo`:\n{}", error);
+            log::warn!("Error in module `mojo`:\n{error}");
             return None;
         }
     });

--- a/src/modules/nats.rs
+++ b/src/modules/nats.rs
@@ -17,7 +17,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         .stdout;
     let nats_context: json::Value = json::from_str(&ctx_str)
         .map_err(|e| {
-            log::warn!("Error parsing nats context JSON: {}\n", e);
+            log::warn!("Error parsing nats context JSON: {e}\n");
             drop(e);
         })
         .ok()?;
@@ -42,7 +42,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `nats`:\n{}", error);
+            log::warn!("Error in module `nats`:\n{error}");
             return None;
         }
     });

--- a/src/modules/netns.rs
+++ b/src/modules/netns.rs
@@ -45,7 +45,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `netns`: \n{}", error);
+            log::warn!("Error in module `netns`: \n{error}");
             return None;
         }
     });
@@ -64,7 +64,7 @@ mod tests {
     #[cfg(target_os = "linux")]
     fn mock_ip_netns_identify(netns_name: &str) -> Option<CommandOutput> {
         Some(CommandOutput {
-            stdout: format!("{}\n", netns_name),
+            stdout: format!("{netns_name}\n"),
             stderr: String::new(),
         })
     }

--- a/src/modules/nim.rs
+++ b/src/modules/nim.rs
@@ -50,7 +50,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `nim`:\n{}", error);
+            log::warn!("Error in module `nim`:\n{error}");
             return None;
         }
     });

--- a/src/modules/nix_shell.rs
+++ b/src/modules/nix_shell.rs
@@ -90,7 +90,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `nix_shell`:\n{}", error);
+            log::warn!("Error in module `nix_shell`:\n{error}");
             return None;
         }
     });

--- a/src/modules/nodejs.rs
+++ b/src/modules/nodejs.rs
@@ -90,7 +90,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `nodejs`:\n{}", error);
+            log::warn!("Error in module `nodejs`:\n{error}");
             return None;
         }
     });

--- a/src/modules/ocaml.rs
+++ b/src/modules/ocaml.rs
@@ -79,7 +79,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `ocaml`: \n{}", error);
+            log::warn!("Error in module `ocaml`: \n{error}");
             return None;
         }
     });

--- a/src/modules/odin.rs
+++ b/src/modules/odin.rs
@@ -49,7 +49,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `odin`:\n{}", error);
+            log::warn!("Error in module `odin`:\n{error}");
             return None;
         }
     });

--- a/src/modules/opa.rs
+++ b/src/modules/opa.rs
@@ -50,7 +50,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `opa`:\n{}", error);
+            log::warn!("Error in module `opa`:\n{error}");
             return None;
         }
     });

--- a/src/modules/openstack.rs
+++ b/src/modules/openstack.rs
@@ -75,7 +75,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::error!("Error in module `openstack`: \n{}", error);
+            log::error!("Error in module `openstack`: \n{error}");
             return None;
         }
     });

--- a/src/modules/os.rs
+++ b/src/modules/os.rs
@@ -41,7 +41,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `os`:\n{}", error);
+            log::warn!("Error in module `os`:\n{error}");
             return None;
         }
     });

--- a/src/modules/package.rs
+++ b/src/modules/package.rs
@@ -36,7 +36,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `package`:\n{}", error);
+            log::warn!("Error in module `package`:\n{error}");
             return None;
         }
     });
@@ -198,7 +198,7 @@ fn get_maven_version(context: &Context, config: &PackageConfig) -> Option<String
             Ok(_) => (),
 
             Err(err) => {
-                log::warn!("Error parsing pom.xml`:\n{}", err);
+                log::warn!("Error parsing pom.xml`:\n{err}");
                 break;
             }
         }

--- a/src/modules/perl.rs
+++ b/src/modules/perl.rs
@@ -49,7 +49,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `perl`:\n{}", error);
+            log::warn!("Error in module `perl`:\n{error}");
             return None;
         }
     });

--- a/src/modules/php.rs
+++ b/src/modules/php.rs
@@ -48,7 +48,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `php`:\n{}", error);
+            log::warn!("Error in module `php`:\n{error}");
             return None;
         }
     });

--- a/src/modules/pijul_channel.rs
+++ b/src/modules/pijul_channel.rs
@@ -53,7 +53,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `pijul_channel`:\n{}", error);
+            log::warn!("Error in module `pijul_channel`:\n{error}");
             return None;
         }
     });

--- a/src/modules/pixi.rs
+++ b/src/modules/pixi.rs
@@ -61,7 +61,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `pixi`:\n{}", error);
+            log::warn!("Error in module `pixi`:\n{error}");
             return None;
         }
     });

--- a/src/modules/pulumi.rs
+++ b/src/modules/pulumi.rs
@@ -75,7 +75,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             Some(module)
         }
         Err(e) => {
-            log::warn!("Error in module `pulumi`:\n{}", e);
+            log::warn!("Error in module `pulumi`:\n{e}");
             None
         }
     }
@@ -108,7 +108,7 @@ fn parse_version(version: &str) -> &str {
 /// Find a file describing a Pulumi package in the current directory (or any parent directory).
 fn find_package_file(path: &Path) -> Option<PathBuf> {
     for path in path.ancestors() {
-        log::trace!("Looking for package file in {:?}", path);
+        log::trace!("Looking for package file in {path:?}");
         let dir = std::fs::read_dir(path).ok()?;
         let goal = dir.filter_map(Result::ok).find(|path| {
             path.file_name() == OsStr::new("Pulumi.yaml")
@@ -133,7 +133,7 @@ fn stack_name(project_file: &Path, context: &Context) -> Option<String> {
     file.read_to_string(&mut contents).ok()?;
     let name = YamlLoader::load_from_str(&contents).ok().and_then(
         |yaml| -> Option<Option<String>> {
-            log::trace!("Parsed {:?} into yaml", project_file);
+            log::trace!("Parsed {project_file:?} into yaml");
             let yaml = yaml.into_iter().next()?;
             yaml.into_hash().map(|mut hash| -> Option<String> {
                 hash.remove(&Yaml::String("name".to_string()))?
@@ -141,20 +141,20 @@ fn stack_name(project_file: &Path, context: &Context) -> Option<String> {
             })
         },
     )??;
-    log::trace!("Found project name: {:?}", name);
+    log::trace!("Found project name: {name:?}");
 
     let workspace_file = get_pulumi_workspace(context, &name, project_file)
         .map(File::open)?
         .ok()?;
-    log::trace!("Trying to read workspace_file: {:?}", workspace_file);
+    log::trace!("Trying to read workspace_file: {workspace_file:?}");
     let workspace: serde_json::Value = match serde_json::from_reader(workspace_file) {
         Ok(k) => k,
         Err(e) => {
-            log::debug!("Failed to parse workspace file: {}", e);
+            log::debug!("Failed to parse workspace file: {e}");
             return None;
         }
     };
-    log::trace!("Read workspace_file: {:?}", workspace);
+    log::trace!("Read workspace_file: {workspace:?}");
     workspace
         .as_object()?
         .get("stack")?

--- a/src/modules/purescript.rs
+++ b/src/modules/purescript.rs
@@ -47,7 +47,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `purescript`:\n{}", error);
+            log::warn!("Error in module `purescript`:\n{error}");
             return None;
         }
     });

--- a/src/modules/python.rs
+++ b/src/modules/python.rs
@@ -68,7 +68,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `python`:\n{}", error);
+            log::warn!("Error in module `python`:\n{error}");
             return None;
         }
     });

--- a/src/modules/quarto.rs
+++ b/src/modules/quarto.rs
@@ -51,7 +51,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `quarto`:\n{}", error);
+            log::warn!("Error in module `quarto`:\n{error}");
             return None;
         }
     });

--- a/src/modules/raku.rs
+++ b/src/modules/raku.rs
@@ -59,7 +59,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `raku`:\n{}", error);
+            log::warn!("Error in module `raku`:\n{error}");
             return None;
         }
     });

--- a/src/modules/red.rs
+++ b/src/modules/red.rs
@@ -47,7 +47,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `red`:\n{}", error);
+            log::warn!("Error in module `red`:\n{error}");
             return None;
         }
     });

--- a/src/modules/rlang.rs
+++ b/src/modules/rlang.rs
@@ -49,7 +49,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `rlang`:\n{}", error);
+            log::warn!("Error in module `rlang`:\n{error}");
             return None;
         }
     });

--- a/src/modules/ruby.rs
+++ b/src/modules/ruby.rs
@@ -58,7 +58,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `ruby`:\n{}", error);
+            log::warn!("Error in module `ruby`:\n{error}");
             return None;
         }
     });
@@ -80,7 +80,7 @@ fn format_ruby_version(ruby_version: &str, version_format: &str) -> Option<Strin
     match VersionFormatter::format_version(version, version_format) {
         Ok(formatted) => Some(formatted),
         Err(error) => {
-            log::warn!("Error formatting `ruby` version:\n{}", error);
+            log::warn!("Error formatting `ruby` version:\n{error}");
             Some(format!("v{version}"))
         }
     }

--- a/src/modules/rust.rs
+++ b/src/modules/rust.rs
@@ -82,7 +82,7 @@ impl RustToolingEnvironmentInfo {
                     })
                     .or_else(|| execute_rustup_default(context));
 
-                log::debug!("Environmental toolchain override is {:?}", out);
+                log::debug!("Environmental toolchain override is {out:?}");
                 out
             })
             .as_deref()
@@ -103,7 +103,7 @@ impl RustToolingEnvironmentInfo {
                             .join("rustc")
                     })
                     .and_then(|rustc| {
-                        log::trace!("Running rustc --version directly with {:?}", rustc);
+                        log::trace!("Running rustc --version directly with {rustc:?}");
                         create_command(rustc).map(|mut cmd| {
                             cmd.arg("--version");
                             cmd
@@ -125,7 +125,7 @@ impl RustToolingEnvironmentInfo {
                 RustupRunRustcVersionOutcome::ToolchainUnknown
             };
 
-            log::debug!("Rustup rustc version is {:?}", out);
+            log::debug!("Rustup rustc version is {out:?}");
             out
         })
     }
@@ -147,7 +147,7 @@ impl RustToolingEnvironmentInfo {
                 let out =
                     format_rustc_version_verbose(std::str::from_utf8(&stdout).ok()?, toolchain);
 
-                log::debug!("Rustup verbose version is {:?}", out);
+                log::debug!("Rustup verbose version is {out:?}");
                 out
             })
             .as_ref()
@@ -195,7 +195,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `rust`:\n{}", error);
+            log::warn!("Error in module `rust`:\n{error}");
             return None;
         }
     });
@@ -393,7 +393,7 @@ fn format_rustc_version(rustc_version: &str, version_format: &str) -> Option<Str
     match VersionFormatter::format_version(version, version_format) {
         Ok(formatted) => Some(formatted),
         Err(error) => {
-            log::warn!("Error formatting `rust` version:\n{}", error);
+            log::warn!("Error formatting `rust` version:\n{error}");
             Some(format!("v{version}"))
         }
     }

--- a/src/modules/scala.rs
+++ b/src/modules/scala.rs
@@ -48,7 +48,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `scala`:\n{}", error);
+            log::warn!("Error in module `scala`:\n{error}");
             return None;
         }
     });

--- a/src/modules/shell.rs
+++ b/src/modules/shell.rs
@@ -56,7 +56,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `shell`: \n{}", error);
+            log::warn!("Error in module `shell`: \n{error}");
             return None;
         }
     });

--- a/src/modules/shlvl.rs
+++ b/src/modules/shlvl.rs
@@ -65,7 +65,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `shlvl`:\n{}", error);
+            log::warn!("Error in module `shlvl`:\n{error}");
             return None;
         }
     });

--- a/src/modules/singularity.rs
+++ b/src/modules/singularity.rs
@@ -32,7 +32,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `singularity`: \n{}", error);
+            log::warn!("Error in module `singularity`: \n{error}");
             return None;
         }
     });

--- a/src/modules/solidity.rs
+++ b/src/modules/solidity.rs
@@ -46,7 +46,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module 'solidity'\n {}", error);
+            log::warn!("Error in module 'solidity'\n {error}");
             return None;
         }
     });

--- a/src/modules/spack.rs
+++ b/src/modules/spack.rs
@@ -38,7 +38,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `spack`:\n{}", error);
+            log::warn!("Error in module `spack`:\n{error}");
             return None;
         }
     });

--- a/src/modules/sudo.rs
+++ b/src/modules/sudo.rs
@@ -40,7 +40,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `sudo`:\n{}", error);
+            log::warn!("Error in module `sudo`:\n{error}");
             return None;
         }
     });

--- a/src/modules/swift.rs
+++ b/src/modules/swift.rs
@@ -49,7 +49,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `swift`:\n{}", error);
+            log::warn!("Error in module `swift`:\n{error}");
             return None;
         }
     });

--- a/src/modules/terraform.rs
+++ b/src/modules/terraform.rs
@@ -55,7 +55,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `terraform`:\n{}", error);
+            log::warn!("Error in module `terraform`:\n{error}");
             return None;
         }
     });

--- a/src/modules/time.rs
+++ b/src/modules/time.rs
@@ -25,10 +25,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let default_format = if config.use_12hr { "%r" } else { "%T" };
     let time_format = config.time_format.unwrap_or(default_format);
 
-    log::trace!(
-        "Timer module is enabled with format string: {}",
-        time_format
-    );
+    log::trace!("Timer module is enabled with format string: {time_format}");
 
     let formatted_time_string = if config.utc_time_offset != "local" {
         match create_offset_time_string(Utc::now(), config.utc_time_offset, time_format) {
@@ -60,7 +57,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `time`: \n{}", error);
+            log::warn!("Error in module `time`: \n{error}");
             return None;
         }
     });
@@ -83,10 +80,10 @@ fn create_offset_time_string(
         let Some(timezone_offset) = FixedOffset::east_opt(utc_offset_in_seconds) else {
             return Err("Invalid offset");
         };
-        log::trace!("Target timezone offset is {}", timezone_offset);
+        log::trace!("Target timezone offset is {timezone_offset}");
 
         let target_time = utc_time.with_timezone(&timezone_offset);
-        log::trace!("Time in target timezone now is {}", target_time);
+        log::trace!("Time in target timezone now is {target_time}");
 
         Ok(format_time_fixed_offset(time_format, target_time))
     } else {

--- a/src/modules/typst.rs
+++ b/src/modules/typst.rs
@@ -47,7 +47,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `typst`:\n{}", error);
+            log::warn!("Error in module `typst`:\n{error}");
             return None;
         }
     });

--- a/src/modules/username.rs
+++ b/src/modules/username.rs
@@ -73,7 +73,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `username`:\n{}", error);
+            log::warn!("Error in module `username`:\n{error}");
             return None;
         }
     });

--- a/src/modules/vagrant.rs
+++ b/src/modules/vagrant.rs
@@ -50,7 +50,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `vagrant`:\n{}", error);
+            log::warn!("Error in module `vagrant`:\n{error}");
             return None;
         }
     });

--- a/src/modules/vcsh.rs
+++ b/src/modules/vcsh.rs
@@ -36,7 +36,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `vcsh`:\n{}", error);
+            log::warn!("Error in module `vcsh`:\n{error}");
             return None;
         }
     });

--- a/src/modules/vlang.rs
+++ b/src/modules/vlang.rs
@@ -48,7 +48,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `vlang`:\n{}", error);
+            log::warn!("Error in module `vlang`:\n{error}");
             return None;
         }
     });

--- a/src/modules/zig.rs
+++ b/src/modules/zig.rs
@@ -48,7 +48,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(error) => {
-            log::warn!("Error in module `zig`:\n{}", error);
+            log::warn!("Error in module `zig`:\n{error}");
             return None;
         }
     });

--- a/src/print.rs
+++ b/src/print.rs
@@ -352,9 +352,7 @@ fn handle_module<'a>(
         }
     } else {
         log::debug!(
-            "Expected top level format to contain value from {:?}. Instead received {}",
-            ALL_MODULES,
-            module,
+            "Expected top level format to contain value from {ALL_MODULES:?}. Instead received {module}",
         );
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -35,12 +35,12 @@ pub fn context_path<S: AsRef<OsStr> + ?Sized>(context: &Context, s: &S) -> PathB
 
 /// Return the string contents of a file
 pub fn read_file<P: AsRef<Path> + Debug>(file_name: P) -> Result<String> {
-    log::trace!("Trying to read from {:?}", file_name);
+    log::trace!("Trying to read from {file_name:?}");
 
     let result = read_to_string(file_name);
 
     if result.is_err() {
-        log::debug!("Error reading file: {:?}", result);
+        log::debug!("Error reading file: {result:?}");
     } else {
         log::trace!("File read successfully");
     };
@@ -65,7 +65,7 @@ pub fn write_file<P: AsRef<Path>, S: AsRef<str>>(file_name: P, text: S) -> Resul
     {
         Ok(file) => file,
         Err(err) => {
-            log::warn!("Error creating file: {:?}", err);
+            log::warn!("Error creating file: {err:?}");
             return Err(err);
         }
     };
@@ -96,15 +96,15 @@ pub fn get_command_string_output(command: CommandOutput) -> String {
 /// This function also initializes std{err,out,in} to protect against processes changing the console mode
 pub fn create_command<T: AsRef<OsStr>>(binary_name: T) -> Result<Command> {
     let binary_name = binary_name.as_ref();
-    log::trace!("Creating Command for binary {:?}", binary_name);
+    log::trace!("Creating Command for binary {binary_name:?}");
 
     let full_path = match which::which(binary_name) {
         Ok(full_path) => {
-            log::trace!("Using {:?} as {:?}", full_path, binary_name);
+            log::trace!("Using {full_path:?} as {binary_name:?}");
             full_path
         }
         Err(error) => {
-            log::trace!("Unable to find {:?} in PATH, {:?}", binary_name, error);
+            log::trace!("Unable to find {binary_name:?} in PATH, {error:?}");
             return Err(Error::new(ErrorKind::NotFound, error));
         }
     };
@@ -148,7 +148,7 @@ pub fn exec_cmd<T: AsRef<OsStr> + Debug, U: AsRef<OsStr> + Debug>(
     args: &[U],
     time_limit: Duration,
 ) -> Option<CommandOutput> {
-    log::trace!("Executing command {:?} with args {:?}", cmd, args);
+    log::trace!("Executing command {cmd:?} with args {args:?}");
     #[cfg(test)]
     if let Some(o) = mock_cmd(&cmd, args) {
         return o;
@@ -634,14 +634,14 @@ pub fn exec_timeout(cmd: &mut Command, time_limit: Duration) -> Option<CommandOu
             let stdout_string = match String::from_utf8(output.stdout) {
                 Ok(stdout) => stdout,
                 Err(error) => {
-                    log::warn!("Unable to decode stdout: {:?}", error);
+                    log::warn!("Unable to decode stdout: {error:?}");
                     return None;
                 }
             };
             let stderr_string = match String::from_utf8(output.stderr) {
                 Ok(stderr) => stderr,
                 Err(error) => {
-                    log::warn!("Unable to decode stderr: {:?}", error);
+                    log::warn!("Unable to decode stderr: {error:?}");
                     return None;
                 }
             };


### PR DESCRIPTION
#### Description

applies the `clippy::uninlined_format_args` lint

#### Motivation and Context

1. reduces clippy warnings/noise
2. consistent styling
3. marginally more readable in most cases
