### PR TITLE
fix(fish): use native transient prompt if available

### DIFF
--- a/src/init/starship.fish
+++ b/src/init/starship.fish
@@ -26,11 +26,13 @@ function fish_prompt
 
     __starship_set_job_count
 
-    if test "$TRANSIENT" = "1"
-        set -g TRANSIENT 0
-        # Clear from cursor to end of screen as `commandline -f repaint` does not do this
-        # See https://github.com/fish-shell/fish-shell/issues/8418
-        printf \e\[0J
+    if contains -- --final-rendering $argv; or test "$TRANSIENT" = "1"
+        if test "$TRANSIENT" = "1"
+            set -g TRANSIENT 0
+            # Clear from cursor to end of screen as `commandline -f repaint` does not do this
+            # See https://github.com/fish-shell/fish-shell/issues/8418
+            printf \e\[0J
+        end
         if type -q starship_transient_prompt_func
             starship_transient_prompt_func --terminal-width="$COLUMNS" --status=$STARSHIP_CMD_STATUS --pipestatus="$STARSHIP_CMD_PIPESTATUS" --keymap=$STARSHIP_KEYMAP --cmd-duration=$STARSHIP_DURATION --jobs=$STARSHIP_JOBS
         else
@@ -57,7 +59,7 @@ function fish_right_prompt
     # Now it's safe to call job count function (after status capture)
     __starship_set_job_count
 
-    if test "$RIGHT_TRANSIENT" = "1"
+    if contains -- --final-rendering $argv; or test "$RIGHT_TRANSIENT" = "1"
         set -g RIGHT_TRANSIENT 0
         if type -q starship_transient_rprompt_func
             starship_transient_rprompt_func --terminal-width="$COLUMNS" --status=$STARSHIP_CMD_STATUS --pipestatus="$STARSHIP_CMD_PIPESTATUS" --keymap=$STARSHIP_KEYMAP --cmd-duration=$STARSHIP_DURATION --jobs=$STARSHIP_JOBS
@@ -78,12 +80,12 @@ builtin functions -e fish_mode_prompt
 set -gx STARSHIP_SHELL "fish"
 
 # Transience related functions
-function reset-transient --on-event fish_postexec
+function __starship_reset_transient --on-event fish_postexec
     set -g TRANSIENT 0
     set -g RIGHT_TRANSIENT 0
 end
 
-function transient_execute
+function __starship_transient_execute
     if commandline --is-valid || test -z (commandline | string collect) && not commandline --paging-mode
         set -g TRANSIENT 1
         set -g RIGHT_TRANSIENT 1
@@ -92,16 +94,50 @@ function transient_execute
     commandline -f execute
 end
 
+function __starship_fish_version_at_least --description 'Check if fish version is at least the given version'
+    set -l parts (string split '.' $FISH_VERSION)
+    set -l major $parts[1]
+    set -l minor 0
+    if set -q parts[2]
+        set minor $parts[2]
+    end
+
+    set req_parts (string split '.' $argv[1])
+    set req_major $req_parts[1]
+    set req_minor 0
+    if set -q req_parts[2]
+        set req_minor $req_parts[2]
+    end
+
+    if test $major -gt $req_major
+        return 0
+    else if test $major -eq $req_major -a $minor -ge $req_minor
+        return 0
+    else
+        return 1
+    end
+end
+
 # --user is the default, but listed anyway to make it explicit.
 function enable_transience --description 'enable transient prompt keybindings'
-    bind --user \r transient_execute
-    bind --user -M insert \r transient_execute
+    # fish >= 4.1 has transient prompt support built
+    if __starship_fish_version_at_least 4.1
+        set -g fish_transient_prompt 1
+        return
+    end
+    bind --user \r __starship_transient_execute
+    bind --user -M insert \r __starship_transient_execute
 end
 
 # Erase the transient prompt related key bindings.
 # --user is the default, but listed anyway to make it explicit.
 # Erasing a user binding will revert to the preset.
 function disable_transience --description 'remove transient prompt keybindings'
+    # fish >= 4.1 has transient prompt support built
+    if __starship_fish_version_at_least 4.1
+        set -g fish_transient_prompt 0
+        return
+    end
     bind --user -e \r
     bind --user -M insert -e \r
 end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Fish v4.1 introduced a native transient prompt feature, this PR makes starship use that instead of our custom version from that version onwards. If `fish_transient_prompt` is `1` the transient prompt is obtained by running the prompt functions with the `--final-rendering` argument.

In addition I prefixed the utility functions around transient prompt support with `__starship_`.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
I tested that `enable_transience` works on both fish 4.1.0 and 4.0.8.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
