### PR TITLE
docs(python): update python_binary tip to reflect argument support

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -4017,7 +4017,7 @@ By default, the module will be shown if any of the following conditions are met:
 | `style`              | `'yellow bold'`                                                                                              | The style for the module.                                                             |
 | `pyenv_version_name` | `false`                                                                                                      | Use pyenv to get Python version                                                       |
 | `pyenv_prefix`       | `'pyenv'`                                                                                                    | Prefix before pyenv version display, only used if pyenv is used                       |
-| `python_binary`      | `['python', 'python3', 'python2']`                                                                           | Configures the python binaries that Starship should execute when getting the version. |
+| `python_binary`      | `['python', 'python3', 'python2']`                                                                           | Configures the python binaries (or binaries with arguments) that Starship should execute when getting the version. |
 | `detect_extensions`  | `['py', 'ipynb']`                                                                                            | Which extensions should trigger this module                                           |
 | `detect_files`       | `['.python-version', 'Pipfile', '__init__.py', 'pyproject.toml', 'requirements.txt', 'setup.py', 'tox.ini']` | Which filenames should trigger this module                                            |
 | `detect_folders`     | `[]`                                                                                                         | Which folders should trigger this module                                              |
@@ -4025,10 +4025,10 @@ By default, the module will be shown if any of the following conditions are met:
 | `disabled`           | `false`                                                                                                      | Disables the `python` module.                                                         |
 
 > [!TIP]
-> The `python_binary` variable accepts either a string or a list of strings.
-> Starship will try executing each binary until it gets a result. Note you can
-> only change the binary that Starship executes to get the version of Python not
-> the arguments that are used.
+> The `python_binary` variable accepts either a string, a list of strings, or a
+> list of lists of strings. Each entry can be a binary name (e.g. `'python3'`) or
+> a binary with arguments (e.g. `['uv', 'run', 'python', '--version']`).
+> Starship will try executing each command until it gets a result.
 >
 > The default values and order for `python_binary` was chosen to first identify
 > the Python version in a virtualenv/conda environments (which currently still
@@ -4073,6 +4073,14 @@ python_binary = 'python3'
 [python]
 # Don't trigger for files with the py extension
 detect_extensions = []
+```
+
+```toml
+# ~/.config/starship.toml
+
+[python]
+# Use `uv run python` to get the Python version managed by uv.
+python_binary = [['uv', 'run', 'python'], 'python3', 'python']
 ```
 
 ## Quarto

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -4027,7 +4027,7 @@ By default, the module will be shown if any of the following conditions are met:
 > [!TIP]
 > The `python_binary` variable accepts either a string, a list of strings, or a
 > list of lists of strings. Each entry can be a binary name (e.g. `'python3'`) or
-> a binary with arguments (e.g. `['uv', 'run', 'python', '--version']`).
+> a binary with arguments (e.g. `['python3.11', '--version']`).
 > Starship will try executing each command until it gets a result.
 >
 > The default values and order for `python_binary` was chosen to first identify
@@ -4073,14 +4073,6 @@ python_binary = 'python3'
 [python]
 # Don't trigger for files with the py extension
 detect_extensions = []
-```
-
-```toml
-# ~/.config/starship.toml
-
-[python]
-# Use `uv run python` to get the Python version managed by uv.
-python_binary = [['uv', 'run', 'python'], 'python3', 'python']
 ```
 
 ## Quarto

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -596,7 +596,7 @@ The `buf` module shows the currently installed version of [Buf](https://buf.buil
 | `symbol`            | `'🐃 '`                                         | The symbol used before displaying the version of Buf. |
 | `detect_extensions` | `[]`                                            | Which extensions should trigger this module.          |
 | `detect_files`      | `['buf.yaml', 'buf.gen.yaml', 'buf.work.yaml']` | Which filenames should trigger this module.           |
-| `detect_folders`    | `[]`                                            | Which folders should trigger this module.            |
+| `detect_folders`    | `[]`                                            | Which folders should trigger this module.             |
 | `style`             | `'bold blue'`                                   | The style for the module.                             |
 | `disabled`          | `false`                                         | Disables the `elixir` module.                         |
 
@@ -1409,7 +1409,7 @@ when there is a `.csproj` file in the current directory.
 | `heuristic`         | `true`                                                                                                  | Use faster version detection to keep starship snappy.                     |
 | `detect_extensions` | `['csproj', 'fsproj', 'xproj']`                                                                         | Which extensions should trigger this module.                              |
 | `detect_files`      | `['global.json', 'project.json', 'Directory.Build.props', 'Directory.Build.targets', 'Packages.props']` | Which filenames should trigger this module.                               |
-| `detect_folders`    | `[]`                                                                                                    | Which folders should trigger this module.                                |
+| `detect_folders`    | `[]`                                                                                                    | Which folders should trigger this module.                                 |
 | `style`             | `'bold blue'`                                                                                           | The style for the module.                                                 |
 | `disabled`          | `false`                                                                                                 | Disables the `dotnet` module.                                             |
 
@@ -1451,7 +1451,7 @@ By default the module will be shown if any of the following conditions are met:
 | `symbol`            | `'💧 '`                                                   | The symbol used before displaying the version of Elixir/Erlang.           |
 | `detect_extensions` | `[]`                                                      | Which extensions should trigger this module.                              |
 | `detect_files`      | `['mix.exs']`                                             | Which filenames should trigger this module.                               |
-| `detect_folders`    | `[]`                                                      | Which folders should trigger this module.                                |
+| `detect_folders`    | `[]`                                                      | Which folders should trigger this module.                                 |
 | `style`             | `'bold purple'`                                           | The style for the module.                                                 |
 | `disabled`          | `false`                                                   | Disables the `elixir` module.                                             |
 
@@ -1495,7 +1495,7 @@ By default the module will be shown if any of the following conditions are met:
 | `symbol`            | `'🌳 '`                                            | A format string representing the symbol of Elm.                           |
 | `detect_extensions` | `['elm']`                                          | Which extensions should trigger this module.                              |
 | `detect_files`      | `['elm.json', 'elm-package.json', '.elm-version']` | Which filenames should trigger this module.                               |
-| `detect_folders`    | `['elm-stuff']`                                    | Which folders should trigger this module.                                |
+| `detect_folders`    | `['elm-stuff']`                                    | Which folders should trigger this module.                                 |
 | `style`             | `'cyan bold'`                                      | The style for the module.                                                 |
 | `disabled`          | `false`                                            | Disables the `elm` module.                                                |
 
@@ -1606,7 +1606,7 @@ By default the module will be shown if any of the following conditions are met:
 | `style`             | `'bold red'`                         | The style for the module.                                                 |
 | `detect_extensions` | `[]`                                 | Which extensions should trigger this module.                              |
 | `detect_files`      | `['rebar.config', 'elang.mk']`       | Which filenames should trigger this module.                               |
-| `detect_folders`    | `[]`                                 | Which folders should trigger this module.                                |
+| `detect_folders`    | `[]`                                 | Which folders should trigger this module.                                 |
 | `disabled`          | `false`                              | Disables the `erlang` module.                                             |
 
 ### Variables
@@ -1645,7 +1645,7 @@ By default the module will be shown if any of the following conditions are met:
 | `style`             | `'bold green'`                       | The style for the module.                                                 |
 | `detect_extensions` | `['fnl']`                            | Which extensions should trigger this module.                              |
 | `detect_files`      | `[]`                                 | Which filenames should trigger this module.                               |
-| `detect_folders`    | `[]`                                 | Which folders should trigger this module.                                |
+| `detect_folders`    | `[]`                                 | Which folders should trigger this module.                                 |
 | `disabled`          | `false`                              | Disables the `fennel` module.                                             |
 
 ### Variables
@@ -2393,7 +2393,7 @@ By default the module will be shown if any of the following conditions are met:
 | `version_format`    | `'v${raw}'`                                                                                     | The version format. Available vars are `raw`, `major`, `minor`, & `patch` |
 | `detect_extensions` | `['hx', 'hxml']`                                                                                | Which extensions should trigger this module.                              |
 | `detect_files`      | `['project.xml', 'Project.xml', 'application.xml', 'haxelib.json', 'hxformat.json', '.haxerc']` | Which filenames should trigger this module.                               |
-| `detect_folders`    | `['.haxelib', 'haxe_libraries']`                                                                | Which folders should trigger this module.                                |
+| `detect_folders`    | `['.haxelib', 'haxe_libraries']`                                                                | Which folders should trigger this module.                                 |
 | `symbol`            | `'⌘ '`                                                                                          | A format string representing the symbol of Haxe.                          |
 | `style`             | `'bold fg:202'`                                                                                 | The style for the module.                                                 |
 | `disabled`          | `false`                                                                                         | Disables the `haxe` module.                                               |
@@ -2433,7 +2433,7 @@ By default the module will be shown if any of the following conditions are met:
 | `version_format`    | `'v${raw}'`                          | The version format. Available vars are `raw`, `major`, `minor`, & `patch` |
 | `detect_extensions` | `[]`                                 | Which extensions should trigger this module.                              |
 | `detect_files`      | `['helmfile.yaml', 'Chart.yaml']`    | Which filenames should trigger this module.                               |
-| `detect_folders`    | `[]`                                 | Which folders should trigger this module.                                |
+| `detect_folders`    | `[]`                                 | Which folders should trigger this module.                                 |
 | `symbol`            | `'⎈ '`                               | A format string representing the symbol of Helm.                          |
 | `style`             | `'bold white'`                       | The style for the module.                                                 |
 | `disabled`          | `false`                              | Disables the `helm` module.                                               |
@@ -2533,7 +2533,7 @@ By default the module will be shown if any of the following conditions are met:
 | `version_format`    | `'v${raw}'`                                                                                                           | The version format. Available vars are `raw`, `major`, `minor`, & `patch` |
 | `detect_extensions` | `['java', 'class', 'gradle', 'jar', 'cljs', 'cljc']`                                                                  | Which extensions should trigger this module.                              |
 | `detect_files`      | `['pom.xml', 'build.gradle.kts', 'build.sbt', '.java-version', 'deps.edn', 'project.clj', 'build.boot', '.sdkmanrc']` | Which filenames should trigger this module.                               |
-| `detect_folders`    | `[]`                                                                                                                  | Which folders should trigger this module.                                |
+| `detect_folders`    | `[]`                                                                                                                  | Which folders should trigger this module.                                 |
 | `symbol`            | `'☕ '`                                                                                                               | A format string representing the symbol of Java                           |
 | `style`             | `'red dimmed'`                                                                                                        | The style for the module.                                                 |
 | `disabled`          | `false`                                                                                                               | Disables the `java` module.                                               |
@@ -2643,7 +2643,7 @@ By default the module will be shown if any of the following conditions are met:
 | `version_format`    | `'v${raw}'`                          | The version format. Available vars are `raw`, `major`, `minor`, & `patch` |
 | `detect_extensions` | `['jl']`                             | Which extensions should trigger this module.                              |
 | `detect_files`      | `['Project.toml', 'Manifest.toml']`  | Which filenames should trigger this module.                               |
-| `detect_folders`    | `[]`                                 | Which folders should trigger this module.                                |
+| `detect_folders`    | `[]`                                 | Which folders should trigger this module.                                 |
 | `symbol`            | `'ஃ '`                               | A format string representing the symbol of Julia.                         |
 | `style`             | `'bold purple'`                      | The style for the module.                                                 |
 | `disabled`          | `false`                              | Disables the `julia` module.                                              |
@@ -2682,7 +2682,7 @@ By default the module will be shown if any of the following conditions are met:
 | `version_format`    | `'v${raw}'`                          | The version format. Available vars are `raw`, `major`, `minor`, & `patch`     |
 | `detect_extensions` | `['kt', 'kts']`                      | Which extensions should trigger this module.                                  |
 | `detect_files`      | `[]`                                 | Which filenames should trigger this module.                                   |
-| `detect_folders`    | `[]`                                 | Which folders should trigger this module.                                    |
+| `detect_folders`    | `[]`                                 | Which folders should trigger this module.                                     |
 | `symbol`            | `'🅺 '`                               | A format string representing the symbol of Kotlin.                            |
 | `style`             | `'bold blue'`                        | The style for the module.                                                     |
 | `kotlin_binary`     | `'kotlin'`                           | Configures the kotlin binary that Starship executes when getting the version. |
@@ -2748,7 +2748,7 @@ If the `$KUBECONFIG` env var is set the module will use that if not it will use 
 | `user_aliases`*     | `{}`                                               | Table of user aliases to display.                                     |
 | `detect_extensions` | `[]`                                               | Which extensions should trigger this module.                          |
 | `detect_files`      | `[]`                                               | Which filenames should trigger this module.                           |
-| `detect_folders`    | `[]`                                               | Which folders should trigger this module.                            |
+| `detect_folders`    | `[]`                                               | Which folders should trigger this module.                             |
 | `detect_env_vars`   | `[]`                                               | Which environmental variables should trigger this module              |
 | `contexts`          | `[]`                                               | Customized styles and symbols for specific contexts.                  |
 | `disabled`          | `true`                                             | Disables the `kubernetes` module.                                     |
@@ -4009,20 +4009,20 @@ By default, the module will be shown if any of the following conditions are met:
 
 ### Options
 
-| Option               | Default                                                                                                      | Description                                                                           |
-| -------------------- | ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------- |
-| `format`             | `'via [${symbol}${pyenv_prefix}(${version} )(\($virtualenv\) )]($style)'`                                    | The format for the module.                                                            |
-| `version_format`     | `'v${raw}'`                                                                                                  | The version format. Available vars are `raw`, `major`, `minor`, & `patch`             |
-| `symbol`             | `'🐍 '`                                                                                                      | A format string representing the symbol of Python                                     |
-| `style`              | `'yellow bold'`                                                                                              | The style for the module.                                                             |
-| `pyenv_version_name` | `false`                                                                                                      | Use pyenv to get Python version                                                       |
-| `pyenv_prefix`       | `'pyenv'`                                                                                                    | Prefix before pyenv version display, only used if pyenv is used                       |
+| Option               | Default                                                                                                      | Description                                                                                                        |
+| -------------------- | ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------ |
+| `format`             | `'via [${symbol}${pyenv_prefix}(${version} )(\($virtualenv\) )]($style)'`                                    | The format for the module.                                                                                         |
+| `version_format`     | `'v${raw}'`                                                                                                  | The version format. Available vars are `raw`, `major`, `minor`, & `patch`                                          |
+| `symbol`             | `'🐍 '`                                                                                                      | A format string representing the symbol of Python                                                                  |
+| `style`              | `'yellow bold'`                                                                                              | The style for the module.                                                                                          |
+| `pyenv_version_name` | `false`                                                                                                      | Use pyenv to get Python version                                                                                    |
+| `pyenv_prefix`       | `'pyenv'`                                                                                                    | Prefix before pyenv version display, only used if pyenv is used                                                    |
 | `python_binary`      | `['python', 'python3', 'python2']`                                                                           | Configures the python binaries (or binaries with arguments) that Starship should execute when getting the version. |
-| `detect_extensions`  | `['py', 'ipynb']`                                                                                            | Which extensions should trigger this module                                           |
-| `detect_files`       | `['.python-version', 'Pipfile', '__init__.py', 'pyproject.toml', 'requirements.txt', 'setup.py', 'tox.ini']` | Which filenames should trigger this module                                            |
-| `detect_folders`     | `[]`                                                                                                         | Which folders should trigger this module                                              |
-| `generic_venv_names` | `[]`                                                                                                         | Which venv names should be replaced with the parent directory name.                   |
-| `disabled`           | `false`                                                                                                      | Disables the `python` module.                                                         |
+| `detect_extensions`  | `['py', 'ipynb']`                                                                                            | Which extensions should trigger this module                                                                        |
+| `detect_files`       | `['.python-version', 'Pipfile', '__init__.py', 'pyproject.toml', 'requirements.txt', 'setup.py', 'tox.ini']` | Which filenames should trigger this module                                                                         |
+| `detect_folders`     | `[]`                                                                                                         | Which folders should trigger this module                                                                           |
+| `generic_venv_names` | `[]`                                                                                                         | Which venv names should be replaced with the parent directory name.                                                |
+| `disabled`           | `false`                                                                                                      | Disables the `python` module.                                                                                      |
 
 > [!TIP]
 > The `python_binary` variable accepts either a string, a list of strings, or a
@@ -4341,7 +4341,7 @@ By default the module will be shown if any of the following conditions are met:
 | `version_format`    | `'v${raw}'`                              | The version format. Available vars are `raw`, `major`, `minor`, & `patch` |
 | `detect_extensions` | `['sbt', 'scala']`                       | Which extensions should trigger this module.                              |
 | `detect_files`      | `['.scalaenv', '.sbtenv', 'build.sbt']`  | Which filenames should trigger this module.                               |
-| `detect_folders`    | `['.metals']`                            | Which folders should trigger this module.                                |
+| `detect_folders`    | `['.metals']`                            | Which folders should trigger this module.                                 |
 | `symbol`            | `'🆂 '`                                   | A format string representing the symbol of Scala.                         |
 | `style`             | `'red dimmed'`                           | The style for the module.                                                 |
 | `disabled`          | `false`                                  | Disables the `scala` module.                                              |


### PR DESCRIPTION
## Description

The `python_binary` option gained support for passing arguments to binaries in #6523 (e.g. `['uv', 'run', 'python', '--version']`), but the documentation tip was never updated and still says:

> Note you can only change the binary that Starship executes to get the version of Python not the arguments that are used.

This is now incorrect and misleading.

## Changes

- Updated the `[!TIP]` block to accurately describe the supported formats: string, list of strings, or list of lists of strings
- Updated the `python_binary` option description in the options table
- Added an example showing how to use `uv run python` to get the Python version

## Related

Fixes #7279