### PR TITLE
feat(claude_usage): add rate limit usage module for Claude Code statusline

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -61,7 +61,7 @@
         "type": "string"
       },
       "default": {
-        "claude-code": "$claude_model$git_branch$claude_context$claude_cost"
+        "claude-code": "$claude_model$git_branch$claude_context$claude_cost$claude_usage"
       }
     },
     "aws": {
@@ -250,6 +250,30 @@
         "symbol": "🤖 ",
         "style": "bold blue",
         "model_aliases": {},
+        "disabled": false
+      }
+    },
+    "claude_usage": {
+      "$ref": "#/$defs/ClaudeUsageConfig",
+      "default": {
+        "format": "[($five_hour_pct% \\(resets in $five_hour_reset\\)  )($seven_day_pct% \\(resets in $seven_day_reset\\)]($style) )",
+        "display": [
+          {
+            "threshold": 0.0,
+            "style": "bold green",
+            "hidden": true
+          },
+          {
+            "threshold": 70.0,
+            "style": "bold yellow",
+            "hidden": false
+          },
+          {
+            "threshold": 90.0,
+            "style": "bold red",
+            "hidden": false
+          }
+        ],
         "disabled": false
       }
     },
@@ -2450,6 +2474,43 @@
             "type": "string"
           },
           "default": {}
+        },
+        "disabled": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "ClaudeUsageConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "type": "string",
+          "default": "[($five_hour_pct% \\(resets in $five_hour_reset\\)  )($seven_day_pct% \\(resets in $seven_day_reset\\)]($style) )"
+        },
+        "display": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ClaudeDisplayConfig"
+          },
+          "default": [
+            {
+              "threshold": 0.0,
+              "style": "bold green",
+              "hidden": true
+            },
+            {
+              "threshold": 70.0,
+              "style": "bold yellow",
+              "hidden": false
+            },
+            {
+              "threshold": 90.0,
+              "style": "bold red",
+              "hidden": false
+            }
+          ]
         },
         "disabled": {
           "type": "boolean",

--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -256,7 +256,7 @@
     "claude_usage": {
       "$ref": "#/$defs/ClaudeUsageConfig",
       "default": {
-        "format": "[($five_hour_pct% \\(resets in $five_hour_reset\\)  )($seven_day_pct% \\(resets in $seven_day_reset\\)]($style) )",
+        "format": "[($five_hour_pct% \\(resets in $five_hour_reset\\)  )($seven_day_pct% \\(resets in $seven_day_reset\\))]($style) ",
         "display": [
           {
             "threshold": 0.0,
@@ -2487,7 +2487,7 @@
       "properties": {
         "format": {
           "type": "string",
-          "default": "[($five_hour_pct% \\(resets in $five_hour_reset\\)  )($seven_day_pct% \\(resets in $seven_day_reset\\)]($style) )"
+          "default": "[($five_hour_pct% \\(resets in $five_hour_reset\\)  )($seven_day_pct% \\(resets in $seven_day_reset\\))]($style) "
         },
         "display": {
           "type": "array",

--- a/docs/advanced-config/README.md
+++ b/docs/advanced-config/README.md
@@ -657,7 +657,7 @@ The `claude_usage` module displays Claude Code's 5-hour and 7-day rate limit usa
 
 | Option     | Default                                                                           | Description                         |
 | ---------- | --------------------------------------------------------------------------------- | ----------------------------------- |
-| `format`   | `'[$five_hour_pct%↺$five_hour_reset  $seven_day_pct%↺$seven_day_reset]($style) '` | The format for the module.          |
+| `format`   | `'[$five_hour_pct% \(resets in $five_hour_reset\)  $seven_day_pct% \(resets in $seven_day_reset\)]($style) '` | The format for the module.          |
 | `display`  | [see below](#display-2)                                                           | Threshold and style configurations. |
 | `disabled` | `false`                                                                           | Disables the `claude_usage` module. |
 
@@ -706,7 +706,7 @@ style = "bold red"
 
 # Show only the 5-hour window
 [claude_usage]
-format = "[$five_hour_pct%↺$five_hour_reset]($style) "
+format = "[$five_hour_pct% \(resets in $five_hour_reset\)]($style) "
 
 # Custom thresholds
 [[claude_usage.display]]

--- a/docs/advanced-config/README.md
+++ b/docs/advanced-config/README.md
@@ -657,7 +657,7 @@ The `claude_usage` module displays Claude Code's 5-hour and 7-day rate limit usa
 
 | Option     | Default                                                                                                       | Description                         |
 | ---------- | ------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
-| `format`   | `'[$five_hour_pct% \(resets in $five_hour_reset\)  $seven_day_pct% \(resets in $seven_day_reset\)]($style) '` | The format for the module.          |
+| `format`   | `'[($five_hour_pct% \(resets in $five_hour_reset\)  )($seven_day_pct% \(resets in $seven_day_reset\))]($style) '` | The format for the module.          |
 | `display`  | [see below](#display-2)                                                                                       | Threshold and style configurations. |
 | `disabled` | `false`                                                                                                       | Disables the `claude_usage` module. |
 

--- a/docs/advanced-config/README.md
+++ b/docs/advanced-config/README.md
@@ -365,17 +365,18 @@ To use Starship as your Claude Code statusline:
 
 When invoked with `starship statusline claude-code`, Starship receives Claude Code session data via stdin and renders a statusline using a dedicated profile named `claude-code`.
 
-The profile includes three specialized modules:
+The profile includes four specialized modules:
 
 - `claude_model`: Displays the current Claude model being used
 - `claude_context`: Shows context window usage with a visual gauge
 - `claude_cost`: Displays session cost and statistics
+- `claude_usage`: Shows 5-hour and 7-day rate limit usage
 
 The default profile format is:
 
 ```toml
 [profiles]
-claude-code = "$claude_model$git_branch$claude_context$claude_cost"
+claude-code = "$claude_model$git_branch$claude_context$claude_cost$claude_usage"
 ```
 
 ### Configuration
@@ -646,6 +647,79 @@ style = "bold red"
 # Show duration information
 [claude_cost]
 format = "[$symbol$cost ($duration)]($style) "
+```
+
+### Claude Usage
+
+The `claude_usage` module displays Claude Code's 5-hour and 7-day rate limit usage. The style automatically changes based on the highest window usage percentage.
+
+#### Options
+
+| Option     | Default                                                                           | Description                         |
+| ---------- | --------------------------------------------------------------------------------- | ----------------------------------- |
+| `format`   | `'[$five_hour_pct%↺$five_hour_reset  $seven_day_pct%↺$seven_day_reset]($style) '` | The format for the module.          |
+| `display`  | [see below](#display-2)                                                           | Threshold and style configurations. |
+| `disabled` | `false`                                                                           | Disables the `claude_usage` module. |
+
+##### Display
+
+The `display` option is an array of objects that define usage percentage thresholds and styles. The module is hidden unless the highest window's percentage meets or exceeds a threshold with `hidden = false`. The style from the highest matching threshold is used.
+
+| Option      | Default      | Description                                                        |
+| ----------- | ------------ | ------------------------------------------------------------------ |
+| `threshold` | `0.0`        | The minimum usage percentage (0–100) to match this configuration   |
+| `style`     | `bold green` | The value of `style` if this display configuration is matched      |
+| `hidden`    | `false`      | Hide the module if this configuration is matched                   |
+
+**Default configuration:**
+
+```toml
+[[claude_usage.display]]
+threshold = 0.0
+hidden = true
+
+[[claude_usage.display]]
+threshold = 70.0
+style = "bold yellow"
+
+[[claude_usage.display]]
+threshold = 90.0
+style = "bold red"
+```
+
+#### Variables
+
+| Variable         | Example  | Description                                            |
+| ---------------- | -------- | ------------------------------------------------------ |
+| five_hour_pct    | `65`     | Percentage of 5-hour window used                       |
+| five_hour_reset  | `1h23m`  | Time until 5-hour window resets                        |
+| seven_day_pct    | `7`      | Percentage of 7-day window used                        |
+| seven_day_reset  | `2d14h`  | Time until 7-day window resets                         |
+| style\*          |          | Mirrors the style from the matching display threshold  |
+
+\*: This variable can only be used as a part of a style string
+
+#### Examples
+
+```toml
+# ~/.config/starship.toml
+
+# Show only the 5-hour window
+[claude_usage]
+format = "[$five_hour_pct%↺$five_hour_reset]($style) "
+
+# Custom thresholds
+[[claude_usage.display]]
+threshold = 0.0
+hidden = true
+
+[[claude_usage.display]]
+threshold = 50.0
+style = "bold yellow"
+
+[[claude_usage.display]]
+threshold = 85.0
+style = "bold red"
 ```
 
 ## Style Strings

--- a/docs/advanced-config/README.md
+++ b/docs/advanced-config/README.md
@@ -365,7 +365,7 @@ To use Starship as your Claude Code statusline:
 
 When invoked with `starship statusline claude-code`, Starship receives Claude Code session data via stdin and renders a statusline using a dedicated profile named `claude-code`.
 
-The profile includes four specialized modules:
+The profile includes some specialized modules:
 
 - `claude_model`: Displays the current Claude model being used
 - `claude_context`: Shows context window usage with a visual gauge

--- a/docs/advanced-config/README.md
+++ b/docs/advanced-config/README.md
@@ -655,11 +655,11 @@ The `claude_usage` module displays Claude Code's 5-hour and 7-day rate limit usa
 
 #### Options
 
-| Option     | Default                                                                                                       | Description                         |
-| ---------- | ------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+| Option     | Default                                                                                                           | Description                         |
+| ---------- | ----------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
 | `format`   | `'[($five_hour_pct% \(resets in $five_hour_reset\)  )($seven_day_pct% \(resets in $seven_day_reset\))]($style) '` | The format for the module.          |
-| `display`  | [see below](#display-2)                                                                                       | Threshold and style configurations. |
-| `disabled` | `false`                                                                                                       | Disables the `claude_usage` module. |
+| `display`  | [see below](#display-2)                                                                                           | Threshold and style configurations. |
+| `disabled` | `false`                                                                                                           | Disables the `claude_usage` module. |
 
 ##### Display
 

--- a/docs/advanced-config/README.md
+++ b/docs/advanced-config/README.md
@@ -655,21 +655,21 @@ The `claude_usage` module displays Claude Code's 5-hour and 7-day rate limit usa
 
 #### Options
 
-| Option     | Default                                                                           | Description                         |
-| ---------- | --------------------------------------------------------------------------------- | ----------------------------------- |
+| Option     | Default                                                                                                       | Description                         |
+| ---------- | ------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
 | `format`   | `'[$five_hour_pct% \(resets in $five_hour_reset\)  $seven_day_pct% \(resets in $seven_day_reset\)]($style) '` | The format for the module.          |
-| `display`  | [see below](#display-2)                                                           | Threshold and style configurations. |
-| `disabled` | `false`                                                                           | Disables the `claude_usage` module. |
+| `display`  | [see below](#display-2)                                                                                       | Threshold and style configurations. |
+| `disabled` | `false`                                                                                                       | Disables the `claude_usage` module. |
 
 ##### Display
 
 The `display` option is an array of objects that define usage percentage thresholds and styles. The module is hidden unless the highest window's percentage meets or exceeds a threshold with `hidden = false`. The style from the highest matching threshold is used.
 
-| Option      | Default      | Description                                                        |
-| ----------- | ------------ | ------------------------------------------------------------------ |
-| `threshold` | `0.0`        | The minimum usage percentage (0–100) to match this configuration   |
-| `style`     | `bold green` | The value of `style` if this display configuration is matched      |
-| `hidden`    | `false`      | Hide the module if this configuration is matched                   |
+| Option      | Default      | Description                                                      |
+| ----------- | ------------ | ---------------------------------------------------------------- |
+| `threshold` | `0.0`        | The minimum usage percentage (0–100) to match this configuration |
+| `style`     | `bold green` | The value of `style` if this display configuration is matched    |
+| `hidden`    | `false`      | Hide the module if this configuration is matched                 |
 
 **Default configuration:**
 
@@ -689,13 +689,13 @@ style = "bold red"
 
 #### Variables
 
-| Variable         | Example  | Description                                            |
-| ---------------- | -------- | ------------------------------------------------------ |
-| five_hour_pct    | `65`     | Percentage of 5-hour window used                       |
-| five_hour_reset  | `1h23m`  | Time until 5-hour window resets                        |
-| seven_day_pct    | `7`      | Percentage of 7-day window used                        |
-| seven_day_reset  | `2d14h`  | Time until 7-day window resets                         |
-| style\*          |          | Mirrors the style from the matching display threshold  |
+| Variable        | Example | Description                                           |
+| --------------- | ------- | ----------------------------------------------------- |
+| five_hour_pct   | `65`    | Percentage of 5-hour window used                      |
+| five_hour_reset | `1h23m` | Time until 5-hour window resets                       |
+| seven_day_pct   | `7`     | Percentage of 7-day window used                       |
+| seven_day_reset | `2d14h` | Time until 7-day window resets                        |
+| style\*         |         | Mirrors the style from the matching display threshold |
 
 \*: This variable can only be used as a part of a style string
 

--- a/src/configs/claude_usage.rs
+++ b/src/configs/claude_usage.rs
@@ -19,7 +19,7 @@ pub struct ClaudeUsageConfig<'a> {
 impl Default for ClaudeUsageConfig<'_> {
     fn default() -> Self {
         Self {
-            format: "[$five_hour_pct%↺$five_hour_reset  $seven_day_pct%↺$seven_day_reset]($style) ",
+            format: "[$five_hour_pct% \\(resets in $five_hour_reset\\)  $seven_day_pct% \\(resets in $seven_day_reset\\)]($style) ",
             display: vec![
                 ClaudeDisplayConfig {
                     threshold: 0.0,

--- a/src/configs/claude_usage.rs
+++ b/src/configs/claude_usage.rs
@@ -19,7 +19,7 @@ pub struct ClaudeUsageConfig<'a> {
 impl Default for ClaudeUsageConfig<'_> {
     fn default() -> Self {
         Self {
-            format: "[($five_hour_pct% \\(resets in $five_hour_reset\\)  )($seven_day_pct% \\(resets in $seven_day_reset\\)]($style) )",
+            format: "[($five_hour_pct% \\(resets in $five_hour_reset\\)  )($seven_day_pct% \\(resets in $seven_day_reset\\))]($style) ",
             display: vec![
                 ClaudeDisplayConfig {
                     threshold: 0.0,

--- a/src/configs/claude_usage.rs
+++ b/src/configs/claude_usage.rs
@@ -19,7 +19,7 @@ pub struct ClaudeUsageConfig<'a> {
 impl Default for ClaudeUsageConfig<'_> {
     fn default() -> Self {
         Self {
-            format: "[$five_hour_pct% \\(resets in $five_hour_reset\\)  $seven_day_pct% \\(resets in $seven_day_reset\\)]($style) ",
+            format: "[($five_hour_pct% \\(resets in $five_hour_reset\\)  )($seven_day_pct% \\(resets in $seven_day_reset\\)]($style) )",
             display: vec![
                 ClaudeDisplayConfig {
                     threshold: 0.0,

--- a/src/configs/claude_usage.rs
+++ b/src/configs/claude_usage.rs
@@ -1,0 +1,43 @@
+use serde::{Deserialize, Serialize};
+
+use crate::configs::claude_context::ClaudeDisplayConfig;
+
+#[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(
+    feature = "config-schema",
+    derive(schemars::JsonSchema),
+    schemars(deny_unknown_fields)
+)]
+#[serde(default)]
+pub struct ClaudeUsageConfig<'a> {
+    pub format: &'a str,
+    #[serde(borrow)]
+    pub display: Vec<ClaudeDisplayConfig<'a>>,
+    pub disabled: bool,
+}
+
+impl Default for ClaudeUsageConfig<'_> {
+    fn default() -> Self {
+        Self {
+            format: "[$five_hour_pct%↺$five_hour_reset  $seven_day_pct%↺$seven_day_reset]($style) ",
+            display: vec![
+                ClaudeDisplayConfig {
+                    threshold: 0.0,
+                    hidden: true,
+                    ..Default::default()
+                },
+                ClaudeDisplayConfig {
+                    threshold: 70.0,
+                    style: "bold yellow",
+                    ..Default::default()
+                },
+                ClaudeDisplayConfig {
+                    threshold: 90.0,
+                    style: "bold red",
+                    ..Default::default()
+                },
+            ],
+            disabled: false,
+        }
+    }
+}

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -12,6 +12,7 @@ pub mod character;
 pub mod claude_context;
 pub mod claude_cost;
 pub mod claude_model;
+pub mod claude_usage;
 pub mod cmake;
 pub mod cmd_duration;
 pub mod cobol;
@@ -147,6 +148,8 @@ pub struct FullConfig<'a> {
     claude_cost: claude_cost::ClaudeCostConfig<'a>,
     #[serde(borrow)]
     claude_model: claude_model::ClaudeModelConfig<'a>,
+    #[serde(borrow)]
+    claude_usage: claude_usage::ClaudeUsageConfig<'a>,
     #[serde(borrow)]
     cmake: cmake::CMakeConfig<'a>,
     #[serde(borrow)]

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 pub fn default_profiles() -> IndexMap<String, String> {
     IndexMap::from_iter([(
         "claude-code".to_string(),
-        "$claude_model$git_branch$claude_context$claude_cost".to_string(),
+        "$claude_model$git_branch$claude_context$claude_cost$claude_usage".to_string(),
     )])
 }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -30,7 +30,8 @@ use terminal_size::terminal_size;
 
 pub use crate::utils::env::Env;
 pub use crate::utils::statusline::{
-    ClaudeCodeData, ContextWindow, CostInfo, CurrentUsage, ModelInfo, Workspace,
+    ClaudeCodeData, ContextWindow, CostInfo, CurrentUsage, ModelInfo, RateLimitWindow, RateLimits,
+    Workspace,
 };
 
 /// Context contains data or common methods that may be used by multiple modules.

--- a/src/module.rs
+++ b/src/module.rs
@@ -18,6 +18,7 @@ pub const ALL_MODULES: &[&str] = &[
     "claude_context",
     "claude_cost",
     "claude_model",
+    "claude_usage",
     "cmake",
     "cmd_duration",
     "cobol",

--- a/src/modules/claude_context.rs
+++ b/src/modules/claude_context.rs
@@ -212,6 +212,7 @@ mod tests {
             },
             cost: None,
             workspace: None,
+            rate_limits: None,
         }
     }
 

--- a/src/modules/claude_cost.rs
+++ b/src/modules/claude_cost.rs
@@ -176,6 +176,7 @@ mod tests {
                 total_lines_removed: 500,
             }),
             workspace: None,
+            rate_limits: None,
         }
     }
 

--- a/src/modules/claude_model.rs
+++ b/src/modules/claude_model.rs
@@ -76,6 +76,7 @@ mod tests {
             context_window: crate::context::ContextWindow::default(),
             cost: None,
             workspace: None,
+            rate_limits: None,
         };
         let actual = ModuleRenderer::new("claude_model")
             .config(toml::toml! {
@@ -98,6 +99,7 @@ mod tests {
             context_window: crate::context::ContextWindow::default(),
             cost: None,
             workspace: None,
+            rate_limits: None,
         };
 
         let actual = ModuleRenderer::new("claude_model")
@@ -125,6 +127,7 @@ mod tests {
             context_window: crate::context::ContextWindow::default(),
             cost: None,
             workspace: None,
+            rate_limits: None,
         };
 
         let actual = ModuleRenderer::new("claude_model")
@@ -153,6 +156,7 @@ mod tests {
             context_window: crate::context::ContextWindow::default(),
             cost: None,
             workspace: None,
+            rate_limits: None,
         };
 
         let actual = ModuleRenderer::new("claude_model")

--- a/src/modules/claude_usage.rs
+++ b/src/modules/claude_usage.rs
@@ -1,0 +1,268 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use super::{Context, Module, ModuleConfig};
+use crate::configs::claude_usage::ClaudeUsageConfig;
+use crate::formatter::StringFormatter;
+
+pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let mut module = context.new_module("claude_usage");
+    let config = ClaudeUsageConfig::try_load(module.config);
+
+    if config.disabled {
+        return None;
+    }
+
+    let claude_data = context.claude_code_data.as_ref()?;
+    let rate_limits = claude_data.rate_limits.as_ref()?;
+
+    let five_hour_pct = rate_limits.five_hour.used_percentage;
+    let seven_day_pct = rate_limits.seven_day.used_percentage;
+    let max_pct = five_hour_pct.max(seven_day_pct);
+
+    let display_style = config
+        .display
+        .iter()
+        .filter(|s| max_pct >= s.threshold)
+        .max_by(|a, b| {
+            a.threshold
+                .partial_cmp(&b.threshold)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+
+    if display_style.is_some_and(|s| s.hidden) {
+        return None;
+    }
+
+    let display_style = display_style?;
+
+    let now_secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+
+    let five_hour_reset = format_duration(
+        rate_limits
+            .five_hour
+            .resets_at
+            .saturating_sub(now_secs),
+    );
+    let seven_day_reset = format_duration(
+        rate_limits
+            .seven_day
+            .resets_at
+            .saturating_sub(now_secs),
+    );
+
+    let five_hour_pct_str = format!("{:.0}", five_hour_pct);
+    let seven_day_pct_str = format!("{:.0}", seven_day_pct);
+
+    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
+        formatter
+            .map_style(|variable| match variable {
+                "style" => Some(Ok(display_style.style)),
+                _ => None,
+            })
+            .map(|variable| match variable {
+                "five_hour_pct" => Some(Ok(five_hour_pct_str.as_str())),
+                "five_hour_reset" => Some(Ok(five_hour_reset.as_str())),
+                "seven_day_pct" => Some(Ok(seven_day_pct_str.as_str())),
+                "seven_day_reset" => Some(Ok(seven_day_reset.as_str())),
+                _ => None,
+            })
+            .parse(None, Some(context))
+    });
+
+    module.set_segments(match parsed {
+        Ok(segments) => segments,
+        Err(error) => {
+            log::warn!("Error in module `claude_usage`: {error}");
+            return None;
+        }
+    });
+
+    Some(module)
+}
+
+fn format_duration(secs: u64) -> String {
+    if secs >= 86400 {
+        format!("{}d{}h", secs / 86400, (secs % 86400) / 3600)
+    } else if secs >= 3600 {
+        format!("{}h{}m", secs / 3600, (secs % 3600) / 60)
+    } else {
+        format!("{}m", secs / 60)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_duration;
+    use crate::test::ModuleRenderer;
+    use nu_ansi_term::Color;
+
+    #[test]
+    fn test_without_data() {
+        let actual = ModuleRenderer::new("claude_usage").collect();
+        assert_eq!(actual, None);
+    }
+
+    #[test]
+    fn test_without_rate_limits() {
+        let data = make_data(0.0, 0.0, u64::MAX, u64::MAX);
+        // rate_limits is present but hidden below 70% threshold
+        let actual = ModuleRenderer::new("claude_usage")
+            .claude_code_data(data)
+            .collect();
+        assert_eq!(actual, None);
+    }
+
+    #[test]
+    fn test_disabled() {
+        let data = make_data(80.0, 10.0, u64::MAX, u64::MAX);
+        let actual = ModuleRenderer::new("claude_usage")
+            .config(toml::toml! {
+                [claude_usage]
+                disabled = true
+            })
+            .claude_code_data(data)
+            .collect();
+        assert_eq!(actual, None);
+    }
+
+    #[test]
+    fn test_hidden_below_threshold() {
+        let data = make_data(50.0, 30.0, u64::MAX, u64::MAX);
+        let actual = ModuleRenderer::new("claude_usage")
+            .claude_code_data(data)
+            .collect();
+        assert_eq!(actual, None);
+    }
+
+    #[test]
+    fn test_warn_threshold() {
+        let data = make_data(75.0, 10.0, u64::MAX, u64::MAX);
+        let actual = ModuleRenderer::new("claude_usage")
+            .config(toml::toml! {
+                [claude_usage]
+                format = "[$five_hour_pct%]($style) "
+                [[claude_usage.display]]
+                threshold = 0.0
+                hidden = true
+                [[claude_usage.display]]
+                threshold = 70.0
+                style = "bold yellow"
+                [[claude_usage.display]]
+                threshold = 90.0
+                style = "bold red"
+            })
+            .claude_code_data(data)
+            .collect();
+        assert_eq!(
+            actual,
+            Some(format!("{} ", Color::Yellow.bold().paint("75%")))
+        );
+    }
+
+    #[test]
+    fn test_critical_threshold() {
+        let data = make_data(92.0, 10.0, u64::MAX, u64::MAX);
+        let actual = ModuleRenderer::new("claude_usage")
+            .config(toml::toml! {
+                [claude_usage]
+                format = "[$five_hour_pct%]($style) "
+                [[claude_usage.display]]
+                threshold = 0.0
+                hidden = true
+                [[claude_usage.display]]
+                threshold = 70.0
+                style = "bold yellow"
+                [[claude_usage.display]]
+                threshold = 90.0
+                style = "bold red"
+            })
+            .claude_code_data(data)
+            .collect();
+        assert_eq!(
+            actual,
+            Some(format!("{} ", Color::Red.bold().paint("92%")))
+        );
+    }
+
+    #[test]
+    fn test_seven_day_drives_threshold() {
+        let data = make_data(50.0, 95.0, u64::MAX, u64::MAX);
+        let actual = ModuleRenderer::new("claude_usage")
+            .config(toml::toml! {
+                [claude_usage]
+                format = "[$seven_day_pct%]($style) "
+                [[claude_usage.display]]
+                threshold = 0.0
+                hidden = true
+                [[claude_usage.display]]
+                threshold = 70.0
+                style = "bold yellow"
+                [[claude_usage.display]]
+                threshold = 90.0
+                style = "bold red"
+            })
+            .claude_code_data(data)
+            .collect();
+        assert_eq!(
+            actual,
+            Some(format!("{} ", Color::Red.bold().paint("95%")))
+        );
+    }
+
+    #[test]
+    fn test_format_duration() {
+        assert_eq!(format_duration(0), "0m");
+        assert_eq!(format_duration(59), "0m");
+        assert_eq!(format_duration(60), "1m");
+        assert_eq!(format_duration(3599), "59m");
+        assert_eq!(format_duration(3600), "1h0m");
+        assert_eq!(format_duration(5025), "1h23m");
+        assert_eq!(format_duration(86400), "1d0h");
+        assert_eq!(format_duration(100000), "1d3h");
+    }
+
+    fn make_data(
+        five_hour_pct: f32,
+        seven_day_pct: f32,
+        five_hour_resets_at: u64,
+        seven_day_resets_at: u64,
+    ) -> crate::context::ClaudeCodeData {
+        use crate::context::{
+            ClaudeCodeData, ContextWindow, CurrentUsage, ModelInfo, RateLimitWindow, RateLimits,
+        };
+        ClaudeCodeData {
+            cwd: None,
+            model: ModelInfo {
+                id: "claude-sonnet-4-6".to_string(),
+                display_name: "Claude Sonnet 4.6".to_string(),
+            },
+            context_window: ContextWindow {
+                context_window_size: 200000,
+                total_input_tokens: 1000,
+                total_output_tokens: 500,
+                used_percentage: 0.0,
+                current_usage: CurrentUsage {
+                    input_tokens: 100,
+                    output_tokens: 50,
+                    cache_creation_input_tokens: 0,
+                    cache_read_input_tokens: 0,
+                },
+            },
+            cost: None,
+            workspace: None,
+            rate_limits: Some(RateLimits {
+                five_hour: RateLimitWindow {
+                    used_percentage: five_hour_pct,
+                    resets_at: five_hour_resets_at,
+                },
+                seven_day: RateLimitWindow {
+                    used_percentage: seven_day_pct,
+                    resets_at: seven_day_resets_at,
+                },
+            }),
+        }
+    }
+}

--- a/src/modules/claude_usage.rs
+++ b/src/modules/claude_usage.rs
@@ -40,18 +40,8 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         .unwrap_or_default()
         .as_secs();
 
-    let five_hour_reset = format_duration(
-        rate_limits
-            .five_hour
-            .resets_at
-            .saturating_sub(now_secs),
-    );
-    let seven_day_reset = format_duration(
-        rate_limits
-            .seven_day
-            .resets_at
-            .saturating_sub(now_secs),
-    );
+    let five_hour_reset = format_duration(rate_limits.five_hour.resets_at.saturating_sub(now_secs));
+    let seven_day_reset = format_duration(rate_limits.seven_day.resets_at.saturating_sub(now_secs));
 
     let five_hour_pct_str = format!("{:.0}", five_hour_pct);
     let seven_day_pct_str = format!("{:.0}", seven_day_pct);
@@ -181,10 +171,7 @@ mod tests {
             })
             .claude_code_data(data)
             .collect();
-        assert_eq!(
-            actual,
-            Some(format!("{} ", Color::Red.bold().paint("92%")))
-        );
+        assert_eq!(actual, Some(format!("{} ", Color::Red.bold().paint("92%"))));
     }
 
     #[test]
@@ -206,10 +193,7 @@ mod tests {
             })
             .claude_code_data(data)
             .collect();
-        assert_eq!(
-            actual,
-            Some(format!("{} ", Color::Red.bold().paint("95%")))
-        );
+        assert_eq!(actual, Some(format!("{} ", Color::Red.bold().paint("95%"))));
     }
 
     #[test]

--- a/src/modules/claude_usage.rs
+++ b/src/modules/claude_usage.rs
@@ -3,6 +3,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use super::{Context, Module, ModuleConfig};
 use crate::configs::claude_usage::ClaudeUsageConfig;
 use crate::formatter::StringFormatter;
+use crate::utils::render_time;
 
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let mut module = context.new_module("claude_usage");
@@ -40,8 +41,14 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         .unwrap_or_default()
         .as_secs();
 
-    let five_hour_reset = format_duration(rate_limits.five_hour.resets_at.saturating_sub(now_secs));
-    let seven_day_reset = format_duration(rate_limits.seven_day.resets_at.saturating_sub(now_secs));
+    let five_hour_reset = render_time(
+        (rate_limits.five_hour.resets_at.saturating_sub(now_secs) as u128) * 1000,
+        false,
+    );
+    let seven_day_reset = render_time(
+        (rate_limits.seven_day.resets_at.saturating_sub(now_secs) as u128) * 1000,
+        false,
+    );
 
     let five_hour_pct_str = format!("{:.0}", five_hour_pct);
     let seven_day_pct_str = format!("{:.0}", seven_day_pct);
@@ -73,19 +80,8 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     Some(module)
 }
 
-fn format_duration(secs: u64) -> String {
-    if secs >= 86400 {
-        format!("{}d{}h", secs / 86400, (secs % 86400) / 3600)
-    } else if secs >= 3600 {
-        format!("{}h{}m", secs / 3600, (secs % 3600) / 60)
-    } else {
-        format!("{}m", secs / 60)
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use super::format_duration;
     use crate::test::ModuleRenderer;
     use nu_ansi_term::Color;
 
@@ -194,18 +190,6 @@ mod tests {
             .claude_code_data(data)
             .collect();
         assert_eq!(actual, Some(format!("{} ", Color::Red.bold().paint("95%"))));
-    }
-
-    #[test]
-    fn test_format_duration() {
-        assert_eq!(format_duration(0), "0m");
-        assert_eq!(format_duration(59), "0m");
-        assert_eq!(format_duration(60), "1m");
-        assert_eq!(format_duration(3599), "59m");
-        assert_eq!(format_duration(3600), "1h0m");
-        assert_eq!(format_duration(5025), "1h23m");
-        assert_eq!(format_duration(86400), "1d0h");
-        assert_eq!(format_duration(100000), "1d3h");
     }
 
     fn make_data(

--- a/src/modules/claude_usage.rs
+++ b/src/modules/claude_usage.rs
@@ -82,6 +82,8 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
 #[cfg(test)]
 mod tests {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
     use crate::test::ModuleRenderer;
     use nu_ansi_term::Color;
 
@@ -190,6 +192,26 @@ mod tests {
             .claude_code_data(data)
             .collect();
         assert_eq!(actual, Some(format!("{} ", Color::Red.bold().paint("95%"))));
+    }
+
+    #[test]
+    fn test_default_format_renders() {
+        // Regression test: the default `format` string must be a valid
+        // format string. A malformed default caused module() to log a parse
+        // error and silently return None, so the module never rendered.
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let data = make_data(75.0, 10.0, now + 3600, now + 86400);
+        let actual = ModuleRenderer::new("claude_usage")
+            .claude_code_data(data)
+            .collect()
+            .expect("claude_usage should render with the default format");
+        assert!(
+            actual.contains("75%"),
+            "rendered output should contain the 5h percentage: {actual}",
+        );
     }
 
     fn make_data(

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -9,6 +9,7 @@ mod character;
 mod claude_context;
 mod claude_cost;
 mod claude_model;
+mod claude_usage;
 mod cmake;
 mod cmd_duration;
 mod cobol;
@@ -135,6 +136,7 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
             "claude_context" => claude_context::module(context),
             "claude_cost" => claude_cost::module(context),
             "claude_model" => claude_model::module(context),
+            "claude_usage" => claude_usage::module(context),
             "cmake" => cmake::module(context),
             "cmd_duration" => cmd_duration::module(context),
             "cobol" => cobol::module(context),
@@ -272,6 +274,7 @@ pub fn description(module: &str) -> &'static str {
         "claude_context" => "Context window usage for Claude Code session",
         "claude_cost" => "Cost info for Claude Code session",
         "claude_model" => "AI model name for Claude Code session",
+        "claude_usage" => "Rate limit usage for Claude Code session",
         "cmake" => "The currently installed version of CMake",
         "cmd_duration" => "How long the last command took to execute",
         "cobol" => "The currently installed version of COBOL/GNUCOBOL",

--- a/src/utils/statusline.rs
+++ b/src/utils/statusline.rs
@@ -10,6 +10,7 @@ pub struct ClaudeCodeData {
     pub context_window: ContextWindow,
     pub cost: Option<CostInfo>,
     pub workspace: Option<Workspace>,
+    pub rate_limits: Option<RateLimits>,
 }
 
 #[derive(Deserialize, Debug, Clone, Default)]
@@ -55,4 +56,18 @@ pub struct CostInfo {
 pub struct Workspace {
     pub current_dir: String,
     pub project_dir: String,
+}
+
+#[derive(Deserialize, Debug, Clone, Default)]
+#[serde(default)]
+pub struct RateLimitWindow {
+    pub used_percentage: f32,
+    pub resets_at: u64,
+}
+
+#[derive(Deserialize, Debug, Clone, Default)]
+#[serde(default)]
+pub struct RateLimits {
+    pub five_hour: RateLimitWindow,
+    pub seven_day: RateLimitWindow,
 }


### PR DESCRIPTION
## Summary

- Adds a new `claude_usage` module that surfaces Claude Code's 5-hour and 7-day rate limit windows in the statusline
- Claude Code v2.1.80+ exposes this data via `rate_limits` in the statusline JSON; the module renders it with threshold-based styling (yellow ≥70%, red ≥90%)
- Time-to-reset is computed from `resets_at` (Unix timestamp) and displayed in human-readable form (`1h23m`, `2d14h`, etc.)
- Adds documentation for the new module in `docs/advanced-config/README.md`

Closes #7441

## Changes

- `src/utils/statusline.rs` — new `RateLimitWindow` and `RateLimits` structs; added `rate_limits` field to `ClaudeCodeData`
- `src/configs/claude_usage.rs` — new config (format, display thresholds, disabled)
- `src/modules/claude_usage.rs` — new module implementation with 8 unit tests
- Registration in `mod.rs`, `module.rs`, `configs/mod.rs`, `starship_root.rs`
- `docs/advanced-config/README.md` — full module documentation with options, variables, and examples

## Test plan

- [x] `cargo test claude_` — all 34 tests pass
- [x] `cargo test all_modules_have_description` — passes
- [x] Smoke tested end-to-end with sample JSON via stdin

🤖 Generated with [Claude Code](https://claude.com/claude-code)