### PR TITLE
fix(time): misleading log message

### DIFF
--- a/src/modules/time.rs
+++ b/src/modules/time.rs
@@ -27,15 +27,18 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
     log::trace!("Timer module is enabled with format string: {time_format}");
 
-    let formatted_time_string = create_offset_time_string(
-        Utc::now(),
-        config.utc_time_offset,
-        time_format,
-    )
-    .unwrap_or_else(|_| {
-        log::warn!("Invalid utc_time_offset configuration provided! Falling back to \"local\".");
+    let formatted_time_string = if config.utc_time_offset != "local" {
+        create_offset_time_string(Utc::now(), config.utc_time_offset, time_format).unwrap_or_else(
+            |_| {
+                log::warn!(
+                    "Invalid utc_time_offset configuration provided! Falling back to \"local\"."
+                );
+                format_time(time_format, Local::now())
+            },
+        )
+    } else {
         format_time(time_format, Local::now())
-    });
+    };
 
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter


### PR DESCRIPTION
This PR fixes a misleading warning message when the `time` module is enabled and no utc offset is configured.

#### Description
Whenever I started a new shell with starship enabled (compiled from master today), I was seeing this log message:

```
[WARN] - (starship::modules::time): Invalid utc_time_offset configuration provided! Falling back to "local".
```

My configuration was not setting  `utc_time_offset`, so it had its default value of "local", making this message very confusing. Looks like the check for "local" was lost during a refactor: https://github.com/starship/starship/commit/3760f29560b7b4b987bacec84df175fa44e6d131

I've restored the previous logic while retaining the `match` -> `unwrap_or_else` refactor.

Closes #7043

#### How Has This Been Tested?
Recompiled and verified the log message is no longer output. 
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
