### PR TITLE
docs: fix macOS capitalization in codesigning docs

### DIFF
--- a/install/macos_packages/readme.md
+++ b/install/macos_packages/readme.md
@@ -1,4 +1,4 @@
-# MacOS Codesigning Scripts
+# macOS Codesigning Scripts
 
 Well, here we are. The Apple notarization procedure is complex enough that I
 need an actual pile of scripts and writeup to be able to remember how to do it.


### PR DESCRIPTION
#### Description
- Fix the macOS capitalization in the codesigning docs heading.

#### Motivation and Context
This keeps the macOS packaging documentation terminology consistent.

Related issue: N/A; trivial docs wording fix.
Guideline alignment: https://github.com/starship/starship/blob/master/CONTRIBUTING.md

#### Screenshots (if appropriate):

#### How Has This Been Tested?
- Not run; markdown-only change.
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
