### PR TITLE
docs: Update Termux installation instructions

### DIFF
--- a/docs/installing/README.md
+++ b/docs/installing/README.md
@@ -27,16 +27,10 @@ choco install starship
 
 ## [termux](https://termux.com)
 
-### Prerequisites
-
-```sh
-pkg install getconf
-```
-
 ### Installation
 
 ```sh
-curl -sS https://starship.rs/install.sh | sh -s -- --bin-dir /data/data/com.termux/files/usr/bin
+pkg install starship
 ```
 
 ## [Funtoo Linux](https://www.funtoo.org/Welcome)


### PR DESCRIPTION
#### Description
Removed prerequisites for Termux installation and added direct starship installation command with `pkg`.

#### Motivation and Context
The package manager `pkg` of Termux supports starship.

#### Screenshots (if appropriate):
https://github.com/termux/termux-packages/tree/master/packages/starship

#### How Has This Been Tested?
* [ ]  I have tested using **MacOS**
* [ ]  I have tested using **Linux**
* [ ]  I have tested using **Windows**

#### Checklist:
* [x]  I have updated the documentation accordingly.
* [ ]  I have updated the tests accordingly.
