### PR TITLE
style(jobs): remove spacing from jobs prompt module when thresholds not met

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -840,7 +840,7 @@
     "jobs": {
       "$ref": "#/$defs/JobsConfig",
       "default": {
-        "format": "[$symbol$number]($style) ",
+        "format": "($symbol$number )($style)",
         "threshold": 1,
         "symbol_threshold": 1,
         "number_threshold": 2,
@@ -4042,7 +4042,7 @@
       "properties": {
         "format": {
           "type": "string",
-          "default": "[$symbol$number]($style) "
+          "default": "($symbol$number )($style)"
         },
         "threshold": {
           "type": "integer",

--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -840,7 +840,7 @@
     "jobs": {
       "$ref": "#/$defs/JobsConfig",
       "default": {
-        "format": "($symbol$number )($style)",
+        "format": "([$symbol$number]($style) )",
         "threshold": 1,
         "symbol_threshold": 1,
         "number_threshold": 2,
@@ -4042,7 +4042,7 @@
       "properties": {
         "format": {
           "type": "string",
-          "default": "($symbol$number )($style)"
+          "default": "([$symbol$number]($style) )"
         },
         "threshold": {
           "type": "integer",

--- a/src/configs/jobs.rs
+++ b/src/configs/jobs.rs
@@ -23,7 +23,7 @@ impl Default for JobsConfig<'_> {
             threshold: 1,
             symbol_threshold: 1,
             number_threshold: 2,
-            format: "[$symbol$number]($style) ",
+            format: "($symbol$number )($style)",
             symbol: "✦",
             style: "bold blue",
             disabled: false,

--- a/src/configs/jobs.rs
+++ b/src/configs/jobs.rs
@@ -23,7 +23,7 @@ impl Default for JobsConfig<'_> {
             threshold: 1,
             symbol_threshold: 1,
             number_threshold: 2,
-            format: "($symbol$number )($style)",
+            format: "([$symbol$number]($style) )",
             symbol: "✦",
             style: "bold blue",
             disabled: false,


### PR DESCRIPTION
### remove spacing from jobs module when thresholds not met

Currently, with symbol and number thresholds set higher than the current number of jobs, the space from the format will still persist. In workflows with "forever jobs" that are ignored, this space will now only become visible when one of the thresholds are met.

#### Description
The default format for the jobs module is changed in two ways:

- migration to conditional brackets `()`
- moving the trailing space inside the main format body so it is conditionally removed

#### Motivation and Context
The motivating factor here is removing an essentially permanent space to the left of the main prompt symbol in the case that the user has a known number of jobs they want to ignore.

In the trivial case of one forever-job (e.g. fswatch polling), the jobs module will be active. Even with `number_threshold` and `symbol_threshold` set > 1, the space from the module format will exist as long as one job runs. This creates a lingering space that is difficult to diagnose as a style problem.

#### Screenshots (if appropriate):

<img width="831" height="515" alt="image" src="https://github.com/user-attachments/assets/41832aa3-c992-47be-bde2-55cb283896da" />

This image shows the trivial example:

1. A "forever job" is instantiated, prompting the jobs module to become visible with default-ish config
2. The thresholds are increased to 2 each, causing the number and symbol to hide, but leaving the remaining space
3. The proposed jobs module format is applied, remediating the issue

#### How Has This Been Tested?

This has only been tested on a local configuration level using similar steps as depicted in the image above. More than happy to oblige in full package testing, just need some direction.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

MacOS machine config:

<img width="818" height="450" alt="Screenshot 2025-09-01 at 10 06 59 AM" src="https://github.com/user-attachments/assets/a74188b9-4441-4b2a-af11-565f8f4452db" />

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.

Again, happy to do both of the above, just need some direction :)