### PR TITLE
chore: handle current compiler & clippy warnings

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -625,9 +625,10 @@ mod tests {
             pub switch_c: Switch,
         }
 
-        #[derive(Debug, PartialEq, Clone)]
+        #[derive(Debug, PartialEq, Clone, Default)]
         enum Switch {
             On,
+            #[default]
             Off,
         }
 
@@ -641,12 +642,6 @@ mod tests {
                     "on" => Ok(Self::On),
                     _ => Ok(Self::Off),
                 }
-            }
-        }
-
-        impl Default for Switch {
-            fn default() -> Self {
-                Self::Off
             }
         }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -552,9 +552,9 @@ impl DirContents {
 
         {
             let worker = move || {
-                let enumerated_dir = fs::read_dir(base).unwrap().enumerate();
-                let _ = enumerated_dir
-                    .filter_map(|(_, entry)| entry.ok())
+                let dir_iter = fs::read_dir(base).unwrap();
+                let _ = dir_iter
+                    .filter_map(|entry| entry.ok())
                     .try_for_each(|entry| tx.send(entry));
             };
 

--- a/src/formatter/model.rs
+++ b/src/formatter/model.rs
@@ -22,7 +22,7 @@ pub enum FormatElement<'a> {
     Text(Cow<'a, str>),
     Variable(Cow<'a, str>),
     TextGroup(TextGroup<'a>),
-    Conditional(Vec<FormatElement<'a>>),
+    Conditional(Vec<Self>),
 }
 
 #[derive(Clone)]

--- a/src/formatter/string_formatter.rs
+++ b/src/formatter/string_formatter.rs
@@ -391,9 +391,10 @@ impl<'a> StringFormatter<'a> {
                                 match format_element {
                                     // Should not usually happen, but if it does, check if the variable
                                     // is set using `should_show_elements`.
-                                    FormatElement::Variable(_) => {
-                                        should_show_elements(&[format_element.clone()], variables)
-                                    }
+                                    FormatElement::Variable(_) => should_show_elements(
+                                        std::slice::from_ref(format_element),
+                                        variables,
+                                    ),
                                     FormatElement::Conditional(format) => {
                                         should_show_elements(format, variables)
                                     }

--- a/src/modules/dotnet.rs
+++ b/src/modules/dotnet.rs
@@ -306,8 +306,7 @@ fn get_latest_sdk_from_cli(context: &Context) -> Option<String> {
             .stdout
             .lines()
             .map(str::trim)
-            .filter(|l| !l.is_empty())
-            .next_back()
+            .rfind(|l| !l.is_empty())
             .or_else(parse_failed)?;
         let take_until = latest_sdk.find('[').or_else(parse_failed)? - 1;
         if take_until > 1 {

--- a/src/modules/utils/path.rs
+++ b/src/modules/utils/path.rs
@@ -51,7 +51,7 @@ mod normalize {
     }
 
     #[cfg(windows)]
-    pub fn normalize_path(path: &Path) -> (NormalizedPrefix, &Path) {
+    pub fn normalize_path(path: &Path) -> (NormalizedPrefix<'_>, &Path) {
         let mut components = path.components();
         if let Some(Component::Prefix(prefix)) = components.next() {
             return (normalize_prefix(prefix.kind()), components.as_path());


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
`cargo clip --fix` plus a fix for a compiler warning on Windows. I renamed `enumerated_dir` to `dir_iter` because `clippy` remove the superfluous `enumerate` call.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
