### PR TITLE
fix(maven): avoid detecting user .mvn config as project

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -1076,9 +1076,7 @@
         "detect_files": [
           "pom.xml"
         ],
-        "detect_folders": [
-          ".mvn"
-        ]
+        "detect_folders": []
       }
     },
     "memory_usage": {
@@ -4846,9 +4844,7 @@
           "items": {
             "type": "string"
           },
-          "default": [
-            ".mvn"
-          ]
+          "default": []
         }
       },
       "additionalProperties": false

--- a/src/configs/maven.rs
+++ b/src/configs/maven.rs
@@ -30,7 +30,7 @@ impl Default for MavenConfig<'_> {
             recursive: false,
             detect_extensions: vec![],
             detect_files: vec!["pom.xml"],
-            detect_folders: vec![".mvn"],
+            detect_folders: vec![],
         }
     }
 }

--- a/src/modules/maven.rs
+++ b/src/modules/maven.rs
@@ -12,18 +12,19 @@ use crate::{
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let mut module = context.new_module("maven");
     let config = MavenConfig::try_load(module.config);
-    let is_maven_project = context
-        .try_begin_scan()?
-        .set_files(&config.detect_files)
-        .set_extensions(&config.detect_extensions)
-        .set_folders(&config.detect_folders)
-        .is_match();
+    let wrapper_properties = get_wrapper_properties_file(context, config.recursive);
+    let is_maven_project = wrapper_properties.is_some()
+        || context
+            .try_begin_scan()?
+            .set_files(&config.detect_files)
+            .set_extensions(&config.detect_extensions)
+            .set_folders(&config.detect_folders)
+            .is_match();
 
     if !is_maven_project {
         return None;
     }
 
-    let wrapper_properties = get_wrapper_properties_file(context, config.recursive);
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter
             .map_meta(|var, _| match var {
@@ -124,6 +125,20 @@ mod tests {
     }
 
     #[test]
+    fn folder_with_maven_config_does_not_trigger_module() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let maven_config = dir.path().join(".mvn").join("maven.config");
+        fs::create_dir_all(maven_config.parent().unwrap())?;
+        File::create(maven_config)?.sync_all()?;
+
+        let actual = ModuleRenderer::new("maven").path(dir.path()).collect();
+
+        let expected = None;
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
     fn folder_with_maven_wrapper_properties() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         let properties = dir
@@ -132,7 +147,6 @@ mod tests {
             .join("wrapper")
             .join("maven-wrapper.properties");
         fs::create_dir_all(properties.parent().unwrap())?;
-        File::create(dir.path().join("pom.xml"))?.sync_all()?;
         let mut file = File::create(properties)?;
         file.write_all(
             b"\


### PR DESCRIPTION
## Summary
- stop treating a bare `.mvn` directory as enough to detect a Maven project
- still detect Maven projects with `pom.xml` or a Maven wrapper properties file
- add regression coverage for `~/.mvn/maven.config`-style directories

Fixes #7418

## Verification
- `cargo fmt --check`
- `cargo test modules::maven --lib`
