### PR TITLE
feat(shlvl): add display value offset

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -1670,6 +1670,7 @@
       "$ref": "#/$defs/ShLvlConfig",
       "default": {
         "threshold": 2,
+        "number_offset": 0,
         "format": "[$symbol$shlvl]($style) ",
         "symbol": "↕️  ",
         "repeat": false,
@@ -6382,6 +6383,11 @@
           "type": "integer",
           "format": "int64",
           "default": 2
+        },
+        "number_offset": {
+          "type": "integer",
+          "format": "int64",
+          "default": 0
         },
         "format": {
           "type": "string",

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -4451,6 +4451,7 @@ set to a number and meets or exceeds the specified threshold.
 | Option          | Default                      | Description                                                         |
 | --------------- | ---------------------------- | ------------------------------------------------------------------- |
 | `threshold`     | `2`                          | Display threshold.                                                  |
+| `number_offset` | `0`                          | Offset applied to the displayed `SHLVL` value.                      |
 | `format`        | `'[$symbol$shlvl]($style) '` | The format for the module.                                          |
 | `symbol`        | `'↕️  '`                      | The symbol used to represent the `SHLVL`.                           |
 | `repeat`        | `false`                      | Causes `symbol` to be repeated by the current `SHLVL` amount.       |
@@ -4460,11 +4461,11 @@ set to a number and meets or exceeds the specified threshold.
 
 ### Variables
 
-| Variable | Example | Description                          |
-| -------- | ------- | ------------------------------------ |
-| shlvl    | `3`     | The current value of `SHLVL`         |
-| symbol   |         | Mirrors the value of option `symbol` |
-| style\*  |         | Mirrors the value of option `style`  |
+| Variable | Example | Description                                             |
+| -------- | ------- | ------------------------------------------------------- |
+| shlvl    | `3`     | The current value of `SHLVL`, including `number_offset` |
+| symbol   |         | Mirrors the value of option `symbol`                    |
+| style\*  |         | Mirrors the value of option `style`                     |
 
 *: This variable can only be used as a part of a style string
 

--- a/src/configs/shlvl.rs
+++ b/src/configs/shlvl.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 #[serde(default)]
 pub struct ShLvlConfig<'a> {
     pub threshold: i64,
+    pub number_offset: i64,
     pub format: &'a str,
     pub symbol: &'a str,
     pub repeat: bool,
@@ -21,6 +22,7 @@ impl Default for ShLvlConfig<'_> {
     fn default() -> Self {
         Self {
             threshold: 2,
+            number_offset: 0,
             format: "[$symbol$shlvl]($style) ",
             symbol: "↕️  ", // extra space for emoji
             repeat: false,

--- a/src/modules/shlvl.rs
+++ b/src/modules/shlvl.rs
@@ -16,17 +16,18 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
     let mut module = context.new_module("shlvl");
     let config: ShLvlConfig = ShLvlConfig::try_load(module.config);
+    let display_shlvl = shlvl.saturating_add(config.number_offset);
 
     // As we default to disabled=true, we have to check here after loading our config module,
     // before it was only checking against whatever is in the config starship.toml
-    if config.disabled || shlvl < config.threshold {
+    if config.disabled || display_shlvl < config.threshold {
         return None;
     }
 
-    let shlvl_str = &shlvl.to_string();
+    let shlvl_str = &display_shlvl.to_string();
 
     let mut repeat_count: usize = if config.repeat {
-        shlvl.try_into().unwrap_or(1)
+        display_shlvl.try_into().unwrap_or(1)
     } else {
         1
     };
@@ -196,6 +197,40 @@ mod tests {
             .env(SHLVL_ENV_VAR, "2")
             .collect();
         let expected = Some(format!("{} ", style().paint("shlvl is 2")));
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn number_offset() {
+        let actual = ModuleRenderer::new("shlvl")
+            .config(toml::toml! {
+                [shlvl]
+                disabled = false
+                number_offset = -1
+                threshold = 1
+            })
+            .env(SHLVL_ENV_VAR, "2")
+            .collect();
+        let expected = Some(format!("{} ", style().paint("↕️  1")));
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn number_offset_applies_to_repeat() {
+        let actual = ModuleRenderer::new("shlvl")
+            .config(toml::toml! {
+                [shlvl]
+                disabled = false
+                format = "[$symbol]($style)"
+                number_offset = -1
+                repeat = true
+                symbol = "~"
+            })
+            .env(SHLVL_ENV_VAR, "3")
+            .collect();
+        let expected = Some(format!("{}", style().paint("~~")));
 
         assert_eq!(expected, actual);
     }


### PR DESCRIPTION
## Summary
- Add a `number_offset` option to the `shlvl` module so users can adjust the displayed SHLVL value, e.g. `number_offset = -1`.
- Apply the adjusted value consistently to threshold checks, `$shlvl` formatting, and repeated symbols.
- Document the new option in the SHLVL configuration docs.

Closes #4815

## Validation
- `cargo fmt --check`
- `cargo test modules::shlvl`
- `cargo clippy --all-targets -- -D warnings`

## Risk
Low: default `number_offset = 0` preserves existing behavior.