### PR TITLE
docs: fix duplicate word in custom module comment

### DIFF
--- a/src/modules/custom.rs
+++ b/src/modules/custom.rs
@@ -280,7 +280,7 @@ fn exec_command(cmd: &str, context: &Context, config: &CustomConfig) -> Option<S
 
 /// If the specified shell refers to `PowerShell`, adds the arguments "-Command -" to the
 /// given command.
-/// Returns `false` if the shell shell expects scripts as arguments, `true` if as `stdin`.
+/// Returns `false` if the shell expects scripts as arguments, `true` if as `stdin`.
 fn handle_shell(command: &mut Command, shell: &str, shell_args: &[&str]) -> bool {
     let shell_exe = Path::new(shell).file_stem();
     let no_args = shell_args.is_empty();


### PR DESCRIPTION
#### Description
- Fix the duplicated word in the `handle_shell` comment in `src/modules/custom.rs`.

#### Motivation and Context
- Keeps the inline documentation clear for a comment-only change.
- Related issue: N/A (trivial comment fix)

Closes #
N/A

#### Screenshots (if appropriate):
- N/A

#### How Has This Been Tested?
- Not run (comment-only change)
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.

#### Guideline alignment
- Reviewed `CONTRIBUTING.md` and the PR template before editing.
- Kept the diff to one comment line with no behavior changes.