### PR TITLE
fix(fish): wrap prompt to terminal width to prevent truncation by shell

### DIFF
--- a/src/init/starship.fish
+++ b/src/init/starship.fish
@@ -11,6 +11,13 @@ function __starship_set_job_count --description 'Set STARSHIP_JOBS using fish jo
     set -g STARSHIP_JOBS $__count
 end
 
+function __starship_set_fish_needs_clear --description 'Set STARSHIP_FISH_NEEDS_CLEAR on fish <= 3.2.x'
+    set vs (string split . $version)
+    if test \( $vs[1] -eq 3 -a $vs[2] -le 2 \) -o \( $vs[1] -lt 3 \)
+        set -gx STARSHIP_FISH_NEEDS_CLEAR 1
+    end
+end
+
 function fish_prompt
     switch "$fish_key_bindings"
         case fish_hybrid_key_bindings fish_vi_key_bindings fish_helix_key_bindings
@@ -25,6 +32,7 @@ function fish_prompt
     set STARSHIP_DURATION "$CMD_DURATION$cmd_duration"
 
     __starship_set_job_count
+    __starship_set_fish_needs_clear
 
     if test "$TRANSIENT" = "1"
         set -g TRANSIENT 0
@@ -56,6 +64,7 @@ function fish_right_prompt
 
     # Now it's safe to call job count function (after status capture)
     __starship_set_job_count
+    __starship_set_fish_needs_clear
 
     if test "$RIGHT_TRANSIENT" = "1"
         set -g RIGHT_TRANSIENT 0

--- a/src/print.rs
+++ b/src/print.rs
@@ -23,14 +23,6 @@ use crate::segment::Segment;
 use crate::shadow;
 use crate::utils::wrap_colorseq_for_shell;
 
-pub struct Grapheme<'a>(pub &'a str);
-
-impl Grapheme<'_> {
-    pub fn width(&self) -> usize {
-        UnicodeWidthStr::width(self.0)
-    }
-}
-
 pub trait UnicodeWidthGraphemes {
     fn width_graphemes(&self) -> usize;
 }
@@ -50,7 +42,6 @@ where
             .replace_all(self.as_ref(), "")
             .into_owned()
             .graphemes(true)
-            .map(Grapheme)
             .map(|g| g.width())
             .sum()
     }
@@ -160,7 +151,7 @@ pub fn get_prompt(context: &Context) -> String {
         let mut push_wrapped_text = |range: Range<usize>, new_buf: &mut String| {
             for g in buf[range].graphemes(true) {
                 let mut newline = g == "\n" || g == "\r\n";
-                let width = if !newline { Grapheme(g).width() } else { 0 };
+                let width = if !newline { g.width() } else { 0 };
 
                 if width > 0 && len > 0 && len + width > context.width {
                     new_buf.push('\n');
@@ -328,7 +319,7 @@ pub fn explain(args: Properties) {
                 }
 
                 // Handle normal wrapping
-                current_pos += Grapheme(g).width();
+                current_pos += g.width();
                 // Wrap when hitting max width or newline
                 if g == "\n" || current_pos > desc_width {
                     // trim spaces on linebreak

--- a/src/print.rs
+++ b/src/print.rs
@@ -83,7 +83,9 @@ pub fn get_prompt(context: &Context) -> String {
 
     // A workaround for a fish bug (see #739,#279). Applying it to all shells
     // breaks things (see #808,#824,#834). Should only be printed in fish.
-    let has_fish_clear_workaround = Shell::Fish == context.shell && context.target == Target::Main;
+    let has_fish_clear_workaround = Shell::Fish == context.shell
+        && context.target == Target::Main
+        && context.get_env("STARSHIP_FISH_NEEDS_CLEAR") == Some("1".to_string());
     if has_fish_clear_workaround {
         buf.push_str(CLEAR_FROM_CURSOR_TO_END);
     }
@@ -869,8 +871,14 @@ mod test {
         context.shell = Shell::Fish;
         context.width = 6;
 
-        let expected = CLEAR_FROM_CURSOR_TO_END.to_owned()
-            + "\u{1b}[35mab\u{1b}[0mcdef\n🫨🙏😺\u{1b}[36m\ntest\u{1b}[0m\n🙈🙉🙊\n❄✈☢❄✈☢\n❄️✈️☢️\n>\n>";
+        let expected = "\u{1b}[35mab\u{1b}[0mcdef\n🫨🙏😺\u{1b}[36m\ntest\u{1b}[0m\n🙈🙉🙊\n❄✈☢❄✈☢\n❄️✈️☢️\n>\n>";
+        let actual = get_prompt(&context);
+        assert_eq!(expected, actual);
+
+        context
+            .env
+            .insert("STARSHIP_FISH_NEEDS_CLEAR", "1".to_string());
+        let expected = CLEAR_FROM_CURSOR_TO_END.to_owned() + expected;
         let actual = get_prompt(&context);
         assert_eq!(expected, actual);
     }
@@ -887,8 +895,14 @@ mod test {
         context.shell = Shell::Fish;
         context.width = 6;
 
-        let expected = CLEAR_FROM_CURSOR_TO_END.to_owned()
-            + "abcdef\n🫨🙏😺\u{1b}[36m\ntest\u{1b}[0m\n🙈🙉🙊\n❄✈☢❄✈☢\n❄️✈️☢️\n>\n>";
+        let expected = "abcdef\n🫨🙏😺\u{1b}[36m\ntest\u{1b}[0m\n🙈🙉🙊\n❄✈☢❄✈☢\n❄️✈️☢️\n>\n>";
+        let actual = get_prompt(&context);
+        assert_eq!(expected, actual);
+
+        context
+            .env
+            .insert("STARSHIP_FISH_NEEDS_CLEAR", "1".to_string());
+        let expected = CLEAR_FROM_CURSOR_TO_END.to_owned() + expected;
         let actual = get_prompt(&context);
         assert_eq!(expected, actual);
     }
@@ -905,8 +919,14 @@ mod test {
         context.shell = Shell::Fish;
         context.width = 6;
 
-        let expected = CLEAR_FROM_CURSOR_TO_END.to_owned()
-            + "abcdef\n🫨🙏😺\ntest\n🙈🙉🙊\n❄✈☢❄✈☢\n❄️✈️☢️\n>\n\u{1b}[35m>\u{1b}[0m";
+        let expected = "abcdef\n🫨🙏😺\ntest\n🙈🙉🙊\n❄✈☢❄✈☢\n❄️✈️☢️\n>\n\u{1b}[35m>\u{1b}[0m";
+        let actual = get_prompt(&context);
+        assert_eq!(expected, actual);
+
+        context
+            .env
+            .insert("STARSHIP_FISH_NEEDS_CLEAR", "1".to_string());
+        let expected = CLEAR_FROM_CURSOR_TO_END.to_owned() + expected;
         let actual = get_prompt(&context);
         assert_eq!(expected, actual);
     }

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -1,9 +1,7 @@
-use crate::{
-    config::Style,
-    print::{Grapheme, UnicodeWidthGraphemes},
-};
+use crate::{config::Style, print::UnicodeWidthGraphemes};
 use nu_ansi_term::{AnsiString, Style as AnsiStyle};
 use unicode_segmentation::UnicodeSegmentation;
+use unicode_width::UnicodeWidthStr;
 
 /// Type that holds text with an associated style
 #[derive(Clone)]
@@ -44,7 +42,7 @@ impl FillSegment {
                 .graphemes(true)
                 .cycle()
                 .scan(0usize, |len, g| {
-                    *len += Grapheme(g).width();
+                    *len += g.width();
                     if *len <= w { Some(g) } else { None }
                 })
                 .collect::<String>(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
- Wrap prompts longer than the terminal width
- Remove a no longer needed workaround for grapheme width. This also fixes width calculation for emoji variants of text symbols   
- Make a workaround for fish <3.2 conditional on the fish version variable 

This PR wraps the main prompt on `fish` by inserting line breaks, which makes it look the same as on other shells. The wrapping is based on grapheme clusters, and the ANSI escape sequences are left untouched.

An existing workaround for calculating width was removed, as the current version of `unicode_width` appears to compute the widths correctly and the test for the past bug no longer fails with `UnicodeWidthStr`. This was needed because the `UnicodeWidthChar` way did not correctly determine the width of symbols presented as emojis using `\u{FE0F}`, such as the double-width `❄️`, instead returning 1 which would be the width of the regular `❄`. 

While implementing the wrapping, I noticed that a workaround for `fish` < 3.2 added in #865 is still in place, and a [previous PR](https://github.com/starship/starship/pull/5500) removing this was rejected because the affected `fish` versions are still distributed. I added a minor change that limits this workaround to the affected fish versions. 

#### Motivation and Context
Fish truncates prompts that are longer than the terminal width, and it starts from the beginning, which can easily make the current directory name unreadable with the default starship configuration. In https://github.com/fish-shell/fish-shell/issues/11341, it was stated that this behaviour is [intended](https://github.com/fish-shell/fish-shell/blob/9814bae727ff891c581a7d9a9149afd2b7e77615/src/screen.rs#L1522) and the prompt should handle wrapping or splitting text wider than `$COLUMNS`. 

Closes #6663

#### Screenshots (if appropriate):
<img width="989" height="286" alt="image" src="https://github.com/user-attachments/assets/d4d3aa9a-8da6-4571-a829-c2de35dbfc82" />

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
