### PR TITLE
fix(elvish): pass terminal width to starship prompt

### DIFF
--- a/src/init/starship.elv
+++ b/src/init/starship.elv
@@ -24,10 +24,10 @@ set edit:after-command = [ $@edit:after-command $starship-after-command-hook~ ]
 # Install starship
 set edit:prompt = {
     var cmd-duration = (printf "%.0f" (* $edit:command-duration 1000))
-    ::STARSHIP:: prompt --jobs=$num-bg-jobs --cmd-duration=$cmd-duration --status=$cmd-status-code --logical-path=$pwd
+    ::STARSHIP:: prompt --terminal-width=$E:COLUMNS --jobs=$num-bg-jobs --cmd-duration=$cmd-duration --status=$cmd-status-code --logical-path=$pwd
 }
 
 set edit:rprompt = {
     var cmd-duration = (printf "%.0f" (* $edit:command-duration 1000))
-    ::STARSHIP:: prompt --right --jobs=$num-bg-jobs --cmd-duration=$cmd-duration --status=$cmd-status-code --logical-path=$pwd
+    ::STARSHIP:: prompt --right --terminal-width=$E:COLUMNS --jobs=$num-bg-jobs --cmd-duration=$cmd-duration --status=$cmd-status-code --logical-path=$pwd
 }


### PR DESCRIPTION
## Summary
- Forward `$E:COLUMNS` via `--terminal-width` in the elvish init script for both left and right prompts
- Aligns elvish with bash/fish/zsh/nushell init scripts that already pass a width hint
- Prevents the time module separator from being clipped at the right edge of the prompt

Fixes #7453

## Test plan
- [x] `cargo test init`
- [ ] Manual: `starship init elvish --print-full-init` shows `--terminal-width=$E:COLUMNS`
- [ ] Manual: verify time module colon no longer disappears in elvish with Catppuccin Powerline preset