### PR TITLE
fix(bash): clear status on empty command line

### DIFF
--- a/src/init/starship.bash
+++ b/src/init/starship.bash
@@ -69,14 +69,24 @@ starship_precmd() {
         eval "$STARSHIP_PROMPT_COMMAND"
     fi
 
-    local -a ARGS=(--terminal-width="${COLUMNS}" --status="${STARSHIP_CMD_STATUS}" --pipestatus="${STARSHIP_PIPE_STATUS[*]}" --jobs="${NUM_JOBS}" --shlvl="${SHLVL}")
-    # Prepare the timer data, if needed.
+    local reported_status="${STARSHIP_CMD_STATUS}"
+    local -a reported_pipe_status=("${STARSHIP_PIPE_STATUS[@]}")
+    local -a ARGS=(--terminal-width="${COLUMNS}" --jobs="${NUM_JOBS}" --shlvl="${SHLVL}")
+    # STARSHIP_START_TIME is set by starship_preexec / PS0 only when an actual
+    # command runs, so an empty value here means the user just pressed ENTER
+    # on an empty line. In that case, drop the status/pipestatus so the prompt
+    # doesn't keep echoing the previous command's failure indicator (#7450).
+    # Matches the zsh init's behavior.
     if [[ -n "${STARSHIP_START_TIME-}" ]]; then
         STARSHIP_END_TIME=$(::STARSHIP:: time)
         STARSHIP_DURATION=$((STARSHIP_END_TIME - STARSHIP_START_TIME))
         ARGS+=( --cmd-duration="${STARSHIP_DURATION}")
         STARSHIP_START_TIME=""
+    else
+        reported_status=""
+        reported_pipe_status=()
     fi
+    ARGS+=(--status="${reported_status}" --pipestatus="${reported_pipe_status[*]}")
     PS1="$(::STARSHIP:: prompt "${ARGS[@]}")"
     if [[ ${BLE_ATTACHED-} ]]; then
         local nlns=${PS1//[!$'\n']}


### PR DESCRIPTION
#### Description

When the user pressed ENTER on an empty prompt after a failed command, the prompt kept rendering the failure indicator (character module's `error_symbol`, status module's exit code) on every subsequent empty line until a real command was run. The zsh init already handles this by dropping the captured status whenever no command actually ran since the last prompt. This change brings the bash init to the same behavior.

In bash, `starship_preexec` (and the PS0 fast-path on bash >= 4.4) only fires when a real command is about to execute, so `STARSHIP_START_TIME` is empty in `starship_precmd` exactly when the user hit ENTER on nothing. That signal is already used to skip the `--cmd-duration` flag; this PR reuses it to drop `--status` and `--pipestatus` in the same case. The CLI already treats an empty `--status` as `None` ([`context.rs:155`](https://github.com/starship/starship/blob/main/src/context.rs#L155)) and the same for an empty `--pipestatus` ([`context.rs:142`](https://github.com/starship/starship/blob/main/src/context.rs#L142)), which then default to a successful render via [`status.rs:31`](https://github.com/starship/starship/blob/main/src/modules/status.rs#L31) / [`character.rs:28`](https://github.com/starship/starship/blob/main/src/modules/character.rs#L28).

The captured `STARSHIP_CMD_STATUS` is preserved in the global so that `STARSHIP_PROMPT_COMMAND` user code still sees the real `$?`; only the values passed to the prompt CLI are reset.

#### Motivation and Context

Closes #7450

#### How Has This Been Tested?

Reproduced #7450 with the reporter's minimal config, then ran the same harness against this branch. Before/after with `format = '$status$character'`:

```
=== BASELINE (origin/main) ===
--- after running: false
PS1 = Exited with code 1 X
--- after running: <empty enter>
PS1 = Exited with code 1 X     <-- bug: empty enter still shows failure
--- after running: <empty enter>
PS1 = Exited with code 1 X     <-- bug: persists indefinitely

=== PATCHED ===
--- after running: false
PS1 = Exited with code 1 X
--- after running: <empty enter>
PS1 = O                        <-- fixed: empty enter renders success
--- after running: <empty enter>
PS1 = O
```

`cargo test --release init::` passes (init scripts are baked via `include_str!`, no shell-script tests upstream).

- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:

- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.