### PR TITLE
fix:added the description of disabled by default in (CPP) module in all languages

### DIFF
--- a/docs/ar-SA/config/README.md
+++ b/docs/ar-SA/config/README.md
@@ -681,6 +681,12 @@ format = 'via [$name $version]($style)'
 
 The `cpp` module shows some information about your `C++` compiler. By default, the module will be shown if the current directory contains a `.cpp`, `.hpp`, or other `C++`-related files.
 
+::: tip
+
+This module is disabled by default. To enable it, set `disabled` to `false` in your configuration file.
+
+:::
+
 ### Options
 
 | Option              | الافتراضي                                                                        | الوصف                                                                     |

--- a/docs/bn-BD/config/README.md
+++ b/docs/bn-BD/config/README.md
@@ -681,6 +681,12 @@ format = 'via [$name $version]($style)'
 
 The `cpp` module shows some information about your `C++` compiler. By default, the module will be shown if the current directory contains a `.cpp`, `.hpp`, or other `C++`-related files.
 
+::: tip
+
+This module is disabled by default. To enable it, set `disabled` to `false` in your configuration file.
+
+:::
+
 ### Options
 
 | Option              | Default                                                                          | Description                                                               |

--- a/docs/ckb-IR/config/README.md
+++ b/docs/ckb-IR/config/README.md
@@ -681,6 +681,13 @@ format = 'via [$name $version]($style)'
 
 The `cpp` module shows some information about your `C++` compiler. By default, the module will be shown if the current directory contains a `.cpp`, `.hpp`, or other `C++`-related files.
 
+::: tip
+
+This module is disabled by default.
+To enable it, set `disabled` to `false` in your configuration file.
+
+:::
+
 ### Options
 
 | Option              | Default                                                                          | Description                                                               |

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -711,7 +711,12 @@ format = 'via [$name $version]($style)'
 
 The `cpp` module shows some information about your `C++` compiler. By default,
 the module will be shown if the current directory contains a `.cpp`, `.hpp`, or other `C++`-related files.
+::: tip
 
+This module is disabled by default.
+To enable it, set `disabled` to `false` in your configuration file.
+
+:::
 ### Options
 
 | Option              | Default                                                                          | Description                                                               |

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -717,6 +717,7 @@ This module is disabled by default.
 To enable it, set `disabled` to `false` in your configuration file.
 
 :::
+
 ### Options
 
 | Option              | Default                                                                          | Description                                                               |

--- a/docs/de-DE/config/README.md
+++ b/docs/de-DE/config/README.md
@@ -682,6 +682,13 @@ format = 'via [$name $version]($style)'
 
 The `cpp` module shows some information about your `C++` compiler. By default, the module will be shown if the current directory contains a `.cpp`, `.hpp`, or other `C++`-related files.
 
+::: tip
+
+Dieses Modul ist standardmäßig deaktiviert. Setze in deiner Konfiguration `disabled` auf `false` um es zu aktivieren.
+
+:::
+
+
 ### Optionen
 
 | Option              | Standardwert                                                                     | Beschreibung                                                              |

--- a/docs/es-ES/config/README.md
+++ b/docs/es-ES/config/README.md
@@ -681,6 +681,12 @@ format = 'via [$name $version]($style)'
 
 The `cpp` module shows some information about your `C++` compiler. By default, the module will be shown if the current directory contains a `.cpp`, `.hpp`, or other `C++`-related files.
 
+::: tip
+
+Este módulo está deshabilitado por defecto. Para activarlo, establece `disabled` como `false` en tu archivo de configuración.
+
+:::
+
 ### Opciones
 
 | Opción              | Predeterminado                                                                   | Descripción                                                                             |

--- a/docs/fr-FR/config/README.md
+++ b/docs/fr-FR/config/README.md
@@ -681,6 +681,12 @@ format = 'via [$name $version]($style)'
 
 The `cpp` module shows some information about your `C++` compiler. By default, the module will be shown if the current directory contains a `.cpp`, `.hpp`, or other `C++`-related files.
 
+::: tip
+
+Ce module est désactivé par défaut. Pour l'activer, configurez `disabled` sur `false` dans votre fichier de configuration.
+
+:::
+
 ### Options
 
 | Option              | Défaut                                                                           | Description                                                                                |

--- a/docs/id-ID/config/README.md
+++ b/docs/id-ID/config/README.md
@@ -681,6 +681,13 @@ format = 'via [$name $version]($style)'
 
 The `cpp` module shows some information about your `C++` compiler. By default, the module will be shown if the current directory contains a `.cpp`, `.hpp`, or other `C++`-related files.
 
+::: tip
+
+This module is disabled by default.
+To enable it, set `disabled` to `false` in your configuration file.
+
+:::
+
 ### Opsi
 
 | Opsi                | Bawaan                                                                           | Deskripsi                                                                           |

--- a/docs/it-IT/config/README.md
+++ b/docs/it-IT/config/README.md
@@ -681,6 +681,13 @@ format = 'via [$name $version]($style)'
 
 The `cpp` module shows some information about your `C++` compiler. By default, the module will be shown if the current directory contains a `.cpp`, `.hpp`, or other `C++`-related files.
 
+::: tip
+
+This module is disabled by default.
+To enable it, set `disabled` to `false` in your configuration file.
+
+:::
+
 ### Opzioni
 
 | Opzione             | Default                                                                          | Descrizione                                                                                 |

--- a/docs/ja-JP/config/README.md
+++ b/docs/ja-JP/config/README.md
@@ -681,6 +681,12 @@ format = 'via [$name $version]($style)'
 
 The `cpp` module shows some information about your `C++` compiler. By default, the module will be shown if the current directory contains a `.cpp`, `.hpp`, or other `C++`-related files.
 
+::: tip
+
+このモジュールはデフォルトで無効になっています。 有効にするには、設定ファイルで `disabled` を `false` に設定します。
+
+:::
+
 ### オプション
 
 | オプション               | デフォルト                                                                            | 説明                                                     |

--- a/docs/ko-KR/config/README.md
+++ b/docs/ko-KR/config/README.md
@@ -681,6 +681,12 @@ format = 'via [$name $version]($style)'
 
 The `cpp` module shows some information about your `C++` compiler. By default, the module will be shown if the current directory contains a `.cpp`, `.hpp`, or other `C++`-related files.
 
+::: tip
+
+This module is disabled by default. To enable it, set `disabled` to `false` in your configuration file.
+
+:::
+
 ### Options
 
 | Option              | Default                                                                          | Description                                                               |

--- a/docs/nl-NL/config/README.md
+++ b/docs/nl-NL/config/README.md
@@ -681,6 +681,14 @@ format = 'via [$name $version]($style)'
 
 The `cpp` module shows some information about your `C++` compiler. By default, the module will be shown if the current directory contains a `.cpp`, `.hpp`, or other `C++`-related files.
 
+::: tip
+
+This module is disabled by default. To enable it, set `disabled` to `false` in your configuration file.
+
+:::
+
+
+
 ### Options
 
 | Option              | Default                                                                          | Description                                                               |

--- a/docs/no-NO/config/README.md
+++ b/docs/no-NO/config/README.md
@@ -681,6 +681,14 @@ format = 'via [$name $version]($style)'
 
 The `cpp` module shows some information about your `C++` compiler. By default, the module will be shown if the current directory contains a `.cpp`, `.hpp`, or other `C++`-related files.
 
+::: tip
+
+This module is disabled by default. To enable it, set `disabled` to `false` in your configuration file.
+
+:::
+
+
+
 ### Options
 
 | Option              | Default                                                                          | Description                                                               |

--- a/docs/pl-PL/config/README.md
+++ b/docs/pl-PL/config/README.md
@@ -681,6 +681,13 @@ format = 'via [$name $version]($style)'
 
 The `cpp` module shows some information about your `C++` compiler. By default, the module will be shown if the current directory contains a `.cpp`, `.hpp`, or other `C++`-related files.
 
+::: porada
+
+This module is disabled by default. To enable it, set `disabled` to `false` in your configuration file.
+
+:::
+
+
 ### Options
 
 | Option              | Default                                                                          | Description                                                               |

--- a/docs/pt-BR/config/README.md
+++ b/docs/pt-BR/config/README.md
@@ -681,6 +681,12 @@ format = 'via [$name $version]($style)'
 
 The `cpp` module shows some information about your `C++` compiler. By default, the module will be shown if the current directory contains a `.cpp`, `.hpp`, or other `C++`-related files.
 
+::: tip
+
+Este módulo é desabilitado por padrão. Para habilitar, defina `disabled` para `false` no seu arquivo de configuração.
+
+:::
+
 ### Opções
 
 | Opções              | Padrão                                                                           | Descrição                                                                            |

--- a/docs/pt-PT/config/README.md
+++ b/docs/pt-PT/config/README.md
@@ -681,6 +681,12 @@ format = 'via [$name $version]($style)'
 
 The `cpp` module shows some information about your `C++` compiler. By default, the module will be shown if the current directory contains a `.cpp`, `.hpp`, or other `C++`-related files.
 
+::: tip
+
+This module is disabled by default. To enable it, set `disabled` to `false` in your configuration file.
+
+:::
+
 ### Options
 
 | Option              | Default                                                                          | Description                                                               |

--- a/docs/ru-RU/config/README.md
+++ b/docs/ru-RU/config/README.md
@@ -681,6 +681,13 @@ format = 'via [$name $version]($style)'
 
 The `cpp` module shows some information about your `C++` compiler. By default, the module will be shown if the current directory contains a `.cpp`, `.hpp`, or other `C++`-related files.
 
+::: tip
+
+По умолчанию этот модуль отключен. Чтобы включить его, установите `disabled` на `false` в файле конфигурации.
+
+:::
+
+
 ### Опции
 
 | Параметр            | По умолчанию                                                                     | Описание                                                                  |

--- a/docs/tr-TR/config/README.md
+++ b/docs/tr-TR/config/README.md
@@ -681,6 +681,12 @@ format = 'via [$name $version]($style)'
 
 The `cpp` module shows some information about your `C++` compiler. By default, the module will be shown if the current directory contains a `.cpp`, `.hpp`, or other `C++`-related files.
 
+::: tip
+
+This module is disabled by default. To enable it, set `disabled` to `false` in your configuration file.
+
+:::
+
 ### Options
 
 | Option              | Default                                                                          | Description                                                               |

--- a/docs/uk-UA/config/README.md
+++ b/docs/uk-UA/config/README.md
@@ -681,6 +681,12 @@ format = 'via [$name $version]($style)'
 
 The `cpp` module shows some information about your `C++` compiler. By default, the module will be shown if the current directory contains a `.cpp`, `.hpp`, or other `C++`-related files.
 
+::: tip
+
+Цей модуль типово є вимкненим. Щоб його увімкнути, встановіть значення параметра `disabled` в `false` у вашому файлі налаштувань.
+
+:::
+
 ### Параметри
 
 | Параметр            | Стандартно                                                                       | Опис                                                              |

--- a/docs/vi-VN/config/README.md
+++ b/docs/vi-VN/config/README.md
@@ -681,6 +681,12 @@ format = 'via [$name $version]($style)'
 
 The `cpp` module shows some information about your `C++` compiler. By default, the module will be shown if the current directory contains a `.cpp`, `.hpp`, or other `C++`-related files.
 
+::: tip
+
+Mặc định, mô đun này được vô hiệu. Để kích hoạt nó, thiết lập `disabled` sang `false` trong tập tin cấu hình của bạn.
+
+:::
+
 ### Options
 
 | Tuỳ chọn            | Mặc định                                                                         | Mô tả                                                                     |

--- a/docs/zh-CN/config/README.md
+++ b/docs/zh-CN/config/README.md
@@ -681,6 +681,13 @@ format = 'via [$name $version]($style)'
 
 The `cpp` module shows some information about your `C++` compiler. By default, the module will be shown if the current directory contains a `.cpp`, `.hpp`, or other `C++`-related files.
 
+::: tip 提示
+
+此组件默认被禁用。 若要启用此组件，请在配置文件中设置 `disable` 字段为 `false`。
+
+:::
+
+
 ### 配置项
 
 | 选项                  | 默认值                                                                              | 描述                                                     |

--- a/docs/zh-TW/config/README.md
+++ b/docs/zh-TW/config/README.md
@@ -681,6 +681,12 @@ format = 'via [$name $version]($style)'
 
 The `cpp` module shows some information about your `C++` compiler. By default, the module will be shown if the current directory contains a `.cpp`, `.hpp`, or other `C++`-related files.
 
+::: tip
+
+這個模組預設是停用的。 想要啟用它的話，請在設定檔中將 `disabled` 設定為 `false`。
+
+:::
+
 ### 選項
 
 | 選項                  | 預設                                                                               | 說明                                                                        |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
I had added that bubble which says the " disabled by default to enable it.... " which specified in other modules but in CPP module its not specified , so its added now.

#### Motivation and Context
This change is required to resolve the missing documentation reported in issue #6788 .

Refer this issue :
https://github.com/starship/starship/issues/6788

Closes #6788 

#### Screenshots (if appropriate):
![starship](https://github.com/user-attachments/assets/c9df4ca8-6477-43f9-9a9f-a95e01bdd99c)

#### How Has This Been Tested?

- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.

