### PR TITLE
feat(python): add dir and prompt variables (#6776 #6777)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3234,6 +3234,7 @@ dependencies = [
  "os_info",
  "parking_lot",
  "path-slash",
+ "pathdiff",
  "pest",
  "pest_derive",
  "process_control",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ os_info = "3.13.0"
 # for efficient shared state between `git_status` and `git_metrics`, allowing parallel printing. This is for poison-free locks.
 parking_lot = "0.12.5"
 path-slash = "0.2.1"
+pathdiff = "0.2.3"
 pest = "2.8.4"
 pest_derive = "2.8.4"
 process_control = "5.2.0"

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -3956,13 +3956,15 @@ By default, the module will be shown if any of the following conditions are met:
 
 ### Variables
 
-| Variable     | Example         | Description                                |
-| ------------ | --------------- | ------------------------------------------ |
-| version      | `'v3.8.1'`      | The version of `python`                    |
-| symbol       | `'🐍 '`         | Mirrors the value of option `symbol`       |
-| style        | `'yellow bold'` | Mirrors the value of option `style`        |
-| pyenv_prefix | `'pyenv '`      | Mirrors the value of option `pyenv_prefix` |
-| virtualenv   | `'venv'`        | The current `virtualenv` name              |
+| Variable     | Example         | Description                                                  |
+| ------------ | --------------- | ------------------------------------------------------------ |
+| version      | `'v3.8.1'`      | The version of `python`                                      |
+| symbol       | `'🐍 '`         | Mirrors the value of option `symbol`                         |
+| style        | `'yellow bold'` | Mirrors the value of option `style`                          |
+| pyenv_prefix | `'pyenv '`      | Mirrors the value of option `pyenv_prefix`                   |
+| virtualenv   | `'venv'`        | The current `virtualenv` name                                |
+| dir          | `'./venv'`      | The `virtualenv` directory relative to the current directory |
+| prompt       | `'venv'`        | The `virtualenv` prompt                                      |
 
 ### Example
 


### PR DESCRIPTION
As an addition to virtualenv, which provides the venv directory name or venv prompt from pyvenv.cfg, dir provides the venv directory path relative to CWD and prompt provides just the prompt configured via pyvenv.cfg

<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
I added 2 variables to the python module and filled the documentation in README.md.

#### Motivation and Context
Closes #6776
Closes #6777

#### Screenshots (if appropriate):
![2025-06-03-224902_1919x52_scrot](https://github.com/user-attachments/assets/652e35be-5974-4027-8d09-15c957d190e4)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
