### PR TITLE
fix(modules): username detect_env_vars logic

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -265,6 +265,28 @@ impl<'a> Context<'a> {
         iter.peek().is_none() || iter.any(|env_var| self.get_env(env_var).is_some())
     }
 
+    /// Returns an enum indicating if `detect_env_vars` contains negated or non-negated variables
+    pub fn detect_env_vars2(&'a self, env_vars: &'a [&'a str]) -> Detected {
+        if env_vars.is_empty() {
+            return Detected::Empty;
+        }
+
+        if self.has_negated_env_var(env_vars) {
+            return Detected::Negated;
+        }
+
+        let mut iter = env_vars
+            .iter()
+            .filter(|env_var| !env_var.starts_with('!'))
+            .peekable();
+
+        if iter.any(|env_var| self.get_env(env_var).is_some()) {
+            Detected::Yes
+        } else {
+            Detected::No
+        }
+    }
+
     // returns a new ScanDir struct with reference to current dir_files of context
     // see ScanDir for methods
     pub fn try_begin_scan(&'a self) -> Option<ScanDir<'a>> {
@@ -460,6 +482,18 @@ impl Default for Context<'_> {
     fn default() -> Self {
         Self::new(Default::default(), Target::Main)
     }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum Detected {
+    /// `detect_env_vars` was empty.
+    Empty,
+    /// A negated variable was found.
+    Negated,
+    /// A non-negated variable was found.
+    Yes,
+    /// No non-negated variables were found.
+    No,
 }
 
 fn home_dir(env: &Env) -> Option<PathBuf> {

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -108,7 +108,7 @@ mod typst;
 pub use self::battery::{BatteryInfoProvider, BatteryInfoProviderImpl};
 
 use crate::config::ModuleConfig;
-use crate::context::{Context, Shell};
+use crate::context::{Context, Detected, Shell};
 use crate::module::Module;
 use std::time::Instant;
 

--- a/src/modules/username.rs
+++ b/src/modules/username.rs
@@ -1,4 +1,4 @@
-use super::{Context, Module, ModuleConfig};
+use super::{Context, Detected, Module, ModuleConfig};
 
 use crate::configs::username::UsernameConfig;
 use crate::formatter::StringFormatter;
@@ -30,7 +30,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
     let mut module = context.new_module("username");
     let config: UsernameConfig = UsernameConfig::try_load(module.config);
-    let has_detected_env_var = context.detect_env_vars(&config.detect_env_vars);
+    let has_detected_env_var = context.detect_env_vars2(&config.detect_env_vars);
 
     let is_root = is_root_user();
     if cfg!(target_os = "windows") && is_root {
@@ -41,9 +41,9 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         || is_root // [1]
         || !is_login_user(context, &username) // [2]
         || is_ssh_session(context) // [3]
-        || ( !config.detect_env_vars.is_empty() && has_detected_env_var ); // [4]
+        || has_detected_env_var == Detected::Yes; // [4]
 
-    if !show_username || !has_detected_env_var {
+    if !show_username || has_detected_env_var == Detected::Negated {
         return None; // [A]
     }
 


### PR DESCRIPTION
problem: `Context::detect_env_vars` is insufficient for the logic used by the username module, as it cannot differentiate between 'a negated variable was found' and 'no non-negated variables were found'

solution: Add a `detect_env_vars2` method which returns an enum `Detected` which can represent the 4 interesting cases:

- `detect_env_vars` is empty
- A negated variable was found
- A non-negated variable was found
- No non-negated variables were found

Fixes #6870 (see for context)