### PR TITLE
fish(init/elvish): improve starship path encoding

### DIFF
--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -50,6 +50,16 @@ impl StarshipPath {
             .map(|s| s.replace('\'', "''"))
             .map(|s| format!("'{s}'"))
     }
+
+    /// `Elvish` specific path escaping
+    fn sprint_elv(&self) -> io::Result<String> {
+        // Prefix with `e:` to force elvish to interpret it as an executable path
+        // also avoids issues with paths starting with `E:` like `E:\path\to\starship.exe`
+        self.str_path()
+            .map(|s| format!("e:{s}"))
+            .map(|s| shell_words::quote(&s).into_owned())
+    }
+
     /// Command Shell specific path escaping
     fn sprint_cmdexe(&self) -> io::Result<String> {
         self.str_path().map(|s| format!("\"{s}\""))
@@ -168,7 +178,7 @@ pub fn init_stub(shell_name: &str) -> io::Result<()> {
         "ion" => print!("eval $({} init ion --print-full-init)", starship.sprint()?),
         "elvish" => print!(
             r"eval ({} init elvish --print-full-init | slurp)",
-            starship.sprint()?
+            starship.sprint_elv()?
         ),
         "tcsh" => print!(
             r"eval `({} init tcsh --print-full-init)`",
@@ -215,7 +225,7 @@ pub fn init_main(shell_name: &str) -> io::Result<()> {
         "fish" => print_script(FISH_INIT, &starship_path.sprint_posix()?),
         "powershell" => print_script(PWSH_INIT, &starship_path.sprint_pwsh()?),
         "ion" => print_script(ION_INIT, &starship_path.sprint()?),
-        "elvish" => print_script(ELVISH_INIT, &starship_path.sprint()?),
+        "elvish" => print_script(ELVISH_INIT, &starship_path.sprint_elv()?),
         "tcsh" => print_script(TCSH_INIT, &starship_path.sprint_posix()?),
         "xonsh" => print_script(XONSH_INIT, &starship_path.sprint_posix()?),
         _ => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
This PR makes prepends the starship binary with `e:` to explicitly signify external command calls. Otherwise issues can arise on Windows, where paths on the `E:` drive can be misinterpreted.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #7021

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
