### PR TITLE
fix(zsh): fix job counting

### DIFF
--- a/src/init/starship.zsh
+++ b/src/init/starship.zsh
@@ -50,7 +50,7 @@ prompt_starship_precmd() {
 
     # Use length of jobstates array as number of jobs. Expansion fails inside
     # quotes so we set it here and then use the value later on.
-    STARSHIP_JOBS_COUNT=${#jobstates}
+    STARSHIP_JOBS_COUNT="${#jobstates[*]}"
 }
 
 # Runs after the user submits the command line, but before it is executed and


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

The current `${#jobstates}` expansion incorrectly uses the length of the first array entry for the job count in Zsh.
This can be fixed by explicitly operating on the whole array using `${jobstates[*]]`.
###### `${jobstates[@]}` would be equivalent here but the `${jobstates[*]}` subscript is more idiomatically correct for this use, since we aren't interested in argument splitting, only the count of array elements.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- This acts as a followup to #7082

While looking through the changelog for 1.24.1 I saw the fix for the jobcount in the Fish shell.
I have previously noticed issues with the jobcount in Zsh, though I had previously assumed this was an issue with my Zsh config.
After looking into it I can however confirm this is just a misbehaving length expansion on the `jobstates` array.

*Technically* this is caused by the `KSH_ARRAYS` shell option, which makes Zsh arrays behave identically to Ksh/Bash arrays[^1].
[^1]: https://man.archlinux.org/man/zshparam.1#Array_Subscripts:~:text=When%20an%20array%20parameter%20is%20referenced%20as%20%60%24name%27%20(with%20no%20subscript)%20it%20evaluates%20to%20%60%24name%5B*%5D%27%2C%20unless%20the%20KSH_ARRAYS%20option%20is%20set

But I decided to make a PR for it anyway since the presence of that shell option should not impact the results of the job count even if it is not set by default.

#### Screenshots (if appropriate):
<img width="1895" height="584" alt="image" src="https://github.com/user-attachments/assets/a713fa4c-b719-47b3-9b22-7cdceaa9a644" />

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
  - [x] I have tested using **Android/Termux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] Not applicable.