### PR TITLE
fix: wrap all CSI sequences in wrap_colorseq_for_shell, not just SGR

### DIFF
--- a/docs/faq/README.md
+++ b/docs/faq/README.md
@@ -129,6 +129,30 @@ Unfortunately, getting font configuration correct is sometimes difficult. Users
 on the Discord may be able to help. If both symbols display correctly, but
 you still don't see them in starship, [file a bug report!](https://github.com/starship/starship/issues/new/choose)
 
+## Why does my background color bleed on wrapped lines?
+
+A lot of terminal emulators (such as xterm, konsole, foot, wezterm, ghostty, rio) have a rendering bug where, if a prompt line with background colors soft-wraps, the background color at the wrap point [bleeds across the rest of the wrapped line](https://stackoverflow.com/questions/53740460/ansi-escape-code-weird-behavior-at-end-of-line), ignoring subsequent color changes and resets.
+
+This is most visible with powerline-style presets that use colored segments. The workaround is to add a custom module that emits an ANSI escape sequence to reset the background color and erase to end of line:
+
+```toml
+# Add $erase_line to the format string where you want the background to reset,
+# typically right before $line_break:
+format = """
+...\
+${custom.erase_line}\
+$line_break$character"""
+
+[custom.erase_line]
+description = "Resets background color and erases to end of line"
+command = "printf '\\e[49m\\e[K'"
+when = true
+format = "$output"
+shell = ["sh"]
+```
+
+`\e[49m` resets the background color to the terminal default, and `\e[K` erases from the cursor to the end of the line using that default background. Together they prevent the color bleed.
+
 ## How do I uninstall Starship?
 
 Starship is just as easy to uninstall as it is to install in the first place.

--- a/docs/presets/README.md
+++ b/docs/presets/README.md
@@ -83,3 +83,9 @@ This is a pseudo minimalist preset inspired by the [geometry](https://github.com
 This preset is a minimally modified version of [Gruvbox Rainbow](./gruvbox-rainbow.md) using the [Catppuccin](https://github.com/catppuccin/catppuccin) theme palette.
 
 [![Screenshot of Catppuccin Powerline preset](/presets/img/catppuccin-powerline.png "Click to view Catppuccin Powerline preset")](./catppuccin-powerline)
+
+## [ANSI Powerline](./ansi-powerline.md)
+
+A powerline-style preset that uses only standard ANSI color names instead of hard-coded hex values, so it adapts to any terminal color scheme.
+
+[![Screenshot of ANSI Powerline preset](/presets/img/ansi-powerline.png "Click to view ANSI Powerline preset")](./ansi-powerline)

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -581,22 +581,12 @@ CMake suite maintained and supported by Kitware (kitware.com/cmake).\n",
     Some(out)
 }
 
-/// Wraps ANSI color escape sequences in the shell-appropriate wrappers.
+/// Many shells cannot deal with raw unprintable characters and miscompute the
+/// cursor position, leading to strange visual bugs like duplicated/missing
+/// chars. This function wraps ANSI escape sequences in shell-specific markers
+/// to avoid these problems. Handles all CSI sequences (\x1b[...X), not just
+/// SGR (\x1b[...m).
 pub fn wrap_colorseq_for_shell(ansi: String, shell: Shell) -> String {
-    const ESCAPE_BEGIN: char = '\u{1b}';
-    const ESCAPE_END: char = 'm';
-    wrap_seq_for_shell(ansi, shell, ESCAPE_BEGIN, ESCAPE_END)
-}
-
-/// Many shells cannot deal with raw unprintable characters and miscompute the cursor position,
-/// leading to strange visual bugs like duplicated/missing chars. This function wraps a specified
-/// sequence in shell-specific escapes to avoid these problems.
-pub fn wrap_seq_for_shell(
-    ansi: String,
-    shell: Shell,
-    escape_begin: char,
-    escape_end: char,
-) -> String {
     let (beg, end) = match shell {
         // \[ and \]
         Shell::Bash => ("\u{5c}\u{5b}", "\u{5c}\u{5d}"),
@@ -605,24 +595,28 @@ pub fn wrap_seq_for_shell(
         _ => return ansi,
     };
 
-    // ANSI escape codes cannot be nested, so we can keep track of whether we're
-    // in an escape or not with a single boolean variable
-    let mut escaped = false;
-    let final_string: String = ansi
-        .chars()
-        .map(|x| {
-            if x == escape_begin && !escaped {
-                escaped = true;
-                format!("{beg}{escape_begin}")
-            } else if x == escape_end && escaped {
-                escaped = false;
-                format!("{escape_end}{end}")
-            } else {
-                x.to_string()
+    // ANSI escape codes cannot be nested, so when we hit \x1b we can just
+    // consume characters until the sequence ends.
+    let mut result = String::new();
+    let mut chars = ansi.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\x1b' {
+            result.push_str(beg);
+            result.push('\x1b');
+            while let Some(&next) = chars.peek() {
+                chars.next();
+                result.push(next);
+                // '[' is the CSI introducer, not a final byte
+                if next != '[' && ('@'..='~').contains(&next) {
+                    break;
+                }
             }
-        })
-        .collect();
-    final_string
+            result.push_str(end);
+        } else {
+            result.push(c);
+        }
+    }
+    result
 }
 
 fn internal_exec_cmd<T: AsRef<OsStr> + Debug, U: AsRef<OsStr> + Debug>(
@@ -976,40 +970,54 @@ mod tests {
 
     #[test]
     fn test_color_sequence_wrappers() {
-        let test0 = "\x1b2mhellomynamekeyes\x1b2m"; // BEGIN: \x1b     END: m
-        let test1 = "\x1b]330;mlol\x1b]0m"; // BEGIN: \x1b     END: m
-        let test2 = "\u{1b}J"; // BEGIN: \x1b     END: J
-        let test3 = "OH NO"; // BEGIN: O    END: O
-        let test4 = "herpaderp";
-        let test5 = "";
+        // SGR sequence
+        let sgr = "\x1b[31mhello\x1b[0m";
+        // Non-SGR CSI sequence (erase line)
+        let csi_k = "\x1b[49m\x1b[K";
+        // Two-char escape
+        let two_char = "\x1bM";
+        // No escape sequences
+        let plain = "herpaderp";
+        // Empty string
+        let empty = "";
 
-        let zresult0 = wrap_seq_for_shell(test0.to_string(), Shell::Zsh, '\x1b', 'm');
-        let zresult1 = wrap_seq_for_shell(test1.to_string(), Shell::Zsh, '\x1b', 'm');
-        let zresult2 = wrap_seq_for_shell(test2.to_string(), Shell::Zsh, '\x1b', 'J');
-        let zresult3 = wrap_seq_for_shell(test3.to_string(), Shell::Zsh, 'O', 'O');
-        let zresult4 = wrap_seq_for_shell(test4.to_string(), Shell::Zsh, '\x1b', 'm');
-        let zresult5 = wrap_seq_for_shell(test5.to_string(), Shell::Zsh, '\x1b', 'm');
+        // Zsh wrapping
+        assert_eq!(
+            wrap_colorseq_for_shell(sgr.to_string(), Shell::Zsh),
+            "%{\x1b[31m%}hello%{\x1b[0m%}"
+        );
+        assert_eq!(
+            wrap_colorseq_for_shell(csi_k.to_string(), Shell::Zsh),
+            "%{\x1b[49m%}%{\x1b[K%}"
+        );
+        assert_eq!(
+            wrap_colorseq_for_shell(two_char.to_string(), Shell::Zsh),
+            "%{\x1bM%}"
+        );
+        assert_eq!(
+            wrap_colorseq_for_shell(plain.to_string(), Shell::Zsh),
+            "herpaderp"
+        );
+        assert_eq!(wrap_colorseq_for_shell(empty.to_string(), Shell::Zsh), "");
 
-        assert_eq!(&zresult0, "%{\x1b2m%}hellomynamekeyes%{\x1b2m%}");
-        assert_eq!(&zresult1, "%{\x1b]330;m%}lol%{\x1b]0m%}");
-        assert_eq!(&zresult2, "%{\x1bJ%}");
-        assert_eq!(&zresult3, "%{OH NO%}");
-        assert_eq!(&zresult4, "herpaderp");
-        assert_eq!(&zresult5, "");
-
-        let bresult0 = wrap_seq_for_shell(test0.to_string(), Shell::Bash, '\x1b', 'm');
-        let bresult1 = wrap_seq_for_shell(test1.to_string(), Shell::Bash, '\x1b', 'm');
-        let bresult2 = wrap_seq_for_shell(test2.to_string(), Shell::Bash, '\x1b', 'J');
-        let bresult3 = wrap_seq_for_shell(test3.to_string(), Shell::Bash, 'O', 'O');
-        let bresult4 = wrap_seq_for_shell(test4.to_string(), Shell::Bash, '\x1b', 'm');
-        let bresult5 = wrap_seq_for_shell(test5.to_string(), Shell::Bash, '\x1b', 'm');
-
-        assert_eq!(&bresult0, "\\[\x1b2m\\]hellomynamekeyes\\[\x1b2m\\]");
-        assert_eq!(&bresult1, "\\[\x1b]330;m\\]lol\\[\x1b]0m\\]");
-        assert_eq!(&bresult2, "\\[\x1bJ\\]");
-        assert_eq!(&bresult3, "\\[OH NO\\]");
-        assert_eq!(&bresult4, "herpaderp");
-        assert_eq!(&bresult5, "");
+        // Bash wrapping
+        assert_eq!(
+            wrap_colorseq_for_shell(sgr.to_string(), Shell::Bash),
+            "\\[\x1b[31m\\]hello\\[\x1b[0m\\]"
+        );
+        assert_eq!(
+            wrap_colorseq_for_shell(csi_k.to_string(), Shell::Bash),
+            "\\[\x1b[49m\\]\\[\x1b[K\\]"
+        );
+        assert_eq!(
+            wrap_colorseq_for_shell(two_char.to_string(), Shell::Bash),
+            "\\[\x1bM\\]"
+        );
+        assert_eq!(
+            wrap_colorseq_for_shell(plain.to_string(), Shell::Bash),
+            "herpaderp"
+        );
+        assert_eq!(wrap_colorseq_for_shell(empty.to_string(), Shell::Bash), "");
     }
 
     #[test]

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -584,8 +584,13 @@ CMake suite maintained and supported by Kitware (kitware.com/cmake).\n",
 /// Many shells cannot deal with raw unprintable characters and miscompute the
 /// cursor position, leading to strange visual bugs like duplicated/missing
 /// chars. This function wraps ANSI escape sequences in shell-specific markers
-/// to avoid these problems. Handles all CSI sequences (\x1b[...X), not just
-/// SGR (\x1b[...m).
+/// to avoid these problems.
+///
+/// Handles:
+/// - CSI sequences: `\x1b[...<final>` (terminated by final byte 0x40–0x7E)
+/// - String-terminated sequences (OSC/DCS/SOS/PM/APC): `\x1b]...<term>` etc.,
+///   terminated by BEL (0x07) or the two-byte String Terminator ST (ESC \)
+/// - Other two-byte ESC sequences: `\x1b<X>` (single char after ESC)
 pub fn wrap_colorseq_for_shell(ansi: String, shell: Shell) -> String {
     let (beg, end) = match shell {
         // \[ and \]
@@ -595,28 +600,85 @@ pub fn wrap_colorseq_for_shell(ansi: String, shell: Shell) -> String {
         _ => return ansi,
     };
 
-    // ANSI escape codes cannot be nested, so when we hit \x1b we can just
-    // consume characters until the sequence ends.
-    let mut result = String::new();
+    let mut result = String::with_capacity(ansi.len());
     let mut chars = ansi.chars().peekable();
+    let mut state = EscapeState::Ground;
+
     while let Some(c) = chars.next() {
-        if c == '\x1b' {
-            result.push_str(beg);
-            result.push('\x1b');
-            while let Some(&next) = chars.peek() {
-                chars.next();
-                result.push(next);
-                // '[' is the CSI introducer, not a final byte
-                if next != '[' && ('@'..='~').contains(&next) {
-                    break;
+        match state {
+            EscapeState::Ground => {
+                if c == '\x1b' {
+                    result.push_str(beg);
+                    result.push('\x1b');
+                    state = EscapeState::Escape;
+                } else {
+                    result.push(c);
                 }
             }
-            result.push_str(end);
-        } else {
-            result.push(c);
+            EscapeState::Escape => {
+                result.push(c);
+                match c {
+                    // CSI: Control Sequence Introducer
+                    '[' => state = EscapeState::Csi,
+                    // String-terminated sequences per ECMA-48:
+                    // ] = OSC, P = DCS, X = SOS, ^ = PM, _ = APC
+                    ']' | 'P' | 'X' | '^' | '_' => state = EscapeState::String,
+                    // All other two-byte ESC sequences (e.g. ESC M, ESC 7)
+                    _ => {
+                        result.push_str(end);
+                        state = EscapeState::Ground;
+                    }
+                }
+            }
+            EscapeState::Csi => {
+                result.push(c);
+                // CSI parameters are 0x30–0x3F, intermediate bytes 0x20–0x2F.
+                // A final byte in 0x40–0x7E terminates the sequence (ECMA-48 §5.4).
+                if ('@'..='~').contains(&c) {
+                    result.push_str(end);
+                    state = EscapeState::Ground;
+                }
+            }
+            EscapeState::String => {
+                result.push(c);
+                // String-terminated sequences end with BEL (0x07) or
+                // ST (ESC \, i.e. \x1b followed by '\\').
+                if c == '\x07' {
+                    result.push_str(end);
+                    state = EscapeState::Ground;
+                } else if c == '\x1b' {
+                    // Peek at next char: if it's '\\', this is ST
+                    if let Some(&'\\') = chars.peek() {
+                        chars.next();
+                        result.push('\\');
+                        result.push_str(end);
+                        state = EscapeState::Ground;
+                    }
+                    // Otherwise the ESC is just part of the string payload.
+                }
+            }
         }
     }
+
+    // If still inside an escape at end-of-string, close the shell wrapper
+    // so the markers stay balanced even for truncated sequences.
+    if !matches!(state, EscapeState::Ground) {
+        result.push_str(end);
+    }
+
     result
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum EscapeState {
+    /// Not inside any escape sequence
+    Ground,
+    /// Just saw ESC, waiting for type byte
+    Escape,
+    /// Inside a CSI sequence (\x1b[)
+    Csi,
+    /// Inside a string-terminated sequence (OSC/DCS/SOS/PM/APC)
+    String,
 }
 
 fn internal_exec_cmd<T: AsRef<OsStr> + Debug, U: AsRef<OsStr> + Debug>(
@@ -974,6 +1036,8 @@ mod tests {
         let sgr = "\x1b[31mhello\x1b[0m";
         // Non-SGR CSI sequence (erase line)
         let csi_k = "\x1b[49m\x1b[K";
+        // DEC private CSI sequence (cursor show)
+        let csi_dec = "\x1b[?25h";
         // Two-char escape
         let two_char = "\x1bM";
         // No escape sequences
@@ -981,7 +1045,24 @@ mod tests {
         // Empty string
         let empty = "";
 
-        // Zsh wrapping
+        // OSC 8 hyperlink (ST-terminated)
+        let osc8 = "\x1b]8;;https://example.com\x1b\\link\x1b]8;;\x1b\\";
+        // OSC 133 semantic prompt (BEL-terminated)
+        let osc133 = "\x1b]133;A\x07";
+        // OSC window title (BEL-terminated)
+        let title = "\x1b]0;my title\x07";
+
+        // DCS sequence (ST-terminated)
+        let dcs = "\x1bP1$p\x1b\\";
+
+        // Truncated CSI at end of string
+        let truncated_csi = "\x1b[31";
+        // Truncated string sequence at end of string
+        let truncated_osc = "\x1b]8;;url";
+
+        // --- Zsh wrapping ---
+
+        // CSI sequences
         assert_eq!(
             wrap_colorseq_for_shell(sgr.to_string(), Shell::Zsh),
             "%{\x1b[31m%}hello%{\x1b[0m%}"
@@ -991,16 +1072,36 @@ mod tests {
             "%{\x1b[49m%}%{\x1b[K%}"
         );
         assert_eq!(
+            wrap_colorseq_for_shell(csi_dec.to_string(), Shell::Zsh),
+            "%{\x1b[?25h%}"
+        );
+        assert_eq!(
             wrap_colorseq_for_shell(two_char.to_string(), Shell::Zsh),
             "%{\x1bM%}"
         );
-        assert_eq!(
-            wrap_colorseq_for_shell(plain.to_string(), Shell::Zsh),
-            "herpaderp"
-        );
-        assert_eq!(wrap_colorseq_for_shell(empty.to_string(), Shell::Zsh), "");
 
-        // Bash wrapping
+        // OSC sequences
+        assert_eq!(
+            wrap_colorseq_for_shell(osc8.to_string(), Shell::Zsh),
+            "%{\x1b]8;;https://example.com\x1b\\\\%}link%{\x1b]8;;\x1b\\\\%}"
+        );
+        assert_eq!(
+            wrap_colorseq_for_shell(osc133.to_string(), Shell::Zsh),
+            "%{\x1b]133;A\x07%}"
+        );
+        assert_eq!(
+            wrap_colorseq_for_shell(title.to_string(), Shell::Zsh),
+            "%{\x1b]0;my title\x07%}"
+        );
+
+        // DCS
+        assert_eq!(
+            wrap_colorseq_for_shell(dcs.to_string(), Shell::Zsh),
+            "%{\x1bP1$p\x1b\\\\%}"
+        );
+
+        // --- Bash wrapping ---
+
         assert_eq!(
             wrap_colorseq_for_shell(sgr.to_string(), Shell::Bash),
             "\\[\x1b[31m\\]hello\\[\x1b[0m\\]"
@@ -1010,14 +1111,54 @@ mod tests {
             "\\[\x1b[49m\\]\\[\x1b[K\\]"
         );
         assert_eq!(
+            wrap_colorseq_for_shell(csi_dec.to_string(), Shell::Bash),
+            "\\[\x1b[?25h\\]"
+        );
+        assert_eq!(
             wrap_colorseq_for_shell(two_char.to_string(), Shell::Bash),
             "\\[\x1bM\\]"
         );
+
+        assert_eq!(
+            wrap_colorseq_for_shell(osc8.to_string(), Shell::Bash),
+            "\\[\x1b]8;;https://example.com\x1b\\\\\\]link\\[\x1b]8;;\x1b\\\\\\]"
+        );
+        assert_eq!(
+            wrap_colorseq_for_shell(osc133.to_string(), Shell::Bash),
+            "\\[\x1b]133;A\x07\\]"
+        );
+        assert_eq!(
+            wrap_colorseq_for_shell(title.to_string(), Shell::Bash),
+            "\\[\x1b]0;my title\x07\\]"
+        );
+
+        assert_eq!(
+            wrap_colorseq_for_shell(dcs.to_string(), Shell::Bash),
+            "\\[\x1bP1$p\x1b\\\\\\]"
+        );
+
+        // --- Plain / empty ---
+
+        assert_eq!(
+            wrap_colorseq_for_shell(plain.to_string(), Shell::Zsh),
+            "herpaderp"
+        );
+        assert_eq!(wrap_colorseq_for_shell(empty.to_string(), Shell::Zsh), "");
         assert_eq!(
             wrap_colorseq_for_shell(plain.to_string(), Shell::Bash),
             "herpaderp"
         );
         assert_eq!(wrap_colorseq_for_shell(empty.to_string(), Shell::Bash), "");
+
+        // --- Truncated sequences (wrapper should still be balanced) ---
+
+        let wrapped = wrap_colorseq_for_shell(truncated_csi.to_string(), Shell::Bash);
+        assert!(wrapped.starts_with("\\["));
+        assert!(wrapped.ends_with("\\]"));
+
+        let wrapped = wrap_colorseq_for_shell(truncated_osc.to_string(), Shell::Zsh);
+        assert!(wrapped.starts_with("%{"));
+        assert!(wrapped.ends_with("%}"));
     }
 
     #[test]


### PR DESCRIPTION
#### Description

`wrap_colorseq_for_shell` now correctly wraps all CSI escape sequences in shell-specific markers (`\[...\]` for bash, `%{...%}` for zsh), not just SGR sequences ending in `m`.

The old code opened a wrapper on `\x1b` and closed it on `m`. But `[` (the CSI introducer in every `\x1b[` sequence) has byte value 0x5B, which falls in `@`..=`~` -- the range of CSI final bytes. The code had no special handling for it, so for something like `\x1b[K`:

1. `\x1b` -> open wrapper
2. `[` -> mistaken for final byte, close wrapper
3. `K` -> emitted as literal outside the wrapper

The fix replaces the boolean escape tracking with a loop that consumes the full sequence, recognizing `[` after `\x1b` as the CSI introducer.

#### Motivation and Context

Closes #7435

Many terminal emulators have a bug where background colors bleed on soft-wrapped lines in powerline-style prompts. The standard workaround is a custom module emitting `\x1b[49m\x1b[K`, but because `wrap_colorseq_for_shell` didn't handle `K`-terminated sequences, this broke readline's width calculation and caused input to overwrite the prompt instead of wrapping.

#### Screenshots (if appropriate):

See #7435 for screenshots of both bugs.

#### How Has This Been Tested?

Verified with `starship prompt | od -c` that `\x1b[K` is now properly wrapped inside `\[...\]`. Tested that long input lines wrap correctly and that the erase_line workaround no longer breaks the prompt.

- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:

- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
