### PR TITLE
feat(python): new list of venv names to replace with parent dir

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -1404,6 +1404,10 @@
         "detect_folders": [],
         "detect_env_vars": [
           "VIRTUAL_ENV"
+        ],
+        "parent_venv_names": [
+          ".venv",
+          "venv"
         ]
       }
     },
@@ -5504,6 +5508,16 @@
           },
           "default": [
             "VIRTUAL_ENV"
+          ]
+        },
+        "parent_venv_names": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            ".venv",
+            "venv"
           ]
         }
       },

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -3937,6 +3937,7 @@ By default, the module will be shown if any of the following conditions are met:
 | `detect_extensions`  | `['py', 'ipynb']`                                                                                            | Which extensions should trigger this module                                           |
 | `detect_files`       | `['.python-version', 'Pipfile', '__init__.py', 'pyproject.toml', 'requirements.txt', 'setup.py', 'tox.ini']` | Which filenames should trigger this module                                            |
 | `detect_folders`     | `[]`                                                                                                         | Which folders should trigger this module                                              |
+| `parent_venv_names`  | `['.venv', 'venv']`                                                                                          | Which venv names should be replaced with the parent directory name.                   |
 | `disabled`           | `false`                                                                                                      | Disables the `python` module.                                                         |
 
 > [!TIP]

--- a/src/configs/python.rs
+++ b/src/configs/python.rs
@@ -22,6 +22,7 @@ pub struct PythonConfig<'a> {
     pub detect_files: Vec<&'a str>,
     pub detect_folders: Vec<&'a str>,
     pub detect_env_vars: Vec<&'a str>,
+    pub parent_venv_names: Vec<&'a str>,
 }
 
 impl Default for PythonConfig<'_> {
@@ -51,6 +52,7 @@ impl Default for PythonConfig<'_> {
             ],
             detect_folders: vec![],
             detect_env_vars: vec!["VIRTUAL_ENV"],
+            parent_venv_names: vec![".venv", "venv"],
         }
     }
 }

--- a/src/modules/python.rs
+++ b/src/modules/python.rs
@@ -56,7 +56,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                     .map(Ok)
                 }
                 "virtualenv" => {
-                    let virtual_env = get_python_virtual_env(context);
+                    let virtual_env = get_python_virtual_env(context, &config);
                     virtual_env.as_ref().map(|e| Ok(e.trim().to_string()))
                 }
                 "pyenv_prefix" => Some(Ok(pyenv_prefix.to_string())),
@@ -123,13 +123,10 @@ fn parse_python_version(python_version_string: &str) -> Option<String> {
     Some(version.to_string())
 }
 
-fn get_python_virtual_env(context: &Context) -> Option<String> {
+fn get_python_virtual_env(context: &Context, config: &PythonConfig) -> Option<String> {
     context.get_env("VIRTUAL_ENV").and_then(|venv| {
-        get_prompt_from_venv(Path::new(&venv)).or_else(|| {
-            Path::new(&venv)
-                .file_name()
-                .map(|filename| String::from(filename.to_str().unwrap_or("")))
-        })
+        get_prompt_from_venv(Path::new(&venv))
+            .or_else(|| get_venv_from_path(Path::new(&venv), &config.parent_venv_names))
     })
 }
 
@@ -139,6 +136,20 @@ fn get_prompt_from_venv(venv_path: &Path) -> Option<String> {
         .general_section()
         .get("prompt")
         .map(|prompt| String::from(prompt.trim_matches(&['(', ')'] as &[_])))
+}
+
+fn get_venv_from_path(venv_path: &Path, parent_venv_names: &Vec<&str>) -> Option<String> {
+    venv_path.file_name()?.to_str().and_then(|venv_name| {
+        if parent_venv_names.contains(&venv_name) {
+            venv_path
+                .parent()?
+                .file_name()?
+                .to_str()
+                .map(|s| s.to_string())
+        } else {
+            Some(venv_name.to_string())
+        }
+    })
 }
 
 #[cfg(test)]
@@ -388,6 +399,28 @@ Python 3.7.9 (7e6e2bb30ac5fbdbd443619cae28c51d5c162a02, Nov 24 2020, 10:03:59)
         let expected = Some(format!(
             "via {}",
             Color::Yellow.bold().paint("🐍 v3.8.0 (my_venv) ")
+        ));
+
+        assert_eq!(actual, expected);
+        dir.close()
+    }
+
+    #[test]
+    fn with_active_venv_and_parent_venv_names() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+
+        let actual = ModuleRenderer::new("python")
+            .path(dir.path())
+            .env("VIRTUAL_ENV", "/foo/bar/my_venv")
+            .config(toml::toml! {
+                [python]
+                parent_venv_names = [".venv", "venv", "my_venv"]
+            })
+            .collect();
+
+        let expected = Some(format!(
+            "via {}",
+            Color::Yellow.bold().paint("🐍 v3.8.0 (bar) ")
         ));
 
         assert_eq!(actual, expected);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description

This PR adds a new list of venv names as a customizable option, where if the resolve virtual venv path matches one of the names in the list, it will be overwritten with the parent directory.

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Every time I create a virtualenv, I always name it `.venv` or `venv` which when activated does not give me information of the project I am working on since it always displays the same.

<!--- If it fixes an open issue, please link to the issue here. -->
Closes #5889 

#### Screenshots (if appropriate):

![venv](https://github.com/user-attachments/assets/7014a603-a9fe-4cac-b85d-66f33b111781)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Create a virtual environment with a standard name like `.venv` or `venv`, activate it, and the parent directory will be displayed instead of the name of the virtualenv folder.

- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.

(PS. This is a rework of an old PR of mine.)