### PR TITLE
fix(install): use portable POSIX `awk` for case conversion in install script

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -205,7 +205,7 @@ install() {
 #   - linux_musl (Alpine)
 #   - freebsd
 detect_platform() {
-  platform="$(uname -s | tr '[:upper:]' '[:lower:]')"
+  platform="$(uname -s | awk '{print tolower($0)}')"
 
   case "${platform}" in
     msys_nt*) platform="pc-windows-msvc" ;;
@@ -227,7 +227,7 @@ detect_platform() {
 #   - arm
 #   - arm64
 detect_arch() {
-arch="$(uname -m | tr '[:upper:]' '[:lower:]')"
+  arch="$(uname -m | awk '{print tolower($0)}')"
 
   case "${arch}" in
     amd64) arch="x86_64" ;;
@@ -268,7 +268,7 @@ confirm() {
     set +e
     read -r yn </dev/tty
     trap - INT
-    yn=$(echo "$yn" | tr '[:upper:]' '[:lower:]')
+    yn=$(echo "$yn" | awk '{print tolower($0)}')
     rc=$?
     set -e
     if [ $rc -ne 0 ]; then

--- a/install/install.sh
+++ b/install/install.sh
@@ -205,7 +205,7 @@ install() {
 #   - linux_musl (Alpine)
 #   - freebsd
 detect_platform() {
-  platform="$(uname -s | dd conv=lcase 2>/dev/null)"
+  platform="$(uname -s | tr '[:upper:]' '[:lower:]')"
 
   case "${platform}" in
     msys_nt*) platform="pc-windows-msvc" ;;
@@ -227,7 +227,7 @@ detect_platform() {
 #   - arm
 #   - arm64
 detect_arch() {
-arch="$(uname -m | dd conv=lcase 2>/dev/null)"
+arch="$(uname -m | tr '[:upper:]' '[:lower:]')"
 
   case "${arch}" in
     amd64) arch="x86_64" ;;
@@ -268,7 +268,7 @@ confirm() {
     set +e
     read -r yn </dev/tty
     trap - INT
-    yn=$(echo "$yn" | dd conv=lcase 2>/dev/null)
+    yn=$(echo "$yn" | tr '[:upper:]' '[:lower:]')
     rc=$?
     set -e
     if [ $rc -ne 0 ]; then

--- a/install/install.sh
+++ b/install/install.sh
@@ -205,7 +205,7 @@ install() {
 #   - linux_musl (Alpine)
 #   - freebsd
 detect_platform() {
-  platform="$(uname -s | tr '[:upper:]' '[:lower:]')"
+  platform="$(uname -s | tr 'A-Z' 'a-z')"
 
   case "${platform}" in
     msys_nt*) platform="pc-windows-msvc" ;;
@@ -227,7 +227,7 @@ detect_platform() {
 #   - arm
 #   - arm64
 detect_arch() {
-  arch="$(uname -m | tr '[:upper:]' '[:lower:]')"
+  arch="$(uname -m | tr 'A-Z' 'a-z')"
 
   case "${arch}" in
     amd64) arch="x86_64" ;;
@@ -268,7 +268,7 @@ confirm() {
     set +e
     read -r yn </dev/tty
     trap - INT
-    yn=$(echo "$yn" | tr '[:upper:]' '[:lower:]')
+    yn=$(echo "$yn" | tr 'A-Z' 'a-z')
     rc=$?
     set -e
     if [ $rc -ne 0 ]; then

--- a/install/install.sh
+++ b/install/install.sh
@@ -205,7 +205,7 @@ install() {
 #   - linux_musl (Alpine)
 #   - freebsd
 detect_platform() {
-  platform="$(uname -s | tr 'A-Z' 'a-z')"
+  platform="$(uname -s | tr 'ABCDEFGHIJKLMNOPQRSTUVWXYZ' 'abcdefghijklmnopqrstuvwxyz')"
 
   case "${platform}" in
     msys_nt*) platform="pc-windows-msvc" ;;
@@ -227,7 +227,7 @@ detect_platform() {
 #   - arm
 #   - arm64
 detect_arch() {
-  arch="$(uname -m | tr 'A-Z' 'a-z')"
+  arch="$(uname -m | tr 'ABCDEFGHIJKLMNOPQRSTUVWXYZ' 'abcdefghijklmnopqrstuvwxyz')"
 
   case "${arch}" in
     amd64) arch="x86_64" ;;
@@ -268,7 +268,7 @@ confirm() {
     set +e
     read -r yn </dev/tty
     trap - INT
-    yn=$(echo "$yn" | tr 'A-Z' 'a-z')
+    yn=$(echo "$yn" | tr 'ABCDEFGHIJKLMNOPQRSTUVWXYZ' 'abcdefghijklmnopqrstuvwxyz')
     rc=$?
     set -e
     if [ $rc -ne 0 ]; then

--- a/install/install.sh
+++ b/install/install.sh
@@ -205,7 +205,7 @@ install() {
 #   - linux_musl (Alpine)
 #   - freebsd
 detect_platform() {
-  platform="$(uname -s | awk '{print tolower($0)}')"
+  platform="$(uname -s | dd conv=lcase 2>/dev/null)"
 
   case "${platform}" in
     msys_nt*) platform="pc-windows-msvc" ;;
@@ -227,7 +227,7 @@ detect_platform() {
 #   - arm
 #   - arm64
 detect_arch() {
-  arch="$(uname -m | awk '{print tolower($0)}')"
+arch="$(uname -m | dd conv=lcase 2>/dev/null)"
 
   case "${arch}" in
     amd64) arch="x86_64" ;;
@@ -268,7 +268,7 @@ confirm() {
     set +e
     read -r yn </dev/tty
     trap - INT
-    yn=$(echo "$yn" | awk '{print tolower($0)}')
+    yn=$(echo "$yn" | dd conv=lcase 2>/dev/null)
     rc=$?
     set -e
     if [ $rc -ne 0 ]; then

--- a/install/install.sh
+++ b/install/install.sh
@@ -205,7 +205,7 @@ install() {
 #   - linux_musl (Alpine)
 #   - freebsd
 detect_platform() {
-  platform="$(uname -s | tr 'ABCDEFGHIJKLMNOPQRSTUVWXYZ' 'abcdefghijklmnopqrstuvwxyz')"
+  platform="$(uname -s | awk '{print tolower($0)}')"
 
   case "${platform}" in
     msys_nt*) platform="pc-windows-msvc" ;;
@@ -227,7 +227,7 @@ detect_platform() {
 #   - arm
 #   - arm64
 detect_arch() {
-  arch="$(uname -m | tr 'ABCDEFGHIJKLMNOPQRSTUVWXYZ' 'abcdefghijklmnopqrstuvwxyz')"
+  arch="$(uname -m | awk '{print tolower($0)}')"
 
   case "${arch}" in
     amd64) arch="x86_64" ;;
@@ -268,7 +268,7 @@ confirm() {
     set +e
     read -r yn </dev/tty
     trap - INT
-    yn=$(echo "$yn" | tr 'ABCDEFGHIJKLMNOPQRSTUVWXYZ' 'abcdefghijklmnopqrstuvwxyz')
+    yn=$(echo "$yn" | awk '{print tolower($0)}')
     rc=$?
     set -e
     if [ $rc -ne 0 ]; then


### PR DESCRIPTION
### Summary

This PR addresses a bug in the `install.sh` script that causes installation to fail on certain systems, like OpenWRT, due to incorrect platform detection. The issue is resolved by replacing the non-portable `tr` command with a more reliable `awk` equivalent for case conversion.

### The Problem

The installation script used `tr 'A-Z' 'a-z'` to convert the output of `uname -s` and `uname -m` to lowercase. However, this command is not consistently supported across all systems. On OpenWRT, for example, it would incorrectly convert "Linux" to "Linlx", causing the platform detection to fail.

### The Solution

This pull request replaces the `tr` command with `awk '{print tolower($0)}'`. This `awk` command is more portable and provides a reliable way to convert strings to lowercase across different environments, ensuring that the installation script works as expected on a wider range of systems.

This change affects the `detect_platform`, `detect_arch`, and `confirm` functions within the `install.sh` script.

Fixes #7013