### PR TITLE
fix(elvish): pass --terminal-width to starship via $E:COLUMNS

### DIFF
--- a/src/init/starship.elv
+++ b/src/init/starship.elv
@@ -24,10 +24,10 @@ set edit:after-command = [ $@edit:after-command $starship-after-command-hook~ ]
 # Install starship
 set edit:prompt = {
     var cmd-duration = (printf "%.0f" (* $edit:command-duration 1000))
-    ::STARSHIP:: prompt --jobs=$num-bg-jobs --cmd-duration=$cmd-duration --status=$cmd-status-code --logical-path=$pwd
+    ::STARSHIP:: prompt --terminal-width=$E:COLUMNS --jobs=$num-bg-jobs --cmd-duration=$cmd-duration --status=$cmd-status-code --logical-path=$pwd
 }
 
 set edit:rprompt = {
     var cmd-duration = (printf "%.0f" (* $edit:command-duration 1000))
-    ::STARSHIP:: prompt --right --jobs=$num-bg-jobs --cmd-duration=$cmd-duration --status=$cmd-status-code --logical-path=$pwd
+    ::STARSHIP:: prompt --right --terminal-width=$E:COLUMNS --jobs=$num-bg-jobs --cmd-duration=$cmd-duration --status=$cmd-status-code --logical-path=$pwd
 }


### PR DESCRIPTION
#### Description

Every other shell init script forwards a width hint to `starship prompt` (bash `COLUMNS`, zsh `COLUMNS`, fish `term-width`, nushell `term size`, etc.); elvish was the lone outlier and starship was falling back to its TTY-probe default. When the probe returned a width slightly smaller than the actual terminal, the time module's separator could be clipped on the right edge — the colon disappearing or the leading minute digit getting chopped is exactly what #7453 reports.

Passes `$E:COLUMNS` and is safe when the variable is unset: clap's `parse_trim` returns `None` on an empty string and starship falls back to `default_width()` (`src/context.rs:1013`, `src/context.rs:1025`) just like it does today.

#### Motivation and Context

Closes #7453

#### How Has This Been Tested?

- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

`cargo test --lib` — 1217 passed. `cargo clippy --all-targets -- -D warnings` clean. `cargo fmt --check` clean. Manually rebuilt and ran `starship init elvish --print-full-init` to confirm the flag appears in both `edit:prompt` and `edit:rprompt`.

#### Checklist:

- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.