### PR TITLE
fix(nushell): Startup `cmd_duration` should be 0ms not 823ms

### DIFF
--- a/src/init/starship.nu
+++ b/src/init/starship.nu
@@ -14,8 +14,11 @@ export-env { $env.STARSHIP_SHELL = "nu"; load-env {
 
     PROMPT_COMMAND: {||
         (
+            # The initial value of `$env.CMD_DURATION_MS` is always `0823`, which is an official setting.
+            # See https://github.com/nushell/nushell/discussions/6402#discussioncomment-3466687.
+            let cmd_duration = if $env.CMD_DURATION_MS == "0823" { 0 } else { $env.CMD_DURATION_MS };
             ^::STARSHIP:: prompt
-                --cmd-duration $env.CMD_DURATION_MS
+                --cmd-duration $cmd_duration
                 $"--status=($env.LAST_EXIT_CODE)"
                 --terminal-width (term size).columns
                 ...(
@@ -34,9 +37,12 @@ export-env { $env.STARSHIP_SHELL = "nu"; load-env {
 
     PROMPT_COMMAND_RIGHT: {||
         (
+            # The initial value of `$env.CMD_DURATION_MS` is always `0823`, which is an official setting.
+            # See https://github.com/nushell/nushell/discussions/6402#discussioncomment-3466687.
+            let cmd_duration = if $env.CMD_DURATION_MS == "0823" { 0 } else { $env.CMD_DURATION_MS };
             ^::STARSHIP:: prompt
                 --right
-                --cmd-duration $env.CMD_DURATION_MS
+                --cmd-duration $cmd_duration
                 $"--status=($env.LAST_EXIT_CODE)"
                 --terminal-width (term size).columns
                 ...(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
Handle the initial value of `$env.CMD_DURATION_MS` (`'0823'`), and treat it as `0ms`.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #6853

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
