### PR TITLE
docs(python): clarify python_binary schema description

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -5834,6 +5834,7 @@
           "default": "pyenv "
         },
         "python_binary": {
+          "description": "Ordered list of Python executables to probe, tried in order until one responds. Each item is a command name (e.g. \"python3\") or an argv prefix array (e.g. [\"python\", \"-3\"]).",
           "$ref": "#/$defs/VecOr_VecOr_string",
           "default": [
             [

--- a/src/configs/python.rs
+++ b/src/configs/python.rs
@@ -12,6 +12,12 @@ use serde::{Deserialize, Serialize};
 pub struct PythonConfig<'a> {
     pub pyenv_version_name: bool,
     pub pyenv_prefix: &'a str,
+    #[cfg_attr(
+        feature = "config-schema",
+        schemars(
+            description = "Ordered list of Python executables to probe, tried in order until one responds. Each item is a command name (e.g. \"python3\") or an argv prefix array (e.g. [\"python\", \"-3\"])."
+        )
+    )]
     pub python_binary: VecOr<VecOr<&'a str>>,
     pub format: &'a str,
     pub version_format: &'a str,


### PR DESCRIPTION
## Summary

Fixes #7351.

The `python_binary` field uses `VecOr<VecOr<&str>>` on purpose: Starship tries each entry in order until one responds. Each entry is either a command name (e.g. `"python3"`) or an argv prefix array (e.g. `["python", "-3"]`).

The nested schema shape (`Either2` of string or string array, repeated as a list) matches that behavior, but the generated JSON schema did not explain it.

This PR adds a `schemars(description = "...")` on `python_binary` and regenerates `.github/config-schema.json`.

## Test plan

- [x] `cargo run --locked --features config-schema -- config-schema` matches committed schema
- [x] `cargo test --locked` compiles