### PR TITLE
feat(aspire): add module for Aspire CLI

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -64,6 +64,21 @@
         "claude-code": "$claude_model$git_branch$claude_context$claude_cost"
       }
     },
+    "aspire": {
+      "$ref": "#/$defs/AspireConfig",
+      "default": {
+        "format": "via [$symbol($version )]($style)",
+        "version_format": "v${raw}",
+        "symbol": "▲ ",
+        "style": "bold purple",
+        "disabled": false,
+        "detect_extensions": [],
+        "detect_files": [
+          "aspire.config.json"
+        ],
+        "detect_folders": []
+      }
+    },
     "aws": {
       "$ref": "#/$defs/AwsConfig",
       "default": {
@@ -1929,6 +1944,55 @@
   },
   "additionalProperties": false,
   "$defs": {
+    "AspireConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "type": "string",
+          "default": "via [$symbol($version )]($style)"
+        },
+        "version_format": {
+          "type": "string",
+          "default": "v${raw}"
+        },
+        "symbol": {
+          "type": "string",
+          "default": "▲ "
+        },
+        "style": {
+          "type": "string",
+          "default": "bold purple"
+        },
+        "disabled": {
+          "type": "boolean",
+          "default": false
+        },
+        "detect_extensions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        },
+        "detect_files": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "aspire.config.json"
+          ]
+        },
+        "detect_folders": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        }
+      },
+      "additionalProperties": false
+    },
     "AwsConfig": {
       "title": "AWS",
       "description": "The `aws` module shows the current AWS region and profile and an expiration timer when using temporary credentials.\nThe output of the module uses the `AWS_REGION`, `AWS_DEFAULT_REGION`, and `AWS_PROFILE` env vars and the `~/.aws/config` and `~/.aws/credentials` files as required.\n\nThe module will display a profile only if its credentials are present in `~/.aws/credentials` or if a `credential_process` or `sso_start_url` are defined in `~/.aws/config`. Alternatively, having any of the `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, or `AWS_SESSION_TOKEN` env vars defined will also suffice.\nIf the option `force_display` is set to `true`, all available information will be displayed even if no credentials per the conditions above are detected.\n\nWhen using [aws-vault](https://github.com/99designs/aws-vault) the profile\nis read from the `AWS_VAULT` env var and the credentials expiration date\nis read from the `AWS_SESSION_EXPIRATION` or `AWS_CREDENTIAL_EXPIRATION`\nvar.\n\nWhen using [awsu](https://github.com/kreuzwerker/awsu) the profile\nis read from the `AWSU_PROFILE` env var.\n\nWhen using [`AWSume`](https://awsu.me) the profile\nis read from the `AWSUME_PROFILE` env var and the credentials expiration\ndate is read from the `AWSUME_EXPIRATION` env var.\n\nWhen using [aws-sso-cli](https://github.com/synfinatic/aws-sso-cli) the profile\nis read from the `AWS_SSO_PROFILE` env var.",

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -373,6 +373,45 @@ modules you explicitly add to the format will not be duplicated. Eg.
 format = '$all$directory$character'
 ```
 
+## Aspire
+
+The `aspire` module shows the currently installed version of the [.NET Aspire](https://github.com/dotnet/aspire) CLI.
+By default the module will be shown if any of the following conditions are met:
+
+- The current directory contains an `aspire.config.json` file
+
+### Options
+
+| Option              | Default                              | Description                                                               |
+| ------------------- | ------------------------------------ | ------------------------------------------------------------------------- |
+| `format`            | `'via [$symbol($version )]($style)'` | The format for the module.                                                |
+| `version_format`    | `'v${raw}'`                          | The version format. Available vars are `raw`, `major`, `minor`, & `patch` |
+| `symbol`            | `'▲ '`                               | A format string representing the symbol of Aspire.                        |
+| `detect_extensions` | `[]`                                 | Which extensions should trigger this module.                              |
+| `detect_files`      | `['aspire.config.json']`             | Which filenames should trigger this module.                               |
+| `detect_folders`    | `[]`                                 | Which folders should trigger this module.                                 |
+| `style`             | `'bold purple'`                      | The style for the module.                                                 |
+| `disabled`          | `false`                              | Disables the `aspire` module.                                             |
+
+### Variables
+
+| Variable | Example   | Description                          |
+| -------- | --------- | ------------------------------------ |
+| version  | `v13.4.0` | The version of `aspire`              |
+| symbol   |           | Mirrors the value of option `symbol` |
+| style\*  |           | Mirrors the value of option `style`  |
+
+*: This variable can only be used as a part of a style string
+
+### Example
+
+```toml
+# ~/.config/starship.toml
+
+[aspire]
+format = 'via [▲ $version](bold purple) '
+```
+
 ## AWS
 
 The `aws` module shows the current AWS region and profile and an expiration timer when using temporary credentials.

--- a/src/configs/aspire.rs
+++ b/src/configs/aspire.rs
@@ -1,0 +1,34 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(
+    feature = "config-schema",
+    derive(schemars::JsonSchema),
+    schemars(deny_unknown_fields)
+)]
+#[serde(default)]
+pub struct AspireConfig<'a> {
+    pub format: &'a str,
+    pub version_format: &'a str,
+    pub symbol: &'a str,
+    pub style: &'a str,
+    pub disabled: bool,
+    pub detect_extensions: Vec<&'a str>,
+    pub detect_files: Vec<&'a str>,
+    pub detect_folders: Vec<&'a str>,
+}
+
+impl Default for AspireConfig<'_> {
+    fn default() -> Self {
+        Self {
+            format: "via [$symbol($version )]($style)",
+            version_format: "v${raw}",
+            symbol: "▲ ",
+            style: "bold purple",
+            disabled: false,
+            detect_extensions: vec![],
+            detect_files: vec!["aspire.config.json"],
+            detect_folders: vec![],
+        }
+    }
+}

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -1,6 +1,7 @@
 use indexmap::IndexMap;
 use serde::{self, Deserialize, Serialize};
 
+pub mod aspire;
 pub mod aws;
 pub mod azure;
 pub mod battery;
@@ -127,6 +128,8 @@ pub struct FullConfig<'a> {
     #[serde(flatten)]
     root: StarshipRootConfig,
     // modules
+    #[serde(borrow)]
+    aspire: aspire::AspireConfig<'a>,
     #[serde(borrow)]
     aws: aws::AwsConfig<'a>,
     #[serde(borrow)]

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -65,6 +65,7 @@ pub const PROMPT_ORDER: &[&str] = &[
     "package",
     // ↓ Toolchain version modules ↓
     // (Let's keep these sorted alphabetically)
+    "aspire",
     "bun",
     "c",
     "cmake",

--- a/src/module.rs
+++ b/src/module.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 // List of all modules
 // Default ordering is handled in configs/starship_root.rs
 pub const ALL_MODULES: &[&str] = &[
+    "aspire",
     "aws",
     "azure",
     #[cfg(feature = "battery")]

--- a/src/modules/aspire.rs
+++ b/src/modules/aspire.rs
@@ -118,9 +118,7 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "via {}",
-            Color::Purple
-                .bold()
-                .paint("▲ v13.4.0-pr.17161.g80e4a73e ")
+            Color::Purple.bold().paint("▲ v13.4.0-pr.17161.g80e4a73e ")
         ));
         assert_eq!(expected, actual);
         dir.close()

--- a/src/modules/aspire.rs
+++ b/src/modules/aspire.rs
@@ -1,0 +1,123 @@
+use super::{Context, Module, ModuleConfig};
+
+use crate::configs::aspire::AspireConfig;
+use crate::formatter::StringFormatter;
+use crate::formatter::VersionFormatter;
+use crate::utils::get_command_string_output;
+
+/// Creates a module with the current Aspire CLI version
+pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let mut module = context.new_module("aspire");
+    let config = AspireConfig::try_load(module.config);
+
+    let is_aspire_project = context
+        .try_begin_scan()?
+        .set_files(&config.detect_files)
+        .set_extensions(&config.detect_extensions)
+        .set_folders(&config.detect_folders)
+        .is_match();
+
+    if !is_aspire_project {
+        return None;
+    }
+
+    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
+        formatter
+            .map_meta(|var, _| match var {
+                "symbol" => Some(config.symbol),
+                _ => None,
+            })
+            .map_style(|variable| match variable {
+                "style" => Some(Ok(config.style)),
+                _ => None,
+            })
+            .map(|variable| match variable {
+                "version" => {
+                    let aspire_version = get_aspire_version(context)?;
+                    VersionFormatter::format_module_version(
+                        module.get_name(),
+                        &aspire_version,
+                        config.version_format,
+                    )
+                    .map(Ok)
+                }
+                _ => None,
+            })
+            .parse(None, Some(context))
+    });
+
+    module.set_segments(match parsed {
+        Ok(segments) => segments,
+        Err(error) => {
+            log::warn!("Error in module `aspire`:\n{error}");
+            return None;
+        }
+    });
+
+    Some(module)
+}
+
+fn get_aspire_version(context: &Context) -> Option<String> {
+    context
+        .exec_cmd("aspire", &["--version"])
+        .map(get_command_string_output)
+        .map(|s| parse_aspire_version(&s))
+}
+
+fn parse_aspire_version(aspire_version: &str) -> String {
+    aspire_version.trim().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test::ModuleRenderer;
+    use nu_ansi_term::Color;
+    use std::fs::File;
+    use std::io;
+
+    #[test]
+    fn folder_without_aspire_files() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        let actual = ModuleRenderer::new("aspire").path(dir.path()).collect();
+        let expected = None;
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn folder_with_aspire_config() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join("aspire.config.json"))?.sync_all()?;
+        let actual = ModuleRenderer::new("aspire")
+            .path(dir.path())
+            .cmd(
+                "aspire --version",
+                Some(crate::utils::CommandOutput {
+                    stdout: String::from("13.4.0-pr.17161.g80e4a73e\n"),
+                    stderr: String::default(),
+                }),
+            )
+            .collect();
+        let expected = Some(format!(
+            "via {}",
+            Color::Purple
+                .bold()
+                .paint("▲ v13.4.0-pr.17161.g80e4a73e ")
+        ));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn no_aspire_installed() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join("aspire.config.json"))?.sync_all()?;
+        let actual = ModuleRenderer::new("aspire")
+            .path(dir.path())
+            .cmd("aspire --version", None)
+            .collect();
+        let expected = Some(format!("via {}", Color::Purple.bold().paint("▲ ")));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+}

--- a/src/modules/aspire.rs
+++ b/src/modules/aspire.rs
@@ -3,7 +3,6 @@ use super::{Context, Module, ModuleConfig};
 use crate::configs::aspire::AspireConfig;
 use crate::formatter::StringFormatter;
 use crate::formatter::VersionFormatter;
-use crate::utils::get_command_string_output;
 
 /// Creates a module with the current Aspire CLI version
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
@@ -58,10 +57,29 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 }
 
 fn get_aspire_version(context: &Context) -> Option<String> {
-    context
-        .exec_cmd("aspire", &["--version"])
-        .map(get_command_string_output)
-        .map(|s| parse_aspire_version(&s))
+    // Run from a neutral working directory so the Aspire CLI doesn't try to
+    // parse the project's `aspire.config.json` just to print its version. That
+    // keeps the version readable even when the config is missing or invalid.
+    #[cfg(not(test))]
+    {
+        use crate::utils::{create_command, exec_timeout};
+        use std::time::Duration;
+
+        let mut cmd = create_command("aspire").ok()?;
+        cmd.arg("--version").current_dir(std::env::temp_dir());
+        let output = exec_timeout(
+            &mut cmd,
+            Duration::from_millis(context.root_config.command_timeout),
+        )?;
+        Some(parse_aspire_version(&output.stdout))
+    }
+    #[cfg(test)]
+    {
+        context
+            .exec_cmd("aspire", &["--version"])
+            .map(crate::utils::get_command_string_output)
+            .map(|s| parse_aspire_version(&s))
+    }
 }
 
 fn parse_aspire_version(aspire_version: &str) -> String {

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -1,4 +1,5 @@
 // While adding out new module add out module to src/module.rs ALL_MODULES const array also.
+mod aspire;
 mod aws;
 mod azure;
 mod buf;
@@ -124,6 +125,7 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
         match module {
             // Keep these ordered alphabetically.
             // Default ordering is handled in configs/starship_root.rs
+            "aspire" => aspire::module(context),
             "aws" => aws::module(context),
             "azure" => azure::module(context),
             #[cfg(feature = "battery")]
@@ -260,6 +262,7 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
 
 pub fn description(module: &str) -> &'static str {
     match module {
+        "aspire" => "The currently installed version of the .NET Aspire CLI",
         "aws" => "The current AWS region and profile",
         "azure" => "The current Azure subscription",
         "battery" => "The current charge of the device's battery and its current charging status",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description

Adds a new `aspire` module that surfaces the locally installed [Aspire](https://github.com/microsoft/aspire) CLI version when the current directory looks like an Aspire project.

- **Detection**: the module activates when an `aspire.config.json` file is present (configurable via the usual `detect_files` / `detect_extensions` / `detect_folders` options).
- **Version**: `aspire --version` is invoked to populate `$version`, then formatted via the standard `VersionFormatter`.
- **Defaults**: `▲ ` symbol (plain Unicode triangle so no Nerd Font is required) in `bold purple` to nod at Aspire's branding.

One non-obvious bit worth flagging: the Aspire CLI parses `aspire.config.json` on every invocation, so running `aspire --version` inside a project with a missing or invalid config returns a non-zero exit and the module would otherwise render only the symbol. To keep the version visible in that case, the version probe runs from `std::env::temp_dir()` instead of the project directory. Other failures (missing binary, timeout, non-zero exit, decode errors) still degrade gracefully via `exec_timeout` returning `None`.

Module wiring follows the New Module Checklist in `CONTRIBUTING.md`: configs/module files, `PROMPT_ORDER`, `FullConfig`, `ALL_MODULES`, `handle()`, `description()`, and an English-only docs section (translations are Crowdin-managed).

This change was developed with the assistance of GitHub Copilot CLI; all code has been reviewed, tested, and validated locally.

#### Motivation and Context

Aspire is increasingly common in .NET solutions and also has TS apphost support so you may find people using it there, and having Starship surface the installed Aspire CLI version (the same way it does for `dotnet`, `bun`, etc.) gives a quick visual confirmation of the toolchain a given Aspire repo will run against, especially useful when juggling dogfood / preview / stable channels.

Closes #

#### Screenshots (if appropriate):

<img width="566" height="88" alt="Screenshot 2026-05-18 at 10 43 06 am" src="https://github.com/user-attachments/assets/d3acf917-965a-4b67-be41-b53ef43b5f18" />


#### How Has This Been Tested?

- Added 3 unit tests (no trigger file, trigger file + mocked version, trigger file + missing CLI).
- `cargo build`, `cargo test --lib modules::aspire`, and `cargo clippy --all-targets -- -D warnings` all pass locally.
- Manually verified end-to-end with a real Aspire CLI install: the segment renders correctly, and stays correct when the project's `aspire.config.json` is empty or malformed.

- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:

- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
