### PR TITLE
fix(test/git_commit): avoid spawning an editor lead to timeout if tag signing is enabled

### DIFF
--- a/src/configure.rs
+++ b/src/configure.rs
@@ -653,7 +653,7 @@ mod tests {
         dir: &TempDir,
         home_file_exists: bool,
         starship_config_env_scenario: StarshipConfigEnvScenario,
-    ) -> io::Result<Context> {
+    ) -> io::Result<Context<'_>> {
         let config_path = dir.path().to_path_buf().join(".config");
         create_dir(&config_path)?;
         let home_starship_toml = config_path.join("starship.toml");

--- a/src/context.rs
+++ b/src/context.rs
@@ -220,7 +220,7 @@ impl<'a> Context<'a> {
     }
 
     /// Create a new module
-    pub fn new_module(&self, name: &str) -> Module {
+    pub fn new_module(&self, name: &str) -> Module<'_> {
         let config = self.config.get_module_config(name);
         let desc = modules::description(name);
 

--- a/src/formatter/parser.rs
+++ b/src/formatter/parser.rs
@@ -33,7 +33,7 @@ fn parse_textgroup(textgroup: Pair<Rule>) -> TextGroup {
     }
 }
 
-fn parse_variable(variable: Pair<Rule>) -> &str {
+fn parse_variable(variable: Pair<'_, Rule>) -> &str {
     variable.into_inner().next().unwrap().as_str()
 }
 
@@ -58,7 +58,7 @@ fn parse_style(style: Pair<Rule>) -> Vec<StyleElement> {
         .collect()
 }
 
-pub fn parse(format: &str) -> Result<Vec<FormatElement>, Box<Error<Rule>>> {
+pub fn parse(format: &str) -> Result<Vec<FormatElement<'_>>, Box<Error<Rule>>> {
     IdentParser::parse(Rule::expression, format)
         .map(|pairs| {
             pairs

--- a/src/module.rs
+++ b/src/module.rs
@@ -173,11 +173,11 @@ impl<'a> Module<'a> {
 
     /// Returns a vector of colored `AnsiString` elements to be later used with
     /// `AnsiStrings()` to optimize ANSI codes
-    pub fn ansi_strings(&self) -> Vec<AnsiString> {
+    pub fn ansi_strings(&self) -> Vec<AnsiString<'_>> {
         self.ansi_strings_for_width(None)
     }
 
-    pub fn ansi_strings_for_width(&self, width: Option<usize>) -> Vec<AnsiString> {
+    pub fn ansi_strings_for_width(&self, width: Option<usize>) -> Vec<AnsiString<'_>> {
         let mut iter = self.segments.iter().peekable();
         let mut ansi_strings: Vec<AnsiString> = Vec::new();
         while iter.peek().is_some() {

--- a/src/modules/git_commit.rs
+++ b/src/modules/git_commit.rs
@@ -348,26 +348,26 @@ mod tests {
         let commit_output = str::from_utf8(&git_commit).unwrap().trim();
 
         create_command("git")?
-            .args(["tag", "v2", "-m", "Testing tags v2"])
+            .args(["tag", "--no-sign", "v2", "-m", "Testing tags v2"])
             .env("GIT_COMMITTER_DATE", "2022-01-01 00:00:00 +0000")
             .current_dir(repo_dir.path())
             .output()?;
 
         create_command("git")?
-            .args(["tag", "v0", "-m", "Testing tags v0", "HEAD~1"])
+            .args(["tag", "--no-sign", "v0", "-m", "Testing tags v0", "HEAD~1"])
             .env("GIT_COMMITTER_DATE", "2022-01-01 00:00:01 +0000")
             .current_dir(repo_dir.path())
             .output()?;
 
         create_command("git")?
-            .args(["tag", "v1", "-m", "Testing tags v1"])
+            .args(["tag", "--no-sign", "v1", "-m", "Testing tags v1"])
             .env("GIT_COMMITTER_DATE", "2022-01-01 00:00:01 +0000")
             .current_dir(repo_dir.path())
             .output()?;
 
         // Annotated tags are preferred over lightweight tags
         create_command("git")?
-            .args(["tag", "l0"])
+            .args(["tag", "--no-sign", "l0"])
             .env("GIT_COMMITTER_DATE", "2022-01-01 00:00:02 +0000")
             .current_dir(repo_dir.path())
             .output()?;
@@ -416,19 +416,19 @@ mod tests {
 
         // Lightweight tags are chosen lexicographically
         create_command("git")?
-            .args(["tag", "v1"])
+            .args(["tag", "--no-sign", "v1"])
             .env("GIT_COMMITTER_DATE", "2022-01-01 00:00:00 +0000")
             .current_dir(repo_dir.path())
             .output()?;
 
         create_command("git")?
-            .args(["tag", "v0", "HEAD~1"])
+            .args(["tag", "--no-sign", "v0", "HEAD~1"])
             .env("GIT_COMMITTER_DATE", "2022-01-01 00:00:01 +0000")
             .current_dir(repo_dir.path())
             .output()?;
 
         create_command("git")?
-            .args(["tag", "v2"])
+            .args(["tag", "--no-sign", "v2"])
             .env("GIT_COMMITTER_DATE", "2022-01-01 00:00:01 +0000")
             .current_dir(repo_dir.path())
             .output()?;

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -17,7 +17,7 @@ pub struct TextSegment {
 
 impl TextSegment {
     // Returns the AnsiString of the segment value
-    fn ansi_string(&self, prev: Option<&AnsiStyle>) -> AnsiString {
+    fn ansi_string(&self, prev: Option<&AnsiStyle>) -> AnsiString<'_> {
         match self.style {
             Some(style) => style.to_ansi_style(prev).paint(&self.value),
             None => AnsiString::from(&self.value),
@@ -37,7 +37,7 @@ pub struct FillSegment {
 
 impl FillSegment {
     // Returns the AnsiString of the segment value, not including its prefix and suffix
-    pub fn ansi_string(&self, width: Option<usize>, prev: Option<&AnsiStyle>) -> AnsiString {
+    pub fn ansi_string(&self, width: Option<usize>, prev: Option<&AnsiStyle>) -> AnsiString<'_> {
         let s = match width {
             Some(w) => self
                 .value
@@ -157,7 +157,7 @@ impl Segment {
     }
 
     // Returns the AnsiString of the segment value, not including its prefix and suffix
-    pub fn ansi_string(&self, prev: Option<&AnsiStyle>) -> AnsiString {
+    pub fn ansi_string(&self, prev: Option<&AnsiStyle>) -> AnsiString<'_> {
         match self {
             Self::Fill(fs) => fs.ansi_string(None, prev),
             Self::Text(ts) => ts.ansi_string(prev),


### PR DESCRIPTION
#### Description
The 
```bash
cargo test
```
command was stalling indefinitely for me in `test_latest_tag_shown_with_tag_enabled_lightweight` and `test_latest_tag_shown_with_tag_enabled` tests. The reason being git was launching my editor for me to add a message for the tags in background which wasn't visible to me as a user for commands like 
```bash
git tag l0
```
when launched from cargo tests.

#### Motivation and Context
The changes essentially enable proper testing of git modules by simply providing the tag message inline instead of waiting for user to provide input to an invisible editor.

#### Screenshots (if appropriate):
**issue before my changes:**
image showing these tests stalling.
<img width="1450" height="226" alt="2025-08-07T23:16:38,610269214+05:30" src="https://github.com/user-attachments/assets/3893c202-11b0-456b-885c-bfabd7835940" />

**the same test with my changes.**
- the full test suite runs properly.
<img width="1214" height="367" alt="2025-08-07T23:01:18,146610449+05:30" src="https://github.com/user-attachments/assets/0312909c-de73-4ed3-9940-2962ac78a4e0" />
- the two tests properly working.
<img width="1261" height="398" alt="2025-08-07T23:01:53,084848085+05:30" src="https://github.com/user-attachments/assets/394fdcfc-2ad4-4e73-b7e8-fa83c5715590" />


#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
