### PR TITLE
fix(status): mirror symbols inside conditional formats

### DIFF
--- a/src/formatter/string_formatter.rs
+++ b/src/formatter/string_formatter.rs
@@ -346,6 +346,8 @@ impl<'a> StringFormatter<'a> {
                             fn should_show_elements<'a>(
                                 format_elements: &[FormatElement],
                                 variables: &'a VariableMapType<'a>,
+                                style_variables: &'a StyleVariableMapType<'a>,
+                                context: Option<&Context>,
                             ) -> bool {
                                 format_elements.get_variables().iter().any(|var| {
                                     variables
@@ -359,14 +361,23 @@ impl<'a> StringFormatter<'a> {
                                                 // that shouldn't show
                                                 .is_some_and(|result| match result {
                                                     // If the variable is a meta variable, also
-                                                    // check the format string inside it.
+                                                    // check the rendered output inside it.
                                                     VariableValue::Meta(meta_elements) => {
                                                         let meta_variables =
                                                             clone_without_meta(variables);
-                                                        should_show_elements(
-                                                            meta_elements,
+                                                        parse_format(
+                                                            meta_elements.clone(),
+                                                            None,
                                                             &meta_variables,
+                                                            style_variables,
+                                                            context,
                                                         )
+                                                        .map(|segments| {
+                                                            segments.iter().any(|segment| {
+                                                                !segment.value().is_empty()
+                                                            })
+                                                        })
+                                                        .unwrap_or(false)
                                                     }
                                                     VariableValue::Plain(plain_value) => {
                                                         !plain_value.is_empty()
@@ -382,7 +393,8 @@ impl<'a> StringFormatter<'a> {
                                 })
                             }
 
-                            let should_show: bool = should_show_elements(&format, variables);
+                            let should_show: bool =
+                                should_show_elements(&format, variables, style_variables, context);
 
                             if should_show {
                                 parse_format(format, style, variables, style_variables, context)
@@ -797,6 +809,36 @@ mod tests {
         let result = formatter.parse(None, None).unwrap();
         let mut result_iter = result.iter();
         match_next!(result_iter, " ", None);
+    }
+
+    #[test]
+    fn test_conditional_meta_variable_literal_text() {
+        const FORMAT_STR: &str = r"($all)";
+
+        let formatter = StringFormatter::new(FORMAT_STR)
+            .unwrap()
+            .map_meta(|var, _| match var {
+                "all" => Some("a"),
+                _ => None,
+            });
+        let result = formatter.parse(None, None).unwrap();
+        let mut result_iter = result.iter();
+        match_next!(result_iter, "a", None);
+    }
+
+    #[test]
+    fn test_conditional_meta_variable_styled_text() {
+        const FORMAT_STR: &str = r"($all)";
+
+        let formatter = StringFormatter::new(FORMAT_STR)
+            .unwrap()
+            .map_meta(|var, _| match var {
+                "all" => Some("[a](bold red)"),
+                _ => None,
+            });
+        let result = formatter.parse(None, None).unwrap();
+        let mut result_iter = result.iter();
+        match_next!(result_iter, "a", Some(Color::Red.bold()));
     }
 
     #[test]

--- a/src/modules/status.rs
+++ b/src/modules/status.rs
@@ -343,6 +343,24 @@ mod tests {
     }
 
     #[test]
+    fn success_symbol_is_mirrored_in_conditional_format() {
+        let expected = Some("aa ".to_string());
+
+        let actual = ModuleRenderer::new("status")
+            .config(toml::toml! {
+                [status]
+                format = "$symbol($symbol) "
+                success_symbol = "a"
+                map_symbol = true
+                disabled = false
+            })
+            .status(0)
+            .collect();
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
     fn not_enabled() {
         let expected = None;
 


### PR DESCRIPTION
#### Description
Fix mirrored `status` symbols inside conditional format segments.

#### Motivation and Context
Closes #5471.

Before this change, a status config such as:

```toml
[status]
disabled = false
map_symbol = true
success_symbol = 'a'
format = '$symbol($symbol) '
```

rendered `a ` instead of `aa `.

The root cause was that the formatter treated meta variables with literal output as empty when deciding whether to render a conditional segment. This patch checks the rendered output of meta variables in that code path, which fixes the mirrored `$symbol` case without changing `status` symbol format-string semantics.

#### How Has This Been Tested?
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.

Validation:
- `cargo test success_symbol_is_mirrored_in_conditional_format -- --nocapture`
- `cargo test test_conditional_meta_variable -- --nocapture`
- `cargo test test_conditional_meta_variable_literal_text -- --nocapture`
- `cargo test test_conditional_meta_variable_styled_text -- --nocapture`
- `cargo test test_nested_conditional -- --nocapture`
- `cargo test modules::status::tests::special_symbols -- --nocapture`
- `cargo test modules::status::tests::pipeline_uses_pipestatus_format -- --nocapture`
- `cargo test modules::status::tests::failure_plaintext_status -- --nocapture`
- `cargo test modules::status::tests::failure_hex_status -- --nocapture`
- `cargo fmt --check`

Unrelated note: `cargo test modules::status::tests::pipestatus_width -- --nocapture` also fails on clean `master` in this environment because `TERM=dumb`, so I treated that as baseline noise rather than a regression from this patch.
