### PR TITLE
docs(presets): fix broken link to parent on Catppuccin Powerline preset page

### DIFF
--- a/docs/presets/catppuccin-powerline.md
+++ b/docs/presets/catppuccin-powerline.md
@@ -1,4 +1,4 @@
-[Return to Presets](./README.md#catppuccin-powerline)
+[Return to Presets](./#catppuccin-powerline)
 
 # Catppuccin Powerline Preset
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR fixes the broken `markdown` link in the [Catppuccin Powerline](https://starship.rs/presets/catppuccin-powerline). 
The file changed is [this markdown file](https://github.com/starship/starship/edit/master/docs/presets/catppuccin-powerline.md). 

This is a minor change where I change the link in [this line](https://github.com/starship/starship/blob/master/docs/presets/catppuccin-powerline.md?plain=1#L1https://github.com/starship/starship/blob/master/docs/presets/catppuccin-powerline.md?plain=1#L1) from `./README.md#catppuccin-powerline` to `./#catppuccin-powerline`. This prevents the `404` page error while clicking the link.


#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

While navigating the [Catppuccin Powerline](https://starship.rs/presets/catppuccin-powerline) page, on clicking the link `return to presets`, it shows a `404` error page.
![image](https://github.com/user-attachments/assets/4ed1f9a0-679f-489e-b5ba-f6c6857ee96d)

This is likely due to redirecting to the wrong link as stated in the description above.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
