### PR TITLE
fix(hostname): detect SSH sessions using SSH_CLIENT and SSH_TTY

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2468,11 +2468,16 @@ format = 'via [⎈ $version](bold white) '
 
 The `hostname` module shows the system hostname.
 
+> [!TIP]
+> SSH connection is detected by checking environment variables
+> `SSH_CONNECTION`, `SSH_CLIENT`, and `SSH_TTY`. If your SSH host does not set up
+> these variables, one workaround is to set one of them with a dummy value.
+
 ### Options
 
 | Option            | Default                                | Description                                                                                                                           |
 | ----------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| `ssh_only`        | `true`                                 | Only show hostname when connected to an SSH session (`SSH_CONNECTION`, `SSH_CLIENT`, or `SSH_TTY`).                                   |
+| `ssh_only`        | `true`                                 | Only show hostname when connected to an SSH session.                                                                                  |
 | `ssh_symbol`      | `'🌐 '`                                | A format string representing the symbol when connected to SSH session.                                                                |
 | `trim_at`         | `'.'`                                  | String that the hostname is cut off at, after the first match. `'.'` will stop after the first dot. `''` will disable any truncation. |
 | `detect_env_vars` | `[]`                                   | Which environment variable(s) should trigger this module.                                                                             |

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2472,7 +2472,7 @@ The `hostname` module shows the system hostname.
 
 | Option            | Default                                | Description                                                                                                                           |
 | ----------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| `ssh_only`        | `true`                                 | Only show hostname when connected to an SSH session (`SSH_CONNECTION`, `SSH_CLIENT`, or `SSH_TTY`).                                  |
+| `ssh_only`        | `true`                                 | Only show hostname when connected to an SSH session (`SSH_CONNECTION`, `SSH_CLIENT`, or `SSH_TTY`).                                   |
 | `ssh_symbol`      | `'🌐 '`                                | A format string representing the symbol when connected to SSH session.                                                                |
 | `trim_at`         | `'.'`                                  | String that the hostname is cut off at, after the first match. `'.'` will stop after the first dot. `''` will disable any truncation. |
 | `detect_env_vars` | `[]`                                   | Which environment variable(s) should trigger this module.                                                                             |

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2472,7 +2472,7 @@ The `hostname` module shows the system hostname.
 
 | Option            | Default                                | Description                                                                                                                           |
 | ----------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| `ssh_only`        | `true`                                 | Only show hostname when connected to an SSH session.                                                                                  |
+| `ssh_only`        | `true`                                 | Only show hostname when connected to an SSH session (`SSH_CONNECTION`, `SSH_CLIENT`, or `SSH_TTY`).                                  |
 | `ssh_symbol`      | `'🌐 '`                                | A format string representing the symbol when connected to SSH session.                                                                |
 | `trim_at`         | `'.'`                                  | String that the hostname is cut off at, after the first match. `'.'` will stop after the first dot. `''` will disable any truncation. |
 | `detect_env_vars` | `[]`                                   | Which environment variable(s) should trigger this module.                                                                             |

--- a/src/modules/hostname.rs
+++ b/src/modules/hostname.rs
@@ -10,17 +10,15 @@ use whoami::hostname;
 ///
 /// Will display the hostname if all of the following criteria are met:
 ///     - `hostname.disabled` is absent or false
-///     - `hostname.ssh_only` is false OR the user is currently connected as an SSH session (`$SSH_CONNECTION`)
+///     - `hostname.ssh_only` is false OR the user is currently connected as an SSH session (`$SSH_CONNECTION`, `$SSH_CLIENT`, or `$SSH_TTY`)
 ///     - `hostname.ssh_only` is false AND `hostname.detect_env_vars` is either empty or contains a defined environment variable
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let mut module = context.new_module("hostname");
     let config: HostnameConfig = HostnameConfig::try_load(module.config);
 
-    let ssh_connection = context.get_env("SSH_CONNECTION");
+    let is_ssh_session = is_ssh_session(context);
 
-    if (config.ssh_only && ssh_connection.is_none())
-        || !context.detect_env_vars(&config.detect_env_vars)
-    {
+    if (config.ssh_only && !is_ssh_session) || !context.detect_env_vars(&config.detect_env_vars) {
         return None;
     }
 
@@ -43,13 +41,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter
             .map_meta(|var, _| match var {
-                "ssh_symbol" => {
-                    if ssh_connection.is_some() {
-                        Some(config.ssh_symbol)
-                    } else {
-                        None
-                    }
-                }
+                "ssh_symbol" => is_ssh_session.then_some(config.ssh_symbol),
                 _ => None,
             })
             .map_style(|variable| match variable {
@@ -72,6 +64,12 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     });
 
     Some(module)
+}
+
+fn is_ssh_session(context: &Context) -> bool {
+    ["SSH_CONNECTION", "SSH_CLIENT", "SSH_TTY"]
+        .iter()
+        .any(|env| context.get_env_os(env).is_some())
 }
 
 #[cfg(test)]
@@ -213,6 +211,44 @@ mod tests {
                 trim_at = ""
             })
             .env("SSH_CONNECTION", "something")
+            .collect();
+        let expected = Some(format!(
+            "{} in ",
+            style().paint("🌐 ".to_owned() + hostname.as_str())
+        ));
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn ssh_client() {
+        let hostname = get_hostname!();
+        let actual = ModuleRenderer::new("hostname")
+            .config(toml::toml! {
+                [hostname]
+                ssh_only = true
+                trim_at = ""
+            })
+            .env("SSH_CLIENT", "something")
+            .collect();
+        let expected = Some(format!(
+            "{} in ",
+            style().paint("🌐 ".to_owned() + hostname.as_str())
+        ));
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn ssh_tty() {
+        let hostname = get_hostname!();
+        let actual = ModuleRenderer::new("hostname")
+            .config(toml::toml! {
+                [hostname]
+                ssh_only = true
+                trim_at = ""
+            })
+            .env("SSH_TTY", "/dev/pts/0")
             .collect();
         let expected = Some(format!(
             "{} in ",

--- a/src/modules/hostname.rs
+++ b/src/modules/hostname.rs
@@ -1,3 +1,4 @@
+use super::username::is_ssh_session;
 use super::{Context, Module};
 
 use crate::config::ModuleConfig;
@@ -64,12 +65,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     });
 
     Some(module)
-}
-
-fn is_ssh_session(context: &Context) -> bool {
-    ["SSH_CONNECTION", "SSH_CLIENT", "SSH_TTY"]
-        .iter()
-        .any(|env| context.get_env_os(env).is_some())
 }
 
 #[cfg(test)]

--- a/src/modules/username.rs
+++ b/src/modules/username.rs
@@ -119,7 +119,7 @@ fn is_root_user() -> bool {
     nix::unistd::geteuid() == nix::unistd::ROOT
 }
 
-fn is_ssh_session(context: &Context) -> bool {
+pub(crate) fn is_ssh_session(context: &Context) -> bool {
     let ssh_env = ["SSH_CONNECTION", "SSH_CLIENT", "SSH_TTY"];
     ssh_env.iter().any(|env| context.get_env_os(env).is_some())
 }


### PR DESCRIPTION
## Summary

The hostname module only checked `SSH_CONNECTION` to detect SSH sessions, while the username module checks `SSH_CONNECTION`, `SSH_CLIENT`, and `SSH_TTY`. This inconsistency caused hostname to not display in valid SSH session scenarios where only `SSH_CLIENT` or `SSH_TTY` were set.

## Changes

- Added `is_ssh_session()` helper function that checks all three SSH environment variables
- Updated hostname module to use the same SSH detection criteria as username module
- Added tests for `SSH_CLIENT` and `SSH_TTY` detection
- Updated hostname config documentation to reflect expanded SSH detection

## Testing

All existing tests pass, including new tests for `SSH_CLIENT` and `SSH_TTY` scenarios. Full test suite verified with `cargo test`.

Fixes #7207