### PR TITLE
fix(presets): Update no-nerd-font to be up-to-date

### DIFF
--- a/docs/public/presets/toml/no-nerd-font.toml
+++ b/docs/public/presets/toml/no-nerd-font.toml
@@ -13,10 +13,8 @@ empty_symbol = "❗ "
 [erlang]
 symbol = "ⓔ "
 
-
 [nodejs]
 symbol = "[⬢](bold green) "
-
 
 [pulumi]
 symbol = "🧊 "

--- a/docs/public/presets/toml/no-nerd-font.toml
+++ b/docs/public/presets/toml/no-nerd-font.toml
@@ -1,5 +1,8 @@
 "$schema" = 'https://starship.rs/config-schema.json'
 
+[azure]
+symbol = "☁️ "
+
 [battery]
 full_symbol = "• "
 charging_symbol = "⇡ "
@@ -10,17 +13,20 @@ empty_symbol = "❗ "
 [erlang]
 symbol = "ⓔ "
 
-[fortran]
-symbol = "F "
+[fossil_branch]
+symbol = "⎇ "
+
+[git_branch]
+symbol = "⎇ "
+
+[hg_branch]
+symbol = "⎇ "
 
 [nodejs]
 symbol = "[⬢](bold green) "
 
-[bun]
-symbol = "bun "
+[pijul_channel]
+symbol = "⎇ "
 
 [pulumi]
 symbol = "🧊 "
-
-[typst]
-symbol = "t "

--- a/docs/public/presets/toml/no-nerd-font.toml
+++ b/docs/public/presets/toml/no-nerd-font.toml
@@ -25,8 +25,6 @@ symbol = "⎇ "
 [nodejs]
 symbol = "[⬢](bold green) "
 
-[pijul_channel]
-symbol = "⎇ "
 
 [pulumi]
 symbol = "🧊 "

--- a/docs/public/presets/toml/no-nerd-font.toml
+++ b/docs/public/presets/toml/no-nerd-font.toml
@@ -13,14 +13,6 @@ empty_symbol = "❗ "
 [erlang]
 symbol = "ⓔ "
 
-[fossil_branch]
-symbol = "⎇ "
-
-[git_branch]
-symbol = "⎇ "
-
-[hg_branch]
-symbol = "⎇ "
 
 [nodejs]
 symbol = "[⬢](bold green) "


### PR DESCRIPTION
Redundancies were removed (as to not add personalized style too much), and missing overrules of nerdfont symbols were added.

<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
The current no-nerd-font preset has a few redundancies now, which were removed.  Furthermore, missing necessary overrules of nerdfont symbols were added: `azure`, `fossil_branch`, `git_branch`, `hg_branch`, `pijul_channel`.

#### Motivation and Context

#2749 is out of date with redundant declarations and missing declarations

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
