### PR TITLE
feat: add support for eshell

### DIFF
--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -179,6 +179,10 @@ pub fn init_stub(shell_name: &str) -> io::Result<()> {
             r#"execx($({} init xonsh --print-full-init))"#,
             starship.sprint_posix()?
         ),
+        "eshell" => print!(
+            r#"(eval (shell-command-to-string "{} init eshell --print-full-init"))"#,
+            starship.sprint()?
+        ),
         "cmd" => print_script(CMDEXE_INIT, &StarshipPath::init()?.sprint_cmdexe()?),
         _ => {
             eprintln!(
@@ -193,6 +197,7 @@ pub fn init_stub(shell_name: &str) -> io::Result<()> {
                  * zsh\n\
                  * nu\n\
                  * xonsh\n\
+                 * eshell\n\
                  * cmd\n\
                  \n\
                  Please open an issue in the starship repo if you would like to \
@@ -218,6 +223,7 @@ pub fn init_main(shell_name: &str) -> io::Result<()> {
         "elvish" => print_script(ELVISH_INIT, &starship_path.sprint()?),
         "tcsh" => print_script(TCSH_INIT, &starship_path.sprint_posix()?),
         "xonsh" => print_script(XONSH_INIT, &starship_path.sprint_posix()?),
+        "eshell" => print_script(ESHELL_INIT, &starship_path.sprint()?),
         _ => {
             println!(
                 "printf \"Shell name detection failed on phase two init.\\n\
@@ -266,6 +272,8 @@ const TCSH_INIT: &str = include_str!("starship.tcsh");
 const NU_INIT: &str = include_str!("starship.nu");
 
 const XONSH_INIT: &str = include_str!("starship.xsh");
+
+const ESHELL_INIT: &str = include_str!("starship.el");
 
 const CMDEXE_INIT: &str = include_str!("starship.lua");
 

--- a/src/init/starship.el
+++ b/src/init/starship.el
@@ -1,0 +1,67 @@
+;;; starship.el --- Description -*- lexical-binding: t; -*-
+;;
+;; Copyright (C) 2025 Starship Contributors
+;; This file is not part of GNU Emacs.
+;;
+;;; Commentary:
+;;
+;;  This is meant to be evaluated in someone's config,
+;;  not be a proper bona fide elisp library
+;;
+;;  Description
+;;
+;; Starship init for eshell
+;;
+;;; Code:
+
+(defvar starship/eshell-is-first-exec t
+  "implementation detail for internal starship use")
+(defvar starship/eshell-last-command-time nil
+  "the time that the last eshell command started")
+(defun starship/reset-eshell-is-first-exec ()
+  (setq starship/eshell-is-first-exec t))
+(defun starship/set-eshell-last-command-time (_cmd)
+  (when starship/eshell-is-first-exec
+    (setq starship/eshell-last-command-time (current-time))
+    (setq starship/eshell-is-first-exec nil)))
+(defun starship/eshell-starship-prompt ()
+  (with-temp-buffer
+    (with-environment-variables (("TERM" "eshell-is-not-dumb")
+                                 ("STARSHIP_SHELL" "eshell")
+                                 ("STARSHIP_SESSION_KEY"
+                                  (format "%016d" (random (expt 10 16)))))
+      (call-process "::STARSHIP::"
+                    nil t nil "prompt"
+                    (concat
+                     "--status=" (number-to-string eshell-last-command-status))
+                    (concat
+                     "--jobs="
+                     (number-to-string (length eshell-background-commands)))
+                    (concat
+                     "--cmd-duration="
+                     (number-to-string
+                      (if (and starship/eshell-last-command-time
+                               (not starship/eshell-is-first-exec))
+                          (car
+                           (time-convert (time-subtract
+                                          (current-time)
+                                          starship/eshell-last-command-time)
+                                         1000))
+                        0)))))
+    (require 'ansi-color)
+    (let ((ansi-color-apply-face-function
+           #'ansi-color-apply-text-property-face))
+      (ansi-color-apply-on-region (point-min) (point-max)))
+    ;; i have no idea why this hack is required...
+    ;; let's just go with it for now
+    (let ((the-string (buffer-string)))
+      (erase-buffer)
+      (goto-char (point-min))
+      (insert-for-yank the-string))
+    (buffer-string)))
+
+(add-hook 'eshell-after-prompt-hook #'starship/reset-eshell-is-first-exec)
+(add-hook 'eshell-exec-hook #'starship/set-eshell-last-command-time)
+(setq eshell-prompt-function #'starship/eshell-starship-prompt)
+
+;;; starship.el ends here


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

Add support for eshell, the builtin emacs shell.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Eshell has a decent userbase but not a lot of multi-shell prompts support it (maybe even none?)

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Tested the code in my personal emacs config. AFAIK shouldn't affect anything since it just adds to the init subcommand.
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ x ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
Unsure what to do with the docs/tests
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
