### PR TITLE
fix(modules): Return contents of /run/systemd/container instead of Systemd

### DIFF
--- a/src/modules/container.rs
+++ b/src/modules/container.rs
@@ -58,13 +58,12 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
         // WSL with systemd will set the contents of this file to "wsl"
         // Avoid showing the container module in that case
-        // Honor the contents of this file if "docker" and not running in podman or wsl
+        // Honor the contents of this file if it contains anything and not running in podman or wsl
         let systemd_path = context_path(context, "/run/systemd/container");
         if let Ok(s) = utils::read_file(systemd_path) {
             match s.trim() {
-                "docker" => return Some("Docker".into()),
                 "wsl" => (),
-                _ => return Some("Systemd".into()),
+                _ => return Some(s.trim().into()),
             }
         }
 
@@ -272,6 +271,17 @@ mod tests {
     #[cfg(target_os = "linux")]
     fn test_containerenv_docker_in_systemd() -> std::io::Result<()> {
         let (actual, expected) = containerenv_systemd(Some("docker"), Some("Docker"))?;
+
+        // Assert that the actual and expected values are the same
+        assert_eq!(actual, expected);
+
+        Ok(())
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn test_containerenv_lxc_in_systemd() -> std::io::Result<()> {
+        let (actual, expected) = containerenv_systemd(Some("lxc"), Some("lxc"))?;
 
         // Assert that the actual and expected values are the same
         assert_eq!(actual, expected);


### PR DESCRIPTION
#### Description
Modified the return value of the container_name function in src/modules/container.rs to return the actual content of the /run/systemd/container file instead of Systemd. I left the wsl arm of the match in place.

#### Motivation and Context
I think this PR can fix #6787 

#### Screenshots (if appropriate):
-

#### How Has This Been Tested?
I created one more testcase named test_containerenv_lxc_in_systemd() and also tested it on a live Proxmox LXC system I have.
- [x] I have tested using **Linux**
- [x] I have tested using **Mac**

#### Checklist:
- [ ] I have updated the documentation accordingly.
       I could'nt find the appropriate place in the documentation, systemd is not mentioned as far as I see. Happy to update the documentation if that is needed!
- [ ] I have updated the tests accordingly.
