### PR TITLE
perf: add get_repo_workdir

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -54,6 +54,9 @@ pub struct Context<'a> {
     /// Private field to store Git information for modules who need it
     repo: OnceLock<Result<Repo, Box<gix::discover::Error>>>,
 
+    /// Cached workdir from lightweight git discovery (avoids full repo open)
+    repo_workdir: OnceLock<Option<PathBuf>>,
+
     /// The shell the user is assumed to be running
     pub shell: Shell,
 
@@ -170,6 +173,7 @@ impl<'a> Context<'a> {
             logical_dir,
             dir_contents: OnceLock::new(),
             repo: OnceLock::new(),
+            repo_workdir: OnceLock::new(),
             shell,
             target,
             width,
@@ -386,6 +390,20 @@ impl<'a> Context<'a> {
             })
             .as_ref()
             .map_err(std::convert::AsRef::as_ref)
+    }
+
+    /// Get repo workdir without opening the full repo
+    pub fn get_repo_workdir(&self) -> Option<&PathBuf> {
+        if let Some(Ok(repo)) = self.repo.get() {
+            return repo.workdir.as_ref();
+        }
+        self.repo_workdir
+            .get_or_init(|| {
+                gix::discover::upwards(&self.current_dir)
+                    .ok()
+                    .and_then(|(path, _)| path.into_repository_and_work_tree_directories().1)
+            })
+            .as_ref()
     }
 
     pub fn dir_contents(&self) -> Result<&DirContents, &std::io::Error> {

--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -51,13 +51,13 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
     // Attempt repository path contraction (if we are in a git repository)
     // Otherwise use the logical path, automatically contracting
-    let repo = if config.truncate_to_repo || config.repo_root_style.is_some() {
-        context.get_repo().ok()
+    let repo_workdir = if config.truncate_to_repo || config.repo_root_style.is_some() {
+        context.get_repo_workdir()
     } else {
         None
     };
     let dir_string = if config.truncate_to_repo {
-        repo.and_then(|r| r.workdir.as_ref())
+        repo_workdir
             .filter(|&root| root != &home_dir)
             .and_then(|root| contract_repo_path(display_dir, root))
     } else {
@@ -103,7 +103,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         String::new()
     };
 
-    let path_vec = match &repo.and_then(|r| r.workdir.as_ref()) {
+    let path_vec = match repo_workdir {
         Some(repo_root) if config.repo_root_style.is_some() => {
             let contracted_path = contract_repo_path(display_dir, repo_root)?;
             let repo_path_vec: Vec<&str> = contracted_path.split('/').collect();

--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -52,13 +52,16 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     // Attempt repository path contraction (if we are in a git repository)
     // Otherwise use the logical path, automatically contracting
     let repo_workdir = if config.truncate_to_repo || config.repo_root_style.is_some() {
-        context.get_repo_workdir()
+        gix::discover::upwards(&context.current_dir)
+            .ok()
+            .and_then(|(path, _)| path.into_repository_and_work_tree_directories().1)
     } else {
         None
     };
     let dir_string = if config.truncate_to_repo {
         repo_workdir
-            .filter(|&root| root != &home_dir)
+            .as_ref()
+            .filter(|root| *root != &home_dir)
             .and_then(|root| contract_repo_path(display_dir, root))
     } else {
         None
@@ -103,7 +106,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         String::new()
     };
 
-    let path_vec = match repo_workdir {
+    let path_vec = match repo_workdir.as_ref() {
         Some(repo_root) if config.repo_root_style.is_some() => {
             let contracted_path = contract_repo_path(display_dir, repo_root)?;
             let repo_path_vec: Vec<&str> = contracted_path.split('/').collect();

--- a/src/modules/dotnet.rs
+++ b/src/modules/dotnet.rs
@@ -53,7 +53,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             .map(|variable| match variable {
                 "version" => {
                     let version = if enable_heuristic {
-                        let repo_root = context.get_repo().ok().and_then(|r| r.workdir.as_deref());
+                        let repo_root = context.get_repo_workdir().map(PathBuf::as_path);
                         estimate_dotnet_version(
                             context,
                             &dotnet_files,

--- a/src/modules/dotnet.rs
+++ b/src/modules/dotnet.rs
@@ -53,12 +53,14 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             .map(|variable| match variable {
                 "version" => {
                     let version = if enable_heuristic {
-                        let repo_root = context.get_repo_workdir().map(PathBuf::as_path);
+                        let repo_root = gix::discover::upwards(&context.current_dir)
+                            .ok()
+                            .and_then(|(path, _)| path.into_repository_and_work_tree_directories().1);
                         estimate_dotnet_version(
                             context,
                             &dotnet_files,
                             &context.current_dir,
-                            repo_root,
+                            repo_root.as_deref(),
                         )
                     } else {
                         get_version_from_cli(context)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

Adds `get_repo_workdir` to `context.rs`, similar to `get_repo` but skips logic unnecessary for just getting the workdir.

In a few modules (directory and dotnet), only the workdir from get_repo() is used. In my setup `directory` was taking ~10ms to run. The new `get_repo_workdir` function is identical for this use case and runs instantaneously in comparison.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Perf improvement for directory and dotenv modules

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

Existing test suite passes

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
