### PR TITLE
docs(c, cpp): remove incorrect note about default `format` string

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -685,8 +685,6 @@ file.
 | symbol   |         | Mirrors the value of option `symbol` |
 | style    |         | Mirrors the value of option `style`  |
 
-NB that `version` is not in the default format.
-
 ### Commands
 
 The `commands` option accepts a list of commands to determine the compiler version and name.
@@ -735,8 +733,6 @@ the module will be shown if the current directory contains a `.cpp`, `.hpp`, or 
 | version  | 13.0.0  | The version of the compiler          |
 | symbol   |         | Mirrors the value of option `symbol` |
 | style    |         | Mirrors the value of option `style`  |
-
-NB that `version` is not in the default format.
 
 ### Commands
 


### PR DESCRIPTION
#### Description

The default `format` string contains `$version`, so the note is incorrect and should be removed.

#### Motivation and Context

#### Screenshots (if appropriate):

#### How Has This Been Tested?

- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:

- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
