### PR TITLE
docs(presets): add bun module to presets missing it

### DIFF
--- a/docs/public/presets/toml/catppuccin-powerline.toml
+++ b/docs/public/presets/toml/catppuccin-powerline.toml
@@ -14,6 +14,7 @@ $c\
 $rust\
 $golang\
 $nodejs\
+$bun\
 $php\
 $java\
 $kotlin\
@@ -86,6 +87,11 @@ format = '[[($all_status$ahead_behind )](fg:crust bg:yellow)]($style)'
 
 [nodejs]
 symbol = ""
+style = "bg:green"
+format = '[[ $symbol( $version) ](fg:crust bg:green)]($style)'
+
+[bun]
+symbol = ""
 style = "bg:green"
 format = '[[ $symbol( $version) ](fg:crust bg:green)]($style)'
 

--- a/docs/public/presets/toml/gruvbox-rainbow.toml
+++ b/docs/public/presets/toml/gruvbox-rainbow.toml
@@ -15,6 +15,7 @@ $cpp\
 $rust\
 $golang\
 $nodejs\
+$bun\
 $php\
 $java\
 $kotlin\
@@ -101,6 +102,11 @@ format = '[[($all_status$ahead_behind )](fg:color_fg0 bg:color_aqua)]($style)'
 
 [nodejs]
 symbol = ""
+style = "bg:color_blue"
+format = '[[ $symbol( $version) ](fg:color_fg0 bg:color_blue)]($style)'
+
+[bun]
+symbol = ""
 style = "bg:color_blue"
 format = '[[ $symbol( $version) ](fg:color_fg0 bg:color_blue)]($style)'
 

--- a/docs/public/presets/toml/jetpack.toml
+++ b/docs/public/presets/toml/jetpack.toml
@@ -55,6 +55,7 @@ $lua\
 $maven\
 $nim\
 $nodejs\
+$bun\
 $ocaml\
 $opa\
 $perl\
@@ -219,6 +220,10 @@ version_format = "${raw}"
 detect_files = ["package-lock.json", "yarn.lock"]
 detect_folders = ["node_modules"]
 detect_extensions = []
+
+[bun]
+format = " [bun](italic) [◫ ($version)](bold bright-green)"
+version_format = "${raw}"
 
 [python]
 format = " [py](italic) [${symbol}${version}]($style)"

--- a/docs/public/presets/toml/no-nerd-font.toml
+++ b/docs/public/presets/toml/no-nerd-font.toml
@@ -16,6 +16,9 @@ symbol = "F "
 [nodejs]
 symbol = "[⬢](bold green) "
 
+[bun]
+symbol = "bun "
+
 [pulumi]
 symbol = "🧊 "
 

--- a/docs/public/presets/toml/pastel-powerline.toml
+++ b/docs/public/presets/toml/pastel-powerline.toml
@@ -20,6 +20,7 @@ $java\
 $julia\
 $maven\
 $nodejs\
+$bun\
 $nim\
 $rust\
 $scala\
@@ -131,6 +132,11 @@ format = '[ $symbol ($version) ]($style)'
 
 [nodejs]
 symbol = ""
+style = "bg:#86BBD8"
+format = '[ $symbol ($version) ]($style)'
+
+[bun]
+symbol = ""
 style = "bg:#86BBD8"
 format = '[ $symbol ($version) ]($style)'
 

--- a/docs/public/presets/toml/tokyo-night.toml
+++ b/docs/public/presets/toml/tokyo-night.toml
@@ -10,6 +10,7 @@ $git_branch\
 $git_status\
 [](fg:#394260 bg:#212736)\
 $nodejs\
+$bun\
 $rust\
 $golang\
 $php\
@@ -41,6 +42,11 @@ format = '[[($all_status$ahead_behind )](fg:#769ff0 bg:#394260)]($style)'
 
 [nodejs]
 symbol = ""
+style = "bg:#212736"
+format = '[[ $symbol ($version) ](fg:#769ff0 bg:#212736)]($style)'
+
+[bun]
+symbol = ""
 style = "bg:#212736"
 format = '[[ $symbol ($version) ](fg:#769ff0 bg:#212736)]($style)'
 


### PR DESCRIPTION
## Summary

- 6 presets included `$nodejs` in their format but were missing `$bun`: `catppuccin-powerline`, `gruvbox-rainbow`, `jetpack`, `no-nerd-font`, `pastel-powerline`, and `tokyo-night`
- Added `$bun\` to each preset's format string (right after `$nodejs\`) and a corresponding `[bun]` section, following the same style/format conventions as the existing `[nodejs]` section in each file

## Test plan

- [x] Verify each updated preset renders the bun version when inside a bun project (i.e. a directory with `bun.lockb` or `package.json` using bun)
- [x] Verify no visual regression in the prompt when not in a bun project (module should not appear)