### PR TITLE
feat(aws): add [aws.sso] require_active to gate module on active SSO session

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -1,58 +1,3 @@
-   Compiling thiserror v2.0.18
-   Compiling serde_json v1.0.149
-   Compiling serde v1.0.228
-   Compiling clap v4.6.1
-   Compiling ref-cast v1.0.25
-   Compiling futures-core v0.3.32
-   Compiling starship v1.25.0 (/Users/brunomoreira/Workspaces/Personal/OpenSource/starship)
-   Compiling pest_generator v2.8.6
-   Compiling clap_complete v4.6.2
-   Compiling gix-path v0.11.2
-   Compiling gix-packetline v0.21.2
-   Compiling futures-lite v2.6.1
-   Compiling gix-features v0.46.2
-   Compiling gix-config-value v0.17.1
-   Compiling gix-command v0.8.0
-   Compiling gix-url v0.35.2
-   Compiling clap_complete_nushell v4.6.0
-   Compiling jsonc-parser v0.32.3
-   Compiling gix-hash v0.23.0
-   Compiling gix-fs v0.19.2
-   Compiling gix-glob v0.24.0
-   Compiling gix-transport v0.55.1
-   Compiling pest_derive v2.8.6
-   Compiling notify-rust v4.16.0
-   Compiling gix-tempfile v21.0.2
-   Compiling gix-hashtable v0.13.0
-   Compiling gix-commitgraph v0.35.0
-   Compiling gix-object v0.58.0
-   Compiling gix-attributes v0.31.0
-   Compiling gix-ignore v0.19.1
-   Compiling gix-lock v21.0.2
-   Compiling gix-shallow v0.10.0
-   Compiling gix-pathspec v0.16.1
-   Compiling schemars v1.2.1
-   Compiling gix-revwalk v0.29.0
-   Compiling gix-ref v0.61.0
-   Compiling gix-filter v0.28.0
-   Compiling gix-pack v0.68.0
-   Compiling gix-traverse v0.55.0
-   Compiling gix-revision v0.43.0
-   Compiling os_info v3.14.0
-   Compiling gix-index v0.49.0
-   Compiling gix-refspec v0.39.0
-   Compiling gix-discover v0.49.0
-   Compiling gix-config v0.54.0
-   Compiling gix-protocol v0.59.0
-   Compiling gix-odb v0.78.0
-   Compiling gix-worktree v0.50.0
-   Compiling gix-diff v0.61.0
-   Compiling gix-dir v0.23.0
-   Compiling gix-status v0.28.0
-   Compiling gix-submodule v0.28.0
-   Compiling gix v0.81.0
-    Finished `dev` profile [unoptimized + debuginfo] target(s) in 14.96s
-     Running `target/debug/starship config-schema`
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "FullConfig",
@@ -2051,11 +1996,11 @@
       "additionalProperties": false
     },
     "AwsSsoConfig": {
-      "description": "SSO-specific configuration for the `aws` module.\n\nGrouped under `[aws.sso]` in `starship.toml`. Currently a single option;\nfuture SSO-specific knobs (expiry-warning thresholds, custom cache paths,\netc.) should live here.",
+      "description": "SSO-specific configuration for the `aws` module (grouped under `[aws.sso]`).",
       "type": "object",
       "properties": {
         "require_active": {
-          "description": "If true, the module hides for SSO-based profiles when no unexpired token\nis cached in `~/.aws/sso/cache/`. The default activation triggers on SSO\n*configuration* presence (e.g. `sso_session` in `~/.aws/config`), which\nproduces a stale indicator when the user hasn't run `aws sso login` or\nthe token has expired. This option only narrows the SSO path — env vars,\nstatic keys, and `credential_process` profiles activate as before. No\nnetwork is performed; the SSO token's `expiresAt` is read from disk.",
+          "description": "If `true`, hides the module for SSO-based profiles when no unexpired token is cached in `~/.aws/sso/cache/`.",
           "type": "boolean",
           "default": false
         }

--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -1,3 +1,58 @@
+   Compiling thiserror v2.0.18
+   Compiling serde_json v1.0.149
+   Compiling serde v1.0.228
+   Compiling clap v4.6.1
+   Compiling ref-cast v1.0.25
+   Compiling futures-core v0.3.32
+   Compiling starship v1.25.0 (/Users/brunomoreira/Workspaces/Personal/OpenSource/starship)
+   Compiling pest_generator v2.8.6
+   Compiling clap_complete v4.6.2
+   Compiling gix-path v0.11.2
+   Compiling gix-packetline v0.21.2
+   Compiling futures-lite v2.6.1
+   Compiling gix-features v0.46.2
+   Compiling gix-config-value v0.17.1
+   Compiling gix-command v0.8.0
+   Compiling gix-url v0.35.2
+   Compiling clap_complete_nushell v4.6.0
+   Compiling jsonc-parser v0.32.3
+   Compiling gix-hash v0.23.0
+   Compiling gix-fs v0.19.2
+   Compiling gix-glob v0.24.0
+   Compiling gix-transport v0.55.1
+   Compiling pest_derive v2.8.6
+   Compiling notify-rust v4.16.0
+   Compiling gix-tempfile v21.0.2
+   Compiling gix-hashtable v0.13.0
+   Compiling gix-commitgraph v0.35.0
+   Compiling gix-object v0.58.0
+   Compiling gix-attributes v0.31.0
+   Compiling gix-ignore v0.19.1
+   Compiling gix-lock v21.0.2
+   Compiling gix-shallow v0.10.0
+   Compiling gix-pathspec v0.16.1
+   Compiling schemars v1.2.1
+   Compiling gix-revwalk v0.29.0
+   Compiling gix-ref v0.61.0
+   Compiling gix-filter v0.28.0
+   Compiling gix-pack v0.68.0
+   Compiling gix-traverse v0.55.0
+   Compiling gix-revision v0.43.0
+   Compiling os_info v3.14.0
+   Compiling gix-index v0.49.0
+   Compiling gix-refspec v0.39.0
+   Compiling gix-discover v0.49.0
+   Compiling gix-config v0.54.0
+   Compiling gix-protocol v0.59.0
+   Compiling gix-odb v0.78.0
+   Compiling gix-worktree v0.50.0
+   Compiling gix-diff v0.61.0
+   Compiling gix-dir v0.23.0
+   Compiling gix-status v0.28.0
+   Compiling gix-submodule v0.28.0
+   Compiling gix v0.81.0
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 14.96s
+     Running `target/debug/starship config-schema`
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "FullConfig",
@@ -74,7 +129,10 @@
         "region_aliases": {},
         "profile_aliases": {},
         "expiration_symbol": "X",
-        "force_display": false
+        "force_display": false,
+        "sso": {
+          "require_active": false
+        }
       }
     },
     "azure": {
@@ -1979,6 +2037,25 @@
         },
         "force_display": {
           "description": "If true displays info even if `credentials`, `credential_process` or `sso_start_url` have not been setup.",
+          "type": "boolean",
+          "default": false
+        },
+        "sso": {
+          "description": "SSO-specific options. See [`AwsSsoConfig`].",
+          "$ref": "#/$defs/AwsSsoConfig",
+          "default": {
+            "require_active": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "AwsSsoConfig": {
+      "description": "SSO-specific configuration for the `aws` module.\n\nGrouped under `[aws.sso]` in `starship.toml`. Currently a single option;\nfuture SSO-specific knobs (expiry-warning thresholds, custom cache paths,\netc.) should live here.",
+      "type": "object",
+      "properties": {
+        "require_active": {
+          "description": "If true, the module hides for SSO-based profiles when no unexpired token\nis cached in `~/.aws/sso/cache/`. The default activation triggers on SSO\n*configuration* presence (e.g. `sso_session` in `~/.aws/config`), which\nproduces a stale indicator when the user hasn't run `aws sso login` or\nthe token has expired. This option only narrows the SSO path — env vars,\nstatic keys, and `credential_process` profiles activate as before. No\nnetwork is performed; the SSO token's `expiresAt` is read from disk.",
           "type": "boolean",
           "default": false
         }

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -381,6 +381,8 @@ The output of the module uses the `AWS_REGION`, `AWS_DEFAULT_REGION`, and `AWS_P
 The module will display a profile only if its credentials are present in `~/.aws/credentials` or if a `credential_process`, `sso_start_url`, or `sso_session` are defined in `~/.aws/config`. Alternatively, having any of the `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, or `AWS_SESSION_TOKEN` env vars defined will also suffice.
 If the option `force_display` is set to `true`, all available information will be displayed even if no credentials per the conditions above are detected.
 
+If the option `sso.require_active` is set to `true`, the module hides when the active profile authenticates via SSO and no unexpired token is cached under `~/.aws/sso/cache/`. Env vars, static access keys, and `credential_process` profiles activate as before. See [SSO Options](#sso-options).
+
 When using [aws-vault](https://github.com/99designs/aws-vault) the profile
 is read from the `AWS_VAULT` env var and the credentials expiration date
 is read from the `AWS_SESSION_EXPIRATION` env var.
@@ -410,6 +412,14 @@ is read from the `AWS_SSO_PROFILE` env var.
 | `expiration_symbol` | `'X'`                                                             | The symbol displayed when the temporary credentials have expired.                                           |
 | `disabled`          | `false`                                                           | Disables the `AWS` module.                                                                                  |
 | `force_display`     | `false`                                                           | If `true` displays info even if `credentials`, `credential_process` or `sso_start_url` have not been setup. |
+
+### SSO Options
+
+SSO-specific settings, configured under `[aws.sso]`. Grouping them here keeps the top-level `aws` options focused and leaves room for future SSO-specific knobs.
+
+| Option           | Default | Description                                                                                                                                                                                                                                                                                                                  |
+| ---------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `require_active` | `false` | If `true`, the module hides when the active profile authenticates via SSO and no unexpired token is cached under `~/.aws/sso/cache/`. The check is purely local — no network request. Env vars, static access keys, and `credential_process` profiles continue to activate the module via the top-level activation chain. |
 
 ### Variables
 
@@ -466,6 +476,17 @@ style = 'bold blue'
 symbol = '🅰 '
 [aws.profile_aliases]
 Enterprise_Naming_Scheme-voidstars = 'void**'
+```
+
+#### Hide AWS when SSO session is inactive
+
+Useful when `~/.aws/config` defines SSO profiles — the module would normally display based on the config being present, regardless of whether you have actually run `aws sso login`. With `require_active`, the module only shows when a cached SSO token is still valid (checked locally via `~/.aws/sso/cache/`).
+
+```toml
+# ~/.config/starship.toml
+
+[aws.sso]
+require_active = true
 ```
 
 ## Azure

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -381,7 +381,7 @@ The output of the module uses the `AWS_REGION`, `AWS_DEFAULT_REGION`, and `AWS_P
 The module will display a profile only if its credentials are present in `~/.aws/credentials` or if a `credential_process`, `sso_start_url`, or `sso_session` are defined in `~/.aws/config`. Alternatively, having any of the `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, or `AWS_SESSION_TOKEN` env vars defined will also suffice.
 If the option `force_display` is set to `true`, all available information will be displayed even if no credentials per the conditions above are detected.
 
-If the option `sso.require_active` is set to `true`, the module hides when the active profile authenticates via SSO and no unexpired token is cached under `~/.aws/sso/cache/`. Env vars, static access keys, and `credential_process` profiles activate as before. See [SSO Options](#sso-options).
+If the option `sso.require_active` is set to `true`, the module hides for SSO-based profiles unless a cached token is present and unexpired. See [SSO Options](#sso-options).
 
 When using [aws-vault](https://github.com/99designs/aws-vault) the profile
 is read from the `AWS_VAULT` env var and the credentials expiration date
@@ -415,11 +415,11 @@ is read from the `AWS_SSO_PROFILE` env var.
 
 ### SSO Options
 
-SSO-specific settings, configured under `[aws.sso]`. Grouping them here keeps the top-level `aws` options focused and leaves room for future SSO-specific knobs.
+Configured under `[aws.sso]`.
 
-| Option           | Default | Description                                                                                                                                                                                                                                                                                                                  |
-| ---------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `require_active` | `false` | If `true`, the module hides when the active profile authenticates via SSO and no unexpired token is cached under `~/.aws/sso/cache/`. The check is purely local — no network request. Env vars, static access keys, and `credential_process` profiles continue to activate the module via the top-level activation chain. |
+| Option           | Default | Description                                                                                                 |
+| ---------------- | ------- | ----------------------------------------------------------------------------------------------------------- |
+| `require_active` | `false` | If `true`, hides the module for SSO-based profiles when no unexpired token is cached in `~/.aws/sso/cache`. |
 
 ### Variables
 
@@ -478,9 +478,7 @@ symbol = '🅰 '
 Enterprise_Naming_Scheme-voidstars = 'void**'
 ```
 
-#### Hide AWS when SSO session is inactive
-
-Useful when `~/.aws/config` defines SSO profiles — the module would normally display based on the config being present, regardless of whether you have actually run `aws sso login`. With `require_active`, the module only shows when a cached SSO token is still valid (checked locally via `~/.aws/sso/cache/`).
+#### Require an active SSO session
 
 ```toml
 # ~/.config/starship.toml

--- a/src/configs/aws.rs
+++ b/src/configs/aws.rs
@@ -47,6 +47,8 @@ pub struct AwsConfig<'a> {
     pub expiration_symbol: &'a str,
     /// If true displays info even if `credentials`, `credential_process` or `sso_start_url` have not been setup.
     pub force_display: bool,
+    /// SSO-specific options. See [`AwsSsoConfig`].
+    pub sso: AwsSsoConfig,
 }
 
 impl Default for AwsConfig<'_> {
@@ -60,6 +62,30 @@ impl Default for AwsConfig<'_> {
             profile_aliases: HashMap::new(),
             expiration_symbol: "X",
             force_display: false,
+            sso: AwsSsoConfig::default(),
         }
     }
+}
+
+#[derive(Clone, Default, Deserialize, Serialize)]
+#[cfg_attr(
+    feature = "config-schema",
+    derive(schemars::JsonSchema),
+    schemars(deny_unknown_fields)
+)]
+#[serde(default)]
+/// SSO-specific configuration for the `aws` module.
+///
+/// Grouped under `[aws.sso]` in `starship.toml`. Currently a single option;
+/// future SSO-specific knobs (expiry-warning thresholds, custom cache paths,
+/// etc.) should live here.
+pub struct AwsSsoConfig {
+    /// If true, the module hides for SSO-based profiles when no unexpired token
+    /// is cached in `~/.aws/sso/cache/`. The default activation triggers on SSO
+    /// *configuration* presence (e.g. `sso_session` in `~/.aws/config`), which
+    /// produces a stale indicator when the user hasn't run `aws sso login` or
+    /// the token has expired. This option only narrows the SSO path — env vars,
+    /// static keys, and `credential_process` profiles activate as before. No
+    /// network is performed; the SSO token's `expiresAt` is read from disk.
+    pub require_active: bool,
 }

--- a/src/configs/aws.rs
+++ b/src/configs/aws.rs
@@ -74,18 +74,8 @@ impl Default for AwsConfig<'_> {
     schemars(deny_unknown_fields)
 )]
 #[serde(default)]
-/// SSO-specific configuration for the `aws` module.
-///
-/// Grouped under `[aws.sso]` in `starship.toml`. Currently a single option;
-/// future SSO-specific knobs (expiry-warning thresholds, custom cache paths,
-/// etc.) should live here.
+/// SSO-specific configuration for the `aws` module (grouped under `[aws.sso]`).
 pub struct AwsSsoConfig {
-    /// If true, the module hides for SSO-based profiles when no unexpired token
-    /// is cached in `~/.aws/sso/cache/`. The default activation triggers on SSO
-    /// *configuration* presence (e.g. `sso_session` in `~/.aws/config`), which
-    /// produces a stale indicator when the user hasn't run `aws sso login` or
-    /// the token has expired. This option only narrows the SSO path — env vars,
-    /// static keys, and `credential_process` profiles activate as before. No
-    /// network is performed; the SSO token's `expiresAt` is read from disk.
+    /// If `true`, hides the module for SSO-based profiles when no unexpired token is cached in `~/.aws/sso/cache/`.
     pub require_active: bool,
 }

--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -238,11 +238,7 @@ fn has_defined_credentials(
     Some(section.contains_key("aws_access_key_id"))
 }
 
-// True when the active profile declares SSO (either `sso_session` referencing a
-// `[sso-session <name>]` block, or the legacy direct `sso_start_url`).
-// Used by the `require_active_sso` gate to narrow its scope: profiles that
-// authenticate via other mechanisms (env vars, static keys, credential_process)
-// are intentionally left untouched.
+// True when the active profile declares SSO (`sso_session` or `sso_start_url`).
 fn profile_uses_sso(
     context: &Context,
     aws_profile: Option<&Profile>,
@@ -300,11 +296,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         return None;
     }
 
-    // Opt-in SSO-specific gate: if the active profile authenticates via SSO and
-    // no unexpired token is cached on disk, hide the module. Env vars, static
-    // keys in the credentials file, and `credential_process` profiles are left
-    // alone — they remain authorized by the general activation chain above.
-    // `force_display` overrides (documented override semantics preserved).
+    // Opt-in SSO gate: hide SSO-based profiles when no cached token is valid.
     if !config.force_display
         && config.sso.require_active
         && profile_uses_sso(context, aws_profile.as_ref(), &aws_config)
@@ -312,8 +304,6 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     {
         let duration =
             get_credentials_duration(context, aws_profile.as_ref(), &aws_config, &aws_creds);
-        // `None` covers the never-logged-in case (cache file missing); `<= 0`
-        // covers expired. Both should hide the module.
         if duration.is_none_or(|d| d <= 0) {
             return None;
         }

--- a/src/modules/aws.rs
+++ b/src/modules/aws.rs
@@ -238,6 +238,22 @@ fn has_defined_credentials(
     Some(section.contains_key("aws_access_key_id"))
 }
 
+// True when the active profile declares SSO (either `sso_session` referencing a
+// `[sso-session <name>]` block, or the legacy direct `sso_start_url`).
+// Used by the `require_active_sso` gate to narrow its scope: profiles that
+// authenticate via other mechanisms (env vars, static keys, credential_process)
+// are intentionally left untouched.
+fn profile_uses_sso(
+    context: &Context,
+    aws_profile: Option<&Profile>,
+    aws_config: &AwsConfigFile,
+) -> bool {
+    get_config(context, aws_config)
+        .and_then(|config| get_profile_config(config, aws_profile))
+        .map(|section| section.contains_key("sso_session") || section.contains_key("sso_start_url"))
+        .unwrap_or(false)
+}
+
 // https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html#cli-configure-files-settings
 fn has_source_profile(
     context: &Context,
@@ -282,6 +298,25 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         && !has_defined_credentials(context, aws_profile.as_ref(), &aws_creds).unwrap_or(false)
     {
         return None;
+    }
+
+    // Opt-in SSO-specific gate: if the active profile authenticates via SSO and
+    // no unexpired token is cached on disk, hide the module. Env vars, static
+    // keys in the credentials file, and `credential_process` profiles are left
+    // alone — they remain authorized by the general activation chain above.
+    // `force_display` overrides (documented override semantics preserved).
+    if !config.force_display
+        && config.sso.require_active
+        && profile_uses_sso(context, aws_profile.as_ref(), &aws_config)
+        && !has_defined_credentials(context, aws_profile.as_ref(), &aws_creds).unwrap_or(false)
+    {
+        let duration =
+            get_credentials_duration(context, aws_profile.as_ref(), &aws_config, &aws_creds);
+        // `None` covers the never-logged-in case (cache file missing); `<= 0`
+        // covers expired. Both should hide the module.
+        if duration.is_none_or(|d| d <= 0) {
+            return None;
+        }
     }
 
     let duration = {
@@ -1290,6 +1325,247 @@ source_profile = starship
         ));
 
         assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    // ---- require_active_sso (opt-in activation gate) -----------------------
+
+    #[test]
+    fn require_active_sso_hides_when_only_sso_config_present() -> io::Result<()> {
+        // SSO configured in ~/.aws/config but no token cache → hides when
+        // `require_active_sso` is enabled. This is the regression this option
+        // is designed to fix.
+        let (module_renderer, dir) = ModuleRenderer::new_with_home("aws")?;
+        std::fs::create_dir_all(dir.path().join(".aws"))?;
+
+        let mut file = File::create(dir.path().join(".aws/config"))?;
+        file.write_all(
+            "[default]
+region = us-east-1
+sso_start_url = https://starship.rs/sso
+sso_region = us-east-1
+sso_account_id = 123456789012
+sso_role_name = ReadOnly
+"
+            .as_bytes(),
+        )?;
+        file.sync_all()?;
+
+        let actual = module_renderer
+            .config(toml::toml! {
+                [aws.sso]
+                require_active = true
+            })
+            .collect();
+
+        assert_eq!(None, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn require_active_sso_shows_with_credential_env_var() -> io::Result<()> {
+        // AWS_ACCESS_KEY_ID env var → always authenticated.
+        let (module_renderer, dir) = ModuleRenderer::new_with_home("aws")?;
+        let actual = module_renderer
+            .env("AWS_REGION", "us-east-1")
+            .env("AWS_ACCESS_KEY_ID", "dummy")
+            .config(toml::toml! {
+                [aws.sso]
+                require_active = true
+            })
+            .collect();
+        let expected = Some(format!(
+            "on {}",
+            Color::Yellow.bold().paint("☁️  (us-east-1) ")
+        ));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn require_active_sso_shows_with_static_credentials_file() -> io::Result<()> {
+        // Static access key in ~/.aws/credentials (no expiration) → authenticated.
+        let (module_renderer, dir) = ModuleRenderer::new_with_home("aws")?;
+        std::fs::create_dir_all(dir.path().join(".aws"))?;
+
+        let mut creds = File::create(dir.path().join(".aws/credentials"))?;
+        creds.write_all(
+            "[default]
+aws_access_key_id = AKIATEST
+aws_secret_access_key = secret
+"
+            .as_bytes(),
+        )?;
+        creds.sync_all()?;
+
+        let mut config = File::create(dir.path().join(".aws/config"))?;
+        config.write_all(
+            "[default]
+region = us-east-1
+"
+            .as_bytes(),
+        )?;
+        config.sync_all()?;
+
+        let actual = module_renderer
+            .config(toml::toml! {
+                [aws.sso]
+                require_active = true
+            })
+            .collect();
+        let expected = Some(format!(
+            "on {}",
+            Color::Yellow.bold().paint("☁️  (us-east-1) ")
+        ));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn require_active_sso_shows_with_unexpired_sso_token() -> io::Result<()> {
+        use chrono::{DateTime, SecondsFormat, Utc};
+
+        let (module_renderer, dir) = ModuleRenderer::new_with_home("aws")?;
+        std::fs::create_dir_all(dir.path().join(".aws/sso/cache"))?;
+
+        let mut config = File::create(dir.path().join(".aws/config"))?;
+        config.write_all(
+            "[default]
+region = us-east-1
+sso_start_url = https://starship.rs/sso
+sso_region = us-east-1
+sso_account_id = 123456789012
+sso_role_name = ReadOnly
+"
+            .as_bytes(),
+        )?;
+        config.sync_all()?;
+
+        // SHA-1 of "https://starship.rs/sso"
+        let mut cache = File::create(
+            dir.path()
+                .join(".aws/sso/cache/a47a4e57aecc96b31b4f083543924bd6f828e65a.json"),
+        )?;
+        let one_hour_ahead: DateTime<Utc> =
+            DateTime::from_timestamp(chrono::Local::now().timestamp() + 3600, 0).unwrap();
+        cache.write_all(
+            format!(
+                r#"{{"expiresAt": "{}"}}"#,
+                one_hour_ahead.to_rfc3339_opts(SecondsFormat::Secs, true)
+            )
+            .as_bytes(),
+        )?;
+        cache.sync_all()?;
+
+        let actual = module_renderer
+            .config(toml::toml! {
+                [aws.sso]
+                require_active = true
+            })
+            .collect();
+
+        // Exact duration text ("1h", "59m59s", …) depends on wall-clock at test
+        // time; verify activation instead of the precise rendered string.
+        assert!(
+            actual.is_some(),
+            "module should render when SSO token is unexpired, got None"
+        );
+        dir.close()
+    }
+
+    #[test]
+    fn require_active_sso_hides_with_expired_sso_token() -> io::Result<()> {
+        use chrono::{DateTime, SecondsFormat, Utc};
+
+        let (module_renderer, dir) = ModuleRenderer::new_with_home("aws")?;
+        std::fs::create_dir_all(dir.path().join(".aws/sso/cache"))?;
+
+        let mut config = File::create(dir.path().join(".aws/config"))?;
+        config.write_all(
+            "[default]
+region = us-east-1
+sso_start_url = https://starship.rs/sso
+sso_region = us-east-1
+sso_account_id = 123456789012
+sso_role_name = ReadOnly
+"
+            .as_bytes(),
+        )?;
+        config.sync_all()?;
+
+        let mut cache = File::create(
+            dir.path()
+                .join(".aws/sso/cache/a47a4e57aecc96b31b4f083543924bd6f828e65a.json"),
+        )?;
+        let one_second_ago: DateTime<Utc> =
+            DateTime::from_timestamp(chrono::Local::now().timestamp() - 1, 0).unwrap();
+        cache.write_all(
+            format!(
+                r#"{{"expiresAt": "{}"}}"#,
+                one_second_ago.to_rfc3339_opts(SecondsFormat::Secs, true)
+            )
+            .as_bytes(),
+        )?;
+        cache.sync_all()?;
+
+        let actual = module_renderer
+            .config(toml::toml! {
+                [aws.sso]
+                require_active = true
+            })
+            .collect();
+
+        assert_eq!(None, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn require_active_sso_force_display_still_wins() -> io::Result<()> {
+        // force_display=true overrides require_active_sso (documented override
+        // semantics preserved).
+        let (module_renderer, dir) = ModuleRenderer::new_with_home("aws")?;
+        let actual = module_renderer
+            .env("AWS_REGION", "us-east-1")
+            .config(toml::toml! {
+                [aws]
+                force_display = true
+                [aws.sso]
+                require_active = true
+            })
+            .collect();
+        let expected = Some(format!(
+            "on {}",
+            Color::Yellow.bold().paint("☁️  (us-east-1) ")
+        ));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn backward_compat_sso_config_without_token_still_shows_by_default() -> io::Result<()> {
+        // Default (require_active_sso=false) must keep activating the module on
+        // SSO config presence alone — existing behavior, guard against regression.
+        let (module_renderer, dir) = ModuleRenderer::new_with_home("aws")?;
+        std::fs::create_dir_all(dir.path().join(".aws"))?;
+
+        let mut file = File::create(dir.path().join(".aws/config"))?;
+        file.write_all(
+            "[default]
+region = us-east-1
+sso_start_url = https://starship.rs/sso
+sso_region = us-east-1
+sso_account_id = 123456789012
+sso_role_name = ReadOnly
+"
+            .as_bytes(),
+        )?;
+        file.sync_all()?;
+
+        let actual = module_renderer.collect();
+        assert!(
+            actual.is_some(),
+            "default (require_active_sso=false) must keep activating on SSO config"
+        );
         dir.close()
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description

Adds an opt-in `[aws.sso] require_active = true` flag. When enabled, the `aws` module hides for SSO-based profiles unless a cached token with a future `expiresAt` exists under `~/.aws/sso/cache/`. Default `false` keeps current behavior. No network — `expiresAt` is read locally via the existing `get_credentials_duration` helper. Env vars, static keys, and `credential_process` profiles are unaffected; the gate is scoped to SSO.

Grouped under `[aws.sso]` to leave room for future SSO-specific options; happy to flatten to a top-level `require_active_sso` if preferred.

#### Motivation and Context

The `aws` module currently activates on SSO *configuration* presence (`sso_session` / `sso_start_url` in `~/.aws/config`), so the module stays visible even when the user hasn't run `aws sso login` or the cached token has expired.

Closes #5993

#### Screenshots (if appropriate):

#### How Has This Been Tested?

Added 7 unit tests in `src/modules/aws.rs` covering no cache, unexpired cache, expired cache, env-var bypass, static-credentials bypass, `force_display` override, and a default-behavior regression guard. Also manually A/B tested the built binary against an isolated `$HOME` with SSO configured.

- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:

- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.