### PR TITLE
feat(nix-shell): Add level variable to show nix shell depth

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -3343,13 +3343,13 @@ The module will be shown when inside a nix-shell environment.
 
 ### Variables
 
-| Variable | Example | Description                          |
-| -------- | ------- | ------------------------------------ |
-| state    | `pure`  | The state of the nix-shell           |
-| name     | `lorri` | The name of the nix-shell            |
+| Variable | Example | Description                                                                   |
+| -------- | ------- | ----------------------------------------------------------------------------- |
+| state    | `pure`  | The state of the nix-shell                                                    |
+| name     | `lorri` | The name of the nix-shell                                                     |
 | level    | `1`     | The depth level of the nix-shell (Only when using [Lix](https://lix.systems)) |
-| symbol   |         | Mirrors the value of option `symbol` |
-| style\*  |         | Mirrors the value of option `style`  |
+| symbol   |         | Mirrors the value of option `symbol`                                          |
+| style\*  |         | Mirrors the value of option `style`                                           |
 
 *: This variable can only be used as a part of a style string
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -3347,6 +3347,7 @@ The module will be shown when inside a nix-shell environment.
 | -------- | ------- | ------------------------------------ |
 | state    | `pure`  | The state of the nix-shell           |
 | name     | `lorri` | The name of the nix-shell            |
+| level    | `1`     | The depth level of the nix-shell (Only when using [Lix](https://lix.systems)) |
 | symbol   |         | Mirrors the value of option `symbol` |
 | style\*  |         | Mirrors the value of option `style`  |
 

--- a/src/modules/nix_shell.rs
+++ b/src/modules/nix_shell.rs
@@ -45,6 +45,7 @@ impl NixShellType {
 /// The module will use the `$IN_NIX_SHELL` and `$name` environment variable to
 /// determine if it's inside a nix-shell and the name of it.
 ///
+///
 /// The following options are available:
 ///     - `impure_msg` (string)  // change the impure msg
 ///     - `pure_msg` (string)    // change the pure msg
@@ -57,6 +58,8 @@ impl NixShellType {
 ///     - impure         // $name == "" in an impure nix-shell
 ///     - unknown (name) // $name == "name" in an unknown nix-shell
 ///     - unknown        // $name == "" in an unknown nix-shell
+///
+///  When using Lix 2.95+, will also have $level from `$NIX_SHELL_LEVEL`
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let mut module = context.new_module("nix_shell");
     let config: NixShellConfig = NixShellConfig::try_load(module.config);
@@ -68,6 +71,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         NixShellType::Impure => config.impure_msg,
         NixShellType::Unknown => config.unknown_msg,
     };
+    let shell_level = context.get_env("NIX_SHELL_LEVEL");
 
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter
@@ -82,6 +86,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             })
             .map(|variable| match variable {
                 "name" => shell_name.as_ref().map(Ok),
+                "level" => shell_level.as_ref().map(Ok),
                 _ => None,
             })
             .parse(None, Some(context))

--- a/src/modules/nix_shell.rs
+++ b/src/modules/nix_shell.rs
@@ -64,14 +64,12 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let mut module = context.new_module("nix_shell");
     let config: NixShellConfig = NixShellConfig::try_load(module.config);
 
-    let shell_name = context.get_env("name");
     let shell_type = NixShellType::detect_shell_type(config.heuristic, context)?;
     let shell_type_format = match shell_type {
         NixShellType::Pure => config.pure_msg,
         NixShellType::Impure => config.impure_msg,
         NixShellType::Unknown => config.unknown_msg,
     };
-    let shell_level = context.get_env("NIX_SHELL_LEVEL");
 
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter
@@ -85,8 +83,8 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 _ => None,
             })
             .map(|variable| match variable {
-                "name" => shell_name.as_ref().map(Ok),
-                "level" => shell_level.as_ref().map(Ok),
+                "name" => context.get_env("name").map(Ok),
+                "level" => context.get_env("NIX_SHELL_LEVEL").map(Ok),
                 _ => None,
             })
             .parse(None, Some(context))

--- a/src/modules/nix_shell.rs
+++ b/src/modules/nix_shell.rs
@@ -231,4 +231,22 @@ mod tests {
 
         assert_eq!(expected, actual);
     }
+
+    #[test]
+    fn nix_shell_level() {
+        let actual = ModuleRenderer::new("nix_shell")
+            .env("IN_NIX_SHELL", "impure")
+            .env(
+                "NIX_SHELL_LEVEL",
+                "3"
+            )
+            .config(toml::toml! {
+                [nix_shell]
+                format = "via [$symbol$state( \\($name\\)) $level]($style) "
+            })
+            .collect();
+        let expected = Some(format!("via {} ", Color::Blue.bold().paint("❄️  impure 3")));
+
+        assert_eq!(expected, actual);
+    }
 }

--- a/src/modules/nix_shell.rs
+++ b/src/modules/nix_shell.rs
@@ -236,10 +236,7 @@ mod tests {
     fn nix_shell_level() {
         let actual = ModuleRenderer::new("nix_shell")
             .env("IN_NIX_SHELL", "impure")
-            .env(
-                "NIX_SHELL_LEVEL",
-                "3"
-            )
+            .env("NIX_SHELL_LEVEL", "3")
             .config(toml::toml! {
                 [nix_shell]
                 format = "via [$symbol$state( \\($name\\)) $level]($style) "


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Adds a variable `$level` that is mirrors the environment variable `$NIX_SHELL_LEVEL` added by Lix.
#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #7369 

In the 2.95 release of Lix, a fork of Nix, they added `$NIX_SHELL_LEVEL`  which is similar to `$SHLVL` but only increments on `nix shell` and `nix-shell`.
This allows prompts to now show how many nested `nix shell`s they are currently in, which is nice to know for people who use it extensively. 

This could be implemented just using the environment variable module but having it as part of the `nix_shell` module is nicer since many people might not know it exists and requires less setup for users.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

Wrote a unit test to ensure that `$NIX_SHELL_LEVEL` maps to `$level`.
Also tested `starship prompt` in both fish and zsh while on NixOS.
I don't have Mac or Windows Lix environments set up and so I can't test there, but I can't imagine there would be much difference.
Changes are pretty minimal overall and so I don't expect much room for bugs.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
