### PR TITLE
docs: Fix stashed example for Git Status to prevent parse warning

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2010,26 +2010,26 @@ You can disable the module or use the `windows_starship` option to use a Windows
 
 ### Options
 
-| Option               | Default                                       | Description                                                                                                 |
-| -------------------- | --------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| `format`             | `'([\[$all_status$ahead_behind\]]($style) )'` | The default format for `git_status`                                                                         |
-| `conflicted`         | `'='`                                         | This branch has merge conflicts.                                                                            |
-| `ahead`              | `'⇡'`                                         | The format of `ahead`                                                                                       |
-| `behind`             | `'⇣'`                                         | The format of `behind`                                                                                      |
-| `diverged`           | `'⇕'`                                         | The format of `diverged`                                                                                    |
-| `up_to_date`         | `''`                                          | The format of `up_to_date`                                                                                  |
-| `untracked`          | `'?'`                                         | The format of `untracked`                                                                                   |
-| `stashed`            | `'$'`                                         | The format of `stashed`                                                                                     |
-| `modified`           | `'!'`                                         | The format of `modified`                                                                                    |
-| `staged`             | `'+'`                                         | The format of `staged`                                                                                      |
-| `renamed`            | `'»'`                                         | The format of `renamed`                                                                                     |
-| `deleted`            | `'✘'`                                         | The format of `deleted`                                                                                     |
-| `typechanged`        | `""`                                          | The format of `typechanged`                                                                                 |
-| `style`              | `'bold red'`                                  | The style for the module.                                                                                   |
-| `ignore_submodules`  | `false`                                       | Ignore changes to submodules.                                                                               |
-| `disabled`           | `false`                                       | Disables the `git_status` module.                                                                           |
-| `windows_starship`   |                                               | Use this (Linux) path to a Windows Starship executable to render `git_status` when on Windows paths in WSL. |
-| `use_git_executable` | `false`                                       | Do not use `gitoxide` for computing the status, but use the `git` executable instead.                       |
+| Option               | Default                                        | Description                                                                                                 |
+| -------------------- | ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `format`             | `'([\[$all_status$ahead_behind\]]($style) )'`  | The default format for `git_status`                                                                         |
+| `conflicted`         | `'='`                                          | This branch has merge conflicts.                                                                            |
+| `ahead`              | `'⇡'`                                          | The format of `ahead`                                                                                       |
+| `behind`             | `'⇣'`                                          | The format of `behind`                                                                                      |
+| `diverged`           | `'⇕'`                                          | The format of `diverged`                                                                                    |
+| `up_to_date`         | `''`                                           | The format of `up_to_date`                                                                                  |
+| `untracked`          | `'?'`                                          | The format of `untracked`                                                                                   |
+| `stashed`            | `'\$'`                                         | The format of `stashed`                                                                                     |
+| `modified`           | `'!'`                                          | The format of `modified`                                                                                    |
+| `staged`             | `'+'`                                          | The format of `staged`                                                                                      |
+| `renamed`            | `'»'`                                          | The format of `renamed`                                                                                     |
+| `deleted`            | `'✘'`                                          | The format of `deleted`                                                                                     |
+| `typechanged`        | `""`                                           | The format of `typechanged`                                                                                 |
+| `style`              | `'bold red'`                                   | The style for the module.                                                                                   |
+| `ignore_submodules`  | `false`                                        | Ignore changes to submodules.                                                                               |
+| `disabled`           | `false`                                        | Disables the `git_status` module.                                                                           |
+| `windows_starship`   |                                                | Use this (Linux) path to a Windows Starship executable to render `git_status` when on Windows paths in WSL. |
+| `use_git_executable` | `false`                                        | Do not use `gitoxide` for computing the status, but use the `git` executable instead.                       |
 
 ### Variables
 


### PR DESCRIPTION
#### Description
When you using the default configuration in your own config for Git Status, and stashing files. You'll receive a warning:
`[WARN] - (starship::modules::git_status): Error parsing format string git_status.stashed`

<img width="712" alt="image" src="https://github.com/user-attachments/assets/dffea244-f519-4671-bd92-812c29cdbe55" />

This change updates the config value to '\$' to get the desired behavior.

To reproduce the issue:

1. Set the stashed value to '$'
2. Make a change to a repository and run `git add <changed_file> && git stash`
3. You should see a warning: `[WARN] - (starship::modules::git_status): Error parsing format string git_status.stashed`
4. Update the value to '\$'
5. Run command to update the terminal prompt and observe the $ being present in the prompt.

#### Motivation and Context
For those that prefer to their own config to be declarative and observable. This change will enable them to have a working configuration when using git stash.
Closes #

#### Screenshots (if appropriate):
<img width="793" alt="image" src="https://github.com/user-attachments/assets/89ca9b51-31a3-49e8-83d1-980603341343" />

#### How Has This Been Tested?
I was able to test by updating my own configuration with the suggested fix and observe the desired behavior.
- [X] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [X] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
