### PR TITLE
fix(formatter): improve format string parse error hints (fixes #7491)

### DIFF
--- a/src/formatter/mod.rs
+++ b/src/formatter/mod.rs
@@ -4,5 +4,5 @@ pub mod string_formatter;
 mod version;
 
 pub use model::{StyleVariableHolder, VariableHolder};
-pub use string_formatter::StringFormatter;
+pub use string_formatter::{StringFormatter, StringFormatterError};
 pub use version::VersionFormatter;

--- a/src/formatter/string_formatter.rs
+++ b/src/formatter/string_formatter.rs
@@ -48,6 +48,49 @@ impl fmt::Display for StringFormatterError {
 
 impl Error for StringFormatterError {}
 
+impl StringFormatterError {
+    /// Log a user-facing warning when a module format string fails to parse.
+    pub fn log_parse_error(config_path: &str, format: &str, error: &Self) {
+        log::warn!("Error parsing format string `{config_path}`: {error}");
+        if contains_unescaped_dollar(format) {
+            log::warn!("  Hint: use `\\$` to display a literal `$` character.");
+        }
+    }
+}
+
+fn contains_unescaped_dollar(format: &str) -> bool {
+    let mut chars = format.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch == '\\' {
+            chars.next();
+            continue;
+        }
+        if ch == '$' {
+            match chars.peek() {
+                Some('{') => {
+                    chars.next();
+                    for c in chars.by_ref() {
+                        if c == '}' {
+                            break;
+                        }
+                    }
+                }
+                Some(c) if c.is_ascii_alphabetic() || *c == '_' => {
+                    let _ = chars.next();
+                    while matches!(
+                        chars.peek(),
+                        Some(c) if c.is_ascii_alphanumeric() || *c == '_' || *c == ':'
+                    ) {
+                        chars.next();
+                    }
+                }
+                _ => return true,
+            }
+        }
+    }
+    false
+}
+
 impl From<String> for StringFormatterError {
     fn from(error: String) -> Self {
         Self::Custom(error)
@@ -820,6 +863,15 @@ mod tests {
         let formatter = StringFormatter::new(FORMAT_STR).unwrap().map(empty_mapper);
         let variables = formatter.get_style_variables();
         assert_eq!(variables, expected_variables);
+    }
+
+    #[test]
+    fn test_contains_unescaped_dollar() {
+        assert!(contains_unescaped_dollar(" ${count}$"));
+        assert!(!contains_unescaped_dollar(r" ${count}\$"));
+        assert!(!contains_unescaped_dollar("plain text"));
+        assert!(!contains_unescaped_dollar("$count"));
+        assert!(contains_unescaped_dollar("$count literal$"));
     }
 
     #[test]

--- a/src/modules/git_status.rs
+++ b/src/modules/git_status.rs
@@ -1,6 +1,6 @@
 use super::{Context, Module, ModuleConfig};
 use crate::configs::git_status::GitStatusConfig;
-use crate::formatter::StringFormatter;
+use crate::formatter::{StringFormatter, StringFormatterError};
 use crate::segment::Segment;
 use crate::{context, num_configured_starship_threads, num_rayon_threads};
 use gix::bstr::ByteVec;
@@ -761,14 +761,15 @@ fn format_text<F>(
 where
     F: Fn(&str) -> Option<String> + Send + Sync,
 {
-    if let Ok(formatter) = StringFormatter::new(format_str) {
-        formatter
+    match StringFormatter::new(format_str) {
+        Ok(formatter) => formatter
             .map(|variable| mapper(variable).map(Ok))
             .parse(None, Some(context))
-            .ok()
-    } else {
-        log::warn!("Error parsing format string `{}`", &config_path);
-        None
+            .ok(),
+        Err(error) => {
+            StringFormatterError::log_parse_error(config_path, format_str, &error);
+            None
+        }
     }
 }
 

--- a/src/modules/status.rs
+++ b/src/modules/status.rs
@@ -3,7 +3,7 @@ use std::string::ToString;
 use super::{Context, Module, ModuleConfig};
 
 use crate::configs::status::StatusConfig;
-use crate::formatter::{StringFormatter, string_formatter::StringFormatterError};
+use crate::formatter::{StringFormatter, StringFormatterError};
 use crate::segment::Segment;
 
 type ExitCode = i32;
@@ -67,13 +67,14 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             .iter()
             .enumerate()
             .filter_map(|(i, ec)| {
+                let segment_format_str = if i == ps.len() - 1 {
+                    segment_format
+                } else {
+                    &segment_format_with_separator
+                };
                 let formatted = format_exit_code(
                     ec.as_str(),
-                    if i == ps.len() - 1 {
-                        segment_format
-                    } else {
-                        &segment_format_with_separator
-                    },
+                    segment_format_str,
                     None,
                     &config,
                     context,
@@ -81,7 +82,11 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 match formatted {
                     Ok(segments) => Some(segments),
                     Err(e) => {
-                        log::warn!("Error parsing format string in `status.pipestatus_segment_format`: {e:?}");
+                        StringFormatterError::log_parse_error(
+                            "status.pipestatus_segment_format",
+                            segment_format_str,
+                            &e,
+                        );
                         None
                     }
                 }
@@ -99,8 +104,8 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
     module.set_segments(match parsed {
         Ok(segments) => segments,
-        Err(_error) => {
-            log::warn!("Error parsing format string in `status.format`");
+        Err(error) => {
+            StringFormatterError::log_parse_error("status.format", main_format, &error);
             return None;
         }
     });


### PR DESCRIPTION
## Summary

- Add `StringFormatterError::log_parse_error()` to log parse failures with the underlying error and a hint when the format string contains an unescaped `$`
- Use the helper in `git_status` and `status` modules instead of generic error logging
- Fix pipestatus error logging to reference the actual format string passed to `format_exit_code` (including separator suffix when applicable)

Fixes #7491

## Test plan

- [x] `cargo test test_contains_unescaped_dollar`
- [x] `cargo clippy -- -D warnings`