### PR TITLE
fix(python): align `python_binary` schema with argument support

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -5832,7 +5832,7 @@
           "default": "pyenv "
         },
         "python_binary": {
-          "$ref": "#/$defs/Either2",
+          "$ref": "#/$defs/Either4",
           "default": [
             [
               "python"
@@ -7220,6 +7220,28 @@
         },
         {
           "type": "string"
+        }
+      ]
+    },
+    "Either4": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
         }
       ]
     }

--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -5668,7 +5668,7 @@
       "type": "object",
       "properties": {
         "pixi_binary": {
-          "$ref": "#/$defs/Either2",
+          "$ref": "#/$defs/VecOr_string",
           "default": [
             "pixi"
           ]
@@ -5724,7 +5724,7 @@
       },
       "additionalProperties": false
     },
-    "Either2": {
+    "VecOr_string": {
       "anyOf": [
         {
           "type": "string"
@@ -5832,7 +5832,7 @@
           "default": "pyenv "
         },
         "python_binary": {
-          "$ref": "#/$defs/Either4",
+          "$ref": "#/$defs/VecOr_VecOr_string",
           "default": [
             [
               "python"
@@ -5915,6 +5915,19 @@
         }
       },
       "additionalProperties": false
+    },
+    "VecOr_VecOr_string": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/VecOr_string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/VecOr_string"
+          }
+        }
+      ]
     },
     "QuartoConfig": {
       "type": "object",
@@ -6449,7 +6462,7 @@
           "default": "S "
         },
         "compiler": {
-          "$ref": "#/$defs/Either2",
+          "$ref": "#/$defs/VecOr_string",
           "default": [
             "solc"
           ]
@@ -7146,7 +7159,7 @@
           "default": ""
         },
         "when": {
-          "$ref": "#/$defs/Either3",
+          "$ref": "#/$defs/Either2",
           "default": false
         },
         "require_repo": {
@@ -7154,7 +7167,7 @@
           "default": false
         },
         "shell": {
-          "$ref": "#/$defs/Either2",
+          "$ref": "#/$defs/VecOr_string",
           "default": []
         },
         "description": {
@@ -7213,35 +7226,13 @@
       },
       "additionalProperties": false
     },
-    "Either3": {
+    "Either2": {
       "anyOf": [
         {
           "type": "boolean"
         },
         {
           "type": "string"
-        }
-      ]
-    },
-    "Either4": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        {
-          "type": "array",
-          "items": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
         }
       ]
     }

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -4036,7 +4036,7 @@ By default, the module will be shown if any of the following conditions are met:
 > - a string (e.g. `'python3'`),
 > - a list of strings (e.g. `['python', 'python3']`)
 > - a list of lists of strings, representing commands with optional arguments (e.g.
->   `[['uv', 'run', 'python'], 'python3']`)
+>   `[['uv', 'run', 'python'], ['python3']]`)
 >
 > Starship will try executing each configured command until it gets a result.
 > Note you can only change the binary that Starship executes to get the version

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -4031,10 +4031,16 @@ By default, the module will be shown if any of the following conditions are met:
 | `disabled`           | `false`                                                                                                      | Disables the `python` module.                                                         |
 
 > [!TIP]
-> The `python_binary` variable accepts either a string or a list of strings.
-> Starship will try executing each binary until it gets a result. Note you can
-> only change the binary that Starship executes to get the version of Python not
-> the arguments that are used.
+> The `python_binary` variable accepts either:
+>
+> - a string (e.g. `'python3'`),
+> - a list of strings (e.g. `['python', 'python3']`)
+> - a list of lists of strings, representing commands with optional arguments (e.g.
+> `[['uv', 'run', 'python'], 'python3']`)
+>
+> Starship will try executing each configured command until it gets a result.
+> Note you can only change the binary that Starship executes to get the version
+> of Python not the arguments that are used.
 >
 > The default values and order for `python_binary` was chosen to first identify
 > the Python version in a virtualenv/conda environments (which currently still
@@ -4071,6 +4077,14 @@ pyenv_version_name = true
 [python]
 # Only use the `python3` binary to get the version.
 python_binary = 'python3'
+```
+
+```toml
+# ~/.config/starship.toml
+
+[python]
+# Use `uv` to get the version.
+python_binary = [['uv', 'run', '--no-python-downloads', '--no-project', 'python']]
 ```
 
 ```toml

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -4036,7 +4036,7 @@ By default, the module will be shown if any of the following conditions are met:
 > - a string (e.g. `'python3'`),
 > - a list of strings (e.g. `['python', 'python3']`)
 > - a list of lists of strings, representing commands with optional arguments (e.g.
-> `[['uv', 'run', 'python'], 'python3']`)
+>   `[['uv', 'run', 'python'], 'python3']`)
 >
 > Starship will try executing each configured command until it gets a result.
 > Note you can only change the binary that Starship executes to get the version

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -4036,7 +4036,7 @@ By default, the module will be shown if any of the following conditions are met:
 > - a string (e.g. `'python3'`),
 > - a list of strings (e.g. `['python', 'python3']`)
 > - a list of lists of strings, representing commands with optional arguments (e.g.
->   `[['uv', 'run', 'python'], ['python3']]`)
+>   `[['mise', 'exec', '--', 'python'], ['python3']]`)
 >
 > Starship will try executing each configured command until it gets a result.
 > Note you can only change the binary that Starship executes to get the version
@@ -4083,7 +4083,15 @@ python_binary = 'python3'
 # ~/.config/starship.toml
 
 [python]
-# Use `uv` to get the version.
+# Use `mise` to get the version.
+python_binary = [['mise', 'exec', '--', 'python']]
+```
+
+```toml
+# ~/.config/starship.toml
+
+[python]
+# Potentially dangerous: `uv` can run any binary at `.venv/bin/python` without interaction
 python_binary = [['uv', 'run', '--no-python-downloads', '--no-project', 'python']]
 ```
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -108,11 +108,7 @@ where
     }
 
     fn schema_id() -> Cow<'static, str> {
-        Cow::Owned(format!(
-            "{}::VecOr<{}>",
-            module_path!(),
-            T::schema_id()
-        ))
+        Cow::Owned(format!("{}::VecOr<{}>", module_path!(), T::schema_id()))
     }
 
     fn json_schema(generator: &mut schemars::generate::SchemaGenerator) -> schemars::Schema {

--- a/src/config.rs
+++ b/src/config.rs
@@ -103,12 +103,16 @@ where
     T: schemars::JsonSchema + Sized,
 {
     fn schema_name() -> Cow<'static, str> {
-        Either::<T, Vec<T>>::schema_name()
+        // `Either::<T, Vec<T>>::schema_name()` is not unique per `T`; nested `VecOr`s must not share a `$defs` entry.
+        Cow::Owned(format!("VecOr_{}", T::schema_name()))
     }
 
     fn schema_id() -> Cow<'static, str> {
-        let mod_path = module_path!();
-        Cow::Owned(format!("{mod_path}::{}", Self::schema_name()))
+        Cow::Owned(format!(
+            "{}::VecOr<{}>",
+            module_path!(),
+            T::schema_id()
+        ))
     }
 
     fn json_schema(generator: &mut schemars::generate::SchemaGenerator) -> schemars::Schema {
@@ -1057,6 +1061,22 @@ mod tests {
             None,
             StarshipConfig::read_config_content_as_str(None),
             "if the platform doesn't have utils::home_dir(), it should return None"
+        );
+    }
+
+    /// Guard against schemars `$defs` collisions by requiring distinct IDs for nested `VecOr` types.
+    #[cfg(feature = "config-schema")]
+    #[test]
+    fn vec_or_schema_ids_distinguish_nesting() {
+        use schemars::JsonSchema;
+
+        assert_ne!(
+            VecOr::<VecOr<&str>>::schema_id(),
+            VecOr::<&str>::schema_id(),
+        );
+        assert_ne!(
+            VecOr::<VecOr<&str>>::schema_name(),
+            VecOr::<&str>::schema_name(),
         );
     }
 }


### PR DESCRIPTION
#### Description
Fixes config schema generation for nested `VecOr` types and regenerates `.github/config-schema.json`.

This updates the Rust schema source (`VecOr<T>: JsonSchema`) so nested forms get unique schema identities, avoiding `$defs` collisions. With that fix, `python_binary` now resolves to `VecOr<VecOr<string>>` (`VecOr_VecOr_string`) in the generated schema and supports:
- `string`
- `string[]`
- `string[][]`

Adds a targeted regression test (`vec_or_schema_ids_distinguish_nesting` in `src/config.rs`, behind `config-schema`) that asserts nested and non-nested `VecOr` types have distinct `schema_id`/`schema_name`, preventing future schema identity collisions.

Also updates Python config docs to with example usage.

#### Motivation and Context
The Python module has supported argument-bearing `python_binary` commands since [#6523](https://github.com/starship/starship/pull/6523), but schema generation could previously collapse different `VecOr` nestings to the same schemars identity and `$defs` entry.

This change addresses that root cause in Rust generation logic, so schema validation stays aligned with actual parser/runtime behavior.  
The regenerated schema now uses `VecOr_*` definitions for `VecOr`-based shapes, and `Either2` now corresponds to the bool/string union used by `custom.when`.

#### How Has This Been Tested?
- [x] Added and ran a regression test asserting nested `VecOr` schema identities are distinct:
  - `cargo test --locked --features config-schema vec_or_schema_ids_distinguish_nesting`
- [x] Regenerated schema and verified committed file matches generator output:
  - `cargo run --locked --features config-schema -- config-schema > .github/config-schema.json`
- [x] Confirmed `python_binary` now references the nested generated `VecOr` schema form
- [x] Tested on **macOS**
- [ ] Tested on **Linux**
- [ ] Tested on **Windows**

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.