### PR TITLE
fix(sudo): render conditional symbol format

### DIFF
--- a/src/modules/sudo.rs
+++ b/src/modules/sudo.rs
@@ -26,8 +26,8 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter
-            .map_meta(|variable, _| match variable {
-                "symbol" => Some(config.symbol),
+            .map(|variable| match variable {
+                "symbol" => Some(Ok(config.symbol)),
                 _ => None,
             })
             .map_style(|variable| match variable {
@@ -85,6 +85,30 @@ mod tests {
             })
             .collect();
         let expected = Some(format!("{}", Color::Blue.bold().paint("as 🧙 ")));
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn test_sudo_cached_conditional_format_with_symbol() {
+        let actual = ModuleRenderer::new("sudo")
+            .cmd(
+                "sudo -n true",
+                Some(CommandOutput {
+                    stdout: String::new(),
+                    stderr: String::new(),
+                }),
+            )
+            .config(toml::toml! {
+                [sudo]
+                disabled = false
+                allow_windows = true
+                symbol = "sudo"
+                style = "197"
+                format = "([$symbol]($style) )"
+            })
+            .collect();
+        let expected = Some(format!("{} ", Color::Fixed(197).paint("sudo")));
 
         assert_eq!(expected, actual);
     }


### PR DESCRIPTION
#### Description
Treat the sudo module's `symbol` as a normal formatter variable so conditional format groups containing `$symbol` are considered non-empty and render when sudo credentials are cached.

#### Motivation and Context
Closes #7433

#### Screenshots (if appropriate):
N/A

#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

Commands run:
- `cargo fmt --check`
- `git diff --check`
- `cargo test sudo`

#### Checklist:
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
