### PR TITLE
style: tiny refactor of the Module constructor

### DIFF
--- a/src/module.rs
+++ b/src/module.rs
@@ -127,11 +127,15 @@ pub struct Module<'a> {
 
 impl<'a> Module<'a> {
     /// Creates a module with no segments.
-    pub fn new(name: &str, desc: &str, config: Option<&'a toml::Value>) -> Self {
+    pub fn new(
+        name: impl Into<String>,
+        desc: impl Into<String>,
+        config: Option<&'a toml::Value>,
+    ) -> Self {
         Module {
             config,
-            name: name.to_string(),
-            description: desc.to_string(),
+            name: name.into(),
+            description: desc.into(),
             segments: Vec::new(),
             duration: Duration::default(),
         }

--- a/src/modules/custom.rs
+++ b/src/modules/custom.rs
@@ -39,7 +39,7 @@ pub fn module<'a>(name: &str, context: &'a Context) -> Option<Module<'a>> {
     }
 
     // Note: Forward config if `Module` ends up needing `config`
-    let mut module = Module::new(&format!("custom.{name}"), config.description, None);
+    let mut module = Module::new(format!("custom.{name}"), config.description, None);
 
     let mut is_match = context
         .try_begin_scan()?

--- a/src/modules/env_var.rs
+++ b/src/modules/env_var.rs
@@ -32,7 +32,7 @@ pub fn module<'a>(name: Option<&str>, context: &'a Context) -> Option<Module<'a>
 
     let config = EnvVarConfig::try_load(toml_config.as_deref());
     // Note: Forward config if `Module` ends up needing `config`
-    let mut module = Module::new(&mod_name, config.description, None);
+    let mut module = Module::new(mod_name, config.description, None);
     if config.disabled {
         return None;
     };


### PR DESCRIPTION
#### Motivation and Context

1. removes two instances where a string is converted to a reference and then back to a string
