### PR TITLE
Fix typo in catppuccin-powerline.md

### DIFF
--- a/docs/ja-JP/presets/catppuccin-powerline.md
+++ b/docs/ja-JP/presets/catppuccin-powerline.md
@@ -20,7 +20,7 @@ starship preset catppuccin-powerline -o ~/.config/starship.toml
 
 - `catppuccin_mocha`
 - `catppuccin_frappe`
-- `catppuccin_macciato`
+- `catppuccin_macchiato`
 - `catppuccin_latte`
 
 [クリックしてTOMLファイルをダウンロード](/presets/toml/catppuccin-powerline.toml)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

I corrected a typo in the Japanese documentation.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The typo prevented the preset from changing the colour theme to `catppuccin_macchiato`, if you copied the line.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
