### PR TITLE
 docs(cpp): add tip to highlight that module is disabled-by-default

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -712,12 +712,9 @@ format = 'via [$name $version]($style)'
 The `cpp` module shows some information about your `C++` compiler. By default,
 the module will be shown if the current directory contains a `.cpp`, `.hpp`, or other `C++`-related files.
 
-::: tip
-
-This module is disabled by default.
-To enable it, set `disabled` to `false` in your configuration file.
-
-:::
+> [!TIP]
+> This module is disabled by default.
+> To enable it, set `disabled` to `false` in your configuration file.
 
 ### Options
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
I had added that bubble which says the " disabled by default to enable it.... " which specified in other modules but in CPP module its not specified , so its added now.

#### Motivation and Context
This change is required to resolve the missing documentation reported in issue #6788 .

Refer this issue :
https://github.com/starship/starship/issues/6788

Closes #6788 

#### Screenshots (if appropriate):
![starship](https://github.com/user-attachments/assets/c9df4ca8-6477-43f9-9a9f-a95e01bdd99c)

#### How Has This Been Tested?

- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.