### PR TITLE
feat: add support to overide all the configuration in kubernetes.contexts

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -4467,6 +4467,13 @@
           ],
           "default": null
         },
+        "format": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        },
         "context_alias": {
           "type": [
             "string",
@@ -4479,6 +4486,53 @@
             "string",
             "null"
           ],
+          "default": null
+        },
+        "disabled": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "default": null
+        },
+        "detect_extensions": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "default": null
+        },
+        "detect_files": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "default": null
+        },
+        "detect_folders": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "default": null
+        },
+        "detect_env_vars": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "string"
+          },
           "default": null
         }
       },

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2757,14 +2757,20 @@ If the `$KUBECONFIG` env var is set the module will use that if not it will use 
 To customize the style of the module for specific environments, use the following configuration as
 part of the `contexts` list:
 
-| Variable          | Description                                                                              |
-| ----------------- | ---------------------------------------------------------------------------------------- |
-| `context_pattern` | **Required** Regular expression to match current Kubernetes context name.                |
-| `user_pattern`    | Regular expression to match current Kubernetes user name.                                |
-| `context_alias`   | Context alias to display instead of the full context name.                               |
-| `user_alias`      | User alias to display instead of the full user name.                                     |
-| `style`           | The style for the module when using this context. If not set, will use module's style.   |
-| `symbol`          | The symbol for the module when using this context. If not set, will use module's symbol. |
+| Variable            | Description                                                                                                             |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `context_pattern`   | **Required** Regular expression to match current Kubernetes context name.                                               |
+| `user_pattern`      | Regular expression to match current Kubernetes user name.                                                               |
+| `context_alias`     | Context alias to display instead of the full context name.                                                              |
+| `user_alias`        | User alias to display instead of the full user name.                                                                    |
+| `style`             | The style for the module when using this context. If not set, will use module's style.                                  |
+| `symbol`            | The symbol for the module when using this context. If not set, will use module's symbol.                                |
+| `format`            | The format for the module when using this context. If not set, will use module's format.                                |
+| `disabled`          | If `true`, the module will not be shown when this context matches.                                                      |
+| `detect_extensions` | Which extensions should trigger this module for this context. Set to `[]` to clear parent's value. Inherits if not set. |
+| `detect_files`      | Which filenames should trigger this module for this context. Set to `[]` to clear parent's value. Inherits if not set.  |
+| `detect_folders`    | Which folders should trigger this module for this context. Set to `[]` to clear parent's value. Inherits if not set.    |
+| `detect_env_vars`   | Which env vars should trigger this module for this context. Set to `[]` to clear parent's value. Inherits if not set.   |
 
 Note that all regular expression are anchored with `^<pattern>$` and so must match the whole string. The `*_pattern`
 regular expressions may contain capture groups, which can be referenced in the corresponding alias via `$name` and `$N`
@@ -2809,8 +2815,9 @@ detect_files = ['k8s']
 
 #### Kubernetes Context specific config
 
-The `contexts` configuration option is used to customise what the current Kubernetes context name looks
-like (style and symbol) if the name matches the defined regular expression.
+The `contexts` configuration option is used to customise how the module renders for specific Kubernetes
+contexts. Each entry can override any module-level property including `format`, `style`, `symbol`,
+`disabled`, and detection rules (`detect_files`, `detect_folders`, `detect_extensions`, `detect_env_vars`).
 
 ```toml
 # ~/.config/starship.toml
@@ -2838,6 +2845,19 @@ context_alias = "openshift"
 # and renames every matching kube context into a more readable format (`gke-cluster-name`):
 context_pattern = "gke_.*_(?P<cluster>[\\w-]+)"
 context_alias = "gke-$cluster"
+
+[[kubernetes.contexts]]
+# Override format and disable detection for dev contexts (always show)
+context_pattern = "dev-.*"
+format = "$symbol$context"
+style = "green"
+detect_files = []
+detect_folders = []
+
+[[kubernetes.contexts]]
+# Hide the module entirely for local contexts
+context_pattern = "local-.*"
+disabled = true
 ```
 
 ## Line Break

--- a/src/configs/kubernetes.rs
+++ b/src/configs/kubernetes.rs
@@ -52,6 +52,12 @@ pub struct KubernetesContextConfig<'a> {
     pub user_pattern: Option<&'a str>,
     pub symbol: Option<&'a str>,
     pub style: Option<&'a str>,
+    pub format: Option<&'a str>,
     pub context_alias: Option<&'a str>,
     pub user_alias: Option<&'a str>,
+    pub disabled: Option<bool>,
+    pub detect_extensions: Option<Vec<&'a str>>,
+    pub detect_files: Option<Vec<&'a str>>,
+    pub detect_folders: Option<Vec<&'a str>>,
+    pub detect_env_vars: Option<Vec<&'a str>>,
 }

--- a/src/modules/kubernetes.rs
+++ b/src/modules/kubernetes.rs
@@ -142,33 +142,8 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         return None;
     }
 
-    let have_env_config = !config.detect_env_vars.is_empty();
-    let have_env_vars = have_env_config.then(|| context.detect_env_vars(&config.detect_env_vars));
-
-    // If we have some config for doing the directory scan then we use it but if we don't then we
-    // assume we should treat it like the module is enabled to preserve backward compatibility.
-    let have_scan_config = [
-        &config.detect_files,
-        &config.detect_folders,
-        &config.detect_extensions,
-    ]
-    .into_iter()
-    .any(|v| !v.is_empty());
-
-    let is_kube_project = have_scan_config.then(|| {
-        context.try_begin_scan().is_some_and(|scanner| {
-            scanner
-                .set_files(&config.detect_files)
-                .set_folders(&config.detect_folders)
-                .set_extensions(&config.detect_extensions)
-                .is_match()
-        })
-    });
-
-    if !is_kube_project.or(have_env_vars).unwrap_or(true) {
-        return None;
-    }
-
+    // Read kubeconfig and match context before detection so per-context
+    // detect_*, disabled, and format overrides can take effect.
     let default_config_file = context.get_home()?.join(".kube").join("config");
 
     let kube_cfg = context
@@ -202,7 +177,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             KubeCtxComponents::default()
         });
 
-    // Select the first style that matches the context_pattern and,
+    // Select the first context config that matches the context_pattern and,
     // if it is defined, the user_pattern
     let (matched_context_config, display_context, display_user) = config
         .contexts
@@ -228,6 +203,55 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         })
         .unwrap_or_else(|| (None, current_kube_ctx_name.to_string(), ctx_components.user));
 
+    if matched_context_config
+        .and_then(|ctx_cfg| ctx_cfg.disabled)
+        .unwrap_or(false)
+    {
+        return None;
+    }
+
+    // Resolve effective detect_* from matched context, falling back to parent config.
+    // None = inherit parent, Some(vec![]) = clear parent, Some(vec![...]) = override.
+    let effective_detect_extensions = matched_context_config
+        .and_then(|ctx_cfg| ctx_cfg.detect_extensions.as_deref())
+        .unwrap_or(&config.detect_extensions);
+    let effective_detect_files = matched_context_config
+        .and_then(|ctx_cfg| ctx_cfg.detect_files.as_deref())
+        .unwrap_or(&config.detect_files);
+    let effective_detect_folders = matched_context_config
+        .and_then(|ctx_cfg| ctx_cfg.detect_folders.as_deref())
+        .unwrap_or(&config.detect_folders);
+    let effective_detect_env_vars = matched_context_config
+        .and_then(|ctx_cfg| ctx_cfg.detect_env_vars.as_deref())
+        .unwrap_or(&config.detect_env_vars);
+
+    let have_env_config = !effective_detect_env_vars.is_empty();
+    let have_env_vars = have_env_config.then(|| context.detect_env_vars(effective_detect_env_vars));
+
+    // If we have some config for doing the directory scan then we use it but if we don't then we
+    // assume we should treat it like the module is enabled to preserve backward compatibility.
+    let have_scan_config = [
+        effective_detect_files,
+        effective_detect_folders,
+        effective_detect_extensions,
+    ]
+    .into_iter()
+    .any(|v| !v.is_empty());
+
+    let is_kube_project = have_scan_config.then(|| {
+        context.try_begin_scan().is_some_and(|scanner| {
+            scanner
+                .set_files(effective_detect_files)
+                .set_folders(effective_detect_folders)
+                .set_extensions(effective_detect_extensions)
+                .is_match()
+        })
+    });
+
+    if !is_kube_project.or(have_env_vars).unwrap_or(true) {
+        return None;
+    }
+
     // TODO: remove deprecated aliases after starship 2.0
     let display_context =
         deprecated::get_alias(display_context, &config.context_aliases, "context").unwrap();
@@ -240,8 +264,11 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let display_symbol = matched_context_config
         .and_then(|ctx_cfg| ctx_cfg.symbol)
         .unwrap_or(config.symbol);
+    let display_format = matched_context_config
+        .and_then(|ctx_cfg| ctx_cfg.format)
+        .unwrap_or(config.format);
 
-    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
+    let parsed = StringFormatter::new(display_format).and_then(|formatter| {
         formatter
             .map_meta(|variable, _| match variable {
                 "symbol" => Some(display_symbol),
@@ -1538,6 +1565,241 @@ users: []
             Color::Red.bold().paint("☸ test_context (test_namespace)")
         ));
         assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn test_config_context_overwrites_format() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let filename = dir.path().join("config");
+        let mut file = File::create(&filename)?;
+        file.write_all(
+            b"
+apiVersion: v1
+clusters: []
+contexts:
+  - context:
+      user: test_user
+      namespace: test_namespace
+    name: test_context
+current-context: test_context
+kind: Config
+preferences: {}
+users: []
+",
+        )?;
+        file.sync_all()?;
+
+        let actual = ModuleRenderer::new("kubernetes")
+            .path(dir.path())
+            .env("KUBECONFIG", filename.to_string_lossy().as_ref())
+            .config(toml::toml! {
+                [kubernetes]
+                disabled = false
+                format = "[$symbol$context( \\($namespace\\))]($style) in "
+
+                [[kubernetes.contexts]]
+                context_pattern = "test.*"
+                format = "$symbol$context >> $namespace"
+                symbol = "§ "
+            })
+            .collect();
+
+        let expected = Some("§ test_context >> test_namespace".to_string());
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn test_config_context_disabled() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let filename = dir.path().join("config");
+        let mut file = File::create(&filename)?;
+        file.write_all(
+            b"
+apiVersion: v1
+clusters: []
+contexts:
+  - context:
+      user: test_user
+      namespace: test_namespace
+    name: test_context
+current-context: test_context
+kind: Config
+preferences: {}
+users: []
+",
+        )?;
+        file.sync_all()?;
+
+        let actual = ModuleRenderer::new("kubernetes")
+            .path(dir.path())
+            .env("KUBECONFIG", filename.to_string_lossy().as_ref())
+            .config(toml::toml! {
+                [kubernetes]
+                disabled = false
+
+                [[kubernetes.contexts]]
+                context_pattern = "test.*"
+                disabled = true
+            })
+            .collect();
+
+        assert_eq!(None, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn test_config_context_detect_files_override() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let filename = dir.path().join("config");
+        let mut file = File::create(&filename)?;
+        file.write_all(
+            b"
+apiVersion: v1
+clusters: []
+contexts:
+  - context:
+      user: test_user
+    name: test_context
+current-context: test_context
+kind: Config
+preferences: {}
+users: []
+",
+        )?;
+        file.sync_all()?;
+
+        let dir_with_file = tempfile::tempdir()?;
+        File::create(dir_with_file.path().join("ctx.ext"))?.sync_all()?;
+
+        let actual_match = ModuleRenderer::new("kubernetes")
+            .path(dir_with_file.path())
+            .env("KUBECONFIG", filename.to_string_lossy().as_ref())
+            .config(toml::toml! {
+                [kubernetes]
+                disabled = false
+
+                [[kubernetes.contexts]]
+                context_pattern = "test.*"
+                detect_files = ["ctx.ext"]
+            })
+            .collect();
+
+        let expected = Some(format!(
+            "{} in ",
+            Color::Cyan.bold().paint("☸ test_context")
+        ));
+        assert_eq!(expected, actual_match);
+
+        let empty_dir = tempfile::tempdir()?;
+
+        let actual_no_match = ModuleRenderer::new("kubernetes")
+            .path(empty_dir.path())
+            .env("KUBECONFIG", filename.to_string_lossy().as_ref())
+            .config(toml::toml! {
+                [kubernetes]
+                disabled = false
+
+                [[kubernetes.contexts]]
+                context_pattern = "test.*"
+                detect_files = ["ctx.ext"]
+            })
+            .collect();
+
+        assert_eq!(None, actual_no_match);
+
+        dir.close()
+    }
+
+    #[test]
+    fn test_config_context_detect_folders_clear() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let filename = dir.path().join("config");
+        let mut file = File::create(&filename)?;
+        file.write_all(
+            b"
+apiVersion: v1
+clusters: []
+contexts:
+  - context:
+      user: test_user
+    name: test_context
+current-context: test_context
+kind: Config
+preferences: {}
+users: []
+",
+        )?;
+        file.sync_all()?;
+
+        // Parent requires k8s_folder, but context clears it with detect_folders = []
+        let empty_dir = tempfile::tempdir()?;
+
+        let actual = ModuleRenderer::new("kubernetes")
+            .path(empty_dir.path())
+            .env("KUBECONFIG", filename.to_string_lossy().as_ref())
+            .config(toml::toml! {
+                [kubernetes]
+                disabled = false
+                detect_folders = ["k8s_folder"]
+
+                [[kubernetes.contexts]]
+                context_pattern = "test.*"
+                detect_folders = []
+            })
+            .collect();
+
+        let expected = Some(format!(
+            "{} in ",
+            Color::Cyan.bold().paint("☸ test_context")
+        ));
+        assert_eq!(expected, actual);
+
+        dir.close()
+    }
+
+    #[test]
+    fn test_config_context_inherits_parent_detect() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let filename = dir.path().join("config");
+        let mut file = File::create(&filename)?;
+        file.write_all(
+            b"
+apiVersion: v1
+clusters: []
+contexts:
+  - context:
+      user: test_user
+    name: test_context
+current-context: test_context
+kind: Config
+preferences: {}
+users: []
+",
+        )?;
+        file.sync_all()?;
+
+        // Context omits detect_files, so it inherits detect_files from parent.
+        // Without the required file present, the module should not show.
+        let empty_dir = tempfile::tempdir()?;
+
+        let actual = ModuleRenderer::new("kubernetes")
+            .path(empty_dir.path())
+            .env("KUBECONFIG", filename.to_string_lossy().as_ref())
+            .config(toml::toml! {
+                [kubernetes]
+                disabled = false
+                detect_files = ["k8s.ext"]
+
+                [[kubernetes.contexts]]
+                context_pattern = "test.*"
+                style = "bold green"
+            })
+            .collect();
+
+        assert_eq!(None, actual);
+
         dir.close()
     }
 


### PR DESCRIPTION
#### Description

Extends `[[kubernetes.contexts]]` entries to support all configuration properties from the parent `[kubernetes]` module, not just `style`, `symbol`, `context_alias`, and `user_alias`.

New per-context overridable fields:
- `format` -- override the format string for a matched context
- `disabled` -- hide the module entirely for a matched context
- `detect_extensions` -- override or clear parent's extension detection
- `detect_files` -- override or clear parent's file detection
- `detect_folders` -- override or clear parent's folder detection
- `detect_env_vars` -- override or clear parent's env var detection

#### Motivation and Context

Previously, `[[kubernetes.contexts]]` only allowed overriding `style`, `symbol`, `context_alias`, and `user_alias`. Properties like `format`, `disabled`, and detection rules (`detect_files`, `detect_folders`, `detect_extensions`, `detect_env_vars`) were always inherited from the parent `[kubernetes]` block and could not vary per context.

This made it impossible to:
- Use a different format string for production vs dev contexts
- Hide the module for local/minikube contexts
- Require specific files to be present only for certain contexts
- Show the module unconditionally for some contexts while keeping file detection for others

Closes #

#### How Has This Been Tested?

5 new tests added following existing `test_config_context_*` patterns:
- `test_config_context_overwrites_format` -- verifies per-context format override
- `test_config_context_disabled` -- verifies per-context disable returns `None`
- `test_config_context_detect_files_override` -- verifies per-context file detection (shows when file present, hidden when absent)
- `test_config_context_detect_folders_clear` -- verifies `detect_folders = []` clears parent's detection (module shows without the folder)
- `test_config_context_inherits_parent_detect` -- verifies omitted `detect_files` inherits parent's detection

All 38 kubernetes tests pass (33 existing + 5 new).

- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:

- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.