### PR TITLE
feat(zsh): add wide character glitch sequences to prevent cursor positioning issues

### DIFF
--- a/src/print.rs
+++ b/src/print.rs
@@ -10,7 +10,7 @@ use std::sync::OnceLock;
 use std::time::Duration;
 use terminal_size::terminal_size;
 use unicode_segmentation::UnicodeSegmentation;
-use unicode_width::UnicodeWidthChar;
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::configs::PROMPT_ORDER;
 use crate::context::{Context, Properties, Shell, Target};
@@ -20,17 +20,21 @@ use crate::module::Module;
 use crate::modules;
 use crate::segment::Segment;
 use crate::shadow;
-use crate::utils::wrap_colorseq_for_shell;
+use crate::utils::{wrap_colorseq_for_shell, wrap_widechar_for_zsh};
 
 pub struct Grapheme<'a>(pub &'a str);
 
 impl Grapheme<'_> {
     pub fn width(&self) -> usize {
-        self.0
-            .chars()
-            .filter_map(UnicodeWidthChar::width)
-            .max()
-            .unwrap_or(0)
+        // The string width accounts for the whole cluster: variation selector 16 gives
+        // emoji presentation (❄️ is two cells), regional indicator pairs form one flag,
+        // and ZWJ sequences render as a single glyph. Control characters occupy no cells,
+        // but `UnicodeWidthStr` counts them as one, so they are handled separately.
+        if self.0.chars().all(|c| UnicodeWidthChar::width(c).is_none()) {
+            return 0;
+        }
+
+        UnicodeWidthStr::width(self.0)
     }
 }
 
@@ -61,12 +65,58 @@ where
 
 #[test]
 fn test_grapheme_aware_width() {
-    // UnicodeWidthStr::width would return 8
     assert_eq!(2, "👩‍👩‍👦‍👦".width_graphemes());
     assert_eq!(1, "Ü".width_graphemes());
     assert_eq!(11, "normal text".width_graphemes());
     // Magenta string test
     assert_eq!(11, "\x1B[35;6mnormal text".width_graphemes());
+    // ❄️ is a snowflake (U+2744) with variation selector 16 (U+FE0F): two cells wide even
+    // though the base character is narrow. 🇬🇧 is two regional indicator symbols forming one
+    // two-cell flag.
+    assert_eq!(2, "❄️".width_graphemes());
+    assert_eq!(2, "🇬🇧".width_graphemes());
+    // Control characters occupy no cells.
+    assert_eq!(2, "a\nb".width_graphemes());
+}
+
+#[test]
+fn test_zsh_wide_char_glitch_sequences() -> std::io::Result<()> {
+    use crate::context::{Shell, Target};
+    use crate::test::default_context;
+
+    let dir = tempfile::tempdir()?;
+    let mut context = default_context().set_config(toml::toml! {
+        add_newline = false
+        format = "$custom"
+        [custom.emoji_test]
+        when = true
+        format = "🥟 test 🐚 ❄️"
+    });
+    context.current_dir = dir.path().to_path_buf();
+    context.shell = Shell::Zsh;
+    context.target = Target::Main;
+
+    let result = get_prompt(&context);
+
+    // The two-cell emoji get glitch sequences; the snowflake (U+2744) followed by variation
+    // selector 16 (U+FE0F) is included because its base character is only one cell wide.
+    assert_eq!(result, "%{🥟%2G%} test %{🐚%2G%} %{❄️%2G%}");
+
+    dir.close()
+}
+
+#[test]
+fn test_term_dumb_disables_prompt() {
+    use crate::context::Target;
+    use crate::test::default_context;
+
+    let mut context = default_context();
+    context.target = Target::Main;
+    context.env.insert("TERM", "dumb".to_string());
+
+    let result = get_prompt(&context);
+
+    assert_eq!(result, "Starship disabled due to TERM=dumb > ");
 }
 
 pub fn prompt(args: Properties, target: Target) {
@@ -94,7 +144,7 @@ pub fn get_prompt(context: &Context) -> String {
     let config = &context.root_config;
     let mut buf = String::new();
 
-    match std::env::var_os("TERM") {
+    match context.get_env_os("TERM") {
         Some(term) if term == "dumb" => {
             log::error!("Under a 'dumb' terminal (TERM=dumb).");
             buf.push_str("Starship disabled due to TERM=dumb > ");
@@ -151,7 +201,10 @@ pub fn get_prompt(context: &Context) -> String {
     // color sequences for this specific shell
     let shell_wrapped_output =
         wrap_colorseq_for_shell(AnsiStrings(&module_strings).to_string(), context.shell);
-    write!(buf, "{shell_wrapped_output}").unwrap();
+
+    // Explicitly tell zsh how many cells wide characters should take up
+    let wide_char_wrapped_output = wrap_widechar_for_zsh(shell_wrapped_output, context.shell);
+    write!(buf, "{wide_char_wrapped_output}").unwrap();
 
     if context.target == Target::Right {
         // right prompts generally do not allow newlines

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -13,6 +13,8 @@ use std::time::{Duration, Instant};
 
 use crate::context::Context;
 use crate::context::Shell;
+use crate::print::Grapheme;
+use unicode_segmentation::UnicodeSegmentation;
 
 /// Default timeout for command execution in milliseconds
 pub const DEFAULT_COMMAND_TIMEOUT_MS: u64 = 500;
@@ -645,28 +647,46 @@ CMake suite maintained and supported by Kitware (kitware.com/cmake).\n",
     Some(out)
 }
 
+/// Wraps a string in shell-specific escape sequences.
+pub fn wrap_seq_for_shell(text: String, shell: Shell) -> String {
+    let Some((beg, end)) = get_shell_wrappers(shell) else {
+        return text;
+    };
+
+    format!("{beg}{text}{end}")
+}
+
 /// Wraps ANSI color escape sequences in the shell-appropriate wrappers.
 pub fn wrap_colorseq_for_shell(ansi: String, shell: Shell) -> String {
     const ESCAPE_BEGIN: char = '\u{1b}';
     const ESCAPE_END: char = 'm';
-    wrap_seq_for_shell(ansi, shell, ESCAPE_BEGIN, ESCAPE_END)
+    wrap_ansi_seq_for_shell(ansi, shell, ESCAPE_BEGIN, ESCAPE_END)
+}
+
+/// Gets the shell-specific wrapper sequences used to escape non-printable characters.
+///
+/// Returns (begin_wrapper, end_wrapper) or None if shell doesn't need wrapping.
+fn get_shell_wrappers(shell: Shell) -> Option<(&'static str, &'static str)> {
+    match shell {
+        // \[ and \]
+        Shell::Bash => Some(("\u{5c}\u{5b}", "\u{5c}\u{5d}")),
+        // %{ and %}
+        Shell::Tcsh | Shell::Zsh => Some(("\u{25}\u{7b}", "\u{25}\u{7d}")),
+        _ => None,
+    }
 }
 
 /// Many shells cannot deal with raw unprintable characters and miscompute the cursor position,
-/// leading to strange visual bugs like duplicated/missing chars. This function wraps a specified
-/// sequence in shell-specific escapes to avoid these problems.
-pub fn wrap_seq_for_shell(
+/// leading to strange visual bugs like duplicated/missing chars. This function wraps ANSI
+/// escape sequences in shell-specific escapes to avoid these problems.
+pub fn wrap_ansi_seq_for_shell(
     ansi: String,
     shell: Shell,
     escape_begin: char,
     escape_end: char,
 ) -> String {
-    let (beg, end) = match shell {
-        // \[ and \]
-        Shell::Bash => ("\u{5c}\u{5b}", "\u{5c}\u{5d}"),
-        // %{ and %}
-        Shell::Tcsh | Shell::Zsh => ("\u{25}\u{7b}", "\u{25}\u{7d}"),
-        _ => return ansi,
+    let Some((beg, end)) = get_shell_wrappers(shell) else {
+        return ansi;
     };
 
     // ANSI escape codes cannot be nested, so we can keep track of whether we're
@@ -687,6 +707,76 @@ pub fn wrap_seq_for_shell(
         })
         .collect();
     final_string
+}
+
+/// Wraps wide Unicode graphemes in zsh-specific [glitch sequences] to explicitly tell the shell
+/// how wide to consider the character, avoiding positioning bugs. For zsh, wide graphemes (width
+/// > 1) are wrapped as `%{<char>%<width>G%}`.
+///
+/// The width is the terminal display width of the whole grapheme cluster, so sequences whose
+/// base character is narrow are still wrapped: emoji taking their two-cell presentation from
+/// variation selector 16 (such as ❄️, U+2744 U+FE0F), keycap sequences and flags.
+///
+/// Graphemes inside an existing `%{...%}` or `%<n>{...%}` region are left untouched: such a
+/// region is a width declaration made by whoever emitted it, and a `%G` glitch adds to the
+/// count even within nested braces, so declaring a width there would misplace the cursor.
+///
+/// [glitch sequences]: https://zsh.sourceforge.io/Doc/Release/Prompt-Expansion.html#Visual-effects
+pub fn wrap_widechar_for_zsh(text: String, shell: Shell) -> String {
+    if shell != Shell::Zsh {
+        return text;
+    }
+
+    let mut result = None;
+    let mut processed_len = 0;
+    let mut wrap_depth = 0usize;
+    let mut after_percent = false;
+
+    for grapheme in text.graphemes(true) {
+        // Track `%{`/`%}` pairs the way zsh parses them: a `%` consumes the following
+        // character, so `%%` produces a literal `%` and does not start a region, and a
+        // numeric argument may sit between the `%` and the brace, as in `%2{`.
+        let part_of_marker = if after_percent {
+            match grapheme {
+                "{" => {
+                    after_percent = false;
+                    wrap_depth += 1;
+                    true
+                }
+                "}" => {
+                    after_percent = false;
+                    wrap_depth = wrap_depth.saturating_sub(1);
+                    true
+                }
+                "-" => true,
+                _ if grapheme.len() == 1 && grapheme.as_bytes()[0].is_ascii_digit() => true,
+                _ => {
+                    after_percent = false;
+                    false
+                }
+            }
+        } else if grapheme == "%" {
+            after_percent = true;
+            true
+        } else {
+            false
+        };
+
+        let width = Grapheme(grapheme).width();
+
+        if !part_of_marker && wrap_depth == 0 && width > 1 {
+            let result = result.get_or_insert_with(|| text[..processed_len].to_string());
+
+            let glitch_seq = format!("{grapheme}%{width}G");
+            result.push_str(&wrap_seq_for_shell(glitch_seq, Shell::Zsh));
+        } else if let Some(ref mut result) = result {
+            result.push_str(grapheme);
+        }
+
+        processed_len += grapheme.len();
+    }
+
+    result.unwrap_or(text)
 }
 
 fn internal_exec_cmd<T: AsRef<OsStr> + Debug, U: AsRef<OsStr> + Debug>(
@@ -1049,12 +1139,12 @@ mod tests {
         let test4 = "herpaderp";
         let test5 = "";
 
-        let zresult0 = wrap_seq_for_shell(test0.to_string(), Shell::Zsh, '\x1b', 'm');
-        let zresult1 = wrap_seq_for_shell(test1.to_string(), Shell::Zsh, '\x1b', 'm');
-        let zresult2 = wrap_seq_for_shell(test2.to_string(), Shell::Zsh, '\x1b', 'J');
-        let zresult3 = wrap_seq_for_shell(test3.to_string(), Shell::Zsh, 'O', 'O');
-        let zresult4 = wrap_seq_for_shell(test4.to_string(), Shell::Zsh, '\x1b', 'm');
-        let zresult5 = wrap_seq_for_shell(test5.to_string(), Shell::Zsh, '\x1b', 'm');
+        let zresult0 = wrap_ansi_seq_for_shell(test0.to_string(), Shell::Zsh, '\x1b', 'm');
+        let zresult1 = wrap_ansi_seq_for_shell(test1.to_string(), Shell::Zsh, '\x1b', 'm');
+        let zresult2 = wrap_ansi_seq_for_shell(test2.to_string(), Shell::Zsh, '\x1b', 'J');
+        let zresult3 = wrap_ansi_seq_for_shell(test3.to_string(), Shell::Zsh, 'O', 'O');
+        let zresult4 = wrap_ansi_seq_for_shell(test4.to_string(), Shell::Zsh, '\x1b', 'm');
+        let zresult5 = wrap_ansi_seq_for_shell(test5.to_string(), Shell::Zsh, '\x1b', 'm');
 
         assert_eq!(&zresult0, "%{\x1b2m%}hellomynamekeyes%{\x1b2m%}");
         assert_eq!(&zresult1, "%{\x1b]330;m%}lol%{\x1b]0m%}");
@@ -1063,12 +1153,12 @@ mod tests {
         assert_eq!(&zresult4, "herpaderp");
         assert_eq!(&zresult5, "");
 
-        let bresult0 = wrap_seq_for_shell(test0.to_string(), Shell::Bash, '\x1b', 'm');
-        let bresult1 = wrap_seq_for_shell(test1.to_string(), Shell::Bash, '\x1b', 'm');
-        let bresult2 = wrap_seq_for_shell(test2.to_string(), Shell::Bash, '\x1b', 'J');
-        let bresult3 = wrap_seq_for_shell(test3.to_string(), Shell::Bash, 'O', 'O');
-        let bresult4 = wrap_seq_for_shell(test4.to_string(), Shell::Bash, '\x1b', 'm');
-        let bresult5 = wrap_seq_for_shell(test5.to_string(), Shell::Bash, '\x1b', 'm');
+        let bresult0 = wrap_ansi_seq_for_shell(test0.to_string(), Shell::Bash, '\x1b', 'm');
+        let bresult1 = wrap_ansi_seq_for_shell(test1.to_string(), Shell::Bash, '\x1b', 'm');
+        let bresult2 = wrap_ansi_seq_for_shell(test2.to_string(), Shell::Bash, '\x1b', 'J');
+        let bresult3 = wrap_ansi_seq_for_shell(test3.to_string(), Shell::Bash, 'O', 'O');
+        let bresult4 = wrap_ansi_seq_for_shell(test4.to_string(), Shell::Bash, '\x1b', 'm');
+        let bresult5 = wrap_ansi_seq_for_shell(test5.to_string(), Shell::Bash, '\x1b', 'm');
 
         assert_eq!(&bresult0, "\\[\x1b2m\\]hellomynamekeyes\\[\x1b2m\\]");
         assert_eq!(&bresult1, "\\[\x1b]330;m\\]lol\\[\x1b]0m\\]");
@@ -1145,5 +1235,82 @@ mod tests {
         assert_eq!(actual, expected);
 
         tmp_dir.close()
+    }
+
+    #[test]
+    fn test_wrap_seq_for_shell() {
+        let test_text = "example";
+
+        let zsh_result = wrap_seq_for_shell(test_text.to_string(), Shell::Zsh);
+        assert_eq!(zsh_result, "%{example%}");
+
+        let bash_result = wrap_seq_for_shell(test_text.to_string(), Shell::Bash);
+        assert_eq!(bash_result, "\\[example\\]");
+
+        let fish_result = wrap_seq_for_shell(test_text.to_string(), Shell::Fish);
+        assert_eq!(fish_result, "example");
+    }
+
+    #[test]
+    fn test_wrap_widechar_for_shell() {
+        let surrounding_wide_chars = "🥟 normal 🐚";
+
+        let zsh_result = wrap_widechar_for_zsh(surrounding_wide_chars.to_string(), Shell::Zsh);
+        assert_eq!(zsh_result, "%{🥟%2G%} normal %{🐚%2G%}");
+
+        let bash_result = wrap_widechar_for_zsh(surrounding_wide_chars.to_string(), Shell::Bash);
+        assert_eq!(bash_result, "🥟 normal 🐚");
+
+        let surrounded_wide_chars = "a🥟b";
+        let surrounded_wide_chars =
+            wrap_widechar_for_zsh(surrounded_wide_chars.to_string(), Shell::Zsh);
+        assert_eq!(surrounded_wide_chars, "a%{🥟%2G%}b");
+
+        let no_wide_chars = "normal text";
+        let no_wide_chars_result = wrap_widechar_for_zsh(no_wide_chars.to_string(), Shell::Zsh);
+        assert_eq!(no_wide_chars_result, "normal text");
+
+        // Graphemes whose base character is narrow but which display two cells wide:
+        // - ❄️: snowflake (U+2744) followed by variation selector 16 (U+FE0F), which requests
+        //   emoji presentation
+        // - 1️⃣: keycap sequence of digit one (U+0031), variation selector 16 and combining
+        //   enclosing keycap (U+20E3)
+        // - 🇬🇧: regional indicator symbols G (U+1F1EC) and B (U+1F1E7)
+        // - 👩‍👩‍👦‍👦: two women (U+1F469) and two boys (U+1F466) joined by zero-width joiners
+        //   (U+200D)
+        let composed_wide_chars = "❄️ 1️⃣ 🇬🇧 👩‍👩‍👦‍👦";
+        let composed_wide_chars_result =
+            wrap_widechar_for_zsh(composed_wide_chars.to_string(), Shell::Zsh);
+        assert_eq!(
+            composed_wide_chars_result,
+            "%{❄️%2G%} %{1️⃣%2G%} %{🇬🇧%2G%} %{👩‍👩‍👦‍👦%2G%}"
+        );
+
+        // ✔︎ is a check mark (U+2714) followed by variation selector 15 (U+FE0E), which
+        // requests text presentation: a single cell wide, so no glitch sequence.
+        let text_presentation = "✔︎ done";
+        let text_presentation_result =
+            wrap_widechar_for_zsh(text_presentation.to_string(), Shell::Zsh);
+        assert_eq!(text_presentation_result, "✔︎ done");
+    }
+
+    #[test]
+    fn test_wrap_widechar_for_zsh_skips_wrapped_regions() {
+        // The input has already been through `wrap_colorseq_for_shell`, so it can contain
+        // `%{...%}` regions that zsh counts as zero cells. A wide grapheme can appear inside
+        // one: a custom module with `unsafe_no_escape` may emit an OSC window title such as
+        // "\x1b]0;🐚 zoom\x07", and the colour wrapping terminates its region at the first
+        // `m` — here the one in "zoom" — leaving the emoji inside the braces. zsh counts a
+        // `%G` glitch even within nested braces, so declaring a width there would add
+        // phantom columns for output that renders zero cells wide.
+        let osc_title = "%{\u{1b}]0;🐚 zoom%} after 🐚";
+        let result = wrap_widechar_for_zsh(osc_title.to_string(), Shell::Zsh);
+        assert_eq!(result, "%{\u{1b}]0;🐚 zoom%} after %{🐚%2G%}");
+
+        // `%<n>{...%}` opens the same region with the width declared in the prefix, so its
+        // contents already carry a width and must not gain a glitch.
+        let numeric_region = "%2{🥟%} and 🐚";
+        let numeric_region_result = wrap_widechar_for_zsh(numeric_region.to_string(), Shell::Zsh);
+        assert_eq!(numeric_region_result, "%2{🥟%} and %{🐚%2G%}");
     }
 }


### PR DESCRIPTION
#### Description

zsh doesn't always have the same idea of character width as terminal emulators do. Wide Unicode characters can cause prompt rendering issues in `zsh:` the cursor overlaps the prompt or `RPROMPT` can push the cursor to the next line inadvertently . This change wraps wide characters in zsh's [glitch prompt sequence] (`%{<char>%<width>G%}`) to explicitly tell zsh the actual display width of the character being drawn.

[glitch prompt sequence]: https://zsh.sourceforge.io/Doc/Release/Prompt-Expansion.html#Visual-effects

#### Screenshots

before, notice the cursor is positioned over the left prompt

![image](https://github.com/user-attachments/assets/32255ec0-8fa0-494a-b1a6-6fc2115d873c)

after

![image](https://github.com/user-attachments/assets/0a4393b0-6b92-4576-bde3-d5ea922430f3)

#### How Has This Been Tested?

- [x] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist

- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
