### PR TITLE
fix(format): allow empty textgroups to set prev_fg/prev_bg

### DIFF
--- a/src/formatter/string_formatter.rs
+++ b/src/formatter/string_formatter.rs
@@ -244,14 +244,13 @@ impl<'a> StringFormatter<'a> {
             style_variables: &'a StyleVariableMapType<'a>,
             context: Option<&Context>,
         ) -> Result<Vec<Segment>, StringFormatterError> {
-            let style = parse_style(textgroup.style, style_variables, context);
-            parse_format(
-                textgroup.format,
-                style.transpose()?,
-                variables,
-                style_variables,
-                context,
-            )
+            let style = parse_style(textgroup.style, style_variables, context).transpose()?;
+
+            // Empty textgroups still produce a segment to preserve style for prev_fg/prev_bg references
+            if textgroup.format.is_empty() {
+                return Ok(Segment::from_text(style, ""));
+            }
+            parse_format(textgroup.format, style, variables, style_variables, context)
         }
 
         fn parse_style<'a>(
@@ -288,11 +287,6 @@ impl<'a> StringFormatter<'a> {
             style_variables: &'a StyleVariableMapType<'a>,
             context: Option<&Context>,
         ) -> Result<Vec<Segment>, StringFormatterError> {
-            // Empty textgroups still produce a segment to preserve style for prev_fg/prev_bg references
-            if format.is_empty() {
-                return Ok(Segment::from_text(style, ""));
-            }
-
             let results: Result<Vec<Vec<Segment>>, StringFormatterError> = format
                 .into_iter()
                 .map(|el| {


### PR DESCRIPTION
#### Description
Empty format strings like `[](bg:#color)` now produce a zero-width styled segment, allowing `prev_fg` and `prev_bg` to reference the style in subsequent segments.

#### Motivation and Context
Previously, empty textgroups did not generate any segments, making it impossible to set `prev_fg` or `prev_bg` without printing visible characters. This was problematic for powerline-style prompts where you want to set a background color before a conditional module.

Closes #6218

#### Screenshots (if appropriate):

<details>
<summary>Test configuration</summary>

```toml
format = """
[](bg:#9A348E)\
[TEST](bg:prev_bg) """
```

</details>

**After**

<img width="1888" height="131" alt="スクリーンショット 2026-01-03 2 25 30" src="https://github.com/user-attachments/assets/221bbeba-a29d-491b-8089-7f8b7957da3a" />


**Before: master branch (c576625343a8)**

<img width="1878" height="126" alt="スクリーンショット 2026-01-03 2 24 16" src="https://github.com/user-attachments/assets/26fc552d-0dde-4beb-98ec-65bc6e9e5520" />


#### How Has This Been Tested?
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.