### PR TITLE
docs(preset): add Void Linux symbol to catppuccin-powerline

### DIFF
--- a/docs/public/presets/toml/catppuccin-powerline.toml
+++ b/docs/public/presets/toml/catppuccin-powerline.toml
@@ -56,6 +56,7 @@ CentOS = ""
 Debian = "󰣚"
 Redhat = "󱄛"
 RedHatEnterprise = "󱄛"
+Void = ""
 
 [username]
 show_always = true


### PR DESCRIPTION
#### Description

Adds `Void = ""` (Nerd Font U+F32E, the standard Void Linux logo) to the `[os.symbols]` table in `docs/public/presets/toml/catppuccin-powerline.toml` so users running Void Linux on the Catppuccin Powerline preset see a themed icon out of the box.

The change is a single-line addition appended to the existing section:

```toml
[os.symbols]
...
Redhat = "..."
RedHatEnterprise = "..."
Void = ""
```

#### Motivation and Context

Closes #7397.

The `Type::Void` enum variant is already handled by:

- `src/configs/os.rs` (default config symbol mapping)
- `src/modules/os.rs` (default fallback symbol)
- `docs/public/presets/toml/nerd-font-symbols.toml`
- `docs/public/presets/toml/plain-text-symbols.toml`

Catppuccin Powerline was the only Nerd-Font-aware preset missing this entry, so Void users had to manually override the symbol when adopting the preset.

#### How Has This Been Tested?

- `cargo fmt --all -- --check` — passes (no Rust changes)
- `cargo clippy --workspace --locked -- -D warnings` — passes
- `cargo check --workspace --locked` — passes
- `cargo test --workspace --locked` (preset + os modules) — passes locally
- TOML syntax sanity-checked manually; insertion is a single `Key = "string"` line within an existing table

The change does not touch Rust code, so behavior of any module is unchanged. Existing Catppuccin users are unaffected unless they re-export the preset.

#### Screenshots (if appropriate)

N/A — preset content addition only.

#### Types of changes

- [x] Documentation update (preset is shipped via `starship preset catppuccin-powerline`)
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

#### Checklist

- [x] My code follows the code style of this project (matches existing entry style: PascalCase key, glyph-only quoted value, no trailing space).
- [x] My change requires a change to the documentation. (The change *is* the documentation.)
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes. (N/A — preset toml content is not unit-tested in repo.)
- [x] All new and existing tests passed.