### PR TITLE
fix(nodejs): avoid deno project files

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -1211,7 +1211,7 @@
           "!bun.lock",
           "!bun.lockb",
           "!deno.json",
-          "!deno.jsonl",
+          "!deno.jsonc",
           "!deno.lock"
         ],
         "detect_folders": [
@@ -5204,7 +5204,7 @@
             "!bun.lock",
             "!bun.lockb",
             "!deno.json",
-            "!deno.jsonl",
+            "!deno.jsonc",
             "!deno.lock"
           ]
         },

--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -1209,7 +1209,10 @@
           ".nvmrc",
           "!bunfig.toml",
           "!bun.lock",
-          "!bun.lockb"
+          "!bun.lockb",
+          "!deno.json",
+          "!deno.jsonl",
+          "!deno.lock"
         ],
         "detect_folders": [
           "node_modules"
@@ -5199,7 +5202,10 @@
             ".nvmrc",
             "!bunfig.toml",
             "!bun.lock",
-            "!bun.lockb"
+            "!bun.lockb",
+            "!deno.json",
+            "!deno.jsonl",
+            "!deno.lock"
           ]
         },
         "detect_folders": {

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -3379,7 +3379,7 @@ By default the module will be shown if any of the following conditions are met:
 - The current directory contains a file with the `.js`, `.mjs` or `.cjs` extension
 - The current directory contains a file with the `.ts`, `.mts` or `.cts` extension
 
-Additionally, the module will be hidden by default if the directory contains a `bunfig.toml`, `bun.lock`, or `bun.lockb` file, overriding the above conditions.
+Additionally, the module will be hidden by default if the directory contains a `deno.json`, `deno.jsonl`, `deno.lock`, `bunfig.toml`, `bun.lock`, or `bun.lockb` file, overriding the above conditions.
 
 ### Options
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -3379,7 +3379,7 @@ By default the module will be shown if any of the following conditions are met:
 - The current directory contains a file with the `.js`, `.mjs` or `.cjs` extension
 - The current directory contains a file with the `.ts`, `.mts` or `.cts` extension
 
-Additionally, the module will be hidden by default if the directory contains a `deno.json`, `deno.jsonl`, `deno.lock`, `bunfig.toml`, `bun.lock`, or `bun.lockb` file, overriding the above conditions.
+Additionally, the module will be hidden by default if the directory contains a `deno.json`, `deno.jsonc`, `deno.lock`, `bunfig.toml`, `bun.lock`, or `bun.lockb` file, overriding the above conditions.
 
 ### Options
 

--- a/src/configs/nodejs.rs
+++ b/src/configs/nodejs.rs
@@ -37,7 +37,7 @@ impl Default for NodejsConfig<'_> {
                 "!bun.lock",
                 "!bun.lockb",
                 "!deno.json",
-                "!deno.jsonl",
+                "!deno.jsonc",
                 "!deno.lock",
             ],
             detect_folders: vec!["node_modules"],

--- a/src/configs/nodejs.rs
+++ b/src/configs/nodejs.rs
@@ -36,6 +36,9 @@ impl Default for NodejsConfig<'_> {
                 "!bunfig.toml",
                 "!bun.lock",
                 "!bun.lockb",
+                "!deno.json",
+                "!deno.jsonl",
+                "!deno.lock",
             ],
             detect_folders: vec!["node_modules"],
         }


### PR DESCRIPTION
#### Description

Hide the Node.js prompt by default if Deno project files are detected.

#### Motivation and Context

The current default prompt shows both the Node.js and Deno prompts in Deno projects, because both runtimes use `package.json` to specify dependencies. However, in Deno projects, this file doesn't actually indicate that Node.js is used. 

This was already implemented for Bun in #6346 so i guess this should also be valid for Deno.


