### PR TITLE
feat: add git_remote module to display provider symbol

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -650,6 +650,24 @@
         "ignore_submodules": false
       }
     },
+    "git_remote": {
+      "$ref": "#/$defs/GitRemoteConfig",
+      "default": {
+        "format": "on [$symbol]($style)",
+        "symbol": "󰊢 ",
+        "no_remote_symbol": " ",
+        "style": "bold dimmed white",
+        "disabled": true,
+        "providers": {
+          "github.com": " ",
+          "gitlab.com": "󰮠 ",
+          "bitbucket.org": "󰂨 ",
+          "codeberg.org": "󰣠 ",
+          "sr.ht": " ",
+          "dev.azure.com": "󰿕 "
+        }
+      }
+    },
     "git_state": {
       "$ref": "#/$defs/GitStateConfig",
       "default": {
@@ -3522,6 +3540,46 @@
         "ignore_submodules": {
           "type": "boolean",
           "default": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "GitRemoteConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "type": "string",
+          "default": "on [$symbol]($style)"
+        },
+        "symbol": {
+          "type": "string",
+          "default": "󰊢 "
+        },
+        "no_remote_symbol": {
+          "type": "string",
+          "default": " "
+        },
+        "style": {
+          "type": "string",
+          "default": "bold dimmed white"
+        },
+        "disabled": {
+          "type": "boolean",
+          "default": true
+        },
+        "providers": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "default": {
+            "github.com": " ",
+            "gitlab.com": "󰮠 ",
+            "bitbucket.org": "󰂨 ",
+            "codeberg.org": "󰣠 ",
+            "sr.ht": " ",
+            "dev.azure.com": "󰿕 "
+          }
         }
       },
       "additionalProperties": false

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -276,6 +276,7 @@ $git_branch\
 $git_commit\
 $git_state\
 $git_metrics\
+$git_remote\
 $git_status\
 $hg_branch\
 $hg_state\
@@ -2054,6 +2055,64 @@ the current git repository.
 [git_metrics]
 added_style = 'bold blue'
 format = '[+$added]($added_style)/[-$deleted]($deleted_style) '
+```
+
+## Git Remote
+
+The `git_remote` module shows a symbol representing the git remote provider
+(GitHub, GitLab, Bitbucket, etc.) based on the remote URL of the current branch.
+When inside a git repo with no remote configured, a fallback symbol is shown.
+
+> [!TIP]
+> This module is disabled by default.
+> To enable it, set `disabled` to `false` in your configuration file.
+
+### Options
+
+| Option             | Default                  | Description                                                                                                        |
+| ------------------ | ------------------------ | ------------------------------------------------------------------------------------------------------------------ |
+| `format`           | `'on [$symbol]($style)'` | The format for the module.                                                                                         |
+| `symbol`           | `'\u{f02a2} '`           | The default symbol shown when the remote provider is not matched.                                                  |
+| `no_remote_symbol` | `'\u{f1d3} '`            | The symbol shown when the repo has no remote configured.                                                           |
+| `style`            | `'bold dimmed white'`    | The style for the module.                                                                                          |
+| `disabled`         | `true`                   | Disables the `git_remote` module.                                                                                  |
+| `providers`        | See below                | A map of domain substrings to symbols. If the remote URL contains the key, the corresponding symbol will be shown. |
+
+#### Default providers
+
+| Domain          | Symbol      |
+| --------------- | ----------- |
+| `github.com`    | `\u{eb00}`  |
+| `gitlab.com`    | `\u{f0ba0}` |
+| `bitbucket.org` | `\u{f00a8}` |
+| `codeberg.org`  | `\u{f08e0}` |
+| `sr.ht`         | `\u{f4aa}`  |
+| `dev.azure.com` | `\u{f0fd5}` |
+
+### Variables
+
+| Variable    | Example                            | Description                                                  |
+| ----------- | ---------------------------------- | ------------------------------------------------------------ |
+| symbol      | `\u{eb00}`                         | The matched provider symbol, `symbol`, or `no_remote_symbol` |
+| url         | `https://github.com/user/repo.git` | The remote URL (empty if no remote)                          |
+| remote_name | `origin`                           | The remote name (empty if no remote)                         |
+| style\*     |                                    | Mirrors the value of option `style`                          |
+
+*: This variable can only be used as a part of a style string
+
+### Example
+
+```toml
+# ~/.config/starship.toml
+
+[git_remote]
+disabled = false
+format = '[$symbol]($style)'
+
+[git_remote.providers]
+"github.com" = "\u{eb00} "
+"gitlab.com" = "\u{f0ba0} "
+"my-company-git.com" = "🏢 "
 ```
 
 ## Git Status

--- a/docs/public/presets/toml/bracketed-segments.toml
+++ b/docs/public/presets/toml/bracketed-segments.toml
@@ -87,6 +87,9 @@ format = '\[[$symbol$branch]($style)\]'
 [git_commit]
 format = '\[[\($hash$tag\)]($style)\]'
 
+[git_remote]
+format = '\[[$symbol]($style)\]'
+
 [git_metrics]
 format = '\[[+$added]($added_style)\]\[[-$deleted]($deleted_style)\]'
 

--- a/docs/public/presets/toml/no-empty-icons.toml
+++ b/docs/public/presets/toml/no-empty-icons.toml
@@ -48,6 +48,9 @@ format = '(via [$symbol($version )]($style))'
 [fortran]
 format = "(via [$symbol($version )]($style))"
 
+[git_remote]
+format = '(on [$symbol]($style))'
+
 [gleam]
 format = '(via [$symbol($version )]($style))'
 

--- a/docs/public/presets/toml/no-nerd-font.toml
+++ b/docs/public/presets/toml/no-nerd-font.toml
@@ -13,6 +13,18 @@ symbol = "ⓔ "
 [fortran]
 symbol = "F "
 
+[git_remote]
+symbol = "remote "
+no_remote_symbol = "no-remote "
+
+[git_remote.providers]
+"github.com" = "gh "
+"gitlab.com" = "gl "
+"bitbucket.org" = "bb "
+"codeberg.org" = "cb "
+"sr.ht" = "srht "
+"dev.azure.com" = "az "
+
 [nodejs]
 symbol = "[⬢](bold green) "
 

--- a/docs/public/presets/toml/plain-text-symbols.toml
+++ b/docs/public/presets/toml/plain-text-symbols.toml
@@ -105,6 +105,18 @@ symbol = "gcp "
 symbol = "git "
 truncation_symbol = "..."
 
+[git_remote]
+symbol = "remote "
+no_remote_symbol = "no-remote "
+
+[git_remote.providers]
+"github.com" = "gh "
+"gitlab.com" = "gl "
+"bitbucket.org" = "bb "
+"codeberg.org" = "cb "
+"sr.ht" = "srht "
+"dev.azure.com" = "az "
+
 [gleam]
 symbol = "gleam "
 

--- a/src/configs/git_remote.rs
+++ b/src/configs/git_remote.rs
@@ -1,0 +1,38 @@
+use indexmap::IndexMap;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(
+    feature = "config-schema",
+    derive(schemars::JsonSchema),
+    schemars(deny_unknown_fields)
+)]
+#[serde(default)]
+pub struct GitRemoteConfig<'a> {
+    pub format: &'a str,
+    pub symbol: &'a str,
+    pub no_remote_symbol: &'a str,
+    pub style: &'a str,
+    pub disabled: bool,
+    pub providers: IndexMap<String, String>,
+}
+
+impl Default for GitRemoteConfig<'_> {
+    fn default() -> Self {
+        Self {
+            format: "on [$symbol]($style)",
+            symbol: "\u{f02a2}",
+            no_remote_symbol: "\u{f1d3}",
+            style: "bold dimmed white",
+            disabled: true,
+            providers: IndexMap::from([
+                ("github.com".to_string(), "\u{eb00}".to_string()),
+                ("gitlab.com".to_string(), "\u{f0ba0}".to_string()),
+                ("bitbucket.org".to_string(), "\u{f00a8}".to_string()),
+                ("codeberg.org".to_string(), "\u{f08e0}".to_string()),
+                ("sr.ht".to_string(), "\u{f4aa}".to_string()),
+                ("dev.azure.com".to_string(), "\u{f0fd5}".to_string()),
+            ]),
+        }
+    }
+}

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -37,6 +37,7 @@ pub mod gcloud;
 pub mod git_branch;
 pub mod git_commit;
 pub mod git_metrics;
+pub mod git_remote;
 pub mod git_state;
 pub mod git_status;
 pub mod gleam;
@@ -192,6 +193,8 @@ pub struct FullConfig<'a> {
     git_commit: git_commit::GitCommitConfig<'a>,
     #[serde(borrow)]
     git_metrics: git_metrics::GitMetricsConfig<'a>,
+    #[serde(borrow)]
+    git_remote: git_remote::GitRemoteConfig<'a>,
     #[serde(borrow)]
     git_state: git_state::GitStateConfig<'a>,
     #[serde(borrow)]

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -46,6 +46,7 @@ pub const PROMPT_ORDER: &[&str] = &[
     "git_commit",
     "git_state",
     "git_metrics",
+    "git_remote",
     "git_status",
     "hg_branch",
     "hg_state",

--- a/src/context.rs
+++ b/src/context.rs
@@ -784,6 +784,7 @@ impl Repo {
 pub struct Remote {
     pub branch: Option<String>,
     pub name: Option<String>,
+    pub url: Option<String>,
 }
 
 // A struct of Criteria which will be used to verify current PathBuf is
@@ -923,7 +924,17 @@ fn get_remote_repository_info(
         .branch_remote_name(branch_name.shorten(), gix::remote::Direction::Fetch)
         .map(|n| n.as_bstr().to_string());
 
-    Some(Remote { branch, name })
+    let url = name.as_ref().and_then(|remote_name| {
+        repository
+            .find_remote(remote_name.as_str())
+            .ok()?
+            .url(gix::remote::Direction::Fetch)?
+            .to_bstring()
+            .to_string()
+            .into()
+    });
+
+    Some(Remote { branch, name, url })
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/module.rs
+++ b/src/module.rs
@@ -41,6 +41,7 @@ pub const ALL_MODULES: &[&str] = &[
     "git_branch",
     "git_commit",
     "git_metrics",
+    "git_remote",
     "git_state",
     "git_status",
     "gleam",

--- a/src/modules/git_remote.rs
+++ b/src/modules/git_remote.rs
@@ -1,0 +1,326 @@
+use super::{Context, Module, ModuleConfig};
+
+use crate::configs::git_remote::GitRemoteConfig;
+use crate::formatter::StringFormatter;
+
+/// Creates a module with the Git remote provider symbol
+///
+/// Will display a symbol for the git remote provider (GitHub, GitLab, Bitbucket, etc.)
+/// based on the remote URL of the current branch. Shows a fallback symbol when
+/// inside a git repo with no remote configured.
+pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let mut module = context.new_module("git_remote");
+    let config = GitRemoteConfig::try_load(module.config);
+
+    let repo = context.get_repo().ok()?;
+
+    // Try to get the URL from the repo's remote info
+    let remote_url = get_remote_url(context, repo);
+
+    // Determine the symbol based on the remote URL (or lack thereof)
+    let symbol = match &remote_url {
+        Some(url) => resolve_symbol(url, &config),
+        None => config.no_remote_symbol.to_string(),
+    };
+
+    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
+        formatter
+            .map_meta(|var, _| match var {
+                "symbol" => Some(symbol.as_str()),
+                _ => None,
+            })
+            .map_style(|variable| match variable {
+                "style" => Some(Ok(config.style)),
+                _ => None,
+            })
+            .map(|variable| match variable {
+                "url" => Some(Ok(remote_url.clone().unwrap_or_default())),
+                "remote_name" => Some(Ok(repo
+                    .remote
+                    .as_ref()
+                    .and_then(|r| r.name.clone())
+                    .unwrap_or_default())),
+                _ => None,
+            })
+            .parse(None, Some(context))
+    });
+
+    module.set_segments(match parsed {
+        Ok(segments) => segments,
+        Err(error) => {
+            log::warn!("Error in module `git_remote`: \n{error}");
+            return None;
+        }
+    });
+
+    Some(module)
+}
+
+/// Get the remote URL, first from cached Remote info, then by opening the gix repo.
+fn get_remote_url(_context: &Context, repo: &crate::context::Repo) -> Option<String> {
+    // First try the cached URL from context
+    if let Some(url) = repo.remote.as_ref().and_then(|r| r.url.clone()) {
+        return Some(url);
+    }
+
+    // Fallback: open gix repo and try to find the "origin" remote URL
+    let gix_repo = repo.open();
+    let remote = gix_repo.find_remote("origin").ok().or_else(|| {
+        // If no "origin", try the first available remote
+        gix_repo
+            .remote_names()
+            .into_iter()
+            .next()
+            .and_then(|name| gix_repo.find_remote(name.as_ref()).ok())
+    })?;
+
+    let url = remote
+        .url(gix::remote::Direction::Fetch)?
+        .to_bstring()
+        .to_string();
+
+    if url.is_empty() { None } else { Some(url) }
+}
+
+/// Normalize an SSH-style remote URL so that provider keys using `/` also match.
+/// e.g. `git@github.com:user/repo.git` → `github.com/user/repo.git`
+fn normalize_url(url: &str) -> String {
+    if let Some(rest) = url.strip_prefix("git@") {
+        rest.replacen(':', "/", 1)
+    } else {
+        url.to_string()
+    }
+}
+
+/// Resolve a provider symbol from the remote URL using the configured providers map.
+/// When multiple keys match, the longest (most specific) key wins.
+fn resolve_symbol<'a>(url: &str, config: &'a GitRemoteConfig<'a>) -> String {
+    let normalized = normalize_url(url);
+    config
+        .providers
+        .iter()
+        .filter(|(domain, _)| normalized.contains(domain.as_str()))
+        .max_by_key(|(domain, _)| domain.len())
+        .map(|(_, symbol)| symbol.clone())
+        .unwrap_or_else(|| config.symbol.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::{FixtureProvider, ModuleRenderer, fixture_repo};
+    use crate::utils::create_command;
+    use std::io;
+
+    const NORMAL_AND_REFTABLE: [FixtureProvider; 2] =
+        [FixtureProvider::Git, FixtureProvider::GitReftable];
+
+    /// Helper: replace the fixture's "origin" remote with a custom URL
+    fn set_remote_url(path: &std::path::Path, url: &str) -> io::Result<()> {
+        create_command("git")?
+            .args(["remote", "set-url", "origin", url])
+            .current_dir(path)
+            .output()?;
+        Ok(())
+    }
+
+    #[test]
+    fn show_nothing_on_empty_dir() -> io::Result<()> {
+        let repo_dir = tempfile::tempdir()?;
+
+        let actual = ModuleRenderer::new("git_remote")
+            .config(toml::toml! {
+                [git_remote]
+                disabled = false
+            })
+            .path(repo_dir.path())
+            .collect();
+
+        assert_eq!(None, actual);
+        repo_dir.close()
+    }
+
+    #[test]
+    fn show_no_remote_symbol_without_remote() -> io::Result<()> {
+        for mode in NORMAL_AND_REFTABLE {
+            let repo_dir = fixture_repo(mode)?;
+
+            // Remove the origin remote that the fixture creates
+            create_command("git")?
+                .args(["remote", "remove", "origin"])
+                .current_dir(repo_dir.path())
+                .output()?;
+
+            let actual = ModuleRenderer::new("git_remote")
+                .config(toml::toml! {
+                    [git_remote]
+                    disabled = false
+                    format = "$symbol"
+                })
+                .path(repo_dir.path())
+                .collect();
+
+            assert_eq!(Some("\u{f1d3}".to_string()), actual);
+            repo_dir.close()?;
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn show_github_symbol() -> io::Result<()> {
+        for mode in NORMAL_AND_REFTABLE {
+            let repo_dir = fixture_repo(mode)?;
+            set_remote_url(repo_dir.path(), "https://github.com/user/repo.git")?;
+
+            let actual = ModuleRenderer::new("git_remote")
+                .config(toml::toml! {
+                    [git_remote]
+                    disabled = false
+                    format = "$symbol"
+                })
+                .path(repo_dir.path())
+                .collect();
+
+            assert_eq!(Some("\u{eb00}".to_string()), actual);
+            repo_dir.close()?;
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn show_gitlab_symbol() -> io::Result<()> {
+        for mode in NORMAL_AND_REFTABLE {
+            let repo_dir = fixture_repo(mode)?;
+            set_remote_url(repo_dir.path(), "git@gitlab.com:user/repo.git")?;
+
+            let actual = ModuleRenderer::new("git_remote")
+                .config(toml::toml! {
+                    [git_remote]
+                    disabled = false
+                    format = "$symbol"
+                })
+                .path(repo_dir.path())
+                .collect();
+
+            assert_eq!(Some("\u{f0ba0}".to_string()), actual);
+            repo_dir.close()?;
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn show_bitbucket_symbol() -> io::Result<()> {
+        for mode in NORMAL_AND_REFTABLE {
+            let repo_dir = fixture_repo(mode)?;
+            set_remote_url(repo_dir.path(), "git@bitbucket.org:user/repo.git")?;
+
+            let actual = ModuleRenderer::new("git_remote")
+                .config(toml::toml! {
+                    [git_remote]
+                    disabled = false
+                    format = "$symbol"
+                })
+                .path(repo_dir.path())
+                .collect();
+
+            assert_eq!(Some("\u{f00a8}".to_string()), actual);
+            repo_dir.close()?;
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn show_default_symbol_for_unknown_remote() -> io::Result<()> {
+        for mode in NORMAL_AND_REFTABLE {
+            let repo_dir = fixture_repo(mode)?;
+            set_remote_url(
+                repo_dir.path(),
+                "https://my-custom-git.example.com/repo.git",
+            )?;
+
+            let actual = ModuleRenderer::new("git_remote")
+                .config(toml::toml! {
+                    [git_remote]
+                    disabled = false
+                    format = "$symbol"
+                })
+                .path(repo_dir.path())
+                .collect();
+
+            assert_eq!(Some("\u{f02a2}".to_string()), actual);
+            repo_dir.close()?;
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn show_custom_provider_symbol() -> io::Result<()> {
+        for mode in NORMAL_AND_REFTABLE {
+            let repo_dir = fixture_repo(mode)?;
+            set_remote_url(repo_dir.path(), "https://git.example.com/repo.git")?;
+
+            let actual = ModuleRenderer::new("git_remote")
+                .config(toml::toml! {
+                    [git_remote]
+                    disabled = false
+                    format = "$symbol"
+                    [git_remote.providers]
+                    "git.example.com" = "EX "
+                })
+                .path(repo_dir.path())
+                .collect();
+
+            assert_eq!(Some("EX ".to_string()), actual);
+            repo_dir.close()?;
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn show_specific_account_symbol() -> io::Result<()> {
+        for mode in NORMAL_AND_REFTABLE {
+            let repo_dir = fixture_repo(mode)?;
+            set_remote_url(repo_dir.path(), "https://github.com/work-org/repo.git")?;
+
+            let actual = ModuleRenderer::new("git_remote")
+                .config(toml::toml! {
+                    [git_remote]
+                    disabled = false
+                    format = "$symbol"
+                    [git_remote.providers]
+                    "github.com" = "GH "
+                    "github.com/work-org" = "WORK "
+                })
+                .path(repo_dir.path())
+                .collect();
+
+            assert_eq!(Some("WORK ".to_string()), actual);
+            repo_dir.close()?;
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn show_url_variable() -> io::Result<()> {
+        for mode in NORMAL_AND_REFTABLE {
+            let repo_dir = fixture_repo(mode)?;
+            set_remote_url(repo_dir.path(), "https://git.example.org/myuser/myrepo.git")?;
+
+            let actual = ModuleRenderer::new("git_remote")
+                .config(toml::toml! {
+                    [git_remote]
+                    disabled = false
+                    format = "$url"
+                })
+                .path(repo_dir.path())
+                .collect();
+
+            let actual_str = actual.expect("expected url output");
+            assert!(
+                actual_str.contains("git.example.org"),
+                "Expected URL to contain 'git.example.org', got: {actual_str}"
+            );
+            repo_dir.close()?;
+        }
+        Ok(())
+    }
+}

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -34,6 +34,7 @@ mod gcloud;
 mod git_branch;
 mod git_commit;
 mod git_metrics;
+mod git_remote;
 mod git_state;
 pub(crate) mod git_status;
 mod gleam;
@@ -155,6 +156,7 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
             "git_branch" => git_branch::module(context),
             "git_commit" => git_commit::module(context),
             "git_metrics" => git_metrics::module(context),
+            "git_remote" => git_remote::module(context),
             "git_state" => git_state::module(context),
             "git_status" => git_status::module(context),
             "gleam" => gleam::module(context),
@@ -289,6 +291,7 @@ pub fn description(module: &str) -> &'static str {
         "git_branch" => "The active branch of the repo in your current directory",
         "git_commit" => "The active commit (and tag if any) of the repo in your current directory",
         "git_metrics" => "The currently added/deleted lines in your repo",
+        "git_remote" => "The symbol for the git remote provider",
         "git_state" => "The current git operation, and it's progress",
         "git_status" => "Symbol representing the state of the repo",
         "gleam" => "The currently installed version of Gleam",


### PR DESCRIPTION
## Summary

Adds a native `git_remote` module that displays a symbol based on the git remote provider (GitHub, GitLab, Bitbucket, etc.).

Resolves #4654.

- Detects the remote URL and matches it against configurable provider keys
- Matches by specificity (longest key wins), allowing per-account symbols (e.g., `github.com/work-org` vs `github.com`)
- Normalizes SSH URLs (`git@host:user/repo`) for consistent matching with slash-based keys
- Default providers: GitHub , GitLab , Bitbucket 󰂨, Codeberg , Gitea 󰮠
- Supports `no_remote_symbol` for repos without a remote
- Uses `IndexMap` for deterministic provider ordering
- Includes config, documentation, presets, schema, and 9 unit tests

### Example config

```toml
[git_remote]
format = "on [$symbol]($style)"

[git_remote.providers]
"github.com" = " "
"gitlab.com" = " "
"github.com/my-work-org" = "󰊢 "
```

## Test plan

- [x] `cargo test git_remote` — 9 tests pass
- [x] `cargo clippy --all-targets --all-features` — no warnings
- [x] `cargo fmt` — clean
- [x] `dprint fmt` — docs formatted
- [x] Schema regenerated
- [x] Manual testing: `cargo run -- module git_remote` shows correct symbol for current repo