### PR TITLE
feat(aws): introduce support for AWS to support alias patterns

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -74,7 +74,8 @@
         "region_aliases": {},
         "profile_aliases": {},
         "expiration_symbol": "X",
-        "force_display": false
+        "force_display": false,
+        "profiles": []
       }
     },
     "azure": {
@@ -1961,7 +1962,7 @@
           "default": false
         },
         "region_aliases": {
-          "description": "Table of region aliases to display in addition to the AWS name.",
+          "description": "Deprecated: Table of region aliases to display in addition to the AWS name.",
           "type": "object",
           "additionalProperties": {
             "type": "string"
@@ -1969,7 +1970,7 @@
           "default": {}
         },
         "profile_aliases": {
-          "description": "Table of profile aliases to display in addition to the AWS name.",
+          "description": "Deprecated: Table of profile aliases to display in addition to the AWS name.",
           "type": "object",
           "additionalProperties": {
             "type": "string"
@@ -1985,6 +1986,65 @@
           "description": "If true displays info even if `credentials`, `credential_process` or `sso_start_url` have not been setup.",
           "type": "boolean",
           "default": false
+        },
+        "profiles": {
+          "description": "Customised styles and symbols for specific profiles.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/AwsProfileConfig"
+          },
+          "default": []
+        }
+      },
+      "additionalProperties": false
+    },
+    "AwsProfileConfig": {
+      "type": "object",
+      "properties": {
+        "profile_pattern": {
+          "description": "Regular expression to match the current AWS profile name.",
+          "type": "string",
+          "default": ""
+        },
+        "region_pattern": {
+          "description": "Regular expression to match the current AWS region name.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        },
+        "profile_alias": {
+          "description": "Profile alias to display instead of the full profile name.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        },
+        "region_alias": {
+          "description": "Region alias to display instead of the full region name.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        },
+        "style": {
+          "description": "The style for the module when this profile matches.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
+        },
+        "symbol": {
+          "description": "The symbol for the module when this profile matches.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "default": null
         }
       },
       "additionalProperties": false

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -400,16 +400,35 @@ is read from the `AWS_SSO_PROFILE` env var.
 
 ### Options
 
+> [!WARNING]
+> The `profile_aliases` and `region_aliases` options are deprecated. Use `profiles` and the corresponding `profile_alias`
+> and `region_alias` options instead.
+
 | Option              | Default                                                           | Description                                                                                                 |
 | ------------------- | ----------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
 | `format`            | `'on [$symbol($profile )(\($region\) )(\[$duration\] )]($style)'` | The format for the module.                                                                                  |
 | `symbol`            | `'☁️ '`                                                            | The symbol used before displaying the current AWS profile.                                                  |
-| `region_aliases`    | `{}`                                                              | Table of region aliases to display in addition to the AWS name.                                             |
-| `profile_aliases`   | `{}`                                                              | Table of profile aliases to display in addition to the AWS name.                                            |
+| `region_aliases`*   | `{}`                                                              | Table of region aliases to display in addition to the AWS name.                                             |
+| `profile_aliases`*  | `{}`                                                              | Table of profile aliases to display in addition to the AWS name.                                            |
 | `style`             | `'bold yellow'`                                                   | The style for the module.                                                                                   |
 | `expiration_symbol` | `'X'`                                                             | The symbol displayed when the temporary credentials have expired.                                           |
 | `disabled`          | `false`                                                           | Disables the `AWS` module.                                                                                  |
 | `force_display`     | `false`                                                           | If `true` displays info even if `credentials`, `credential_process` or `sso_start_url` have not been setup. |
+| `profiles`          | `[]`                                                              | Customised styles and symbols for specific profiles.                                                        |
+
+*: This option is deprecated, please add `profiles` with the corresponding `profile_alias` and `region_alias` options instead.
+
+To customise the style of the module for specific profiles, use the following configuration as
+part of the `profiles` list:
+
+| Variable          | Description                                                                              |
+| ----------------- | ---------------------------------------------------------------------------------------- |
+| `profile_pattern` | **Required** Regular expression to match the current AWS profile name.                   |
+| `region_pattern`  | Regular expression to match the current AWS region name.                                 |
+| `profile_alias`   | Profile alias to display instead of the full profile name.                               |
+| `region_alias`    | Region alias to display instead of the full region name.                                 |
+| `style`           | The style for the module when using this profile. If not set, will use module's style.   |
+| `symbol`          | The symbol for the module when using this profile. If not set, will use module's symbol. |
 
 ### Variables
 
@@ -434,11 +453,11 @@ is read from the `AWS_SSO_PROFILE` env var.
 format = 'on [$symbol($profile )(\($region\) )]($style)'
 style = 'bold blue'
 symbol = '🅰 '
-[aws.region_aliases]
-ap-southeast-2 = 'au'
-us-east-1 = 'va'
-[aws.profile_aliases]
-CompanyGroupFrobozzOnCallAccess = 'Frobozz'
+profiles = [
+  { profile_pattern = "CompanyGroup_(?P<team>[\\w]+)_OnCallAccess", profile_alias = "$team" },
+  { profile_pattern = ".*", region_pattern = "ap-southeast-.*", region_alias = "au" },
+  { profile_pattern = ".*", region_pattern = "us-east-.*", region_alias = "va" },
+]
 ```
 
 #### Display region
@@ -450,9 +469,10 @@ CompanyGroupFrobozzOnCallAccess = 'Frobozz'
 format = 'on [$symbol$region]($style) '
 style = 'bold blue'
 symbol = '🅰 '
-[aws.region_aliases]
-ap-southeast-2 = 'au'
-us-east-1 = 'va'
+profiles = [
+  { profile_pattern = ".*", region_pattern = "ap-southeast-.*", region_alias = "au" },
+  { profile_pattern = ".*", region_pattern = "us-east-.*", region_alias = "va" },
+]
 ```
 
 #### Display profile
@@ -464,8 +484,39 @@ us-east-1 = 'va'
 format = 'on [$symbol$profile]($style) '
 style = 'bold blue'
 symbol = '🅰 '
-[aws.profile_aliases]
-Enterprise_Naming_Scheme-voidstars = 'void**'
+profiles = [
+  { profile_pattern = "Enterprise_Naming_Scheme-.*", profile_alias = "void**" },
+]
+```
+
+#### AWS Profile specific config
+
+The `profiles` configuration option is used to customise what the current AWS profile name looks
+like (style and symbol) if the name matches the defined regular expression.
+
+```toml
+# ~/.config/starship.toml
+
+[[aws.profiles]]
+# "bold red" style + default symbol when AWS profile equals "production" *and* the current region
+# matches "us-east-*"
+profile_pattern = "production"
+region_pattern = "us-east-.*"
+style = "bold red"
+profile_alias = "prod"
+
+[[aws.profiles]]
+# "green" style + a different symbol when AWS profile contains "staging"
+profile_pattern = ".*staging.*"
+style = "green"
+symbol = "🔶 "
+profile_alias = "staging"
+
+[[aws.profiles]]
+# Using capture groups
+# Profiles with a company prefix like "company-prod-team" can be shortened to "team (prod)":
+profile_pattern = "company-(?P<env>[\\w-]+)-(?P<team>[\\w-]+)"
+profile_alias = "$team ($env)"
 ```
 
 ## Azure

--- a/src/configs/aws.rs
+++ b/src/configs/aws.rs
@@ -39,14 +39,16 @@ pub struct AwsConfig<'a> {
     pub style: &'a str,
     /// Disables the AWS module.
     pub disabled: bool,
-    /// Table of region aliases to display in addition to the AWS name.
+    /// Deprecated: Table of region aliases to display in addition to the AWS name.
     pub region_aliases: HashMap<String, &'a str>,
-    /// Table of profile aliases to display in addition to the AWS name.
+    /// Deprecated: Table of profile aliases to display in addition to the AWS name.
     pub profile_aliases: HashMap<String, &'a str>,
     /// The symbol displayed when the temporary credentials have expired.
     pub expiration_symbol: &'a str,
     /// If true displays info even if `credentials`, `credential_process` or `sso_start_url` have not been setup.
     pub force_display: bool,
+    /// Customised styles and symbols for specific profiles.
+    pub profiles: Vec<AwsProfileConfig<'a>>,
 }
 
 impl Default for AwsConfig<'_> {
@@ -60,6 +62,29 @@ impl Default for AwsConfig<'_> {
             profile_aliases: HashMap::new(),
             expiration_symbol: "X",
             force_display: false,
+            profiles: vec![],
         }
     }
+}
+
+#[derive(Clone, Deserialize, Serialize, Default)]
+#[cfg_attr(
+    feature = "config-schema",
+    derive(schemars::JsonSchema),
+    schemars(deny_unknown_fields)
+)]
+#[serde(default)]
+pub struct AwsProfileConfig<'a> {
+    /// Regular expression to match the current AWS profile name.
+    pub profile_pattern: &'a str,
+    /// Regular expression to match the current AWS region name.
+    pub region_pattern: Option<&'a str>,
+    /// Profile alias to display instead of the full profile name.
+    pub profile_alias: Option<&'a str>,
+    /// Region alias to display instead of the full region name.
+    pub region_alias: Option<&'a str>,
+    /// The style for the module when this profile matches.
+    pub style: Option<&'a str>,
+    /// The symbol for the module when this profile matches.
+    pub symbol: Option<&'a str>,
 }

--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -1,5 +1,5 @@
+use std::borrow::Cow;
 use std::cell::OnceCell;
-use std::collections::HashMap;
 use std::path::PathBuf;
 use std::str::FromStr;
 
@@ -182,13 +182,74 @@ fn get_credentials_duration(
     Some(expiration_date.as_second() - Zoned::now().timestamp().as_second())
 }
 
-fn alias_name(name: Option<String>, aliases: &HashMap<String, &str>) -> Option<String> {
-    name.as_ref()
-        .and_then(|n| aliases.get(n))
-        .map(|&a| a.to_string())
-        .or(name)
+fn get_aliased_name<'a>(
+    pattern: Option<&'a str>,
+    current_value: Option<&str>,
+    alias: Option<&'a str>,
+) -> Option<String> {
+    let replacement = alias.or(current_value)?.to_string();
+    let Some(pattern) = pattern else {
+        return Some(replacement);
+    };
+    let value = current_value?;
+    if value == pattern {
+        return Some(replacement);
+    }
+    let re = match regex::Regex::new(&format!("^{pattern}$")) {
+        Ok(re) => re,
+        Err(error) => {
+            log::warn!(
+                "Could not compile regular expression `{}`:\n{}",
+                &format!("^{pattern}$"),
+                error
+            );
+            return None;
+        }
+    };
+    let replaced = re.replace(value, replacement.as_str());
+    match replaced {
+        Cow::Owned(replaced) => Some(replaced),
+        Cow::Borrowed(_) => None,
+    }
 }
 
+mod deprecated {
+    use std::borrow::Cow;
+    use std::collections::HashMap;
+
+    pub fn get_alias<'a>(
+        current_value: String,
+        aliases: &'a HashMap<String, &'a str>,
+        name: &'a str,
+    ) -> Option<String> {
+        let alias = if let Some(val) = aliases.get(current_value.as_str()) {
+            Some((*val).to_string())
+        } else {
+            aliases.iter().find_map(|(k, v)| {
+                let re = regex::Regex::new(&format!("^{k}$")).ok()?;
+                let replaced = re.replace(current_value.as_str(), *v);
+                match replaced {
+                    Cow::Owned(replaced) => Some(replaced),
+                    Cow::Borrowed(_) => None,
+                }
+            })
+        };
+
+        match alias {
+            Some(alias) => {
+                log::warn!(
+                    "Usage of '{}_aliases' is deprecated and will be removed in 2.0; Use 'profiles' with '{}_alias' instead. (`{}` -> `{}`)",
+                    name,
+                    name,
+                    current_value,
+                    alias
+                );
+                Some(alias)
+            }
+            None => Some(current_value),
+        }
+    }
+}
 fn has_credential_process_or_sso(
     context: &Context,
     aws_profile: Option<&Profile>,
@@ -300,23 +361,59 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         )
     };
 
-    let mapped_region = alias_name(aws_region, &config.region_aliases);
+    let (matched_profile_config, display_profile, display_region) = config
+        .profiles
+        .iter()
+        .find_map(|profile_config| {
+            let profile_alias = get_aliased_name(
+                Some(profile_config.profile_pattern),
+                aws_profile.as_deref(),
+                profile_config.profile_alias,
+            )?;
 
-    let mapped_profile = alias_name(aws_profile, &config.profile_aliases);
+            let region_alias = get_aliased_name(
+                profile_config.region_pattern,
+                aws_region.as_deref(),
+                profile_config.region_alias,
+            );
+            if matches!(
+                (profile_config.region_pattern, &region_alias),
+                (Some(_), None)
+            ) {
+                return None;
+            }
+
+            Some((Some(profile_config), Some(profile_alias), region_alias))
+        })
+        .unwrap_or((None, aws_profile, aws_region));
+
+    let display_profile = display_profile
+        .map(|p| deprecated::get_alias(p, &config.profile_aliases, "profile"))
+        .unwrap_or(None);
+    let display_region = display_region
+        .map(|r| deprecated::get_alias(r, &config.region_aliases, "region"))
+        .unwrap_or(None);
+
+    let display_style = matched_profile_config
+        .and_then(|cfg| cfg.style)
+        .unwrap_or(config.style);
+    let display_symbol = matched_profile_config
+        .and_then(|cfg| cfg.symbol)
+        .unwrap_or(config.symbol);
 
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter
             .map_meta(|variable, _| match variable {
-                "symbol" => Some(config.symbol),
+                "symbol" => Some(display_symbol),
                 _ => None,
             })
             .map_style(|variable| match variable {
-                "style" => Some(Ok(config.style)),
+                "style" => Some(Ok(display_style)),
                 _ => None,
             })
             .map(|variable| match variable {
-                "profile" => mapped_profile.as_ref().map(Ok),
-                "region" => mapped_region.as_ref().map(Ok),
+                "profile" => display_profile.as_ref().map(Ok),
+                "region" => display_region.as_ref().map(Ok),
                 "duration" => duration.as_ref().map(Ok),
                 _ => None,
             })
@@ -341,6 +438,190 @@ mod tests {
     use nu_ansi_term::Color;
     use std::fs::{File, create_dir};
     use std::io::{self, Write};
+
+    #[test]
+    fn profiles_simple_pattern_match() {
+        let actual = ModuleRenderer::new("aws")
+            .env("AWS_PROFILE", "astronauts")
+            .env("AWS_REGION", "ap-northeast-2")
+            .env("AWS_ACCESS_KEY_ID", "dummy")
+            .config(toml::toml! {
+                [[aws.profiles]]
+                profile_pattern = "astronauts"
+                profile_alias = "astro"
+            })
+            .collect();
+        let expected = Some(format!(
+            "on {}",
+            Color::Yellow.bold().paint("☁️  astro (ap-northeast-2) ")
+        ));
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn profiles_regex_pattern_match() {
+        let actual = ModuleRenderer::new("aws")
+            .env("AWS_PROFILE", "company-prod-astronauts")
+            .env("AWS_REGION", "ap-northeast-2")
+            .env("AWS_ACCESS_KEY_ID", "dummy")
+            .config(toml::toml! {
+                [[aws.profiles]]
+                profile_pattern = "company-.*-astronauts"
+                profile_alias = "astro"
+            })
+            .collect();
+        let expected = Some(format!(
+            "on {}",
+            Color::Yellow.bold().paint("☁️  astro (ap-northeast-2) ")
+        ));
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn profiles_capture_group_replacement() {
+        let actual = ModuleRenderer::new("aws")
+            .env("AWS_PROFILE", "company-prod-astronauts")
+            .env("AWS_ACCESS_KEY_ID", "dummy")
+            .config(toml::toml! {
+                [[aws.profiles]]
+                profile_pattern = "company-(?P<env>[\\w-]+)-astronauts"
+                profile_alias = "astro-$env"
+            })
+            .collect();
+        let expected = Some(format!(
+            "on {}",
+            Color::Yellow.bold().paint("☁️  astro-prod ")
+        ));
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn profiles_region_pattern_match() {
+        let actual = ModuleRenderer::new("aws")
+            .env("AWS_PROFILE", "astronauts")
+            .env("AWS_REGION", "ap-southeast-2")
+            .env("AWS_ACCESS_KEY_ID", "dummy")
+            .config(toml::toml! {
+                [[aws.profiles]]
+                profile_pattern = "astronauts"
+                profile_alias = "astro"
+                region_pattern = "ap-southeast-.*"
+                region_alias = "au"
+            })
+            .collect();
+        let expected = Some(format!(
+            "on {}",
+            Color::Yellow.bold().paint("☁️  astro (au) ")
+        ));
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn profiles_region_pattern_no_match_skips_entry() {
+        let actual = ModuleRenderer::new("aws")
+            .env("AWS_PROFILE", "astronauts")
+            .env("AWS_REGION", "us-east-1")
+            .env("AWS_ACCESS_KEY_ID", "dummy")
+            .config(toml::toml! {
+                [[aws.profiles]]
+                profile_pattern = "astronauts"
+                profile_alias = "astro-au"
+                region_pattern = "ap-southeast-.*"
+                region_alias = "au"
+
+                [[aws.profiles]]
+                profile_pattern = "astronauts"
+                profile_alias = "astro-us"
+            })
+            .collect();
+        let expected = Some(format!(
+            "on {}",
+            Color::Yellow.bold().paint("☁️  astro-us (us-east-1) ")
+        ));
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn profiles_custom_style_and_symbol() {
+        let actual = ModuleRenderer::new("aws")
+            .env("AWS_PROFILE", "production")
+            .env("AWS_ACCESS_KEY_ID", "dummy")
+            .config(toml::toml! {
+                [[aws.profiles]]
+                profile_pattern = "production"
+                style = "bold red"
+                symbol = "🔴 "
+            })
+            .collect();
+        let expected = Some(format!("on {}", Color::Red.bold().paint("🔴 production ")));
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn profiles_no_match_falls_through() {
+        let actual = ModuleRenderer::new("aws")
+            .env("AWS_PROFILE", "astronauts")
+            .env("AWS_ACCESS_KEY_ID", "dummy")
+            .config(toml::toml! {
+                [[aws.profiles]]
+                profile_pattern = "production"
+                profile_alias = "prod"
+            })
+            .collect();
+        let expected = Some(format!(
+            "on {}",
+            Color::Yellow.bold().paint("☁️  astronauts ")
+        ));
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn profiles_first_match_wins() {
+        let actual = ModuleRenderer::new("aws")
+            .env("AWS_PROFILE", "astronauts")
+            .env("AWS_ACCESS_KEY_ID", "dummy")
+            .config(toml::toml! {
+                [[aws.profiles]]
+                profile_pattern = "astronauts"
+                profile_alias = "first"
+
+                [[aws.profiles]]
+                profile_pattern = "astronauts"
+                profile_alias = "second"
+            })
+            .collect();
+        let expected = Some(format!("on {}", Color::Yellow.bold().paint("☁️  first ")));
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn profiles_region_capture_group() {
+        let actual = ModuleRenderer::new("aws")
+            .env("AWS_PROFILE", "astronauts")
+            .env("AWS_REGION", "ap-southeast-2")
+            .env("AWS_ACCESS_KEY_ID", "dummy")
+            .config(toml::toml! {
+                [[aws.profiles]]
+                profile_pattern = "astronauts"
+                region_pattern = "(?P<area>[a-z]+)-(?P<dir>[a-z]+)-(?P<num>\\d+)"
+                region_alias = "$area-$num"
+            })
+            .collect();
+        let expected = Some(format!(
+            "on {}",
+            Color::Yellow.bold().paint("☁️  astronauts (ap-2) ")
+        ));
+
+        assert_eq!(expected, actual);
+    }
 
     #[test]
     #[ignore]


### PR DESCRIPTION
Much like the Kubernetes module, it is often nice to have a regex pattern for aliases or regions which can map to more usable or friendly names.

Examples

```toml
[[aws.profiles]]
# "bold red" style + default symbol when AWS profile equals "production" *and* the current region
# matches "us-east-*"
profile_pattern = "production"
region_pattern = "us-east-.*"
style = "bold red"
profile_alias = "prod"

[[aws.profiles]]
# Using capture groups
# Profiles with a company prefix like "company-prod-team" can be shortened to "team (prod)":
profile_pattern = "company-(?P<env>[\\w-]+)-(?P<team>[\\w-]+)"
profile_alias = "$team ($env)"
```

As part of this change, I've left the previous AWS region + profile aliases in place but deprecated to be removed in a much later version.

Closes #6099 

#### Screenshots (if appropriate):

n/a

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
