### PR TITLE
style: use 'Self' to refer to own type (clippy::use_self)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,3 +134,6 @@ strip = false
 [[bin]]
 name = "starship"
 path = "src/main.rs"
+
+[lints.clippy]
+use_self = "warn"

--- a/src/configs/aws.rs
+++ b/src/configs/aws.rs
@@ -51,7 +51,7 @@ pub struct AwsConfig<'a> {
 
 impl Default for AwsConfig<'_> {
     fn default() -> Self {
-        AwsConfig {
+        Self {
             format: "on [$symbol($profile )(\\($region\\) )(\\[$duration\\] )]($style)",
             symbol: "☁️  ",
             style: "bold yellow",

--- a/src/configs/azure.rs
+++ b/src/configs/azure.rs
@@ -18,7 +18,7 @@ pub struct AzureConfig<'a> {
 
 impl Default for AzureConfig<'_> {
     fn default() -> Self {
-        AzureConfig {
+        Self {
             format: "on [$symbol($subscription)]($style) ",
             symbol: "󰠅 ",
             style: "blue bold",

--- a/src/configs/battery.rs
+++ b/src/configs/battery.rs
@@ -21,7 +21,7 @@ pub struct BatteryConfig<'a> {
 
 impl Default for BatteryConfig<'_> {
     fn default() -> Self {
-        BatteryConfig {
+        Self {
             full_symbol: "󰁹 ",
             charging_symbol: "󰂄 ",
             discharging_symbol: "󰂃 ",
@@ -50,7 +50,7 @@ pub struct BatteryDisplayConfig<'a> {
 
 impl Default for BatteryDisplayConfig<'_> {
     fn default() -> Self {
-        BatteryDisplayConfig {
+        Self {
             threshold: 10,
             style: "red bold",
             charging_symbol: None,

--- a/src/configs/buf.rs
+++ b/src/configs/buf.rs
@@ -20,7 +20,7 @@ pub struct BufConfig<'a> {
 
 impl Default for BufConfig<'_> {
     fn default() -> Self {
-        BufConfig {
+        Self {
             format: "with [$symbol($version )]($style)",
             version_format: "v${raw}",
             symbol: "🐃 ",

--- a/src/configs/bun.rs
+++ b/src/configs/bun.rs
@@ -20,7 +20,7 @@ pub struct BunConfig<'a> {
 
 impl Default for BunConfig<'_> {
     fn default() -> Self {
-        BunConfig {
+        Self {
             format: "via [$symbol($version )]($style)",
             version_format: "v${raw}",
             symbol: "🥟 ",

--- a/src/configs/c.rs
+++ b/src/configs/c.rs
@@ -13,7 +13,7 @@ pub type CConfig<'a> = CcConfig<'a, CConfigMarker>;
 
 impl Default for CConfig<'_> {
     fn default() -> Self {
-        CcConfig {
+        Self {
             marker: std::marker::PhantomData::<CConfigMarker>,
 
             format: "via [$symbol($version(-$name) )]($style)",

--- a/src/configs/character.rs
+++ b/src/configs/character.rs
@@ -21,7 +21,7 @@ pub struct CharacterConfig<'a> {
 
 impl Default for CharacterConfig<'_> {
     fn default() -> Self {
-        CharacterConfig {
+        Self {
             format: "$symbol ",
             success_symbol: "[❯](bold green)",
             error_symbol: "[❯](bold red)",

--- a/src/configs/cmake.rs
+++ b/src/configs/cmake.rs
@@ -20,7 +20,7 @@ pub struct CMakeConfig<'a> {
 
 impl Default for CMakeConfig<'_> {
     fn default() -> Self {
-        CMakeConfig {
+        Self {
             format: "via [$symbol($version )]($style)",
             version_format: "v${raw}",
             symbol: "△ ",

--- a/src/configs/cmd_duration.rs
+++ b/src/configs/cmd_duration.rs
@@ -22,7 +22,7 @@ pub struct CmdDurationConfig<'a> {
 
 impl Default for CmdDurationConfig<'_> {
     fn default() -> Self {
-        CmdDurationConfig {
+        Self {
             min_time: 2_000,
             format: "took [$duration]($style) ",
             show_milliseconds: false,

--- a/src/configs/cobol.rs
+++ b/src/configs/cobol.rs
@@ -20,7 +20,7 @@ pub struct CobolConfig<'a> {
 
 impl Default for CobolConfig<'_> {
     fn default() -> Self {
-        CobolConfig {
+        Self {
             format: "via [$symbol($version )]($style)",
             version_format: "v${raw}",
             symbol: "⚙️ ",

--- a/src/configs/conda.rs
+++ b/src/configs/conda.rs
@@ -19,7 +19,7 @@ pub struct CondaConfig<'a> {
 
 impl Default for CondaConfig<'_> {
     fn default() -> Self {
-        CondaConfig {
+        Self {
             truncation_length: 1,
             format: "via [$symbol$environment]($style) ",
             symbol: "🅒 ",

--- a/src/configs/container.rs
+++ b/src/configs/container.rs
@@ -16,7 +16,7 @@ pub struct ContainerConfig<'a> {
 
 impl Default for ContainerConfig<'_> {
     fn default() -> Self {
-        ContainerConfig {
+        Self {
             format: "[$symbol \\[$name\\]]($style) ",
             symbol: "⬢",
             style: "red bold dimmed",

--- a/src/configs/cpp.rs
+++ b/src/configs/cpp.rs
@@ -13,7 +13,7 @@ pub type CppConfig<'a> = CcConfig<'a, CppConfigMarker>;
 
 impl Default for CppConfig<'_> {
     fn default() -> Self {
-        CcConfig {
+        Self {
             marker: std::marker::PhantomData::<CppConfigMarker>,
 
             format: "via [$symbol($version(-$name) )]($style)",

--- a/src/configs/crystal.rs
+++ b/src/configs/crystal.rs
@@ -20,7 +20,7 @@ pub struct CrystalConfig<'a> {
 
 impl Default for CrystalConfig<'_> {
     fn default() -> Self {
-        CrystalConfig {
+        Self {
             format: "via [$symbol($version )]($style)",
             version_format: "v${raw}",
             symbol: "🔮 ",

--- a/src/configs/custom.rs
+++ b/src/configs/custom.rs
@@ -35,7 +35,7 @@ pub struct CustomConfig<'a> {
 
 impl Default for CustomConfig<'_> {
     fn default() -> Self {
-        CustomConfig {
+        Self {
             format: "[$symbol($output )]($style)",
             symbol: "",
             command: "",

--- a/src/configs/daml.rs
+++ b/src/configs/daml.rs
@@ -20,7 +20,7 @@ pub struct DamlConfig<'a> {
 
 impl Default for DamlConfig<'_> {
     fn default() -> Self {
-        DamlConfig {
+        Self {
             symbol: "Λ ",
             format: "via [$symbol($version )]($style)",
             version_format: "v${raw}",

--- a/src/configs/dart.rs
+++ b/src/configs/dart.rs
@@ -20,7 +20,7 @@ pub struct DartConfig<'a> {
 
 impl Default for DartConfig<'_> {
     fn default() -> Self {
-        DartConfig {
+        Self {
             format: "via [$symbol($version )]($style)",
             version_format: "v${raw}",
             symbol: "🎯 ",

--- a/src/configs/deno.rs
+++ b/src/configs/deno.rs
@@ -20,7 +20,7 @@ pub struct DenoConfig<'a> {
 
 impl Default for DenoConfig<'_> {
     fn default() -> Self {
-        DenoConfig {
+        Self {
             format: "via [$symbol($version )]($style)",
             version_format: "v${raw}",
             symbol: "🦕 ",

--- a/src/configs/directory.rs
+++ b/src/configs/directory.rs
@@ -30,7 +30,7 @@ pub struct DirectoryConfig<'a> {
 
 impl Default for DirectoryConfig<'_> {
     fn default() -> Self {
-        DirectoryConfig {
+        Self {
             truncation_length: 3,
             truncate_to_repo: true,
             fish_style_pwd_dir_length: 0,

--- a/src/configs/docker_context.rs
+++ b/src/configs/docker_context.rs
@@ -20,7 +20,7 @@ pub struct DockerContextConfig<'a> {
 
 impl Default for DockerContextConfig<'_> {
     fn default() -> Self {
-        DockerContextConfig {
+        Self {
             symbol: "🐳 ",
             style: "blue bold",
             format: "via [$symbol$context]($style) ",

--- a/src/configs/dotnet.rs
+++ b/src/configs/dotnet.rs
@@ -21,7 +21,7 @@ pub struct DotnetConfig<'a> {
 
 impl Default for DotnetConfig<'_> {
     fn default() -> Self {
-        DotnetConfig {
+        Self {
             format: "via [$symbol($version )(🎯 $tfm )]($style)",
             version_format: "v${raw}",
             symbol: ".NET ",

--- a/src/configs/elixir.rs
+++ b/src/configs/elixir.rs
@@ -20,7 +20,7 @@ pub struct ElixirConfig<'a> {
 
 impl Default for ElixirConfig<'_> {
     fn default() -> Self {
-        ElixirConfig {
+        Self {
             format: "via [$symbol($version \\(OTP $otp_version\\) )]($style)",
             version_format: "v${raw}",
             symbol: "💧 ",

--- a/src/configs/elm.rs
+++ b/src/configs/elm.rs
@@ -20,7 +20,7 @@ pub struct ElmConfig<'a> {
 
 impl Default for ElmConfig<'_> {
     fn default() -> Self {
-        ElmConfig {
+        Self {
             format: "via [$symbol($version )]($style)",
             version_format: "v${raw}",
             symbol: "🌳 ",

--- a/src/configs/env_var.rs
+++ b/src/configs/env_var.rs
@@ -21,7 +21,7 @@ pub struct EnvVarConfig<'a> {
 
 impl Default for EnvVarConfig<'_> {
     fn default() -> Self {
-        EnvVarConfig {
+        Self {
             symbol: "",
             style: "black bold dimmed",
             variable: None,

--- a/src/configs/erlang.rs
+++ b/src/configs/erlang.rs
@@ -20,7 +20,7 @@ pub struct ErlangConfig<'a> {
 
 impl Default for ErlangConfig<'_> {
     fn default() -> Self {
-        ErlangConfig {
+        Self {
             format: "via [$symbol($version )]($style)",
             version_format: "v${raw}",
             symbol: " ",

--- a/src/configs/fennel.rs
+++ b/src/configs/fennel.rs
@@ -21,7 +21,7 @@ pub struct FennelConfig<'a> {
 
 impl Default for FennelConfig<'_> {
     fn default() -> Self {
-        FennelConfig {
+        Self {
             format: "via [$symbol($version )]($style)",
             version_format: "v${raw}",
             symbol: "🧅 ",

--- a/src/configs/fill.rs
+++ b/src/configs/fill.rs
@@ -15,7 +15,7 @@ pub struct FillConfig<'a> {
 
 impl Default for FillConfig<'_> {
     fn default() -> Self {
-        FillConfig {
+        Self {
             style: "bold black",
             symbol: ".",
             disabled: false,

--- a/src/configs/fossil_branch.rs
+++ b/src/configs/fossil_branch.rs
@@ -18,7 +18,7 @@ pub struct FossilBranchConfig<'a> {
 
 impl Default for FossilBranchConfig<'_> {
     fn default() -> Self {
-        FossilBranchConfig {
+        Self {
             format: "on [$symbol$branch]($style) ",
             symbol: " ",
             style: "bold purple",

--- a/src/configs/fossil_metrics.rs
+++ b/src/configs/fossil_metrics.rs
@@ -17,7 +17,7 @@ pub struct FossilMetricsConfig<'a> {
 
 impl Default for FossilMetricsConfig<'_> {
     fn default() -> Self {
-        FossilMetricsConfig {
+        Self {
             format: "([+$added]($added_style) )([-$deleted]($deleted_style) )",
             added_style: "bold green",
             deleted_style: "bold red",

--- a/src/configs/gcloud.rs
+++ b/src/configs/gcloud.rs
@@ -20,7 +20,7 @@ pub struct GcloudConfig<'a> {
 
 impl Default for GcloudConfig<'_> {
     fn default() -> Self {
-        GcloudConfig {
+        Self {
             format: "on [$symbol$account(@$domain)(\\($region\\))]($style) ",
             symbol: "☁️  ",
             style: "bold blue",

--- a/src/configs/git_branch.rs
+++ b/src/configs/git_branch.rs
@@ -21,7 +21,7 @@ pub struct GitBranchConfig<'a> {
 
 impl Default for GitBranchConfig<'_> {
     fn default() -> Self {
-        GitBranchConfig {
+        Self {
             format: "on [$symbol$branch(:$remote_branch)]($style) ",
             symbol: " ",
             style: "bold purple",

--- a/src/configs/git_commit.rs
+++ b/src/configs/git_commit.rs
@@ -20,7 +20,7 @@ pub struct GitCommitConfig<'a> {
 
 impl Default for GitCommitConfig<'_> {
     fn default() -> Self {
-        GitCommitConfig {
+        Self {
             // be consistent with git by default, which has DEFAULT_ABBREV set to 7
             commit_hash_length: 7,
             format: "[\\($hash$tag\\)]($style) ",

--- a/src/configs/git_metrics.rs
+++ b/src/configs/git_metrics.rs
@@ -18,7 +18,7 @@ pub struct GitMetricsConfig<'a> {
 
 impl Default for GitMetricsConfig<'_> {
     fn default() -> Self {
-        GitMetricsConfig {
+        Self {
             added_style: "bold green",
             deleted_style: "bold red",
             only_nonzero_diffs: true,

--- a/src/configs/git_state.rs
+++ b/src/configs/git_state.rs
@@ -22,7 +22,7 @@ pub struct GitStateConfig<'a> {
 
 impl Default for GitStateConfig<'_> {
     fn default() -> Self {
-        GitStateConfig {
+        Self {
             rebase: "REBASING",
             merge: "MERGING",
             revert: "REVERTING",

--- a/src/configs/git_status.rs
+++ b/src/configs/git_status.rs
@@ -31,7 +31,7 @@ pub struct GitStatusConfig<'a> {
 
 impl Default for GitStatusConfig<'_> {
     fn default() -> Self {
-        GitStatusConfig {
+        Self {
             format: "([\\[$all_status$ahead_behind\\]]($style) )",
             style: "red bold",
             stashed: "\\$",

--- a/src/configs/gleam.rs
+++ b/src/configs/gleam.rs
@@ -20,7 +20,7 @@ pub struct GleamConfig<'a> {
 
 impl Default for GleamConfig<'_> {
     fn default() -> Self {
-        GleamConfig {
+        Self {
             format: "via [$symbol($version )]($style)",
             version_format: "v${raw}",
             symbol: "⭐ ",

--- a/src/configs/go.rs
+++ b/src/configs/go.rs
@@ -21,7 +21,7 @@ pub struct GoConfig<'a> {
 
 impl Default for GoConfig<'_> {
     fn default() -> Self {
-        GoConfig {
+        Self {
             format: "via [$symbol($version )]($style)",
             version_format: "v${raw}",
             symbol: "🐹 ",

--- a/src/configs/gradle.rs
+++ b/src/configs/gradle.rs
@@ -21,7 +21,7 @@ pub struct GradleConfig<'a> {
 
 impl Default for GradleConfig<'_> {
     fn default() -> Self {
-        GradleConfig {
+        Self {
             format: "via [$symbol($version )]($style)",
             version_format: "v${raw}",
             symbol: "🅶 ",

--- a/src/configs/guix_shell.rs
+++ b/src/configs/guix_shell.rs
@@ -16,7 +16,7 @@ pub struct GuixShellConfig<'a> {
 
 impl Default for GuixShellConfig<'_> {
     fn default() -> Self {
-        GuixShellConfig {
+        Self {
             format: "via [$symbol]($style) ",
             symbol: "🐃 ",
             style: "yellow bold",

--- a/src/configs/haskell.rs
+++ b/src/configs/haskell.rs
@@ -20,7 +20,7 @@ pub struct HaskellConfig<'a> {
 
 impl Default for HaskellConfig<'_> {
     fn default() -> Self {
-        HaskellConfig {
+        Self {
             format: "via [$symbol($version )]($style)",
             version_format: "v${raw}",
             symbol: "λ ",

--- a/src/configs/haxe.rs
+++ b/src/configs/haxe.rs
@@ -20,7 +20,7 @@ pub struct HaxeConfig<'a> {
 
 impl Default for HaxeConfig<'_> {
     fn default() -> Self {
-        HaxeConfig {
+        Self {
             format: "via [$symbol($version )]($style)",
             version_format: "v${raw}",
             symbol: "⌘ ",

--- a/src/configs/helm.rs
+++ b/src/configs/helm.rs
@@ -20,7 +20,7 @@ pub struct HelmConfig<'a> {
 
 impl Default for HelmConfig<'_> {
     fn default() -> Self {
-        HelmConfig {
+        Self {
             format: "via [$symbol($version )]($style)",
             version_format: "v${raw}",
             symbol: "⎈ ",

--- a/src/configs/hg_branch.rs
+++ b/src/configs/hg_branch.rs
@@ -18,7 +18,7 @@ pub struct HgBranchConfig<'a> {
 
 impl Default for HgBranchConfig<'_> {
     fn default() -> Self {
-        HgBranchConfig {
+        Self {
             symbol: " ",
             style: "bold purple",
             format: "on [$symbol$branch(:$topic)]($style) ",

--- a/src/configs/hostname.rs
+++ b/src/configs/hostname.rs
@@ -21,7 +21,7 @@ pub struct HostnameConfig<'a> {
 
 impl Default for HostnameConfig<'_> {
     fn default() -> Self {
-        HostnameConfig {
+        Self {
             ssh_only: true,
             ssh_symbol: "🌐 ",
             trim_at: ".",

--- a/src/configs/java.rs
+++ b/src/configs/java.rs
@@ -20,7 +20,7 @@ pub struct JavaConfig<'a> {
 
 impl Default for JavaConfig<'_> {
     fn default() -> Self {
-        JavaConfig {
+        Self {
             format: "via [$symbol($version )]($style)",
             version_format: "v${raw}",
             disabled: false,

--- a/src/configs/jobs.rs
+++ b/src/configs/jobs.rs
@@ -19,7 +19,7 @@ pub struct JobsConfig<'a> {
 
 impl Default for JobsConfig<'_> {
     fn default() -> Self {
-        JobsConfig {
+        Self {
             threshold: 1,
             symbol_threshold: 1,
             number_threshold: 2,

--- a/src/configs/julia.rs
+++ b/src/configs/julia.rs
@@ -20,7 +20,7 @@ pub struct JuliaConfig<'a> {
 
 impl Default for JuliaConfig<'_> {
     fn default() -> Self {
-        JuliaConfig {
+        Self {
             format: "via [$symbol($version )]($style)",
             version_format: "v${raw}",
             symbol: "ஃ ",

--- a/src/configs/kotlin.rs
+++ b/src/configs/kotlin.rs
@@ -21,7 +21,7 @@ pub struct KotlinConfig<'a> {
 
 impl Default for KotlinConfig<'_> {
     fn default() -> Self {
-        KotlinConfig {
+        Self {
             format: "via [$symbol($version )]($style)",
             version_format: "v${raw}",
             symbol: "🅺 ",

--- a/src/configs/kubernetes.rs
+++ b/src/configs/kubernetes.rs
@@ -24,7 +24,7 @@ pub struct KubernetesConfig<'a> {
 
 impl Default for KubernetesConfig<'_> {
     fn default() -> Self {
-        KubernetesConfig {
+        Self {
             symbol: "☸ ",
             format: "[$symbol$context( \\($namespace\\))]($style) in ",
             style: "cyan bold",

--- a/src/configs/localip.rs
+++ b/src/configs/localip.rs
@@ -16,7 +16,7 @@ pub struct LocalipConfig<'a> {
 
 impl Default for LocalipConfig<'_> {
     fn default() -> Self {
-        LocalipConfig {
+        Self {
             ssh_only: true,
             format: "[$localipv4]($style) ",
             style: "yellow bold",

--- a/src/configs/lua.rs
+++ b/src/configs/lua.rs
@@ -21,7 +21,7 @@ pub struct LuaConfig<'a> {
 
 impl Default for LuaConfig<'_> {
     fn default() -> Self {
-        LuaConfig {
+        Self {
             format: "via [$symbol($version )]($style)",
             version_format: "v${raw}",
             symbol: "🌙 ",

--- a/src/configs/memory_usage.rs
+++ b/src/configs/memory_usage.rs
@@ -17,7 +17,7 @@ pub struct MemoryConfig<'a> {
 
 impl Default for MemoryConfig<'_> {
     fn default() -> Self {
-        MemoryConfig {
+        Self {
             threshold: 75,
             format: "via $symbol[$ram( | $swap)]($style) ",
             style: "white bold dimmed",

--- a/src/configs/meson.rs
+++ b/src/configs/meson.rs
@@ -18,7 +18,7 @@ pub struct MesonConfig<'a> {
 
 impl Default for MesonConfig<'_> {
     fn default() -> Self {
-        MesonConfig {
+        Self {
             truncation_length: u32::MAX,
             truncation_symbol: "…",
             format: "via [$symbol$project]($style) ",

--- a/src/configs/mojo.rs
+++ b/src/configs/mojo.rs
@@ -22,7 +22,7 @@ pub struct MojoConfig<'a> {
 
 impl Default for MojoConfig<'_> {
     fn default() -> Self {
-        MojoConfig {
+        Self {
             format: "with [$symbol($version )]($style)",
             symbol: "🔥 ",
             style: "bold 208",

--- a/src/configs/nats.rs
+++ b/src/configs/nats.rs
@@ -16,7 +16,7 @@ pub struct NatsConfig<'a> {
 
 impl Default for NatsConfig<'_> {
     fn default() -> Self {
-        NatsConfig {
+        Self {
             format: "[$symbol($name )]($style)",
             symbol: "✉️ ",
             style: "bold purple",

--- a/src/configs/netns.rs
+++ b/src/configs/netns.rs
@@ -16,7 +16,7 @@ pub struct NetnsConfig<'a> {
 
 impl Default for NetnsConfig<'_> {
     fn default() -> Self {
-        NetnsConfig {
+        Self {
             format: "[$symbol \\[$name\\]]($style) ",
             symbol: "🛜",
             style: "blue bold dimmed",

--- a/src/configs/nim.rs
+++ b/src/configs/nim.rs
@@ -20,7 +20,7 @@ pub struct NimConfig<'a> {
 
 impl Default for NimConfig<'_> {
     fn default() -> Self {
-        NimConfig {
+        Self {
             format: "via [$symbol($version )]($style)",
             version_format: "v${raw}",
             symbol: "👑 ",

--- a/src/configs/nix_shell.rs
+++ b/src/configs/nix_shell.rs
@@ -23,7 +23,7 @@ multiwidth emoji support in some shells. Please do not file a PR to change this
 unless you can show that your changes do not affect this workaround.  */
 impl Default for NixShellConfig<'_> {
     fn default() -> Self {
-        NixShellConfig {
+        Self {
             format: "via [$symbol$state( \\($name\\))]($style) ",
             symbol: "❄️  ",
             style: "bold blue",

--- a/src/configs/nodejs.rs
+++ b/src/configs/nodejs.rs
@@ -21,7 +21,7 @@ pub struct NodejsConfig<'a> {
 
 impl Default for NodejsConfig<'_> {
     fn default() -> Self {
-        NodejsConfig {
+        Self {
             format: "via [$symbol($version )]($style)",
             version_format: "v${raw}",
             symbol: " ",

--- a/src/configs/ocaml.rs
+++ b/src/configs/ocaml.rs
@@ -22,7 +22,7 @@ pub struct OCamlConfig<'a> {
 
 impl Default for OCamlConfig<'_> {
     fn default() -> Self {
-        OCamlConfig {
+        Self {
             format: "via [$symbol($version )(\\($switch_indicator$switch_name\\) )]($style)",
             version_format: "v${raw}",
             global_switch_indicator: "",

--- a/src/configs/odin.rs
+++ b/src/configs/odin.rs
@@ -20,7 +20,7 @@ pub struct OdinConfig<'a> {
 
 impl Default for OdinConfig<'_> {
     fn default() -> Self {
-        OdinConfig {
+        Self {
             format: "via [$symbol($version )]($style)",
             show_commit: false,
             symbol: "Ø ",

--- a/src/configs/opa.rs
+++ b/src/configs/opa.rs
@@ -20,7 +20,7 @@ pub struct OpaConfig<'a> {
 
 impl Default for OpaConfig<'_> {
     fn default() -> Self {
-        OpaConfig {
+        Self {
             format: "via [$symbol($version )]($style)",
             version_format: "v${raw}",
             symbol: "🪖  ",

--- a/src/configs/openstack.rs
+++ b/src/configs/openstack.rs
@@ -16,7 +16,7 @@ pub struct OspConfig<'a> {
 
 impl Default for OspConfig<'_> {
     fn default() -> Self {
-        OspConfig {
+        Self {
             format: "on [$symbol$cloud(\\($project\\))]($style) ",
             symbol: "☁️  ",
             style: "bold yellow",

--- a/src/configs/os.rs
+++ b/src/configs/os.rs
@@ -24,7 +24,7 @@ impl<'a> OSConfig<'a> {
 
 impl Default for OSConfig<'_> {
     fn default() -> Self {
-        OSConfig {
+        Self {
             format: "[$symbol]($style)",
             style: "bold white",
             symbols: indexmap! {

--- a/src/configs/package.rs
+++ b/src/configs/package.rs
@@ -18,7 +18,7 @@ pub struct PackageConfig<'a> {
 
 impl Default for PackageConfig<'_> {
     fn default() -> Self {
-        PackageConfig {
+        Self {
             format: "is [$symbol$version]($style) ",
             symbol: "📦 ",
             style: "208 bold",

--- a/src/configs/perl.rs
+++ b/src/configs/perl.rs
@@ -20,7 +20,7 @@ pub struct PerlConfig<'a> {
 
 impl Default for PerlConfig<'_> {
     fn default() -> Self {
-        PerlConfig {
+        Self {
             format: "via [$symbol($version )]($style)",
             version_format: "v${raw}",
             symbol: "🐪 ",

--- a/src/configs/php.rs
+++ b/src/configs/php.rs
@@ -20,7 +20,7 @@ pub struct PhpConfig<'a> {
 
 impl Default for PhpConfig<'_> {
     fn default() -> Self {
-        PhpConfig {
+        Self {
             format: "via [$symbol($version )]($style)",
             version_format: "v${raw}",
             symbol: "🐘 ",

--- a/src/configs/pijul_channel.rs
+++ b/src/configs/pijul_channel.rs
@@ -18,7 +18,7 @@ pub struct PijulConfig<'a> {
 
 impl Default for PijulConfig<'_> {
     fn default() -> Self {
-        PijulConfig {
+        Self {
             symbol: " ",
             style: "bold purple",
             format: "on [$symbol$channel]($style) ",

--- a/src/configs/pixi.rs
+++ b/src/configs/pixi.rs
@@ -24,7 +24,7 @@ pub struct PixiConfig<'a> {
 
 impl Default for PixiConfig<'_> {
     fn default() -> Self {
-        PixiConfig {
+        Self {
             pixi_binary: VecOr(vec!["pixi"]),
             show_default_environment: true,
             format: "via [$symbol($version )(\\($environment\\) )]($style)",

--- a/src/configs/pulumi.rs
+++ b/src/configs/pulumi.rs
@@ -18,7 +18,7 @@ pub struct PulumiConfig<'a> {
 
 impl Default for PulumiConfig<'_> {
     fn default() -> Self {
-        PulumiConfig {
+        Self {
             format: "via [$symbol($username@)$stack]($style) ",
             version_format: "v${raw}",
             symbol: " ",

--- a/src/configs/purescript.rs
+++ b/src/configs/purescript.rs
@@ -20,7 +20,7 @@ pub struct PureScriptConfig<'a> {
 
 impl Default for PureScriptConfig<'_> {
     fn default() -> Self {
-        PureScriptConfig {
+        Self {
             format: "via [$symbol($version )]($style)",
             version_format: "v${raw}",
             symbol: "<=> ",

--- a/src/configs/python.rs
+++ b/src/configs/python.rs
@@ -26,7 +26,7 @@ pub struct PythonConfig<'a> {
 
 impl Default for PythonConfig<'_> {
     fn default() -> Self {
-        PythonConfig {
+        Self {
             pyenv_version_name: false,
             pyenv_prefix: "pyenv ",
             python_binary: VecOr(vec![

--- a/src/configs/quarto.rs
+++ b/src/configs/quarto.rs
@@ -20,7 +20,7 @@ pub struct QuartoConfig<'a> {
 
 impl Default for QuartoConfig<'_> {
     fn default() -> Self {
-        QuartoConfig {
+        Self {
             format: "via [$symbol($version )]($style)",
             version_format: "v${raw}",
             symbol: "⨁ ",

--- a/src/configs/red.rs
+++ b/src/configs/red.rs
@@ -20,7 +20,7 @@ pub struct RedConfig<'a> {
 
 impl Default for RedConfig<'_> {
     fn default() -> Self {
-        RedConfig {
+        Self {
             format: "via [$symbol($version )]($style)",
             version_format: "v${raw}",
             symbol: "🔺 ",

--- a/src/configs/rlang.rs
+++ b/src/configs/rlang.rs
@@ -20,7 +20,7 @@ pub struct RLangConfig<'a> {
 
 impl Default for RLangConfig<'_> {
     fn default() -> Self {
-        RLangConfig {
+        Self {
             format: "via [$symbol($version )]($style)",
             version_format: "v${raw}",
             style: "blue bold",

--- a/src/configs/ruby.rs
+++ b/src/configs/ruby.rs
@@ -21,7 +21,7 @@ pub struct RubyConfig<'a> {
 
 impl Default for RubyConfig<'_> {
     fn default() -> Self {
-        RubyConfig {
+        Self {
             format: "via [$symbol($version )]($style)",
             version_format: "v${raw}",
             symbol: "💎 ",

--- a/src/configs/rust.rs
+++ b/src/configs/rust.rs
@@ -20,7 +20,7 @@ pub struct RustConfig<'a> {
 
 impl Default for RustConfig<'_> {
     fn default() -> Self {
-        RustConfig {
+        Self {
             format: "via [$symbol($version )]($style)",
             version_format: "v${raw}",
             symbol: "🦀 ",

--- a/src/configs/scala.rs
+++ b/src/configs/scala.rs
@@ -20,7 +20,7 @@ pub struct ScalaConfig<'a> {
 
 impl Default for ScalaConfig<'_> {
     fn default() -> Self {
-        ScalaConfig {
+        Self {
             format: "via [$symbol($version )]($style)",
             version_format: "v${raw}",
             disabled: false,

--- a/src/configs/shell.rs
+++ b/src/configs/shell.rs
@@ -28,7 +28,7 @@ pub struct ShellConfig<'a> {
 
 impl Default for ShellConfig<'_> {
     fn default() -> Self {
-        ShellConfig {
+        Self {
             format: "[$indicator]($style) ",
             bash_indicator: "bsh",
             fish_indicator: "fsh",

--- a/src/configs/shlvl.rs
+++ b/src/configs/shlvl.rs
@@ -19,7 +19,7 @@ pub struct ShLvlConfig<'a> {
 
 impl Default for ShLvlConfig<'_> {
     fn default() -> Self {
-        ShLvlConfig {
+        Self {
             threshold: 2,
             format: "[$symbol$shlvl]($style) ",
             symbol: "↕️  ", // extra space for emoji

--- a/src/configs/singularity.rs
+++ b/src/configs/singularity.rs
@@ -16,7 +16,7 @@ pub struct SingularityConfig<'a> {
 
 impl Default for SingularityConfig<'_> {
     fn default() -> Self {
-        SingularityConfig {
+        Self {
             format: "[$symbol\\[$env\\]]($style) ",
             symbol: "",
             style: "blue bold dimmed",

--- a/src/configs/solidity.rs
+++ b/src/configs/solidity.rs
@@ -23,7 +23,7 @@ pub struct SolidityConfig<'a> {
 
 impl Default for SolidityConfig<'_> {
     fn default() -> Self {
-        SolidityConfig {
+        Self {
             format: "via [$symbol($version)]($style)",
             symbol: "S ",
             style: "bold blue",

--- a/src/configs/spack.rs
+++ b/src/configs/spack.rs
@@ -17,7 +17,7 @@ pub struct SpackConfig<'a> {
 
 impl Default for SpackConfig<'_> {
     fn default() -> Self {
-        SpackConfig {
+        Self {
             truncation_length: 1,
             format: "via [$symbol$environment]($style) ",
             symbol: "🅢 ",

--- a/src/configs/status.rs
+++ b/src/configs/status.rs
@@ -32,7 +32,7 @@ pub struct StatusConfig<'a> {
 
 impl Default for StatusConfig<'_> {
     fn default() -> Self {
-        StatusConfig {
+        Self {
             format: "[$symbol$status]($style) ",
             symbol: "❌",
             success_symbol: "",

--- a/src/configs/sudo.rs
+++ b/src/configs/sudo.rs
@@ -17,7 +17,7 @@ pub struct SudoConfig<'a> {
 
 impl Default for SudoConfig<'_> {
     fn default() -> Self {
-        SudoConfig {
+        Self {
             format: "[as $symbol]($style)",
             symbol: "🧙 ",
             style: "bold blue",

--- a/src/configs/swift.rs
+++ b/src/configs/swift.rs
@@ -20,7 +20,7 @@ pub struct SwiftConfig<'a> {
 
 impl Default for SwiftConfig<'_> {
     fn default() -> Self {
-        SwiftConfig {
+        Self {
             format: "via [$symbol($version )]($style)",
             version_format: "v${raw}",
             symbol: "🐦 ",

--- a/src/configs/terraform.rs
+++ b/src/configs/terraform.rs
@@ -20,7 +20,7 @@ pub struct TerraformConfig<'a> {
 
 impl Default for TerraformConfig<'_> {
     fn default() -> Self {
-        TerraformConfig {
+        Self {
             format: "via [$symbol$workspace]($style) ",
             version_format: "v${raw}",
             symbol: "💠 ",

--- a/src/configs/time.rs
+++ b/src/configs/time.rs
@@ -20,7 +20,7 @@ pub struct TimeConfig<'a> {
 
 impl Default for TimeConfig<'_> {
     fn default() -> Self {
-        TimeConfig {
+        Self {
             format: "at [$time]($style) ",
             style: "bold yellow",
             use_12hr: false,

--- a/src/configs/typst.rs
+++ b/src/configs/typst.rs
@@ -20,7 +20,7 @@ pub struct TypstConfig<'a> {
 
 impl Default for TypstConfig<'_> {
     fn default() -> Self {
-        TypstConfig {
+        Self {
             format: "via [$symbol($version )]($style)",
             version_format: "v${raw}",
             symbol: "t ",

--- a/src/configs/username.rs
+++ b/src/configs/username.rs
@@ -20,7 +20,7 @@ pub struct UsernameConfig<'a> {
 
 impl Default for UsernameConfig<'_> {
     fn default() -> Self {
-        UsernameConfig {
+        Self {
             detect_env_vars: vec![],
             format: "[$user]($style) in ",
             style_root: "red bold",

--- a/src/configs/v.rs
+++ b/src/configs/v.rs
@@ -20,7 +20,7 @@ pub struct VConfig<'a> {
 
 impl Default for VConfig<'_> {
     fn default() -> Self {
-        VConfig {
+        Self {
             format: "via [$symbol($version )]($style)",
             version_format: "v${raw}",
             symbol: "V ",

--- a/src/configs/vagrant.rs
+++ b/src/configs/vagrant.rs
@@ -20,7 +20,7 @@ pub struct VagrantConfig<'a> {
 
 impl Default for VagrantConfig<'_> {
     fn default() -> Self {
-        VagrantConfig {
+        Self {
             format: "via [$symbol($version )]($style)",
             version_format: "v${raw}",
             symbol: "⍱ ",

--- a/src/configs/vcsh.rs
+++ b/src/configs/vcsh.rs
@@ -16,7 +16,7 @@ pub struct VcshConfig<'a> {
 
 impl Default for VcshConfig<'_> {
     fn default() -> Self {
-        VcshConfig {
+        Self {
             symbol: "",
             style: "bold yellow",
             format: "vcsh [$symbol$repo]($style) ",

--- a/src/configs/zig.rs
+++ b/src/configs/zig.rs
@@ -20,7 +20,7 @@ pub struct ZigConfig<'a> {
 
 impl Default for ZigConfig<'_> {
     fn default() -> Self {
-        ZigConfig {
+        Self {
             format: "via [$symbol($version )]($style)",
             version_format: "v${raw}",
             symbol: "↯ ",

--- a/src/context.rs
+++ b/src/context.rs
@@ -109,7 +109,7 @@ impl<'a> Context<'a> {
             .or_else(|| env::var("PWD").map(PathBuf::from).ok())
             .unwrap_or_else(|| path.clone());
 
-        Context::new_with_shell_and_path(
+        Self::new_with_shell_and_path(
             arguments,
             shell,
             target,
@@ -162,7 +162,7 @@ impl<'a> Context<'a> {
 
         let width = properties.terminal_width;
 
-        Context {
+        Self {
             config,
             properties,
             current_dir,
@@ -462,7 +462,7 @@ impl<'a> Context<'a> {
 
 impl Default for Context<'_> {
     fn default() -> Self {
-        Context::new(Default::default(), Target::Main)
+        Self::new(Default::default(), Target::Main)
     }
 }
 

--- a/src/formatter/model.rs
+++ b/src/formatter/model.rs
@@ -34,13 +34,13 @@ pub enum StyleElement<'a> {
 impl<'a> VariableHolder<Cow<'a, str>> for FormatElement<'a> {
     fn get_variables(&self) -> BTreeSet<Cow<'a, str>> {
         match self {
-            FormatElement::Variable(var) => {
+            Self::Variable(var) => {
                 let mut variables = BTreeSet::new();
                 variables.insert(var.clone());
                 variables
             }
-            FormatElement::TextGroup(textgroup) => textgroup.format.get_variables(),
-            FormatElement::Conditional(format) => format.get_variables(),
+            Self::TextGroup(textgroup) => textgroup.format.get_variables(),
+            Self::Conditional(format) => format.get_variables(),
             _ => Default::default(),
         }
     }
@@ -67,7 +67,7 @@ impl<'a> VariableHolder<Cow<'a, str>> for &[FormatElement<'a>] {
 impl<'a> StyleVariableHolder<Cow<'a, str>> for StyleElement<'a> {
     fn get_style_variables(&self) -> BTreeSet<Cow<'a, str>> {
         match self {
-            StyleElement::Variable(var) => {
+            Self::Variable(var) => {
                 let mut variables = BTreeSet::new();
                 variables.insert(var.clone());
                 variables

--- a/src/formatter/string_formatter.rs
+++ b/src/formatter/string_formatter.rs
@@ -22,7 +22,7 @@ enum VariableValue<'a> {
 
 impl Default for VariableValue<'_> {
     fn default() -> Self {
-        VariableValue::Plain(Cow::Borrowed(""))
+        Self::Plain(Cow::Borrowed(""))
     }
 }
 

--- a/src/module.rs
+++ b/src/module.rs
@@ -128,7 +128,7 @@ pub struct Module<'a> {
 impl<'a> Module<'a> {
     /// Creates a module with no segments.
     pub fn new(name: &str, desc: &str, config: Option<&'a toml::Value>) -> Self {
-        Module {
+        Self {
             config,
             name: name.to_string(),
             description: desc.to_string(),

--- a/src/modules/git_metrics.rs
+++ b/src/modules/git_metrics.rs
@@ -373,8 +373,8 @@ impl GitDiff {
         let deleted_re = Regex::new(r"(\d+) \w+\(\-\)").unwrap();
 
         Self {
-            added: GitDiff::get_matched_str(diff, &added_re).to_owned(),
-            deleted: GitDiff::get_matched_str(diff, &deleted_re).to_owned(),
+            added: Self::get_matched_str(diff, &added_re).to_owned(),
+            deleted: Self::get_matched_str(diff, &deleted_re).to_owned(),
         }
     }
 

--- a/src/serde_utils.rs
+++ b/src/serde_utils.rs
@@ -21,20 +21,20 @@ pub enum ValueRef<'a> {
 impl<'de> From<&'de Value> for ValueRef<'de> {
     fn from(value: &'de Value) -> Self {
         match value {
-            Value::Boolean(b) => ValueRef::Boolean(*b),
-            Value::Integer(i) => ValueRef::Integer(*i),
-            Value::Float(f) => ValueRef::Float(*f),
-            Value::String(s) => ValueRef::String(s),
-            Value::Array(a) => ValueRef::Array(a),
-            Value::Table(t) => ValueRef::Table(t),
-            Value::Datetime(d) => ValueRef::Datetime(d),
+            Value::Boolean(b) => Self::Boolean(*b),
+            Value::Integer(i) => Self::Integer(*i),
+            Value::Float(f) => Self::Float(*f),
+            Value::String(s) => Self::String(s),
+            Value::Array(a) => Self::Array(a),
+            Value::Table(t) => Self::Table(t),
+            Value::Datetime(d) => Self::Datetime(d),
         }
     }
 }
 
 impl<'de> From<&'de toml::Table> for ValueRef<'de> {
     fn from(value: &'de toml::Table) -> Self {
-        ValueRef::Table(value)
+        Self::Table(value)
     }
 }
 
@@ -57,7 +57,7 @@ struct StructInfo {
 
 impl<'de> ValueDeserializer<'de> {
     pub fn new<T: Into<ValueRef<'de>>>(value: T) -> Self {
-        ValueDeserializer {
+        Self {
             value: value.into(),
             info: None,
             current_key: None,
@@ -71,7 +71,7 @@ impl<'de> ValueDeserializer<'de> {
         current_key: &'de str,
         ignored: bool,
     ) -> Self {
-        ValueDeserializer {
+        Self {
             value,
             info,
             current_key: Some(current_key),
@@ -80,7 +80,7 @@ impl<'de> ValueDeserializer<'de> {
     }
 
     pub fn with_allow_unknown_keys(self) -> Self {
-        ValueDeserializer {
+        Self {
             error_on_ignored: false,
             ..self
         }


### PR DESCRIPTION
#### Description

applies the `clippy::use_self` lint

#### Motivation and Context

1. makes the code slightly less verbose
2. marginally easier to refactor object names
3. makes 'constructor' methods more obvious
