### PR TITLE
feat(fish): permit overriding job count/status in Fish

### DIFF
--- a/src/init/starship.fish
+++ b/src/init/starship.fish
@@ -18,12 +18,14 @@ function fish_prompt
             set STARSHIP_KEYMAP insert
     end
 
-    set STARSHIP_CMD_PIPESTATUS $pipestatus
-    set STARSHIP_CMD_STATUS $status
+    set -l _pipestatus $pipestatus
+    set -l _status $status
+    set -q STARSHIP_CMD_PIPESTATUS; or set STARSHIP_CMD_PIPESTATUS $_pipestatus
+    set -q STARSHIP_CMD_STATUS; or set STARSHIP_CMD_STATUS $_status
     # Account for changes in variable name between v2.7 and v3.0
     set STARSHIP_DURATION "$CMD_DURATION$cmd_duration"
 
-    __starship_set_job_count
+    set -q STARSHIP_JOBS; or __starship_set_job_count
 
     if contains -- --final-rendering $argv; or test "$TRANSIENT" = "1"
         if test "$TRANSIENT" = "1"
@@ -40,6 +42,8 @@ function fish_prompt
     else
         ::STARSHIP:: prompt --terminal-width="$COLUMNS" --status=$STARSHIP_CMD_STATUS --pipestatus="$STARSHIP_CMD_PIPESTATUS" --keymap=$STARSHIP_KEYMAP --cmd-duration=$STARSHIP_DURATION --jobs=$STARSHIP_JOBS
     end
+
+    set -eg STARSHIP_CMD_PIPESTATUS STARSHIP_CMD_STATUS STARSHIP_JOBS
 end
 
 function fish_right_prompt
@@ -50,13 +54,15 @@ function fish_right_prompt
             set STARSHIP_KEYMAP insert
     end
 
-    set STARSHIP_CMD_PIPESTATUS $pipestatus
-    set STARSHIP_CMD_STATUS $status
+    set -l _pipestatus $pipestatus
+    set -l _status $status
+    set -q STARSHIP_CMD_PIPESTATUS; or set STARSHIP_CMD_PIPESTATUS $_pipestatus
+    set -q STARSHIP_CMD_STATUS; or set STARSHIP_CMD_STATUS $_status
     # Account for changes in variable name between v2.7 and v3.0
     set STARSHIP_DURATION "$CMD_DURATION$cmd_duration"
 
     # Now it's safe to call job count function (after status capture)
-    __starship_set_job_count
+    set -q STARSHIP_JOBS; or __starship_set_job_count
 
     if contains -- --final-rendering $argv; or test "$RIGHT_TRANSIENT" = "1"
         set -g RIGHT_TRANSIENT 0
@@ -68,6 +74,8 @@ function fish_right_prompt
     else
         ::STARSHIP:: prompt --right --terminal-width="$COLUMNS" --status=$STARSHIP_CMD_STATUS --pipestatus="$STARSHIP_CMD_PIPESTATUS" --keymap=$STARSHIP_KEYMAP --cmd-duration=$STARSHIP_DURATION --jobs=$STARSHIP_JOBS
     end
+
+    set -eg STARSHIP_CMD_PIPESTATUS STARSHIP_CMD_STATUS STARSHIP_JOBS
 end
 
 # Disable virtualenv prompt, it breaks starship


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

If `$STARSHIP_CMD_PIPESTATUS`, `$STARSHIP_CMD_STATUS`, and/or `$STARSHIP_JOBS` are set when Starship's `fish_prompt` is invoked, use their values directly rather than actually checking the exit status or number of jobs. (To prevent this breaking when they aren't set by something else, we now also unset those variables at the end of each `fish_prompt`.)

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When using plugins like [fish-async-prompt][1], the automatic detection of exit status and running jobs can be flaky. To facilitate workarounds, let preexisting values for the job count and exit status variables take precedence over the values determined by Starship.

For example, with this commit (and `$async_prompt_inherit_variables` set to `all`), adding the following snippet to `config.fish` fixes my own problems with fish-async-prompt and Starship:

```fish
function __update_starship_job_count --on-event fish_postexec
  set -g STARSHIP_CMD_PIPESTATUS $pipestatus
  set -g STARSHIP_CMD_STATUS $status
  set -g STARSHIP_JOBS (jobs -g 2>/dev/null | count)
end
```

[1]: https://github.com/acomagu/fish-async-prompt

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

With the `__update_starship_job_count` function, this fixes my problems with job count/exit status not being detected; without that function, the behaviour doesn't change, as far as I can tell.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.

I'm not sure where this should be documented, it's a pretty niche problem. I also can't see any existing tests for the shell-specific bits of Starship?