### PR TITLE
fix(elvish): pass terminal width to starship prompt (fixes #7453)

### DIFF
--- a/src/init/starship.elv
+++ b/src/init/starship.elv
@@ -24,10 +24,10 @@ set edit:after-command = [ $@edit:after-command $starship-after-command-hook~ ]
 # Install starship
 set edit:prompt = {
     var cmd-duration = (printf "%.0f" (* $edit:command-duration 1000))
-    ::STARSHIP:: prompt --jobs=$num-bg-jobs --cmd-duration=$cmd-duration --status=$cmd-status-code --logical-path=$pwd
+    ::STARSHIP:: prompt --terminal-width=$E:COLUMNS --jobs=$num-bg-jobs --cmd-duration=$cmd-duration --status=$cmd-status-code --logical-path=$pwd
 }
 
 set edit:rprompt = {
     var cmd-duration = (printf "%.0f" (* $edit:command-duration 1000))
-    ::STARSHIP:: prompt --right --jobs=$num-bg-jobs --cmd-duration=$cmd-duration --status=$cmd-status-code --logical-path=$pwd
+    ::STARSHIP:: prompt --right --terminal-width=$E:COLUMNS --jobs=$num-bg-jobs --cmd-duration=$cmd-duration --status=$cmd-status-code --logical-path=$pwd
 }


### PR DESCRIPTION
## Summary

Elvish was the only supported shell whose init script did not pass `--terminal-width` to `starship prompt`. Without terminal width, `$fill` and right-aligned modules (such as `$time`) miscalculate column usage, causing prompt misalignment (e.g. missing digits or colons in the time segment).

Pass `--terminal-width=$E:COLUMNS` for both the main and right prompts, matching bash/zsh/fish/nushell.

Fixes #7453

## Test plan

- [x] Verified elvish init script matches other shells' terminal-width handling
- [x] `cargo clippy -- -D warnings`