### PR TITLE
fix(bash): clear status after empty command

### DIFF
--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -282,6 +282,9 @@ const CMDEXE_INIT: &str = include_str!("starship.lua");
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Write;
+    use std::process::Stdio;
+
     #[test]
     fn escape_pwsh() -> io::Result<()> {
         let starship_path = StarshipPath {
@@ -317,6 +320,73 @@ mod tests {
         assert_eq!(
             starship_path.sprint_cmdexe()?,
             r#""C:\Cool Tools\starship.exe""#
+        );
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn bash_empty_command_clears_status_args() -> io::Result<()> {
+        let args_log = tempfile::NamedTempFile::new()?;
+        let init_script = BASH_INIT.replace("::STARSHIP::", "__starship_mock");
+        let harness = r#"
+__starship_mock() {
+  case "$1" in
+    time) printf '1000\n' ;;
+    prompt)
+      shift
+      printf '<prompt>'
+      printf '%s\n' "$*" >> "$STARSHIP_ARGS_LOG"
+      ;;
+  esac
+}
+COLUMNS=80
+SHLVL=1
+source /dev/stdin <<< "$STARSHIP_INIT_SCRIPT"
+false
+
+exit
+"#;
+
+        let mut command = create_command("bash")?;
+        let mut child = command
+            .arg("--noprofile")
+            .arg("--norc")
+            .arg("-i")
+            .env("STARSHIP_INIT_SCRIPT", init_script)
+            .env("STARSHIP_ARGS_LOG", args_log.path())
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()?;
+
+        child
+            .stdin
+            .as_mut()
+            .expect("bash stdin should be piped")
+            .write_all(harness.as_bytes())?;
+
+        let output = child.wait_with_output()?;
+
+        let calls = std::fs::read_to_string(args_log.path())?;
+        let prompt_calls = calls
+            .lines()
+            .filter(|line| line.contains("--terminal-width"))
+            .collect::<Vec<_>>();
+
+        assert!(
+            prompt_calls.len() >= 3,
+            "expected prompts after init, false, and empty enter:\n{calls}\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            prompt_calls[1].contains("--status=1"),
+            "failed command should pass its status:\n{calls}"
+        );
+        assert!(
+            prompt_calls[2].contains("--status= --pipestatus= "),
+            "empty command should clear the previous status:\n{calls}"
         );
         Ok(())
     }

--- a/src/init/starship.bash
+++ b/src/init/starship.bash
@@ -20,6 +20,10 @@ starship_preexec() {
     # Save previous command's last argument, otherwise it will be set to "starship_preexec"
     local PREV_LAST_ARG=$1
 
+    if [[ "${BASH_COMMAND-}" = "starship_precmd" ]]; then
+        return
+    fi
+
     # Avoid restarting the timer for commands in the same pipeline
     if [ "${STARSHIP_PREEXEC_READY:-}" = "true" ]; then
         STARSHIP_PREEXEC_READY=false
@@ -69,13 +73,21 @@ starship_precmd() {
         eval "$STARSHIP_PROMPT_COMMAND"
     fi
 
-    local -a ARGS=(--terminal-width="${COLUMNS}" --status="${STARSHIP_CMD_STATUS}" --pipestatus="${STARSHIP_PIPE_STATUS[*]}" --jobs="${NUM_JOBS}" --shlvl="${SHLVL}")
+    local STARSHIP_PROMPT_STATUS="${STARSHIP_CMD_STATUS}"
+    local STARSHIP_PROMPT_PIPE_STATUS="${STARSHIP_PIPE_STATUS[*]}"
     # Prepare the timer data, if needed.
     if [[ -n "${STARSHIP_START_TIME-}" ]]; then
         STARSHIP_END_TIME=$(::STARSHIP:: time)
         STARSHIP_DURATION=$((STARSHIP_END_TIME - STARSHIP_START_TIME))
-        ARGS+=( --cmd-duration="${STARSHIP_DURATION}")
         STARSHIP_START_TIME=""
+    else
+        STARSHIP_PROMPT_STATUS=""
+        STARSHIP_PROMPT_PIPE_STATUS=""
+        STARSHIP_DURATION=""
+    fi
+    local -a ARGS=(--terminal-width="${COLUMNS}" --status="${STARSHIP_PROMPT_STATUS}" --pipestatus="${STARSHIP_PROMPT_PIPE_STATUS}" --jobs="${NUM_JOBS}" --shlvl="${SHLVL}")
+    if [[ -n "${STARSHIP_DURATION-}" ]]; then
+        ARGS+=( --cmd-duration="${STARSHIP_DURATION}")
     fi
     PS1="$(::STARSHIP:: prompt "${ARGS[@]}")"
     if [[ ${BLE_ATTACHED-} ]]; then
@@ -150,4 +162,3 @@ export STARSHIP_SESSION_KEY=${STARSHIP_SESSION_KEY:0:16}; # Trim to 16-digits if
 
 # Set the continuation prompt
 PS2="$(::STARSHIP:: prompt --continuation)"
-


### PR DESCRIPTION
#### Description
This clears the status and pipestatus values passed to `starship prompt` when Bash renders a prompt after an empty command line. That makes pressing Enter on an empty prompt behave like a successful command for the `status` and `character` modules, matching the behavior already used to skip `cmd_duration`.

For the older DEBUG-trap path, this also avoids treating `starship_precmd` itself as a preexec event. Without that guard, Bash 3.2 immediately started a new timer while drawing the prompt, so the empty prompt still received the previous failed status.

#### Motivation and Context
Closes #7450

#### How Has This Been Tested?
- Reproduced the issue with an interactive Bash harness before the fix: after `false`, an empty command still sent `--status=1` to `starship prompt`.
- Verified the same harness after the fix with `/bin/bash` 3.2.57 and Homebrew Bash 5.3.9: the empty command sends empty `--status` and `--pipestatus`.
- `CARGO_HOME="$PWD/.cargo-home" CARGO_TARGET_DIR="$PWD/target" cargo fmt --check`
- `CARGO_HOME="$PWD/.cargo-home" CARGO_TARGET_DIR="$PWD/target" cargo test init::tests::bash_empty_command_clears_status_args`
- `CARGO_HOME="$PWD/.cargo-home" CARGO_TARGET_DIR="$PWD/target" cargo test init::`
- `CARGO_HOME="$PWD/.cargo-home" CARGO_TARGET_DIR="$PWD/target" cargo clippy --all-targets --all-features -- -D warnings`
- `PATH="/opt/homebrew/bin:$PATH" TERM=xterm-256color CARGO_HOME="$PWD/.cargo-home" CARGO_TARGET_DIR="$PWD/target" cargo test`

- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist:
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.