### PR TITLE
fix: show nothing on empty git status

### DIFF
--- a/src/modules/git_status.rs
+++ b/src/modules/git_status.rs
@@ -818,7 +818,7 @@ pub(crate) mod tests {
         let actual = ModuleRenderer::new("git_status")
             .config(toml::toml! {
                 [git_status]
-                format = r"rendered"
+                format = "rendered"
             })
             .path(repo_dir.path())
             .collect();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description

if i have below config:

```toml
[git_status]
format = 'there should not render when git status is empty ([$all_status$ahead_behind]($style))'
```

This is what i actually get:
<img width="1215" height="64" alt="image" src="https://github.com/user-attachments/assets/531168b1-4d91-4072-8237-8cbaa6ecf8eb" />

when git status is empty, then whole part should not render.

This PR fix this question.


#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
