### PR TITLE
fix: Check if XMakeConfig is disabled

### DIFF
--- a/src/modules/xmake.rs
+++ b/src/modules/xmake.rs
@@ -8,6 +8,10 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let mut module = context.new_module("xmake");
     let config = XMakeConfig::try_load(module.config);
 
+    if config.disabled {
+        return None;
+    }
+
     let is_xmake_project = context
         .try_begin_scan()?
         .set_files(&config.detect_files)


### PR DESCRIPTION


#### Description
https://github.com/starship/starship/blob/ff0acb193eaa04ab63a8e56e1bd18019444b886f/src/modules/xmake.rs added a module for xmake.
But the `disabled` property is not consulted before loading the module.



#### Motivation and Context
Do not load the module if XMakeConfig says it is disabled.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
