### PR TITLE
fix(cmd_duration): avoid freezing on notify on macOS 26

### DIFF
--- a/src/modules/cmd_duration.rs
+++ b/src/modules/cmd_duration.rs
@@ -83,6 +83,11 @@ fn undistract_me<'a>(
             };
         }
 
+        // On macOS 26+ notify-rust will get stuck finding the current application identifier
+        // so we set it manually to the default terminal app.
+        #[cfg(target_os = "macos")]
+        let _ = notify_rust::set_application("com.apple.Terminal");
+
         let body = format!(
             "Command execution {}",
             unstyle(&AnsiStrings(&module.ansi_strings()))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
On macOS 26 `notify_rust::get_bundle_identifier_or_default` appears to get stuck, avoid this by setting the notification bundle identifier.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #7128

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
