### PR TITLE
feat: implement referencing next segment's style in conf file

### DIFF
--- a/docs/advanced-config/README.md
+++ b/docs/advanced-config/README.md
@@ -356,7 +356,8 @@ Style strings are a list of words, separated by whitespace. The words are not ca
 - `none`
 
 where `<color>` is a color specifier (discussed below). `fg:<color>` and `<color>` currently do the same thing, though this may change in the future.
-`<color>` can also be set to `prev_fg` or `prev_bg` which evaluates to the previous item's foreground or background color respectively if available or `none` otherwise.
+`<color>` can also be set to `prev_fg`, `prev_bg`, `next_fg` or `next_fg`, which evaluates to, respectively, the previous and next item's foreground or background color if available or `none` otherwise.
+Please also note that if the previous or next module also references a color with, for instance, `bg:next_fg`, the reference won't be followed and the default style will apply.
 `inverted` swaps the background and foreground colors. The order of words in the string does not matter.
 
 The `none` token overrides all other tokens in a string if it is not part of a `bg:` specifier, so that e.g. `fg:red none fg:blue` will still create a string with no styling. `bg:none` sets the background to the default color so `fg:red bg:none` is equivalent to `red` or `fg:red` and `bg:green fg:red bg:none` is also equivalent to `fg:red` or `red`. It may become an error to use `none` in conjunction with other tokens in the future.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,3 +1,5 @@
+use crate::context::Context;
+use crate::context::Shell;
 use process_control::{ChildExt, Control};
 use std::ffi::OsStr;
 use std::fmt::Debug;
@@ -6,9 +8,6 @@ use std::io::{Error, ErrorKind, Result};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
-
-use crate::context::Context;
-use crate::context::Shell;
 
 /// Create a `PathBuf` from an absolute path, where the root directory will be mocked in test
 #[cfg(not(test))]


### PR DESCRIPTION
#### Description
Solves [#6558-2888265896](https://github.com/starship/starship/issues/6558#issuecomment-2888265896). Add ability to reference next modules' foreground and background. Useful to make a spacer seperating 2 modules, merging the style of both.

#### Motivation and Context
Starship is missing the ability to create a spacer sharing colors from surrounding modules. Some presets like [Gruvbox](https://starship.rs/presets/gruvbox-rainbow) partly implement this design. But since color needs to be hard-coded, it gets broken as soon as one module is conditionnaly rendered. This PR allows to define colors that will always match the following module no matter what it is.

#### Screenshots (if appropriate):

<img width="1954" height="75" src="https://github.com/user-attachments/assets/0489f770-ee74-4770-a15e-0d030bfe88a1" />

#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
