### PR TITLE
fix(git): improve bare repository detection

### DIFF
--- a/src/modules/git_branch.rs
+++ b/src/modules/git_branch.rs
@@ -30,7 +30,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let repo = context.get_repo().ok()?;
 
     let gix_repo = repo.open();
-    if config.ignore_bare_repo && gix_repo.is_bare() {
+    if config.ignore_bare_repo && gix_repo.workdir().is_none() {
         return None;
     }
 
@@ -228,6 +228,7 @@ fn get_first_grapheme(text: &str) -> &str {
 #[cfg(test)]
 mod tests {
     use nu_ansi_term::Color;
+    use std::ffi::OsStr;
     use std::io;
 
     use crate::test::{FixtureProvider, ModuleRenderer, fixture_repo};
@@ -539,6 +540,46 @@ mod tests {
             let expected = None;
 
             assert_eq!(expected, actual);
+            repo_dir.close()?;
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_works_in_worktree_backed_by_bare_repo_with_ignore_bare() -> io::Result<()> {
+        for mode in BARE_AND_REFTABLE {
+            let repo_dir = fixture_repo(mode)?;
+            let worktree_dir = tempfile::tempdir()?;
+
+            create_command("git")?
+                .args([
+                    OsStr::new("worktree"),
+                    OsStr::new("add"),
+                    worktree_dir.path().as_os_str(),
+                    OsStr::new("-b"),
+                    OsStr::new("my-worktree-feature"),
+                ])
+                .current_dir(repo_dir.path())
+                .output()?;
+
+            let actual = ModuleRenderer::new("git_branch")
+                .config(toml::toml! {
+                    [git_branch]
+                    ignore_bare_repo = true
+
+                })
+                .path(worktree_dir.path())
+                .collect();
+
+            let expected = Some(format!(
+                "on {} ",
+                Color::Purple
+                    .bold()
+                    .paint(format!("\u{e0a0} {}", "my-worktree-feature")),
+            ));
+
+            assert_eq!(expected, actual);
+            worktree_dir.close()?;
             repo_dir.close()?;
         }
         Ok(())

--- a/src/modules/git_metrics.rs
+++ b/src/modules/git_metrics.rs
@@ -26,9 +26,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
     let repo = context.get_repo().ok()?;
     let gix_repo = repo.open();
-    if gix_repo.is_bare() {
-        return None;
-    }
+    gix_repo.workdir()?;
     let status_module = context.new_module("git_status");
     let status_config = GitStatusConfig::try_load(status_module.config);
     // TODO: remove this special case once `gitoxide` can handle sparse indices for tree-index comparisons.
@@ -718,6 +716,34 @@ mod tests {
             let actual = render_metrics(repo_dir.path());
             assert_eq!(None, actual);
 
+            repo_dir.close()?;
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn does_generate_git_metrics_for_worktree_backed_by_bare_repo() -> io::Result<()> {
+        for mode in BARE_AND_REFTABLE {
+            let repo_dir = fixture_repo(mode)?;
+            let worktree_dir = tempfile::tempdir()?;
+
+            create_command("git")?
+                .args(["worktree", "add"])
+                .arg(worktree_dir.path())
+                .args(["-b", "metrics-worktree"])
+                .current_dir(repo_dir.path())
+                .output()?;
+
+            let file_path = worktree_dir.path().join("readme.md");
+            let mut the_file = OpenOptions::new().append(true).open(&file_path)?;
+            writeln!(the_file, "Added line")?;
+            the_file.sync_all()?;
+
+            let actual = render_metrics(worktree_dir.path());
+            let expected = Some(format!("{} ", Color::Green.bold().paint("+1")));
+
+            assert_eq!(expected, actual);
+            worktree_dir.close()?;
             repo_dir.close()?;
         }
         Ok(())

--- a/src/modules/git_status.rs
+++ b/src/modules/git_status.rs
@@ -35,7 +35,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     // Return None if not in git repository
     let repo = context.get_repo().ok()?;
 
-    if repo.open().is_bare() {
+    if repo.open().workdir().is_none() {
         log::debug!("This is a bare repository, git_status is not applicable");
         return None;
     }
@@ -1954,6 +1954,38 @@ pub(crate) mod tests {
 
             assert_eq!(None, actual);
 
+            repo_dir.close()?;
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn does_generate_git_status_for_worktree_backed_by_bare_repo() -> io::Result<()> {
+        for mode in BARE_AND_REFTABLE {
+            let worktree_dir = tempfile::tempdir()?;
+            let repo_dir = fixture_repo(mode)?;
+
+            create_command("git")?
+                .args([
+                    OsStr::new("worktree"),
+                    OsStr::new("add"),
+                    worktree_dir.path().as_os_str(),
+                    OsStr::new("HEAD"),
+                ])
+                .current_dir(repo_dir.path())
+                .output()?;
+
+            let mut the_file = std::fs::File::create(worktree_dir.path().join("test_file"))?;
+            writeln!(the_file, "content")?;
+            the_file.sync_all()?;
+
+            let actual = ModuleRenderer::new("git_status")
+                .path(worktree_dir.path())
+                .collect();
+            let expected = format_output("?");
+
+            assert_eq!(expected, actual);
+            worktree_dir.close()?;
             repo_dir.close()?;
         }
         Ok(())


### PR DESCRIPTION


#### Description
When using a worktree backed by a bare repository, the is_bare() method from gix repository returns true, even though the user is in a checked out worktree. This is a change in behaviour of is_bare() some time between version 0.76.0 (used in starship v1.24.2) and 0.81.0 (used in starship v1.25.0). A better way of handling this is to instead check if workdir() returns None.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #7414


#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
