### PR TITLE
fix: correctly use platform-specific cache directories; respect `$XDG_CACHE_HOME` on Linux

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -1777,24 +1777,20 @@
       }
     },
     "vcs": {
+      "$ref": "#/$defs/VcsConfig",
       "default": {
-        "disabled": false,
-        "fossil_modules": "$fossil_branch$fossil_metrics",
-        "git_modules": "$git_branch$git_commit$git_state$git_metrics$git_status",
-        "hg_modules": "$hg_branch$hg_state",
         "order": [
           "git",
           "hg",
           "pijul",
           "fossil"
         ],
+        "disabled": false,
+        "fossil_modules": "$fossil_branch$fossil_metrics",
+        "git_modules": "$git_branch$git_commit$git_state$git_metrics$git_status",
+        "hg_modules": "$hg_branch$hg_state",
         "pijul_modules": "$pijul_channel"
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/VcsConfig"
-        }
-      ]
+      }
     },
     "vcsh": {
       "$ref": "#/$defs/VcshConfig",
@@ -6696,54 +6692,45 @@
       "type": "object",
       "properties": {
         "order": {
-          "description": "Order in which to discover VCSes. The first one found is the one used.",
+          "description": "Order in which to discover VCSes.\nThe first one found is the one used.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
           "default": [
             "git",
             "hg",
             "pijul",
             "fossil"
-          ],
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Vcs"
-          }
+          ]
         },
         "disabled": {
           "description": "Disables the VCS module.",
-          "default": false,
-          "type": "boolean"
+          "type": "boolean",
+          "default": false
         },
         "fossil_modules": {
           "description": "Modules to use when Fossil is matched.\n\nThey are configured separately at the top level.",
-          "default": "$fossil_branch$fossil_metrics",
-          "type": "string"
+          "type": "string",
+          "default": "$fossil_branch$fossil_metrics"
         },
         "git_modules": {
           "description": "Modules to use when Git is matched.\n\nThey are configured separately at the top level.",
-          "default": "$git_branch$git_commit$git_state$git_metrics$git_status",
-          "type": "string"
+          "type": "string",
+          "default": "$git_branch$git_commit$git_state$git_metrics$git_status"
         },
         "hg_modules": {
           "description": "Modules to use when Mercurial is matched.\n\nThey are configured separately at the top level.",
-          "default": "$hg_branch$hg_state",
-          "type": "string"
+          "type": "string",
+          "default": "$hg_branch$hg_state"
         },
         "pijul_modules": {
           "description": "Modules to use when Pijul is matched.\n\nThey are configured separately at the top level.",
-          "default": "$pijul_channel",
-          "type": "string"
+          "type": "string",
+          "default": "$pijul_channel"
         }
       },
       "additionalProperties": false
-    },
-    "Vcs": {
-      "type": "string",
-      "enum": [
-        "fossil",
-        "git",
-        "hg",
-        "pijul"
-      ]
     },
     "VcshConfig": {
       "type": "object",

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -46,7 +46,14 @@ os.setenv('STARSHIP_CONFIG', 'C:\\Users\\user\\example\\non\\default\\path\\star
 
 ### Logging
 
-By default starship logs warnings and errors into a file named `~/.cache/starship/session_${STARSHIP_SESSION_KEY}.log`, where the session key is corresponding to an instance of your terminal.
+Starship logs warnings and errors into files named `session_${STARSHIP_SESSION_KEY}.log`, where `STARSHIP_SESSION_KEY` corresponds to an instance of your terminal.
+
+These files are stored in platform-specific cache directories:
+
+- Linux: `XDG_CACHE_HOME` (if set) or `~/.cache/starship` (default)
+- macOS: `~/Library/Caches/starship`
+- Windows: `~/AppData/Local/starship`
+
 This, however can be changed using the `STARSHIP_CACHE` environment variable:
 
 ```sh

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -21,15 +21,21 @@ pub struct StarshipLogger {
 
 /// Returns the path to the log directory.
 pub fn get_log_dir() -> PathBuf {
-    env::var_os("STARSHIP_CACHE")
+    let log_dir = env::var_os("STARSHIP_CACHE")
         .map(PathBuf::from)
-        .unwrap_or_else(|| {
-            utils::home_dir()
-                .map(|home| home.join(".cache"))
-                .or_else(dirs::cache_dir)
-                .unwrap_or_else(std::env::temp_dir)
-                .join("starship")
-        })
+        .or_else(dirs::cache_dir)
+        .unwrap_or_else(std::env::temp_dir)
+        .join("starship");
+
+    if !log_dir.exists()
+        && let Some(home_dir) = utils::home_dir()
+    {
+        let old_log_dir = home_dir.join(".cache/starship");
+        let _ = fs::create_dir_all(&log_dir);
+        let _ = fs::rename(&old_log_dir, &log_dir);
+    }
+
+    log_dir
 }
 
 /// Deletes all log files in the log directory that were modified more than 24 hours ago.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
The default config cache home `~/.cache` can now be overriden by `XDG_CACHE_HOME`.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
While the current cache file location is standard in some platform, it is not objectively cross-platform. Adding support for `XDG_CACHE_HOME` solves this issue _without_ introducing any complexity of different locations.
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #6672

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
