### PR TITLE
feat(install.sh): handle installation directory prompt responses case-insensitively

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -279,6 +279,7 @@ confirm() {
       if [ "$yn" = "n" ] || [ "$yn" = "no" ]; then
         set_interrupt_handler
         set +e
+        printf "${MAGENTA}?${NO_COLOR} Where would you like to install Starship? ${GREY}(e.g., /usr/local/bin)${NO_COLOR}\n"
         read -p "${MAGENTA}?${NO_COLOR} Install Starship ${GREEN}${VERSION}${NO_COLOR} to: " path
         trap - INT
         rc=$?

--- a/install/install.sh
+++ b/install/install.sh
@@ -257,12 +257,14 @@ detect_target() {
   printf '%s' "${target}"
 }
 
-
 confirm() {
   if [ -z "${FORCE-}" ]; then
+    trap 'echo; error "Interrupted (please re-run with the '--yes' option)"; exit 130' INT
     printf "%s " "${MAGENTA}?${NO_COLOR} $* ${BOLD}[y/N]${NO_COLOR}"
     set +e
     read -r yn </dev/tty
+    trap - INT
+    yn=$(echo "$yn" | tr '[:upper:]' '[:lower:]')
     rc=$?
     set -e
     if [ $rc -ne 0 ]; then
@@ -270,8 +272,28 @@ confirm() {
       exit 1
     fi
     if [ "$yn" != "y" ] && [ "$yn" != "yes" ]; then
-      error 'Aborting (please answer "yes" to continue)'
-      exit 1
+      if [ "$yn" = "n" ] || [ "$yn" = "no" ]; then
+        trap 'echo; error "Interrupted (please re-run with the '--yes' option)"; exit 130' INT
+        set +e
+        read -p "${MAGENTA}?${NO_COLOR} Install Starship ${GREEN}${VERSION}${NO_COLOR} to: " path
+        trap - INT
+        rc=$?
+        set -e
+        BIN_DIR=$path
+        if [ $rc != 0 ] || [ -z "$path"]; then
+          if [ -z "$path"]; then
+            echo
+          fi
+          error "Error reading from prompt (please re-run with '--yes' or provide path)"
+          exit 1
+        fi
+      else
+        if [ -z "$yn" ]; then
+          echo
+        fi
+        error 'Aborting (please answer "yes" to continue)'
+        exit 1
+      fi
     fi
   fi
 }

--- a/install/install.sh
+++ b/install/install.sh
@@ -257,9 +257,13 @@ detect_target() {
   printf '%s' "${target}"
 }
 
+set_interrupt_handler() {
+  trap 'echo; error "Interrupted (please re-run with the '--yes' option)"; exit 130' INT
+}
+
 confirm() {
   if [ -z "${FORCE-}" ]; then
-    trap 'echo; error "Interrupted (please re-run with the '--yes' option)"; exit 130' INT
+    set_interrupt_handler
     printf "%s " "${MAGENTA}?${NO_COLOR} $* ${BOLD}[y/N]${NO_COLOR}"
     set +e
     read -r yn </dev/tty
@@ -273,15 +277,15 @@ confirm() {
     fi
     if [ "$yn" != "y" ] && [ "$yn" != "yes" ]; then
       if [ "$yn" = "n" ] || [ "$yn" = "no" ]; then
-        trap 'echo; error "Interrupted (please re-run with the '--yes' option)"; exit 130' INT
+        set_interrupt_handler
         set +e
         read -p "${MAGENTA}?${NO_COLOR} Install Starship ${GREEN}${VERSION}${NO_COLOR} to: " path
         trap - INT
         rc=$?
         set -e
         BIN_DIR=$path
-        if [ $rc != 0 ] || [ -z "$path"]; then
-          if [ -z "$path"]; then
+        if [ $rc != 0 ] || [ -z "$path" ]; then
+          if [ -z "$path" ]; then
             echo
           fi
           error "Error reading from prompt (please re-run with '--yes' or provide path)"

--- a/install/install.sh
+++ b/install/install.sh
@@ -279,8 +279,8 @@ confirm() {
       if [ "$yn" = "n" ] || [ "$yn" = "no" ]; then
         set_interrupt_handler
         set +e
-        printf "${MAGENTA}?${NO_COLOR} Where would you like to install Starship? ${GREY}(e.g., /usr/local/bin)${NO_COLOR}\n"
-        read -p "${MAGENTA}?${NO_COLOR} Install Starship ${GREEN}${VERSION}${NO_COLOR} to: " path
+        printf "Where would you like to install Starship? ${GREY}(e.g., /usr/local/bin)${NO_COLOR}\n"
+        read -p "> Install Starship ${GREEN}${VERSION}${NO_COLOR} to: " path
         trap - INT
         rc=$?
         set -e


### PR DESCRIPTION
#### Description

Improve input handling in `install/install.sh` for confirmation prompts. Specifically:

- Interprets user responses case-insensitively to correctly handle both affirmative and negative answers.
- Adds clearer error messages when the user aborts input with `Ctrl+C` or `Ctrl+D`.
- Ensures that if the user declines installation in the default folder, the prompt exits gracefully with appropriate messaging.

#### Motivation and Context

This change ensures a more robust and user-friendly install experience, particularly when users provide lowercase or uppercase variants of "no" (`n`, `N`, `no`, `NO`) or interrupt input unexpectedly. Previously, such responses could lead to unclear errors or unintended behaviour.

Closes #5608 

#### How Has This Been Tested?

Manually tested the following cases in Starship:

- User inputs `y`, `Y`, `yes`, `YES` → script proceeds as expected.
- User inputs `n`, `N`, `no`, `NO` → script prompts again for an alternative installation path.
- User presses `Ctrl+C` → script exits cleanly.
- User presses `Ctrl+D` → script exits with error message.

#### Checklist:

- [x] I have tested using **Linux**
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.