### PR TITLE
docs(preset/*-powerline): Remove "rainbow effect"

### DIFF
--- a/docs/public/presets/toml/catppuccin-powerline.toml
+++ b/docs/public/presets/toml/catppuccin-powerline.toml
@@ -4,12 +4,9 @@ format = """
 [](red)\
 $os\
 $username\
-[](bg:peach fg:red)\
 $directory\
-[](bg:yellow fg:peach)\
 $git_branch\
 $git_status\
-[](fg:yellow bg:green)\
 $c\
 $rust\
 $golang\
@@ -19,11 +16,9 @@ $java\
 $kotlin\
 $haskell\
 $python\
-[](fg:green bg:sapphire)\
 $conda\
-[](fg:sapphire bg:lavender)\
 $time\
-[ ](fg:lavender)\
+[ ](fg:prev_bg)\
 $cmd_duration\
 $line_break\
 $character"""
@@ -64,7 +59,7 @@ format = '[ $user]($style)'
 
 [directory]
 style = "bg:peach fg:crust"
-format = "[ $path ]($style)"
+format = "[](fg:prev_bg bg:peach)[ $path ]($style)"
 truncation_length = 3
 truncation_symbol = "…/"
 
@@ -78,7 +73,7 @@ truncation_symbol = "…/"
 [git_branch]
 symbol = ""
 style = "bg:yellow"
-format = '[[ $symbol $branch ](fg:crust bg:yellow)]($style)'
+format = '[](fg:prev_bg bg:yellow)[[ $symbol $branch ](fg:crust bg:yellow)]($style)'
 
 [git_status]
 style = "bg:yellow"
@@ -87,64 +82,64 @@ format = '[[($all_status$ahead_behind )](fg:crust bg:yellow)]($style)'
 [nodejs]
 symbol = ""
 style = "bg:green"
-format = '[[ $symbol( $version) ](fg:crust bg:green)]($style)'
+format = '[](fg:prev_bg bg:green)[[ $symbol( $version) ](fg:crust bg:green)]($style)'
 
 [c]
 symbol = " "
 style = "bg:green"
-format = '[[ $symbol( $version) ](fg:crust bg:green)]($style)'
+format = '[](fg:prev_bg bg:green)[[ $symbol( $version) ](fg:crust bg:green)]($style)'
 
 [rust]
 symbol = ""
 style = "bg:green"
-format = '[[ $symbol( $version) ](fg:crust bg:green)]($style)'
+format = '[](fg:prev_bg bg:green)[[ $symbol( $version) ](fg:crust bg:green)]($style)'
 
 [golang]
 symbol = ""
 style = "bg:green"
-format = '[[ $symbol( $version) ](fg:crust bg:green)]($style)'
+format = '[](fg:prev_bg bg:green)[[ $symbol( $version) ](fg:crust bg:green)]($style)'
 
 [php]
 symbol = ""
 style = "bg:green"
-format = '[[ $symbol( $version) ](fg:crust bg:green)]($style)'
+format = '[](fg:prev_bg bg:green)[[ $symbol( $version) ](fg:crust bg:green)]($style)'
 
 [java]
 symbol = " "
 style = "bg:green"
-format = '[[ $symbol( $version) ](fg:crust bg:green)]($style)'
+format = '[](fg:prev_bg bg:green)[[ $symbol( $version) ](fg:crust bg:green)]($style)'
 
 [kotlin]
 symbol = ""
 style = "bg:green"
-format = '[[ $symbol( $version) ](fg:crust bg:green)]($style)'
+format = '[](fg:prev_bg bg:green)[[ $symbol( $version) ](fg:crust bg:green)]($style)'
 
 [haskell]
 symbol = ""
 style = "bg:green"
-format = '[[ $symbol( $version) ](fg:crust bg:green)]($style)'
+format = '[](fg:prev_bg bg:green)[[ $symbol( $version) ](fg:crust bg:green)]($style)'
 
 [python]
 symbol = ""
 style = "bg:green"
-format = '[[ $symbol( $version)(\(#$virtualenv\)) ](fg:crust bg:green)]($style)'
+format = '[](fg:prev_bg bg:green)[[ $symbol( $version)(\(#$virtualenv\)) ](fg:crust bg:green)]($style)'
 
 [docker_context]
 symbol = ""
 style = "bg:sapphire"
-format = '[[ $symbol( $context) ](fg:crust bg:sapphire)]($style)'
+format = '[](fg:prev_bg bg:green)[[ $symbol( $context) ](fg:crust bg:sapphire)]($style)'
 
 [conda]
 symbol = "  "
 style = "fg:crust bg:sapphire"
-format = '[$symbol$environment ]($style)'
+format = '[](fg:prev_bg bg:sapphire)[$symbol$environment ]($style)'
 ignore_base = false
 
 [time]
 disabled = false
 time_format = "%R"
 style = "bg:lavender"
-format = '[[  $time ](fg:crust bg:lavender)]($style)'
+format = '[](fg:prev_bg bg:lavender)[[  $time ](fg:crust bg:lavender)]($style)'
 
 [line_break]
 disabled = true

--- a/docs/public/presets/toml/catppuccin-powerline.toml
+++ b/docs/public/presets/toml/catppuccin-powerline.toml
@@ -4,12 +4,9 @@ format = """
 [](red)\
 $os\
 $username\
-[](bg:peach fg:red)\
 $directory\
-[](bg:yellow fg:peach)\
 $git_branch\
 $git_status\
-[](fg:yellow bg:green)\
 $c\
 $rust\
 $golang\
@@ -20,11 +17,9 @@ $java\
 $kotlin\
 $haskell\
 $python\
-[](fg:green bg:sapphire)\
 $conda\
-[](fg:sapphire bg:lavender)\
 $time\
-[ ](fg:lavender)\
+[ ](fg:prev_bg)\
 $cmd_duration\
 $line_break\
 $character"""
@@ -65,7 +60,7 @@ format = '[ $user]($style)'
 
 [directory]
 style = "bg:peach fg:crust"
-format = "[ $path ]($style)"
+format = "[](fg:prev_bg bg:peach)[ $path ]($style)"
 truncation_length = 3
 truncation_symbol = "…/"
 
@@ -79,7 +74,7 @@ truncation_symbol = "…/"
 [git_branch]
 symbol = ""
 style = "bg:yellow"
-format = '[[ $symbol $branch ](fg:crust bg:yellow)]($style)'
+format = '[](fg:prev_bg bg:yellow)[[ $symbol $branch ](fg:crust bg:yellow)]($style)'
 
 [git_status]
 style = "bg:yellow"
@@ -88,7 +83,7 @@ format = '[[($all_status$ahead_behind )](fg:crust bg:yellow)]($style)'
 [nodejs]
 symbol = ""
 style = "bg:green"
-format = '[[ $symbol( $version) ](fg:crust bg:green)]($style)'
+format = '[](fg:prev_bg bg:green)[[ $symbol( $version) ](fg:crust bg:green)]($style)'
 
 [bun]
 symbol = ""
@@ -98,59 +93,59 @@ format = '[[ $symbol( $version) ](fg:crust bg:green)]($style)'
 [c]
 symbol = " "
 style = "bg:green"
-format = '[[ $symbol( $version) ](fg:crust bg:green)]($style)'
+format = '[](fg:prev_bg bg:green)[[ $symbol( $version) ](fg:crust bg:green)]($style)'
 
 [rust]
 symbol = ""
 style = "bg:green"
-format = '[[ $symbol( $version) ](fg:crust bg:green)]($style)'
+format = '[](fg:prev_bg bg:green)[[ $symbol( $version) ](fg:crust bg:green)]($style)'
 
 [golang]
 symbol = ""
 style = "bg:green"
-format = '[[ $symbol( $version) ](fg:crust bg:green)]($style)'
+format = '[](fg:prev_bg bg:green)[[ $symbol( $version) ](fg:crust bg:green)]($style)'
 
 [php]
 symbol = ""
 style = "bg:green"
-format = '[[ $symbol( $version) ](fg:crust bg:green)]($style)'
+format = '[](fg:prev_bg bg:green)[[ $symbol( $version) ](fg:crust bg:green)]($style)'
 
 [java]
 symbol = " "
 style = "bg:green"
-format = '[[ $symbol( $version) ](fg:crust bg:green)]($style)'
+format = '[](fg:prev_bg bg:green)[[ $symbol( $version) ](fg:crust bg:green)]($style)'
 
 [kotlin]
 symbol = ""
 style = "bg:green"
-format = '[[ $symbol( $version) ](fg:crust bg:green)]($style)'
+format = '[](fg:prev_bg bg:green)[[ $symbol( $version) ](fg:crust bg:green)]($style)'
 
 [haskell]
 symbol = ""
 style = "bg:green"
-format = '[[ $symbol( $version) ](fg:crust bg:green)]($style)'
+format = '[](fg:prev_bg bg:green)[[ $symbol( $version) ](fg:crust bg:green)]($style)'
 
 [python]
 symbol = ""
 style = "bg:green"
-format = '[[ $symbol( $version)(\(#$virtualenv\)) ](fg:crust bg:green)]($style)'
+format = '[](fg:prev_bg bg:green)[[ $symbol( $version)(\(#$virtualenv\)) ](fg:crust bg:green)]($style)'
 
 [docker_context]
 symbol = ""
 style = "bg:sapphire"
-format = '[[ $symbol( $context) ](fg:crust bg:sapphire)]($style)'
+format = '[](fg:prev_bg bg:green)[[ $symbol( $context) ](fg:crust bg:sapphire)]($style)'
 
 [conda]
 symbol = "  "
 style = "fg:crust bg:sapphire"
-format = '[$symbol$environment ]($style)'
+format = '[](fg:prev_bg bg:sapphire)[$symbol$environment ]($style)'
 ignore_base = false
 
 [time]
 disabled = false
 time_format = "%R"
 style = "bg:lavender"
-format = '[[  $time ](fg:crust bg:lavender)]($style)'
+format = '[](fg:prev_bg bg:lavender)[[  $time ](fg:crust bg:lavender)]($style)'
 
 [line_break]
 disabled = true

--- a/docs/public/presets/toml/pastel-powerline.toml
+++ b/docs/public/presets/toml/pastel-powerline.toml
@@ -4,12 +4,9 @@ format = """
 [](#9A348E)\
 $os\
 $username\
-[](bg:#DA627D fg:#9A348E)\
 $directory\
-[](fg:#DA627D bg:#FCA17D)\
 $git_branch\
 $git_status\
-[](fg:#FCA17D bg:#86BBD8)\
 $c\
 $elixir\
 $elm\
@@ -23,11 +20,9 @@ $nodejs\
 $nim\
 $rust\
 $scala\
-[](fg:#86BBD8 bg:#06969A)\
 $docker_context\
-[](fg:#06969A bg:#33658A)\
 $time\
-[ ](fg:#33658A)\
+[ ](fg:prev_bg)\
 """
 
 # Disable the blank line at the start of the prompt
@@ -50,7 +45,7 @@ disabled = true # Disabled by default
 
 [directory]
 style = "bg:#DA627D"
-format = "[ $path ]($style)"
+format = "[](fg:prev_bg bg:#DA627D)[ $path ]($style)"
 truncation_length = 3
 truncation_symbol = "…/"
 
@@ -70,32 +65,32 @@ truncation_symbol = "…/"
 [c]
 symbol = " "
 style = "bg:#86BBD8"
-format = '[ $symbol ($version) ]($style)'
+format = '[](fg:prev_bg bg:#86BBD8)[ $symbol ($version) ]($style)'
 
 [cpp]
 symbol = " "
 style = "bg:#86BBD8"
-format = '[ $symbol ($version) ]($style)'
+format = '[](fg:prev_bg bg:#86BBD8)[ $symbol ($version) ]($style)'
 
 [docker_context]
 symbol = " "
 style = "bg:#06969A"
-format = '[ $symbol $context ]($style)'
+format = '[](fg:prev_bg bg:#06969A)[ $symbol $context ]($style)'
 
 [elixir]
 symbol = " "
 style = "bg:#86BBD8"
-format = '[ $symbol ($version) ]($style)'
+format = '[](fg:prev_bg bg:#86BBD8)[ $symbol ($version) ]($style)'
 
 [elm]
 symbol = " "
 style = "bg:#86BBD8"
-format = '[ $symbol ($version) ]($style)'
+format = '[](fg:prev_bg bg:#86BBD8)[ $symbol ($version) ]($style)'
 
 [git_branch]
 symbol = ""
 style = "bg:#FCA17D"
-format = '[ $symbol $branch ]($style)'
+format = '[](fg:prev_bg bg:#FCA17D)[ $symbol $branch ]($style)'
 
 [git_status]
 style = "bg:#FCA17D"
@@ -104,26 +99,26 @@ format = '[$all_status$ahead_behind ]($style)'
 [golang]
 symbol = " "
 style = "bg:#86BBD8"
-format = '[ $symbol ($version) ]($style)'
+format = '[](fg:prev_bg bg:#86BBD8)[ $symbol ($version) ]($style)'
 
 [gradle]
 style = "bg:#86BBD8"
-format = '[ $symbol ($version) ]($style)'
+format = '[](fg:prev_bg bg:#86BBD8)[ $symbol ($version) ]($style)'
 
 [haskell]
 symbol = " "
 style = "bg:#86BBD8"
-format = '[ $symbol ($version) ]($style)'
+format = '[](fg:prev_bg bg:#86BBD8)[ $symbol ($version) ]($style)'
 
 [java]
 symbol = " "
 style = "bg:#86BBD8"
-format = '[ $symbol ($version) ]($style)'
+format = '[](fg:prev_bg bg:#86BBD8)[ $symbol ($version) ]($style)'
 
 [julia]
 symbol = " "
 style = "bg:#86BBD8"
-format = '[ $symbol ($version) ]($style)'
+format = '[](fg:prev_bg bg:#86BBD8)[ $symbol ($version) ]($style)'
 
 [maven]
 style = "bg:#86BBD8"
@@ -132,25 +127,25 @@ format = '[ $symbol ($version) ]($style)'
 [nodejs]
 symbol = ""
 style = "bg:#86BBD8"
-format = '[ $symbol ($version) ]($style)'
+format = '[](fg:prev_bg bg:#86BBD8)[ $symbol ($version) ]($style)'
 
 [nim]
 symbol = "󰆥 "
 style = "bg:#86BBD8"
-format = '[ $symbol ($version) ]($style)'
+format = '[](fg:prev_bg bg:#86BBD8)[ $symbol ($version) ]($style)'
 
 [rust]
 symbol = ""
 style = "bg:#86BBD8"
-format = '[ $symbol ($version) ]($style)'
+format = '[](fg:prev_bg bg:#86BBD8)[ $symbol ($version) ]($style)'
 
 [scala]
 symbol = " "
 style = "bg:#86BBD8"
-format = '[ $symbol ($version) ]($style)'
+format = '[](fg:prev_bg bg:#86BBD8)[ $symbol ($version) ]($style)'
 
 [time]
 disabled = false
 time_format = "%R" # Hour:Minute Format
 style = "bg:#33658A"
-format = '[ ♥ $time ]($style)'
+format = '[](fg:prev_bg bg:#33658A)[ ♥ $time ]($style)'

--- a/docs/public/presets/toml/pastel-powerline.toml
+++ b/docs/public/presets/toml/pastel-powerline.toml
@@ -4,12 +4,9 @@ format = """
 [](#9A348E)\
 $os\
 $username\
-[](bg:#DA627D fg:#9A348E)\
 $directory\
-[](fg:#DA627D bg:#FCA17D)\
 $git_branch\
 $git_status\
-[](fg:#FCA17D bg:#86BBD8)\
 $c\
 $elixir\
 $elm\
@@ -24,11 +21,9 @@ $bun\
 $nim\
 $rust\
 $scala\
-[](fg:#86BBD8 bg:#06969A)\
 $docker_context\
-[](fg:#06969A bg:#33658A)\
 $time\
-[ ](fg:#33658A)\
+[ ](fg:prev_bg)\
 """
 
 # Disable the blank line at the start of the prompt
@@ -51,7 +46,7 @@ disabled = true # Disabled by default
 
 [directory]
 style = "bg:#DA627D"
-format = "[ $path ]($style)"
+format = "[](fg:prev_bg bg:#DA627D)[ $path ]($style)"
 truncation_length = 3
 truncation_symbol = "…/"
 
@@ -71,32 +66,32 @@ truncation_symbol = "…/"
 [c]
 symbol = " "
 style = "bg:#86BBD8"
-format = '[ $symbol ($version) ]($style)'
+format = '[](fg:prev_bg bg:#86BBD8)[ $symbol ($version) ]($style)'
 
 [cpp]
 symbol = " "
 style = "bg:#86BBD8"
-format = '[ $symbol ($version) ]($style)'
+format = '[](fg:prev_bg bg:#86BBD8)[ $symbol ($version) ]($style)'
 
 [docker_context]
 symbol = " "
 style = "bg:#06969A"
-format = '[ $symbol $context ]($style)'
+format = '[](fg:prev_bg bg:#06969A)[ $symbol $context ]($style)'
 
 [elixir]
 symbol = " "
 style = "bg:#86BBD8"
-format = '[ $symbol ($version) ]($style)'
+format = '[](fg:prev_bg bg:#86BBD8)[ $symbol ($version) ]($style)'
 
 [elm]
 symbol = " "
 style = "bg:#86BBD8"
-format = '[ $symbol ($version) ]($style)'
+format = '[](fg:prev_bg bg:#86BBD8)[ $symbol ($version) ]($style)'
 
 [git_branch]
 symbol = ""
 style = "bg:#FCA17D"
-format = '[ $symbol $branch ]($style)'
+format = '[](fg:prev_bg bg:#FCA17D)[ $symbol $branch ]($style)'
 
 [git_status]
 style = "bg:#FCA17D"
@@ -105,26 +100,26 @@ format = '[$all_status$ahead_behind ]($style)'
 [golang]
 symbol = " "
 style = "bg:#86BBD8"
-format = '[ $symbol ($version) ]($style)'
+format = '[](fg:prev_bg bg:#86BBD8)[ $symbol ($version) ]($style)'
 
 [gradle]
 style = "bg:#86BBD8"
-format = '[ $symbol ($version) ]($style)'
+format = '[](fg:prev_bg bg:#86BBD8)[ $symbol ($version) ]($style)'
 
 [haskell]
 symbol = " "
 style = "bg:#86BBD8"
-format = '[ $symbol ($version) ]($style)'
+format = '[](fg:prev_bg bg:#86BBD8)[ $symbol ($version) ]($style)'
 
 [java]
 symbol = " "
 style = "bg:#86BBD8"
-format = '[ $symbol ($version) ]($style)'
+format = '[](fg:prev_bg bg:#86BBD8)[ $symbol ($version) ]($style)'
 
 [julia]
 symbol = " "
 style = "bg:#86BBD8"
-format = '[ $symbol ($version) ]($style)'
+format = '[](fg:prev_bg bg:#86BBD8)[ $symbol ($version) ]($style)'
 
 [maven]
 style = "bg:#86BBD8"
@@ -133,7 +128,7 @@ format = '[ $symbol ($version) ]($style)'
 [nodejs]
 symbol = ""
 style = "bg:#86BBD8"
-format = '[ $symbol ($version) ]($style)'
+format = '[](fg:prev_bg bg:#86BBD8)[ $symbol ($version) ]($style)'
 
 [bun]
 symbol = ""
@@ -143,20 +138,20 @@ format = '[ $symbol ($version) ]($style)'
 [nim]
 symbol = "󰆥 "
 style = "bg:#86BBD8"
-format = '[ $symbol ($version) ]($style)'
+format = '[](fg:prev_bg bg:#86BBD8)[ $symbol ($version) ]($style)'
 
 [rust]
 symbol = ""
 style = "bg:#86BBD8"
-format = '[ $symbol ($version) ]($style)'
+format = '[](fg:prev_bg bg:#86BBD8)[ $symbol ($version) ]($style)'
 
 [scala]
 symbol = " "
 style = "bg:#86BBD8"
-format = '[ $symbol ($version) ]($style)'
+format = '[](fg:prev_bg bg:#86BBD8)[ $symbol ($version) ]($style)'
 
 [time]
 disabled = false
 time_format = "%R" # Hour:Minute Format
 style = "bg:#33658A"
-format = '[ ♥ $time ]($style)'
+format = '[](fg:prev_bg bg:#33658A)[ ♥ $time ]($style)'


### PR DESCRIPTION
#### Description

#### Motivation and Context
With pastel-powerline/catppuccin-powerline, when there are modules with
no output, the  characters is always printed, resulting in something
like rainbow when there are several empty modules.

This commit moves this  character to the individual module `format`
directive, and uses `prev_bg` as its background to get the correct
color.

This also makes it easier to change the color of each prompt section as
the colors choices are all done in the module configuration.




#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.