### PR TITLE
fix(cmd_duration): strip PUA chars from desktop notifications (fixes #7464)

### DIFF
--- a/src/modules/cmd_duration.rs
+++ b/src/modules/cmd_duration.rs
@@ -71,6 +71,8 @@ fn undistract_me<'a>(
     use notify_rust::{Notification, Timeout};
     use nu_ansi_term::{AnsiStrings, unstyle};
 
+    use crate::utils::strip_private_use_characters;
+
     if config.show_notifications && config.min_time_to_notify as u128 <= elapsed {
         if cfg!(target_os = "linux") {
             let in_graphical_session = ["DISPLAY", "WAYLAND_DISPLAY", "MIR_SOCKET"]
@@ -90,7 +92,7 @@ fn undistract_me<'a>(
 
         let body = format!(
             "Command execution {}",
-            unstyle(&AnsiStrings(&module.ansi_strings()))
+            strip_private_use_characters(&unstyle(&AnsiStrings(&module.ansi_strings())))
         );
 
         let timeout = match config.notification_timeout {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -817,9 +817,41 @@ impl PathExt for Path {
     }
 }
 
+/// Removes Unicode Private Use Area characters that system notification fonts
+/// typically cannot render (e.g. Nerd Font icons).
+pub fn strip_private_use_characters(text: &str) -> String {
+    text.chars().filter(|&c| !is_private_use(c)).collect()
+}
+
+const fn is_private_use(c: char) -> bool {
+    matches!(
+        c,
+        '\u{E000}'..='\u{F8FF}'
+            | '\u{F0000}'..='\u{FFFFD}'
+            | '\u{100000}'..='\u{10FFFD}'
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn strip_private_use_characters_removes_nerd_font_icons() {
+        let icon = '\u{EAF4}';
+        assert_eq!(
+            strip_private_use_characters(&format!("{icon} in 5s")),
+            " in 5s"
+        );
+    }
+
+    #[test]
+    fn strip_private_use_characters_preserves_regular_text() {
+        assert_eq!(
+            strip_private_use_characters("Command in 5s"),
+            "Command in 5s"
+        );
+    }
 
     #[test]
     fn render_time_test_0ms() {


### PR DESCRIPTION
## Summary

Fixes #7464.

When `cmd_duration` uses Nerd Font icons in its format string and `show_notifications = true`, the desktop notification body can show tofu (□) because system notification fonts do not include Private Use Area glyphs.

## Changes

- Add `strip_private_use_characters()` in `utils` to remove BMP and supplementary PUA code points
- Apply it to the notification body after `unstyle()` in `undistract_me`
- Add unit tests for PUA stripping and plain text preservation

## Test plan

- [x] `cargo test strip_private_use`
- [x] `cargo clippy -- -D warnings`