### PR TITLE
docs(themes): sync language icons

### DIFF
--- a/docs/public/presets/toml/catppuccin-powerline.toml
+++ b/docs/public/presets/toml/catppuccin-powerline.toml
@@ -19,6 +19,15 @@ $java\
 $kotlin\
 $haskell\
 $python\
+$cpp\
+$elixir\
+$elm\
+$gradle\
+$julia\
+$maven\
+$nim\
+$ruby\
+$scala\
 [](fg:green bg:sapphire)\
 $conda\
 [](fg:sapphire bg:lavender)\
@@ -128,6 +137,49 @@ format = '[[ $symbol( $version) ](fg:crust bg:green)]($style)'
 symbol = ""
 style = "bg:green"
 format = '[[ $symbol( $version)(\(#$virtualenv\)) ](fg:crust bg:green)]($style)'
+
+[cpp]
+symbol = " "
+style = "bg:green"
+format = '[[ $symbol( $version) ](fg:crust bg:green)]($style)'
+
+[elixir]
+symbol = " "
+style = "bg:green"
+format = '[[ $symbol( $version) ](fg:crust bg:green)]($style)'
+
+[elm]
+symbol = " "
+style = "bg:green"
+format = '[[ $symbol( $version) ](fg:crust bg:green)]($style)'
+
+[gradle]
+style = "bg:green"
+format = '[[ $symbol( $version) ](fg:crust bg:green)]($style)'
+
+[julia]
+symbol = " "
+style = "bg:green"
+format = '[[ $symbol( $version) ](fg:crust bg:green)]($style)'
+
+[maven]
+style = "bg:green"
+format = '[[ $symbol( $version) ](fg:crust bg:green)]($style)'
+
+[nim]
+symbol = "󰆥 "
+style = "bg:green"
+format = '[[ $symbol( $version) ](fg:crust bg:green)]($style)'
+
+[ruby]
+symbol = ""
+style = "bg:green"
+format = '[[ $symbol( $version) ](fg:crust bg:green)]($style)'
+
+[scala]
+symbol = " "
+style = "bg:green"
+format = '[[ $symbol( $version) ](fg:crust bg:green)]($style)'
 
 [docker_context]
 symbol = ""

--- a/docs/public/presets/toml/gruvbox-rainbow.toml
+++ b/docs/public/presets/toml/gruvbox-rainbow.toml
@@ -20,6 +20,14 @@ $java\
 $kotlin\
 $haskell\
 $python\
+$ruby\
+$elixir\
+$elm\
+$gradle\
+$julia\
+$maven\
+$nim\
+$scala\
 [](fg:color_blue bg:color_bg3)\
 $docker_context\
 $conda\
@@ -146,6 +154,44 @@ format = '[[ $symbol( $version) ](fg:color_fg0 bg:color_blue)]($style)'
 
 [python]
 symbol = ""
+style = "bg:color_blue"
+format = '[[ $symbol( $version) ](fg:color_fg0 bg:color_blue)]($style)'
+
+[ruby]
+symbol = ""
+style = "bg:color_blue"
+format = '[[ $symbol( $version) ](fg:color_fg0 bg:color_blue)]($style)'
+
+[elixir]
+symbol = " "
+style = "bg:color_blue"
+format = '[[ $symbol( $version) ](fg:color_fg0 bg:color_blue)]($style)'
+
+[elm]
+symbol = " "
+style = "bg:color_blue"
+format = '[[ $symbol( $version) ](fg:color_fg0 bg:color_blue)]($style)'
+
+[gradle]
+style = "bg:color_blue"
+format = '[[ $symbol( $version) ](fg:color_fg0 bg:color_blue)]($style)'
+
+[julia]
+symbol = " "
+style = "bg:color_blue"
+format = '[[ $symbol( $version) ](fg:color_fg0 bg:color_blue)]($style)'
+
+[maven]
+style = "bg:color_blue"
+format = '[[ $symbol( $version) ](fg:color_fg0 bg:color_blue)]($style)'
+
+[nim]
+symbol = "󰆥 "
+style = "bg:color_blue"
+format = '[[ $symbol( $version) ](fg:color_fg0 bg:color_blue)]($style)'
+
+[scala]
+symbol = " "
 style = "bg:color_blue"
 format = '[[ $symbol( $version) ](fg:color_fg0 bg:color_blue)]($style)'
 

--- a/docs/public/presets/toml/pastel-powerline.toml
+++ b/docs/public/presets/toml/pastel-powerline.toml
@@ -23,6 +23,11 @@ $nodejs\
 $nim\
 $rust\
 $scala\
+$ruby\
+$cpp\
+$kotlin\
+$php\
+$python\
 [](fg:#86BBD8 bg:#06969A)\
 $docker_context\
 [](fg:#06969A bg:#33658A)\
@@ -146,6 +151,26 @@ format = '[ $symbol ($version) ]($style)'
 
 [scala]
 symbol = " "
+style = "bg:#86BBD8"
+format = '[ $symbol ($version) ]($style)'
+
+[ruby]
+symbol = ""
+style = "bg:#86BBD8"
+format = '[ $symbol ($version) ]($style)'
+
+[kotlin]
+symbol = ""
+style = "bg:#86BBD8"
+format = '[ $symbol ($version) ]($style)'
+
+[php]
+symbol = ""
+style = "bg:#86BBD8"
+format = '[ $symbol ($version) ]($style)'
+
+[python]
+symbol = ""
 style = "bg:#86BBD8"
 format = '[ $symbol ($version) ]($style)'
 

--- a/docs/public/presets/toml/tokyo-night.toml
+++ b/docs/public/presets/toml/tokyo-night.toml
@@ -13,6 +13,20 @@ $nodejs\
 $rust\
 $golang\
 $php\
+$c\
+$cpp\
+$elixir\
+$elm\
+$gradle\
+$haskell\
+$java\
+$julia\
+$kotlin\
+$maven\
+$nim\
+$python\
+$ruby\
+$scala\
 [](fg:#212736 bg:#1d2230)\
 $time\
 [ ](fg:#1d2230)\
@@ -56,6 +70,74 @@ format = '[[ $symbol ($version) ](fg:#769ff0 bg:#212736)]($style)'
 
 [php]
 symbol = ""
+style = "bg:#212736"
+format = '[[ $symbol ($version) ](fg:#769ff0 bg:#212736)]($style)'
+
+[c]
+symbol = " "
+style = "bg:#212736"
+format = '[[ $symbol ($version) ](fg:#769ff0 bg:#212736)]($style)'
+
+[cpp]
+symbol = " "
+style = "bg:#212736"
+format = '[[ $symbol ($version) ](fg:#769ff0 bg:#212736)]($style)'
+
+[elixir]
+symbol = " "
+style = "bg:#212736"
+format = '[[ $symbol ($version) ](fg:#769ff0 bg:#212736)]($style)'
+
+[elm]
+symbol = " "
+style = "bg:#212736"
+format = '[[ $symbol ($version) ](fg:#769ff0 bg:#212736)]($style)'
+
+[gradle]
+style = "bg:#212736"
+format = '[[ $symbol ($version) ](fg:#769ff0 bg:#212736)]($style)'
+
+[haskell]
+symbol = ""
+style = "bg:#212736"
+format = '[[ $symbol ($version) ](fg:#769ff0 bg:#212736)]($style)'
+
+[java]
+symbol = ""
+style = "bg:#212736"
+format = '[[ $symbol ($version) ](fg:#769ff0 bg:#212736)]($style)'
+
+[julia]
+symbol = " "
+style = "bg:#212736"
+format = '[[ $symbol ($version) ](fg:#769ff0 bg:#212736)]($style)'
+
+[kotlin]
+symbol = ""
+style = "bg:#212736"
+format = '[[ $symbol ($version) ](fg:#769ff0 bg:#212736)]($style)'
+
+[maven]
+style = "bg:#212736"
+format = '[[ $symbol ($version) ](fg:#769ff0 bg:#212736)]($style)'
+
+[nim]
+symbol = "󰆥 "
+style = "bg:#212736"
+format = '[[ $symbol ($version) ](fg:#769ff0 bg:#212736)]($style)'
+
+[python]
+symbol = ""
+style = "bg:#212736"
+format = '[[ $symbol ($version) ](fg:#769ff0 bg:#212736)]($style)'
+
+[ruby]
+symbol = ""
+style = "bg:#212736"
+format = '[[ $symbol ($version) ](fg:#769ff0 bg:#212736)]($style)'
+
+[scala]
+symbol = " "
 style = "bg:#212736"
 format = '[[ $symbol ($version) ](fg:#769ff0 bg:#212736)]($style)'
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
Current state of languages "support" across four themes that use glyphs is non-uniform. This change makes all of them to support current superset.

_State before the change._

| Language |  Gruvbox Rainbow  |  Pastel Powerline  |   Tokyo Night   | Catppuccin Powerline |
|:--------:|:-----------------:|:------------------:|:---------------:|:--------------------:|
|    c     |         X         |         X          |                 |          X           |
|   cpp    |         X         |         X          |                 |                      |
|   rust   |         X         |         X          |        X        |          X           |
|  golang  |         X         |         X          |        X        |          X           |
|  nodejs  |         X         |         X          |        X        |          X           |
|   php    |         X         |         X          |        X        |          X           |
|   java   |         X         |         X          |                 |          X           |
|  kotlin  |         X         |                    |                 |          X           |
| haskell  |         X         |         X          |                 |          X           |
|  python  |         X         |                    |                 |          X           |
|   ruby   |         X         |                    |                 |                      |
|  elixir  |                   |         X          |                 |                      |
|   elm    |                   |         X          |                 |                      |
|  julia   |                   |         X          |                 |                      |
|  gradle  |                   |         X          |                 |                      |
|  maven   |                   |         X          |                 |                      |
|   nim    |                   |         X          |                 |                      |
|  scala   |                   |         X          |                 |                      |


#### Motivation and Context
I noticed that [Gruvbox Rainbow](https://starship.rs/presets/gruvbox-rainbow) theme doesn't have ruby, but Ruby is alive!

#### Screenshots (if appropriate):
<img width="1253" height="295" alt="image" src="https://github.com/user-attachments/assets/2d4d37c0-ebe9-4309-8136-daed74db3b99" />

_This WARN is caused by my homebrew 1.24.2 version that doesn't have maven yet that was added late January_

#### How Has This Been Tested?
- [x] I have tested using **MacOS**

See screenshot above.

#### Checklist:
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
