### PR TITLE
docs(username): note that elevation needs starship init in target rc

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -4902,6 +4902,15 @@ The module will be shown if any of the following conditions are met:
 > `SSH_CONNECTION`, `SSH_CLIENT`, and `SSH_TTY`. If your SSH host does not set up
 > these variables, one workaround is to set one of them with a dummy value.
 
+> [!TIP]
+> `style_root` only changes how the `username` module renders when Starship is
+> already running. Elevation commands like `su`, `sudo -i`, and `doas` start a
+> new shell process that loads the target user's init scripts (e.g.
+> `/root/.bashrc`), so Starship must be initialized there as well. Otherwise
+> the prompt falls back to the target user's default. Add the `starship init`
+> line for your shell to the target user's rc file to keep the prompt across
+> elevation.
+
 ### Options
 
 | Option            | Default                 | Description                                               |


### PR DESCRIPTION
#### Description

Adds a TIP block to the `username` module section noting that `style_root` only changes rendering when Starship is already running, and that `su` / `sudo -i` / `doas` start a new shell process whose init scripts must source `starship init` separately.

#### Motivation and Context

Closes #7407.

The reporter assumed `style_root` made starship govern the prompt globally, so when their `/root/.bashrc` had no `eval "$(starship init bash)"` line, the post-`su` prompt fell through to the default and the missing prompt looked like a bug in starship rather than a missing init in root's rc.

Slotted next to the existing `SSH_CONNECTION` TIP, which already uses the same shape for a similar surprise (env-var dependence not obvious from the option list).

#### Screenshots (if appropriate):

n/a — markdown TIP block follows the existing pattern.

#### How Has This Been Tested?

- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

Docs-only, no behavior change.

#### Checklist:

- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.