### PR TITLE
feat(container): Add detection of Incus containers

### DIFF
--- a/src/modules/container.rs
+++ b/src/modules/container.rs
@@ -300,4 +300,36 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn test_incus_container() -> std::io::Result<()> {
+        let renderer = ModuleRenderer::new("container")
+            .config(toml::toml! {
+                [container]
+                disabled = false
+            });
+
+        let root_path = renderer.root_path();
+
+        // Create the Incus socket path
+        let incus_socket_path = root_path.join("dev/incus/sock");
+        fs::create_dir_all(incus_socket_path.parent().unwrap())?;
+        fs::File::create(&incus_socket_path)?;
+
+        // The output of the module
+        let actual = renderer.collect();
+
+        // The value that should be rendered by the module
+        let expected = Some(format!(
+            "{} ",
+            Color::Red
+                .bold()
+                .dimmed()
+                .paint("⬢ [Incus]")
+        ));
+
+        assert_eq!(actual, expected);
+        Ok(())
+    }
 }

--- a/src/modules/container.rs
+++ b/src/modules/container.rs
@@ -304,11 +304,10 @@ mod tests {
     #[test]
     #[cfg(target_os = "linux")]
     fn test_incus_container() -> std::io::Result<()> {
-        let renderer = ModuleRenderer::new("container")
-            .config(toml::toml! {
-                [container]
-                disabled = false
-            });
+        let renderer = ModuleRenderer::new("container").config(toml::toml! {
+            [container]
+            disabled = false
+        });
 
         let root_path = renderer.root_path();
 
@@ -323,10 +322,7 @@ mod tests {
         // The value that should be rendered by the module
         let expected = Some(format!(
             "{} ",
-            Color::Red
-                .bold()
-                .dimmed()
-                .paint("⬢ [Incus]")
+            Color::Red.bold().dimmed().paint("⬢ [Incus]")
         ));
 
         assert_eq!(actual, expected);

--- a/src/modules/container.rs
+++ b/src/modules/container.rs
@@ -26,8 +26,12 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             return Some("OCI".into());
         }
 
-        let container_env_path = context_path(context, "/run/.containerenv");
+        if context_path(context, "/dev/incus/sock").exists() {
+            // Incus
+            return Some("Incus".into());
+        }
 
+        let container_env_path = context_path(context, "/run/.containerenv");
         if container_env_path.exists() {
             // podman and others
 


### PR DESCRIPTION

#### Description

Adds awareness of running inside an [incus](https://linuxcontainers.org/incus/) by checking for the existence of `/dev/incus/sock`, which is created by default.

#### Motivation and Context

Without this the prompt falls-back to `[Systemd]`.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [/] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [/] I have updated the tests accordingly.
