### PR TITLE
feat(pixi): expose PIXI_PROJECT_NAME as $project placeholder

### DIFF
--- a/src/configs/pixi.rs
+++ b/src/configs/pixi.rs
@@ -12,6 +12,7 @@ use crate::config::VecOr;
 pub struct PixiConfig<'a> {
     pub pixi_binary: VecOr<&'a str>,
     pub show_default_environment: bool,
+    pub show_default_project: bool,
     pub format: &'a str,
     pub version_format: &'a str,
     pub symbol: &'a str,
@@ -27,7 +28,8 @@ impl Default for PixiConfig<'_> {
         Self {
             pixi_binary: VecOr(vec!["pixi"]),
             show_default_environment: true,
-            format: "via [$symbol($version )(\\($environment\\) )]($style)",
+            show_default_project: true,
+            format: "via [$symbol($version )(\\($project\\) )(\\($environment\\) )]($style)",
             version_format: "v${raw}",
             symbol: "🧚 ",
             style: "yellow bold",

--- a/src/modules/pixi.rs
+++ b/src/modules/pixi.rs
@@ -13,7 +13,9 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let config: PixiConfig = PixiConfig::try_load(module.config);
 
     let pixi_environment_name = context.get_env("PIXI_ENVIRONMENT_NAME");
+    let pixi_project_name = context.get_env("PIXI_PROJECT_NAME");
     let is_pixi_project = pixi_environment_name.is_some()
+        || pixi_project_name.is_some()
         || context
             .try_begin_scan()?
             .set_files(&config.detect_files)
@@ -32,6 +34,14 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         pixi_environment_name
     };
 
+    let pixi_project_name = if !config.show_default_project
+        && pixi_project_name == Some("default".to_string())
+    {
+        None
+    } else {
+        pixi_project_name
+    };
+
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter
             .map_meta(|variable, _| match variable {
@@ -43,6 +53,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 _ => None,
             })
             .map(|variable| match variable {
+                "project" => pixi_project_name.clone().map(Ok),
                 "environment" => pixi_environment_name.clone().map(Ok),
                 "version" => {
                     let pixi_version = get_pixi_version(context, &config)?;


### PR DESCRIPTION
## What does this PR do?

Fixes #7239

Adds support for displaying the Pixi project name in the prompt via a new `$project` variable in the pixi module format string.

## Why?

`$PIXI_ENVIRONMENT_NAME` is just `default` unless you create custom environments. Users who want to show the project they're in have no way to do so. `$PIXI_PROJECT_NAME` contains the actual project name from `pixi.toml`.

## Changes

- `src/configs/pixi.rs`: Added `show_default_project` config option (mirrors `show_default_environment`). Updated default format to include `($project )`.
- `src/modules/pixi.rs`: Read `PIXI_PROJECT_NAME` env var and expose it as the `$project` placeholder.

## Example

With `PIXI_PROJECT_NAME=my-app` set:

```
via 🧚 v0.33.0 (my-app) (default)
```