### PR TITLE
docs(presets): fix incorrect "Return to Presets" anchor links

### DIFF
--- a/docs/presets/pure-preset.md
+++ b/docs/presets/pure-preset.md
@@ -1,4 +1,4 @@
-[Return to Presets](./#pure)
+[Return to Presets](./#pure-prompt)
 
 # Pure Preset
 

--- a/docs/presets/tokyo-night.md
+++ b/docs/presets/tokyo-night.md
@@ -1,4 +1,4 @@
-[Return to Presets](./#pastel-powerline)
+[Return to Presets](./#tokyo-night)
 
 # Tokyo Night Preset
 


### PR DESCRIPTION
#### Description
Fixed broken anchor links in two preset documentation files that were pointing to incorrect section IDs in the presets README:
- `pure-preset.md`: Changed anchor from `#pure` to `#pure-prompt`
- `tokyo-night.md`: Changed anchor from `#pastel-powerline` to `#tokyo-night`

#### Motivation and Context
The "Return to Presets" links at the top of these preset pages were broken, leading users to incorrect sections. This fix ensures that clicking these links properly navigates users back to the correct preset section in the main presets page.

The tokyo-night preset was particularly problematic as it was linking to the pastel-powerline section instead of its own section.

Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.(No update required)
- [x] I have updated the tests accordingly.(No update required)
