### PR TITLE
fix(hg_branch): Strip extraneous newlines from hg topic.

### DIFF
--- a/src/modules/hg_branch.rs
+++ b/src/modules/hg_branch.rs
@@ -84,7 +84,10 @@ fn get_hg_current_bookmark(hg_root: &Path) -> Result<String, Error> {
 }
 
 fn get_hg_topic_name(hg_root: &Path) -> Result<String, Error> {
-    read_file(hg_root.join(".hg").join("topic"))
+    match read_file(hg_root.join(".hg").join("topic")) {
+        Ok(b) => Ok(b.trim().to_string()),
+        Err(e) => Err(e),
+    }
 }
 
 #[cfg(test)]
@@ -182,7 +185,7 @@ mod tests {
     fn test_hg_topic() -> io::Result<()> {
         let tempdir = fixture_repo(FixtureProvider::Hg)?;
         let repo_dir = tempdir.path();
-        fs::write(repo_dir.join(".hg").join("topic"), "feature")?;
+        fs::write(repo_dir.join(".hg").join("topic"), "feature\n")?;
 
         let actual = ModuleRenderer::new("hg_branch")
             .path(repo_dir.to_str().unwrap())


### PR DESCRIPTION
HG topic file, like the branch file, can end with a newline. Strip it out the same way to avoid dumping extra newlines into the prompt.

#### Description

I'm currently running mercurial version 6.9.4. In this version, the .hg/topic file ends with a newline. The code to handle branch files strips out similar newlines, so I preserved the structure from `hg_branch::get_hg_branch_name`. Interestingly the current bookmark file does still seem to end without a newline. I am unsure if this is a change in behavior across mercurial versions, but the new code will still work fine if no newline is generated.


#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [X] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [X] I have updated the tests accordingly.
