### PR TITLE
feat(git_branch): add ignore_bare_repo flag

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -574,6 +574,7 @@
         "only_attached": false,
         "always_show_remote": false,
         "ignore_branches": [],
+        "ignore_bare_repo": false,
         "disabled": false
       }
     },
@@ -3290,6 +3291,10 @@
             "type": "string"
           },
           "default": []
+        },
+        "ignore_bare_repo": {
+          "type": "boolean",
+          "default": false
         },
         "disabled": {
           "type": "boolean",

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1847,6 +1847,7 @@ The `git_branch` module shows the active branch of the repo in your current dire
 | `truncation_symbol`  | `'…'`                                             | The symbol used to indicate a branch name was truncated. You can use `''` for no symbol. |
 | `only_attached`      | `false`                                           | Only show the branch name when not in a detached `HEAD` state.                           |
 | `ignore_branches`    | `[]`                                              | A list of names to avoid displaying. Useful for 'master' or 'main'.                      |
+| `ignore_bare_repo`   | `false`                                           | Do not show when in a bare repo.                                                         |
 | `disabled`           | `false`                                           | Disables the `git_branch` module.                                                        |
 
 ### Variables

--- a/src/configs/git_branch.rs
+++ b/src/configs/git_branch.rs
@@ -16,6 +16,7 @@ pub struct GitBranchConfig<'a> {
     pub only_attached: bool,
     pub always_show_remote: bool,
     pub ignore_branches: Vec<&'a str>,
+    pub ignore_bare_repo: bool,
     pub disabled: bool,
 }
 
@@ -30,6 +31,7 @@ impl Default for GitBranchConfig<'_> {
             only_attached: false,
             always_show_remote: false,
             ignore_branches: vec![],
+            ignore_bare_repo: false,
             disabled: false,
         }
     }

--- a/src/modules/git_branch.rs
+++ b/src/modules/git_branch.rs
@@ -26,6 +26,11 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
     let repo = context.get_repo().ok()?;
 
+    let gix_repo = repo.open();
+    if config.ignore_bare_repo && gix_repo.is_bare() {
+        return None;
+    }
+
     if config.only_attached && repo.open().head().ok()?.is_detached() {
         return None;
     }
@@ -382,6 +387,25 @@ mod tests {
             .config(toml::toml! {
                 [git_branch]
                     ignore_branches = ["dummy", "test_branch"]
+            })
+            .path(repo_dir.path())
+            .collect();
+
+        let expected = None;
+
+        assert_eq!(expected, actual);
+        repo_dir.close()
+    }
+
+    #[test]
+    fn test_ignore_bare_repo() -> io::Result<()> {
+        let repo_dir = fixture_repo(FixtureProvider::GitBare)?;
+
+        let actual = ModuleRenderer::new("git_branch")
+            .config(toml::toml! {
+                [git_branch]
+                    ignore_bare_repo = true
+
             })
             .path(repo_dir.path())
             .collect();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Add the flag `ignore_bare_repo` (defaults to `false`) to `git_branch` to hide the branch on bare repos.


#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The `git_branch` module displays the default branch when entering a bare repo despite no branch being checked out. I often work with git worktrees and my workflow makes use of git bare repo feature. I do not want to fully disable `git_branch`, it just needs to be disabled while in the bare repo's root. `git_metrics` already does this.

Consider the following setups:

1. basic bare clone

```sh
$ git clone --bare git@github.com:starship/starship
$ cd starship
# displays `master`
```

2. custom path
 
```sh
$ git clone --bare git@github.com:starship/starship starship/.git
$ cd starship
# displays `master`
```

There are no branches checked out, but starship will display `master` (see the screenshot below).

<!--- If it fixes an open issue, please link to the issue here. -->
Closes #6367

#### Screenshots (if appropriate):
<img width="614" height="693" alt="image" src="https://github.com/user-attachments/assets/a05f2a55-1ab2-4b55-a9b0-15b277ae1c5c" />

<img width="627" height="562" alt="image" src="https://github.com/user-attachments/assets/6b5f3202-cf53-4f70-9bd9-fc1066350ac9" />


#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
