### PR TITLE
fix(fish): correctly fetch exit status/job count with fish-async-prompt

### DIFF
--- a/docs/advanced-config/README.md
+++ b/docs/advanced-config/README.md
@@ -377,3 +377,11 @@ Not every style string will be displayed correctly by every terminal. In particu
 - Many terminals disable support for `blink` by default.
 - `hidden` is [not supported on iTerm](https://gitlab.com/gnachman/iterm2/-/issues/4564).
 - `strikethrough` is not supported by the default macOS Terminal.app.
+
+## Async prompt in Fish
+
+If using [fish-async-prompt][fish-async-prompt] to render the prompt asynchronously, you'll need to make sure some of Starship's internal variables are correctly propagated to the `fish_prompt` function.
+To do this, you should either set `$async_prompt_inherit_variables` to `all`, or make sure it includes `STARSHIP_CMD_PIPESTATUS`, `STARSHIP_CMD_STATUS`, `STARSHIP_DURATION`, `STARSHIP_JOBS`, and `STARSHIP_KEYMAP`.
+If you don't do this, it's likely that the `character`, `cmd_duration`, `jobs`, and `status` modules won't work properly.
+
+[fish-async-prompt]: https://github.com/acomagu/fish-async-prompt

--- a/src/init/starship.fish
+++ b/src/init/starship.fish
@@ -1,4 +1,9 @@
-function __starship_set_job_count --description 'Set STARSHIP_JOBS using fish job groups (or legacy PIDs if toggled)'
+function __starship_update_variables --on-event fish_postexec
+    set -g STARSHIP_CMD_PIPESTATUS $pipestatus
+    set -g STARSHIP_CMD_STATUS $status
+    # Account for changes in variable name between v2.7 and v3.0
+    set -g STARSHIP_DURATION "$CMD_DURATION$cmd_duration"
+
     # To force legacy behavior (process PIDs), set this variable to "false":
     #   set -g __starship_fish_use_job_groups "false"
     if test "$__starship_fish_use_job_groups" = "false"
@@ -7,24 +12,17 @@ function __starship_set_job_count --description 'Set STARSHIP_JOBS using fish jo
     else
         # Default behavior: count job groups
         set -g STARSHIP_JOBS (jobs -g 2>/dev/null | count)
-    end    
+    end
+
+    switch "$fish_key_bindings"
+        case fish_hybrid_key_bindings fish_vi_key_bindings fish_helix_key_bindings
+            set -g STARSHIP_KEYMAP "$fish_bind_mode"
+        case '*'
+            set -g STARSHIP_KEYMAP insert
+    end
 end
 
 function fish_prompt
-    switch "$fish_key_bindings"
-        case fish_hybrid_key_bindings fish_vi_key_bindings fish_helix_key_bindings
-            set STARSHIP_KEYMAP "$fish_bind_mode"
-        case '*'
-            set STARSHIP_KEYMAP insert
-    end
-
-    set STARSHIP_CMD_PIPESTATUS $pipestatus
-    set STARSHIP_CMD_STATUS $status
-    # Account for changes in variable name between v2.7 and v3.0
-    set STARSHIP_DURATION "$CMD_DURATION$cmd_duration"
-
-    __starship_set_job_count
-
     if contains -- --final-rendering $argv; or test "$TRANSIENT" = "1"
         if test "$TRANSIENT" = "1"
             set -g TRANSIENT 0
@@ -43,21 +41,6 @@ function fish_prompt
 end
 
 function fish_right_prompt
-    switch "$fish_key_bindings"
-        case fish_hybrid_key_bindings fish_vi_key_bindings fish_helix_keybindings
-            set STARSHIP_KEYMAP "$fish_bind_mode"
-        case '*'
-            set STARSHIP_KEYMAP insert
-    end
-
-    set STARSHIP_CMD_PIPESTATUS $pipestatus
-    set STARSHIP_CMD_STATUS $status
-    # Account for changes in variable name between v2.7 and v3.0
-    set STARSHIP_DURATION "$CMD_DURATION$cmd_duration"
-
-    # Now it's safe to call job count function (after status capture)
-    __starship_set_job_count
-
     if contains -- --final-rendering $argv; or test "$RIGHT_TRANSIENT" = "1"
         set -g RIGHT_TRANSIENT 0
         if type -q starship_transient_rprompt_func


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

Rather than populating `$STARSHIP_CMD_PIPESTATUS` etc. in `fish_prompt` and `fish_right_prompt`, we now set them in a `fish_postexec` event handler. This avoids some code duplication and also improves Starship's behaviour in situations where `fish_prompt` is executed asynchronously in the background.

(This is an alternative to #7275, but doesn't require any explicit configuration by the user besides making sure the `$STARSHIP_*` variables get passed to the environment that `fish_prompt` runs in.)

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

When using plugins like [fish-async-prompt][1], the automatic detection of exit status and running jobs can be flaky, because `fish_prompt` gets executed in a different process and fish-async-prompt isn't always able to exactly emulate the environment it would normally run in. To improve the situation, let's retrieve the exit status and job count as soon as possible after a command exits, since this will always happen in the Fish process no matter what.

[1]: https://github.com/acomagu/fish-async-prompt

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

This fixes my problems with job count/exit status not being detected!

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.

I can't see any existing tests for the shell-specific bits of Starship, so I'm not sure how to write a test for this change.