### PR TITLE
feat: blank-fill module

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -105,6 +105,12 @@
         "format": "[$symbol$percentage]($style) "
       }
     },
+    "blank_fill": {
+      "$ref": "#/$defs/BlankFillConfig",
+      "default": {
+        "disabled": false
+      }
+    },
     "buf": {
       "$ref": "#/$defs/BufConfig",
       "default": {
@@ -1967,6 +1973,16 @@
             "null"
           ],
           "default": null
+        }
+      },
+      "additionalProperties": false
+    },
+    "BlankFillConfig": {
+      "type": "object",
+      "properties": {
+        "disabled": {
+          "type": "boolean",
+          "default": false
         }
       },
       "additionalProperties": false

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1674,6 +1674,35 @@ Produces a prompt that looks like:
 AA -------------------------------------------- BB -------------------------------------------- CC
 ```
 
+## Blank Fill
+
+The `blank_fill` module fills any extra space on the line with specifically empty space. If multiple `blank_fill` modules are
+present in a line they will split the space evenly between them. This is useful for aligning
+other modules.
+
+### Options
+
+| Option     | Default | Description                      |
+| ---------- | ------- | -------------------------------- |
+| `disabled` | `false` | Disables the `blank_fill` module |
+
+### Example
+
+```toml
+# ~/.config/starship.toml
+format = 'AA $blank_fill BB $blank_fill CC'
+
+[blank_fill]
+symbol = '-'
+style = 'bold green'
+```
+
+Produces a prompt that looks like:
+
+```
+AA                                              BB                                              CC
+```
+
 ## Fortran
 
 The `fortran` module shows the current compiler version of Fortran.

--- a/docs/public/presets/toml/jetpack.toml
+++ b/docs/public/presets/toml/jetpack.toml
@@ -3,7 +3,7 @@
 add_newline = true
 continuation_prompt = "[▸▹ ](dimmed white)"
 
-format = """($nix_shell$container$fill$git_metrics\n)$cmd_duration\
+format = """($nix_shell$container$blank_fill$git_metrics\n)$cmd_duration\
 $hostname\
 $localip\
 $shlvl\
@@ -89,9 +89,6 @@ $status\
 $os\
 $battery\
 $time"""
-
-[fill]
-symbol = ' '
 
 [character]
 format = "$symbol "

--- a/src/configs/blank_fill.rs
+++ b/src/configs/blank_fill.rs
@@ -1,0 +1,18 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(
+    feature = "config-schema",
+    derive(schemars::JsonSchema),
+    schemars(deny_unknown_fields)
+)]
+#[serde(default)]
+pub struct BlankFillConfig {
+    pub disabled: bool,
+}
+
+impl Default for BlankFillConfig {
+    fn default() -> Self {
+        Self { disabled: false }
+    }
+}

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -4,6 +4,7 @@ use serde::{self, Deserialize, Serialize};
 pub mod aws;
 pub mod azure;
 pub mod battery;
+pub mod blank_fill;
 pub mod buf;
 pub mod bun;
 pub mod c;
@@ -128,6 +129,7 @@ pub struct FullConfig<'a> {
     azure: azure::AzureConfig<'a>,
     #[serde(borrow)]
     battery: battery::BatteryConfig<'a>,
+    blank_fill: blank_fill::BlankFillConfig,
     #[serde(borrow)]
     buf: buf::BufConfig<'a>,
     #[serde(borrow)]

--- a/src/module.rs
+++ b/src/module.rs
@@ -11,6 +11,7 @@ pub const ALL_MODULES: &[&str] = &[
     "azure",
     #[cfg(feature = "battery")]
     "battery",
+    "blank_fill",
     "buf",
     "bun",
     "c",

--- a/src/modules/blank_fill.rs
+++ b/src/modules/blank_fill.rs
@@ -1,0 +1,45 @@
+use super::{Context, Module};
+
+use crate::config::ModuleConfig;
+use crate::configs::blank_fill::BlankFillConfig;
+use crate::segment::Segment;
+
+/// Creates a module that fills space with a single blank.
+///
+pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let mut module = context.new_module("blank_fill");
+    let config: BlankFillConfig = BlankFillConfig::try_load(module.config);
+
+    if config.disabled {
+        return None;
+    }
+
+    // no style, no configurable symbol — just one space
+    module.set_segments(vec![Segment::fill(None, " ")]);
+
+    Some(module)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::ModuleRenderer;
+
+    #[test]
+    fn basic() {
+        let actual = ModuleRenderer::new("blank_fill").collect();
+        let expected = Some(" ".to_string());
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn module_disabled() {
+        let actual = ModuleRenderer::new("blank_fill")
+            .config(toml::toml! {
+                [blank_fill]
+                disabled = true
+            })
+            .collect();
+        let expected = Option::<String>::None;
+        assert_eq!(expected, actual);
+    }
+}

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -1,6 +1,7 @@
 // While adding out new module add out module to src/module.rs ALL_MODULES const array also.
 mod aws;
 mod azure;
+mod blank_fill;
 mod buf;
 mod bun;
 mod c;
@@ -123,6 +124,7 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
             "azure" => azure::module(context),
             #[cfg(feature = "battery")]
             "battery" => battery::module(context),
+            "blank_fill" => blank_fill::module(context),
             "buf" => buf::module(context),
             "bun" => bun::module(context),
             "c" => c::module(context),
@@ -253,6 +255,7 @@ pub fn description(module: &str) -> &'static str {
         "aws" => "The current AWS region and profile",
         "azure" => "The current Azure subscription",
         "battery" => "The current charge of the device's battery and its current charging status",
+        "blank_fill" => "Fills the remaining space on the line with blank space",
         "buf" => "The currently installed version of the Buf CLI",
         "bun" => "The currently installed version of the Bun",
         "c" => "Your C compiler type",


### PR DESCRIPTION
#### Description
The blank-fill module allows for the behavior of the standard `fill` module, but with a hard-coded, single space as the fill character.

#### Motivation and Context
I wanted to make this because of a limitation I ran into when writing my own config. I wanted a wrap around effect, but to do that I needed to both fill a line with horizontal lines as well as fill other parts with empty space. However, since there is just one fill module, this wasn't possible. The blank-fill module fixes that.

#### Screenshots:
![Here](https://github.com/user-attachments/assets/04113cc3-01e2-476b-9725-59566b8317fc) This an effect this module allows for.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I've been using this feature on my own computers. My main PC running Manjaro and my laptop running Arch. Both using Fish, Wezterm, and the 0x Proto Mono NerdFont for the past 2 weeks with no issues.
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.

#### Note:
I have observed a bug with not just the blank-fill module, but with the existing fill module, which the blank-fill module is entirely based on. To my knowledge it only presents on bash and zsh. The issue doesn't present on fish (thanks to @TomJo2000 from the discord for discovering that). I do plan to open an issue for this, just haven't gotten around to it. Here it is though. Weird off-by-one error. Doesn't respond to manual padding:
 ![zsh_and_bash_off_by_one_error](https://github.com/user-attachments/assets/ee3a1a95-ac56-4d05-82ba-3a59b8c7bd7c) 
