### PR TITLE
feat(fish): support input-mode detection for helix-keybinds

### DIFF
--- a/src/init/starship.fish
+++ b/src/init/starship.fish
@@ -1,6 +1,6 @@
 function fish_prompt
     switch "$fish_key_bindings"
-        case fish_hybrid_key_bindings fish_vi_key_bindings
+        case fish_hybrid_key_bindings fish_vi_key_bindings fish_helix_key_bindings
             set STARSHIP_KEYMAP "$fish_bind_mode"
         case '*'
             set STARSHIP_KEYMAP insert
@@ -27,7 +27,7 @@ end
 
 function fish_right_prompt
     switch "$fish_key_bindings"
-        case fish_hybrid_key_bindings fish_vi_key_bindings
+        case fish_hybrid_key_bindings fish_vi_key_bindings fish_helix_keybindings
             set STARSHIP_KEYMAP "$fish_bind_mode"
         case '*'
             set STARSHIP_KEYMAP insert


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description

Adding the `fish_helix_key_bindings` value to the possible values of `fish_key_bindings`.

#### Motivation and Context

There is a project providing helix editor keybindings to fish: https://github.com/sshilovsky/fish-helix

I would like to see the mode with fish and starship.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
