### PR TITLE
fix: show main repo name in directory prompt for git worktrees (#6981)

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -1405,7 +1405,8 @@ mod tests {
     #[test]
     fn test_worktree_detection() -> io::Result<()> {
         let main_dir = tempfile::TempDir::new()?;
-        let worktree_dir = tempfile::TempDir::new()?;
+        let worktree_parent_dir = tempfile::TempDir::new()?;
+        let worktree_path = worktree_parent_dir.path().join("worktree");
         // Init main repo
         create_command("git")?
             .args(["init", "--quiet"])
@@ -1421,12 +1422,12 @@ mod tests {
             .current_dir(main_dir.path())
             .output()?;
         // Create worktree
-        create_command("git")?
-            .args(["worktree", "add", "../worktree-test"])
+        let output = create_command("git")?
+            .args(["worktree", "add", worktree_path.to_str().unwrap()])
             .current_dir(main_dir.path())
             .output()?;
+        assert!(output.status.success());
 
-        let worktree_path = main_dir.path().parent().unwrap().join("worktree-test");
         let context = Context::new_with_shell_and_path(
             Properties::default(),
             Shell::Bash,
@@ -1442,7 +1443,7 @@ mod tests {
         assert_eq!(repo.main_workdir.as_ref().unwrap(), &main_path); // Matches main dir
 
         main_dir.close()?;
-        worktree_dir.close()
+        worktree_parent_dir.close()
     }
 
     #[test]

--- a/src/context.rs
+++ b/src/context.rs
@@ -1440,7 +1440,10 @@ mod tests {
         assert!(repo.main_workdir.is_some());
         assert_ne!(repo.main_workdir, repo.workdir); // Detects main
         let main_path = main_dir.path().to_path_buf();
-        assert_eq!(repo.main_workdir.as_ref().unwrap(), &main_path); // Matches main dir
+        assert_eq!(
+            dunce::canonicalize(repo.main_workdir.as_ref().unwrap()).unwrap(),
+            dunce::canonicalize(&main_path).unwrap()
+        ); // Matches main dir
 
         main_dir.close()?;
         worktree_parent_dir.close()

--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -57,7 +57,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         None
     };
     let dir_string = if config.truncate_to_repo {
-        repo.and_then(|r| r.workdir.as_ref())
+        repo.and_then(|r| r.main_workdir.as_ref().or(r.workdir.as_ref()))
             .filter(|&root| root != &home_dir)
             .and_then(|root| contract_repo_path(display_dir, root))
     } else {
@@ -103,7 +103,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         String::new()
     };
 
-    let path_vec = match &repo.and_then(|r| r.workdir.as_ref()) {
+    let path_vec = match &repo.and_then(|r| r.main_workdir.as_ref().or(r.workdir.as_ref())) {
         Some(repo_root) if config.repo_root_style.is_some() => {
             let contracted_path = contract_repo_path(display_dir, repo_root)?;
             let repo_path_vec: Vec<&str> = contracted_path.split('/').collect();


### PR DESCRIPTION
closed
