### PR TITLE
Add support for `detect_folders` and `detect_files` to the AWS module

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -402,8 +402,8 @@ is read from the `AWS_SSO_PROFILE` env var.
 | `expiration_symbol` | `'X'`                                                             | The symbol displayed when the temporary credentials have expired.                                           |
 | `disabled`          | `false`                                                           | Disables the `AWS` module.                                                                                  |
 | `force_display`     | `false`                                                           | If `true` displays info even if `credentials`, `credential_process` or `sso_start_url` have not been setup. |
-| `detect_folders`     | []                                                               | Which folders should trigger this module.                                                                 |
-| `detect_files`     | []                                                                 | Which filenames should trigger this modules.                                                                  |
+| `detect_folders`    | []                                                                | Which folders should trigger this module.                                                                   |
+| `detect_files`      | []                                                                | Which filenames should trigger this modules.                                                                |
 
 ### Variables
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -402,6 +402,8 @@ is read from the `AWS_SSO_PROFILE` env var.
 | `expiration_symbol` | `'X'`                                                             | The symbol displayed when the temporary credentials have expired.                                           |
 | `disabled`          | `false`                                                           | Disables the `AWS` module.                                                                                  |
 | `force_display`     | `false`                                                           | If `true` displays info even if `credentials`, `credential_process` or `sso_start_url` have not been setup. |
+| `detect_folders`     | []                                                               | Which folders should trigger this module.                                                                 |
+| `detect_files`     | []                                                                 | Which filenames should trigger this modules.                                                                  |
 
 ### Variables
 

--- a/src/configs/aws.rs
+++ b/src/configs/aws.rs
@@ -47,6 +47,10 @@ pub struct AwsConfig<'a> {
     pub expiration_symbol: &'a str,
     /// If true displays info even if `credentials`, `credential_process` or `sso_start_url` have not been setup.
     pub force_display: bool,
+    /// Only show the AWS module when in supplied directories
+    pub detect_folders: Vec<&'a str>,
+    /// Only show the AWS module when with supplied files
+    pub detect_files: Vec<&'a str>,
 }
 
 impl Default for AwsConfig<'_> {
@@ -60,6 +64,8 @@ impl Default for AwsConfig<'_> {
             profile_aliases: HashMap::new(),
             expiration_symbol: "X",
             force_display: false,
+            detect_folders: vec![],
+            detect_files: vec![],
         }
     }
 }

--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -1259,4 +1259,88 @@ source_profile = starship
         assert_eq!(expected, actual);
         dir.close()
     }
+
+    #[test]
+    fn detect_files_present() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join("terraform.tfvars"))?;
+
+        let actual = ModuleRenderer::new("aws")
+            .env("AWS_REGION", "us-east-1")
+            .env("AWS_ACCESS_KEY_ID", "dummy")
+            .config(toml::toml! {
+                [aws]
+                detect_files = ["terraform.tfvars"]
+            })
+            .path(dir.path())
+            .collect();
+        let expected = Some(format!(
+            "on {}",
+            Color::Yellow.bold().paint("☁️  (us-east-1) ")
+        ));
+
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn detect_files_absent() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+
+        let actual = ModuleRenderer::new("aws")
+            .env("AWS_REGION", "us-east-1")
+            .env("AWS_ACCESS_KEY_ID", "dummy")
+            .config(toml::toml! {
+                [aws]
+                detect_files = ["terraform.tfvars"]
+            })
+            .path(dir.path())
+            .collect();
+        let expected = None;
+
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn detect_folders_present() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        create_dir(dir.path().join(".terraform"))?;
+
+        let actual = ModuleRenderer::new("aws")
+            .env("AWS_REGION", "us-east-1")
+            .env("AWS_ACCESS_KEY_ID", "dummy")
+            .config(toml::toml! {
+                [aws]
+                detect_folders = [".terraform"]
+            })
+            .path(dir.path())
+            .collect();
+        let expected = Some(format!(
+            "on {}",
+            Color::Yellow.bold().paint("☁️  (us-east-1) ")
+        ));
+
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn detect_folders_absent() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+
+        let actual = ModuleRenderer::new("aws")
+            .env("AWS_REGION", "us-east-1")
+            .env("AWS_ACCESS_KEY_ID", "dummy")
+            .config(toml::toml! {
+                [aws]
+                detect_folders = [".terraform"]
+            })
+            .path(dir.path())
+            .collect();
+        let expected = None;
+
+        assert_eq!(expected, actual);
+        dir.close()
+    }
 }

--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -256,11 +256,15 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let mut module = context.new_module("aws");
     let config: AwsConfig = AwsConfig::try_load(module.config);
 
-    let is_aws_wanted = context
-        .try_begin_scan()?
-        .set_files(&config.detect_files)
-        .set_folders(&config.detect_folders)
-        .is_match();
+    let is_aws_wanted = if config.detect_files.is_empty() && config.detect_folders.is_empty() {
+        true
+    } else {
+        context
+            .try_begin_scan()?
+            .set_files(&config.detect_files)
+            .set_folders(&config.detect_folders)
+            .is_match()
+    };
 
     if !is_aws_wanted {
         return None;

--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -256,6 +256,16 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let mut module = context.new_module("aws");
     let config: AwsConfig = AwsConfig::try_load(module.config);
 
+    let is_aws_wanted = context
+        .try_begin_scan()?
+        .set_files(&config.detect_files)
+        .set_folders(&config.detect_folders)
+        .is_match();
+
+    if !is_aws_wanted {
+        return None;
+    }
+
     let aws_config = OnceCell::new();
     let aws_creds = OnceCell::new();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

- Added support for the `detect_folders` and `detect_files` config options to the AWS module

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- I wanted to only show the AWS profile details when I'm in a relevant directory. Not all the time.


#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly 

### Todo

- Still need to add tests
