### PR TITLE
fix(zsh): avoid glob pattern in ZSH version check

### DIFF
--- a/src/init/starship.zsh
+++ b/src/init/starship.zsh
@@ -10,7 +10,7 @@
 zmodload zsh/parameter  # Needed to access jobstates variable for STARSHIP_JOBS_COUNT
 
 # Defines a function `__starship_get_time` that sets the time since epoch in millis in STARSHIP_CAPTURED_TIME.
-if [[ $ZSH_VERSION == ([1-4]*) ]]; then
+if (( ${ZSH_VERSION%%.*} <= 4 )); then
     # ZSH <= 5; Does not have a built-in variable so we will rely on Starship's inbuilt time function.
     __starship_get_time() {
         STARSHIP_CAPTURED_TIME=$(::STARSHIP:: time)


### PR DESCRIPTION
## Summary

Fixes #7218.

When `setopt sh_glob` is enabled before `eval "$(starship init zsh)"`, the init script fails to load because the ZSH version check uses a glob alternation pattern:

```zsh
[[ $ZSH_VERSION == ([1-4]*) ]]
```

With `sh_glob`, parentheses lose their glob grouping meaning and zsh reports `bad pattern`.

Replace this with an arithmetic major-version comparison, which is unaffected by `sh_glob`.

## Test plan

- [x] `setopt sh_glob; source <(starship init zsh)` succeeds
- [x] `cargo build --locked` succeeds