### PR TITLE
build(deps): bump schemars, quick-xml & windows

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -88,7 +88,6 @@
     "battery": {
       "$ref": "#/$defs/BatteryConfig",
       "default": {
-        "format": "[$symbol$percentage]($style) ",
         "full_symbol": "󰁹 ",
         "charging_symbol": "󰂄 ",
         "discharging_symbol": "󰂃 ",
@@ -102,7 +101,8 @@
             "discharging_symbol": null
           }
         ],
-        "disabled": false
+        "disabled": false,
+        "format": "[$symbol$percentage]($style) "
       }
     },
     "buf": {
@@ -140,7 +140,7 @@
       }
     },
     "c": {
-      "$ref": "#/$defs/CcConfig_for_CConfigMarker",
+      "$ref": "#/$defs/CcConfig",
       "default": {
         "format": "via [$symbol($version(-$name) )]($style)",
         "version_format": "v${raw}",
@@ -201,8 +201,8 @@
     "cmd_duration": {
       "$ref": "#/$defs/CmdDurationConfig",
       "default": {
-        "format": "took [$duration]($style) ",
         "min_time": 2000,
+        "format": "took [$duration]($style) ",
         "style": "yellow bold",
         "show_milliseconds": false,
         "disabled": false,
@@ -231,8 +231,8 @@
     "conda": {
       "$ref": "#/$defs/CondaConfig",
       "default": {
-        "format": "via [$symbol$environment]($style) ",
         "truncation_length": 1,
+        "format": "via [$symbol$environment]($style) ",
         "symbol": "🅒 ",
         "style": "green bold",
         "ignore_base": true,
@@ -252,7 +252,7 @@
       }
     },
     "cpp": {
-      "$ref": "#/$defs/CcConfig_for_CppConfigMarker",
+      "$ref": "#/$defs/CcConfig",
       "default": {
         "format": "via [$symbol($version(-$name) )]($style)",
         "version_format": "v${raw}",
@@ -308,8 +308,8 @@
     "daml": {
       "$ref": "#/$defs/DamlConfig",
       "default": {
-        "format": "via [$symbol($version )]($style)",
         "symbol": "Λ ",
+        "format": "via [$symbol($version )]($style)",
         "version_format": "v${raw}",
         "style": "bold cyan",
         "disabled": false,
@@ -365,12 +365,12 @@
     "directory": {
       "$ref": "#/$defs/DirectoryConfig",
       "default": {
-        "format": "[$path]($style)[$read_only]($read_only_style) ",
         "truncation_length": 3,
         "truncate_to_repo": true,
         "substitutions": {},
         "fish_style_pwd_dir_length": 0,
         "use_logical_path": true,
+        "format": "[$path]($style)[$read_only]($read_only_style) ",
         "repo_root_format": "[$before_root_path]($before_repo_root_style)[$repo_root]($repo_root_style)[$path]($style)[$read_only]($read_only_style) ",
         "style": "cyan bold",
         "repo_root_style": null,
@@ -408,9 +408,9 @@
     "docker_context": {
       "$ref": "#/$defs/DockerContextConfig",
       "default": {
-        "format": "via [$symbol$context]($style) ",
         "symbol": "🐳 ",
         "style": "blue bold",
+        "format": "via [$symbol$context]($style) ",
         "only_with_files": true,
         "disabled": false,
         "detect_extensions": [],
@@ -580,8 +580,8 @@
     "git_commit": {
       "$ref": "#/$defs/GitCommitConfig",
       "default": {
-        "format": "[\\($hash$tag\\)]($style) ",
         "commit_hash_length": 7,
+        "format": "[\\($hash$tag\\)]($style) ",
         "style": "green bold",
         "only_detached": true,
         "disabled": false,
@@ -593,10 +593,10 @@
     "git_metrics": {
       "$ref": "#/$defs/GitMetricsConfig",
       "default": {
-        "format": "([+$added]($added_style) )([-$deleted]($deleted_style) )",
         "added_style": "bold green",
         "deleted_style": "bold red",
         "only_nonzero_diffs": true,
+        "format": "([+$added]($added_style) )([-$deleted]($deleted_style) )",
         "disabled": true,
         "ignore_submodules": false
       }
@@ -604,7 +604,6 @@
     "git_state": {
       "$ref": "#/$defs/GitStateConfig",
       "default": {
-        "format": "\\([$state( $progress_current/$progress_total)]($style)\\) ",
         "rebase": "REBASING",
         "merge": "MERGING",
         "revert": "REVERTING",
@@ -613,6 +612,7 @@
         "am": "AM",
         "am_or_rebase": "AM/REBASE",
         "style": "bold yellow",
+        "format": "\\([$state( $progress_current/$progress_total)]($style)\\) ",
         "disabled": false
       }
     },
@@ -771,9 +771,9 @@
     "hg_branch": {
       "$ref": "#/$defs/HgBranchConfig",
       "default": {
-        "format": "on [$symbol$branch(:$topic)]($style) ",
         "symbol": " ",
         "style": "bold purple",
+        "format": "on [$symbol$branch(:$topic)]($style) ",
         "truncation_length": 9223372036854775807,
         "truncation_symbol": "…",
         "disabled": true
@@ -782,7 +782,6 @@
     "hg_state": {
       "$ref": "#/$defs/HgStateConfig",
       "default": {
-        "format": "\\([$state]($style)\\) ",
         "merge": "MERGING",
         "rebase": "REBASING",
         "update": "UPDATING",
@@ -792,17 +791,18 @@
         "transplant": "TRANSPLANTING",
         "histedit": "HISTEDITING",
         "style": "bold yellow",
+        "format": "\\([$state]($style)\\) ",
         "disabled": true
       }
     },
     "hostname": {
       "$ref": "#/$defs/HostnameConfig",
       "default": {
-        "format": "[$ssh_symbol$hostname]($style) in ",
         "ssh_only": true,
         "ssh_symbol": "🌐 ",
         "trim_at": ".",
         "detect_env_vars": [],
+        "format": "[$ssh_symbol$hostname]($style) in ",
         "style": "green dimmed bold",
         "disabled": false,
         "aliases": {}
@@ -811,8 +811,8 @@
     "java": {
       "$ref": "#/$defs/JavaConfig",
       "default": {
-        "format": "via [$symbol($version )]($style)",
         "disabled": false,
+        "format": "via [$symbol($version )]($style)",
         "version_format": "v${raw}",
         "style": "red dimmed",
         "symbol": "☕ ",
@@ -840,10 +840,10 @@
     "jobs": {
       "$ref": "#/$defs/JobsConfig",
       "default": {
-        "format": "[$symbol$number]($style) ",
         "threshold": 1,
         "symbol_threshold": 1,
         "number_threshold": 2,
+        "format": "[$symbol$number]($style) ",
         "symbol": "✦",
         "style": "bold blue",
         "disabled": false
@@ -887,8 +887,8 @@
     "kubernetes": {
       "$ref": "#/$defs/KubernetesConfig",
       "default": {
-        "format": "[$symbol$context( \\($namespace\\))]($style) in ",
         "symbol": "☸ ",
+        "format": "[$symbol$context( \\($namespace\\))]($style) in ",
         "style": "cyan bold",
         "disabled": true,
         "context_aliases": {},
@@ -909,8 +909,8 @@
     "localip": {
       "$ref": "#/$defs/LocalipConfig",
       "default": {
-        "format": "[$localipv4]($style) ",
         "ssh_only": true,
+        "format": "[$localipv4]($style) ",
         "style": "yellow bold",
         "disabled": true
       }
@@ -938,8 +938,8 @@
     "memory_usage": {
       "$ref": "#/$defs/MemoryConfig",
       "default": {
-        "format": "via $symbol[$ram( | $swap)]($style) ",
         "threshold": 75,
+        "format": "via $symbol[$ram( | $swap)]($style) ",
         "style": "white bold dimmed",
         "symbol": "🐏 ",
         "disabled": true
@@ -948,9 +948,9 @@
     "meson": {
       "$ref": "#/$defs/MesonConfig",
       "default": {
-        "format": "via [$symbol$project]($style) ",
         "truncation_length": 4294967295,
         "truncation_symbol": "…",
+        "format": "via [$symbol$project]($style) ",
         "symbol": "⬢ ",
         "style": "blue bold",
         "disabled": false
@@ -1260,9 +1260,9 @@
     "pijul_channel": {
       "$ref": "#/$defs/PijulConfig",
       "default": {
-        "format": "on [$symbol$channel]($style) ",
         "symbol": " ",
         "style": "bold purple",
+        "format": "on [$symbol$channel]($style) ",
         "truncation_length": 9223372036854775807,
         "truncation_symbol": "…",
         "disabled": true
@@ -1271,11 +1271,11 @@
     "pixi": {
       "$ref": "#/$defs/PixiConfig",
       "default": {
-        "format": "via [$symbol($version )(\\($environment\\) )]($style)",
         "pixi_binary": [
           "pixi"
         ],
         "show_default_environment": true,
+        "format": "via [$symbol($version )(\\($environment\\) )]($style)",
         "version_format": "v${raw}",
         "symbol": "🧚 ",
         "style": "yellow bold",
@@ -1321,7 +1321,6 @@
     "python": {
       "$ref": "#/$defs/PythonConfig",
       "default": {
-        "format": "via [${symbol}${pyenv_prefix}(${version} )(\\($virtualenv\\) )]($style)",
         "pyenv_version_name": false,
         "pyenv_prefix": "pyenv ",
         "python_binary": [
@@ -1335,6 +1334,7 @@
             "python2"
           ]
         ],
+        "format": "via [${symbol}${pyenv_prefix}(${version} )(\\($virtualenv\\) )]($style)",
         "version_format": "v${raw}",
         "style": "yellow bold",
         "symbol": "🐍 ",
@@ -1518,8 +1518,8 @@
     "shlvl": {
       "$ref": "#/$defs/ShLvlConfig",
       "default": {
-        "format": "[$symbol$shlvl]($style) ",
         "threshold": 2,
+        "format": "[$symbol$shlvl]($style) ",
         "symbol": "↕️  ",
         "repeat": false,
         "repeat_offset": 0,
@@ -1530,8 +1530,8 @@
     "singularity": {
       "$ref": "#/$defs/SingularityConfig",
       "default": {
-        "format": "[$symbol\\[$env\\]]($style) ",
         "symbol": "",
+        "format": "[$symbol\\[$env\\]]($style) ",
         "style": "blue bold dimmed",
         "disabled": false
       }
@@ -1557,8 +1557,8 @@
     "spack": {
       "$ref": "#/$defs/SpackConfig",
       "default": {
-        "format": "via [$symbol$environment]($style) ",
         "truncation_length": 1,
+        "format": "via [$symbol$environment]($style) ",
         "symbol": "🅢 ",
         "style": "blue bold",
         "disabled": false
@@ -1618,6 +1618,15 @@
         "symbol": "💠 ",
         "style": "bold 105",
         "disabled": false,
+        "detect_extensions": [
+          "tf",
+          "tfplan",
+          "tfstate"
+        ],
+        "detect_files": [],
+        "detect_folders": [
+          ".terraform"
+        ],
         "commands": [
           [
             "terraform",
@@ -1627,15 +1636,6 @@
             "tofu",
             "version"
           ]
-        ],
-        "detect_extensions": [
-          "tf",
-          "tfplan",
-          "tfstate"
-        ],
-        "detect_files": [],
-        "detect_folders": [
-          ".terraform"
         ]
       }
     },
@@ -1670,8 +1670,8 @@
     "username": {
       "$ref": "#/$defs/UsernameConfig",
       "default": {
-        "format": "[$user]($style) in ",
         "detect_env_vars": [],
+        "format": "[$user]($style) in ",
         "style_root": "red bold",
         "style_user": "yellow bold",
         "show_always": false,
@@ -1697,9 +1697,9 @@
     "vcsh": {
       "$ref": "#/$defs/VcshConfig",
       "default": {
-        "format": "vcsh [$symbol$repo]($style) ",
         "symbol": "",
         "style": "bold yellow",
+        "format": "vcsh [$symbol$repo]($style) ",
         "disabled": false
       }
     },
@@ -1764,7 +1764,7 @@
   "$defs": {
     "AwsConfig": {
       "title": "AWS",
-      "description": "The `aws` module shows the current AWS region and profile and an expiration timer when using temporary credentials.\n The output of the module uses the `AWS_REGION`, `AWS_DEFAULT_REGION`, and `AWS_PROFILE` env vars and the `~/.aws/config` and `~/.aws/credentials` files as required.\n\n The module will display a profile only if its credentials are present in `~/.aws/credentials` or if a `credential_process` or `sso_start_url` are defined in `~/.aws/config`. Alternatively, having any of the `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, or `AWS_SESSION_TOKEN` env vars defined will also suffice.\n If the option `force_display` is set to `true`, all available information will be displayed even if no credentials per the conditions above are detected.\n\n When using [aws-vault](https://github.com/99designs/aws-vault) the profile\n is read from the `AWS_VAULT` env var and the credentials expiration date\n is read from the `AWS_SESSION_EXPIRATION` or `AWS_CREDENTIAL_EXPIRATION`\n var.\n\n When using [awsu](https://github.com/kreuzwerker/awsu) the profile\n is read from the `AWSU_PROFILE` env var.\n\n When using [`AWSume`](https://awsu.me) the profile\n is read from the `AWSUME_PROFILE` env var and the credentials expiration\n date is read from the `AWSUME_EXPIRATION` env var.\n\n When using [aws-sso-cli](https://github.com/synfinatic/aws-sso-cli) the profile\n is read from the `AWS_SSO_PROFILE` env var.",
+      "description": "The `aws` module shows the current AWS region and profile and an expiration timer when using temporary credentials.\nThe output of the module uses the `AWS_REGION`, `AWS_DEFAULT_REGION`, and `AWS_PROFILE` env vars and the `~/.aws/config` and `~/.aws/credentials` files as required.\n\nThe module will display a profile only if its credentials are present in `~/.aws/credentials` or if a `credential_process` or `sso_start_url` are defined in `~/.aws/config`. Alternatively, having any of the `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, or `AWS_SESSION_TOKEN` env vars defined will also suffice.\nIf the option `force_display` is set to `true`, all available information will be displayed even if no credentials per the conditions above are detected.\n\nWhen using [aws-vault](https://github.com/99designs/aws-vault) the profile\nis read from the `AWS_VAULT` env var and the credentials expiration date\nis read from the `AWS_SESSION_EXPIRATION` or `AWS_CREDENTIAL_EXPIRATION`\nvar.\n\nWhen using [awsu](https://github.com/kreuzwerker/awsu) the profile\nis read from the `AWSU_PROFILE` env var.\n\nWhen using [`AWSume`](https://awsu.me) the profile\nis read from the `AWSUME_PROFILE` env var and the credentials expiration\ndate is read from the `AWSUME_EXPIRATION` env var.\n\nWhen using [aws-sso-cli](https://github.com/synfinatic/aws-sso-cli) the profile\nis read from the `AWS_SSO_PROFILE` env var.",
       "type": "object",
       "properties": {
         "format": {
@@ -1848,10 +1848,6 @@
     "BatteryConfig": {
       "type": "object",
       "properties": {
-        "format": {
-          "type": "string",
-          "default": "[$symbol$percentage]($style) "
-        },
         "full_symbol": {
           "type": "string",
           "default": "󰁹 "
@@ -1889,6 +1885,10 @@
         "disabled": {
           "type": "boolean",
           "default": false
+        },
+        "format": {
+          "type": "string",
+          "default": "[$symbol$percentage]($style) "
         }
       },
       "additionalProperties": false
@@ -2024,7 +2024,7 @@
       },
       "additionalProperties": false
     },
-    "CcConfig_for_CConfigMarker": {
+    "CcConfig": {
       "type": "object",
       "properties": {
         "format": {
@@ -2188,14 +2188,14 @@
     "CmdDurationConfig": {
       "type": "object",
       "properties": {
-        "format": {
-          "type": "string",
-          "default": "took [$duration]($style) "
-        },
         "min_time": {
           "type": "integer",
           "format": "int64",
           "default": 2000
+        },
+        "format": {
+          "type": "string",
+          "default": "took [$duration]($style) "
         },
         "style": {
           "type": "string",
@@ -2284,15 +2284,15 @@
     "CondaConfig": {
       "type": "object",
       "properties": {
-        "format": {
-          "type": "string",
-          "default": "via [$symbol$environment]($style) "
-        },
         "truncation_length": {
           "type": "integer",
           "format": "uint",
           "minimum": 0,
           "default": 1
+        },
+        "format": {
+          "type": "string",
+          "default": "via [$symbol$environment]($style) "
         },
         "symbol": {
           "type": "string",
@@ -2340,86 +2340,6 @@
         "disabled": {
           "type": "boolean",
           "default": false
-        }
-      },
-      "additionalProperties": false
-    },
-    "CcConfig_for_CppConfigMarker": {
-      "type": "object",
-      "properties": {
-        "format": {
-          "type": "string",
-          "default": "via [$symbol($version(-$name) )]($style)"
-        },
-        "version_format": {
-          "type": "string",
-          "default": "v${raw}"
-        },
-        "style": {
-          "type": "string",
-          "default": "149 bold"
-        },
-        "symbol": {
-          "type": "string",
-          "default": "C++ "
-        },
-        "disabled": {
-          "type": "boolean",
-          "default": true
-        },
-        "detect_extensions": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": [
-            "cpp",
-            "cc",
-            "cxx",
-            "c++",
-            "hpp",
-            "hh",
-            "hxx",
-            "h++",
-            "tcc"
-          ]
-        },
-        "detect_files": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": []
-        },
-        "detect_folders": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "default": []
-        },
-        "commands": {
-          "type": "array",
-          "items": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "default": [
-            [
-              "c++",
-              "--version"
-            ],
-            [
-              "g++",
-              "--version"
-            ],
-            [
-              "clang++",
-              "--version"
-            ]
-          ]
         }
       },
       "additionalProperties": false
@@ -2478,13 +2398,13 @@
     "DamlConfig": {
       "type": "object",
       "properties": {
-        "format": {
-          "type": "string",
-          "default": "via [$symbol($version )]($style)"
-        },
         "symbol": {
           "type": "string",
           "default": "Λ "
+        },
+        "format": {
+          "type": "string",
+          "default": "via [$symbol($version )]($style)"
         },
         "version_format": {
           "type": "string",
@@ -2637,10 +2557,6 @@
     "DirectoryConfig": {
       "type": "object",
       "properties": {
-        "format": {
-          "type": "string",
-          "default": "[$path]($style)[$read_only]($read_only_style) "
-        },
         "truncation_length": {
           "type": "integer",
           "format": "int64",
@@ -2665,6 +2581,10 @@
         "use_logical_path": {
           "type": "boolean",
           "default": true
+        },
+        "format": {
+          "type": "string",
+          "default": "[$path]($style)[$read_only]($read_only_style) "
         },
         "repo_root_format": {
           "type": "string",
@@ -2792,10 +2712,6 @@
     "DockerContextConfig": {
       "type": "object",
       "properties": {
-        "format": {
-          "type": "string",
-          "default": "via [$symbol$context]($style) "
-        },
         "symbol": {
           "type": "string",
           "default": "🐳 "
@@ -2803,6 +2719,10 @@
         "style": {
           "type": "string",
           "default": "blue bold"
+        },
+        "format": {
+          "type": "string",
+          "default": "via [$symbol$context]($style) "
         },
         "only_with_files": {
           "type": "boolean",
@@ -3010,14 +2930,6 @@
     "EnvVarConfig": {
       "type": "object",
       "properties": {
-        "description": {
-          "type": "string",
-          "default": "<env_var module>"
-        },
-        "format": {
-          "type": "string",
-          "default": "with [$env_value]($style) "
-        },
         "symbol": {
           "type": "string",
           "default": ""
@@ -3038,9 +2950,17 @@
             "null"
           ]
         },
+        "format": {
+          "type": "string",
+          "default": "with [$env_value]($style) "
+        },
         "disabled": {
           "type": "boolean",
           "default": false
+        },
+        "description": {
+          "type": "string",
+          "default": "<env_var module>"
         }
       },
       "additionalProperties": false
@@ -3311,15 +3231,15 @@
     "GitCommitConfig": {
       "type": "object",
       "properties": {
-        "format": {
-          "type": "string",
-          "default": "[\\($hash$tag\\)]($style) "
-        },
         "commit_hash_length": {
           "type": "integer",
           "format": "uint",
           "minimum": 0,
           "default": 7
+        },
+        "format": {
+          "type": "string",
+          "default": "[\\($hash$tag\\)]($style) "
         },
         "style": {
           "type": "string",
@@ -3353,10 +3273,6 @@
     "GitMetricsConfig": {
       "type": "object",
       "properties": {
-        "format": {
-          "type": "string",
-          "default": "([+$added]($added_style) )([-$deleted]($deleted_style) )"
-        },
         "added_style": {
           "type": "string",
           "default": "bold green"
@@ -3368,6 +3284,10 @@
         "only_nonzero_diffs": {
           "type": "boolean",
           "default": true
+        },
+        "format": {
+          "type": "string",
+          "default": "([+$added]($added_style) )([-$deleted]($deleted_style) )"
         },
         "disabled": {
           "type": "boolean",
@@ -3383,10 +3303,6 @@
     "GitStateConfig": {
       "type": "object",
       "properties": {
-        "format": {
-          "type": "string",
-          "default": "\\([$state( $progress_current/$progress_total)]($style)\\) "
-        },
         "rebase": {
           "type": "string",
           "default": "REBASING"
@@ -3418,6 +3334,10 @@
         "style": {
           "type": "string",
           "default": "bold yellow"
+        },
+        "format": {
+          "type": "string",
+          "default": "\\([$state( $progress_current/$progress_total)]($style)\\) "
         },
         "disabled": {
           "type": "boolean",
@@ -3862,10 +3782,6 @@
     "HgBranchConfig": {
       "type": "object",
       "properties": {
-        "format": {
-          "type": "string",
-          "default": "on [$symbol$branch(:$topic)]($style) "
-        },
         "symbol": {
           "type": "string",
           "default": " "
@@ -3873,6 +3789,10 @@
         "style": {
           "type": "string",
           "default": "bold purple"
+        },
+        "format": {
+          "type": "string",
+          "default": "on [$symbol$branch(:$topic)]($style) "
         },
         "truncation_length": {
           "type": "integer",
@@ -3893,10 +3813,6 @@
     "HgStateConfig": {
       "type": "object",
       "properties": {
-        "format": {
-          "type": "string",
-          "default": "\\([$state]($style)\\) "
-        },
         "merge": {
           "type": "string",
           "default": "MERGING"
@@ -3933,6 +3849,10 @@
           "type": "string",
           "default": "bold yellow"
         },
+        "format": {
+          "type": "string",
+          "default": "\\([$state]($style)\\) "
+        },
         "disabled": {
           "type": "boolean",
           "default": true
@@ -3943,10 +3863,6 @@
     "HostnameConfig": {
       "type": "object",
       "properties": {
-        "format": {
-          "type": "string",
-          "default": "[$ssh_symbol$hostname]($style) in "
-        },
         "ssh_only": {
           "type": "boolean",
           "default": true
@@ -3965,6 +3881,10 @@
             "type": "string"
           },
           "default": []
+        },
+        "format": {
+          "type": "string",
+          "default": "[$ssh_symbol$hostname]($style) in "
         },
         "style": {
           "type": "string",
@@ -3987,13 +3907,13 @@
     "JavaConfig": {
       "type": "object",
       "properties": {
-        "format": {
-          "type": "string",
-          "default": "via [$symbol($version )]($style)"
-        },
         "disabled": {
           "type": "boolean",
           "default": false
+        },
+        "format": {
+          "type": "string",
+          "default": "via [$symbol($version )]($style)"
         },
         "version_format": {
           "type": "string",
@@ -4050,10 +3970,6 @@
     "JobsConfig": {
       "type": "object",
       "properties": {
-        "format": {
-          "type": "string",
-          "default": "[$symbol$number]($style) "
-        },
         "threshold": {
           "type": "integer",
           "format": "int64",
@@ -4068,6 +3984,10 @@
           "type": "integer",
           "format": "int64",
           "default": 2
+        },
+        "format": {
+          "type": "string",
+          "default": "[$symbol$number]($style) "
         },
         "symbol": {
           "type": "string",
@@ -4193,13 +4113,13 @@
     "KubernetesConfig": {
       "type": "object",
       "properties": {
-        "format": {
-          "type": "string",
-          "default": "[$symbol$context( \\($namespace\\))]($style) in "
-        },
         "symbol": {
           "type": "string",
           "default": "☸ "
+        },
+        "format": {
+          "type": "string",
+          "default": "[$symbol$context( \\($namespace\\))]($style) in "
         },
         "style": {
           "type": "string",
@@ -4319,13 +4239,13 @@
     "LocalipConfig": {
       "type": "object",
       "properties": {
-        "format": {
-          "type": "string",
-          "default": "[$localipv4]($style) "
-        },
         "ssh_only": {
           "type": "boolean",
           "default": true
+        },
+        "format": {
+          "type": "string",
+          "default": "[$localipv4]($style) "
         },
         "style": {
           "type": "string",
@@ -4398,14 +4318,14 @@
     "MemoryConfig": {
       "type": "object",
       "properties": {
-        "format": {
-          "type": "string",
-          "default": "via $symbol[$ram( | $swap)]($style) "
-        },
         "threshold": {
           "type": "integer",
           "format": "int64",
           "default": 75
+        },
+        "format": {
+          "type": "string",
+          "default": "via $symbol[$ram( | $swap)]($style) "
         },
         "style": {
           "type": "string",
@@ -4425,10 +4345,6 @@
     "MesonConfig": {
       "type": "object",
       "properties": {
-        "format": {
-          "type": "string",
-          "default": "via [$symbol$project]($style) "
-        },
         "truncation_length": {
           "type": "integer",
           "format": "uint32",
@@ -4438,6 +4354,10 @@
         "truncation_symbol": {
           "type": "string",
           "default": "…"
+        },
+        "format": {
+          "type": "string",
+          "default": "via [$symbol$project]($style) "
         },
         "symbol": {
           "type": "string",
@@ -5172,10 +5092,6 @@
     "PijulConfig": {
       "type": "object",
       "properties": {
-        "format": {
-          "type": "string",
-          "default": "on [$symbol$channel]($style) "
-        },
         "symbol": {
           "type": "string",
           "default": " "
@@ -5183,6 +5099,10 @@
         "style": {
           "type": "string",
           "default": "bold purple"
+        },
+        "format": {
+          "type": "string",
+          "default": "on [$symbol$channel]($style) "
         },
         "truncation_length": {
           "type": "integer",
@@ -5203,12 +5123,8 @@
     "PixiConfig": {
       "type": "object",
       "properties": {
-        "format": {
-          "type": "string",
-          "default": "via [$symbol($version )(\\($environment\\) )]($style)"
-        },
         "pixi_binary": {
-          "$ref": "#/$defs/Either_for_string_and_Array_of_string",
+          "$ref": "#/$defs/Either",
           "default": [
             "pixi"
           ]
@@ -5216,6 +5132,10 @@
         "show_default_environment": {
           "type": "boolean",
           "default": true
+        },
+        "format": {
+          "type": "string",
+          "default": "via [$symbol($version )(\\($environment\\) )]($style)"
         },
         "version_format": {
           "type": "string",
@@ -5260,7 +5180,7 @@
       },
       "additionalProperties": false
     },
-    "Either_for_string_and_Array_of_string": {
+    "Either": {
       "anyOf": [
         {
           "type": "string"
@@ -5359,10 +5279,6 @@
     "PythonConfig": {
       "type": "object",
       "properties": {
-        "format": {
-          "type": "string",
-          "default": "via [${symbol}${pyenv_prefix}(${version} )(\\($virtualenv\\) )]($style)"
-        },
         "pyenv_version_name": {
           "type": "boolean",
           "default": false
@@ -5372,7 +5288,7 @@
           "default": "pyenv "
         },
         "python_binary": {
-          "$ref": "#/$defs/Either_for_Either_for_string_and_Array_of_string_and_Array_of_Either_for_string_and_Array_of_string",
+          "$ref": "#/$defs/Either",
           "default": [
             [
               "python"
@@ -5384,6 +5300,10 @@
               "python2"
             ]
           ]
+        },
+        "format": {
+          "type": "string",
+          "default": "via [${symbol}${pyenv_prefix}(${version} )(\\($virtualenv\\) )]($style)"
         },
         "version_format": {
           "type": "string",
@@ -5444,19 +5364,6 @@
         }
       },
       "additionalProperties": false
-    },
-    "Either_for_Either_for_string_and_Array_of_string_and_Array_of_Either_for_string_and_Array_of_string": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/Either_for_string_and_Array_of_string"
-        },
-        {
-          "type": "array",
-          "items": {
-            "$ref": "#/$defs/Either_for_string_and_Array_of_string"
-          }
-        }
-      ]
     },
     "QuartoConfig": {
       "type": "object",
@@ -5911,14 +5818,14 @@
     "ShLvlConfig": {
       "type": "object",
       "properties": {
-        "format": {
-          "type": "string",
-          "default": "[$symbol$shlvl]($style) "
-        },
         "threshold": {
           "type": "integer",
           "format": "int64",
           "default": 2
+        },
+        "format": {
+          "type": "string",
+          "default": "[$symbol$shlvl]($style) "
         },
         "symbol": {
           "type": "string",
@@ -5948,13 +5855,13 @@
     "SingularityConfig": {
       "type": "object",
       "properties": {
-        "format": {
-          "type": "string",
-          "default": "[$symbol\\[$env\\]]($style) "
-        },
         "symbol": {
           "type": "string",
           "default": ""
+        },
+        "format": {
+          "type": "string",
+          "default": "[$symbol\\[$env\\]]($style) "
         },
         "style": {
           "type": "string",
@@ -5991,7 +5898,7 @@
           "default": "S "
         },
         "compiler": {
-          "$ref": "#/$defs/Either_for_string_and_Array_of_string",
+          "$ref": "#/$defs/Either",
           "default": [
             "solc"
           ]
@@ -6025,15 +5932,15 @@
     "SpackConfig": {
       "type": "object",
       "properties": {
-        "format": {
-          "type": "string",
-          "default": "via [$symbol$environment]($style) "
-        },
         "truncation_length": {
           "type": "integer",
           "format": "uint",
           "minimum": 0,
           "default": 1
+        },
+        "format": {
+          "type": "string",
+          "default": "via [$symbol$environment]($style) "
         },
         "symbol": {
           "type": "string",
@@ -6256,6 +6163,25 @@
           "default": [
             ".terraform"
           ]
+        },
+        "commands": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "default": [
+            [
+              "terraform",
+              "version"
+            ],
+            [
+              "tofu",
+              "version"
+            ]
+          ]
         }
       },
       "additionalProperties": false
@@ -6350,16 +6276,16 @@
     "UsernameConfig": {
       "type": "object",
       "properties": {
-        "format": {
-          "type": "string",
-          "default": "[$user]($style) in "
-        },
         "detect_env_vars": {
           "type": "array",
           "items": {
             "type": "string"
           },
           "default": []
+        },
+        "format": {
+          "type": "string",
+          "default": "[$user]($style) in "
         },
         "style_root": {
           "type": "string",
@@ -6439,10 +6365,6 @@
     "VcshConfig": {
       "type": "object",
       "properties": {
-        "format": {
-          "type": "string",
-          "default": "vcsh [$symbol$repo]($style) "
-        },
         "symbol": {
           "type": "string",
           "default": ""
@@ -6450,6 +6372,10 @@
         "style": {
           "type": "string",
           "default": "bold yellow"
+        },
+        "format": {
+          "type": "string",
+          "default": "vcsh [$symbol$repo]($style) "
         },
         "disabled": {
           "type": "boolean",
@@ -6612,10 +6538,6 @@
     "CustomConfig": {
       "type": "object",
       "properties": {
-        "description": {
-          "type": "string",
-          "default": "<custom config>"
-        },
         "format": {
           "type": "string",
           "default": "[$symbol($output )]($style)"
@@ -6629,7 +6551,7 @@
           "default": ""
         },
         "when": {
-          "$ref": "#/$defs/Either_for_boolean_and_string",
+          "$ref": "#/$defs/Either2",
           "default": false
         },
         "require_repo": {
@@ -6637,8 +6559,12 @@
           "default": false
         },
         "shell": {
-          "$ref": "#/$defs/Either_for_string_and_Array_of_string",
+          "$ref": "#/$defs/Either",
           "default": []
+        },
+        "description": {
+          "type": "string",
+          "default": "<custom config>"
         },
         "style": {
           "type": "string",
@@ -6692,7 +6618,7 @@
       },
       "additionalProperties": false
     },
-    "Either_for_boolean_and_string": {
+    "Either2": {
       "anyOf": [
         {
           "type": "boolean"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1832,7 +1832,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -2995,9 +2995,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.9.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
 dependencies = [
  "dyn-clone",
  "indexmap",
@@ -3009,9 +3009,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.9.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5016d94c77c6d32f0b8e08b781f7dc8a90c2007d4e77472cc2807bc10a8438fe"
+checksum = "33d020396d1d138dc19f1165df7545479dcd58d93810dc5d646a16e55abefa80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3273,7 +3273,7 @@ dependencies = [
  "pest",
  "pest_derive",
  "process_control",
- "quick-xml 0.37.5",
+ "quick-xml 0.38.3",
  "rand 0.9.2",
  "rayon",
  "regex",
@@ -3298,7 +3298,7 @@ dependencies = [
  "versions",
  "which",
  "whoami",
- "windows",
+ "windows 0.62.0",
  "winres",
  "yaml-rust2",
 ]
@@ -3388,7 +3388,7 @@ checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
 dependencies = [
  "quick-xml 0.37.5",
  "thiserror 2.0.16",
- "windows",
+ "windows 0.61.3",
  "windows-version",
 ]
 
@@ -4006,11 +4006,24 @@ version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections",
- "windows-core",
- "windows-future",
+ "windows-collections 0.2.0",
+ "windows-core 0.61.2",
+ "windows-future 0.2.1",
  "windows-link 0.1.3",
- "windows-numerics",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9579d0e6970fd5250aa29aba5994052385ff55cf7b28a059e484bb79ea842e42"
+dependencies = [
+ "windows-collections 0.3.0",
+ "windows-core 0.62.0",
+ "windows-future 0.3.0",
+ "windows-link 0.2.0",
+ "windows-numerics 0.3.0",
 ]
 
 [[package]]
@@ -4019,7 +4032,16 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a90dd7a7b86859ec4cdf864658b311545ef19dbcf17a672b52ab7cefe80c336f"
+dependencies = [
+ "windows-core 0.62.0",
 ]
 
 [[package]]
@@ -4031,8 +4053,21 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link 0.1.3",
- "windows-result",
- "windows-strings",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57fe7168f7de578d2d8a05b07fd61870d2e73b4020e9f49aa00da8471723497c"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.2.0",
+ "windows-result 0.4.0",
+ "windows-strings 0.5.0",
 ]
 
 [[package]]
@@ -4041,9 +4076,20 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
  "windows-link 0.1.3",
- "windows-threading",
+ "windows-threading 0.1.0",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2194dee901458cb79e1148a4e9aac2b164cc95fa431891e7b296ff0b2f1d8a6"
+dependencies = [
+ "windows-core 0.62.0",
+ "windows-link 0.2.0",
+ "windows-threading 0.2.0",
 ]
 
 [[package]]
@@ -4086,8 +4132,18 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ce3498fe0aba81e62e477408383196b4b0363db5e0c27646f932676283b43d8"
+dependencies = [
+ "windows-core 0.62.0",
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -4100,12 +4156,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7084dcc306f89883455a206237404d3eaf961e5bd7e0f312f7c91f57eb44167f"
+dependencies = [
+ "windows-link 0.2.0",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7218c655a553b0bed4426cf54b20d7ba363ef543b52d515b3e48d7fd55318dda"
+dependencies = [
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -4184,6 +4258,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab47f085ad6932defa48855254c758cdd0e2f2d48e62a34118a268d8f345e118"
+dependencies = [
+ "windows-link 0.2.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ path-slash = "0.2.1"
 pest = "2.8.1"
 pest_derive = "2.8.1"
 process_control = "5.2.0"
-quick-xml = "0.37.5"
+quick-xml = "0.38.3"
 rand = "0.9.2"
 rayon = "1.11.0"
 regex = { version = "1.11.2", default-features = false, features = ["perf", "std", "unicode-perl"] }
@@ -90,7 +90,7 @@ home = "0.5.11"
 shell-words = "1.1.0"
 
 [dependencies.schemars]
-version = "0.9.0"
+version = "1.0.4"
 optional = true
 features = ["preserve_order", "indexmap2"]
 
@@ -98,7 +98,7 @@ features = ["preserve_order", "indexmap2"]
 deelevate = "0.2.0"
 
 [target.'cfg(windows)'.dependencies.windows]
-version = "0.61.3"
+version = "0.62.0"
 features = [
   "Win32_Foundation",
   "Win32_UI_Shell",

--- a/src/configs/os.rs
+++ b/src/configs/os.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 pub struct OSConfig<'a> {
     pub format: &'a str,
     pub style: &'a str,
+    #[cfg_attr(feature = "config-schema", schemars(with = "IndexMap<String, String>"))]
     pub symbols: IndexMap<Type, &'a str>,
     pub disabled: bool,
 }

--- a/src/modules/dotnet.rs
+++ b/src/modules/dotnet.rs
@@ -119,7 +119,7 @@ fn get_tfm_from_project_file(path: &Path) -> Option<String> {
             // unescape and decode the text event using the reader encoding
             Ok(Event::Text(e)) => {
                 if in_tfm {
-                    return e.unescape().ok().map(std::borrow::Cow::into_owned);
+                    return e.decode().ok().map(std::borrow::Cow::into_owned);
                 }
             }
             Ok(Event::Eof) => break, // exits the loop when reaching end of file

--- a/src/modules/package.rs
+++ b/src/modules/package.rs
@@ -188,7 +188,7 @@ fn get_maven_version(context: &Context, config: &PackageConfig) -> Option<String
                 depth -= 1;
             }
             Ok(QXEvent::Text(t)) if in_ver => {
-                let ver = t.unescape().ok().map(std::borrow::Cow::into_owned);
+                let ver = t.decode().ok().map(std::borrow::Cow::into_owned);
                 return match ver {
                     // Ignore version which is just a property reference
                     Some(ref v) if !v.starts_with('$') => format_version(v, config.version_format),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR bumps schemars to v1 and quick-xml to v0.38, handling the incompatibilities.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
