### PR TITLE
fix(gcloud): honor CLOUDSDK_COMPUTE_REGION env variable

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1824,6 +1824,7 @@ format = '[+$added]($added_style)/[-$deleted]($deleted_style) '
 
 The `gcloud` module shows the current configuration for [`gcloud`](https://cloud.google.com/sdk/gcloud) CLI.
 This is based on the `~/.config/gcloud/active_config` file and the `~/.config/gcloud/configurations/config_{CONFIG NAME}` file and the `CLOUDSDK_CONFIG` env var.
+The `CLOUDSDK_CORE_PROJECT` and `CLOUDSDK_COMPUTE_REGION` environment variables, when set, override the `project` and `region` values from the active configuration, mirroring the behavior of `gcloud` itself.
 
 When the module is enabled it will always be active, unless `detect_env_vars` has
 been set in which case the module will only be active when one of the

--- a/src/modules/gcloud.rs
+++ b/src/modules/gcloud.rs
@@ -116,10 +116,17 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                     .and_then(|(_, domain)| domain)
                     .map(Cow::Borrowed)
                     .map(Ok),
-                "region" => gcloud_context
-                    .get_region()
-                    .map(|region| config.region_aliases.get(region).copied().unwrap_or(region))
-                    .map(Cow::Borrowed)
+                "region" => context
+                    .get_env("CLOUDSDK_COMPUTE_REGION")
+                    .map(Cow::Owned)
+                    .or_else(|| gcloud_context.get_region().map(Cow::Borrowed))
+                    .map(|region| {
+                        config
+                            .region_aliases
+                            .get(region.as_ref())
+                            .copied()
+                            .map_or(region, Cow::Borrowed)
+                    })
                     .map(Ok),
                 "project" => context
                     .get_env("CLOUDSDK_CORE_PROJECT")
@@ -446,6 +453,63 @@ project = very-long-project-name
             })
             .collect();
         let expected = Some(format!("on {} ", Color::Blue.bold().paint("☁️  vlpn")));
+
+        assert_eq!(actual, expected);
+        dir.close()
+    }
+
+    #[test]
+    fn region_set_in_env() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let active_config_path = dir.path().join("active_config");
+        let mut active_config_file = File::create(active_config_path)?;
+        active_config_file.write_all(b"default")?;
+
+        create_dir(dir.path().join("configurations"))?;
+        let config_default_path = dir.path().join("configurations").join("config_default");
+        let mut config_default_file = File::create(config_default_path)?;
+        config_default_file.write_all(
+            b"\
+[compute]
+region = us-central1
+",
+        )?;
+
+        let actual = ModuleRenderer::new("gcloud")
+            .env("CLOUDSDK_COMPUTE_REGION", "europe-west2")
+            .env("CLOUDSDK_CONFIG", dir.path().to_string_lossy())
+            .config(toml::toml! {
+                [gcloud]
+                format = "on [$symbol$region]($style) "
+            })
+            .collect();
+        let expected = Some(format!(
+            "on {} ",
+            Color::Blue.bold().paint("☁️  europe-west2")
+        ));
+
+        assert_eq!(actual, expected);
+        dir.close()
+    }
+
+    #[test]
+    fn region_set_in_env_with_alias() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let active_config_path = dir.path().join("active_config");
+        let mut active_config_file = File::create(active_config_path)?;
+        active_config_file.write_all(b"default")?;
+
+        let actual = ModuleRenderer::new("gcloud")
+            .env("CLOUDSDK_COMPUTE_REGION", "europe-west2")
+            .env("CLOUDSDK_CONFIG", dir.path().to_string_lossy())
+            .config(toml::toml! {
+                [gcloud]
+                format = "on [$symbol$region]($style) "
+                [gcloud.region_aliases]
+                europe-west2 = "ew2"
+            })
+            .collect();
+        let expected = Some(format!("on {} ", Color::Blue.bold().paint("☁️  ew2")));
 
         assert_eq!(actual, expected);
         dir.close()


### PR DESCRIPTION
#### Description

The gcloud CLI lets `CLOUDSDK_COMPUTE_REGION` override the active configuration's `[compute] region`. Starship was reading region only from the config file, so its prompt drifted from what gcloud itself reports when the env var was set.

Mirror the `CLOUDSDK_CORE_PROJECT` precedent from #2596: check the env var first, fall back to `gcloud_context.get_region()`, then run the resulting value through `region_aliases` (so aliases keep working for env-sourced regions).

While the env override path was a doc gap (`CLOUDSDK_CORE_PROJECT` was supported since 2021 but never documented), I added a one-line note in `docs/config/README.md` covering both env vars together so users can see the full override surface.

#### Motivation and Context

Closes #7448

`gcloud config list` already warns when `CLOUDSDK_COMPUTE_REGION` overrides `[compute] region`:

> WARNING: Property [region] is overridden by environment setting [CLOUDSDK_COMPUTE_REGION=europe-west2]

Starship should reflect the same precedence, just like it already does for `CLOUDSDK_CORE_PROJECT`.

#### How Has This Been Tested?

- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

Two new tests in `src/modules/gcloud.rs` mirror the project counterparts:

- `region_set_in_env`: env var + config file both set, env var wins.
- `region_set_in_env_with_alias`: env var set, `region_aliases` still applies.

`cargo test --lib gcloud` — 14 tests pass (12 existing + 2 new).

#### Checklist:

- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.