### PR TITLE
fix(cli): accept negative status values

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -964,7 +964,7 @@ pub enum Target {
 #[derive(Parser, Debug)]
 pub struct Properties {
     /// The status code of the previously run command as an unsigned or signed 32bit integer
-    #[clap(short = 's', long = "status")]
+    #[clap(short = 's', long = "status", allow_hyphen_values = true)]
     pub status_code: Option<String>,
     /// Bash, Fish and Zsh support returning codes for each process in a pipeline.
     #[clap(long, value_delimiter = ' ')]

--- a/src/main.rs
+++ b/src/main.rs
@@ -314,3 +314,27 @@ fn init_global_threadpool() {
         .build_global()
         .expect("Failed to initialize worker thread pool");
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parsed_prompt_status(args: &[&str]) -> Option<String> {
+        let cli = Cli::try_parse_from(args).expect("valid prompt arguments");
+        match cli.command {
+            Commands::Prompt { properties, .. } => properties.status_code,
+            _ => panic!("expected prompt command"),
+        }
+    }
+
+    #[test]
+    fn prompt_accepts_negative_status_code() {
+        for args in [
+            ["starship", "prompt", "-s", "-1"].as_slice(),
+            ["starship", "prompt", "--status", "-1"].as_slice(),
+            ["starship", "prompt", "--status=-1"].as_slice(),
+        ] {
+            assert_eq!(parsed_prompt_status(args).as_deref(), Some("-1"));
+        }
+    }
+}


### PR DESCRIPTION
#### Description
Allow `starship prompt --status` / `-s` to accept negative status values passed as separate arguments, matching the documented signed 32-bit status support. Adds parser coverage for short, long, and equals-form status arguments.

#### Motivation and Context
Closes #4980

Negative values such as `-1` were interpreted by clap as a new option-like argument when passed as `-s -1` or `--status -1`, even though the status option documents signed values.

#### Screenshots (if appropriate):

#### How Has This Been Tested?
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

Ran:

```sh
cargo fmt -- --check
CARGO_BUILD_JOBS=1 cargo test --no-default-features --bin starship prompt_accepts_negative_status_code --locked
```

#### Checklist:
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
