### PR TITLE
[docs] Update the Windows package manager used in the intro

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -61,16 +61,16 @@ onMounted(() => {
 
    #### Install via Package Manager
 
-   With [Homebrew](https://brew.sh/):
+   With [Homebrew](https://brew.sh):
 
    ```sh
    brew install starship
    ```
 
-   With [Winget](https://github.com/microsoft/winget-cli):
+   With [Scoop](https://scoop.sh):
 
    ```powershell
-   winget install starship
+   scoop install starship
    ```
 
 1. Add the init script to your shell's config file:


### PR DESCRIPTION
#### Motivation and Context

This section stood out to me as odd because Scoop is far more preferable for managing CLIs and is considered the Homebrew equivalent, making it the usual recommendation ([example](https://mise.jdx.dev/installing-mise.html#installation-methods)). Also, there are several open [issues](https://github.com/search?q=repo%3Astarship%2Fstarship+winget&type=issues) and [discussions](https://github.com/search?q=repo%3Astarship%2Fstarship+winget&type=discussions) related to `winget`.