### PR TITLE
fix(git_status): include staged renames and deletions in count

### DIFF
--- a/src/modules/git_status.rs
+++ b/src/modules/git_status.rs
@@ -476,6 +476,7 @@ fn get_repo_status(
                             repo_status.index_added += 1;
                         }
                         Change::Deletion { .. } => {
+                            repo_status.staged += 1;
                             repo_status.deleted += 1;
                             repo_status.index_deleted += 1;
                         }
@@ -492,6 +493,7 @@ fn get_repo_status(
                             }
                         }
                         Change::Rewrite { .. } => {
+                            repo_status.staged += 1;
                             repo_status.renamed += 1;
                         }
                     }
@@ -692,7 +694,11 @@ impl RepoStatus {
 
         self.deleted = self.worktree_deleted + self.index_deleted;
         self.modified = self.worktree_modified + self.worktree_added;
-        self.staged = self.index_modified + self.index_added + self.index_typechanged;
+        self.staged = self.index_modified
+            + self.index_added
+            + self.index_deleted
+            + self.index_typechanged
+            + self.renamed;
         self.typechanged = self.worktree_typechanged;
     }
 
@@ -1612,6 +1618,58 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn shows_staged_deleted_file_with_count() -> io::Result<()> {
+        let repo_dir = fixture_repo(FixtureProvider::Git)?;
+
+        create_indexed_deleted(repo_dir.path())?;
+
+        let actual = ModuleRenderer::new("git_status")
+            .config(toml::toml! {
+                [git_status]
+                staged = "+[$count](green)"
+            })
+            .path(repo_dir.path())
+            .collect();
+        let expected = Some(format!(
+            "{} ",
+            AnsiStrings(&[
+                Color::Red.bold().paint("[✘+"),
+                Color::Green.paint("1"),
+                Color::Red.bold().paint("]"),
+            ])
+        ));
+
+        assert_eq!(expected, actual);
+        repo_dir.close()
+    }
+
+    #[test]
+    fn shows_staged_renamed_file_with_count() -> io::Result<()> {
+        let repo_dir = fixture_repo(FixtureProvider::Git)?;
+
+        create_renamed(repo_dir.path())?;
+
+        let actual = ModuleRenderer::new("git_status")
+            .config(toml::toml! {
+                [git_status]
+                staged = "+[$count](green)"
+            })
+            .path(repo_dir.path())
+            .collect();
+        let expected = Some(format!(
+            "{} ",
+            AnsiStrings(&[
+                Color::Red.bold().paint("[»+"),
+                Color::Green.paint("1"),
+                Color::Red.bold().paint("]"),
+            ])
+        ));
+
+        assert_eq!(expected, actual);
+        repo_dir.close()
+    }
+
+    #[test]
     fn shows_index_added_with_count() -> io::Result<()> {
         let repo_dir = fixture_repo(FixtureProvider::Git)?;
 
@@ -1708,7 +1766,7 @@ pub(crate) mod tests {
             let actual = ModuleRenderer::new("git_status")
                 .path(repo_dir.path())
                 .collect();
-            let expected = format_output("»");
+            let expected = format_output("»+");
 
             assert_eq!(expected, actual);
             repo_dir.close()?;
@@ -1730,7 +1788,7 @@ pub(crate) mod tests {
                 })
                 .path(repo_dir.path())
                 .collect();
-            let expected = format_output("»1");
+            let expected = format_output("»1+");
 
             assert_eq!(expected, actual);
             repo_dir.close()?;
@@ -1748,7 +1806,7 @@ pub(crate) mod tests {
             let actual = ModuleRenderer::new("git_status")
                 .path(repo_dir.path())
                 .collect();
-            let expected = format_output("»!");
+            let expected = format_output("»!+");
 
             assert_eq!(expected, actual);
             repo_dir.close()?;
@@ -1784,7 +1842,7 @@ pub(crate) mod tests {
             let actual = ModuleRenderer::new("git_status")
                 .path(repo_dir.path())
                 .collect();
-            let expected = format_output("✘");
+            let expected = format_output("✘+");
 
             assert_eq!(expected, actual);
             repo_dir.close()?;


### PR DESCRIPTION
## Summary
- count staged deletions in `$staged`
- count staged rewrites/renames in `$staged`
- add regression coverage for staged deletion and rename counts

Fixes #7424

## Verification
- `cargo fmt --check`
- `cargo test modules::git_status::tests::shows_staged_deleted_file_with_count --lib`
- `cargo test modules::git_status::tests::shows_staged_renamed_file_with_count --lib`

Note: a broader local `cargo test modules::git_status::tests::shows_staged --lib` also runs existing reftable fixture cases that fail in this container with `Could not find a git repository`; the two new focused regression tests pass with the normal Git fixture.
