### PR TITLE
fix: zsh command exit status not populated

### DIFF
--- a/src/init/starship.zsh
+++ b/src/init/starship.zsh
@@ -30,7 +30,8 @@ fi
 # Runs before each new command line.
 prompt_starship_precmd() {
     # Save the status, because subsequent commands in this function will change $?
-    STARSHIP_CMD_STATUS=$? STARSHIP_PIPE_STATUS=(${pipestatus[@]})
+    STARSHIP_CMD_STATUS=$?
+    STARSHIP_PIPE_STATUS=(${pipestatus[@]})
 
     # Calculate duration if a command was executed
     if (( ${+STARSHIP_START_TIME} )); then


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
The exit code of the last command is not received by starship, it's always 0. The status/character modules are always successful. The pipeline status works well. The variable $? is correctly set.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #6255

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
