### PR TITLE
fix: enable std feature for whoami crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3878,6 +3878,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "which"
 version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3896,6 +3906,7 @@ checksum = "86dc1eeef7866078951fc09f1857d3d33a37432fe376d7ff45449c8bb50318c1"
 dependencies = [
  "libredox",
  "wasite",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ unicode-width = "0.2.2"
 urlencoding = "2.1.3"
 versions = "7.0.0"
 which = "8.0.0"
-whoami = { version = "2.0.0", default-features = false, features = ["wasi-wasite"] }
+whoami = { version = "2.0.0", default-features = false, features = ["std", "wasi-wasite"] }
 yaml-rust2 = "0.11.0"
 
 guess_host_triple = "0.1.5"


### PR DESCRIPTION
Without the "std" feature enabled, whoami falls back to the stub implementation and Starship shows anonymous@localhost regardless of the actual user or hostname.

#### Description
Enable the `std` feature for the `whoami` crate to include the `unix.rs` implementation.

#### Motivation and Context
The prompt currently shows `anonymous@localhost` from the `whoami` stub implementation.

#### How Has This Been Tested?

```
$ ./target/release/starship explain

 Here's a breakdown of your prompt:
 " my-username" (<1ms)                  -  The active user's username
 "@my-hostname " (<1ms)         -  The system hostname
...
```

This previously would report ` anonymous` for the username and `localhost` for the hostname.

- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:

Pure bug fix so I don't think these are necessary?

- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
