### PR TITLE
feat(cli): accept 'powershell' for completions; keep 'power-shell' as…

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use std::io;
 use std::path::PathBuf;
 use std::time::SystemTime;
 
-use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
+use clap::{CommandFactory, Parser, Subcommand, ValueEnum, builder::PossibleValue};
 use clap_complete::generate;
 use rand::Rng;
 use starship::context::{Context, Properties, Target};
@@ -26,7 +26,7 @@ struct Cli {
     command: Commands,
 }
 
-#[derive(clap::Parser, ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum CompletionShell {
     Bash,
     Elvish,
@@ -34,6 +34,32 @@ enum CompletionShell {
     Nushell,
     PowerShell,
     Zsh,
+}
+
+impl ValueEnum for CompletionShell {
+    fn value_variants<'a>() -> &'a [Self] {
+        &[
+            Self::Bash,
+            Self::Elvish,
+            Self::Fish,
+            Self::Nushell,
+            Self::PowerShell,
+            Self::Zsh,
+        ]
+    }
+
+    fn to_possible_value(&self) -> Option<PossibleValue> {
+        Some(match self {
+            Self::Bash => PossibleValue::new("bash"),
+            Self::Elvish => PossibleValue::new("elvish"),
+            Self::Fish => PossibleValue::new("fish"),
+            Self::Nushell => PossibleValue::new("nushell"),
+            Self::PowerShell => PossibleValue::new("powershell")
+                .alias("power-shell")
+                .alias("pwsh"),
+            Self::Zsh => PossibleValue::new("zsh"),
+        })
+    }
 }
 
 fn generate_shell(shell: impl clap_complete::Generator) {


### PR DESCRIPTION
… alias

The `starship completions` command now accepts 'powershell' (matching `starship init powershell`), while maintaining backward compatibility with the old 'power-shell' syntax. Also added 'pwsh' as a convenient alias.

Changes:
- Convert CompletionShell from derived ValueEnum to manual impl
- Set primary name to 'powershell' (shown in --help)
- Add 'power-shell' and 'pwsh' as hidden aliases
- All three variants generate identical PowerShell completion script

Closes #7020
Closes #7021

<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
