### PR TITLE
feat: Modify mise module to add installed packages

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -1016,9 +1016,20 @@
     "mise": {
       "$ref": "#/$defs/MiseConfig",
       "default": {
-        "format": "on [$symbol$health]($style) ",
+        "local_only": true,
+        "health_check_enabled": false,
+        "format": "on [$symbol($status )($installed/$required )]($style)",
         "symbol": "mise ",
+        "healthy_symbol": "healthy",
+        "unhealthy_symbol": "unhealthy",
+        "untrusted_symbol": "untrusted",
+        "error_symbol": "error",
         "style": "bold purple",
+        "style_missing_some": "bold yellow",
+        "style_missing_all": "bold red",
+        "style_unhealthy": "bold red",
+        "style_untrusted": "bold red",
+        "style_error": "bold red",
         "disabled": true,
         "detect_extensions": [],
         "detect_files": [
@@ -1029,9 +1040,7 @@
         ],
         "detect_folders": [
           ".mise"
-        ],
-        "healthy_symbol": "healthy",
-        "unhealthy_symbol": "unhealthy"
+        ]
       }
     },
     "mojo": {
@@ -1758,24 +1767,20 @@
       }
     },
     "vcs": {
+      "$ref": "#/$defs/VcsConfig",
       "default": {
-        "disabled": false,
-        "fossil_modules": "$fossil_branch$fossil_metrics",
-        "git_modules": "$git_branch$git_commit$git_state$git_metrics$git_status",
-        "hg_modules": "$hg_branch$hg_state",
         "order": [
           "git",
           "hg",
           "pijul",
           "fossil"
         ],
+        "disabled": false,
+        "fossil_modules": "$fossil_branch$fossil_metrics",
+        "git_modules": "$git_branch$git_commit$git_state$git_metrics$git_status",
+        "hg_modules": "$hg_branch$hg_state",
         "pijul_modules": "$pijul_channel"
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/VcsConfig"
-        }
-      ]
+      }
     },
     "vcsh": {
       "$ref": "#/$defs/VcshConfig",
@@ -4587,17 +4592,61 @@
     "MiseConfig": {
       "type": "object",
       "properties": {
+        "local_only": {
+          "type": "boolean",
+          "default": true
+        },
+        "health_check_enabled": {
+          "type": "boolean",
+          "default": false
+        },
         "format": {
           "type": "string",
-          "default": "on [$symbol$health]($style) "
+          "default": "on [$symbol($status )($installed/$required )]($style)"
         },
         "symbol": {
           "type": "string",
           "default": "mise "
         },
+        "healthy_symbol": {
+          "type": "string",
+          "default": "healthy"
+        },
+        "unhealthy_symbol": {
+          "type": "string",
+          "default": "unhealthy"
+        },
+        "untrusted_symbol": {
+          "type": "string",
+          "default": "untrusted"
+        },
+        "error_symbol": {
+          "type": "string",
+          "default": "error"
+        },
         "style": {
           "type": "string",
           "default": "bold purple"
+        },
+        "style_missing_some": {
+          "type": "string",
+          "default": "bold yellow"
+        },
+        "style_missing_all": {
+          "type": "string",
+          "default": "bold red"
+        },
+        "style_unhealthy": {
+          "type": "string",
+          "default": "bold red"
+        },
+        "style_untrusted": {
+          "type": "string",
+          "default": "bold red"
+        },
+        "style_error": {
+          "type": "string",
+          "default": "bold red"
         },
         "disabled": {
           "type": "boolean",
@@ -4630,14 +4679,6 @@
           "default": [
             ".mise"
           ]
-        },
-        "healthy_symbol": {
-          "type": "string",
-          "default": "healthy"
-        },
-        "unhealthy_symbol": {
-          "type": "string",
-          "default": "unhealthy"
         }
       },
       "additionalProperties": false
@@ -6582,54 +6623,45 @@
       "type": "object",
       "properties": {
         "order": {
-          "description": "Order in which to discover VCSes. The first one found is the one used.",
+          "description": "Order in which to discover VCSes.\nThe first one found is the one used.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
           "default": [
             "git",
             "hg",
             "pijul",
             "fossil"
-          ],
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Vcs"
-          }
+          ]
         },
         "disabled": {
           "description": "Disables the VCS module.",
-          "default": false,
-          "type": "boolean"
+          "type": "boolean",
+          "default": false
         },
         "fossil_modules": {
           "description": "Modules to use when Fossil is matched.\n\nThey are configured separately at the top level.",
-          "default": "$fossil_branch$fossil_metrics",
-          "type": "string"
+          "type": "string",
+          "default": "$fossil_branch$fossil_metrics"
         },
         "git_modules": {
           "description": "Modules to use when Git is matched.\n\nThey are configured separately at the top level.",
-          "default": "$git_branch$git_commit$git_state$git_metrics$git_status",
-          "type": "string"
+          "type": "string",
+          "default": "$git_branch$git_commit$git_state$git_metrics$git_status"
         },
         "hg_modules": {
           "description": "Modules to use when Mercurial is matched.\n\nThey are configured separately at the top level.",
-          "default": "$hg_branch$hg_state",
-          "type": "string"
+          "type": "string",
+          "default": "$hg_branch$hg_state"
         },
         "pijul_modules": {
           "description": "Modules to use when Pijul is matched.\n\nThey are configured separately at the top level.",
-          "default": "$pijul_channel",
-          "type": "string"
+          "type": "string",
+          "default": "$pijul_channel"
         }
       },
       "additionalProperties": false
-    },
-    "Vcs": {
-      "type": "string",
-      "enum": [
-        "fossil",
-        "git",
-        "hg",
-        "pijul"
-      ]
     },
     "VcshConfig": {
       "type": "object",

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -3080,7 +3080,7 @@ _BISECTING_, etc.
 
 ## Mise
 
-The `mise` module shows the current mise health as reported by running `mise doctor`.
+The `mise` module shows the current [mise](https://mise.jdx.dev/) tool installation status by displaying the count of installed tools versus required tools. The module can optionally check mise health status.
 
 > [!TIP]
 > This module is disabled by default.
@@ -3088,27 +3088,39 @@ The `mise` module shows the current mise health as reported by running `mise doc
 
 ### Options
 
-| Option              | Default                                                              | Description                                      |
-| ------------------- | -------------------------------------------------------------------- | ------------------------------------------------ |
-| `symbol`            | `'mise '`                                                            | The symbol used before displaying _mise_ health. |
-| `style`             | `'bold purple'`                                                      | The style for the module.                        |
-| `format`            | `'on [$symbol$health]($style) '`                                     | The format for the module.                       |
-| `detect_extensions` | `[]`                                                                 | Which extensions should trigger this module.     |
-| `detect_files`      | `['mise.toml', 'mise.local.toml', '.mise.toml', '.mise.local.toml']` | Which filenames should trigger this module.      |
-| `detect_folders`    | `['.mise']`                                                          | Which folders should trigger this module.        |
-| `healthy_symbol`    | `healthy`                                                            | The message displayed when _mise_ is healthy.    |
-| `unhealthy_symbol`  | `unhealthy`                                                          | The message displayed when _mise_ is unhealthy.  |
-| `disabled`          | `true`                                                               | Disables the `mise` module.                      |
+| Option                 | Default                                                              | Description                                                          |
+| ---------------------- | -------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| `local_only`           | `true`                                                               | Only show tools from local mise configuration (adds `--local` flag). |
+| `health_check_enabled` | `false`                                                              | Enable health check (runs `mise doctor`).                            |
+| `format`               | `'on [$symbol($status )($installed/$required )]($style)'`            | The format for the module.                                           |
+| `symbol`               | `'mise '`                                                            | The symbol used before displaying the tool count.                    |
+| `healthy_symbol`       | `'healthy'`                                                          | The symbol displayed when mise is healthy.                           |
+| `unhealthy_symbol`     | `'unhealthy'`                                                        | The symbol displayed when mise is unhealthy.                         |
+| `error_symbol`         | `'error'`                                                            | The symbol displayed when mise encounters an error.                  |
+| `style`                | `'bold purple'`                                                      | The style used when all tools are installed.                         |
+| `style_missing_some`   | `'bold yellow'`                                                      | The style used when some tools are missing.                          |
+| `style_missing_all`    | `'bold red'`                                                         | The style used when no tools are installed.                          |
+| `style_unhealthy`      | `'bold red'`                                                         | The style used when mise is unhealthy.                               |
+| `style_untrusted`      | `'bold red'`                                                         | The style used when mise has a trust error.                          |
+| `style_error`          | `'bold red'`                                                         | The style used when mise errors.                                     |
+| `disabled`             | `true`                                                               | Disables the `mise` module.                                          |
+| `detect_extensions`    | `[]`                                                                 | Which extensions should trigger this module.                         |
+| `detect_files`         | `['mise.toml', 'mise.local.toml', '.mise.toml', '.mise.local.toml']` | Which filenames should trigger this module.                          |
+| `detect_folders`       | `['.mise']`                                                          | Which folders should trigger this module.                            |
 
 ### Variables
 
-| Variable | Example   | Description                          |
-| -------- | --------- | ------------------------------------ |
-| health   | `healthy` | The health of _mise_                 |
-| symbol   |           | Mirrors the value of option `symbol` |
-| style\*  |           | Mirrors the value of option `style`  |
+| Variable  | Example                                      | Description                                                |
+| --------- | -------------------------------------------- | ---------------------------------------------------------- |
+| status    | `healthy`, `unhealthy`, `untrusted`, `error` | The status of the `mise` configuration.                    |
+| installed | 2                                            | The number of tools that are currently installed.          |
+| required  | 3                                            | The number of tools that are required to be installed.     |
+| symbol    |                                              | Mirrors the value of option `symbol`                       |
+| style\*   |                                              | Mirrors the value of option `style` (dynamically selected) |
 
 *: This variable can only be used as a part of a style string
+
+The module will not be displayed if no tools are configured (required count is 0).
 
 ### Example
 
@@ -3116,7 +3128,30 @@ The `mise` module shows the current mise health as reported by running `mise doc
 # ~/.config/starship.toml
 
 [mise]
-health = 'ready'
+disabled = false
+```
+
+Display with health check enabled:
+
+```toml
+# ~/.config/starship.toml
+
+[mise]
+disabled = false
+healthy_enabled = true
+healthy_symbol = '✓ '
+unhealthy_symbol = '✗ '
+format = 'on [$symbol$health_status$tool_status]($style)'
+```
+
+Include global tools (not just local):
+
+```toml
+# ~/.config/starship.toml
+
+[mise]
+disabled = false
+local_only = false
 ```
 
 ## Mojo

--- a/src/configs/mise.rs
+++ b/src/configs/mise.rs
@@ -8,23 +8,43 @@ use serde::{Deserialize, Serialize};
 )]
 #[serde(default)]
 pub struct MiseConfig<'a> {
+    pub local_only: bool,
+    pub health_check_enabled: bool,
     pub format: &'a str,
     pub symbol: &'a str,
+    pub healthy_symbol: &'a str,
+    pub unhealthy_symbol: &'a str,
+    pub untrusted_symbol: &'a str,
+    pub error_symbol: &'a str,
     pub style: &'a str,
+    pub style_missing_some: &'a str,
+    pub style_missing_all: &'a str,
+    pub style_unhealthy: &'a str,
+    pub style_untrusted: &'a str,
+    pub style_error: &'a str,
     pub disabled: bool,
     pub detect_extensions: Vec<&'a str>,
     pub detect_files: Vec<&'a str>,
     pub detect_folders: Vec<&'a str>,
-    pub healthy_symbol: &'a str,
-    pub unhealthy_symbol: &'a str,
 }
 
 impl Default for MiseConfig<'_> {
     fn default() -> Self {
         Self {
-            format: "on [$symbol$health]($style) ",
+            local_only: true,
+            health_check_enabled: false,
+            format: "on [$symbol($status )($installed/$required )]($style)",
             symbol: "mise ",
+            healthy_symbol: "healthy",
+            unhealthy_symbol: "unhealthy",
+            untrusted_symbol: "untrusted",
+            error_symbol: "error",
             style: "bold purple",
+            style_missing_some: "bold yellow",
+            style_missing_all: "bold red",
+            style_unhealthy: "bold red",
+            style_untrusted: "bold red",
+            style_error: "bold red",
             disabled: true,
             detect_extensions: vec![],
             detect_files: vec![
@@ -34,8 +54,6 @@ impl Default for MiseConfig<'_> {
                 ".mise.local.toml",
             ],
             detect_folders: vec![".mise"],
-            healthy_symbol: "healthy",
-            unhealthy_symbol: "unhealthy",
         }
     }
 }

--- a/src/modules/mise.rs
+++ b/src/modules/mise.rs
@@ -1,7 +1,106 @@
+use std::collections::HashMap;
+
 use super::{Context, Module, ModuleConfig};
 
 use crate::configs::mise::MiseConfig;
 use crate::formatter::StringFormatter;
+use serde::Deserialize;
+
+type MiseTools = HashMap<String, Vec<MiseToolInfo>>;
+
+#[derive(Deserialize, Debug)]
+struct MiseToolInfo {
+    // version: String,
+    // requested_version: String,
+    // install_path: PathBuf,
+    // source: MiseSource, (type: String, path: PathBuf)
+    installed: bool,
+    // active: bool,
+}
+
+/// Represents the state of mise that will be displayed
+#[derive(Debug)]
+enum MiseState {
+    /// Tools installed / required
+    Ok { installed: usize, required: usize },
+    /// Mise configuration is untrusted
+    Untrusted,
+    /// General error with mise
+    Error,
+    /// Mise doctor reports unhealthy
+    Unhealthy,
+}
+
+/// Check if mise is healthy using `mise doctor`
+/// Returns true if healthy, false if unhealthy or command fails
+fn check_mise_health(context: &Context) -> bool {
+    context.exec_cmd("mise", &["doctor"]).is_some()
+}
+
+/// Check if the current directory's mise config is trusted
+/// Returns Some(true) if trusted, Some(false) if untrusted, None if unable to determine
+fn check_mise_trust(context: &Context) -> Option<bool> {
+    let output = context.exec_cmd("mise", &["trust", "--show"])?;
+
+    // Expected format: "<path>: <status>"
+    // where status is "trusted" or "untrusted"
+    let stdout = output.stdout.trim();
+
+    // Parse the trust status
+    if let Some((_, status)) = stdout.rsplit_once(':') {
+        let status = status.trim();
+        return Some(status == "trusted");
+    }
+
+    None
+}
+
+/// Get the count of installed vs required tools from mise
+/// Returns (required_count, installed_count) or None if unable to parse
+fn get_tool_counts(context: &Context, local_only: bool) -> Option<(usize, usize)> {
+    // Build the mise ls command with appropriate flags
+    let mut args = vec!["ls", "--current", "--json"];
+    if local_only {
+        args.push("--local");
+    }
+
+    // Execute mise ls command and parse the output
+    let output = context.exec_cmd("mise", &args)?;
+    let tools: MiseTools = serde_json::from_str(&output.stdout).ok()?;
+
+    let (required_count, installed_count) = tools
+        .values()
+        .flatten()
+        .fold((0, 0), |(required, installed), tool_info| {
+            (required + 1, installed + tool_info.installed as usize)
+        });
+
+    Some((required_count, installed_count))
+}
+
+/// Determine the current state of mise
+/// This function orchestrates the health check, trust check, and tool counting
+fn determine_mise_state(context: &Context, config: &MiseConfig) -> Option<MiseState> {
+    // If health check is enabled, check health first
+    // If unhealthy, don't proceed with tool counting
+    if config.health_check_enabled && !check_mise_health(context) {
+        return Some(MiseState::Unhealthy);
+    }
+
+    // Try to get tool counts. If this fails, it might be due to trust issues or other errors
+    match get_tool_counts(context, config.local_only) {
+        Some((required, installed)) => Some(MiseState::Ok {
+            installed,
+            required,
+        }),
+        // Check if it's a trust issue
+        None => match check_mise_trust(context) {
+            Some(false) => Some(MiseState::Untrusted),
+            Some(true) => Some(MiseState::Error), // Trusted but still failed
+            None => Some(MiseState::Error),       // Can't determine trust status
+        },
+    }
+}
 
 /// Creates a module with the current mise config
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
@@ -20,18 +119,60 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         return None;
     }
 
+    let state = determine_mise_state(context, &config)?;
+    log::trace!("mise state: {:?}", &state);
+
+    if let MiseState::Ok { required: 0, .. } = state
+        && !config.health_check_enabled
+    {
+        // When healthy is disabled and there are no required versions, we don't want to show the module at all
+        log::trace!("no required versions, and no health check enabled - returning None");
+        return None;
+    }
+
+    let selected_style = match &state {
+        MiseState::Ok {
+            installed,
+            required,
+        } if installed >= required => config.style,
+        MiseState::Ok { installed: 0, .. } => config.style_missing_all,
+        MiseState::Ok { .. } => config.style_missing_some,
+        MiseState::Unhealthy => config.style_unhealthy,
+        MiseState::Untrusted => config.style_untrusted,
+        MiseState::Error => config.style_error,
+    };
+    log::trace!("style: {:?}", selected_style);
+
+    let status: Option<String> = match &state {
+        MiseState::Ok { .. } if config.health_check_enabled => Some(config.healthy_symbol.into()),
+        MiseState::Ok { .. } => None,
+        MiseState::Unhealthy => Some(config.unhealthy_symbol.into()),
+        MiseState::Untrusted => Some(config.untrusted_symbol.into()),
+        MiseState::Error => Some(config.error_symbol.into()),
+    };
+    log::trace!("status: {:?}", status);
+
+    let (installed, required) = match &state {
+        MiseState::Ok {
+            installed,
+            required,
+        } if *required > 0 => (Some(installed.to_string()), Some(required.to_string())),
+        _ => (None, None),
+    };
+    log::trace!("installed: {:?}", installed);
+    log::trace!("required : {:?}", required);
+
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter
             .map_style(|variable| match variable {
-                "style" => Some(Ok(config.style)),
+                "style" => Some(Ok(selected_style)),
                 _ => None,
             })
             .map(|variable| match variable {
-                "symbol" => Some(Ok(config.symbol)),
-                "health" => match context.exec_cmd("mise", &["doctor"]) {
-                    Some(_) => Some(Ok(config.healthy_symbol)),
-                    None => Some(Ok(config.unhealthy_symbol)),
-                },
+                "symbol" => Some(Ok(config.symbol.to_string())),
+                "status" => status.as_ref().map(|s| Ok(s.clone())),
+                "installed" => installed.as_ref().map(|s| Ok(s.clone())),
+                "required" => required.as_ref().map(|s| Ok(s.clone())),
                 _ => None,
             })
             .parse(None, Some(context))
@@ -40,8 +181,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     module.set_segments(match parsed {
         Ok(segments) => segments,
         Err(e) => {
-            log::warn!("{e}");
-
+            log::warn!("error in module `mise`: {e}");
             return None;
         }
     });
@@ -68,7 +208,7 @@ mod tests {
     }
 
     #[test]
-    fn folder_with_mise_config_file_healthy() -> io::Result<()> {
+    fn folder_with_mise_config_all_installed() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         let config_path = dir.path().join(".mise.toml");
 
@@ -81,24 +221,189 @@ mod tests {
                 disabled = false
             })
             .cmd(
-                "mise doctor",
+                "mise ls --current --json --local",
                 Some(CommandOutput {
-                    stdout: String::default(),
+                    stdout: String::from(
+                        r#"{
+                            "node": [
+                                {
+                                    "version": "20.0.0",
+                                    "requested_version": "lts",
+                                    "install_path": "/home/user/.local/share/mise/installs/node/20.0.0",
+                                    "source": {
+                                        "type": "mise.toml",
+                                        "url": "/home/user/.config/mise/mise.toml"
+                                    },
+                                    "installed": true,
+                                    "active": true
+                                }
+                            ],
+                            "python": [
+                                {
+                                    "version": "3.11.0",
+                                    "requested_version": "latest",
+                                    "install_path": "/home/user/.local/share/mise/installs/python/3.11.0",
+                                    "source": {
+                                        "type": "mise.toml",
+                                        "url": "/home/user/.config/mise/mise.toml"
+                                    },
+                                    "installed": true,
+                                    "active": true
+                                }
+                            ]
+                        }"#,
+                    ),
                     stderr: String::default(),
                 }),
             );
 
-        let expected = Some(format!(
-            "on {} ",
-            Color::Purple.bold().paint("mise healthy")
-        ));
+        let expected = Some(format!("on {}", Color::Purple.bold().paint("mise 2/2 ")));
         assert_eq!(expected, renderer.collect());
 
         dir.close()
     }
 
     #[test]
-    fn folder_with_mise_config_folder_healthy() -> io::Result<()> {
+    fn folder_with_mise_config_some_installed() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let config_path = dir.path().join(".mise.toml");
+
+        std::fs::File::create(config_path)?.sync_all()?;
+
+        let renderer = ModuleRenderer::new("mise")
+            .path(dir.path())
+            .config(toml::toml! {
+                [mise]
+                disabled = false
+            })
+            .cmd(
+                "mise ls --current --json --local",
+                Some(CommandOutput {
+                    stdout: String::from(
+                        r#"{
+                            "node": [
+                                {
+                                    "version": "20.0.0",
+                                    "requested_version": "lts",
+                                    "install_path": "/home/user/.local/share/mise/installs/node/20.0.0",
+                                    "source": {
+                                        "type": "mise.toml",
+                                        "url": "/home/user/.config/mise/mise.toml"
+                                    },
+                                    "installed": true,
+                                    "active": true
+                                }
+                            ],
+                            "python": [
+                                {
+                                    "version": "3.11.0",
+                                    "requested_version": "latest",
+                                    "install_path": "/home/user/.local/share/mise/installs/python/3.11.0",
+                                    "source": {
+                                        "type": "mise.toml",
+                                        "url": "/home/user/.config/mise/mise.toml"
+                                    },
+                                    "installed": false,
+                                    "active": false
+                                }
+                            ]
+                        }"#,
+                    ),
+                    stderr: String::default(),
+                }),
+            );
+
+        let expected = Some(format!("on {}", Color::Yellow.bold().paint("mise 1/2 ")));
+        assert_eq!(expected, renderer.collect());
+
+        dir.close()
+    }
+
+    #[test]
+    fn folder_with_mise_config_none_installed() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let config_path = dir.path().join(".mise.toml");
+
+        std::fs::File::create(config_path)?.sync_all()?;
+
+        let renderer = ModuleRenderer::new("mise")
+            .path(dir.path())
+            .config(toml::toml! {
+                [mise]
+                disabled = false
+            })
+            .cmd(
+                "mise ls --current --json --local",
+                Some(CommandOutput {
+                    stdout: String::from(
+                        r#"{
+                            "node": [
+                                {
+                                    "version": "20.0.0",
+                                    "requested_version": "lts",
+                                    "install_path": "/home/user/.local/share/mise/installs/node/20.0.0",
+                                    "source": {
+                                        "type": "mise.toml",
+                                        "url": "/home/user/.config/mise/mise.toml"
+                                    },
+                                    "installed": false,
+                                    "active": false
+                                }
+                            ],
+                            "python": [
+                                {
+                                    "version": "3.11.0",
+                                    "requested_version": "latest",
+                                    "install_path": "/home/user/.local/share/mise/installs/python/3.11.0",
+                                    "source": {
+                                        "type": "mise.toml",
+                                        "url": "/home/user/.config/mise/mise.toml"
+                                    },
+                                    "installed": false,
+                                    "active": false
+                                }
+                            ]
+                        }"#,
+                    ),
+                    stderr: String::default(),
+                }),
+            );
+
+        let expected = Some(format!("on {}", Color::Red.bold().paint("mise 0/2 ")));
+        assert_eq!(expected, renderer.collect());
+
+        dir.close()
+    }
+
+    #[test]
+    fn folder_with_mise_config_no_tools() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let config_path = dir.path().join(".mise.toml");
+
+        std::fs::File::create(config_path)?.sync_all()?;
+
+        let renderer = ModuleRenderer::new("mise")
+            .path(dir.path())
+            .config(toml::toml! {
+                [mise]
+                disabled = false
+            })
+            .cmd(
+                "mise ls --current --json --local",
+                Some(CommandOutput {
+                    stdout: String::from("{}"),
+                    stderr: String::default(),
+                }),
+            );
+
+        // Should return None when no tools are configured
+        assert_eq!(None, renderer.collect());
+
+        dir.close()
+    }
+
+    #[test]
+    fn folder_with_mise_config_folder() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         let config_dir = dir.path().join(".mise");
 
@@ -111,24 +416,81 @@ mod tests {
                 disabled = false
             })
             .cmd(
-                "mise doctor",
+                "mise ls --current --json --local",
                 Some(CommandOutput {
-                    stdout: String::default(),
+                    stdout: String::from(
+                        r#"{
+                            "ruby": [
+                                {
+                                    "version": "3.2.0",
+                                    "requested_version": "latest",
+                                    "install_path": "/home/user/.local/share/mise/installs/ruby/3.2.0",
+                                    "source": {
+                                        "type": "mise.toml",
+                                        "url": "/home/user/.config/mise/mise.toml"
+                                    },
+                                    "installed": true,
+                                    "active": true
+                                }
+                            ]
+                        }"#,
+                    ),
                     stderr: String::default(),
                 }),
             );
 
-        let expected = Some(format!(
-            "on {} ",
-            Color::Purple.bold().paint("mise healthy")
-        ));
+        let expected = Some(format!("on {}", Color::Purple.bold().paint("mise 1/1 ")));
         assert_eq!(expected, renderer.collect());
 
         dir.close()
     }
 
     #[test]
-    fn folder_with_mise_config_file_unhealthy() -> io::Result<()> {
+    fn folder_with_mise_config_local_only_false() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let config_path = dir.path().join(".mise.toml");
+
+        std::fs::File::create(config_path)?.sync_all()?;
+
+        let renderer = ModuleRenderer::new("mise")
+            .path(dir.path())
+            .config(toml::toml! {
+                [mise]
+                disabled = false
+                local_only = false
+            })
+            .cmd(
+                "mise ls --current --json",
+                Some(CommandOutput {
+                    stdout: String::from(
+                        r#"{
+                            "ruby": [
+                                {
+                                    "version": "3.2.0",
+                                    "requested_version": "latest",
+                                    "install_path": "/home/user/.local/share/mise/installs/ruby/3.2.0",
+                                    "source": {
+                                        "type": "mise.toml",
+                                        "url": "/home/user/.config/mise/mise.toml"
+                                    },
+                                    "installed": true,
+                                    "active": true
+                                }
+                            ]
+                        }"#,
+                    ),
+                    stderr: String::default(),
+                }),
+            );
+
+        let expected = Some(format!("on {}", Color::Purple.bold().paint("mise 1/1 ")));
+        assert_eq!(expected, renderer.collect());
+
+        dir.close()
+    }
+
+    #[test]
+    fn folder_with_mise_config_untrusted() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         let config_path = dir.path().join(".mise.toml");
 
@@ -140,12 +502,211 @@ mod tests {
                 [mise]
                 disabled = false
             })
-            .cmd("mise doctor", None);
+            .cmd("mise ls --current --json --local", None)
+            .cmd(
+                "mise trust --show",
+                Some(CommandOutput {
+                    stdout: format!("{}: untrusted", dir.path().display()),
+                    stderr: String::default(),
+                }),
+            );
+
+        let expected = Some(format!("on {}", Color::Red.bold().paint("mise untrusted ")));
+        assert_eq!(expected, renderer.collect());
+
+        dir.close()
+    }
+
+    #[test]
+    fn folder_with_mise_config_error() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let config_path = dir.path().join(".mise.toml");
+
+        std::fs::File::create(config_path)?.sync_all()?;
+
+        let renderer = ModuleRenderer::new("mise")
+            .path(dir.path())
+            .config(toml::toml! {
+                [mise]
+                disabled = false
+            })
+            .cmd("mise ls --current --json --local", None)
+            .cmd("mise trust --show", None);
+
+        let expected = Some(format!("on {}", Color::Red.bold().paint("mise error ")));
+        assert_eq!(expected, renderer.collect());
+
+        dir.close()
+    }
+
+    #[test]
+    fn folder_with_mise_config_health_check_enabled_healthy() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let config_path = dir.path().join(".mise.toml");
+
+        std::fs::File::create(config_path)?.sync_all()?;
+
+        let renderer = ModuleRenderer::new("mise")
+            .path(dir.path())
+            .config(toml::toml! {
+                [mise]
+                disabled = false
+                health_check_enabled = true
+            })
+            .cmd(
+                "mise doctor",
+                Some(CommandOutput {
+                    stdout: String::default(),
+                    stderr: String::default(),
+                }),
+            )
+            .cmd(
+                "mise ls --current --json --local",
+                Some(CommandOutput {
+                    stdout: String::from(
+                        r#"{
+                            "node": [
+                                {
+                                    "version": "20.0.0",
+                                    "requested_version": "lts",
+                                    "install_path": "/home/user/.local/share/mise/installs/node/20.0.0",
+                                    "source": {
+                                        "type": "mise.toml",
+                                        "url": "/home/user/.config/mise/mise.toml"
+                                    },
+                                    "installed": true,
+                                    "active": true
+                                }
+                            ]
+                        }"#,
+                    ),
+                    stderr: String::default(),
+                }),
+            );
 
         let expected = Some(format!(
-            "on {} ",
-            Color::Purple.bold().paint("mise unhealthy")
+            "on {}",
+            Color::Purple.bold().paint("mise healthy 1/1 ")
         ));
+        assert_eq!(expected, renderer.collect());
+
+        dir.close()
+    }
+
+    #[test]
+    fn folder_with_mise_config_health_check_enabled_unhealthy() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let config_path = dir.path().join(".mise.toml");
+
+        std::fs::File::create(config_path)?.sync_all()?;
+
+        let renderer = ModuleRenderer::new("mise")
+            .path(dir.path())
+            .config(toml::toml! {
+                [mise]
+                disabled = false
+                health_check_enabled = true
+            })
+            .cmd("mise doctor", None);
+
+        let expected = Some(format!("on {}", Color::Red.bold().paint("mise unhealthy ")));
+        assert_eq!(expected, renderer.collect());
+
+        dir.close()
+    }
+
+    #[test]
+    fn folder_with_mise_config_health_check_enabled_healthy_no_tools() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let config_path = dir.path().join(".mise.toml");
+
+        std::fs::File::create(config_path)?.sync_all()?;
+
+        let renderer = ModuleRenderer::new("mise")
+            .path(dir.path())
+            .config(toml::toml! {
+                [mise]
+                disabled = false
+                health_check_enabled = true
+            })
+            .cmd(
+                "mise doctor",
+                Some(CommandOutput {
+                    stdout: String::default(),
+                    stderr: String::default(),
+                }),
+            )
+            .cmd(
+                "mise ls --current --json --local",
+                Some(CommandOutput {
+                    stdout: "{}".into(),
+                    stderr: String::default(),
+                }),
+            );
+
+        let expected = Some(format!(
+            "on {}",
+            Color::Purple.bold().paint("mise healthy ")
+        ));
+        assert_eq!(expected, renderer.collect());
+
+        dir.close()
+    }
+
+    #[test]
+    fn folder_with_mise_config_custom_unhealthy_symbol() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let config_path = dir.path().join(".mise.toml");
+
+        std::fs::File::create(config_path)?.sync_all()?;
+
+        let renderer = ModuleRenderer::new("mise")
+            .path(dir.path())
+            .config(toml::toml! {
+                [mise]
+                disabled = false
+                health_check_enabled = true
+                unhealthy_symbol = "💀"
+            })
+            .cmd("mise doctor", None);
+
+        let expected = Some(format!("on {}", Color::Red.bold().paint("mise 💀 ")));
+        assert_eq!(expected, renderer.collect());
+
+        dir.close()
+    }
+
+    #[test]
+    fn folder_with_mise_config_custom_healthy_symbol() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let config_path = dir.path().join(".mise.toml");
+
+        std::fs::File::create(config_path)?.sync_all()?;
+
+        let renderer = ModuleRenderer::new("mise")
+            .path(dir.path())
+            .config(toml::toml! {
+                [mise]
+                disabled = false
+                health_check_enabled = true
+                healthy_symbol = "✅"
+            })
+            .cmd(
+                "mise doctor",
+                Some(CommandOutput {
+                    stdout: String::default(),
+                    stderr: String::default(),
+                }),
+            )
+            .cmd(
+                "mise ls --current --json --local",
+                Some(CommandOutput {
+                    stdout: "{}".into(),
+                    stderr: String::default(),
+                }),
+            );
+
+        let expected = Some(format!("on {}", Color::Purple.bold().paint("mise ✅ ")));
         assert_eq!(expected, renderer.collect());
 
         dir.close()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Currently the mise module is a simple healthy/unhealthy check. This is useful but it would be nice to have the number of tools installed.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
It's nice to have more information :)

Wasn't sure whether to add a separate color for just the X/Y part, or the whole mise X/Y. I did the whole text as I think that's what the current tools do, but I'm not sure - up for changing.

#### Screenshots (if appropriate):
Before:
<img width="572" height="71" alt="image" src="https://github.com/user-attachments/assets/247bb924-b6e1-4111-b735-fd84152dc8c6" />

After:
<img width="582" height="32" alt="image" src="https://github.com/user-attachments/assets/c08ab142-eb9f-467c-b3da-9d0186ddef8c" />

<img width="586" height="35" alt="image" src="https://github.com/user-attachments/assets/901596d3-daf0-4b64-adcb-bc019a5ce081" />

<img width="583" height="35" alt="image" src="https://github.com/user-attachments/assets/0de77052-ca42-4af7-b627-22d083083b08" />

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
