### PR TITLE
feat: add Maven module

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -992,6 +992,24 @@
         ]
       }
     },
+    "maven": {
+      "$ref": "#/$defs/MavenConfig",
+      "default": {
+        "format": "via [$symbol($version )]($style)",
+        "version_format": "v${raw}",
+        "symbol": "🅼 ",
+        "style": "bold bright-cyan",
+        "disabled": false,
+        "recursive": false,
+        "detect_extensions": [],
+        "detect_files": [
+          "pom.xml"
+        ],
+        "detect_folders": [
+          ".mvn"
+        ]
+      }
+    },
     "memory_usage": {
       "$ref": "#/$defs/MemoryConfig",
       "default": {
@@ -4520,6 +4538,61 @@
           },
           "default": [
             "lua"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "MavenConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "type": "string",
+          "default": "via [$symbol($version )]($style)"
+        },
+        "version_format": {
+          "type": "string",
+          "default": "v${raw}"
+        },
+        "symbol": {
+          "type": "string",
+          "default": "🅼 "
+        },
+        "style": {
+          "type": "string",
+          "default": "bold bright-cyan"
+        },
+        "disabled": {
+          "type": "boolean",
+          "default": false
+        },
+        "recursive": {
+          "type": "boolean",
+          "default": false
+        },
+        "detect_extensions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        },
+        "detect_files": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "pom.xml"
+          ]
+        },
+        "detect_folders": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            ".mvn"
           ]
         }
       },

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -305,6 +305,7 @@ $julia\
 $kotlin\
 $gradle\
 $lua\
+$maven\
 $nim\
 $nodejs\
 $ocaml\
@@ -2914,6 +2915,41 @@ By default the module will be shown if any of the following conditions are met:
 [lua]
 format = 'via [🌕 $version](bold blue) '
 ```
+
+## Maven
+
+The `maven` module indicates the presence of a Maven project in the current directory. If the [Maven Wrapper](https://maven.apache.org/wrapper/) is enabled, the Maven version will be parsed from `.mvn/wrapper/maven-wrapper.properties` and shown.
+
+By default the module will be shown if any of the following conditions are met:
+
+- The current directory contains a `pom.xml` file.
+- The current directory contains a `.mvn/wrapper/maven-wrapper.properties` file.
+
+If you use an alternate POM syntax (for example `pom.hocon`), add its filename to `detect_files`.
+
+### Options
+
+| Option              | Default                              | Description                                                               |
+| ------------------- | ------------------------------------ | ------------------------------------------------------------------------- |
+| `format`            | `'via [$symbol($version )]($style)'` | The format for the module.                                                |
+| `version_format`    | `'v${raw}'`                          | The version format. Available vars are `raw`, `major`, `minor`, & `patch` |
+| `symbol`            | `'🅼 '`                               | A format string representing the symbol of Maven.                         |
+| `detect_extensions` | `[]`                                 | Which extensions should trigger this module.                              |
+| `detect_files`      | `['pom.xml']`                        | Which filenames should trigger this module.                               |
+| `detect_folders`    | `['.mvn']`                           | Which folders should trigger this module.                                 |
+| `style`             | `'bold bright-cyan'`                 | The style for the module.                                                 |
+| `disabled`          | `false`                              | Disables the `maven` module.                                              |
+| `recursive`         | `false`                              | Enables recursive finding for the `.mvn` directory.                       |
+
+### Variables
+
+| Variable | Example  | Description                          |
+| -------- | -------- | ------------------------------------ |
+| version  | `v3.2.0` | The version of `maven`               |
+| symbol   |          | Mirrors the value of option `symbol` |
+| style*   |          | Mirrors the value of option `style`  |
+
+*: This variable can only be used as a part of a style string
 
 ## Memory Usage
 

--- a/docs/public/presets/toml/bracketed-segments.toml
+++ b/docs/public/presets/toml/bracketed-segments.toml
@@ -144,6 +144,9 @@ format = '\[[$localipv4]($style)\]'
 [lua]
 format = '\[[$symbol($version)]($style)\]'
 
+[maven]
+format = '\[[$symbol($version)]($style)\]'
+
 [memory_usage]
 format = '\[$symbol[$ram( | $swap)]($style)\]'
 

--- a/docs/public/presets/toml/jetpack.toml
+++ b/docs/public/presets/toml/jetpack.toml
@@ -52,6 +52,7 @@ $julia\
 $kotlin\
 $gradle\
 $lua\
+$maven\
 $nim\
 $nodejs\
 $ocaml\

--- a/docs/public/presets/toml/nerd-font-symbols.toml
+++ b/docs/public/presets/toml/nerd-font-symbols.toml
@@ -93,6 +93,9 @@ symbol = " "
 [lua]
 symbol = " "
 
+[maven]
+symbol = " "
+
 [memory_usage]
 symbol = "󰍛 "
 

--- a/docs/public/presets/toml/no-runtime-versions.toml
+++ b/docs/public/presets/toml/no-runtime-versions.toml
@@ -78,6 +78,9 @@ format = 'via [$symbol]($style)'
 [lua]
 format = 'via [$symbol]($style)'
 
+[maven]
+format = 'via [$symbol]($style)'
+
 [meson]
 format = 'via [$symbol]($style)'
 

--- a/docs/public/presets/toml/pastel-powerline.toml
+++ b/docs/public/presets/toml/pastel-powerline.toml
@@ -18,6 +18,7 @@ $gradle\
 $haskell\
 $java\
 $julia\
+$maven\
 $nodejs\
 $nim\
 $rust\
@@ -121,6 +122,10 @@ format = '[ $symbol ($version) ]($style)'
 
 [julia]
 symbol = " "
+style = "bg:#86BBD8"
+format = '[ $symbol ($version) ]($style)'
+
+[maven]
 style = "bg:#86BBD8"
 format = '[ $symbol ($version) ]($style)'
 

--- a/docs/public/presets/toml/plain-text-symbols.toml
+++ b/docs/public/presets/toml/plain-text-symbols.toml
@@ -151,6 +151,9 @@ symbol = "kubernetes "
 [lua]
 symbol = "lua "
 
+[maven]
+symbol = "maven "
+
 [nodejs]
 symbol = "nodejs "
 

--- a/src/configs/maven.rs
+++ b/src/configs/maven.rs
@@ -1,0 +1,36 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(
+    feature = "config-schema",
+    derive(schemars::JsonSchema),
+    schemars(deny_unknown_fields)
+)]
+#[serde(default)]
+pub struct MavenConfig<'a> {
+    pub format: &'a str,
+    pub version_format: &'a str,
+    pub symbol: &'a str,
+    pub style: &'a str,
+    pub disabled: bool,
+    pub recursive: bool,
+    pub detect_extensions: Vec<&'a str>,
+    pub detect_files: Vec<&'a str>,
+    pub detect_folders: Vec<&'a str>,
+}
+
+impl Default for MavenConfig<'_> {
+    fn default() -> Self {
+        Self {
+            format: "via [$symbol($version )]($style)",
+            version_format: "v${raw}",
+            symbol: "🅼 ",
+            style: "bold bright-cyan",
+            disabled: false,
+            recursive: false,
+            detect_extensions: vec![],
+            detect_files: vec!["pom.xml"],
+            detect_folders: vec![".mvn"],
+        }
+    }
+}

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -57,6 +57,7 @@ pub mod kubernetes;
 pub mod line_break;
 pub mod localip;
 pub mod lua;
+pub mod maven;
 pub mod memory_usage;
 pub mod meson;
 pub mod mise;
@@ -230,6 +231,8 @@ pub struct FullConfig<'a> {
     localip: localip::LocalipConfig<'a>,
     #[serde(borrow)]
     lua: lua::LuaConfig<'a>,
+    #[serde(borrow)]
+    maven: maven::MavenConfig<'a>,
     #[serde(borrow)]
     memory_usage: memory_usage::MemoryConfig<'a>,
     #[serde(borrow)]

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -78,6 +78,7 @@ pub const PROMPT_ORDER: &[&str] = &[
     "julia",
     "kotlin",
     "lua",
+    "maven",
     "mojo",
     "nim",
     "nodejs",

--- a/src/module.rs
+++ b/src/module.rs
@@ -61,6 +61,7 @@ pub const ALL_MODULES: &[&str] = &[
     "line_break",
     "localip",
     "lua",
+    "maven",
     "memory_usage",
     "meson",
     "mise",

--- a/src/modules/maven.rs
+++ b/src/modules/maven.rs
@@ -1,0 +1,226 @@
+use std::path::Path;
+
+use crate::{
+    config::ModuleConfig,
+    configs::maven::MavenConfig,
+    context::Context,
+    formatter::{StringFormatter, VersionFormatter},
+    module::Module,
+    utils,
+};
+
+pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let mut module = context.new_module("maven");
+    let config = MavenConfig::try_load(module.config);
+    let is_maven_project = context
+        .try_begin_scan()?
+        .set_files(&config.detect_files)
+        .set_extensions(&config.detect_extensions)
+        .set_folders(&config.detect_folders)
+        .is_match();
+
+    if !is_maven_project {
+        return None;
+    }
+
+    let wrapper_properties = get_wrapper_properties_file(context, config.recursive);
+    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
+        formatter
+            .map_meta(|var, _| match var {
+                "symbol" => Some(config.symbol),
+                _ => None,
+            })
+            .map_style(|variable| match variable {
+                "style" => Some(Ok(config.style)),
+                _ => None,
+            })
+            .map(|variable| match variable {
+                "version" => {
+                    let properties = wrapper_properties.as_deref()?;
+                    let maven_version = parse_maven_version_from_properties(properties)?;
+                    VersionFormatter::format_module_version(
+                        module.get_name(),
+                        &maven_version,
+                        config.version_format,
+                    )
+                    .map(Ok)
+                }
+                _ => None,
+            })
+            .parse(None, Some(context))
+    });
+
+    module.set_segments(match parsed {
+        Ok(segments) => segments,
+        Err(error) => {
+            log::warn!("Error in module `maven`:\n{error}");
+            return None;
+        }
+    });
+
+    Some(module)
+}
+
+fn parse_maven_version_from_properties(wrapper_properties: &str) -> Option<String> {
+    // Example `maven-wrapper.properties` content
+    /*
+        wrapperVersion=3.3.4
+        distributionType=only-script
+        distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.12/apache-maven-3.9.12-bin.zip
+    */
+    let version = wrapper_properties
+        .lines()
+        .find(|line| line.starts_with("distributionUrl="))?
+        .rsplit_once('/')?
+        .1
+        .strip_prefix("apache-maven-")?
+        .rsplit_once('-')?
+        .0;
+    Some(version.to_string())
+}
+
+/// Tries to find the maven-wrapper.properties file.
+fn get_wrapper_properties_file(context: &Context, recursive: bool) -> Option<String> {
+    let read_wrapper_properties = |base_dir: &Path| {
+        utils::read_file(base_dir.join(".mvn/wrapper/maven-wrapper.properties")).ok()
+    };
+
+    // Try current directory first
+    if context.try_begin_scan()?.set_folders(&[".mvn"]).is_match()
+        && let Some(properties) = read_wrapper_properties(&context.current_dir)
+    {
+        return Some(properties);
+    }
+
+    // Try parent directories if recursive
+    if recursive
+        && let Some(base_dir) = context.begin_ancestor_scan().set_folders(&[".mvn"]).scan()
+        && let Some(properties) = read_wrapper_properties(&base_dir)
+    {
+        return Some(properties);
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use nu_ansi_term::Color;
+
+    use super::*;
+    use crate::test::ModuleRenderer;
+    use std::fs::{self, File};
+    use std::io::{self, Write};
+
+    #[test]
+    fn folder_without_maven_files() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+
+        let actual = ModuleRenderer::new("maven").path(dir.path()).collect();
+
+        let expected = None;
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn folder_with_maven_wrapper_properties() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let properties = dir
+            .path()
+            .join(".mvn")
+            .join("wrapper")
+            .join("maven-wrapper.properties");
+        fs::create_dir_all(properties.parent().unwrap())?;
+        File::create(dir.path().join("pom.xml"))?.sync_all()?;
+        let mut file = File::create(properties)?;
+        file.write_all(
+            b"\
+wrapperVersion=3.3.4
+distributionType=only-script
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.12/apache-maven-3.9.12-bin.zip
+",
+        )?;
+        file.sync_all()?;
+
+        let actual = ModuleRenderer::new("maven").path(dir.path()).collect();
+
+        let expected = Some(format!(
+            "via {}",
+            Color::LightCyan.bold().paint("🅼 v3.9.12 ")
+        ));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn maven_wrapper_recursive() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let properties = dir
+            .path()
+            .join(".mvn")
+            .join("wrapper")
+            .join("maven-wrapper.properties");
+        fs::create_dir_all(properties.parent().unwrap())?;
+        File::create(dir.path().join("pom.xml"))?.sync_all()?;
+        let mut file = File::create(properties)?;
+        file.write_all(
+            b"\
+distributionUrl=https\\://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.4/apache-maven-3.9.4-bin.zip
+wrapperVersion=3.3.4
+",
+        )?;
+        file.sync_all()?;
+
+        let target_dir = dir.path().join("working_dir");
+        fs::create_dir(&target_dir)?;
+        File::create(target_dir.join("pom.xml"))?.sync_all()?;
+
+        let actual = ModuleRenderer::new("maven")
+            .config(toml::toml! {
+                [maven]
+                recursive = true
+            })
+            .path(target_dir)
+            .collect();
+
+        let expected = Some(format!(
+            "via {}",
+            Color::LightCyan.bold().paint("🅼 v3.9.4 ")
+        ));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn test_format_wrapper_properties() {
+        let input = "\
+distributionUrl=https\\://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.4/apache-maven-3.9.4-bin.zip
+wrapperVersion=3.3.4
+        ";
+        assert_eq!(
+            parse_maven_version_from_properties(input),
+            Some("3.9.4".to_string())
+        );
+    }
+
+    #[test]
+    fn test_format_wrapper_properties_unstable_versions() {
+        let input = |version: &str| {
+            format!(
+                "\
+distributionUrl=https\\://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/{version}/apache-maven-{version}-bin.zip
+wrapperVersion=3.3.4
+        "
+            )
+        };
+        assert_eq!(
+            parse_maven_version_from_properties(&input("4.0.0-rc-1")),
+            Some("4.0.0-rc-1".to_string())
+        );
+        assert_eq!(
+            parse_maven_version_from_properties(&input("3.9.0-SNAPSHOT")),
+            Some("3.9.0-SNAPSHOT".to_string())
+        );
+    }
+}

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -54,6 +54,7 @@ mod kubernetes;
 mod line_break;
 mod localip;
 mod lua;
+mod maven;
 mod memory_usage;
 mod meson;
 mod mise;
@@ -174,6 +175,7 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
             "line_break" => line_break::module(context),
             "localip" => localip::module(context),
             "lua" => lua::module(context),
+            "maven" => maven::module(context),
             "memory_usage" => memory_usage::module(context),
             "meson" => meson::module(context),
             "mise" => mise::module(context),
@@ -307,6 +309,7 @@ pub fn description(module: &str) -> &'static str {
         "line_break" => "Separates the prompt into two lines",
         "localip" => "The currently assigned ipv4 address",
         "lua" => "The currently installed version of Lua",
+        "maven" => "The Maven Wrapper version of the current project",
         "memory_usage" => "Current system memory and swap usage",
         "meson" => {
             "The current Meson environment, if $MESON_DEVENV and $MESON_PROJECT_NAME are set"


### PR DESCRIPTION
#### Description
This adds a `maven` module that exposes the presence of a Maven project in the current directory, as well as the Maven wrapper version if present. In terms of behavior and configuration, this feature is essentially identical to the `gradle` module.

#### Motivation and Context

This provides feature parity for Maven projects, given the existing support for Gradle. Maven 4 is currently in release candidate; as this is the first new major version of Maven in over fifteen years, I expect that developers will start paying more attention to the specific Maven version used by a particular project, and I also expect that use of the Maven wrapper will become more common.

Closes #7188.

#### How Has This Been Tested?

In addition to the unit tests, I tested this manually in various projects and folders and with various config options (e.g. `version_format`, `recursive`). I tested various Maven wrapper versions, including 3.9.12 and 4.0.0-rc-5.

- [x] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
