### PR TITLE
fix(fish): restore job counting compability with older versions

### DIFF
--- a/src/init/starship.fish
+++ b/src/init/starship.fish
@@ -3,12 +3,11 @@ function __starship_set_job_count --description 'Set STARSHIP_JOBS using fish jo
     #   set -g __starship_fish_use_job_groups "false"
     if test "$__starship_fish_use_job_groups" = "false"
         # Legacy behavior: counts PIDs (may overcount pipelines with terminated producers)
-        set -f __count (jobs -p 2>/dev/null | count)
+        set -g STARSHIP_JOBS (jobs -p 2>/dev/null | count)
     else
         # Default behavior: count job groups
-        set -f __count (jobs -g 2>/dev/null | count)
-    end
-    set -g STARSHIP_JOBS $__count
+        set -g STARSHIP_JOBS (jobs -g 2>/dev/null | count)
+    end    
 end
 
 function fish_prompt


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
`set -f` is not supported by some of the less recent 3.x versions, just use `set -g` directly without an intermediary variable.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #7158

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS** (fish 3.3.1)
- [x] I have tested using **MacOS** (fish 4.2.1)
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
