### PR TITLE
docs(xmake): correct style color from blue to green

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -4912,14 +4912,14 @@ the module will be activated if any of the following conditions are met:
 | `detect_extensions` | `[]`                                 | Which extensions should trigger this module                               |
 | `detect_files`      | `['xmake.lua']`                      | Which filenames should trigger this module                                |
 | `detect_folders`    | `[]`                                 | Which folders should trigger this module                                  |
-| `style`             | `'bold blue'`                        | The style for the module.                                                 |
+| `style`             | `'bold green'`                       | The style for the module.                                                 |
 | `disabled`          | `false`                              | Disables the `xmake` module.                                              |
 
 ### Variables
 
 | Variable | Example  | Description                          |
 | -------- | -------- | ------------------------------------ |
-| version  | `v2.9.5` | The version of cmake                 |
+| version  | `v2.9.5` | The version of xmake                 |
 | symbol   |          | Mirrors the value of option `symbol` |
 | style\*  |          | Mirrors the value of option `style`  |
 


### PR DESCRIPTION

#### Description

According to https://github.com/starship/starship/blob/678ce4758b5fa8b42400aec1879f9d4888254db0/src/configs/xmake.rs#L27 the xmake's color is `green`, not `blue`.

Fix a copy/paste (?) error: s/cmake/xmake/

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
