### PR TITLE
feat(python): add support for `pyenv.cfg` version

### DIFF
--- a/src/configs/python.rs
+++ b/src/configs/python.rs
@@ -11,6 +11,8 @@ use serde::{Deserialize, Serialize};
 #[serde(default)]
 pub struct PythonConfig<'a> {
     pub pyenv_version_name: bool,
+    pub venv_pyenvcfg_version: bool,
+    pub force_venv_pyenvcfg_version: bool,
     pub pyenv_prefix: &'a str,
     pub python_binary: VecOr<VecOr<&'a str>>,
     pub format: &'a str,
@@ -28,6 +30,8 @@ impl Default for PythonConfig<'_> {
     fn default() -> Self {
         PythonConfig {
             pyenv_version_name: false,
+            venv_pyenvcfg_version: false,
+            force_venv_pyenvcfg_version: false,
             pyenv_prefix: "pyenv ",
             python_binary: VecOr(vec![
                 VecOr(vec!["python"]),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
As mentioned [`here`](https://github.com/starship/starship/pull/6523#issuecomment-2708925618), `.venv/pyvenv.cfg` has a `version_info` field:
```
home = ...
implementation = CPython
uv = 0.7.4
version_info = 3.11.12
include-system-site-packages = false
prompt = test
```



#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This can be used to read a version number without having to run any binaries, potentially reducing the surface area for an attack, as was also discussed.

Closes #

#### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/dd927a50-eef8-4a6a-a3e9-68a106ae5be6)

With a config of:
```toml
pyenv_version_name = true
python_binary = []
```

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I copied the binary to run in my running shell.

- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
