### PR TITLE
Revert "fix: consider text-only meta variables in conditionals set if non-empty (#6338)"

### DIFF
--- a/src/modules/shell.rs
+++ b/src/modules/shell.rs
@@ -407,21 +407,22 @@ mod tests {
         assert_eq!(expected, actual);
     }
 
-    #[test]
-    fn test_custom_format_conditional_indicator_no_match() {
-        let expected = None;
-        let actual = ModuleRenderer::new("shell")
-            .shell(Shell::Fish)
-            .config(toml::toml! {
-                [shell]
-                fish_indicator = ""
-                format = "($indicator )"
-                disabled = false
-            })
-            .collect();
+    // Known issue #3409,
+    // #[test]
+    // fn test_custom_format_conditional_indicator_no_match() {
+    //     let expected = None;
+    //     let actual = ModuleRenderer::new("shell")
+    //         .shell(Shell::Fish)
+    //         .config(toml::toml! {
+    //             [shell]
+    //             fish_indicator = ""
+    //             format = "($indicator )"
+    //             disabled = false
+    //         })
+    //         .collect();
 
-        assert_eq!(expected, actual);
-    }
+    //     assert_eq!(expected, actual);
+    // }
 
     #[test]
     fn test_default_style() {


### PR DESCRIPTION
This reverts commit 286b0f2be30db81bc948579c137f0cc646fcde65.

<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
The #6338 PR some fallout, so I would suggest reverting it. E.g. the no-empty-icon preset was broken with #6338 applied.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #7077

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
