### PR TITLE
feat: implement referencing next styles & improve fill handling

### DIFF
--- a/docs/advanced-config/README.md
+++ b/docs/advanced-config/README.md
@@ -666,7 +666,7 @@ Style strings are a list of words, separated by whitespace. The words are not ca
 - `none`
 
 where `<color>` is a color specifier (discussed below). `fg:<color>` and `<color>` currently do the same thing, though this may change in the future.
-`<color>` can also be set to `prev_fg` or `prev_bg` which evaluates to the previous item's foreground or background color respectively if available or `none` otherwise.
+`<color>` can also be set to `prev_fg`, `prev_bg`, `next_fg` or `next_bg`, which evaluates to, respectively, the previous and next item's foreground or background color if available or `none` otherwise. `prev_fg` and `prev_bg` can be used transitively, whereas `next_fg` and `next_bg` can not be be used transitively.
 `inverted` swaps the background and foreground colors. The order of words in the string does not matter.
 
 The `none` token overrides all other tokens in a string if it is not part of a `bg:` specifier, so that e.g. `fg:red none fg:blue` will still create a string with no styling. `bg:none` sets the background to the default color so `fg:red bg:none` is equivalent to `red` or `fg:red` and `bg:green fg:red bg:none` is also equivalent to `fg:red` or `red`. It may become an error to use `none` in conjunction with other tokens in the future.

--- a/docs/advanced-config/README.md
+++ b/docs/advanced-config/README.md
@@ -666,7 +666,7 @@ Style strings are a list of words, separated by whitespace. The words are not ca
 - `none`
 
 where `<color>` is a color specifier (discussed below). `fg:<color>` and `<color>` currently do the same thing, though this may change in the future.
-`<color>` can also be set to `prev_fg`, `prev_bg`, `next_fg` or `next_bg`, which evaluates to, respectively, the previous and next item's foreground or background color if available or `none` otherwise. `prev_fg` and `prev_bg` can be used transitively, whereas `next_fg` and `next_bg` can not be be used transitively.
+`<color>` can also be set to `prev_fg`, `prev_bg`, `next_fg` or `next_bg`, which evaluates to, respectively, the previous and next item's foreground or background color if available or `none` otherwise. `prev_fg` and `prev_bg` can be used transitively, whereas `next_fg` and `next_bg` cannot be used transitively.
 `inverted` swaps the background and foreground colors. The order of words in the string does not matter.
 
 The `none` token overrides all other tokens in a string if it is not part of a `bg:` specifier, so that e.g. `fg:red none fg:blue` will still create a string with no styling. `bg:none` sets the background to the default color so `fg:red bg:none` is equivalent to `red` or `fg:red` and `bg:green fg:red bg:none` is also equivalent to `fg:red` or `red`. It may become an error to use `none` in conjunction with other tokens in the future.

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,7 +3,7 @@ use crate::context::Context;
 
 use crate::utils;
 use crate::utils::serde::{ValueDeserializer, ValueRef};
-use nu_ansi_term::Color;
+use nu_ansi_term::{Color, Style as AnsiStyle};
 use serde::{
     Deserialize, Deserializer, Serialize, de::Error as SerdeError, de::value::Error as ValueError,
 };
@@ -268,39 +268,82 @@ where
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-enum PrevColor {
-    Fg,
-    Bg,
+pub enum RefColor {
+    PrevFg,
+    PrevBg,
+    NextFg,
+    NextBg,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 /// Wrapper for `nu_ansi_term::Style` that supports referencing the previous style's foreground/background color.
 pub struct Style {
     style: nu_ansi_term::Style,
-    bg: Option<PrevColor>,
-    fg: Option<PrevColor>,
+    bg: Option<RefColor>,
+    fg: Option<RefColor>,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct StyleRefs {
+    prev: Option<AnsiStyle>,
+    next: Option<AnsiStyle>,
+}
+
+impl StyleRefs {
+    pub fn new(prev: Option<AnsiStyle>, next: Option<AnsiStyle>) -> Self {
+        Self { prev, next }
+    }
+
+    pub fn prev(&self) -> Option<AnsiStyle> {
+        self.prev
+    }
+
+    pub fn next(&self) -> Option<AnsiStyle> {
+        self.next
+    }
+
+    pub fn with_prev(&self, prev: Option<AnsiStyle>) -> Self {
+        Self {
+            prev,
+            next: self.next,
+        }
+    }
+
+    pub fn with_next(&self, next: Option<AnsiStyle>) -> Self {
+        Self {
+            prev: self.prev,
+            next,
+        }
+    }
+
+    pub fn to_ansi_style(&self, ref_color: RefColor) -> Option<nu_ansi_term::Color> {
+        match ref_color {
+            RefColor::PrevFg => self.prev.and_then(|s| s.foreground),
+            RefColor::PrevBg => self.prev.and_then(|s| s.background),
+            RefColor::NextFg => self.next.and_then(|s| s.foreground),
+            RefColor::NextBg => self.next.and_then(|s| s.background),
+        }
+    }
 }
 
 impl Style {
-    pub fn to_ansi_style(&self, prev: Option<&nu_ansi_term::Style>) -> nu_ansi_term::Style {
-        let Some(prev_style) = prev else {
-            return self.style;
-        };
+    pub fn has_ref_color(&self) -> bool {
+        self.fg.is_some() || self.bg.is_some()
+    }
 
+    pub fn to_ansi_style(&self, ref_styles: Option<StyleRefs>) -> AnsiStyle {
         let mut current = self.style;
 
-        if let Some(prev_color) = self.bg {
-            match prev_color {
-                PrevColor::Fg => current.background = prev_style.foreground,
-                PrevColor::Bg => current.background = prev_style.background,
-            }
+        if let Some(prev_color) = self.bg
+            && let Some(s) = ref_styles
+        {
+            current.background = s.to_ansi_style(prev_color);
         }
 
-        if let Some(prev_color) = self.fg {
-            match prev_color {
-                PrevColor::Fg => current.foreground = prev_style.foreground,
-                PrevColor::Bg => current.foreground = prev_style.background,
-            }
+        if let Some(prev_color) = self.fg
+            && let Some(s) = ref_styles
+        {
+            current.foreground = s.to_ansi_style(prev_color);
         }
 
         current
@@ -316,14 +359,14 @@ impl Style {
         }
     }
 
-    fn fg(&self, prev_color: PrevColor) -> Self {
+    fn fg(&self, prev_color: RefColor) -> Self {
         Self {
             fg: Some(prev_color),
             ..*self
         }
     }
 
-    fn bg(&self, prev_color: PrevColor) -> Self {
+    fn bg(&self, prev_color: RefColor) -> Self {
         Self {
             bg: Some(prev_color),
             ..*self
@@ -360,6 +403,8 @@ impl From<nu_ansi_term::Color> for Style {
  - 'blink'
  - '`prev_fg`'        (specifies the color should be the previous foreground color)
  - '`prev_bg`'        (specifies the color should be the previous background color)
+ - '`next_fg`'        (specifies the color should be the next foreground color)
+ - '`next_bg`'        (specifies the color should be the next background color)
  - '<color>'       (see the `parse_color_string` doc for valid color strings)
 */
 pub fn parse_style_string(style_string: &str, context: Option<&Context>) -> Option<Style> {
@@ -388,11 +433,17 @@ pub fn parse_style_string(style_string: &str, context: Option<&Context>) -> Opti
                 "hidden" => Some(style.map_style(nu_ansi_term::Style::hidden)),
                 "strikethrough" => Some(style.map_style(nu_ansi_term::Style::strikethrough)),
 
-                "prev_fg" if col_fg => Some(style.fg(PrevColor::Fg)),
-                "prev_fg" => Some(style.bg(PrevColor::Fg)),
+                "prev_fg" if col_fg => Some(style.fg(RefColor::PrevFg)),
+                "prev_fg" => Some(style.bg(RefColor::PrevFg)),
 
-                "prev_bg" if col_fg => Some(style.fg(PrevColor::Bg)),
-                "prev_bg" => Some(style.bg(PrevColor::Bg)),
+                "prev_bg" if col_fg => Some(style.fg(RefColor::PrevBg)),
+                "prev_bg" => Some(style.bg(RefColor::PrevBg)),
+
+                "next_fg" if col_fg => Some(style.fg(RefColor::NextFg)),
+                "next_fg" => Some(style.bg(RefColor::NextFg)),
+
+                "next_bg" if col_fg => Some(style.fg(RefColor::NextBg)),
+                "next_bg" => Some(style.bg(RefColor::NextBg)),
 
                 // When the string is supposed to be a color:
                 // Decide if we yield none, reset background or set color.
@@ -915,7 +966,7 @@ mod tests {
             .on(Color::Red);
 
         assert_eq!(
-            both_prevfg.to_ansi_style(Some(&prev_style)),
+            both_prevfg.to_ansi_style(Some(StyleRefs::new(Some(prev_style), None))),
             AnsiStyle::new()
                 .fg(Color::Red)
                 .on(Color::Yellow)
@@ -928,7 +979,7 @@ mod tests {
             .unwrap()
             .0;
         assert_eq!(
-            fg_prev_fg.to_ansi_style(Some(&prev_style)),
+            fg_prev_fg.to_ansi_style(Some(StyleRefs::new(Some(prev_style), None))),
             AnsiStyle::new().fg(Color::Yellow)
         );
 
@@ -936,7 +987,7 @@ mod tests {
             .unwrap()
             .0;
         assert_eq!(
-            fg_prev_bg.to_ansi_style(Some(&prev_style)),
+            fg_prev_bg.to_ansi_style(Some(StyleRefs::new(Some(prev_style), None))),
             AnsiStyle::new().fg(Color::Red)
         );
 
@@ -944,7 +995,7 @@ mod tests {
             .unwrap()
             .0;
         assert_eq!(
-            bg_prev_fg.to_ansi_style(Some(&prev_style)),
+            bg_prev_fg.to_ansi_style(Some(StyleRefs::new(Some(prev_style), None))),
             AnsiStyle::new().on(Color::Yellow)
         );
 
@@ -952,8 +1003,68 @@ mod tests {
             .unwrap()
             .0;
         assert_eq!(
-            bg_prev_bg.to_ansi_style(Some(&prev_style)),
+            bg_prev_bg.to_ansi_style(Some(StyleRefs::new(Some(prev_style), None))),
             AnsiStyle::new().on(Color::Red)
+        );
+    }
+
+    #[test]
+    fn table_get_styles_next() {
+        // Test that next has no effect when there is no next style
+        let both_next = <StyleWrapper>::from_config(&Value::from(
+            "bold fg:black fg:next_bg bg:next_fg underline",
+        ))
+        .unwrap()
+        .0;
+
+        assert_eq!(
+            both_next.to_ansi_style(None),
+            AnsiStyle::default().fg(Color::Black).bold().underline()
+        );
+
+        // But if there is a style on the next string, then use that
+        let next_style = AnsiStyle::new().underline().fg(Color::Blue).on(Color::Cyan);
+
+        assert_eq!(
+            both_next.to_ansi_style(Some(StyleRefs::new(None, Some(next_style)))),
+            AnsiStyle::new()
+                .fg(Color::Cyan)
+                .on(Color::Blue)
+                .bold()
+                .underline()
+        );
+
+        // Test that all the combinations of next colors work
+        let fg_next_fg = <StyleWrapper>::from_config(&Value::from("fg:next_fg"))
+            .unwrap()
+            .0;
+        assert_eq!(
+            fg_next_fg.to_ansi_style(Some(StyleRefs::new(None, Some(next_style)))),
+            AnsiStyle::new().fg(Color::Blue)
+        );
+
+        let fg_next_bg = <StyleWrapper>::from_config(&Value::from("fg:next_bg"))
+            .unwrap()
+            .0;
+        assert_eq!(
+            fg_next_bg.to_ansi_style(Some(StyleRefs::new(None, Some(next_style)))),
+            AnsiStyle::new().fg(Color::Cyan)
+        );
+
+        let bg_next_fg = <StyleWrapper>::from_config(&Value::from("bg:next_fg"))
+            .unwrap()
+            .0;
+        assert_eq!(
+            bg_next_fg.to_ansi_style(Some(StyleRefs::new(None, Some(next_style)))),
+            AnsiStyle::new().on(Color::Blue)
+        );
+
+        let bg_next_bg = <StyleWrapper>::from_config(&Value::from("bg:next_bg"))
+            .unwrap()
+            .0;
+        assert_eq!(
+            bg_next_bg.to_ansi_style(Some(StyleRefs::new(None, Some(next_style)))),
+            AnsiStyle::new().on(Color::Cyan)
         );
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -334,16 +334,27 @@ impl Style {
     pub fn to_ansi_style(&self, ref_styles: Option<StyleRefs>) -> AnsiStyle {
         let mut current = self.style;
 
-        if let Some(prev_color) = self.bg
+        if let Some(ref_color) = self.bg
             && let Some(s) = ref_styles
         {
-            current.background = s.to_ansi_style(prev_color);
+            let should_apply = match ref_color {
+                RefColor::PrevFg | RefColor::PrevBg => s.prev().is_some(),
+                RefColor::NextFg | RefColor::NextBg => s.next().is_some(),
+            };
+            if should_apply {
+                current.background = s.to_ansi_style(ref_color);
+            }
         }
-
-        if let Some(prev_color) = self.fg
+        if let Some(ref_color) = self.fg
             && let Some(s) = ref_styles
         {
-            current.foreground = s.to_ansi_style(prev_color);
+            let should_apply = match ref_color {
+                RefColor::PrevFg | RefColor::PrevBg => s.prev().is_some(),
+                RefColor::NextFg | RefColor::NextBg => s.next().is_some(),
+            };
+            if should_apply {
+                current.foreground = s.to_ansi_style(ref_color);
+            }
         }
 
         current

--- a/src/formatter/string_formatter.rs
+++ b/src/formatter/string_formatter.rs
@@ -460,6 +460,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::StyleRefs;
     use nu_ansi_term::Color;
 
     // match_next(result: IterMut<Segment>, value, style)
@@ -758,9 +759,26 @@ mod tests {
         let prev_style = first_ansi.style_ref();
 
         // Second segment: should inherit bg from first
-        let second_ansi = result[1].ansi_string(Some(prev_style));
+        let second_ansi = result[1].ansi_string(Some(StyleRefs::new(Some(*prev_style), None)));
         assert_eq!(
             second_ansi.style_ref().background,
+            Some(nu_ansi_term::Color::Rgb(154, 52, 142))
+        );
+    }
+
+    #[test]
+    fn test_empty_textgroup_propagates_next_bg() {
+        const FORMAT_STR: &str = "[X](bg:next_bg)[](bg:#9A348E)";
+
+        let formatter = StringFormatter::new(FORMAT_STR).unwrap();
+        let result = formatter.parse(None, None).unwrap();
+
+        assert_eq!(result.len(), 2);
+
+        let next_style = result[1].style();
+        let first_ansi = result[0].ansi_string(Some(StyleRefs::new(None, next_style)));
+        assert_eq!(
+            first_ansi.style_ref().background,
             Some(nu_ansi_term::Color::Rgb(154, 52, 142))
         );
     }

--- a/src/module.rs
+++ b/src/module.rs
@@ -256,11 +256,12 @@ where
 
         let wanted_len = fill_size.map(|s| s + fill_slack);
         prev_style = strs.last().map(|s| *s.style_ref());
-        let next_style = chunk_iter
-            .peek()
-            .and_then(|(s, _)| s.first().map(|s| *s.style_ref()))
+        let next_style = if let Some((s, _)) = chunk_iter.peek() {
+            s.first().map(|s| *s.style_ref())
+        } else {
             // For the last fill there is no next chunk; the trailing text is in `current`.
-            .or_else(|| current.first().map(|s| *s.style_ref()));
+            current.first().map(|s| *s.style_ref())
+        };
         let style_refs = StyleRefs::new(prev_style, next_style);
 
         let (fill_string, actual_len) = fill.ansi_string_with_width(wanted_len, Some(style_refs));

--- a/src/module.rs
+++ b/src/module.rs
@@ -1,7 +1,9 @@
+use crate::config::StyleRefs;
 use crate::segment;
 use crate::segment::{FillSegment, Segment};
 use nu_ansi_term::{AnsiString, AnsiStrings, Style as AnsiStyle};
 use std::fmt;
+use std::iter::Peekable;
 use std::time::Duration;
 
 // List of all modules
@@ -200,7 +202,7 @@ impl fmt::Display for Module<'_> {
     }
 }
 
-fn ansi_line<'a, I>(segments: &mut I, term_width: Option<usize>) -> Vec<AnsiString<'a>>
+fn ansi_line<'a, I>(segments: &mut Peekable<I>, term_width: Option<usize>) -> Vec<AnsiString<'a>>
 where
     I: Iterator<Item = &'a Segment>,
 {
@@ -209,7 +211,7 @@ where
     let mut chunks: Vec<(Vec<AnsiString>, &FillSegment)> = Vec::new();
     let mut prev_style: Option<AnsiStyle> = None;
 
-    for segment in segments {
+    while let Some(segment) = segments.next() {
         match segment {
             Segment::Fill(fs) => {
                 chunks.push((current, fs));
@@ -218,7 +220,10 @@ where
             }
             _ => {
                 used += segment.width_graphemes();
-                let current_segment_string = segment.ansi_string(prev_style.as_ref());
+                let next_style = segments.peek().and_then(|s| s.style());
+
+                let style_refs = StyleRefs::new(prev_style, next_style);
+                let current_segment_string = segment.ansi_string(Some(style_refs));
 
                 prev_style = Some(*current_segment_string.style_ref());
                 current.push(current_segment_string);
@@ -231,28 +236,50 @@ where
     }
 
     if chunks.is_empty() {
-        current
-    } else {
-        let fill_size = term_width
-            .and_then(|tw| if tw > used { Some(tw - used) } else { None })
-            .map(|remaining| remaining / chunks.len());
-        chunks
-            .into_iter()
-            .flat_map(|(strs, fill)| {
-                let fill_string = fill.ansi_string(
-                    fill_size,
-                    strs.last().map(nu_ansi_term::AnsiGenericString::style_ref),
-                );
-                strs.into_iter().chain(std::iter::once(fill_string))
-            })
-            .chain(current)
-            .collect::<Vec<AnsiString>>()
+        return current;
     }
+
+    let (fill_size, mut fill_remainder) = term_width
+        .and_then(|tw| if tw > used { Some(tw - used) } else { None })
+        .map(|remaining| (Some(remaining / chunks.len()), remaining % chunks.len()))
+        .unwrap_or((None, 0));
+    let mut fill_slack = 0usize;
+
+    let mut chunk_iter = chunks.iter_mut().peekable();
+    let mut output = Vec::new();
+
+    while let Some((strs, fill)) = chunk_iter.next() {
+        if fill_remainder > 0 {
+            fill_remainder -= 1;
+            fill_slack += 1;
+        }
+
+        let wanted_len = fill_size.map(|s| s + fill_slack);
+        prev_style = strs.last().map(|s| *s.style_ref());
+        let next_style = chunk_iter
+            .peek()
+            .and_then(|(s, _)| s.first().map(|s| *s.style_ref()))
+            // For the last fill there is no next chunk; the trailing text is in `current`.
+            .or_else(|| current.first().map(|s| *s.style_ref()));
+        let style_refs = StyleRefs::new(prev_style, next_style);
+
+        let (fill_string, actual_len) = fill.ansi_string_with_width(wanted_len, Some(style_refs));
+        output.extend_from_slice(strs);
+        output.extend_from_slice(&fill_string);
+
+        fill_slack = wanted_len.map_or(0, |w| w.saturating_sub(actual_len));
+    }
+    // `current` stores the non-fill tail after the last fill segment.
+    output.extend(current);
+    output
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::parse_style_string;
+    use crate::print::UnicodeWidthGraphemes;
+    use nu_ansi_term::Color;
 
     #[test]
     fn test_all_modules_is_in_alphabetical_order() {
@@ -319,5 +346,73 @@ mod tests {
         };
 
         assert!(!module.is_empty());
+    }
+
+    #[test]
+    fn test_fill_segment_resolves_next_style_from_trailing_text() {
+        let mut module = Module::new("unit_test", "This is a unit test", None);
+        module.set_segments(vec![
+            Segment::from_text(parse_style_string("fg:red", None), "A")
+                .into_iter()
+                .next()
+                .unwrap(),
+            Segment::fill(parse_style_string("fg:next_bg", None), "."),
+            Segment::from_text(parse_style_string("bg:blue", None), "B")
+                .into_iter()
+                .next()
+                .unwrap(),
+        ]);
+
+        // width=6, "A"(1)+"B"(1)=2 used, fill gets 4 dots.
+        // fill uses fg:next_bg; next segment has bg:blue → fill renders in blue fg.
+        let rendered = module.ansi_strings_for_width(Some(6));
+        let combined = AnsiStrings(&rendered).to_string();
+        let expected = AnsiStrings(&[
+            Color::Red.paint("A"),
+            Color::Blue.paint("...."),
+            nu_ansi_term::Style::new().on(Color::Blue).paint("B"),
+        ])
+        .to_string();
+        assert_eq!(combined, expected);
+    }
+
+    #[test]
+    fn test_fill_remainder_is_distributed_to_leading_fills() {
+        let mut module = Module::new("unit_test", "This is a unit test", None);
+        module.set_segments(vec![
+            Segment::from_text(None, "L").into_iter().next().unwrap(),
+            Segment::fill(None, "."),
+            Segment::from_text(None, "M").into_iter().next().unwrap(),
+            Segment::fill(None, "."),
+            Segment::from_text(None, "R").into_iter().next().unwrap(),
+        ]);
+
+        // width=12, used=3, remaining=9, two fills → base_size=4, remainder=1.
+        // fill1 gets the extra cell first: 5; fill2 gets 4.
+        let rendered = module.ansi_strings_for_width(Some(12));
+        let combined = AnsiStrings(&rendered).to_string();
+        assert_eq!(combined, "L.....M....R");
+        assert_eq!(combined.width_graphemes(), 12);
+    }
+
+    #[test]
+    fn test_fill_slack_is_carried_to_following_fill_segments() {
+        let mut module = Module::new("unit_test", "This is a unit test", None);
+        module.set_segments(vec![
+            Segment::from_text(None, "L").into_iter().next().unwrap(),
+            Segment::fill(None, "🟦"),
+            Segment::from_text(None, "M").into_iter().next().unwrap(),
+            Segment::fill(None, "🟦"),
+            Segment::from_text(None, "R").into_iter().next().unwrap(),
+        ]);
+
+        // width=10, "L"+"M"+"R"=3 used, remaining=7, two fills → fill_size=3, fill_remainder=1.
+        // fill1 gets the extra remainder cell: wants 4 → 🟦🟦 (4).
+        // fill2 gets base only: wants 3 → 🟦 (2 used, 1 wasted at end).
+        // Result: "L🟦🟦M🟦R" with total width 9.
+        let rendered = module.ansi_strings_for_width(Some(10));
+        let combined = AnsiStrings(&rendered).to_string();
+        assert_eq!(combined, "L🟦🟦M🟦R");
+        assert_eq!(combined.width_graphemes(), 9);
     }
 }

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -1,5 +1,5 @@
 use crate::{
-    config::Style,
+    config::{Style, StyleRefs},
     print::{Grapheme, UnicodeWidthGraphemes},
 };
 use nu_ansi_term::{AnsiString, Style as AnsiStyle};
@@ -17,9 +17,9 @@ pub struct TextSegment {
 
 impl TextSegment {
     // Returns the AnsiString of the segment value
-    fn ansi_string(&self, prev: Option<&AnsiStyle>) -> AnsiString<'_> {
+    fn ansi_string(&self, style_refs: Option<StyleRefs>) -> AnsiString<'_> {
         match self.style {
-            Some(style) => style.to_ansi_style(prev).paint(&self.value),
+            Some(style) => style.to_ansi_style(style_refs).paint(&self.value),
             None => AnsiString::from(&self.value),
         }
     }
@@ -37,30 +37,80 @@ pub struct FillSegment {
 
 impl FillSegment {
     // Returns the AnsiString of the segment value, not including its prefix and suffix
-    pub fn ansi_string(&self, width: Option<usize>, prev: Option<&AnsiStyle>) -> AnsiString<'_> {
-        let s = match width {
-            Some(w) => self
-                .value
-                .graphemes(true)
+    pub fn ansi_string(
+        &self,
+        width: Option<usize>,
+        style_refs: Option<StyleRefs>,
+    ) -> Vec<AnsiString<'_>> {
+        self.ansi_string_with_width(width, style_refs).0
+    }
+
+    // Returns the AnsiString of the segment value, not including its prefix and suffix, and the width of the resulting string
+    pub fn ansi_string_with_width(
+        &self,
+        width: Option<usize>,
+        style_refs: Option<StyleRefs>,
+    ) -> (Vec<AnsiString<'_>>, usize) {
+        let values_with_width = self
+            .value
+            .graphemes(true)
+            .map(|g| {
+                let w = Grapheme(g).width();
+                (g, w)
+            })
+            .collect::<Vec<(&str, usize)>>();
+        let mut len = 0;
+        let graphemes = match width {
+            Some(total_w) => values_with_width
+                .into_iter()
                 .cycle()
-                .scan(0usize, |len, g| {
-                    *len += Grapheme(g).width();
-                    if *len <= w { Some(g) } else { None }
+                .take_while(|(_, grapheme_width)| {
+                    if len + grapheme_width <= total_w {
+                        len += grapheme_width;
+                        true
+                    } else {
+                        false
+                    }
                 })
-                .collect::<String>(),
-            None => String::from(&self.value),
+                .collect::<Vec<(&str, usize)>>(),
+            None => {
+                len = values_with_width.iter().map(|(_, w)| *w).sum::<usize>();
+                values_with_width
+            }
         };
-        match self.style {
-            Some(style) => style.to_ansi_style(prev).paint(s),
-            None => AnsiString::from(s),
-        }
+
+        let s = graphemes.iter().map(|(g, _)| *g).collect::<String>();
+        let output = match self.style {
+            Some(style) if !style.has_ref_color() || style_refs.is_none() => {
+                let ansi_style = style.to_ansi_style(style_refs);
+                vec![ansi_style.paint(s)]
+            }
+            Some(style) => {
+                graphemes
+                    .iter()
+                    .scan(style_refs, |style_ref_cursor, (g, _)| {
+                        let ansi_style = style.to_ansi_style(*style_ref_cursor);
+
+                        // Update the cursor for the next grapheme.
+                        *style_ref_cursor =
+                            style_ref_cursor.map(|refs| refs.with_prev(Some(ansi_style)));
+
+                        Some(ansi_style.paint(*g))
+                    })
+                    .collect()
+            }
+            None => vec![AnsiString::from(s)],
+        };
+        (output, len)
     }
 }
 
 #[cfg(test)]
 mod fill_seg_tests {
     use super::FillSegment;
-    use nu_ansi_term::Color;
+    use crate::config::{StyleRefs, parse_style_string};
+    use nu_ansi_term::Style as AnsiStyle;
+    use nu_ansi_term::{AnsiStrings, Color};
 
     #[test]
     fn ansi_string_width() {
@@ -81,8 +131,134 @@ mod fill_seg_tests {
                 style: Some(style.into()),
             };
             let actual = f.ansi_string(Some(width), None);
-            assert_eq!(style.paint(*expected), actual);
+            let actual_combined = AnsiStrings(&actual).to_string();
+            assert_eq!(style.paint(*expected).to_string(), actual_combined);
         }
+    }
+
+    #[test]
+    fn ansi_string_with_refs_uses_next_style_for_single_grapheme() {
+        let fill = FillSegment {
+            value: ".".to_string(),
+            style: parse_style_string("fg:next_bg", None),
+        };
+
+        let refs = StyleRefs::new(
+            Some(AnsiStyle::new().fg(Color::Red).on(Color::Yellow)),
+            Some(AnsiStyle::new().fg(Color::Blue).on(Color::Cyan)),
+        );
+
+        let rendered = fill.ansi_string(Some(1), Some(refs));
+        assert_eq!(
+            rendered
+                .last()
+                .and_then(|s| Some(s.style_ref().foreground))
+                .flatten(),
+            Some(Color::Cyan)
+        );
+    }
+
+    #[test]
+    fn ansi_string_with_refs_keeps_last_grapheme_connected_to_next_style() {
+        let fill = FillSegment {
+            value: ".".to_string(),
+            style: parse_style_string("fg:prev_fg bg:next_fg", None),
+        };
+
+        let refs = StyleRefs::new(
+            Some(AnsiStyle::new().fg(Color::Red)),
+            Some(AnsiStyle::new().fg(Color::Blue)),
+        );
+
+        let rendered = fill.ansi_string(Some(2), Some(refs));
+        assert_eq!(
+            rendered
+                .last()
+                .and_then(|s| Some(s.style_ref().foreground))
+                .flatten(),
+            Some(Color::Red)
+        );
+        assert_eq!(
+            rendered
+                .last()
+                .and_then(|s| Some(s.style_ref().background))
+                .flatten(),
+            Some(Color::Blue)
+        );
+    }
+
+    #[test]
+    fn ansi_string_with_refs_applies_fill_striping() {
+        let fill = FillSegment {
+            value: ".:".to_string(),
+            style: parse_style_string("fg:prev_fg", None),
+        };
+
+        let refs = StyleRefs::new(
+            Some(AnsiStyle::new().fg(Color::Red)),
+            Some(AnsiStyle::new().fg(Color::Blue)),
+        );
+
+        let rendered = fill.ansi_string(Some(4), Some(refs));
+        let rendered_str = AnsiStrings(&rendered).to_string();
+
+        let expected = AnsiStyle::new().fg(Color::Red).paint(".:.:").to_string();
+
+        assert_eq!(rendered_str, expected);
+    }
+
+    #[test]
+    fn ansi_string_with_refs_striping_handles_odd_width_tail() {
+        let fill = FillSegment {
+            value: ".:".to_string(),
+            style: parse_style_string("fg:next_fg", None),
+        };
+
+        let refs = StyleRefs::new(
+            Some(AnsiStyle::new().fg(Color::Red)),
+            Some(AnsiStyle::new().fg(Color::Blue)),
+        );
+
+        let rendered = fill.ansi_string(Some(3), Some(refs));
+        let rendered_str = AnsiStrings(&rendered).to_string();
+
+        // The last grapheme should stay connected to the base next style.
+        let expected = AnsiStyle::new().fg(Color::Blue).paint(".:.").to_string();
+
+        assert_eq!(rendered_str, expected);
+    }
+
+    #[test]
+    fn ansi_string_with_refs_next_only_without_next_style_falls_back_cleanly() {
+        let fill = FillSegment {
+            value: ".:".to_string(),
+            style: parse_style_string("fg:next_fg", None),
+        };
+
+        let rendered = fill.ansi_string(Some(4), Some(StyleRefs::new(None, None)));
+
+        assert_eq!(
+            rendered
+                .last()
+                .and_then(|s| Some(s.style_ref().foreground))
+                .flatten(),
+            None
+        );
+    }
+
+    #[test]
+    fn ansi_string_with_refs_uses_self_for_missing_next_until_last_grapheme() {
+        let fill = FillSegment {
+            value: ".:".to_string(),
+            style: parse_style_string("bg:next_bg", None),
+        };
+
+        let refs = StyleRefs::new(Some(AnsiStyle::new().on(Color::Red)), None);
+        let rendered = fill.ansi_string(Some(2), Some(refs));
+        let rendered_str = AnsiStrings(&rendered).to_string();
+
+        let expected = ".:";
+        assert_eq!(rendered_str, expected);
     }
 }
 
@@ -157,10 +333,15 @@ impl Segment {
     }
 
     // Returns the AnsiString of the segment value, not including its prefix and suffix
-    pub fn ansi_string(&self, prev: Option<&AnsiStyle>) -> AnsiString<'_> {
+    pub fn ansi_string(&self, style_refs: Option<StyleRefs>) -> AnsiString<'_> {
         match self {
-            Self::Fill(fs) => fs.ansi_string(None, prev),
-            Self::Text(ts) => ts.ansi_string(prev),
+            Self::Fill(fs) => AnsiString::from(
+                fs.ansi_string(None, style_refs)
+                    .into_iter()
+                    .map(|s| s.to_string())
+                    .collect::<String>(),
+            ),
+            Self::Text(ts) => ts.ansi_string(style_refs),
             Self::LineTerm => AnsiString::from(LINE_TERMINATOR_STRING),
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

>  Add ability to reference next modules' foreground and background. Useful to make a spacer seperating 2 modules, merging the style of both.

I also added some changes to `$fill` handling. Unlike #7381 next-segment styles are only read one-step ahead.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #7381
Closes #5059

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
