### PR TITLE
fix(git): render modules inside attached worktrees of bare repositories

### DIFF
--- a/src/modules/git_branch.rs
+++ b/src/modules/git_branch.rs
@@ -30,7 +30,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let repo = context.get_repo().ok()?;
 
     let gix_repo = repo.open();
-    if config.ignore_bare_repo && gix_repo.is_bare() {
+    if config.ignore_bare_repo && repo.workdir.is_none() {
         return None;
     }
 
@@ -540,6 +540,51 @@ mod tests {
 
             assert_eq!(expected, actual);
             repo_dir.close()?;
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_ignore_bare_repo_still_renders_in_attached_worktree() -> io::Result<()> {
+        for mode in NORMAL_AND_REFTABLE {
+            let src = fixture_repo(mode)?;
+            let tmp = tempfile::tempdir()?;
+            let bare = tmp.path().join(".bare");
+            let wt = tmp.path().join("wt");
+
+            create_command("git")?
+                .arg("clone")
+                .args(maybe_reftable_format(mode))
+                .args(["--bare", "-b", "master"])
+                .arg(src.path())
+                .arg(&bare)
+                .output()?;
+
+            create_command("git")?
+                .arg("-C")
+                .arg(&bare)
+                .args(["worktree", "add"])
+                .arg(&wt)
+                .arg("master")
+                .output()?;
+
+            let actual = ModuleRenderer::new("git_branch")
+                .config(toml::toml! {
+                    [git_branch]
+                        ignore_bare_repo = true
+                })
+                .path(&wt)
+                .collect();
+
+            let expected = Some(format!(
+                "on {} ",
+                Color::Purple.bold().paint(format!("\u{e0a0} {}", "master")),
+            ));
+
+            assert_eq!(expected, actual);
+
+            src.close()?;
+            tmp.close()?;
         }
         Ok(())
     }

--- a/src/modules/git_branch.rs
+++ b/src/modules/git_branch.rs
@@ -614,6 +614,7 @@ mod tests {
             let actual = ModuleRenderer::new("git_branch")
                 .path(repo_dir.path())
                 .config(toml::toml! {
+                    command_timeout = 2_000
                     [git_branch]
                     format = "$branch(:$remote_name/$remote_branch)"
                 })

--- a/src/modules/git_metrics.rs
+++ b/src/modules/git_metrics.rs
@@ -26,7 +26,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
     let repo = context.get_repo().ok()?;
     let gix_repo = repo.open();
-    if gix_repo.is_bare() {
+    if repo.workdir.is_none() {
         return None;
     }
     let status_module = context.new_module("git_status");
@@ -724,6 +724,46 @@ mod tests {
     }
 
     #[test]
+    fn generates_git_metrics_inside_worktree_of_bare_repo() -> io::Result<()> {
+        for mode in NORMAL_AND_REFTABLES {
+            let src = create_repo_with_commit(mode)?;
+            let tmp = tempfile::tempdir()?;
+            let bare = tmp.path().join(".bare");
+            let wt = tmp.path().join("wt");
+
+            create_command("git")?
+                .arg("clone")
+                .args(maybe_reftable_format(mode))
+                .args(["--bare", "-b", "master"])
+                .arg(src.path())
+                .arg(&bare)
+                .output()?;
+
+            create_command("git")?
+                .arg("-C")
+                .arg(&bare)
+                .args(["worktree", "add"])
+                .arg(&wt)
+                .arg("master")
+                .output()?;
+
+            let the_file = wt.join("the_file");
+            let mut the_file = OpenOptions::new().append(true).open(the_file)?;
+            writeln!(the_file, "Added line")?;
+            the_file.sync_all()?;
+
+            let actual = render_metrics(&wt);
+            let expected = Some(format!("{} ", Color::Green.bold().paint("+1"),));
+
+            assert_eq!(expected, actual);
+
+            src.close()?;
+            tmp.close()?;
+        }
+        Ok(())
+    }
+
+    #[test]
     fn shows_all_changes_with_ignored_submodules() -> io::Result<()> {
         for mode in NORMAL_AND_REFTABLES {
             let repo_dir = create_repo_with_commit(mode)?;
@@ -869,5 +909,9 @@ mod tests {
         )?;
 
         Ok(repo_dir)
+    }
+
+    fn maybe_reftable_format(provider: FixtureProvider) -> Option<&'static str> {
+        matches!(provider, FixtureProvider::GitReftable).then(|| "--ref-format=reftable")
     }
 }

--- a/src/modules/git_status.rs
+++ b/src/modules/git_status.rs
@@ -35,8 +35,8 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     // Return None if not in git repository
     let repo = context.get_repo().ok()?;
 
-    if repo.open().is_bare() {
-        log::debug!("This is a bare repository, git_status is not applicable");
+    if repo.workdir.is_none() {
+        log::debug!("No working tree present, git_status is not applicable");
         return None;
     }
 
@@ -1957,6 +1957,44 @@ pub(crate) mod tests {
             repo_dir.close()?;
         }
         Ok(())
+    }
+
+    #[test]
+    fn generates_git_status_inside_worktree_of_bare_repo() -> io::Result<()> {
+        let src = fixture_repo(FixtureProvider::Git)?;
+        let tmp = tempfile::tempdir()?;
+        let bare = tmp.path().join(".bare");
+        let wt = tmp.path().join("wt");
+
+        create_command("git")?
+            .arg("clone")
+            .args(["--bare", "-b", "master"])
+            .arg(src.path())
+            .arg(&bare)
+            .output()?;
+
+        create_command("git")?
+            .arg("-C")
+            .arg(&bare)
+            .args(["worktree", "add"])
+            .arg(&wt)
+            .arg("master")
+            .output()?;
+
+        create_untracked(&wt)?;
+
+        let actual = ModuleRenderer::new("git_status")
+            .config(toml::toml! {
+                [git_status]
+                untracked = "U"
+            })
+            .path(&wt)
+            .collect();
+
+        assert_eq!(format_output("U"), actual);
+
+        src.close()?;
+        tmp.close()
     }
 
     fn ahead(repo_dir: &Path) -> io::Result<()> {


### PR DESCRIPTION
#### Description

Replace the early bare-repository guards in `git_status`, `git_branch`, and
`git_metrics` so attached worktrees of bare repositories are treated as
worktrees instead of true bare repositories.

This switches the guard from `repo.open().is_bare()` / `gix_repo.is_bare()` to
`repo.workdir.is_none()` and adds regression tests for all three modules using
the `git clone --bare` + `git worktree add` layout.

#### Motivation and Context

`git_status` regressed in v1.25.0 after #5655, and the same bare-vs-worktree
distinction also affected `git_branch` and `git_metrics`.

In an attached worktree of a bare-cloned repository, the shared repo config
still has `core.bare = true`, so `gix::Repository::is_bare()` returns `true`
even though the current context has a writable working tree. Starship already
discovers that working tree and stores it in `context::Repo.workdir`, so using
that signal is both smaller and more accurate for these module guards.

`git_status.use_git_executable = true` does not mitigate the `git_status` part
of the bug because the early return happens before either status backend runs.

Related: #6367, #6417, #6725

#### Screenshots (if appropriate):

N/A

#### How Has This Been Tested?

- `git diff --check`
- Added regression tests for attached worktrees of bare repositories in:
  - `git_status`
  - `git_branch`
  - `git_metrics`
- I could not run `cargo fmt`, `cargo test`, or `cargo clippy` in this
  environment because the Rust toolchain is not installed locally

- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:

- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
