### PR TITLE
fix: improve format string parse error messages (fixes #7491)

### DIFF
--- a/src/formatter/mod.rs
+++ b/src/formatter/mod.rs
@@ -4,5 +4,5 @@ pub mod string_formatter;
 mod version;
 
 pub use model::{StyleVariableHolder, VariableHolder};
-pub use string_formatter::StringFormatter;
+pub use string_formatter::{StringFormatter, StringFormatterError};
 pub use version::VersionFormatter;

--- a/src/formatter/string_formatter.rs
+++ b/src/formatter/string_formatter.rs
@@ -48,6 +48,49 @@ impl fmt::Display for StringFormatterError {
 
 impl Error for StringFormatterError {}
 
+impl StringFormatterError {
+    /// Log a user-facing warning when a module format string fails to parse.
+    pub fn log_parse_error(config_path: &str, format: &str, error: &Self) {
+        log::warn!("Error parsing format string `{config_path}`: {error}");
+        if contains_unescaped_dollar(format) {
+            log::warn!("  Hint: use `\\$` to display a literal `$` character.");
+        }
+    }
+}
+
+fn contains_unescaped_dollar(format: &str) -> bool {
+    let mut chars = format.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch == '\\' {
+            chars.next();
+            continue;
+        }
+        if ch == '$' {
+            match chars.peek() {
+                Some('{') => {
+                    chars.next();
+                    for c in chars.by_ref() {
+                        if c == '}' {
+                            break;
+                        }
+                    }
+                }
+                Some(c) if c.is_ascii_alphabetic() || *c == '_' => {
+                    let _ = chars.next();
+                    while matches!(
+                        chars.peek(),
+                        Some(c) if c.is_ascii_alphanumeric() || *c == '_' || *c == ':'
+                    ) {
+                        chars.next();
+                    }
+                }
+                _ => return true,
+            }
+        }
+    }
+    false
+}
+
 impl From<String> for StringFormatterError {
     fn from(error: String) -> Self {
         Self::Custom(error)
@@ -834,6 +877,15 @@ mod tests {
             const FORMAT_STR: &str = "$ ";
             assert!(StringFormatter::new(FORMAT_STR).is_err());
         }
+    }
+
+    #[test]
+    fn test_contains_unescaped_dollar() {
+        assert!(contains_unescaped_dollar(" ${count}$"));
+        assert!(!contains_unescaped_dollar(r" ${count}\$"));
+        assert!(!contains_unescaped_dollar("plain text"));
+        assert!(!contains_unescaped_dollar("$count"));
+        assert!(contains_unescaped_dollar("$count literal$"));
     }
 
     #[test]

--- a/src/modules/git_status.rs
+++ b/src/modules/git_status.rs
@@ -1,6 +1,6 @@
 use super::{Context, Module, ModuleConfig};
 use crate::configs::git_status::GitStatusConfig;
-use crate::formatter::StringFormatter;
+use crate::formatter::{StringFormatter, StringFormatterError};
 use crate::segment::Segment;
 use crate::{context, num_configured_starship_threads, num_rayon_threads};
 use gix::bstr::ByteVec;
@@ -761,14 +761,15 @@ fn format_text<F>(
 where
     F: Fn(&str) -> Option<String> + Send + Sync,
 {
-    if let Ok(formatter) = StringFormatter::new(format_str) {
-        formatter
+    match StringFormatter::new(format_str) {
+        Ok(formatter) => formatter
             .map(|variable| mapper(variable).map(Ok))
             .parse(None, Some(context))
-            .ok()
-    } else {
-        log::warn!("Error parsing format string `{}`", &config_path);
-        None
+            .ok(),
+        Err(error) => {
+            StringFormatterError::log_parse_error(config_path, format_str, &error);
+            None
+        }
     }
 }
 

--- a/src/modules/status.rs
+++ b/src/modules/status.rs
@@ -81,7 +81,11 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 match formatted {
                     Ok(segments) => Some(segments),
                     Err(e) => {
-                        log::warn!("Error parsing format string in `status.pipestatus_segment_format`: {e:?}");
+                        StringFormatterError::log_parse_error(
+                            "status.pipestatus_segment_format",
+                            segment_format,
+                            &e,
+                        );
                         None
                     }
                 }
@@ -99,8 +103,8 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
     module.set_segments(match parsed {
         Ok(segments) => segments,
-        Err(_error) => {
-            log::warn!("Error parsing format string in `status.format`");
+        Err(error) => {
+            StringFormatterError::log_parse_error("status.format", main_format, &error);
             return None;
         }
     });


### PR DESCRIPTION
## Summary

Fixes #7491.

When a module format string fails to parse (e.g. `stashed = " ${count}$"`), the warning now includes the parse error reason and, when a stray `$` is detected, a hint to escape it with `\$`.

## Changes

- Add `StringFormatterError::log_parse_error()` with actionable output
- Use it in `git_status` and `status` modules instead of generic warnings
- Detect invalid `$` characters while skipping valid `$variable` / `${...}` references

## Example

Before:
```
[WARN] - (starship::modules::git_status): Error parsing format string `git_status.stashed`
```

After:
```
[WARN] - (starship::modules::git_status): Error parsing format string `git_status.stashed`: ...
[WARN] -   Hint: use `\$` to display a literal `$` character.
```

## Test plan

- [x] `cargo test formatter::string_formatter::tests`
- [x] `cargo clippy -- -D warnings`