### PR TITLE
fix(fossil_metrics): match single-file

### DIFF
--- a/src/modules/fossil_metrics.rs
+++ b/src/modules/fossil_metrics.rs
@@ -72,7 +72,7 @@ impl<'a> FossilDiff<'a> {
     pub fn parse(diff_numstat: &'a str, only_nonzero_diffs: bool) -> Self {
         // Fossil formats the last line of the output as "%10d %10d TOTAL over %d changed files\n"
         // where the 1st and 2nd placeholders are the number of added and deleted lines respectively
-        let re = Regex::new(r"^\s*(\d+)\s+(\d+) TOTAL over \d+ changed files$").unwrap();
+        let re = Regex::new(r"^\s*(\d+)\s+(\d+) TOTAL over \d+ changed files?$").unwrap();
 
         let (added, deleted) = diff_numstat
             .lines()


### PR DESCRIPTION
#### Description
Add `?` after the trailing `filess` in the regex to support the singular form.

```rust
- let re = Regex::new(r"^\s*(\d+)\s+(\d+) TOTAL over \d+ changed files$")?;
+ let re = Regex::new(r"^\s*(\d+)\s+(\d+) TOTAL over \d+ changed files?$")?;
```

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #6728



#### How Has This Been Tested?
1118 tests passed
- [ ] I have tested using **MacOS**

