### PR TITLE
fix(sudo): render conditional format groups containing symbol (fixes #7433)

### DIFF
--- a/src/modules/sudo.rs
+++ b/src/modules/sudo.rs
@@ -26,8 +26,8 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter
-            .map_meta(|variable, _| match variable {
-                "symbol" => Some(config.symbol),
+            .map(|variable| match variable {
+                "symbol" => Some(Ok(config.symbol)),
                 _ => None,
             })
             .map_style(|variable| match variable {
@@ -85,6 +85,30 @@ mod tests {
             })
             .collect();
         let expected = Some(format!("{}", Color::Blue.bold().paint("as 🧙 ")));
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn test_sudo_cached_conditional_format_with_symbol() {
+        let actual = ModuleRenderer::new("sudo")
+            .cmd(
+                "sudo -n true",
+                Some(CommandOutput {
+                    stdout: String::new(),
+                    stderr: String::new(),
+                }),
+            )
+            .config(toml::toml! {
+                [sudo]
+                disabled = false
+                allow_windows = true
+                symbol = "sudo"
+                style = "197"
+                format = "([$symbol]($style) )"
+            })
+            .collect();
+        let expected = Some(format!("{} ", Color::Fixed(197).paint("sudo")));
 
         assert_eq!(expected, actual);
     }


### PR DESCRIPTION
## Summary

Conditional format strings like `format = "([$symbol]($style) )"` did not render because `symbol` was registered as a meta-variable. Meta-variables are handled differently inside conditional groups, causing the module to output nothing even when sudo credentials are cached.

Register `symbol` as a normal formatter variable instead.

Fixes #7433

## Test plan

- [x] `cargo test sudo --lib`
- [x] `cargo clippy -- -D warnings`
- [x] Added `test_sudo_cached_conditional_format_with_symbol`