### PR TITLE
docs: fix env_var comment typo

### DIFF
--- a/src/print.rs
+++ b/src/print.rs
@@ -342,7 +342,7 @@ fn handle_module<'a>(
         // custom.<name> and env_var.<name> are special cases and handle disabled modules themselves
         modules.extend(modules::handle(module, context));
     } else if matches!(module, "custom" | "env_var") {
-        // env var is a spacial case and may contain a top-level module definition
+        // env var is a special case and may contain a top-level module definition
         if module == "env_var" {
             modules.extend(modules::handle(module, context));
         }


### PR DESCRIPTION
#### Description

Fix a typo in the `env_var` comment in `src/print.rs`.

#### Motivation and Context

This is a comment-only cleanup with no behavior changes.

Related issue: N/A

Guideline alignment: https://github.com/starship/starship/blob/master/CONTRIBUTING.md

#### Screenshots (if appropriate):

N/A

#### How Has This Been Tested?

- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

Not run; comment-only change.

#### Checklist:

- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
