### PR TITLE
docs: fix PowerShell heading capitalization

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -105,7 +105,7 @@ onMounted(() => {
    eval "$(starship init zsh)"
    ```
 
-   #### Powershell
+   #### PowerShell
 
    Add the following to the end of `Microsoft.PowerShell_profile.ps1`. You can check the location of this file by querying the `$PROFILE` variable in PowerShell. Typically the path is `~\Documents\PowerShell\Microsoft.PowerShell_profile.ps1` or `~/.config/powershell/Microsoft.PowerShell_profile.ps1` on -Nix.
 


### PR DESCRIPTION
#### Description
- Fix the PowerShell heading capitalization in the docs README.

#### Motivation and Context
- Documentation polish.

#### Screenshots (if appropriate):
- N/A

#### How Has This Been Tested?
Not run (docs change only).
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.