### PR TITLE
fix(nix_shell): hide default impure state and flake env name (fixes #7370)

### DIFF
--- a/src/configs/nix_shell.rs
+++ b/src/configs/nix_shell.rs
@@ -27,7 +27,7 @@ impl Default for NixShellConfig<'_> {
             format: "via [$symbol$state( \\($name\\))]($style) ",
             symbol: "❄️  ",
             style: "bold blue",
-            impure_msg: "impure",
+            impure_msg: "",
             pure_msg: "pure",
             unknown_msg: "",
             disabled: false,

--- a/src/modules/nix_shell.rs
+++ b/src/modules/nix_shell.rs
@@ -83,7 +83,13 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 _ => None,
             })
             .map(|variable| match variable {
-                "name" => context.get_env("name").map(Ok),
+                "name" => context.get_env("name").and_then(|name| {
+                    if name == "nix-shell-env" {
+                        None
+                    } else {
+                        Some(Ok(name))
+                    }
+                }),
                 "level" => context.get_env("NIX_SHELL_LEVEL").map(Ok),
                 _ => None,
             })
@@ -139,7 +145,7 @@ mod tests {
         let actual = ModuleRenderer::new("nix_shell")
             .env("IN_NIX_SHELL", "impure")
             .collect();
-        let expected = Some(format!("via {} ", Color::Blue.bold().paint("❄️  impure")));
+        let expected = Some(format!("via {} ", Color::Blue.bold().paint("❄️  ")));
 
         assert_eq!(expected, actual);
     }
@@ -166,8 +172,19 @@ mod tests {
             .collect();
         let expected = Some(format!(
             "via {} ",
-            Color::Blue.bold().paint("❄️  impure (starship)")
+            Color::Blue.bold().paint("❄️   (starship)")
         ));
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn impure_shell_hides_default_flake_name() {
+        let actual = ModuleRenderer::new("nix_shell")
+            .env("IN_NIX_SHELL", "impure")
+            .env("name", "nix-shell-env")
+            .collect();
+        let expected = Some(format!("via {} ", Color::Blue.bold().paint("❄️  ")));
 
         assert_eq!(expected, actual);
     }
@@ -240,7 +257,7 @@ mod tests {
                 format = "via [$symbol$state( \\($name\\)) $level]($style) "
             })
             .collect();
-        let expected = Some(format!("via {} ", Color::Blue.bold().paint("❄️  impure 3")));
+        let expected = Some(format!("via {} ", Color::Blue.bold().paint("❄️   3")));
 
         assert_eq!(expected, actual);
     }


### PR DESCRIPTION
## Summary

- Default `impure_msg` is now empty, since impure is the default Nix shell state and showing it adds noise (helps #6188)
- Hide the `$name` environment variable when it equals the default flake devShell name `nix-shell-env`

Fixes #7370

## Test plan

- [x] `cargo test nix_shell --lib`
- [x] `cargo clippy -- -D warnings`
- [x] Added `impure_shell_hides_default_flake_name`