### PR TITLE
chore: remove redundant config in cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,3 @@ strip = true
 codegen-units = 16
 lto = "thin"
 strip = false
-
-[[bin]]
-name = "starship"
-path = "src/main.rs"


### PR DESCRIPTION
this config block is not required, since this is the default behaviour when `src/main.rs` is present
