### PR TITLE
docs: update advanced-config docs with zsh prompt indent instructions

### DIFF
--- a/docs/advanced-config/README.md
+++ b/docs/advanced-config/README.md
@@ -315,6 +315,14 @@ Produces a prompt like the following:
 ▶                                   starship on  rprompt [!] is 📦 v0.57.0 via 🦀 v1.54.0 took 17s
 ```
 
+While using `zsh` shell, by default, zsh writes an extra space on the right end of the prompt, which produces a gap/allignment mismatch in the starship format on the right side. Therefore, while using `zsh` versions >= 5.0.5, users must add the following to their `.zshrc` to eradicate the extra indent.
+
+```
+ZLE_RPROMPT_INDENT=0
+```
+
+This extra space was hardcoded in version 5.0.2 of zsh and the option to change the indent was added in 5.0.5
+
 ## Continuation Prompt
 
 Some shells support a continuation prompt along with the normal prompt. This prompt is rendered instead of the normal prompt when the user has entered an incomplete statement (such as a single left parenthesis or quote).

--- a/docs/advanced-config/README.md
+++ b/docs/advanced-config/README.md
@@ -315,7 +315,7 @@ Produces a prompt like the following:
 ▶                                   starship on  rprompt [!] is 📦 v0.57.0 via 🦀 v1.54.0 took 17s
 ```
 
-While using `zsh` shell, by default, zsh writes an extra space on the right end of the prompt, which produces a gap/allignment mismatch in the starship format on the right side. Therefore, while using `zsh` versions >= 5.0.5, users must add the following to their `.zshrc` to eradicate the extra indent.
+While using `zsh` shell, by default, zsh writes an extra space on the right end of the prompt, which produces a gap/alignment mismatch in the starship format on the right side. Therefore, while using `zsh` versions >= 5.0.5, users must add the following to their `.zshrc` to eradicate the extra indent.
 
 ```
 ZLE_RPROMPT_INDENT=0

--- a/docs/advanced-config/README.md
+++ b/docs/advanced-config/README.md
@@ -315,13 +315,11 @@ Produces a prompt like the following:
 ▶                                   starship on  rprompt [!] is 📦 v0.57.0 via 🦀 v1.54.0 took 17s
 ```
 
-While using `zsh` shell, by default, zsh writes an extra space on the right end of the prompt, which produces a gap/alignment mismatch in the starship format on the right side. Therefore, while using `zsh` versions >= 5.0.5, users must add the following to their `.zshrc` to eradicate the extra indent.
+When using `zsh` (v5.0.5+), the shell adds a default trailing space to the right prompt. This can cause alignment issues specifically when using the Starship `$fill` module. To remove this gap, add the following to your `.zshrc`:
 
-```
+```zsh
 ZLE_RPROMPT_INDENT=0
 ```
-
-This extra space was hardcoded in version 5.0.2 of zsh and the option to change the indent was added in 5.0.5
 
 ## Continuation Prompt
 


### PR DESCRIPTION
Added instructions for zsh users to adjust prompt indent.

Add documentation in `Enable Right Prompt` of advanced-config part of docs.

#### Description
Added instructions for `zsh` users to add required config in `.zshrc` to eliminate alignment issues in `right_format`

#### Motivation and Context
Closes #7289

#### How Has This Been Tested?
Simple documentation update. I haven't tested the changes, since I have only updated the documentation markdown contents, which should obviously not break anything.

#### Checklist:
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
