### PR TITLE
fix(explain): show jobs module by reading STARSHIPS_JOBS_COUNT env var

### DIFF
--- a/src/init/starship.bash
+++ b/src/init/starship.bash
@@ -57,7 +57,7 @@ starship_precmd() {
     # like z/autojump, which background certain jobs, do not cause spurious background jobs
     # to be displayed by starship. Also avoids forking to run `wc`, slightly improving perf.
     for job in $(jobs -p); do [[ $job ]] && ((NUM_JOBS++)); done
-    export STARSHIP_JOBS_COUNT="${NUM_JOBS}"
+    export STARSHIP_JOB_COUNT="${NUM_JOBS}"
 
     # Run the bash precmd function, if it's set. If not set, evaluates to no-op
     "${starship_precmd_user_func-:}"

--- a/src/init/starship.bash
+++ b/src/init/starship.bash
@@ -57,6 +57,7 @@ starship_precmd() {
     # like z/autojump, which background certain jobs, do not cause spurious background jobs
     # to be displayed by starship. Also avoids forking to run `wc`, slightly improving perf.
     for job in $(jobs -p); do [[ $job ]] && ((NUM_JOBS++)); done
+    export STARSHIP_JOBS_COUNT="${NUM_JOBS}"
 
     # Run the bash precmd function, if it's set. If not set, evaluates to no-op
     "${starship_precmd_user_func-:}"

--- a/src/init/starship.fish
+++ b/src/init/starship.fish
@@ -7,7 +7,8 @@ function __starship_set_job_count --description 'Set STARSHIP_JOBS using fish jo
     else
         # Default behavior: count job groups
         set -g STARSHIP_JOBS (jobs -g 2>/dev/null | count)
-    end    
+    end
+    set -gx STARSHIP_JOBS_COUNT $STARSHIP_JOBS
 end
 
 function fish_prompt

--- a/src/init/starship.fish
+++ b/src/init/starship.fish
@@ -1,14 +1,13 @@
-function __starship_set_job_count --description 'Set STARSHIP_JOBS using fish job groups (or legacy PIDs if toggled)'
+function __starship_set_job_count --description 'Set STARSHIP_JOB_COUNT using fish job groups (or legacy PIDs if toggled)'
     # To force legacy behavior (process PIDs), set this variable to "false":
     #   set -g __starship_fish_use_job_groups "false"
     if test "$__starship_fish_use_job_groups" = "false"
         # Legacy behavior: counts PIDs (may overcount pipelines with terminated producers)
-        set -g STARSHIP_JOBS (jobs -p 2>/dev/null | count)
+        set -gx STARSHIP_JOB_COUNT (jobs -p 2>/dev/null | count)
     else
         # Default behavior: count job groups
-        set -g STARSHIP_JOBS (jobs -g 2>/dev/null | count)
+        set -gx STARSHIP_JOB_COUNT (jobs -g 2>/dev/null | count)
     end
-    set -gx STARSHIP_JOBS_COUNT $STARSHIP_JOBS
 end
 
 function fish_prompt
@@ -34,12 +33,12 @@ function fish_prompt
             printf \e\[0J
         end
         if type -q starship_transient_prompt_func
-            starship_transient_prompt_func --terminal-width="$COLUMNS" --status=$STARSHIP_CMD_STATUS --pipestatus="$STARSHIP_CMD_PIPESTATUS" --keymap=$STARSHIP_KEYMAP --cmd-duration=$STARSHIP_DURATION --jobs=$STARSHIP_JOBS
+            starship_transient_prompt_func --terminal-width="$COLUMNS" --status=$STARSHIP_CMD_STATUS --pipestatus="$STARSHIP_CMD_PIPESTATUS" --keymap=$STARSHIP_KEYMAP --cmd-duration=$STARSHIP_DURATION --jobs=$STARSHIP_JOB_COUNT
         else
             printf "\e[1;32m❯\e[0m "
         end
     else
-        ::STARSHIP:: prompt --terminal-width="$COLUMNS" --status=$STARSHIP_CMD_STATUS --pipestatus="$STARSHIP_CMD_PIPESTATUS" --keymap=$STARSHIP_KEYMAP --cmd-duration=$STARSHIP_DURATION --jobs=$STARSHIP_JOBS
+        ::STARSHIP:: prompt --terminal-width="$COLUMNS" --status=$STARSHIP_CMD_STATUS --pipestatus="$STARSHIP_CMD_PIPESTATUS" --keymap=$STARSHIP_KEYMAP --cmd-duration=$STARSHIP_DURATION --jobs=$STARSHIP_JOB_COUNT
     end
 end
 
@@ -62,12 +61,12 @@ function fish_right_prompt
     if contains -- --final-rendering $argv; or test "$RIGHT_TRANSIENT" = "1"
         set -g RIGHT_TRANSIENT 0
         if type -q starship_transient_rprompt_func
-            starship_transient_rprompt_func --terminal-width="$COLUMNS" --status=$STARSHIP_CMD_STATUS --pipestatus="$STARSHIP_CMD_PIPESTATUS" --keymap=$STARSHIP_KEYMAP --cmd-duration=$STARSHIP_DURATION --jobs=$STARSHIP_JOBS
+            starship_transient_rprompt_func --terminal-width="$COLUMNS" --status=$STARSHIP_CMD_STATUS --pipestatus="$STARSHIP_CMD_PIPESTATUS" --keymap=$STARSHIP_KEYMAP --cmd-duration=$STARSHIP_DURATION --jobs=$STARSHIP_JOB_COUNT
         else
             printf ""
         end
     else
-        ::STARSHIP:: prompt --right --terminal-width="$COLUMNS" --status=$STARSHIP_CMD_STATUS --pipestatus="$STARSHIP_CMD_PIPESTATUS" --keymap=$STARSHIP_KEYMAP --cmd-duration=$STARSHIP_DURATION --jobs=$STARSHIP_JOBS
+        ::STARSHIP:: prompt --right --terminal-width="$COLUMNS" --status=$STARSHIP_CMD_STATUS --pipestatus="$STARSHIP_CMD_PIPESTATUS" --keymap=$STARSHIP_KEYMAP --cmd-duration=$STARSHIP_DURATION --jobs=$STARSHIP_JOB_COUNT
     end
 end
 

--- a/src/init/starship.zsh
+++ b/src/init/starship.zsh
@@ -7,7 +7,7 @@
 # after drawing the prompt. This ensures that the timing for one command is only
 # ever drawn once (for the prompt immediately after it is run).
 
-zmodload zsh/parameter  # Needed to access jobstates variable for STARSHIP_JOBS_COUNT
+zmodload zsh/parameter  # Needed to access jobstates variable for STARSHIP_JOB_COUNT
 
 # Defines a function `__starship_get_time` that sets the time since epoch in millis in STARSHIP_CAPTURED_TIME.
 if [[ $ZSH_VERSION == ([1-4]*) ]]; then
@@ -50,7 +50,7 @@ prompt_starship_precmd() {
 
     # Use length of jobstates array as number of jobs. Expansion fails inside
     # quotes so we set it here and then use the value later on.
-    export STARSHIP_JOBS_COUNT="${#jobstates[*]}"
+    export STARSHIP_JOB_COUNT="${#jobstates[*]}"
 }
 
 # Runs after the user submits the command line, but before it is executed and
@@ -97,6 +97,6 @@ VIRTUAL_ENV_DISABLE_PROMPT=1
 
 setopt promptsubst
 
-PROMPT='$('::STARSHIP::' prompt --terminal-width="$COLUMNS" --keymap="${KEYMAP:-}" --status="${STARSHIP_CMD_STATUS:-}" --pipestatus="${STARSHIP_PIPE_STATUS[*]:-}" --cmd-duration="${STARSHIP_DURATION:-}" --jobs="$STARSHIP_JOBS_COUNT")'
-RPROMPT='$('::STARSHIP::' prompt --right --terminal-width="$COLUMNS" --keymap="${KEYMAP:-}" --status="${STARSHIP_CMD_STATUS:-}" --pipestatus="${STARSHIP_PIPE_STATUS[*]:-}" --cmd-duration="${STARSHIP_DURATION:-}" --jobs="$STARSHIP_JOBS_COUNT")'
+PROMPT='$('::STARSHIP::' prompt --terminal-width="$COLUMNS" --keymap="${KEYMAP:-}" --status="${STARSHIP_CMD_STATUS:-}" --pipestatus="${STARSHIP_PIPE_STATUS[*]:-}" --cmd-duration="${STARSHIP_DURATION:-}" --jobs="$STARSHIP_JOB_COUNT")'
+RPROMPT='$('::STARSHIP::' prompt --right --terminal-width="$COLUMNS" --keymap="${KEYMAP:-}" --status="${STARSHIP_CMD_STATUS:-}" --pipestatus="${STARSHIP_PIPE_STATUS[*]:-}" --cmd-duration="${STARSHIP_DURATION:-}" --jobs="$STARSHIP_JOB_COUNT")'
 PROMPT2="$(::STARSHIP:: prompt --continuation)"

--- a/src/init/starship.zsh
+++ b/src/init/starship.zsh
@@ -50,7 +50,7 @@ prompt_starship_precmd() {
 
     # Use length of jobstates array as number of jobs. Expansion fails inside
     # quotes so we set it here and then use the value later on.
-    STARSHIP_JOBS_COUNT="${#jobstates[*]}"
+    export STARSHIP_JOBS_COUNT="${#jobstates[*]}"
 }
 
 # Runs after the user submits the command line, but before it is executed and

--- a/src/print.rs
+++ b/src/print.rs
@@ -211,10 +211,10 @@ pub fn timings(args: Properties) {
 }
 
 pub fn explain(mut args: Properties) {
-    if args.jobs == 0 {
-        if let Ok(val) = std::env::var("STARSHIP_JOBS_COUNT") {
-            args.jobs = val.parse().unwrap_or(0);
-        }
+    if args.jobs == 0
+        && let Ok(val) = std::env::var("STARSHIP_JOBS_COUNT")
+    {
+        args.jobs = val.parse().unwrap_or(0);
     }
     let context = Context::new(args, Target::Main);
 

--- a/src/print.rs
+++ b/src/print.rs
@@ -210,7 +210,12 @@ pub fn timings(args: Properties) {
     }
 }
 
-pub fn explain(args: Properties) {
+pub fn explain(mut args: Properties) {
+    if args.jobs == 0 {
+        if let Ok(val) = std::env::var("STARSHIP_JOBS_COUNT") {
+            args.jobs = val.parse().unwrap_or(0);
+        }
+    }
     let context = Context::new(args, Target::Main);
 
     struct ModuleInfo {

--- a/src/print.rs
+++ b/src/print.rs
@@ -212,7 +212,7 @@ pub fn timings(args: Properties) {
 
 pub fn explain(mut args: Properties) {
     if args.jobs == 0
-        && let Ok(val) = std::env::var("STARSHIP_JOBS_COUNT")
+        && let Ok(val) = std::env::var("STARSHIP_JOB_COUNT")
     {
         args.jobs = val.parse().unwrap_or(0);
     }


### PR DESCRIPTION
This PR introduces a fix to the `jobs` module in `starship explain` when there are active background jobs. 
This was previously not happening because `explain` creates a fresh context with `--jobs` defaulting to `0`, causing the jobs module to return `None` and be filtered out of the output.




#### Description
Two changes:

1. **`src/init/starship.zsh`** (and `bash`, `fish`): export `STARSHIP_JOBS_COUNT` as an environment variable so it is visible to subprocesses. Previously it was only a shell-local variable used to build the prompt string.

2. **`src/print.rs`**: in `explain`, if `--jobs` was not explicitly passed (i.e. it is `0`), fall back to reading `STARSHIP_JOBS_COUNT` from the environment. Explicit `--jobs N` still takes priority.

#### Considered Alternatives

Chosen alternative: the resolved jobs value is written back into `args` before passing it to
  `Context::new`:


```rust
pub fn explain(mut args: Properties) {
      if args.jobs == 0 {
          if let Ok(val) = std::env::var("STARSHIP_JOBS_COUNT") {
              args.jobs = val.parse().unwrap_or(0);
          }
      }
      let context = Context::new(args, Target::Main);
```
This makes `explain` take `mut args` which did compile, but changes the interface.
But it is now essentially what the function does and invisible to callers. 

An alternative without mut was considered using struct update syntax:

```rust
let context = Context::new(Properties { jobs, ..args }, Target::Main);
```
This would need changes to the `Context` as its fields `terminal_width`, `path`, and `logical_path` are private and inaccessible from outside `context.rs`. 
A workaround could have been to add a `with_jobs` method on Properties:

```rust
impl Properties {
      pub fn with_jobs(self, jobs: i64) -> Self {
          Self { jobs, ..self }
      }
  }
```
I found it preferable to keep the changes localized. But let me know what you think.

#### Motivation and Context
I came across this because I was wondering about the star symbol in my prompt, found out what it was via the issue below and thought I could provide a fix following the suggestion in the first comment. 
Closes https://github.com/starship/starship/issues/3264

#### Screenshots (if appropriate):
Screenshot for the difference with release version installed on my system and the one off this branch.
<img width="1268" height="691" alt="Screenshot 2026-03-24 at 01 09 16" src="https://github.com/user-attachments/assets/8d4f2fc8-f81b-4ea4-bd28-fb27db273f8c" />

#### How Has This Been Tested?
See screenshot above
- [x] I have tested using **MacOS** (M4 Tahoe 26.2)
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

I'm unsure how to provide tests but happy to do so with guidance. 

#### Checklist:
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
