### PR TITLE
fix(cmd_duration): strip PUA characters from notification body

### DIFF
--- a/src/modules/cmd_duration.rs
+++ b/src/modules/cmd_duration.rs
@@ -88,9 +88,21 @@ fn undistract_me<'a>(
         #[cfg(target_os = "macos")]
         let _ = notify_rust::set_application("com.apple.Terminal");
 
+        let unstyled = unstyle(&AnsiStrings(&module.ansi_strings()));
+        // Strip Unicode Private Use Area characters (e.g., Nerd Font icons) that
+        // cannot be rendered by system notification fonts like SF Pro on macOS.
         let body = format!(
             "Command execution {}",
-            unstyle(&AnsiStrings(&module.ansi_strings()))
+            unstyled
+                .chars()
+                .filter(|c| {
+                    let cp = *c as u32;
+                    !(0xE000..=0xF8FF).contains(&cp)
+                        && !(0xF0000..=0xFFFFD).contains(&cp)
+                        && !(0x100000..=0x10FFFD).contains(&cp)
+                })
+                .collect::<String>()
+                .trim()
         );
 
         let timeout = match config.notification_timeout {


### PR DESCRIPTION
## Summary

- Strip Unicode Private Use Area (PUA) characters from the desktop notification body in `cmd_duration`'s `undistract_me` function
- Fixes Nerd Font icons (e.g., U+EAF4 timer icon) rendering as tofu (□) in macOS system notifications
- Affects the official `catppuccin-powerline` preset out of the box

## Problem

The `catppuccin-powerline` preset configures:

```toml
[cmd_duration]
format = "<nerd-font-timer-icon> in $duration "
show_notifications = true
```

The Nerd Font icon U+EAF4 renders fine in terminals with Nerd Fonts installed, but when `undistract_me` sends a desktop notification, the character is passed verbatim to the system notification API. macOS renders notifications using SF Pro, which has no glyphs for PUA characters → tofu (□).

## Fix

After `unstyle()` removes ANSI escape codes, filter out all Unicode PUA ranges before constructing the notification body:

- BMP Private Use Area: U+E000–U+F8FF
- Supplementary Private Use Area-A: U+F0000–U+FFFFD
- Supplementary Private Use Area-B: U+100000–U+10FFFD

The `.trim()` call handles any extra whitespace left after icon removal.

## Test Plan

- [ ] Verify that notification body with format containing PUA characters no longer includes those characters
- [ ] Verify that normal ASCII/Unicode text in format strings is preserved
- [ ] Verify existing tests pass (`cargo test -p starship -- cmd_duration`)

Fixes #7464

🤖 Generated with [Claude Code](https://claude.com/claude-code)