### PR TITLE
feat: add different time formats to `cmd_duration`

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -183,7 +183,8 @@
         "min_time_to_notify": 45000,
         "show_milliseconds": false,
         "show_notifications": false,
-        "style": "yellow bold"
+        "style": "yellow bold",
+        "time_format": "None"
       },
       "allOf": [
         {
@@ -2559,6 +2560,10 @@
           "default": 45000,
           "type": "integer",
           "format": "int64"
+        },
+        "time_format": {
+          "default": "None",
+          "type": "string"
         },
         "notification_timeout": {
           "type": [

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -918,6 +918,7 @@ running `eval $(starship init $0)`, and then proceed as normal.
 | `show_notifications`   | `false`                       | Show desktop notifications when command completes.                                                                                                                |
 | `min_time_to_notify`   | `45_000`                      | Shortest duration for notification (in milliseconds).                                                                                                             |
 | `notification_timeout` |                               | Duration to show notification for (in milliseconds). If unset, notification timeout will be determined by daemon. Not all notification daemons honor this option. |
+| `time_format`          | `None`                        | Defines how the duration will be formatted (ignores `show_milliseconds` if not `None`), see below for examples and valid values.                                  |
 
 ### Variables
 
@@ -927,6 +928,23 @@ running `eval $(starship init $0)`, and then proceed as normal.
 | style\*  |          | Mirrors the value of option `style`     |
 
 *: This variable can only be used as a part of a style string
+
+### Format
+
+Specifies the format in which the time will be displayed. The table below shows some example times in each option.
+
+| format        | 0.001s         | 2.1s           | 3m2.1s         | 4h3m2.1s         |
+| ------------- | -------------- | -------------- | -------------- | ---------------- |
+| `austin`      | `1ms`          | `2.1s`         | `3m 2.1s`      | `4h 3m 2.1s`     |
+| `roundrock`   | `1ms`          | `2s 100ms`     | `3m 2s 100ms`  | `4h 3m 2s 100ms` |
+| `dallas`      | `0.001`        | `2.1`          | `3:2.1`        | `4:3:2.1`        |
+| `galveston`   | `00:00:00`     | `00:00:02`     | `00:03:02`     | `04:03:02`       |
+| `galvestonms` | `00:00:00:001` | `00:00:02:100` | `00:03:02:100` | `04:03:02:100`   |
+| `houston`     | `00:00:00.001` | `00:00:02.1`   | `00:03:02.1`   | `04:03:02.1`     |
+| `amarillo`    | `0.001s`       | `2.1s`         | `182.1s`       | `14,582.1s`      |
+| `round`       | `1ms`          | `2s`           | `3m 2s`        | `4h 3m`          |
+| `lucky7`      | `    1ms`      | ` 2.00s `      | ` 3m  2s`      | ` 4h  3m`        |
+
 
 ### Example
 

--- a/src/configs/cmd_duration.rs
+++ b/src/configs/cmd_duration.rs
@@ -1,6 +1,41 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
+pub enum TimeFormat {
+    None,
+    Austin,
+    Roundrock,
+    Dallas,
+    Galveston,
+    Galvestonms,
+    Houston,
+    Amarillo,
+    Round,
+    Lucky7,
+}
+
+impl From<&str> for TimeFormat {
+    fn from(value: &str) -> Self {
+        match value {
+            "None" | "none" => TimeFormat::None,
+            "Austin" | "austin" => TimeFormat::Austin,
+            "Roundrock" | "roundrock" => TimeFormat::Roundrock,
+            "Dallas" | "dallas" => TimeFormat::Dallas,
+            "Galveston" | "galveston" => TimeFormat::Galveston,
+            "Galvestonms" | "galvestonms" => TimeFormat::Galvestonms,
+            "Houston" | "houston" => TimeFormat::Houston,
+            "Amarillo" | "amarillo" => TimeFormat::Amarillo,
+            "Round" | "round" => TimeFormat::Round,
+            "Lucky7" | "lucky7" => TimeFormat::Lucky7,
+            s => {
+                log::warn!("time_format in [cmd_duration] ({}) is unknown", s);
+                TimeFormat::None
+            }
+        }
+    }
+}
+
+#[derive(Clone, Deserialize, Serialize)]
 #[cfg_attr(
     feature = "config-schema",
     derive(schemars::JsonSchema),
@@ -15,6 +50,7 @@ pub struct CmdDurationConfig<'a> {
     pub disabled: bool,
     pub show_notifications: bool,
     pub min_time_to_notify: i64,
+    pub time_format: &'a str,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub notification_timeout: Option<u32>,
@@ -30,6 +66,7 @@ impl Default for CmdDurationConfig<'_> {
             disabled: false,
             show_notifications: false,
             min_time_to_notify: 45_000,
+            time_format: "None",
             notification_timeout: None,
         }
     }

--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -9,6 +9,7 @@ use std::cell::OnceCell;
 use super::{Context, Module, ModuleConfig};
 
 use crate::configs::aws::AwsConfig;
+use crate::configs::cmd_duration::TimeFormat;
 use crate::formatter::StringFormatter;
 use crate::utils::render_time;
 
@@ -260,7 +261,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let duration = {
         get_credentials_duration(context, aws_profile.as_ref(), &aws_creds).map(|duration| {
             if duration > 0 {
-                render_time((duration * 1000) as u128, false)
+                render_time((duration * 1000) as u128, false, &TimeFormat::None)
             } else {
                 config.expiration_symbol.to_string()
             }

--- a/src/modules/cmd_duration.rs
+++ b/src/modules/cmd_duration.rs
@@ -171,7 +171,7 @@ mod tests {
             .config(toml::toml! {
                 [cmd_duration]
                 min_time = 5000
-                time_style = "Austin"
+                time_format = "Austin"
             })
             .cmd_duration(182100)
             .collect();
@@ -186,7 +186,7 @@ mod tests {
             .config(toml::toml! {
                 [cmd_duration]
                 min_time = 5000
-                time_style = "roundrock"
+                time_format = "roundrock"
             })
             .cmd_duration(182100)
             .collect();
@@ -204,7 +204,7 @@ mod tests {
             .config(toml::toml! {
                 [cmd_duration]
                 min_time = 5000
-                time_style = "dallas"
+                time_format = "dallas"
             })
             .cmd_duration(182100)
             .collect();
@@ -219,7 +219,7 @@ mod tests {
             .config(toml::toml! {
                 [cmd_duration]
                 min_time = 5000
-                time_style = "galveston"
+                time_format = "galveston"
             })
             .cmd_duration(182100)
             .collect();
@@ -234,7 +234,7 @@ mod tests {
             .config(toml::toml! {
                 [cmd_duration]
                 min_time = 5000
-                time_style = "galvestonms"
+                time_format = "galvestonms"
             })
             .cmd_duration(182100)
             .collect();
@@ -252,7 +252,7 @@ mod tests {
             .config(toml::toml! {
                 [cmd_duration]
                 min_time = 5000
-                time_style = "Houston"
+                time_format = "Houston"
             })
             .cmd_duration(182100)
             .collect();
@@ -270,7 +270,7 @@ mod tests {
             .config(toml::toml! {
                 [cmd_duration]
                 min_time = 5000
-                time_style = "amarillo"
+                time_format = "amarillo"
             })
             .cmd_duration(182100)
             .collect();
@@ -285,7 +285,7 @@ mod tests {
             .config(toml::toml! {
                 [cmd_duration]
                 min_time = 5000
-                time_style = "round"
+                time_format = "round"
             })
             .cmd_duration(182100)
             .collect();
@@ -300,7 +300,7 @@ mod tests {
             .config(toml::toml! {
                 [cmd_duration]
                 min_time = 5000
-                time_style = "Lucky7"
+                time_format = "Lucky7"
             })
             .cmd_duration(182100)
             .collect();

--- a/src/modules/cmd_duration.rs
+++ b/src/modules/cmd_duration.rs
@@ -34,7 +34,11 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 _ => None,
             })
             .map(|variable| match variable {
-                "duration" => Some(Ok(render_time(elapsed, config.show_milliseconds))),
+                "duration" => Some(Ok(render_time(
+                    elapsed,
+                    config.show_milliseconds,
+                    &config.time_format.into(),
+                ))),
                 _ => None,
             })
             .parse(None, Some(context))
@@ -158,6 +162,150 @@ mod tests {
             .collect();
 
         let expected = Some(format!("took {} ", Color::Yellow.bold().paint("10s")));
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn config_austin() {
+        let actual = ModuleRenderer::new("cmd_duration")
+            .config(toml::toml! {
+                [cmd_duration]
+                min_time = 5000
+                time_style = "Austin"
+            })
+            .cmd_duration(182100)
+            .collect();
+
+        let expected = Some(format!("took {} ", Color::Yellow.bold().paint("3m 2.1s")));
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn config_roundrock() {
+        let actual = ModuleRenderer::new("cmd_duration")
+            .config(toml::toml! {
+                [cmd_duration]
+                min_time = 5000
+                time_style = "roundrock"
+            })
+            .cmd_duration(182100)
+            .collect();
+
+        let expected = Some(format!(
+            "took {} ",
+            Color::Yellow.bold().paint("3m 2s 100ms")
+        ));
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn config_dallas() {
+        let actual = ModuleRenderer::new("cmd_duration")
+            .config(toml::toml! {
+                [cmd_duration]
+                min_time = 5000
+                time_style = "dallas"
+            })
+            .cmd_duration(182100)
+            .collect();
+
+        let expected = Some(format!("took {} ", Color::Yellow.bold().paint("3:2.1")));
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn config_galveston() {
+        let actual = ModuleRenderer::new("cmd_duration")
+            .config(toml::toml! {
+                [cmd_duration]
+                min_time = 5000
+                time_style = "galveston"
+            })
+            .cmd_duration(182100)
+            .collect();
+
+        let expected = Some(format!("took {} ", Color::Yellow.bold().paint("00:03:02")));
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn config_galvestonms() {
+        let actual = ModuleRenderer::new("cmd_duration")
+            .config(toml::toml! {
+                [cmd_duration]
+                min_time = 5000
+                time_style = "galvestonms"
+            })
+            .cmd_duration(182100)
+            .collect();
+
+        let expected = Some(format!(
+            "took {} ",
+            Color::Yellow.bold().paint("00:03:02:100")
+        ));
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn config_houston() {
+        let actual = ModuleRenderer::new("cmd_duration")
+            .config(toml::toml! {
+                [cmd_duration]
+                min_time = 5000
+                time_style = "Houston"
+            })
+            .cmd_duration(182100)
+            .collect();
+
+        let expected = Some(format!(
+            "took {} ",
+            Color::Yellow.bold().paint("00:03:02.1")
+        ));
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn config_amarillo() {
+        let actual = ModuleRenderer::new("cmd_duration")
+            .config(toml::toml! {
+                [cmd_duration]
+                min_time = 5000
+                time_style = "amarillo"
+            })
+            .cmd_duration(182100)
+            .collect();
+
+        let expected = Some(format!("took {} ", Color::Yellow.bold().paint("182.1s")));
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn config_round() {
+        let actual = ModuleRenderer::new("cmd_duration")
+            .config(toml::toml! {
+                [cmd_duration]
+                min_time = 5000
+                time_style = "round"
+            })
+            .cmd_duration(182100)
+            .collect();
+
+        let expected = Some(format!("took {} ", Color::Yellow.bold().paint("3m 2s")));
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn config_lucky7() {
+        let actual = ModuleRenderer::new("cmd_duration")
+            .config(toml::toml! {
+                [cmd_duration]
+                min_time = 5000
+                time_style = "Lucky7"
+            })
+            .cmd_duration(182100)
+            .collect();
+
+        let expected = Some(format!("took {} ", Color::Yellow.bold().paint(" 3m  2s")));
         assert_eq!(expected, actual);
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR introduces different ways to format the duration displayed by the `cmd_duration` module. 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I've recently switched from `oh-my-posh` to `starship.rs` and was missing a readable time duration format. I've implemented [all formats](https://ohmyposh.dev/docs/segments/system/executiontime#style) from `oh-my-posh` and copied [all their tests](https://github.com/JanDeDobbeleer/oh-my-posh/blob/fb6d8fc9965170959af8087e0dec800eb7bdc97f/src/segments/executiontime_test.go#L86-L347) (tests cover both `utils.rs` and `cmd_duration.rs`).

Closes #6642 

#### (Possible) Open Points
- I'm making heavy use of `format!`, no idea if this has a relevant impact on performance.
- I've failed to directly deserialize the new format enum from `toml` and therefore went the `From<&str>` route. The side-effect of this is that the config struct takes a `&str` instead of the enum itself. Looking at existing modules, every config option seems to be a primitiv type (or vector) :thinking: I'm open to suggestions.
- This could be seen as a breaking change, though the current behavior is kept when no format is specified. The `show_milliseconds` switch is obsolete (but kept to keep the previous behavior when the format is `None`). Any suggestion on how to deal with this?

#### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/b20872b0-7623-4277-87c7-101e5677ba8a)
![image](https://github.com/user-attachments/assets/ed9828cf-9924-4155-8b8f-929aea541933)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [X] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have updated the documentation accordingly.
- [X] I have updated the tests accordingly.
