### PR TITLE
fix: use cargo-zigbuild for riscv64gc-unknown-linux-musl release builds

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -135,5 +135,16 @@
             ],
             datasourceTemplate: 'crate',
         },
+        {
+            customType: 'regex',
+            managerFilePatterns: [
+                '/^(workflow-templates|\\.github\\/workflows)\\/[^/]+\\.ya?ml$/',
+            ],
+            matchStrings: [
+                'ziglang==(?<currentValue>\\S+)',
+            ],
+            datasourceTemplate: 'pypi',
+            depNameTemplate: 'ziglang',
+        },
     ],
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,9 +114,7 @@ jobs:
 
       - name: Setup | Install Zig [riscv64]
         if: matrix.use_zigbuild
-        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
-        with:
-          version: 0.13.0
+        run: pip install ziglang==0.13.0
 
       - name: Setup | Install cargo-zigbuild [riscv64]
         if: matrix.use_zigbuild

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,7 @@ jobs:
           - target: riscv64gc-unknown-linux-musl
             os: ubuntu-latest
             name: starship-riscv64gc-unknown-linux-musl.tar.gz
+            use_zigbuild: true
 
           - target: x86_64-apple-darwin
             os: macos-latest
@@ -106,18 +107,34 @@ jobs:
           RUSTFLAGS: ""
 
       - name: Setup | Install cross [Linux]
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-latest' && !matrix.use_zigbuild
         uses: taiki-e/install-action@cca35edeb1d01366c2843b68fc3ca441446d73d3 # v2.77.1
         with:
           tool: cross@0.2.5
+
+      - name: Setup | Install Zig [riscv64]
+        if: matrix.use_zigbuild
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+        with:
+          version: 0.13.0
+
+      - name: Setup | Install cargo-zigbuild [riscv64]
+        if: matrix.use_zigbuild
+        uses: taiki-e/install-action@cca35edeb1d01366c2843b68fc3ca441446d73d3 # v2.77.1
+        with:
+          tool: cargo-zigbuild
 
       - name: Build | Build [Cargo]
         if: matrix.os != 'ubuntu-latest'
         run: cargo build --release --locked --target ${{ matrix.target }}
 
       - name: Build | Build [Cross]
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-latest' && !matrix.use_zigbuild
         run: cross build --release --locked --target ${{ matrix.target }}
+
+      - name: Build | Build [Zigbuild]
+        if: matrix.use_zigbuild
+        run: cargo zigbuild --release --locked --target ${{ matrix.target }}
 
       - name: Build | Installer [Windows]
         continue-on-error: true


### PR DESCRIPTION
#### Description

Switch the `riscv64gc-unknown-linux-musl` release target from `cross` to `cargo-zigbuild`.

`cross` 0.2.5's Docker image for `riscv64gc-unknown-linux-musl` does not set up the musl cross-linker correctly: when the build runs, `/usr/bin/ld` (the x86_64 host linker) is invoked instead of an riscv64 musl linker, producing a `file in wrong format` linker error. The cross job exits with code 0 because the error goes to stderr and the build step doesn't catch it, so releases are published without the riscv64 artifact.

`cargo-zigbuild` uses Zig's built-in riscv64 musl toolchain as a drop-in cross-linker. No custom Docker image or linker script needed.

Changes:
- Add `use_zigbuild: true` flag to the `riscv64gc-unknown-linux-musl` matrix entry
- Conditionalise the existing `cross` setup/build steps so they only run when `use_zigbuild` is false
- Add Zig setup (`mlugg/setup-zig@v2.2.1`) and `cargo-zigbuild` install steps gated on `use_zigbuild`
- Add a `Build [Zigbuild]` step for the riscv64 target

All other targets are unaffected.

#### Motivation and Context

Closes #

riscv64 binaries have been silently missing from releases since v1.25.0 (after the riscv64 target was added in #7337). This fixes the linker setup so the artifact actually gets built and uploaded.

#### Screenshots (if appropriate):

N/A — CI build artifact and release asset list.

#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

Pushed the branch to my fork and verified the `riscv64gc-unknown-linux-musl` job completes via the fork's CI.

#### Checklist:
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.