### PR TITLE
feat: implement referencing next segment's style in conf file

### DIFF
--- a/docs/advanced-config/README.md
+++ b/docs/advanced-config/README.md
@@ -666,7 +666,7 @@ Style strings are a list of words, separated by whitespace. The words are not ca
 - `none`
 
 where `<color>` is a color specifier (discussed below). `fg:<color>` and `<color>` currently do the same thing, though this may change in the future.
-`<color>` can also be set to `prev_fg` or `prev_bg` which evaluates to the previous item's foreground or background color respectively if available or `none` otherwise.
+`<color>` can also be set to `prev_fg`, `prev_bg`, `next_fg` or `next_fg`, which evaluates to, respectively, the previous and next item's foreground or background color if available or `none` otherwise.
 `inverted` swaps the background and foreground colors. The order of words in the string does not matter.
 
 The `none` token overrides all other tokens in a string if it is not part of a `bg:` specifier, so that e.g. `fg:red none fg:blue` will still create a string with no styling. `bg:none` sets the background to the default color so `fg:red bg:none` is equivalent to `red` or `fg:red` and `bg:green fg:red bg:none` is also equivalent to `fg:red` or `red`. It may become an error to use `none` in conjunction with other tokens in the future.

--- a/src/config.rs
+++ b/src/config.rs
@@ -268,42 +268,24 @@ where
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-enum PrevColor {
-    Fg,
-    Bg,
+pub(crate) enum RefColor {
+    PrevFg,
+    PrevBg,
+    NextFg,
+    NextBg,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 /// Wrapper for `nu_ansi_term::Style` that supports referencing the previous style's foreground/background color.
 pub struct Style {
-    style: nu_ansi_term::Style,
-    bg: Option<PrevColor>,
-    fg: Option<PrevColor>,
+    pub(crate) style: nu_ansi_term::Style,
+    pub(crate) bg: Option<RefColor>,
+    pub(crate) fg: Option<RefColor>,
 }
 
 impl Style {
-    pub fn to_ansi_style(&self, prev: Option<&nu_ansi_term::Style>) -> nu_ansi_term::Style {
-        let Some(prev_style) = prev else {
-            return self.style;
-        };
-
-        let mut current = self.style;
-
-        if let Some(prev_color) = self.bg {
-            match prev_color {
-                PrevColor::Fg => current.background = prev_style.foreground,
-                PrevColor::Bg => current.background = prev_style.background,
-            }
-        }
-
-        if let Some(prev_color) = self.fg {
-            match prev_color {
-                PrevColor::Fg => current.foreground = prev_style.foreground,
-                PrevColor::Bg => current.foreground = prev_style.background,
-            }
-        }
-
-        current
+    pub fn to_ansi_style(&self) -> nu_ansi_term::Style {
+        self.style
     }
 
     fn map_style<F>(&self, f: F) -> Self
@@ -316,18 +298,126 @@ impl Style {
         }
     }
 
-    fn fg(&self, prev_color: PrevColor) -> Self {
+    fn fg(&self, prev_color: RefColor) -> Self {
         Self {
             fg: Some(prev_color),
             ..*self
         }
     }
 
-    fn bg(&self, prev_color: PrevColor) -> Self {
+    fn bg(&self, prev_color: RefColor) -> Self {
         Self {
             bg: Some(prev_color),
             ..*self
         }
+    }
+
+    pub fn resolve(&self, maybe_previous: Option<&Self>, maybe_next: Option<&Self>) -> Self {
+        if maybe_previous.is_none() && maybe_next.is_none() {
+            return Self { ..*self };
+        }
+
+        let mut result = Self {
+            style: nu_ansi_term::Style {
+                foreground: self.style.foreground,
+                background: self.style.background,
+                ..self.style
+            },
+            bg: self.bg,
+            fg: self.fg,
+        };
+
+        if let Some(prev_style) = maybe_previous {
+            if let Some(ref_color) = self.bg {
+                match ref_color {
+                    RefColor::PrevFg => {
+                        if prev_style.fg.is_some() {
+                            panic!(
+                                "Circular reference: segment background references back to a segment itself referencing forward"
+                            )
+                        }
+                        result.style.background = prev_style.style.foreground
+                    }
+                    RefColor::PrevBg => {
+                        if prev_style.bg.is_some() {
+                            panic!(
+                                "Circular reference: segment background references back to a segment itself referencing forward"
+                            )
+                        }
+                        result.style.background = prev_style.style.background
+                    }
+                    _ => { /* Referencing forward not resolved here */ }
+                }
+            }
+            if let Some(ref_color) = self.fg {
+                match ref_color {
+                    RefColor::PrevFg => {
+                        if prev_style.fg.is_some() {
+                            panic!(
+                                "Circular reference: segment foreground references back to a segment itself referencing forward"
+                            )
+                        }
+                        result.style.foreground = prev_style.style.foreground
+                    }
+                    RefColor::PrevBg => {
+                        if prev_style.bg.is_some() {
+                            panic!(
+                                "Circular reference: segment foreground references back to a segment itself referencing forward"
+                            )
+                        }
+                        result.style.foreground = prev_style.style.background
+                    }
+                    _ => { /* Referencing forward not resolved here */ }
+                }
+            }
+        }
+
+        if let Some(next_style) = maybe_next {
+            if let Some(ref_color) = self.fg {
+                match ref_color {
+                    RefColor::NextFg => {
+                        if next_style.fg.is_some() {
+                            panic!(
+                                "Circular reference: segment foreground references forward to a segment itself referencing backwards"
+                            )
+                        }
+                        result.style.foreground = next_style.style.foreground
+                    }
+                    RefColor::NextBg => {
+                        if next_style.bg.is_some() {
+                            panic!(
+                                "Circular reference: segment foreground references forward to a segment itself referencing backwards"
+                            )
+                        }
+                        result.style.foreground = next_style.style.background
+                    }
+                    _ => { /* Referencing forward not resolved here */ }
+                }
+            }
+            if let Some(ref_color) = self.bg {
+                match ref_color {
+                    RefColor::NextFg => {
+                        if next_style.fg.is_some() {
+                            panic!(
+                                "Circular reference: segment background references forward to a segment itself referencing backwards"
+                            )
+                        }
+                        result.style.background = next_style.style.foreground
+                    }
+                    RefColor::NextBg => {
+                        if next_style.bg.is_some() {
+                            panic!(
+                                "Circular reference: segment background references forward to a segment itself referencing backwards"
+                            )
+                        }
+                        result.style.background = next_style.style.background
+                    }
+                    _ => { /* Referencing forward not resolved here */ }
+                }
+            }
+        }
+
+        result
     }
 }
 
@@ -350,17 +440,17 @@ impl From<nu_ansi_term::Color> for Style {
 }
 
 /** Parse a style string which represents an ansi style. Valid tokens in the style
- string include the following:
- - 'fg:<color>'    (specifies that the color read should be a foreground color)
- - 'bg:<color>'    (specifies that the color read should be a background color)
- - 'underline'
- - 'bold'
- - 'italic'
- - 'inverted'
- - 'blink'
- - '`prev_fg`'        (specifies the color should be the previous foreground color)
- - '`prev_bg`'        (specifies the color should be the previous background color)
- - '<color>'       (see the `parse_color_string` doc for valid color strings)
+string include the following:
+- 'fg:<color>'    (specifies that the color read should be a foreground color)
+- 'bg:<color>'    (specifies that the color read should be a background color)
+- 'underline'
+- 'bold'
+- 'italic'
+- 'inverted'
+- 'blink'
+- '`prev_fg`'        (specifies the color should be the previous foreground color)
+- '`prev_bg`'        (specifies the color should be the previous background color)
+- '<color>'       (see the `parse_color_string` doc for valid color strings)
 */
 pub fn parse_style_string(style_string: &str, context: Option<&Context>) -> Option<Style> {
     style_string
@@ -388,11 +478,17 @@ pub fn parse_style_string(style_string: &str, context: Option<&Context>) -> Opti
                 "hidden" => Some(style.map_style(nu_ansi_term::Style::hidden)),
                 "strikethrough" => Some(style.map_style(nu_ansi_term::Style::strikethrough)),
 
-                "prev_fg" if col_fg => Some(style.fg(PrevColor::Fg)),
-                "prev_fg" => Some(style.bg(PrevColor::Fg)),
+                "prev_fg" if col_fg => Some(style.fg(RefColor::PrevFg)),
+                "prev_fg" => Some(style.bg(RefColor::PrevFg)),
 
-                "prev_bg" if col_fg => Some(style.fg(PrevColor::Bg)),
-                "prev_bg" => Some(style.bg(PrevColor::Bg)),
+                "prev_bg" if col_fg => Some(style.fg(RefColor::PrevBg)),
+                "prev_bg" => Some(style.bg(RefColor::PrevBg)),
+
+                "next_fg" if col_fg => Some(style.fg(RefColor::NextFg)),
+                "next_fg" => Some(style.bg(RefColor::NextFg)),
+
+                "next_bg" if col_fg => Some(style.fg(RefColor::NextBg)),
+                "next_bg" => Some(style.bg(RefColor::NextBg)),
 
                 // When the string is supposed to be a color:
                 // Decide if we yield none, reset background or set color.
@@ -432,10 +528,10 @@ pub fn parse_style_string(style_string: &str, context: Option<&Context>) -> Opti
 }
 
 /** Parse a string that represents a color setting, returning None if this fails
- There are three valid color formats:
-  - #RRGGBB      (a hash followed by an RGB hex)
-  - u8           (a number from 0-255, representing an ANSI color)
-  - colstring    (one of the 16 predefined color strings or a custom user-defined color)
+There are three valid color formats:
+ - #RRGGBB      (a hash followed by an RGB hex)
+ - u8           (a number from 0-255, representing an ANSI color)
+ - colstring    (one of the 16 predefined color strings or a custom user-defined color)
 */
 fn parse_color_string(
     color_string: &str,
@@ -735,12 +831,12 @@ mod tests {
     fn table_get_styles_bold_italic_underline_green_dimmed_silly_caps() {
         let config = Value::from("bOlD ItAlIc uNdErLiNe GrEeN diMMeD");
         let mystyle = <StyleWrapper>::from_config(&config).unwrap().0;
-        assert!(mystyle.to_ansi_style(None).is_bold);
-        assert!(mystyle.to_ansi_style(None).is_italic);
-        assert!(mystyle.to_ansi_style(None).is_underline);
-        assert!(mystyle.to_ansi_style(None).is_dimmed);
+        assert!(mystyle.to_ansi_style().is_bold);
+        assert!(mystyle.to_ansi_style().is_italic);
+        assert!(mystyle.to_ansi_style().is_underline);
+        assert!(mystyle.to_ansi_style().is_dimmed);
         assert_eq!(
-            mystyle.to_ansi_style(None),
+            mystyle.to_ansi_style(),
             AnsiStyle::new()
                 .bold()
                 .italic()
@@ -754,13 +850,13 @@ mod tests {
     fn table_get_styles_bold_italic_underline_green_dimmed_inverted_silly_caps() {
         let config = Value::from("bOlD ItAlIc uNdErLiNe GrEeN diMMeD InVeRTed");
         let mystyle = <StyleWrapper>::from_config(&config).unwrap().0;
-        assert!(mystyle.to_ansi_style(None).is_bold);
-        assert!(mystyle.to_ansi_style(None).is_italic);
-        assert!(mystyle.to_ansi_style(None).is_underline);
-        assert!(mystyle.to_ansi_style(None).is_dimmed);
-        assert!(mystyle.to_ansi_style(None).is_reverse);
+        assert!(mystyle.to_ansi_style().is_bold);
+        assert!(mystyle.to_ansi_style().is_italic);
+        assert!(mystyle.to_ansi_style().is_underline);
+        assert!(mystyle.to_ansi_style().is_dimmed);
+        assert!(mystyle.to_ansi_style().is_reverse);
         assert_eq!(
-            mystyle.to_ansi_style(None),
+            mystyle.to_ansi_style(),
             AnsiStyle::new()
                 .bold()
                 .italic()
@@ -775,13 +871,13 @@ mod tests {
     fn table_get_styles_bold_italic_underline_green_dimmed_blink_silly_caps() {
         let config = Value::from("bOlD ItAlIc uNdErLiNe GrEeN diMMeD bLiNk");
         let mystyle = <StyleWrapper>::from_config(&config).unwrap().0;
-        assert!(mystyle.to_ansi_style(None).is_bold);
-        assert!(mystyle.to_ansi_style(None).is_italic);
-        assert!(mystyle.to_ansi_style(None).is_underline);
-        assert!(mystyle.to_ansi_style(None).is_dimmed);
-        assert!(mystyle.to_ansi_style(None).is_blink);
+        assert!(mystyle.to_ansi_style().is_bold);
+        assert!(mystyle.to_ansi_style().is_italic);
+        assert!(mystyle.to_ansi_style().is_underline);
+        assert!(mystyle.to_ansi_style().is_dimmed);
+        assert!(mystyle.to_ansi_style().is_blink);
         assert_eq!(
-            mystyle.to_ansi_style(None),
+            mystyle.to_ansi_style(),
             AnsiStyle::new()
                 .bold()
                 .italic()
@@ -796,13 +892,13 @@ mod tests {
     fn table_get_styles_bold_italic_underline_green_dimmed_hidden_silly_caps() {
         let config = Value::from("bOlD ItAlIc uNdErLiNe GrEeN diMMeD hIDDen");
         let mystyle = <StyleWrapper>::from_config(&config).unwrap().0;
-        assert!(mystyle.to_ansi_style(None).is_bold);
-        assert!(mystyle.to_ansi_style(None).is_italic);
-        assert!(mystyle.to_ansi_style(None).is_underline);
-        assert!(mystyle.to_ansi_style(None).is_dimmed);
-        assert!(mystyle.to_ansi_style(None).is_hidden);
+        assert!(mystyle.to_ansi_style().is_bold);
+        assert!(mystyle.to_ansi_style().is_italic);
+        assert!(mystyle.to_ansi_style().is_underline);
+        assert!(mystyle.to_ansi_style().is_dimmed);
+        assert!(mystyle.to_ansi_style().is_hidden);
         assert_eq!(
-            mystyle.to_ansi_style(None),
+            mystyle.to_ansi_style(),
             AnsiStyle::new()
                 .bold()
                 .italic()
@@ -817,13 +913,13 @@ mod tests {
     fn table_get_styles_bold_italic_underline_green_dimmed_strikethrough_silly_caps() {
         let config = Value::from("bOlD ItAlIc uNdErLiNe GrEeN diMMeD StRiKEthROUgh");
         let mystyle = <StyleWrapper>::from_config(&config).unwrap().0;
-        assert!(mystyle.to_ansi_style(None).is_bold);
-        assert!(mystyle.to_ansi_style(None).is_italic);
-        assert!(mystyle.to_ansi_style(None).is_underline);
-        assert!(mystyle.to_ansi_style(None).is_dimmed);
-        assert!(mystyle.to_ansi_style(None).is_strikethrough);
+        assert!(mystyle.to_ansi_style().is_bold);
+        assert!(mystyle.to_ansi_style().is_italic);
+        assert!(mystyle.to_ansi_style().is_underline);
+        assert!(mystyle.to_ansi_style().is_dimmed);
+        assert!(mystyle.to_ansi_style().is_strikethrough);
         assert_eq!(
-            mystyle.to_ansi_style(None),
+            mystyle.to_ansi_style(),
             AnsiStyle::new()
                 .bold()
                 .italic()
@@ -839,7 +935,7 @@ mod tests {
         // Test a "plain" style with no formatting
         let config = Value::from("");
         let plain_style = <StyleWrapper>::from_config(&config).unwrap().0;
-        assert_eq!(plain_style.to_ansi_style(None), AnsiStyle::new());
+        assert_eq!(plain_style.to_ansi_style(), AnsiStyle::new());
 
         // Test a string that's clearly broken
         let config = Value::from("djklgfhjkldhlhk;j");
@@ -904,18 +1000,29 @@ mod tests {
         .0;
 
         assert_eq!(
-            both_prevfg.to_ansi_style(None),
+            both_prevfg.to_ansi_style(),
             AnsiStyle::default().fg(Color::Black).bold().underline()
         );
 
         // But if there is a style on the previous string, then use that
-        let prev_style = AnsiStyle::new()
-            .underline()
-            .fg(Color::Yellow)
-            .on(Color::Red);
+        let next_style = Style {
+            style: AnsiStyle::new().underline().fg(Color::Blue).on(Color::Cyan),
+            bg: None,
+            fg: None,
+        };
+        let prev_style = Style {
+            style: AnsiStyle::new()
+                .underline()
+                .fg(Color::Yellow)
+                .on(Color::Red),
+            bg: None,
+            fg: None,
+        };
 
         assert_eq!(
-            both_prevfg.to_ansi_style(Some(&prev_style)),
+            both_prevfg
+                .resolve(Some(&prev_style), Some(&next_style))
+                .to_ansi_style(),
             AnsiStyle::new()
                 .fg(Color::Red)
                 .on(Color::Yellow)
@@ -928,7 +1035,9 @@ mod tests {
             .unwrap()
             .0;
         assert_eq!(
-            fg_prev_fg.to_ansi_style(Some(&prev_style)),
+            fg_prev_fg
+                .resolve(Some(&prev_style), Some(&next_style))
+                .to_ansi_style(),
             AnsiStyle::new().fg(Color::Yellow)
         );
 
@@ -936,7 +1045,9 @@ mod tests {
             .unwrap()
             .0;
         assert_eq!(
-            fg_prev_bg.to_ansi_style(Some(&prev_style)),
+            fg_prev_bg
+                .resolve(Some(&prev_style), Some(&next_style))
+                .to_ansi_style(),
             AnsiStyle::new().fg(Color::Red)
         );
 
@@ -944,7 +1055,9 @@ mod tests {
             .unwrap()
             .0;
         assert_eq!(
-            bg_prev_fg.to_ansi_style(Some(&prev_style)),
+            bg_prev_fg
+                .resolve(Some(&prev_style), Some(&next_style))
+                .to_ansi_style(),
             AnsiStyle::new().on(Color::Yellow)
         );
 
@@ -952,8 +1065,92 @@ mod tests {
             .unwrap()
             .0;
         assert_eq!(
-            bg_prev_bg.to_ansi_style(Some(&prev_style)),
+            bg_prev_bg
+                .resolve(Some(&prev_style), Some(&next_style))
+                .to_ansi_style(),
             AnsiStyle::new().on(Color::Red)
+        );
+    }
+
+    #[test]
+    fn table_get_styles_next() {
+        // Test that next has no effect when there is no next style
+        let both_prevfg = <StyleWrapper>::from_config(&Value::from(
+            "bold fg:black fg:next_bg bg:next_fg underline",
+        ))
+        .unwrap()
+        .0;
+
+        assert_eq!(
+            both_prevfg.to_ansi_style(),
+            AnsiStyle::default().fg(Color::Black).bold().underline()
+        );
+
+        // But if there is a style on the previous string, then use that
+        let next_style = Style {
+            style: AnsiStyle::new().underline().fg(Color::Blue).on(Color::Cyan),
+            bg: None,
+            fg: None,
+        };
+        let prev_style = Style {
+            style: AnsiStyle::new()
+                .underline()
+                .fg(Color::Yellow)
+                .on(Color::Red),
+            bg: None,
+            fg: None,
+        };
+
+        assert_eq!(
+            both_prevfg
+                .resolve(Some(&prev_style), Some(&next_style))
+                .to_ansi_style(),
+            AnsiStyle::new()
+                .fg(Color::Cyan)
+                .on(Color::Blue)
+                .bold()
+                .underline()
+        );
+
+        // Test that all the combinations of previous colors work
+        let fg_prev_fg = <StyleWrapper>::from_config(&Value::from("fg:next_fg"))
+            .unwrap()
+            .0;
+        assert_eq!(
+            fg_prev_fg
+                .resolve(Some(&prev_style), Some(&next_style))
+                .to_ansi_style(),
+            AnsiStyle::new().fg(Color::Blue)
+        );
+
+        let fg_prev_bg = <StyleWrapper>::from_config(&Value::from("fg:next_bg"))
+            .unwrap()
+            .0;
+        assert_eq!(
+            fg_prev_bg
+                .resolve(Some(&prev_style), Some(&next_style))
+                .to_ansi_style(),
+            AnsiStyle::new().fg(Color::Cyan)
+        );
+
+        let bg_prev_fg = <StyleWrapper>::from_config(&Value::from("bg:next_fg"))
+            .unwrap()
+            .0;
+        assert_eq!(
+            bg_prev_fg
+                .resolve(Some(&prev_style), Some(&next_style))
+                .to_ansi_style(),
+            AnsiStyle::new().on(Color::Blue)
+        );
+
+        let bg_prev_bg = <StyleWrapper>::from_config(&Value::from("bg:next_bg"))
+            .unwrap()
+            .0;
+        assert_eq!(
+            bg_prev_bg
+                .resolve(Some(&prev_style), Some(&next_style))
+                .to_ansi_style(),
+            AnsiStyle::new().on(Color::Cyan)
         );
     }
 
@@ -963,7 +1160,7 @@ mod tests {
         let config = Value::from("bg:#050505 underline fg:120");
         let flipped_style = <StyleWrapper>::from_config(&config).unwrap().0;
         assert_eq!(
-            flipped_style.to_ansi_style(None),
+            flipped_style.to_ansi_style(),
             AnsiStyle::new()
                 .underline()
                 .fg(Color::Fixed(120))
@@ -974,7 +1171,7 @@ mod tests {
         let config = Value::from("bg:120 bg:125 bg:127 fg:127 122 125");
         let multi_style = <StyleWrapper>::from_config(&config).unwrap().0;
         assert_eq!(
-            multi_style.to_ansi_style(None),
+            multi_style.to_ansi_style(),
             AnsiStyle::new().fg(Color::Fixed(125)).on(Color::Fixed(127))
         );
     }

--- a/src/formatter/string_formatter.rs
+++ b/src/formatter/string_formatter.rs
@@ -460,6 +460,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::module::ansi_line;
     use nu_ansi_term::Color;
 
     // match_next(result: IterMut<Segment>, value, style)
@@ -748,19 +749,38 @@ mod tests {
     fn test_empty_textgroup_propagates_prev_bg() {
         const FORMAT_STR: &str = "[](bg:#9A348E)[X](bg:prev_bg)";
 
-        let formatter = StringFormatter::new(FORMAT_STR).unwrap();
-        let result = formatter.parse(None, None).unwrap();
+        let segments = StringFormatter::new(FORMAT_STR)
+            .unwrap()
+            .parse(None, None)
+            .unwrap();
+        let result = ansi_line(&mut segments.iter().peekable(), None);
 
         assert_eq!(result.len(), 2);
 
-        // First segment: empty with bg:#9A348E
-        let first_ansi = result[0].ansi_string(None);
-        let prev_style = first_ansi.style_ref();
-
         // Second segment: should inherit bg from first
-        let second_ansi = result[1].ansi_string(Some(prev_style));
+        let second_ansi = result.get(1).unwrap();
         assert_eq!(
             second_ansi.style_ref().background,
+            Some(nu_ansi_term::Color::Rgb(154, 52, 142))
+        );
+    }
+
+    #[test]
+    fn test_empty_textgroup_propagates_next_bg() {
+        const FORMAT_STR: &str = "[x](bg:next_bg)[X](bg:#9A348E)";
+
+        let segments = StringFormatter::new(FORMAT_STR)
+            .unwrap()
+            .parse(None, None)
+            .unwrap();
+        let result = ansi_line(&mut segments.iter().peekable(), None);
+
+        assert_eq!(result.len(), 2);
+
+        // First segment: should inherit bg from second
+        let first_ansi = result.get(0).unwrap();
+        assert_eq!(
+            first_ansi.style_ref().background,
             Some(nu_ansi_term::Color::Rgb(154, 52, 142))
         );
     }

--- a/src/module.rs
+++ b/src/module.rs
@@ -1,6 +1,7 @@
 use crate::segment;
 use crate::segment::{FillSegment, Segment};
-use nu_ansi_term::{AnsiString, AnsiStrings, Style as AnsiStyle};
+use nu_ansi_term::{AnsiString, AnsiStrings};
+use std::collections::VecDeque;
 use std::fmt;
 use std::time::Duration;
 
@@ -200,28 +201,27 @@ impl fmt::Display for Module<'_> {
     }
 }
 
-fn ansi_line<'a, I>(segments: &mut I, term_width: Option<usize>) -> Vec<AnsiString<'a>>
+pub(crate) fn ansi_line<'a, I>(
+    segments: &mut I,
+    term_width: Option<usize>,
+) -> VecDeque<AnsiString<'a>>
 where
-    I: Iterator<Item = &'a Segment>,
+    I: Iterator<Item = &'a Segment> + Sized,
 {
     let mut used = 0usize;
-    let mut current: Vec<AnsiString> = Vec::new();
-    let mut chunks: Vec<(Vec<AnsiString>, &FillSegment)> = Vec::new();
-    let mut prev_style: Option<AnsiStyle> = None;
+    let mut current: Vec<Segment> = Vec::new();
+    let mut chunks: Vec<(Vec<Segment>, Option<&FillSegment>)> = Vec::new();
 
     for segment in segments {
         match segment {
             Segment::Fill(fs) => {
-                chunks.push((current, fs));
+                chunks.push((current, Some(fs)));
                 current = Vec::new();
-                prev_style = None;
             }
             _ => {
                 used += segment.width_graphemes();
-                let current_segment_string = segment.ansi_string(prev_style.as_ref());
-
-                prev_style = Some(*current_segment_string.style_ref());
-                current.push(current_segment_string);
+                let prev_style = current.last().and_then(|s| s.segment_style());
+                current.push(segment.with_style(prev_style, None));
             }
         }
 
@@ -230,24 +230,43 @@ where
         }
     }
 
-    if chunks.is_empty() {
-        current
-    } else {
-        let fill_size = term_width
-            .and_then(|tw| if tw > used { Some(tw - used) } else { None })
-            .map(|remaining| remaining / chunks.len());
-        chunks
-            .into_iter()
-            .flat_map(|(strs, fill)| {
-                let fill_string = fill.ansi_string(
-                    fill_size,
-                    strs.last().map(nu_ansi_term::AnsiGenericString::style_ref),
-                );
-                strs.into_iter().chain(std::iter::once(fill_string))
-            })
-            .chain(current)
-            .collect::<Vec<AnsiString>>()
+    if !current.is_empty() {
+        chunks.push((current, None));
     }
+
+    let chunk_size_without_current = chunks.len() - 1;
+    let fill_size = if chunk_size_without_current > 0 {
+        term_width
+            .and_then(|tw| if tw > used { Some(tw - used) } else { None })
+            .map(|remaining| remaining / chunk_size_without_current)
+    } else {
+        None
+    };
+
+    let mut result = VecDeque::<AnsiString<'a>>::new();
+    for (strs, fill) in chunks {
+        let mut acc = VecDeque::<AnsiString<'a>>::new();
+        let mut next_segments: Vec<Segment> = Vec::new();
+
+        for segment in strs.iter().rev() {
+            next_segments.push(
+                segment.with_style(None, next_segments.last().and_then(|s| s.segment_style())),
+            );
+            if let Some(s) = next_segments.last() {
+                acc.push_front(s.ansi_string())
+            }
+        }
+
+        if let Some(segment) = fill {
+            acc.push_front(
+                segment
+                    .with_style(None, next_segments.last().and_then(|s| s.segment_style()))
+                    .ansi_string(fill_size),
+            );
+        }
+        result.append(&mut acc)
+    }
+    result
 }
 
 #[cfg(test)]

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -9,18 +9,24 @@ use unicode_segmentation::UnicodeSegmentation;
 #[derive(Clone)]
 pub struct TextSegment {
     /// The segment's style. If None, will inherit the style of the module containing it.
-    style: Option<Style>,
+    pub(crate) style: Option<Style>,
 
     /// The string value of the current segment.
-    value: String,
+    pub(crate) value: String,
 }
 
 impl TextSegment {
     // Returns the AnsiString of the segment value
-    fn ansi_string(&self, prev: Option<&AnsiStyle>) -> AnsiString<'_> {
+    fn ansi_string<'a>(&self) -> AnsiString<'a> {
         match self.style {
-            Some(style) => style.to_ansi_style(prev).paint(&self.value),
-            None => AnsiString::from(&self.value),
+            Some(style) => style.to_ansi_style().paint(self.value.to_string()),
+            None => AnsiString::from(self.value.to_string()),
+        }
+    }
+    pub fn with_style(&self, previous: Option<&Style>, next: Option<&Style>) -> Self {
+        Self {
+            style: self.style.map(|s| s.resolve(previous, next)),
+            value: self.value.clone(),
         }
     }
 }
@@ -29,7 +35,7 @@ impl TextSegment {
 #[derive(Clone)]
 pub struct FillSegment {
     /// The segment's style. If None, will inherit the style of the module containing it.
-    style: Option<Style>,
+    pub(crate) style: Option<Style>,
 
     /// The string value of the current segment.
     value: String,
@@ -37,7 +43,7 @@ pub struct FillSegment {
 
 impl FillSegment {
     // Returns the AnsiString of the segment value, not including its prefix and suffix
-    pub fn ansi_string(&self, width: Option<usize>, prev: Option<&AnsiStyle>) -> AnsiString<'_> {
+    pub fn ansi_string<'a>(&self, width: Option<usize>) -> AnsiString<'a> {
         let s = match width {
             Some(w) => self
                 .value
@@ -51,8 +57,15 @@ impl FillSegment {
             None => String::from(&self.value),
         };
         match self.style {
-            Some(style) => style.to_ansi_style(prev).paint(s),
+            Some(style) => style.to_ansi_style().paint(s),
             None => AnsiString::from(s),
+        }
+    }
+
+    pub fn with_style(&self, previous: Option<&Style>, next: Option<&Style>) -> Self {
+        Self {
+            style: self.style.map(|s| s.resolve(previous, next)),
+            value: self.value.clone(),
         }
     }
 }
@@ -80,7 +93,7 @@ mod fill_seg_tests {
                 value: String::from(*text),
                 style: Some(style.into()),
             };
-            let actual = f.ansi_string(Some(width), None);
+            let actual = f.ansi_string(Some(width));
             assert_eq!(style.paint(*expected), actual);
         }
     }
@@ -126,8 +139,16 @@ impl Segment {
 
     pub fn style(&self) -> Option<AnsiStyle> {
         match self {
-            Self::Fill(fs) => fs.style.map(|cs| cs.to_ansi_style(None)),
-            Self::Text(ts) => ts.style.map(|cs| cs.to_ansi_style(None)),
+            Self::Fill(fs) => fs.style.map(|cs| cs.to_ansi_style()),
+            Self::Text(ts) => ts.style.map(|cs| cs.to_ansi_style()),
+            Self::LineTerm => None,
+        }
+    }
+
+    pub fn segment_style(&self) -> Option<&Style> {
+        match self {
+            Self::Fill(fs) => fs.style.as_ref(),
+            Self::Text(ts) => ts.style.as_ref(),
             Self::LineTerm => None,
         }
     }
@@ -157,10 +178,10 @@ impl Segment {
     }
 
     // Returns the AnsiString of the segment value, not including its prefix and suffix
-    pub fn ansi_string(&self, prev: Option<&AnsiStyle>) -> AnsiString<'_> {
+    pub fn ansi_string<'a>(&self) -> AnsiString<'a> {
         match self {
-            Self::Fill(fs) => fs.ansi_string(None, prev),
-            Self::Text(ts) => ts.ansi_string(prev),
+            Self::Fill(fs) => fs.ansi_string(None),
+            Self::Text(ts) => ts.ansi_string(),
             Self::LineTerm => AnsiString::from(LINE_TERMINATOR_STRING),
         }
     }
@@ -172,7 +193,14 @@ impl Segment {
             Self::LineTerm => 0,
         }
     }
-}
 
+    pub fn with_style(&self, previous: Option<&Style>, next: Option<&Style>) -> Self {
+        match self {
+            Self::Text(s) => Self::Text(s.with_style(previous, next)),
+            Self::Fill(s) => Self::Fill(s.with_style(previous, next)),
+            Self::LineTerm => Self::LineTerm,
+        }
+    }
+}
 const LINE_TERMINATOR: char = '\n';
 const LINE_TERMINATOR_STRING: &str = "\n";


### PR DESCRIPTION
Ref: #7143

#### Description
Solves [#6558-2888265896](https://github.com/starship/starship/issues/6558#issuecomment-2888265896). Add ability to reference next modules' foreground and background. Useful to make a spacer seperating 2 modules, merging the style of both.

#### Motivation and Context
Starship is missing the ability to create a spacer sharing colors from surrounding modules. Some presets like [Gruvbox](https://starship.rs/presets/gruvbox-rainbow) partly implement this design. But since color needs to be hard-coded, it gets broken as soon as one module is conditionnaly rendered. This PR allows to define colors that will always match the following module no matter what it is.

#### Screenshots (if appropriate):

<img width="1954" height="75" src="https://github.com/user-attachments/assets/0489f770-ee74-4770-a15e-0d030bfe88a1" />

#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
