### PR TITLE
fix(aws): isolate tests from host AWS config files

### DIFF
--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -520,15 +520,19 @@ mod tests {
     #[test]
     fn credentials_file_is_ignored_when_is_directory() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
-        let config_path = dir.path().join("credentials");
-        create_dir(&config_path)?;
+        let creds_path = dir.path().join("credentials");
+        create_dir(&creds_path)?;
+
+        let config_path = dir.path().join("config");
+        File::create(&config_path)?.sync_all()?;
 
         assert!(
             ModuleRenderer::new("aws")
                 .env(
                     "AWS_SHARED_CREDENTIALS_FILE",
-                    config_path.to_string_lossy().as_ref(),
+                    creds_path.to_string_lossy().as_ref(),
                 )
+                .env("AWS_CONFIG_FILE", config_path.to_string_lossy().as_ref())
                 .collect()
                 .is_none()
         );
@@ -542,9 +546,16 @@ mod tests {
         let config_path = dir.path().join("config");
         create_dir(&config_path)?;
 
+        let creds_path = dir.path().join("credentials");
+        File::create(&creds_path)?.sync_all()?;
+
         assert!(
             ModuleRenderer::new("aws")
                 .env("AWS_CONFIG_FILE", config_path.to_string_lossy().as_ref())
+                .env(
+                    "AWS_SHARED_CREDENTIALS_FILE",
+                    creds_path.to_string_lossy().as_ref(),
+                )
                 .collect()
                 .is_none()
         );


### PR DESCRIPTION
#### Description

The tests `credentials_file_is_ignored_when_is_directory` and `config_file_path_is_ignored_when_is_directory` were failing on machines with `~/.aws/config` or `~/.aws/credentials` present.

Each test now sets both `AWS_CONFIG_FILE` and `AWS_SHARED_CREDENTIALS_FILE` environment variables to ensure complete isolation from the host environment.

#### Motivation and Context

When running `cargo test` on a machine with AWS credentials configured (e.g., `~/.aws/config` containing region information), the AWS module tests would fail because:

1. `credentials_file_is_ignored_when_is_directory` only set `AWS_SHARED_CREDENTIALS_FILE` but not `AWS_CONFIG_FILE`, so the module would read region from `~/.aws/config` and return `Some(...)` instead of `None`.

2. Similarly, `config_file_path_is_ignored_when_is_directory` only set `AWS_CONFIG_FILE` but not `AWS_SHARED_CREDENTIALS_FILE`.

This violates the principle stated in CONTRIBUTING.md:
> Unit tests should be fully isolated, only testing a given function's expected output given a specific input, and should be reproducible on any machine.

These tests were introduced in #3335 (2021-12-20) and have been environment-dependent since then.

#### How Has This Been Tested?

- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

Tested on macOS with `~/.aws/config` present. Before the fix, the test failed. After the fix, all tests pass.

#### Checklist:

- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
