### PR TITLE
feat: new module `xmake`

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -1712,6 +1712,21 @@
         "detect_folders": []
       }
     },
+    "xmake": {
+      "$ref": "#/$defs/XMakeConfig",
+      "default": {
+        "format": "via [$symbol($version )]($style)",
+        "version_format": "v${raw}",
+        "symbol": "△ ",
+        "style": "bold green",
+        "disabled": false,
+        "detect_extensions": [],
+        "detect_files": [
+          "xmake.lua"
+        ],
+        "detect_folders": []
+      }
+    },
     "zig": {
       "$ref": "#/$defs/ZigConfig",
       "default": {
@@ -6474,6 +6489,55 @@
             "v.mod",
             "vpkg.json",
             ".vpkg-lock.json"
+          ]
+        },
+        "detect_folders": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        }
+      },
+      "additionalProperties": false
+    },
+    "XMakeConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "type": "string",
+          "default": "via [$symbol($version )]($style)"
+        },
+        "version_format": {
+          "type": "string",
+          "default": "v${raw}"
+        },
+        "symbol": {
+          "type": "string",
+          "default": "△ "
+        },
+        "style": {
+          "type": "string",
+          "default": "bold green"
+        },
+        "disabled": {
+          "type": "boolean",
+          "default": false
+        },
+        "detect_extensions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        },
+        "detect_files": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "xmake.lua"
           ]
         },
         "detect_folders": {

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -4848,6 +4848,36 @@ The module will be shown only if a repository is currently in use.
 format = '[🆅 $repo](bold blue) '
 ```
 
+## XMake
+
+The `xmake` module shows the currently installed version of [XMake](https://xmake.io/). By default
+the module will be activated if any of the following conditions are met:
+
+- The current directory contains a `xmake.lua` file
+
+### Options
+
+| Option              | Default                              | Description                                                               |
+| ------------------- | ------------------------------------ | ------------------------------------------------------------------------- |
+| `format`            | `'via [$symbol($version )]($style)'` | The format for the module.                                                |
+| `version_format`    | `'v${raw}'`                          | The version format. Available vars are `raw`, `major`, `minor`, & `patch` |
+| `symbol`            | `'△ '`                               | The symbol used before the version of cmake.                              |
+| `detect_extensions` | `[]`                                 | Which extensions should trigger this module                               |
+| `detect_files`      | `['xmake.lua']`                      | Which filenames should trigger this module                                |
+| `detect_folders`    | `[]`                                 | Which folders should trigger this module                                  |
+| `style`             | `'bold blue'`                        | The style for the module.                                                 |
+| `disabled`          | `false`                              | Disables the `xmake` module.                                              |
+
+### Variables
+
+| Variable | Example  | Description                          |
+| -------- | -------- | ------------------------------------ |
+| version  | `v2.9.5` | The version of cmake                 |
+| symbol   |          | Mirrors the value of option `symbol` |
+| style\*  |          | Mirrors the value of option `style`  |
+
+*: This variable can only be used as a part of a style string
+
 ## Zig
 
 By default the `zig` module shows the currently installed version of [Zig](https://ziglang.org/).

--- a/docs/public/presets/toml/bracketed-segments.toml
+++ b/docs/public/presets/toml/bracketed-segments.toml
@@ -196,6 +196,9 @@ format = '\[[$symbol($version)]($style)\]'
 [vlang]
 format = '\[[$symbol($version)]($style)\]'
 
+[xmake]
+format = '\[[$symbol($version)]($style)\]'
+
 [zig]
 format = '\[[$symbol($version)]($style)\]'
 

--- a/docs/public/presets/toml/jetpack.toml
+++ b/docs/public/presets/toml/jetpack.toml
@@ -70,6 +70,7 @@ $swift\
 $terraform\
 $vlang\
 $vagrant\
+$xmake\
 $zig\
 $buf\
 $conda\

--- a/docs/public/presets/toml/nerd-font-symbols.toml
+++ b/docs/public/presets/toml/nerd-font-symbols.toml
@@ -184,6 +184,9 @@ symbol = " "
 [swift]
 symbol = " "
 
+[xmake]
+symbol = " "
+
 [zig]
 symbol = " "
 

--- a/docs/public/presets/toml/no-empty-icons.toml
+++ b/docs/public/presets/toml/no-empty-icons.toml
@@ -127,5 +127,8 @@ format = '(via [$symbol($version )]($style))'
 [vlang]
 format = '(via [$symbol($version )]($style))'
 
+[xmake]
+format = '(via [$symbol($version )]($style))'
+
 [zig]
 format = '(via [$symbol($version )]($style))'

--- a/docs/public/presets/toml/no-runtime-versions.toml
+++ b/docs/public/presets/toml/no-runtime-versions.toml
@@ -130,5 +130,8 @@ format = 'via [$symbol]($style)'
 [vlang]
 format = 'via [$symbol]($style)'
 
+[xmake]
+format = "via [$symbol]($style)"
+
 [zig]
 format = 'via [$symbol]($style)'

--- a/docs/public/presets/toml/plain-text-symbols.toml
+++ b/docs/public/presets/toml/plain-text-symbols.toml
@@ -256,5 +256,8 @@ symbol = "typst "
 [terraform]
 symbol = "terraform "
 
+[xmake]
+symbol = "xmake "
+
 [zig]
 symbol = "zig "

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -101,6 +101,7 @@ pub mod username;
 pub mod v;
 pub mod vagrant;
 pub mod vcsh;
+pub mod xmake;
 pub mod zig;
 
 pub use starship_root::*;
@@ -313,6 +314,8 @@ pub struct FullConfig<'a> {
     vcsh: vcsh::VcshConfig<'a>,
     #[serde(borrow)]
     vlang: v::VConfig<'a>,
+    #[serde(borrow)]
+    xmake: xmake::XMakeConfig<'a>,
     #[serde(borrow)]
     zig: zig::ZigConfig<'a>,
     #[serde(borrow)]

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -101,6 +101,7 @@ pub const PROMPT_ORDER: &[&str] = &[
     "typst",
     "vlang",
     "vagrant",
+    "xmake",
     "zig",
     // ↑ Toolchain version modules ↑
     "buf",

--- a/src/configs/xmake.rs
+++ b/src/configs/xmake.rs
@@ -1,0 +1,34 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(
+    feature = "config-schema",
+    derive(schemars::JsonSchema),
+    schemars(deny_unknown_fields)
+)]
+#[serde(default)]
+pub struct XMakeConfig<'a> {
+    pub format: &'a str,
+    pub version_format: &'a str,
+    pub symbol: &'a str,
+    pub style: &'a str,
+    pub disabled: bool,
+    pub detect_extensions: Vec<&'a str>,
+    pub detect_files: Vec<&'a str>,
+    pub detect_folders: Vec<&'a str>,
+}
+
+impl Default for XMakeConfig<'_> {
+    fn default() -> Self {
+        Self {
+            format: "via [$symbol($version )]($style)",
+            version_format: "v${raw}",
+            symbol: "△ ",
+            style: "bold green",
+            disabled: false,
+            detect_extensions: vec![],
+            detect_files: vec!["xmake.lua"],
+            detect_folders: vec![],
+        }
+    }
+}

--- a/src/module.rs
+++ b/src/module.rs
@@ -104,6 +104,7 @@ pub const ALL_MODULES: &[&str] = &[
     "vagrant",
     "vcsh",
     "vlang",
+    "xmake",
     "zig",
 ];
 

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -97,6 +97,7 @@ mod utils;
 mod vagrant;
 mod vcsh;
 mod vlang;
+mod xmake;
 mod zig;
 
 #[cfg(feature = "battery")]
@@ -215,6 +216,7 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
             "vlang" => vlang::module(context),
             "vagrant" => vagrant::module(context),
             "vcsh" => vcsh::module(context),
+            "xmake" => xmake::module(context),
             "zig" => zig::module(context),
             env if env.starts_with("env_var.") => {
                 env_var::module(env.strip_prefix("env_var."), context)
@@ -348,6 +350,7 @@ pub fn description(module: &str) -> &'static str {
         "vagrant" => "The currently installed version of Vagrant",
         "vcsh" => "The currently active VCSH repository",
         "vlang" => "The currently installed version of V",
+        "xmake" => "The currently installed version of XMake",
         "zig" => "The currently installed version of Zig",
         _ => "<no description>",
     }

--- a/src/modules/xmake.rs
+++ b/src/modules/xmake.rs
@@ -1,0 +1,99 @@
+use super::{Context, Module, ModuleConfig};
+
+use crate::configs::xmake::XMakeConfig;
+use crate::formatter::{StringFormatter, VersionFormatter};
+
+/// Creates a module with the current `XMake` version
+pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let mut module = context.new_module("xmake");
+    let config = XMakeConfig::try_load(module.config);
+
+    let is_xmake_project = context
+        .try_begin_scan()?
+        .set_files(&config.detect_files)
+        .set_extensions(&config.detect_extensions)
+        .set_folders(&config.detect_folders)
+        .is_match();
+
+    if !is_xmake_project {
+        return None;
+    }
+
+    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
+        formatter
+            .map_meta(|variable, _| match variable {
+                "symbol" => Some(config.symbol),
+                _ => None,
+            })
+            .map_style(|variable| match variable {
+                "style" => Some(Ok(config.style)),
+                _ => None,
+            })
+            .map(|variable| match variable {
+                "version" => {
+                    let xmake_version =
+                        parse_xmake_version(&context.exec_cmd("xmake", &["--version"])?.stdout)?;
+                    VersionFormatter::format_module_version(
+                        module.get_name(),
+                        &xmake_version,
+                        config.version_format,
+                    )
+                    .map(Ok)
+                }
+                _ => None,
+            })
+            .parse(None, Some(context))
+    });
+
+    module.set_segments(match parsed {
+        Ok(segments) => segments,
+        Err(error) => {
+            log::warn!("Error in module `xmake`: \n{error}");
+            return None;
+        }
+    });
+
+    Some(module)
+}
+
+fn parse_xmake_version(xmake_version: &str) -> Option<String> {
+    Some(
+        xmake_version.
+        // split into ["xmake", "v3.0.0+HEAD.0db4fe6", ".."]
+        split_whitespace().
+        // get "v3.0.0+HEAD.0db4fe6"
+        nth(1)?.
+        // remove the "v" prefix
+        trim_start_matches('v').
+        // remove "+HEAD.0db4fe6" suffix
+        split('+').next()?.
+        to_string(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::ModuleRenderer;
+    use nu_ansi_term::Color;
+    use std::fs::File;
+    use std::io;
+
+    #[test]
+    fn folder_without_xmake_lists() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let actual = ModuleRenderer::new("xmake").path(dir.path()).collect();
+        let expected = None;
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn folder_with_xmake_lists() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join("xmake.lua"))?.sync_all()?;
+        let actual = ModuleRenderer::new("xmake").path(dir.path()).collect();
+        let expected = Some(format!("via {}", Color::Green.bold().paint("△ v2.9.5 ")));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -527,6 +527,21 @@ Target: x86_64-apple-darwin19.4.0\n",
             stdout: String::from("V 0.2 30c0659"),
             stderr: String::default(),
         }),
+        "xmake --version" => Some(CommandOutput {
+            stdout: String::from(
+                r"xmake v2.9.5+HEAD.0db4fe6, A cross-platform build utility based on Lua
+Copyright (C) 2015-present Ruki Wang, tboox.org, xmake.io
+                         _
+    __  ___ __  __  __ _| | ______
+    \ \/ / |  \/  |/ _  | |/ / __ \
+     >  <  | \__/ | /_| |   <  ___/
+    /_/\_\_|_|  |_|\__ \|_|\_\____|
+                         by ruki, xmake.io
+    👉  Manual: https://xmake.io/#/getting_started
+    🙏  Donate: https://xmake.io/#/sponsor",
+            ),
+            stderr: String::default(),
+        }),
         "zig version" => Some(CommandOutput {
             stdout: String::from("0.6.0\n"),
             stderr: String::default(),


### PR DESCRIPTION
#### Description
Add new module `xmake` for [XMake](https://xmake.io), which is a cross-platform build utility for C++ based on Lua.

#### Motivation and Context
XMake is not natively supported by Starship.

#### Screenshots (if appropriate):
![图片](https://github.com/user-attachments/assets/e1a7c971-023a-4e0c-9154-dc180c71afb6)

#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
