### PR TITLE
feat(cmd_duration): add `notifications_transient` config to suppress persistent notifications

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -278,6 +278,7 @@
         "show_milliseconds": false,
         "disabled": false,
         "show_notifications": false,
+        "notifications_transient": false,
         "min_time_to_notify": 45000
       }
     },
@@ -2534,6 +2535,10 @@
           "default": false
         },
         "show_notifications": {
+          "type": "boolean",
+          "default": false
+        },
+        "notifications_transient": {
           "type": "boolean",
           "default": false
         },

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -914,16 +914,17 @@ running `eval $(starship init $0)`, and then proceed as normal.
 
 ### Options
 
-| Option                 | Default                       | Description                                                                                                                                                       |
-| ---------------------- | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `min_time`             | `2_000`                       | Shortest duration to show time for (in milliseconds).                                                                                                             |
-| `show_milliseconds`    | `false`                       | Show milliseconds in addition to seconds for the duration.                                                                                                        |
-| `format`               | `'took [$duration]($style) '` | The format for the module.                                                                                                                                        |
-| `style`                | `'bold yellow'`               | The style for the module.                                                                                                                                         |
-| `disabled`             | `false`                       | Disables the `cmd_duration` module.                                                                                                                               |
-| `show_notifications`   | `false`                       | Show desktop notifications when command completes.                                                                                                                |
-| `min_time_to_notify`   | `45_000`                      | Shortest duration for notification (in milliseconds).                                                                                                             |
-| `notification_timeout` |                               | Duration to show notification for (in milliseconds). If unset, notification timeout will be determined by daemon. Not all notification daemons honor this option. |
+| Option                    | Default                       | Description                                                                                                                                                       |
+| ------------------------- | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `min_time`                | `2_000`                       | Shortest duration to show time for (in milliseconds).                                                                                                             |
+| `show_milliseconds`       | `false`                       | Show milliseconds in addition to seconds for the duration.                                                                                                        |
+| `format`                  | `'took [$duration]($style) '` | The format for the module.                                                                                                                                        |
+| `style`                   | `'bold yellow'`               | The style for the module.                                                                                                                                         |
+| `disabled`                | `false`                       | Disables the `cmd_duration` module.                                                                                                                               |
+| `show_notifications`      | `false`                       | Show desktop notifications when command completes.                                                                                                                |
+| `notifications_transient` | `false`                       | Requests that the desktop notification not be retained in the system's notification history. Effectiveness depends on the notification daemon.                    |
+| `min_time_to_notify`      | `45_000`                      | Shortest duration for notification (in milliseconds).                                                                                                             |
+| `notification_timeout`    |                               | Duration to show notification for (in milliseconds). If unset, notification timeout will be determined by daemon. Not all notification daemons honor this option. |
 
 ### Variables
 

--- a/docs/public/presets/toml/catppuccin-powerline.toml
+++ b/docs/public/presets/toml/catppuccin-powerline.toml
@@ -170,6 +170,7 @@ format = " in $duration "
 style = "bg:lavender"
 disabled = false
 show_notifications = true
+notifications_transient = true
 min_time_to_notify = 45000
 
 [palettes.catppuccin_mocha]

--- a/src/configs/cmd_duration.rs
+++ b/src/configs/cmd_duration.rs
@@ -14,6 +14,7 @@ pub struct CmdDurationConfig<'a> {
     pub show_milliseconds: bool,
     pub disabled: bool,
     pub show_notifications: bool,
+    pub notifications_transient: bool,
     pub min_time_to_notify: i64,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -29,6 +30,7 @@ impl Default for CmdDurationConfig<'_> {
             style: "yellow bold",
             disabled: false,
             show_notifications: false,
+            notifications_transient: false,
             min_time_to_notify: 45_000,
             notification_timeout: None,
         }

--- a/src/configs/cmd_duration.rs
+++ b/src/configs/cmd_duration.rs
@@ -36,3 +36,19 @@ impl Default for CmdDurationConfig<'_> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_notifications_transient_is_false() {
+        assert!(!CmdDurationConfig::default().notifications_transient);
+    }
+
+    #[test]
+    fn notifications_transient_deserializes() {
+        let config: CmdDurationConfig = toml::from_str("notifications_transient = true").unwrap();
+        assert!(config.notifications_transient);
+    }
+}

--- a/src/modules/cmd_duration.rs
+++ b/src/modules/cmd_duration.rs
@@ -68,7 +68,7 @@ fn undistract_me<'a>(
     context: &'a Context,
     elapsed: u128,
 ) -> Module<'a> {
-    use notify_rust::{Notification, Timeout};
+    use notify_rust::{Hint, Notification, Timeout};
     use nu_ansi_term::{AnsiStrings, unstyle};
 
     if config.show_notifications && config.min_time_to_notify as u128 <= elapsed {
@@ -104,6 +104,11 @@ fn undistract_me<'a>(
             .body(&body)
             .icon("utilities-terminal")
             .timeout(timeout);
+
+        #[cfg(target_os = "linux")]
+        if config.notifications_transient {
+            notification.hint(Hint::Transient(true));
+        }
 
         if let Err(err) = notification.show() {
             log::trace!("Cannot show notification: {err}");

--- a/src/modules/cmd_duration.rs
+++ b/src/modules/cmd_duration.rs
@@ -68,7 +68,7 @@ fn undistract_me<'a>(
     context: &'a Context,
     elapsed: u128,
 ) -> Module<'a> {
-    use notify_rust::{Hint, Notification, Timeout};
+    use notify_rust::{Notification, Timeout};
     use nu_ansi_term::{AnsiStrings, unstyle};
 
     if config.show_notifications && config.min_time_to_notify as u128 <= elapsed {
@@ -106,8 +106,11 @@ fn undistract_me<'a>(
             .timeout(timeout);
 
         #[cfg(target_os = "linux")]
-        if config.notifications_transient {
-            notification.hint(Hint::Transient(true));
+        {
+            use notify_rust::Hint;
+            if config.notifications_transient {
+                notification.hint(Hint::Transient(true));
+            }
         }
 
         if let Err(err) = notification.show() {


### PR DESCRIPTION
Adds a new `notifications_transient` boolean option to the `cmd_duration` module. When enabled, the module will request that desktop notifications are not stored in the notification center/tray via Hint::Transient(true).

<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description

This change introduces an optional `notifications_transient` setting in the `cmd_duration` module config.

When `true`, Starship will set the `Transient` hint on the notification, signaling that it should not be kept in the system's notification history/tray. Note this only works on Linux.

#### Motivation and Context

The cmd_duration module displays how long the last command took to run, and optionally shows a desktop notification if the command exceeded a configured threshold. These notifications help the user in knowing long-running tasks are over even if the terminal isn’t in focus. Without transient behavior, repeated "command finished" notifications can accumulate and clutter the notification tray. Adding a transient hint will make brief notifications that disappear after being shown.

Enabling notifications_transient helps mitigate this by requesting that the notification be displayed without being retained. This is useful in (Linux) environments where Hint::Transient(true) is supported (like GNOME, KDE, Sway, XFCE...).

If the notification daemon does not support the transient hint, enabling this option will have no effect: the notification will behave as it normally would.

The default is set to `false` to preserve current behavior, but would agree in considering changing it to `true`, which imo feels like a better default UX.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ x ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.

Note: not updated tests since it does not look applicable to this feature.