### PR TITLE
feat: add substitutions table to git_branch like in directory module

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -617,6 +617,7 @@
         "format": "on [$symbol$branch(:$remote_branch)]($style) ",
         "symbol": " ",
         "style": "bold purple",
+        "substitutions": {},
         "truncation_length": 9223372036854775807,
         "truncation_symbol": "…",
         "only_attached": false,
@@ -1758,24 +1759,20 @@
       }
     },
     "vcs": {
+      "$ref": "#/$defs/VcsConfig",
       "default": {
-        "disabled": false,
-        "fossil_modules": "$fossil_branch$fossil_metrics",
-        "git_modules": "$git_branch$git_commit$git_state$git_metrics$git_status",
-        "hg_modules": "$hg_branch$hg_state",
         "order": [
           "git",
           "hg",
           "pijul",
           "fossil"
         ],
+        "disabled": false,
+        "fossil_modules": "$fossil_branch$fossil_metrics",
+        "git_modules": "$git_branch$git_commit$git_state$git_metrics$git_status",
+        "hg_modules": "$hg_branch$hg_state",
         "pijul_modules": "$pijul_channel"
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/VcsConfig"
-        }
-      ]
+      }
     },
     "vcsh": {
       "$ref": "#/$defs/VcshConfig",
@@ -3370,6 +3367,13 @@
         "style": {
           "type": "string",
           "default": "bold purple"
+        },
+        "substitutions": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {}
         },
         "truncation_length": {
           "type": "integer",
@@ -6582,54 +6586,45 @@
       "type": "object",
       "properties": {
         "order": {
-          "description": "Order in which to discover VCSes. The first one found is the one used.",
+          "description": "Order in which to discover VCSes.\nThe first one found is the one used.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
           "default": [
             "git",
             "hg",
             "pijul",
             "fossil"
-          ],
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Vcs"
-          }
+          ]
         },
         "disabled": {
           "description": "Disables the VCS module.",
-          "default": false,
-          "type": "boolean"
+          "type": "boolean",
+          "default": false
         },
         "fossil_modules": {
           "description": "Modules to use when Fossil is matched.\n\nThey are configured separately at the top level.",
-          "default": "$fossil_branch$fossil_metrics",
-          "type": "string"
+          "type": "string",
+          "default": "$fossil_branch$fossil_metrics"
         },
         "git_modules": {
           "description": "Modules to use when Git is matched.\n\nThey are configured separately at the top level.",
-          "default": "$git_branch$git_commit$git_state$git_metrics$git_status",
-          "type": "string"
+          "type": "string",
+          "default": "$git_branch$git_commit$git_state$git_metrics$git_status"
         },
         "hg_modules": {
           "description": "Modules to use when Mercurial is matched.\n\nThey are configured separately at the top level.",
-          "default": "$hg_branch$hg_state",
-          "type": "string"
+          "type": "string",
+          "default": "$hg_branch$hg_state"
         },
         "pijul_modules": {
           "description": "Modules to use when Pijul is matched.\n\nThey are configured separately at the top level.",
-          "default": "$pijul_channel",
-          "type": "string"
+          "type": "string",
+          "default": "$pijul_channel"
         }
       },
       "additionalProperties": false
-    },
-    "Vcs": {
-      "type": "string",
-      "enum": [
-        "fossil",
-        "git",
-        "hg",
-        "pijul"
-      ]
     },
     "VcshConfig": {
       "type": "object",

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1881,12 +1881,22 @@ The `git_branch` module shows the active branch of the repo in your current dire
 | `format`             | `'on [$symbol$branch(:$remote_branch)]($style) '` | The format for the module. Use `'$branch'` to refer to the current branch name.          |
 | `symbol`             | `' '`                                            | A format string representing the symbol of git branch.                                   |
 | `style`              | `'bold purple'`                                   | The style for the module.                                                                |
+| `substitutions`      |                                                   | A table of substitutions to be made to the branch name.                                  |
 | `truncation_length`  | `2^63 - 1`                                        | Truncates a git branch to `N` graphemes.                                                 |
 | `truncation_symbol`  | `'…'`                                             | The symbol used to indicate a branch name was truncated. You can use `''` for no symbol. |
 | `only_attached`      | `false`                                           | Only show the branch name when not in a detached `HEAD` state.                           |
 | `ignore_branches`    | `[]`                                              | A list of names to avoid displaying. Useful for 'master' or 'main'.                      |
 | `ignore_bare_repo`   | `false`                                           | Do not show when in a bare repo.                                                         |
 | `disabled`           | `false`                                           | Disables the `git_branch` module.                                                        |
+
+`substitutions` allows you to define arbitrary replacements for literal strings that occur in the branch name, for example project specific
+prefixes like `feature/` or `bugfix/`.
+
+```toml
+[git_branch.substitutions]
+'branch/feature/' = 'F:'
+'branch/bugfix/' = 'B:'
+```
 
 ### Variables
 

--- a/src/configs/git_branch.rs
+++ b/src/configs/git_branch.rs
@@ -1,3 +1,5 @@
+use indexmap::IndexMap;
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Deserialize, Serialize)]
@@ -11,6 +13,7 @@ pub struct GitBranchConfig<'a> {
     pub format: &'a str,
     pub symbol: &'a str,
     pub style: &'a str,
+    pub substitutions: IndexMap<String, &'a str>,
     pub truncation_length: i64,
     pub truncation_symbol: &'a str,
     pub only_attached: bool,
@@ -26,6 +29,7 @@ impl Default for GitBranchConfig<'_> {
             format: "on [$symbol$branch(:$remote_branch)]($style) ",
             symbol: " ",
             style: "bold purple",
+            substitutions: IndexMap::new(),
             truncation_length: i64::MAX,
             truncation_symbol: "…",
             only_attached: false,

--- a/src/modules/git_branch.rs
+++ b/src/modules/git_branch.rs
@@ -1,6 +1,4 @@
 use gix::bstr::ByteSlice;
-use indexmap::IndexMap;
-
 use unicode_segmentation::UnicodeSegmentation;
 
 use super::{Context, Module, ModuleConfig};
@@ -9,6 +7,7 @@ use crate::configs::git_branch::GitBranchConfig;
 use crate::context::Repo;
 use crate::formatter::StringFormatter;
 use crate::modules::git_status::uses_reftables;
+use crate::modules::utils::substitute::substitute_text;
 
 /// Creates a module with the Git branch in the current directory
 ///
@@ -102,7 +101,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     }
 
     // Apply branch name substitutions
-    let branch_string = substitute_path(branch_name, &config.substitutions);
+    let branch_string = substitute_text(branch_name, &config.substitutions);
 
     let mut graphemes: Vec<&str> = branch_string.graphemes(true).collect();
 
@@ -228,18 +227,6 @@ fn get_first_grapheme(text: &str) -> &str {
     UnicodeSegmentation::graphemes(text, true)
         .next()
         .unwrap_or("")
-}
-
-/// Perform a list of string substitutions on the branch name
-///
-/// Given a list of (from, to) pairs, this will perform the string
-/// substitutions, in order, on the branch name. Any non-pair of strings is ignored.
-fn substitute_path(branch_name: String, substitutions: &IndexMap<String, &str>) -> String {
-    let mut substituted_branch = branch_name;
-    for substitution_pair in substitutions {
-        substituted_branch = substituted_branch.replace(substitution_pair.0, substitution_pair.1);
-    }
-    substituted_branch
 }
 
 #[cfg(test)]

--- a/src/modules/utils/mod.rs
+++ b/src/modules/utils/mod.rs
@@ -8,4 +8,6 @@ pub mod directory_nix;
 
 pub mod path;
 
+pub mod substitute;
+
 pub mod truncate;

--- a/src/modules/utils/substitute.rs
+++ b/src/modules/utils/substitute.rs
@@ -1,0 +1,41 @@
+use indexmap::IndexMap;
+
+/// Perform a list of string substitutions on the text
+///
+/// Given a list of (from, to) pairs, this will perform the string
+/// substitutions, in order, on the input text. Any non-pair of strings is ignored.
+pub fn substitute_text(text: String, substitutions: &IndexMap<String, &str>) -> String {
+    let mut substituted_text = text;
+    for substitution_pair in substitutions {
+        substituted_text = substituted_text.replace(substitution_pair.0, substitution_pair.1);
+    }
+    substituted_text
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn substitute_prefix_and_middle() {
+        let full_text = "my-prefix-some-middle-text";
+        let mut substitutions = IndexMap::new();
+        substitutions.insert("my-prefix-".to_string(), "");
+        substitutions.insert("-middle-".to_string(), "-");
+
+        let output = substitute_text(full_text.to_string(), &substitutions);
+        assert_eq!(output, "some-text");
+    }
+
+    #[test]
+    fn substitution_order() {
+        let full_text = "some-super-random-text";
+        let mut substitutions = IndexMap::new();
+        substitutions.insert("super-random".to_string(), "correct");
+        substitutions.insert("super".to_string(), "wrong");
+
+        let output = substitute_text(full_text.to_string(), &substitutions);
+
+        assert_eq!(output, "some-correct-text");
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
Added substitutions table to `git_branch` module like in `directory` module.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

In many projects there exist naming conventions for branches, e.g. prefixes like `branch/feature/` or `branch/bugfix/`. These don't contain much useful information, but can lead to very long branch names. Truncating those branch names would cut the name at the wrong end regarding useful information. With substitutions on the other hand one can define meaningful replacements like `branch/feature/` -> `F:` to shorten the displayed branch name without loosing any information.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
