### PR TITLE
fix(print): strip OSC sequences for grapheme width (helps #7420)

### DIFF
--- a/src/print.rs
+++ b/src/print.rs
@@ -40,8 +40,20 @@ pub trait UnicodeWidthGraphemes {
 
 static ANSI_REGEX: OnceLock<Regex> = OnceLock::new();
 
+/// Sequences stripped before measuring [`UnicodeWidthGraphemes::width_graphemes`]:
+/// CSI SGR color/style (`ESC [ … m`), and OSC operating-system commands terminated with
+/// BEL (`ASCII 7`) or ST (`ESC \`), since they occupy no terminal columns but would
+/// otherwise break `$fill` / `right_format` alignment (see e.g. shell integration OSC 133
+/// or hyperlinks OSC 8).
 fn ansi_strip() -> &'static Regex {
-    ANSI_REGEX.get_or_init(|| Regex::new(r"\x1B\[[0-9;]*m").unwrap())
+    ANSI_REGEX.get_or_init(|| {
+        Regex::new(concat!(
+            r"(?:\x1B\[[0-9;]*m",               // SGR/select graphic rendition
+            r"|\x1B\][^\x07]*?(?:\x07|\x1B\\)", // OSC … BEL | OSC … ST
+            r")",
+        ))
+        .unwrap()
+    })
 }
 
 impl<T> UnicodeWidthGraphemes for T
@@ -67,6 +79,27 @@ fn test_grapheme_aware_width() {
     assert_eq!(11, "normal text".width_graphemes());
     // Magenta string test
     assert_eq!(11, "\x1B[35;6mnormal text".width_graphemes());
+}
+
+#[test]
+fn test_strip_osc_shell_integration_for_width() {
+    assert_eq!(
+        "~/src".width_graphemes(),
+        "\x1B]133;A\x07\x1B[34m~/src".width_graphemes()
+    );
+}
+
+#[test]
+fn test_strip_osc_string_terminator_for_width() {
+    assert_eq!(
+        "hello".width_graphemes(),
+        "\x1B]133;B\x1B\\\x1B[32mhello".width_graphemes()
+    );
+}
+
+#[test]
+fn test_zwj_profession_emoji_width() {
+    assert_eq!(2, "🧑🏻‍🔬".width_graphemes());
 }
 
 pub fn prompt(args: Properties, target: Target) {


### PR DESCRIPTION
## Summary

`UnicodeWidthGraphemes::width_graphemes()` only stripped CSI SGR (`ESC [ … m`). OSC sequences (e.g. iTerm2 shell integration `\e]133;…\a`, hyperlinks `\e]8;…`) were counted as terminal columns, skewing `$fill` and `right_format` alignment.

Strip OSC payloads terminated by **BEL** (`ASCII 7`) or **ST** (`ESC \`), in addition to SGR.

Helps #7420 (fill misalignment with iTerm2 shell integration + complex prompts) and relates to #7296.

## Changes

- Extend `ansi_strip()` regex to cover OSC sequences
- Add tests for OSC 133 BEL/ST terminators
- Add regression test for ZWJ profession emoji width (`🧑🏻‍🔬` → 2 columns)

## Test plan

- [x] `cargo test strip_osc --lib`
- [x] `cargo test test_zwj_profession --lib`
- [x] `cargo test test_grapheme_aware_width --lib`
- [x] `cargo clippy -- -D warnings`