### PR TITLE
fix: Add missing plain text preset entries

### DIFF
--- a/docs/public/presets/toml/plain-text-symbols.toml
+++ b/docs/public/presets/toml/plain-text-symbols.toml
@@ -1,7 +1,12 @@
+continuation_prompt = "[.](bright-black) "
+
 [character]
 success_symbol = "[>](bold green)"
 error_symbol = "[x](bold red)"
 vimcmd_symbol = "[<](bold green)"
+vimcmd_visual_symbol = "[<](bold yellow)"
+vimcmd_replace_symbol = "[<](bold purple)"
+vimcmd_replace_one_symbol = "[<](bold purple)"
 
 [git_commit]
 tag_symbol = " tag "
@@ -18,6 +23,13 @@ symbol = "aws "
 
 [azure]
 symbol = "az "
+
+[battery]
+full_symbol = "full "
+charging_symbol = "charging "
+discharging_symbol = "discharging "
+unknown_symbol = "unknown "
+empty_symbol = "empty "
 
 [buf]
 symbol = "buf "
@@ -56,6 +68,7 @@ symbol = "dart "
 symbol = "deno "
 
 [dotnet]
+format = "via [$symbol($version )(target $tfm )]($style)"
 symbol = ".NET "
 
 [directory]
@@ -70,17 +83,22 @@ symbol = "exs "
 [elm]
 symbol = "elm "
 
+[erlang]
+symbol = "erl "
+
 [fennel]
 symbol = "fnl "
 
 [fossil_branch]
 symbol = "fossil "
+truncation_symbol = "..."
 
 [gcloud]
 symbol = "gcp "
 
 [git_branch]
 symbol = "git "
+truncation_symbol = "..."
 
 [gleam]
 symbol = "gleam "
@@ -97,20 +115,33 @@ symbol = "guix "
 [haskell]
 symbol = "haskell "
 
+[haxe]
+symbol = "hx "
+
 [helm]
 symbol = "helm "
 
 [hg_branch]
 symbol = "hg "
+truncation_symbol = "..."
+
+[hostname]
+ssh_symbol = "ssh "
 
 [java]
 symbol = "java "
+
+[jobs]
+symbol = "*"
 
 [julia]
 symbol = "jl "
 
 [kotlin]
 symbol = "kt "
+
+[kubernetes]
+symbol = "kubernetes "
 
 [lua]
 symbol = "lua "
@@ -123,9 +154,16 @@ symbol = "memory "
 
 [meson]
 symbol = "meson "
+truncation_symbol = "..."
+
+[mojo]
+symbol = "mojo "
 
 [nats]
 symbol = "nats "
+
+[netns]
+symbol = "netns "
 
 [nim]
 symbol = "nim "
@@ -136,8 +174,14 @@ symbol = "nix "
 [ocaml]
 symbol = "ml "
 
+[odin]
+symbol = "odin "
+
 [opa]
 symbol = "opa "
+
+[openstack]
+symbol = "openstack "
 
 [os.symbols]
 AIX = "aix "
@@ -204,6 +248,7 @@ symbol = "php "
 
 [pijul_channel]
 symbol = "pijul "
+truncation_symbol = "..."
 
 [pixi]
 symbol = "pixi "
@@ -223,6 +268,9 @@ symbol = "quarto "
 [raku]
 symbol = "raku "
 
+[red]
+symbol = "red "
+
 [rlang]
 symbol = "r "
 
@@ -235,6 +283,9 @@ symbol = "rs "
 [scala]
 symbol = "scala "
 
+[shlvl]
+symbol = "shlvl "
+
 [spack]
 symbol = "spack "
 
@@ -243,6 +294,10 @@ symbol = "solidity "
 
 [status]
 symbol = "[x](bold red) "
+not_executable_symbol = "noexec"
+not_found_symbol = "notfound"
+sigint_symbol = "sigint"
+signal_symbol = "sig"
 
 [sudo]
 symbol = "sudo "
@@ -252,6 +307,9 @@ symbol = "swift "
 
 [typst]
 symbol = "typst "
+
+[vagrant]
+symbol = "vagrant "
 
 [terraform]
 symbol = "terraform "


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
The existing plain text preset lacks some entries, such that even with the preset applied, non-ASCII characters may be output. This commit adds the missing entries, which were found by

1. Applying the plain text preset: `starship preset --output ~/.config/starship.toml plain-text-symbols`
2. Printing the resulting starship configuration: `starship print-config > ~/.config/starship.toml.plain-text`
3. Parsing the printed configuration for non-ASCII code points: `grep -vnPB10 '^[[:ascii:]]*$' ~/.config/starship.toml`

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Ensure only ASCII characters are output with the plain text preset.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly. (No update required)
- [x] I have updated the tests accordingly. (No update required)