### PR TITLE
feat(battery): Update default `unknown_symbol`

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -91,7 +91,7 @@
         "full_symbol": "󰁹 ",
         "charging_symbol": "󰂄 ",
         "discharging_symbol": "󰂃 ",
-        "unknown_symbol": "󰁽 ",
+        "unknown_symbol": "󰂑 ",
         "empty_symbol": "󰂎 ",
         "display": [
           {
@@ -1960,7 +1960,7 @@
         },
         "unknown_symbol": {
           "type": "string",
-          "default": "󰁽 "
+          "default": "󰂑 "
         },
         "empty_symbol": {
           "type": "string",

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -527,7 +527,7 @@ The module is only visible when the device's battery is below 10%.
 | `full_symbol`        | `'󰁹 '`                            | The symbol shown when the battery is full.          |
 | `charging_symbol`    | `'󰂄 '`                            | The symbol shown when the battery is charging.      |
 | `discharging_symbol` | `'󰂃 '`                            | The symbol shown when the battery is discharging.   |
-| `unknown_symbol`     | `'󰁽 '`                            | The symbol shown when the battery state is unknown. |
+| `unknown_symbol`     | `'󰂑 '`                            | The symbol shown when the battery state is unknown. |
 | `empty_symbol`       | `'󰂎 '`                            | The symbol shown when the battery state is empty.   |
 | `format`             | `'[$symbol$percentage]($style) '` | The format for the module.                          |
 | `display`            | [link](#battery-display)          | Display threshold and style for the module.         |

--- a/src/configs/battery.rs
+++ b/src/configs/battery.rs
@@ -25,7 +25,7 @@ impl Default for BatteryConfig<'_> {
             full_symbol: "󰁹 ",
             charging_symbol: "󰂄 ",
             discharging_symbol: "󰂃 ",
-            unknown_symbol: "󰁽 ",
+            unknown_symbol: "󰂑 ",
             empty_symbol: "󰂎 ",
             format: "[$symbol$percentage]($style) ",
             display: vec![BatteryDisplayConfig::default()],

--- a/src/modules/battery.rs
+++ b/src/modules/battery.rs
@@ -313,7 +313,7 @@ mod tests {
             })
             .battery_info_provider(&mock)
             .collect();
-        let expected = Some(String::from("󰁽 0% "));
+        let expected = Some(String::from("󰂑 0% "));
 
         assert_eq!(expected, actual);
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Update the battery module unknown symbol from `󰁽` to `󰂑`.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Use the question mark to convey the status.

#### Screenshots (if appropriate):
Current vs. suggested: <img width="54" height="29" alt="image" src="https://github.com/user-attachments/assets/5d7517a8-c903-47ec-8703-d6f591030088" /> vs. <img width="52" height="28" alt="image" src="https://github.com/user-attachments/assets/1828228b-806f-47be-bad0-022843ace694" />

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
