### PR TITLE
docs: add missing "style" option on "Enviroment Variable"

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1531,6 +1531,7 @@ The module will be shown only if any of the following conditions are met:
 | `format`      | `"with [$env_value]($style) "` | The format for the module.                                                   |
 | `description` | `"<env_var module>"`           | The description of the module that is shown when running `starship explain`. |
 | `disabled`    | `false`                        | Disables the `env_var` module.                                               |
+| `style`       | `"black bold dimmed"`          | The style for the module.                                                    |
 
 ### Variables
 
@@ -1538,7 +1539,7 @@ The module will be shown only if any of the following conditions are met:
 | --------- | ------------------------------------------- | ------------------------------------------ |
 | env_value | `Windows NT` (if _variable_ would be `$OS`) | The environment value of option `variable` |
 | symbol    |                                             | Mirrors the value of option `symbol`       |
-| style\*   | `black bold dimmed`                         | Mirrors the value of option `style`        |
+| style\*   |                                             | Mirrors the value of option `style`        |
 
 *: This variable can only be used as a part of a style string
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
I added the `style` option on the table for the "Enviroment Variable" module. Delete the value `example` for the "Variables" table because the other modules don't have a value there either. And I'm not sure if I have to put it in any particular order in the “style” table and if you prefer " or ' or nothing for this kind of example (like: `"black bold dimmed"` vs `'black bold dimmed'` vs `black bold dimmed`).

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #7209

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
I don't test this change. I just check that is the correct color (from [`src/configs/env_var.rs`](https://github.com/starship/starship/blob/master/src/configs/env_var.rs#L26))
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
