### PR TITLE
feat(config): add Kit language config defaults

### DIFF
--- a/src/configs/kit.rs
+++ b/src/configs/kit.rs
@@ -1,0 +1,34 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(
+    feature = "config-schema",
+    derive(schemars::JsonSchema),
+    schemars(deny_unknown_fields)
+)]
+#[serde(default)]
+pub struct KitConfig<'a> {
+    pub format: &'a str,
+    pub version_format: &'a str,
+    pub symbol: &'a str,
+    pub style: &'a str,
+    pub disabled: bool,
+    pub detect_extensions: Vec<&'a str>,
+    pub detect_files: Vec<&'a str>,
+    pub detect_folders: Vec<&'a str>,
+}
+
+impl Default for KitConfig<'_> {
+    fn default() -> Self {
+        Self {
+            format: "via [$symbol($version )]($style)",
+            version_format: "v${raw}",
+            symbol: "🦊 ",
+            style: "bold 208",
+            disabled: false,
+            detect_extensions: vec!["kit"],
+            detect_files: vec!["kit.toml"],
+            detect_folders: vec![],
+        }
+    }
+}

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -55,6 +55,7 @@ pub mod hostname;
 pub mod java;
 pub mod jobs;
 pub mod julia;
+pub mod kit;
 pub mod kotlin;
 pub mod kubernetes;
 pub mod line_break;


### PR DESCRIPTION
#### Description

  Adds a new `KitConfig` for the Kit programming language.

  The config includes:

  - default prompt format and version format
  - fox emoji symbol: `🦊`
  - `.kit` source file detection
  - `kit.toml` manifest detection
  - module declaration in `src/configs/mod.rs`

  #### Motivation and Context

  This adds default configuration support for detecting Kit language projects.

  #### Screenshots (if appropriate):

  N/A

  #### How Has This Been Tested?

  Tested locally on macOS with:

  ```sh
  cargo fmt --check
  git diff --check
  cargo +stable check --all-targets
  cargo +stable test test_all_modules_in_full_config --lib
```

  - [x] I have tested using MacOS
  - [ ] I have tested using Linux
  - [ ] I have tested using Windows

  #### Checklist:

  - [ ] I have updated the documentation accordingly.
  - [ ] I have updated the tests accordingly.