### PR TITLE
Add a fallback (with 1 retry with another downloader) Incase first one fails.

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -84,33 +84,35 @@ test_writeable() {
 		return 1
 	fi
 }
+
 download() {
     file="$1"
     url="$2"
 
-    downloaders=()
     if has curl && ! curl_is_snap; then
-        downloaders+=("curl --fail --silent --location --output $file $url")
-    fi
-    if has wget; then
-        downloaders+=("wget --quiet --output-document=$file $url")
-    fi
-    if has fetch; then
-        downloaders+=("fetch --quiet --output=$file $url")
-    fi
-
-    if [ ${#downloaders[@]} -eq 0 ]; then
-        error "No HTTP download program (curl, wget, fetch) found, exiting…"
-        return 1
-    fi
-
-    for cmd in "${downloaders[@]}"; do
+        cmd="curl --fail --silent --location --output $file $url"
         $cmd && return 0
         rc=$?
-        warn "Failed (exit code $rc): ${cmd}"
-    done
+        warn "curl failed (exit code $rc): ${cmd}"
+    fi
 
+    if has wget; then
+        cmd="wget --quiet --output-document=$file $url"
+        $cmd && return 0
+        rc=$?
+        warn "wget failed (exit code $rc): ${cmd}"
+    fi
+
+    if has fetch; then
+        cmd="fetch --quiet --output=$file $url"
+        $cmd && return 0
+        rc=$?
+        warn "fetch failed (exit code $rc): ${cmd}"
+    fi
+
+    error "No HTTP download program (curl, wget, fetch) succeeded, exiting…"
     printf "\n" >&2
+
     case "${VERSION}" in
         latest) ;;
         v*) ;;
@@ -120,12 +122,12 @@ download() {
             printf "\n" >&2
             ;;
     esac
-	
+
     info "This is likely due to Starship not yet supporting your configuration."
     info "If you would like to see a build for your configuration,"
     info "please create an issue requesting a build for ${MAGENTA}${TARGET}${NO_COLOR}:"
     info "${BOLD}${UNDERLINE}https://github.com/starship/starship/issues/new/${NO_COLOR}"
-    return $rc
+    return ${rc:-1}
 }
 
 unpack() {

--- a/install/install.sh
+++ b/install/install.sh
@@ -93,40 +93,41 @@ download() {
         cmd="curl --fail --silent --location --output $file $url"
         $cmd && return 0
         rc=$?
-        warn "curl failed (exit code $rc): ${cmd}"
+        warn "Command failed (exit code $rc): ${cmd}"
     fi
 
     if has wget; then
         cmd="wget --quiet --output-document=$file $url"
         $cmd && return 0
         rc=$?
-        warn "wget failed (exit code $rc): ${cmd}"
+        warn "Command failed (exit code $rc): ${cmd}"
     fi
 
     if has fetch; then
         cmd="fetch --quiet --output=$file $url"
         $cmd && return 0
         rc=$?
-        warn "fetch failed (exit code $rc): ${cmd}"
+        warn "Command failed (exit code $rc): ${cmd}"
     fi
 
     error "No HTTP download program (curl, wget, fetch) succeeded, exiting…"
     printf "\n" >&2
 
     case "${VERSION}" in
-        latest) ;;
-        v*) ;;
-        *)
-            info "Note: Release tags include the 'v' prefix (e.g., 'v1.2.3')."
-            info "You specified '${VERSION}'. Did you mean 'v${VERSION}'?"
-            printf "\n" >&2
-            ;;
+    latest) ;;
+    v*) ;;
+    *)
+        info "Note: Release tags include the 'v' prefix (e.g., 'v1.2.3')."
+        info "You specified '${VERSION}'. Did you mean 'v${VERSION}'?"
+        printf "\n" >&2
+        ;;
     esac
 
     info "This is likely due to Starship not yet supporting your configuration."
     info "If you would like to see a build for your configuration,"
     info "please create an issue requesting a build for ${MAGENTA}${TARGET}${NO_COLOR}:"
     info "${BOLD}${UNDERLINE}https://github.com/starship/starship/issues/new/${NO_COLOR}"
+
     return ${rc:-1}
 }
 

--- a/install/install.sh
+++ b/install/install.sh
@@ -84,46 +84,48 @@ test_writeable() {
 		return 1
 	fi
 }
-
 download() {
-	file="$1"
-	url="$2"
+    file="$1"
+    url="$2"
 
-	if has curl && curl_is_snap; then
-		warn "curl installed through snap cannot download starship."
-		warn "See https://github.com/starship/starship/issues/5403 for details."
-		warn "Searching for other HTTP download programs..."
-	fi
+    downloaders=()
+    if has curl && ! curl_is_snap; then
+        downloaders+=("curl --fail --silent --location --output $file $url")
+    fi
+    if has wget; then
+        downloaders+=("wget --quiet --output-document=$file $url")
+    fi
+    if has fetch; then
+        downloaders+=("fetch --quiet --output=$file $url")
+    fi
 
-	if has curl && ! curl_is_snap; then
-		cmd="curl --fail --silent --location --output $file $url"
-	elif has wget; then
-		cmd="wget --quiet --output-document=$file $url"
-	elif has fetch; then
-		cmd="fetch --quiet --output=$file $url"
-	else
-		error "No HTTP download program (curl, wget, fetch) found, exiting…"
-		return 1
-	fi
+    if [ ${#downloaders[@]} -eq 0 ]; then
+        error "No HTTP download program (curl, wget, fetch) found, exiting…"
+        return 1
+    fi
 
-	$cmd && return 0 || rc=$?
+    for cmd in "${downloaders[@]}"; do
+        $cmd && return 0
+        rc=$?
+        warn "Failed (exit code $rc): ${cmd}"
+    done
 
-	error "Command failed (exit code $rc): ${BLUE}${cmd}${NO_COLOR}"
-	printf "\n" >&2
-	case "${VERSION}" in
-	latest) ;;
-	v*) ;;
-	*)
-		info "Note: Release tags include the 'v' prefix (e.g., 'v1.2.3')."
-		info "You specified '${VERSION}'. Did you mean 'v${VERSION}'?"
-		printf "\n" >&2
-		;;
-	esac
-	info "This is likely due to Starship not yet supporting your configuration."
-	info "If you would like to see a build for your configuration,"
-	info "please create an issue requesting a build for ${MAGENTA}${TARGET}${NO_COLOR}:"
-	info "${BOLD}${UNDERLINE}https://github.com/starship/starship/issues/new/${NO_COLOR}"
-	return $rc
+    printf "\n" >&2
+    case "${VERSION}" in
+        latest) ;;
+        v*) ;;
+        *)
+            info "Note: Release tags include the 'v' prefix (e.g., 'v1.2.3')."
+            info "You specified '${VERSION}'. Did you mean 'v${VERSION}'?"
+            printf "\n" >&2
+            ;;
+    esac
+	
+    info "This is likely due to Starship not yet supporting your configuration."
+    info "If you would like to see a build for your configuration,"
+    info "please create an issue requesting a build for ${MAGENTA}${TARGET}${NO_COLOR}:"
+    info "${BOLD}${UNDERLINE}https://github.com/starship/starship/issues/new/${NO_COLOR}"
+    return $rc
 }
 
 unpack() {


### PR DESCRIPTION
#### Description
Basically a change to make it fallback to any other downloader incase the first one fails.

#### Motivation and Context
To fix the fact that curl is janky on some systems.
Also I don't have anything to program, so I wrote this pull request.

#### Screenshots (if appropriate):
<img width="1291" height="237" alt="Screenshot 2026-01-04 at 12 12 50 PM" src="https://github.com/user-attachments/assets/4d7086cf-d435-40f7-9458-67408ec3080e" />

#### How Has This Been Tested?
Tested on alpine linux, used `sh install.sh` in the directory.

- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
