### PR TITLE
feat(modules): allow to set prompt character depending on user type

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -777,16 +777,18 @@ look at [this example](#with-custom-error-shape).
 
 ### Options
 
-| Option                      | Default              | Description                                                                             |
-| --------------------------- | -------------------- | --------------------------------------------------------------------------------------- |
-| `format`                    | `'$symbol '`         | The format string used before the text input.                                           |
-| `success_symbol`            | `'[❯](bold green)'`  | The format string used before the text input if the previous command succeeded.         |
-| `error_symbol`              | `'[❯](bold red)'`    | The format string used before the text input if the previous command failed.            |
-| `vimcmd_symbol`             | `'[❮](bold green)'`  | The format string used before the text input if the shell is in vim normal mode.        |
-| `vimcmd_replace_one_symbol` | `'[❮](bold purple)'` | The format string used before the text input if the shell is in vim `replace_one` mode. |
-| `vimcmd_replace_symbol`     | `'[❮](bold purple)'` | The format string used before the text input if the shell is in vim replace mode.       |
-| `vimcmd_visual_symbol`      | `'[❮](bold yellow)'` | The format string used before the text input if the shell is in vim visual mode.        |
-| `disabled`                  | `false`              | Disables the `character` module.                                                        |
+| Option                      | Default              | Description                                                                                                             |
+| --------------------------- | -------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `format`                    | `'$symbol '`         | The format string used before the text input.                                                                           |
+| `success_symbol`            | `'[❯](bold green)'`  | The format string used before the text input if the previous command succeeded.                                         |
+| `error_symbol`              | `'[❯](bold red)'`    | The format string used before the text input if the previous command failed.                                            |
+| `success_symbol_root`       | `'[❯](bold green)'`  | The format string used before the text input when the current user is root/admin and if the previous command succeeded. |
+| `error_symbol_root`         | `'[❯](bold red)'`    | The Format string used before the text input when the current user is root/admin and if the previous command failed.    |
+| `vimcmd_symbol`             | `'[❮](bold green)'`  | The format string used before the text input if the shell is in vim normal mode.                                        |
+| `vimcmd_replace_one_symbol` | `'[❮](bold purple)'` | The format string used before the text input if the shell is in vim `replace_one` mode.                                 |
+| `vimcmd_replace_symbol`     | `'[❮](bold purple)'` | The format string used before the text input if the shell is in vim replace mode.                                       |
+| `vimcmd_visual_symbol`      | `'[❮](bold yellow)'` | The format string used before the text input if the shell is in vim visual mode.                                        |
+| `disabled`                  | `false`              | Disables the `character` module.                                                                                        |
 
 ### Variables
 

--- a/src/configs/character.rs
+++ b/src/configs/character.rs
@@ -11,6 +11,8 @@ pub struct CharacterConfig<'a> {
     pub format: &'a str,
     pub success_symbol: &'a str,
     pub error_symbol: &'a str,
+    pub success_symbol_root: &'a str,
+    pub error_symbol_root: &'a str,
     #[serde(alias = "vicmd_symbol")]
     pub vimcmd_symbol: &'a str,
     pub vimcmd_visual_symbol: &'a str,
@@ -25,6 +27,8 @@ impl Default for CharacterConfig<'_> {
             format: "$symbol ",
             success_symbol: "[❯](bold green)",
             error_symbol: "[❯](bold red)",
+            success_symbol_root: "[❯](bold green)",
+            error_symbol_root: "[❯](bold red)",
             vimcmd_symbol: "[❮](bold green)",
             vimcmd_visual_symbol: "[❮](bold yellow)",
             vimcmd_replace_symbol: "[❮](bold purple)",

--- a/src/modules/utils/mod.rs
+++ b/src/modules/utils/mod.rs
@@ -9,3 +9,5 @@ pub mod directory_nix;
 pub mod path;
 
 pub mod truncate;
+
+pub mod user;

--- a/src/modules/utils/user.rs
+++ b/src/modules/utils/user.rs
@@ -1,0 +1,33 @@
+/// Checks if the current user is a root/administrator user
+
+#[cfg(all(target_os = "windows", not(test)))]
+pub fn is_root_user() -> bool {
+    use deelevate::{PrivilegeLevel, Token};
+    let token = match Token::with_current_process() {
+        Ok(token) => token,
+        Err(e) => {
+            log::warn!("Failed to get process token: {e:?}");
+            return false;
+        }
+    };
+    matches!(
+        match token.privilege_level() {
+            Ok(level) => level,
+            Err(e) => {
+                log::warn!("Failed to get privilege level: {e:?}");
+                return false;
+            }
+        },
+        PrivilegeLevel::Elevated | PrivilegeLevel::HighIntegrityAdmin
+    )
+}
+
+#[cfg(test)]
+pub fn is_root_user() -> bool {
+    false
+}
+
+#[cfg(all(not(target_os = "windows"), not(test)))]
+pub fn is_root_user() -> bool {
+    nix::unistd::geteuid() == nix::unistd::ROOT
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
In the first step the `is_root_user` function was refactored from the username module into utils, so that it can be re-used.
The second step was to use the `is_root_user` function in the characters module, to set a custom symbol for root/admin users.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #2421
The workarounds described there are not good enough for me, since they are always lacking in one capacity.
I don't want to install a separate config for root if possible for convenience sake.
The `[custom.root]` solution allows to set a prompt, but cannot differ between command success and failure.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.

If the documentation gets parsed from the README, I have updated it correctly.