### PR TITLE
fix(init): use explicit path to starship binary when directly invoked

### DIFF
--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -25,9 +25,18 @@ struct StarshipPath {
 }
 impl StarshipPath {
     fn init() -> io::Result<Self> {
-        let exe_name = option_env!("CARGO_PKG_NAME").unwrap_or("starship");
-
-        let native_path = which(exe_name).or_else(|_| env::current_exe())?;
+        // If we were invoked via a direct path, prefer to use the current
+        // binary for init. Otherwise, prefer to look it up in the system `PATH`,
+        // falling back to the current binary in case of failure.
+        let native_path = if env::args_os()
+            .next()
+            .is_some_and(|s| Path::new(&s).components().count() > 1)
+        {
+            env::current_exe()?
+        } else {
+            let exe_name = option_env!("CARGO_PKG_NAME").unwrap_or("starship");
+            which(exe_name).or_else(|_| env::current_exe())?
+        };
 
         Ok(Self { native_path })
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
When invoking the starship binary via an explicit path (i.e. for testing local changes to the codebase), have `init` prefer the explicit path when substituting for `::STARSHIP::` in the various init shell scripts.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #6775.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.

A note on tests: should this new behavior be tested? Mocking `std::env::args_os()` feels like it would be troublesome, and the changes are pretty small.
