### PR TITLE
feat(haskell): Improve `haskell` module

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -4145,7 +4145,30 @@
             "cabal.project"
           ]
         },
-        "detect_folders": {
+        "cabal_folders": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        },
+        "stack_extensions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        },
+        "stack_files": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "stack.yaml"
+          ]
+        },
+        "stack_folders": {
           "type": "array",
           "items": {
             "type": "string"

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2351,34 +2351,60 @@ The `gradle` module is only able to read your Gradle Wrapper version from your c
 
 ## Haskell
 
-The `haskell` module finds the current selected GHC version and/or the selected Stack snapshot.
+The `haskell` module finds the current selected compiler version and/or the selected Stack snapshot.
+In order to decide how to populate the output fields this module does the
+following (in that order):
+
+1. Check if the current directory is part of a Stack project.
+
+   This is done using the `stack_*` configuration options.
+
+2. Check if the current directory is part of a Cabal project.
+
+   This is done using the `cabal_*` configuration options.
+
+3. If neither is the case, check if there are other Haskell files in the
+   current directory.
+
+   This is done using the `detect_*` configuration options.
 
 By default the module will be shown if any of the following conditions are met:
 
-- The current directory contains a `stack.yaml` file
-- The current directory contains any `.hs`, `.cabal`, or `.hs-boot` file
+- The current directory or an ancestor directory contains a `stack.yaml` file.
+- The current directory or an ancestor directory contains a `cabal.project` file, or the current directory contains a `.cabal` file.
+- The current directory contains any `.hs`, or `.hs-boot` file.
 
 ### Options
 
-| Option              | Default                              | Description                                        |
-| ------------------- | ------------------------------------ | -------------------------------------------------- |
-| `format`            | `'via [$symbol($version )]($style)'` | The format for the module.                         |
-| `symbol`            | `'λ '`                               | A format string representing the symbol of Haskell |
-| `detect_extensions` | `['hs', 'cabal', 'hs-boot']`         | Which extensions should trigger this module.       |
-| `detect_files`      | `['stack.yaml', 'cabal.project']`    | Which filenames should trigger this module.        |
-| `detect_folders`    | `[]`                                 | Which folders should trigger this module.          |
-| `style`             | `'bold purple'`                      | The style for the module.                          |
-| `disabled`          | `false`                              | Disables the `haskell` module.                     |
+| Option              | Default                              | Description                                                                       |
+| ------------------- | ------------------------------------ | --------------------------------------------------------------------------------- |
+| `format`            | `'via [$symbol($version )]($style)'` | The format for the module.                                                        |
+| `symbol`            | `'λ '`                               | A format string representing the symbol of Haskell.                               |
+| `default_compiler`  | `'ghc'`                              | The executable name of the Haskell compiler used outside of Cabal/Stack projects. |
+| `detect_extensions` | `['hs', 'hs-boot']`                  | Extensions used to discover a non-project Haskell setup.                          |
+| `detect_files`      | `[]`                                 | Filenames used to discover a non-project Haskell setup.                           |
+| `detect_folders`    | `[]`                                 | Folders names used to discover a non-project Haskell setup.                       |
+| `cabal_extensions`  | `['cabal']`                          | Extensions used to discover a Cabal project.                                      |
+| `cabal_files`       | `['cabal.project']`                  | Filenames used to discover a Cabal project.                                       |
+| `cabal_folders`     | `[]`                                 | Folders used to discover a Cabal project.                                         |
+| `stack_extensions`  | `[]`                                 | Extensions used to discover a Stack project.                                      |
+| `stack_files`       | `['stack.yaml']`                     | Filenames used to discover a Stack project.                                       |
+| `stack_folders`     | `[]`                                 | Folders used to discover a Stack project.                                         |
+| `style`             | `'bold purple'`                      | The style for the module.                                                         |
+| `disabled`          | `false`                              | Disables the `haskell` module.                                                    |
 
 ### Variables
 
-| Variable     | Example     | Description                                                                             |
-| ------------ | ----------- | --------------------------------------------------------------------------------------- |
-| version      |             | `ghc_version` or `snapshot` depending on whether the current project is a Stack project |
-| snapshot     | `lts-18.12` | Currently selected Stack snapshot                                                       |
-| ghc\_version | `9.2.1`     | Currently installed GHC version                                                         |
-| symbol       |             | Mirrors the value of option `symbol`                                                    |
-| style\*      |             | Mirrors the value of option `style`                                                     |
+| Variable         | Example     | Description                                                                             |
+| ---------------- | ----------- | --------------------------------------------------------------------------------------- |
+| version          |             | `ghc_version` or `snapshot` depending on whether the current project is a Stack project |
+| snapshot         | `lts-18.12` | Currently selected Stack snapshot                                                       |
+| compiler_id      | `ghc-9.2.1` | The ID (i.e. "NAME-VERSION") of the currently used compiler                             |
+| compiler_name    | `ghc`       | The name of the currently used compiler                                                 |
+| compiler_version | `9.2.1`     | The version of the currently used compiler                                              |
+| ghc\_version     | `9.2.1`     | An alias for `compiler_version`                                                         |
+| symbol           |             | Mirrors the value of option `symbol`                                                    |
+| style\*          |             | Mirrors the value of option `style`                                                     |
 
 *: This variable can only be used as a part of a style string
 

--- a/src/configs/haskell.rs
+++ b/src/configs/haskell.rs
@@ -13,9 +13,16 @@ pub struct HaskellConfig<'a> {
     pub symbol: &'a str,
     pub style: &'a str,
     pub disabled: bool,
+    pub default_compiler: &'a str,
     pub detect_extensions: Vec<&'a str>,
     pub detect_files: Vec<&'a str>,
     pub detect_folders: Vec<&'a str>,
+    pub cabal_extensions: Vec<&'a str>,
+    pub cabal_files: Vec<&'a str>,
+    pub cabal_folders: Vec<&'a str>,
+    pub stack_extensions: Vec<&'a str>,
+    pub stack_files: Vec<&'a str>,
+    pub stack_folders: Vec<&'a str>,
 }
 
 impl Default for HaskellConfig<'_> {
@@ -26,9 +33,16 @@ impl Default for HaskellConfig<'_> {
             symbol: "λ ",
             style: "bold purple",
             disabled: false,
-            detect_extensions: vec!["hs", "cabal", "hs-boot"],
-            detect_files: vec!["stack.yaml", "cabal.project"],
+            default_compiler: "ghc",
+            detect_extensions: vec!["hs", "hs-boot"],
+            detect_files: vec![],
             detect_folders: vec![],
+            cabal_extensions: vec!["cabal"],
+            cabal_files: vec!["cabal.project"],
+            cabal_folders: vec![],
+            stack_extensions: vec![],
+            stack_files: vec!["stack.yaml"],
+            stack_folders: vec![],
         }
     }
 }

--- a/src/modules/haskell.rs
+++ b/src/modules/haskell.rs
@@ -2,22 +2,23 @@ use super::{Context, Module, ModuleConfig};
 
 use crate::configs::haskell::HaskellConfig;
 use crate::formatter::StringFormatter;
+use crate::utils::read_file;
+use std::path::PathBuf;
+
+struct HaskellResult {
+    compiler_name: Option<String>,
+    compiler_version: Option<String>,
+    snapshot: Option<String>,
+}
 
 /// Creates a module with the current Haskell version
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let mut module = context.new_module("haskell");
     let config = HaskellConfig::try_load(module.config);
 
-    let is_hs_project = context
-        .try_begin_scan()?
-        .set_files(&config.detect_files)
-        .set_extensions(&config.detect_extensions)
-        .set_folders(&config.detect_folders)
-        .is_match();
-
-    if !is_hs_project {
-        return None;
-    }
+    let haskell_result: HaskellResult = stack_result(context, &config)
+        .or_else(|| cabal_result(context, &config))
+        .or_else(|| plain_haskell_result(context, &config))?;
 
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter
@@ -30,9 +31,12 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 _ => None,
             })
             .map(|variable| match variable {
-                "version" => get_version(context).map(Ok),
-                "ghc_version" => get_ghc_version(context).map(Ok),
-                "snapshot" => get_snapshot(context).map(Ok),
+                "compiler_name" => haskell_result.compiler_name.clone().map(Ok),
+                "compiler_id" => get_compiler_id(&haskell_result).map(Ok),
+                "compiler_version" => haskell_result.compiler_version.clone().map(Ok),
+                "ghc_version" => haskell_result.compiler_version.clone().map(Ok), // TODO: The `ghc_version` field should be removed in favour of `compiler_version`.
+                "snapshot" => haskell_result.snapshot.clone().map(Ok),
+                "version" => get_version(&haskell_result).map(Ok),
                 _ => None,
             })
             .parse(None, Some(context))
@@ -49,21 +53,68 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     Some(module)
 }
 
-fn get_ghc_version(context: &Context) -> Option<String> {
-    Some(
-        context
-            .exec_cmd("ghc", &["--numeric-version"])?
-            .stdout
-            .trim()
-            .to_string(),
-    )
+fn get_compiler_id(haskell_result: &HaskellResult) -> Option<String> {
+    let compiler_name = haskell_result.compiler_name.clone()?;
+    let compiler_version = haskell_result.compiler_version.clone()?;
+    Some(format!("{compiler_name}-{compiler_version}"))
 }
 
-fn get_snapshot(context: &Context) -> Option<String> {
-    if !is_stack_project(context) {
-        return None;
-    }
-    let file_contents = context.read_file_from_pwd("stack.yaml")?;
+fn get_version(haskell_result: &HaskellResult) -> Option<String> {
+    haskell_result
+        .snapshot
+        .clone()
+        .or(get_compiler_id(haskell_result))
+}
+
+/// Try to get a Stack project setup
+fn stack_result<'a>(context: &'a Context, config: &HaskellConfig) -> Option<HaskellResult> {
+    let is_project_in_current_dir: bool = context
+        .try_begin_scan()?
+        .set_files(&config.stack_files)
+        .set_extensions(&config.stack_extensions)
+        .set_folders(&config.stack_folders)
+        .is_match();
+
+    let maybe_project_root: Option<PathBuf> = if is_project_in_current_dir {
+        Some(context.current_dir.clone())
+    } else {
+        context
+            .begin_ancestor_scan()
+            .set_files(&config.stack_files)
+            .set_folders(&config.stack_folders)
+            .scan()
+    };
+
+    maybe_project_root.map(|project_root| {
+        log::trace!("Found Stack project at {:?}", project_root);
+        let compiler = get_stack_compiler(context);
+        HaskellResult {
+            compiler_name: compiler.clone().map(|pair| pair.0),
+            compiler_version: compiler.clone().map(|pair| pair.1),
+            snapshot: get_stack_snapshot(context, project_root),
+        }
+    })
+}
+
+fn get_stack_compiler(context: &Context) -> Option<(String, String)> {
+    let compiler_version = context
+        .exec_cmd(
+            "stack",
+            &["--no-install-ghc", "query", "compiler", "wanted"],
+        )?
+        .stdout
+        .trim()
+        .strip_prefix("ghc-")?
+        .to_string();
+    Some(("ghc".to_string(), compiler_version))
+}
+
+fn get_stack_snapshot(context: &Context, project_root: PathBuf) -> Option<String> {
+    let stack_yaml_name: String = context
+        .get_env("STACK_YAML")
+        .unwrap_or("stack.yaml".to_string());
+    let stack_yaml_path: PathBuf = project_root.join(stack_yaml_name);
+    let file_contents = read_file(stack_yaml_path).ok()?;
     let yaml = yaml_rust2::YamlLoader::load_from_str(&file_contents).ok()?;
     let version = yaml.first()?["resolver"]
         .as_str()
@@ -73,15 +124,85 @@ fn get_snapshot(context: &Context) -> Option<String> {
     Some(version.to_string())
 }
 
-fn get_version(context: &Context) -> Option<String> {
-    get_snapshot(context).or_else(|| get_ghc_version(context))
+/// Try to get a Cabal project setup
+fn cabal_result<'a>(context: &'a Context, config: &HaskellConfig) -> Option<HaskellResult> {
+    let is_project_in_current_dir: bool = context
+        .try_begin_scan()?
+        .set_files(&config.cabal_files)
+        .set_extensions(&config.cabal_extensions)
+        .set_folders(&config.cabal_folders)
+        .is_match();
+
+    let maybe_project_root: Option<PathBuf> = if is_project_in_current_dir {
+        Some(context.current_dir.clone())
+    } else {
+        context
+            .begin_ancestor_scan()
+            .set_files(&config.cabal_files)
+            .set_folders(&config.cabal_folders)
+            .scan()
+    };
+
+    maybe_project_root.map(|project_root| {
+        log::trace!("Found Cabal project at {:?}", project_root);
+        let compiler = get_cabal_compiler(context);
+        HaskellResult {
+            compiler_name: compiler.clone().map(|pair| pair.0),
+            compiler_version: compiler.clone().map(|pair| pair.1),
+            snapshot: None,
+        }
+    })
 }
 
-fn is_stack_project(context: &Context) -> bool {
-    match context.dir_contents() {
-        Ok(dir) => dir.has_file_name("stack.yaml"),
-        Err(_) => false,
+fn get_cabal_compiler(context: &Context) -> Option<(String, String)> {
+    let output: String = context
+        .exec_cmd(
+            "cabal",
+            &["-v0", "path", "--format=json", "--compiler-info"],
+        )?
+        .stdout;
+    let parsed_json: serde_json::Value = serde_json::from_str(output.as_str()).ok()?;
+    let compiler = parsed_json.get("compiler")?;
+    let compiler_name = compiler.get("flavour")?.as_str()?;
+    let compiler_version = compiler
+        .get("id")?
+        .as_str()?
+        .strip_prefix(format!("{compiler_name}-").as_str())?;
+    log::trace!("Cabal output 4: {:?}", compiler_version);
+    Some((compiler_name.to_string(), compiler_version.to_string()))
+}
+
+/// Neither a Cabal nor a Stack project; But maybe there are some Haskell files in the current
+/// directory.
+fn plain_haskell_result<'a>(context: &'a Context, config: &HaskellConfig) -> Option<HaskellResult> {
+    let is_haskell_directory: bool = context
+        .try_begin_scan()?
+        .set_files(&config.detect_files)
+        .set_extensions(&config.detect_extensions)
+        .set_folders(&config.detect_folders)
+        .is_match();
+
+    if !is_haskell_directory {
+        return None;
     }
+
+    log::trace!("Found Haskell files in current directory");
+    let compiler = get_plain_compiler(context, config);
+    Some(HaskellResult {
+        compiler_name: compiler.clone().map(|pair| pair.0),
+        compiler_version: compiler.clone().map(|pair| pair.1),
+        snapshot: None,
+    })
+}
+
+fn get_plain_compiler(context: &Context, config: &HaskellConfig) -> Option<(String, String)> {
+    let compiler_name = config.default_compiler.to_string();
+    let compiler_version = context
+        .exec_cmd(config.default_compiler, &["--numeric-version"])?
+        .stdout
+        .trim()
+        .to_string();
+    Some((compiler_name, compiler_version))
 }
 
 #[cfg(test)]
@@ -89,85 +210,213 @@ mod tests {
     use crate::test::ModuleRenderer;
     use nu_ansi_term::Color;
     use std::fs::File;
+    use std::fs::create_dir;
     use std::io;
     use std::io::Write;
 
     #[test]
-    fn folder_without_hs_files() -> io::Result<()> {
+    fn folder_without_haskell_files() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
+
         let actual = ModuleRenderer::new("haskell").path(dir.path()).collect();
         let expected = None;
         assert_eq!(expected, actual);
+
         dir.close()
     }
 
     #[test]
     fn folder_stack() -> io::Result<()> {
         let cases = vec![
-            ("resolver: lts-18.12\n", "lts-18.12"),
+            ("resolver: lts-18.12", "lts-18.12"),
             ("snapshot: nightly-2011-11-11", "nightly-2011-11-11"),
             ("snapshot: ghc-8.10.7", "ghc-8.10.7"),
             (
-                "snapshot: https://github.com/whatever/xxx.yaml\n",
+                "snapshot: https://example.com/whatever/xxx.yaml",
                 "<custom snapshot>",
             ),
             (
-                "resolver:\n  url: https://github.com/whatever/xxx.yaml\n",
+                "resolver:\n  url: https://example.com/whatever/xxx.yaml",
                 "<custom snapshot>",
             ),
-            (REANIMATE_STACK_YAML, "lts-14.27"),
         ];
+        let other_hs_files = vec!["M.hs", "M.hs-boot", "cabal.project"];
         for (yaml, resolver) in &cases {
             let dir = tempfile::tempdir()?;
+
             let mut file = File::create(dir.path().join("stack.yaml"))?;
             file.write_all(yaml.as_bytes())?;
             file.sync_all()?;
+
+            for hs_file in &other_hs_files {
+                File::create(dir.path().join(hs_file))?.sync_all()?;
+            }
+
             let actual = ModuleRenderer::new("haskell").path(dir.path()).collect();
             let expected = Some(format!(
                 "via {}",
                 Color::Purple.bold().paint(format!("λ {resolver} "))
             ));
             assert_eq!(expected, actual);
+
             dir.close()?;
         }
         Ok(())
     }
 
     #[test]
-    fn folder_cabal() -> io::Result<()> {
-        let should_trigger = vec!["a.hs", "b.hs-boot", "cabal.project"];
-        for hs_file in &should_trigger {
-            let dir = tempfile::tempdir()?;
+    fn folder_stack_nested() -> io::Result<()> {
+        let other_hs_files = vec!["M.hs", "M.hs-boot", "cabal.project"];
+        let dir = tempfile::tempdir()?;
+        let nested = dir.path().join("nested");
+
+        let mut file = File::create(dir.path().join("stack.yaml"))?;
+        file.write_all("resolver: lts-18.12".as_bytes())?;
+        file.sync_all()?;
+
+        create_dir(&nested)?;
+        for hs_file in &other_hs_files {
+            File::create(nested.as_path().join(hs_file))?.sync_all()?;
+        }
+
+        let actual = ModuleRenderer::new("haskell")
+            .path(nested.as_path())
+            .collect();
+        let expected = Some(format!(
+            "via {}",
+            Color::Purple.bold().paint(format!("λ lts-18.12 "))
+        ));
+        assert_eq!(expected, actual);
+
+        dir.close()?;
+        Ok(())
+    }
+
+    #[test]
+    fn folder_dotcabal() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+
+        File::create(dir.path().join("name.cabal"))?.sync_all()?;
+
+        let other_hs_files = vec!["M.hs", "M.hs-boot"];
+        for hs_file in &other_hs_files {
             File::create(dir.path().join(hs_file))?.sync_all()?;
+        }
+
+        let actual = ModuleRenderer::new("haskell").path(dir.path()).collect();
+        let expected = Some(format!(
+            "via {}",
+            Color::Purple.bold().paint("λ ghc-9.2.1 ")
+        ));
+        assert_eq!(expected, actual);
+
+        dir.close()?;
+        Ok(())
+    }
+
+    #[test]
+    fn folder_cabalproject() -> io::Result<()> {
+        // We mock the `cabal` command while testing, so there is really no point to run multiple
+        // tests with different cabal.project content.
+        let cases = vec![
+            "with-compiler: ghc",
+            // "with-compiler: ghc-9.2.1",
+        ];
+        let other_hs_files = vec!["M.hs", "M.hs-boot"];
+        for content in &cases {
+            let dir = tempfile::tempdir()?;
+
+            let mut file = File::create(dir.path().join("cabal.project"))?;
+            file.write_all(content.as_bytes())?;
+            file.sync_all()?;
+
+            for hs_file in &other_hs_files {
+                File::create(dir.path().join(hs_file))?.sync_all()?;
+            }
+
             let actual = ModuleRenderer::new("haskell").path(dir.path()).collect();
-            let expected = Some(format!("via {}", Color::Purple.bold().paint("λ 9.2.1 ")));
+            let expected = Some(format!(
+                "via {}",
+                Color::Purple.bold().paint("λ ghc-9.2.1 ")
+            ));
             assert_eq!(expected, actual);
+
             dir.close()?;
         }
         Ok(())
     }
 
-    static REANIMATE_STACK_YAML: &str = r"
-resolver: lts-14.27
+    #[test]
+    fn folder_cabalproject_nested() -> io::Result<()> {
+        let other_hs_files = vec!["M.hs", "M.hs-boot"];
+        let dir = tempfile::tempdir()?;
+        let nested = dir.path().join("nested");
 
-allow-newer: false
+        let mut file = File::create(dir.path().join("cabal.project"))?;
+        file.write_all("with-compiler: ghc".as_bytes())?;
+        file.sync_all()?;
 
-packages:
-- .
+        create_dir(&nested)?;
+        for hs_file in &other_hs_files {
+            File::create(nested.as_path().join(hs_file))?.sync_all()?;
+        }
 
-extra-deps:
-- reanimate-svg-0.13.0.1
-- chiphunk-0.1.2.1
-- cubicbezier-0.6.0.6@sha256:2191ff47144d9a13a2784651a33d340cd31be1926a6c188925143103eb3c8db3
-- fast-math-1.0.2@sha256:91181eb836e54413cc5a841e797c42b2264954e893ea530b6fc4da0dccf6a8b7
-- matrices-0.5.0@sha256:b2761813f6a61c84224559619cc60a16a858ac671c8436bbac8ec89e85473058
-- hmatrix-0.20.0.0@sha256:d79a9218e314f1a2344457c3851bd1d2536518ecb5f1a2fcd81daa45e46cd025,4870
-- earcut-0.1.0.4@sha256:d5118b3eecf24d130263d81fb30f1ff56b1db43036582bfd1d8cc9ba3adae8be,1010
-- tasty-rerun-1.1.17@sha256:d4a3ccb0f63f499f36edc71b33c0f91c850eddb22dd92b928aa33b8459f3734a,1373
-- hgeometry-0.11.0.0@sha256:09ead201a6ac3492c0be8dda5a6b32792b9ae87cab730b8362d46ee8d5c2acb4,11714
-- hgeometry-combinatorial-0.11.0.0@sha256:03176f235a1c49a415fe1266274dafca84deb917cbcbf9a654452686b4cd2bfe,8286
-- vinyl-0.13.0@sha256:0f247cd3f8682b30881a07de18e6fec52d540646fbcb328420049cc8d63cd407,3724
-- hashable-1.3.0.0@sha256:4c70f1407881059e93550d3742191254296b2737b793a742bd901348fb3e1fb1,5206
-- network-3.1.2.1@sha256:188d6daea8cd91bc3553efd5a90a1e7c6d0425fa66a53baa74db5b6d9fd75c8b,4968
-";
+        let actual = ModuleRenderer::new("haskell")
+            .path(nested.as_path())
+            .collect();
+        let expected = Some(format!(
+            "via {}",
+            Color::Purple.bold().paint(format!("λ ghc-9.2.1 "))
+        ));
+        assert_eq!(expected, actual);
+
+        dir.close()?;
+        Ok(())
+    }
+
+    #[test]
+    fn folder_plain() -> io::Result<()> {
+        let should_trigger = vec!["M.hs", "M.hs-boot"];
+        for hs_file in &should_trigger {
+            let dir = tempfile::tempdir()?;
+
+            File::create(dir.path().join(hs_file))?.sync_all()?;
+
+            let actual = ModuleRenderer::new("haskell").path(dir.path()).collect();
+            let expected = Some(format!(
+                "via {}",
+                Color::Purple.bold().paint("λ ghc-9.2.1 ")
+            ));
+            assert_eq!(expected, actual);
+
+            dir.close()?;
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn non_default_compiler() -> io::Result<()> {
+        let should_trigger = vec!["M.hs", "M.hs-boot"];
+        for hs_file in &should_trigger {
+            let dir = tempfile::tempdir()?;
+
+            File::create(dir.path().join(hs_file))?.sync_all()?;
+
+            let renderer = ModuleRenderer::new("haskell")
+                .path(dir.path())
+                .config(toml::toml! {
+                    [haskell]
+                    default_compiler = "mhs"
+                });
+            let actual = renderer.collect();
+            let expected = Some(format!(
+                "via {}",
+                Color::Purple.bold().paint("λ mhs-0.13.3.0 ")
+            ));
+            assert_eq!(expected, actual);
+
+            dir.close()?;
+        }
+        Ok(())
+    }
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -178,6 +178,12 @@ pub fn mock_cmd<T: AsRef<OsStr> + Debug, U: AsRef<OsStr> + Debug>(
             stdout: String::from("1.0.0"),
             stderr: String::default(),
         }),
+        "cabal -v0 path --format=json --compiler-info" => Some(CommandOutput {
+            stdout: String::from(
+                "{\"cabal-version\":\"3.14.2.0\",\"compiler\":{\"flavour\":\"ghc\",\"id\":\"ghc-9.2.1\",\"path\":\"/path/to/ghc\"}}",
+            ),
+            stderr: String::default(),
+        }),
         "cc --version" => Some(CommandOutput {
             stdout: String::from(
                 "\
@@ -366,6 +372,10 @@ Elixir 1.10 (compiled with Erlang/OTP 22)\n",
             ),
             stderr: String::default(),
         }),
+        "mhs --numeric-version" => Some(CommandOutput {
+            stdout: String::from("0.13.3.0\n"),
+            stderr: String::default(),
+        }),
         "mojo --version" => Some(CommandOutput {
             stdout: String::from("mojo 24.4.0 (2cb57382)\n"),
             stderr: String::default(),
@@ -514,6 +524,10 @@ Version: 0.8.16+commit.07a7930e.Linux.g++",
         }),
         "solcjs --version" => Some(CommandOutput {
             stdout: String::from("0.8.15+commit.e14f2714.Emscripten.clang"),
+            stderr: String::default(),
+        }),
+        "stack --no-install-ghc query compiler wanted" => Some(CommandOutput {
+            stdout: String::from("ghc-9.2.1"),
             stderr: String::default(),
         }),
         "swift --version" => Some(CommandOutput {


### PR DESCRIPTION
This commit refactors the Haskell module to provide a cleaner discovery for Haskell setups. The following setups are tried in order:

 1. Check if we are in a directory tree below a Stack project.
 2. Check if we are in a directory tree below a Cabal project.
 3. If neither is the case, look for Haskell files in the current directory.

For Stack and Cabal the compiler used by the project is now determined correctly using the respective `stack` or `cabal` tool: Before, the output was simply the version of GHC compiler found in PATH, which may not be the one used by the project setup.

#### Description

  * There are new configuration options `stack_extensions`, `stack_files`, `stack_folders` we use to check if we are below a Stack project.
    _Note:_ We also look in ancestor directories for `stack_files` and `stack_folders` now.

  * Similarly, there are new configuration options `cabal_extensions`, `cabal_files`, `cabal_folders` we use to check if we are below a Cabal project.
    _Note:_ We also look in ancestor directories for `cabal_files` and `cabal_folders` now.

  * The configuration options `detect_extensions`, `detect_files` and `detect_folders` are now used to detect a "plain" Haskell setup, i.e. one that is neither a Cabal nor a Stack project.

  * A new configuration option `default_compiler` was added. This can be used to override the executable name that is queried for version information if we are neither in Stack nor in a Cabal project. The executable is expected to understand the flag `--numeric-version`.

  * New output fields `compiler_id`, `compiler_name` and `compiler_version` were added.
    The already existing field `ghc_version` is now an alias for `compiler_version`, where the latter has the benefit that its name does not suggest a particular Haskell compiler implementation.

#### Motivation and Context

The module only scanned the _current_ for Cabal- and Stack project files. So when you were working in a source directory of a project (i.e. in a directory below the project root) Starship did not pick that up and displayed the wrong information (or none at all).

In addition to that, I found it irritating that the module displays the installed instead of the used compiler:
Both Cabal and Stack allow you to specify the version (or path) of the used compiler in their project files, and when working with those the default compiler in `PATH` may not be used.

#### How Has This Been Tested?

I updated the tests and added mock-commands for `cabal`, `ghc`, `mhs` and `stack`.

- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:

- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
