### PR TITLE
feat(vcs): add style options for repository clean and dirty states

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -5001,16 +5001,26 @@ The module will be shown only if a configured VCS is currently in use.
 
 ### Options
 
-| Option           | Default                                                     | Description                                           |
-| ---------------- | ----------------------------------------------------------- | ----------------------------------------------------- |
-| `order`          | `["git", "hg", "pijul", "fossil"]`                          | The order in which to search VCSes.                   |
-| `fossil_modules` | `"$fossil_branch$fossil_metrics"`                           | Modules to show when a Fossil repository is found.    |
-| `git_modules`    | `"$git_branch$git_commit$git_state$git_metrics$git_status"` | Modules to show when a Git repository is found.       |
-| `hg_modules`     | `"$hg_branch$hg_state"`                                     | Modules to show when a Mercurial repository is found. |
-| `pijul_modules`  | `"$pijul_channel"`                                          | Modules to show when a Pijul repository is found.     |
-| `disabled`       | `false`                                                     | Disables the `vcs` module.                            |
+| Option           | Default                                                     | Description                                                 |
+| ---------------- | ----------------------------------------------------------- | ----------------------------------------------------------- |
+| `order`          | `["git", "hg", "pijul", "fossil"]`                          | The order in which to search VCSes.                         |
+| `style_clean`    | `'bold green'`                                              | The style used when the VCS repository is in a clean state. |
+| `style_dirty`    | `'bold yellow'`                                             | The style used when the VCS repository is in a dirty state. |
+| `fossil_modules` | `"$fossil_branch$fossil_metrics"`                           | Modules to show when a Fossil repository is found.          |
+| `git_modules`    | `"$git_branch$git_commit$git_state$git_metrics$git_status"` | Modules to show when a Git repository is found.             |
+| `hg_modules`     | `"$hg_branch$hg_state"`                                     | Modules to show when a Mercurial repository is found.       |
+| `pijul_modules`  | `"$pijul_channel"`                                          | Modules to show when a Pijul repository is found.           |
+| `disabled`       | `false`                                                     | Disables the `vcs` module.                                  |
 
 ### Example
+
+### Variables
+
+| Variable | Description                                                                                   |
+| -------- | --------------------------------------------------------------------------------------------- |
+| style\*  | Mirrors the value of option `style_dirty` when the VCS is dirty, and `style_clean` otherwise. |
+
+*: This variable can only be used as a part of a style string
 
 ```toml
 # ~/.config/starship.toml

--- a/src/configs/vcs.rs
+++ b/src/configs/vcs.rs
@@ -24,6 +24,10 @@ pub struct VcsConfig<'a> {
     pub order: Vec<&'a str>,
     /// Disables the VCS module.
     pub disabled: bool,
+    /// The style for the module if the VCS is in a clean state.
+    pub style_clean: &'a str,
+    /// The style for the module if the VCS is in a dirty state.
+    pub style_dirty: &'a str,
     /// Modules to use when Fossil is matched.
     ///
     /// They are configured separately at the top level.
@@ -47,6 +51,8 @@ impl Default for VcsConfig<'_> {
         VcsConfig {
             order: vec!["git", "hg", "pijul", "fossil"],
             disabled: false,
+            style_clean: "bold green",
+            style_dirty: "bold yellow",
             fossil_modules: "$fossil_branch$fossil_metrics",
             git_modules: "$git_branch$git_commit$git_state$git_metrics$git_status",
             hg_modules: "$hg_branch$hg_state",

--- a/src/modules/git_status.rs
+++ b/src/modules/git_status.rs
@@ -625,6 +625,16 @@ pub(crate) struct RepoStatus {
 }
 
 impl RepoStatus {
+    pub(crate) fn is_dirty(&self) -> bool {
+        self.staged
+            + self.modified
+            + self.deleted
+            + self.renamed
+            + self.typechanged
+            + self.conflicted
+            > 0
+    }
+
     fn is_index_typechanged(short_status: &str) -> bool {
         short_status.starts_with('T')
     }

--- a/src/modules/vcs.rs
+++ b/src/modules/vcs.rs
@@ -3,9 +3,11 @@ use std::path::Path;
 
 use super::{Context, Module, ModuleConfig};
 
+use crate::configs::git_status::GitStatusConfig;
 use crate::configs::vcs::VcsConfig;
 use crate::formatter::StringFormatter;
 use crate::formatter::string_formatter::StringFormatterError;
+use crate::modules::git_status::get_static_repo_status;
 
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let mut module = context.new_module("vcs");
@@ -34,6 +36,16 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
     let parsed = StringFormatter::new(modules).and_then(|formatter| {
         formatter
+            .map_style(|variable: &str| match variable {
+                "style" => {
+                    if is_repo_clean(context, vcs).unwrap_or(true) {
+                        Some(Ok(config.style_clean))
+                    } else {
+                        Some(Ok(config.style_dirty))
+                    }
+                }
+                _ => None,
+            })
             .map_variables_to_segments(|variable| match variable {
                 "vcs" => Some(Err(StringFormatterError::Custom(
                     "cannot recursively include the `vcs` module in itself".into(),
@@ -69,6 +81,26 @@ pub fn discover_repo_root<'a>(context: &'a Context, vcs: Vcs) -> Option<Cow<'a, 
     };
 
     scan.scan().map(Into::into)
+}
+
+fn is_repo_clean(context: &Context, vcs: Vcs) -> Option<bool> {
+    let is_clean = match vcs {
+        Vcs::Fossil => context.exec_cmd("fossil", &["changes"])?.stdout.is_empty(),
+        Vcs::Git => {
+            let status_module = context.new_module("git_status");
+            let status_config = GitStatusConfig::try_load(status_module.config);
+            let repo = context.get_repo().ok()?;
+            let status = get_static_repo_status(context, repo, &status_config)?;
+            !status.is_dirty()
+        }
+        Vcs::Hg => context
+            .exec_cmd("hg", &["status", "-mard"])?
+            .stdout
+            .is_empty(),
+        Vcs::Pijul => context.exec_cmd("pijul", &["status"])?.stdout.is_empty(),
+    };
+
+    Some(is_clean)
 }
 
 #[derive(Debug, Copy, Clone)]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
Adds two config options, `style_clean` and `style_dirty` to the `vcs` module, as well as a `style` variable, which allows for setting the style of vcs modules according to the repository's status. A git repository is considered "dirty" if there are any tracked changes either staged or unstaged, including additions, modifications, renames, deletions, and type changes, with untracked files not being included. Similar logic is applied to Mercurial, Fossil, and Pijul repos.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #3062

#### Screenshots (if appropriate):
<img width="663" height="455" alt="image" src="https://github.com/user-attachments/assets/aa50fbcc-d538-4914-b70b-89c1078008a3" />

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
