### PR TITLE
fix(zsh): safe check vars are set before using them

### DIFF
--- a/src/init/starship.zsh
+++ b/src/init/starship.zsh
@@ -63,9 +63,12 @@ starship_zle-keymap-select() {
 }
 
 ## Check for existing keymap-select widget.
-# zle-keymap-select is a special widget so it'll be "user:fnName" or nothing. Let's get fnName only.
-__starship_preserved_zle_keymap_select=${widgets[zle-keymap-select]#user:}
-if [[ -z $__starship_preserved_zle_keymap_select ]]; then
+if [[ -v widgets[zle-keymap-select] ]]; then
+    # zle-keymap-select is a special widget so it'll be "user:fnName" or nothing. Let's get fnName only.
+    __starship_preserved_zle_keymap_select=${widgets[zle-keymap-select]#user:}
+fi
+
+if [[ -z ${__starship_preserved_zle_keymap_select:-} ]]; then
     zle -N zle-keymap-select starship_zle-keymap-select;
 else
     # Define a wrapper fn to call the original widget fn and then Starship's.
@@ -87,6 +90,6 @@ VIRTUAL_ENV_DISABLE_PROMPT=1
 
 setopt promptsubst
 
-PROMPT='$('::STARSHIP::' prompt --terminal-width="$COLUMNS" --keymap="${KEYMAP:-}" --status="$STARSHIP_CMD_STATUS" --pipestatus="${STARSHIP_PIPE_STATUS[*]}" --cmd-duration="${STARSHIP_DURATION:-}" --jobs="$STARSHIP_JOBS_COUNT")'
-RPROMPT='$('::STARSHIP::' prompt --right --terminal-width="$COLUMNS" --keymap="${KEYMAP:-}" --status="$STARSHIP_CMD_STATUS" --pipestatus="${STARSHIP_PIPE_STATUS[*]}" --cmd-duration="${STARSHIP_DURATION:-}" --jobs="$STARSHIP_JOBS_COUNT")'
+PROMPT='$('::STARSHIP::' prompt --terminal-width="$COLUMNS" --keymap="${KEYMAP:-}" --status="${STARSHIP_CMD_STATUS:-}" --pipestatus="${STARSHIP_PIPE_STATUS[*]:-}" --cmd-duration="${STARSHIP_DURATION:-}" --jobs="$STARSHIP_JOBS_COUNT")'
+RPROMPT='$('::STARSHIP::' prompt --right --terminal-width="$COLUMNS" --keymap="${KEYMAP:-}" --status="${STARSHIP_CMD_STATUS:-}" --pipestatus="${STARSHIP_PIPE_STATUS[*]:-}" --cmd-duration="${STARSHIP_DURATION:-}" --jobs="$STARSHIP_JOBS_COUNT")'
 PROMPT2="$(::STARSHIP:: prompt --continuation)"


### PR DESCRIPTION
#### Description
Adds a guard clause to check if `$widgets[zle-keymap-select]` is set before trying to use it in the init script for zsh.
Also defaults `$STARSHIP_CMD_STATUS` and `$STARSHIP_PIPE_STATUS` to empty when setting `$PROMPT` and `RPROMPT`.

#### Motivation and Context
The script was breaking for me when `NO_UNSET` (`set -u`) was set before sourcing it, as `$widgets[zle-keymap-select]` is only set when using `zle-keymap-select` and `$STARSHIP_CMD_STATUS` and `$STARSHIP_PIPE_STATUS` aren't set initially.

#### How Has This Been Tested?
Testing was done by sourcing `starship.zsh` with and without the `NO_UNSET` option, as well as with and without the `zle-keymap-select` widget. I'm running zsh v5.9 on Arch Linux.

- [ ] I have tested using **MacOS**
- [X] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.

Not sure if this needs to be documented as it should be a transparent fix.
Didn't find relevant tests either, please lmk if I should add them.

Side: thanks for the hard and well-done work, really enjoying Starship!