### PR TITLE
feat(prompt): add OSC 133 semantic prompt support

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -35,6 +35,10 @@
       "type": "boolean",
       "default": true
     },
+    "osc_133": {
+      "type": "boolean",
+      "default": false
+    },
     "follow_symlinks": {
       "type": "boolean",
       "default": true

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -210,20 +210,26 @@ This is the list of prompt-wide configuration options.
 
 ### Options
 
-| Option            | Default                        | Description                                                                                                                                                                        |
-| ----------------- | ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `format`          | [link](#default-prompt-format) | Configure the format of the prompt.                                                                                                                                                |
-| `right_format`    | `''`                           | See [Enable Right Prompt](../advanced-config/#enable-right-prompt)                                                                                                                 |
-| `scan_timeout`    | `30`                           | Timeout for starship to scan files (in milliseconds).                                                                                                                              |
-| `command_timeout` | `500`                          | Timeout for commands executed by starship (in milliseconds).                                                                                                                       |
-| `add_newline`     | `true`                         | Inserts blank line between shell prompts.                                                                                                                                          |
-| `palette`         | `''`                           | Sets which color palette from `palettes` to use.                                                                                                                                   |
-| `palettes`        | `{}`                           | Collection of color palettes that assign [colors](../advanced-config/#style-strings) to user-defined names. Note that color palettes cannot reference their own color definitions. |
-| `follow_symlinks` | `true`                         | Follows symlinks to check if they're directories; used in modules such as git.                                                                                                     |
+| Option            | Default                        | Description                                                                                                                                                                                                      |
+| ----------------- | ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `format`          | [link](#default-prompt-format) | Configure the format of the prompt.                                                                                                                                                                              |
+| `right_format`    | `''`                           | See [Enable Right Prompt](../advanced-config/#enable-right-prompt)                                                                                                                                               |
+| `scan_timeout`    | `30`                           | Timeout for starship to scan files (in milliseconds).                                                                                                                                                            |
+| `command_timeout` | `500`                          | Timeout for commands executed by starship (in milliseconds).                                                                                                                                                     |
+| `add_newline`     | `true`                         | Inserts blank line between shell prompts.                                                                                                                                                                        |
+| `osc_133`         | `false`                        | Emit [OSC 133](https://gitlab.freedesktop.org/Per_Bothner/specifications/-/blob/master/proposals/semantic-prompts.md) semantic-prompt escape sequences (A/B/D from the prompt). |
+| `palette`         | `''`                           | Sets which color palette from `palettes` to use.                                                                                                                                                                 |
+| `palettes`        | `{}`                           | Collection of color palettes that assign [colors](../advanced-config/#style-strings) to user-defined names. Note that color palettes cannot reference their own color definitions.                               |
+| `follow_symlinks` | `true`                         | Follows symlinks to check if they're directories; used in modules such as git.                                                                                                                                   |
 
 > [!TIP]
 > If you have symlinks to networked filesystems, consider setting
 > `follow_symlinks` to `false`.
+
+> [!NOTE]
+> `osc_133` is read at `starship init <shell>` time, so re-source your
+> shell after toggling it. The `C` (start of command output) marker is
+> not supported.
 
 ### Example
 

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -25,6 +25,7 @@ pub struct StarshipRootConfig {
     pub scan_timeout: u64,
     pub command_timeout: u64,
     pub add_newline: bool,
+    pub osc_133: bool,
     pub follow_symlinks: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub palette: Option<String>,
@@ -162,6 +163,7 @@ impl Default for StarshipRootConfig {
             scan_timeout: 30,
             command_timeout: 500,
             add_newline: true,
+            osc_133: false,
             follow_symlinks: true,
             palette: None,
             palettes: HashMap::default(),

--- a/src/print.rs
+++ b/src/print.rs
@@ -109,6 +109,21 @@ pub fn get_prompt(context: &Context) -> String {
         buf.push_str("\x1b[J"); // An ASCII control code to clear screen
     }
 
+    // OSC 133 semantic prompt: emit a D (command-finished, with exit status when
+    // available) followed by A (prompt start). The matching B (prompt end / input
+    // start) is appended later, after the prompt body. Right prompts are skipped
+    // since they don't represent the input cursor location.
+    if config.osc_133 && context.target != Target::Right {
+        if let Some(status) = context.properties.status_code.as_deref() {
+            buf.push_str(&osc_133_seq(&format!("D;{status}"), context.shell));
+        }
+        let a_args = match context.target {
+            Target::Continuation => "A;k=s",
+            _ => "A",
+        };
+        buf.push_str(&osc_133_seq(a_args, context.shell));
+    }
+
     let (formatter, modules) = load_formatter_and_modules(context);
 
     let formatter = formatter.map_variables_to_segments(|module| {
@@ -165,7 +180,24 @@ pub fn get_prompt(context: &Context) -> String {
         buf = buf.replace('\n', " \\n");
     }
 
+    // OSC 133;B marks the end of the prompt / start of user input.
+    if config.osc_133 && context.target != Target::Right {
+        buf.push_str(&osc_133_seq("B", context.shell));
+    }
+
     buf
+}
+
+/// Build an OSC 133 escape sequence with shell-appropriate wrappers so that the
+/// non-printing bytes don't confuse the shell's prompt width calculation. See
+/// https://gitlab.freedesktop.org/Per_Bothner/specifications/-/blob/master/proposals/semantic-prompts.md
+fn osc_133_seq(args: &str, shell: Shell) -> String {
+    let (beg, end) = match shell {
+        Shell::Bash => ("\\[", "\\]"),
+        Shell::Zsh | Shell::Tcsh => ("%{", "%}"),
+        _ => ("", ""),
+    };
+    format!("{beg}\x1b]133;{args}\x07{end}")
 }
 
 pub fn module(module_name: &str, args: Properties) {
@@ -670,6 +702,119 @@ mod test {
         context.target = Target::Continuation;
 
         let expected = String::from("><>");
+        let actual = get_prompt(&context);
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn osc_133_main_prompt() {
+        let mut context = default_context().set_config(toml::toml! {
+                add_newline = false
+                osc_133 = true
+                format = "$character"
+                [character]
+                format = ">"
+        });
+        context.target = Target::Main;
+
+        let expected = "\x1b]133;A\x07>\x1b]133;B\x07";
+        let actual = get_prompt(&context);
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn osc_133_main_prompt_with_status() {
+        let mut context = default_context().set_config(toml::toml! {
+                add_newline = false
+                osc_133 = true
+                format = "$character"
+                [character]
+                format = ">"
+        });
+        context.target = Target::Main;
+        context.properties.status_code = Some("0".to_string());
+
+        let expected = "\x1b]133;D;0\x07\x1b]133;A\x07>\x1b]133;B\x07";
+        let actual = get_prompt(&context);
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn osc_133_continuation_prompt() {
+        let mut context = default_context().set_config(toml::toml! {
+                osc_133 = true
+                continuation_prompt = "><>"
+        });
+        context.target = Target::Continuation;
+
+        let expected = "\x1b]133;A;k=s\x07><>\x1b]133;B\x07";
+        let actual = get_prompt(&context);
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn osc_133_right_prompt_is_skipped() {
+        let mut context = default_context().set_config(toml::toml! {
+                osc_133 = true
+                right_format = "$character"
+                [character]
+                format = ">"
+        });
+        context.target = Target::Right;
+        context.properties.status_code = Some("0".to_string());
+
+        let expected = ">";
+        let actual = get_prompt(&context);
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn osc_133_disabled_emits_no_sequences() {
+        let mut context = default_context().set_config(toml::toml! {
+                add_newline = false
+                format = "$character"
+                [character]
+                format = ">"
+        });
+        context.target = Target::Main;
+        context.properties.status_code = Some("0".to_string());
+
+        let expected = ">";
+        let actual = get_prompt(&context);
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn osc_133_bash_wraps_sequence() {
+        let mut context = default_context().set_config(toml::toml! {
+                add_newline = false
+                osc_133 = true
+                format = "$character"
+                [character]
+                format = ">"
+        });
+        context.target = Target::Main;
+        context.shell = Shell::Bash;
+        context.properties.status_code = Some("0".to_string());
+
+        let expected = "\\[\x1b]133;D;0\x07\\]\\[\x1b]133;A\x07\\]>\\[\x1b]133;B\x07\\]";
+        let actual = get_prompt(&context);
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn osc_133_zsh_wraps_sequence() {
+        let mut context = default_context().set_config(toml::toml! {
+                add_newline = false
+                osc_133 = true
+                format = "$character"
+                [character]
+                format = ">"
+        });
+        context.target = Target::Main;
+        context.shell = Shell::Zsh;
+
+        let expected = "%{\x1b]133;A\x07%}>%{\x1b]133;B\x07%}";
         let actual = get_prompt(&context);
         assert_eq!(expected, actual);
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
 Adds OSC 133 (semantic prompts) emission, gated behind a new top-level `osc_133` config option (default `false`).

When enabled, `starship prompt` emits:
 - `OSC 133;D;<exit>` - previous command finished, with exit status (when known)
 - `OSC 133;A` - prompt start (`A;k=s` for continuation prompts)
 - `OSC 133;B` - end of prompt / start of user input

~and the bash/zsh/fish init scripts emit `OSC 133;C` from their preexec hooks to mark the start of command output. The bash 4.4+ PS0 fallback path (which bypasses `starship_preexec`) injects the C marker directly into `PS0`.~ (dropped as requested)

Sequences are wrapped in `\[\]` / `%{%}` for bash / zsh / tcsh so width calculation stays correct (the issue that broke #3018 and #5381). `Target::Right` is skipped since the right prompt isn't the input cursor position. The `osc_133` flag is read at `starship init <shell>` time, so users need to re-source their shell after flipping it.

Other shells (powershell, nu, elvish, ion, tcsh, xonsh, cmd) don't get the C marker in this PR - their preexec story varies and is left for a follow-up. They still get A/B/D from `starship prompt`.

Per @WhyNotHugo's suggestion in the issue, the A/B/D logic lives in the prompt renderer, not in shell init scripts.


#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Modern terminals (VS Code, iTerm2, kitty, WezTerm, Windows Terminal, foot, KDE Konsole, ...) use OSC 133 to enable prompt-to-prompt navigation, click-to-position cursor in the input area, exit-status indicators in the gutter, and selecting command output as a unit.

Closes #5463

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.

#### AI-Assistance

Per the AI Policy proposed in #7481.

- [x] Yes
- [ ] No

Scope: Claude Code (Opus) was used for implementation drafting, test authoring, and explaining the OSC 133 spec / shell-escape semantics. The design (where to emit each marker, scope of C in this PR, deferral of non-preexec shells) and the structural feedback were human-directed. I have read every line of the diff and can explain each escape sequence, the shell wrapping (`\[\]` / `%{%}`), and the bash PS0 prompt-escape form (`\[\e]133;C\a\]`).


