### PR TITLE
perf(git_status): avoid gix index load when `core.fsmonitor` is used

### DIFF
--- a/src/modules/git_metrics.rs
+++ b/src/modules/git_metrics.rs
@@ -29,7 +29,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         return None;
     }
     // TODO: remove this special case once `gitoxide` can handle sparse indices for tree-index comparisons.
-    let stats = if gix_repo.index_or_empty().ok()?.is_sparse() || repo.fs_monitor_value_is_true {
+    let stats = if repo.fs_monitor_value_is_true || gix_repo.index_or_empty().ok()?.is_sparse() {
         let mut git_args = vec!["diff", "--shortstat"];
         if config.ignore_submodules {
             git_args.push("--ignore-submodules");

--- a/src/modules/git_status.rs
+++ b/src/modules/git_status.rs
@@ -250,8 +250,8 @@ fn get_repo_status(
     let has_untracked = !config.untracked.is_empty();
     let git_config = gix_repo.config_snapshot();
     if config.use_git_executable
-        || gix_repo.index_or_empty().ok()?.is_sparse()
         || repo.fs_monitor_value_is_true
+        || gix_repo.index_or_empty().ok()?.is_sparse()
     {
         let mut args = vec!["status", "--porcelain=2"];
 


### PR DESCRIPTION
#### Description
This improves the performance of `git_status` when:
* git `core.fsmonitor` is `true`
* starship `use_git_executable` is `false` (the default setting)

#### Motivation and Context
* Re-ordering an if statement can reduce the runtime of `git_status` if `core.fsmonitor` is being used
* The reason is that `gix_repo.index_or_empty()` reads the git index, which will be slower than checking a boolean that is already loaded (`repo.fs_monitor_value_is_true`)
* The workaround I was using was `use_git_executable` as `true`. It's better to fix this performance problem though, since the gix implementation of git_status is faster than the git cli in most cases: https://github.com/starship/starship/issues/6519#issuecomment-2935779826

#### How Has This Been Tested?
1. Clone [chromium](https://github.com/chromium/chromium)
2. Enable `core.fsmonitor` using this command: `git config core.fsmonitor true`
   * This command verifies that it's working: `git fsmonitor--daemon status`
3. Use the following `starship config`
```toml
[git_status]
untracked = ""
ignore_submodules = true
```
4. Use `starship timings` to see the difference

Before:
> git_status     -  350ms  -   ""

After:
> git_status     -  145ms  -   ""

Note that the performance gain can only be seen in large repos like chromium, there are a few closed source repos that had similar gains of a few hundred ms. 

- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
