### PR TITLE
docs(kubernetes): fix typo `environmental` in module documentation

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2652,7 +2652,7 @@ If the `$KUBECONFIG` env var is set the module will use that if not it will use 
 > When the module is enabled it will always be active, unless any of
 > `detect_env_vars`, `detect_extensions`, `detect_files` or `detect_folders` have
 > been set in which case the module will only be active in directories that match
-> those conditions or one of the environmatal variable has been set.
+> those conditions or one of the environmental variables has been set.
 
 ### Options
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
