### PR TITLE
fix(preset/nerd-font): remove double spaces in `gcloud` default value and use Google Cloud-specific icon

### DIFF
--- a/docs/public/presets/toml/nerd-font-symbols.toml
+++ b/docs/public/presets/toml/nerd-font-symbols.toml
@@ -47,7 +47,7 @@ symbol = " "
 symbol = " "
 
 [gcloud]
-symbol = " "
+symbol = " "
 
 [git_branch]
 symbol = " "


### PR DESCRIPTION
#### Description

https://github.com/starship/starship/pull/6649 appears to have missed a double space in the `gcloud` section.

#### Motivation and Context

Follow-up of https://github.com/starship/starship/pull/6649

#### Screenshots (if appropriate):

#### How Has This Been Tested?

- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:

- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.