### PR TITLE
docs: document zsh ZLE_RPROMPT_INDENT gap in right_format section

### DIFF
--- a/docs/advanced-config/README.md
+++ b/docs/advanced-config/README.md
@@ -1,4 +1,4 @@
-﻿# Advanced Configuration
+# Advanced Configuration
 
 While Starship is a versatile shell, sometimes you need to do more than edit
 `starship.toml` to get it to do certain things. This page details some of the more

--- a/docs/advanced-config/README.md
+++ b/docs/advanced-config/README.md
@@ -1,4 +1,4 @@
-# Advanced Configuration
+﻿# Advanced Configuration
 
 While Starship is a versatile shell, sometimes you need to do more than edit
 `starship.toml` to get it to do certain things. This page details some of the more
@@ -313,6 +313,16 @@ Produces a prompt like the following:
 
 ```
 ▶                                   starship on  rprompt [!] is 📦 v0.57.0 via 🦀 v1.54.0 took 17s
+```
+
+### Zsh Right Prompt Alignment Gap
+
+In zsh, the right prompt may appear with a small gap from the right edge of the terminal. This is
+caused by zsh's default `ZLE_RPROMPT_INDENT=1` setting, which reserves one character of padding.
+To remove the gap, add the following to your shell configuration (`~/.zshrc`):
+
+```sh
+ZLE_RPROMPT_INDENT=0
 ```
 
 ## Continuation Prompt


### PR DESCRIPTION
Fixes #7289

## What does this PR do?

Adds a note to the [Enable Right Prompt](https://starship.rs/advanced-config/#enable-right-prompt) documentation explaining the alignment gap that zsh users see when using `right_format`.

## Why?

The gap is caused by zsh's default `ZLE_RPROMPT_INDENT=1` behavior, which reserves one character of padding at the right edge. This is not a starship bug, but it is confusing for users who expect the right prompt to align with the terminal edge.

The fix (`ZLE_RPROMPT_INDENT=0` in `~/.zshrc`) is simple but undiscoverable without documentation.