### PR TITLE
docs(presets/nerd-font): fix section ordering in nerd-font-symbols preset

### DIFF
--- a/docs/public/presets/toml/nerd-font-symbols.toml
+++ b/docs/public/presets/toml/nerd-font-symbols.toml
@@ -58,6 +58,9 @@ tag_symbol = '  '
 [golang]
 symbol = " "
 
+[gradle]
+symbol = " "
+
 [guix_shell]
 symbol = " "
 
@@ -186,6 +189,3 @@ symbol = " "
 
 [zig]
 symbol = " "
-
-[gradle]
-symbol = " "


### PR DESCRIPTION
#### Description

In https://github.com/starship/starship/pull/6221, the `gradle` section was added at the end of the file, instead of in the existing alphabetical ordering.

#### Motivation and Context

Fix the sorting.

#### Screenshots (if appropriate):

#### How Has This Been Tested?

- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:

- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.