### PR TITLE
fix: Add hostname module to bracketed-segments preset

### DIFF
--- a/docs/public/presets/toml/bracketed-segments.toml
+++ b/docs/public/presets/toml/bracketed-segments.toml
@@ -88,6 +88,9 @@ format = '\[[$symbol$branch]($style)\]'
 [hg_state]
 format = '\([$state]($style)\) '
 
+[hostname]
+format = '\[[$ssh_symbol($hostname)]($style)\] '
+
 [java]
 format = '\[[$symbol($version)]($style)\]'
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

The hostname module is not currently styled by the bracketed-segments preset. This leads to a mixture of default and preset when a user ssh-es into a system running this preset.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The motivation for this change is my own use of the preset.

#### Screenshots (if appropriate):

Before:
![Screenshot_20250613-175732](https://github.com/user-attachments/assets/9b69016f-5147-4744-9764-950a637d4ec9)

After:
![Screenshot_20250613-175511](https://github.com/user-attachments/assets/3fe838d3-2bd9-4282-a64d-30f4196eddd5)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

Config change to test styling
Cargo test
Cargo run prompt

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly. (Built automatically)
- [ ] I have updated the tests accordingly. (N/A)
