### PR TITLE
fix(bash): move prompt to new line when output lacks trailing newline

### DIFF
--- a/src/init/starship.bash
+++ b/src/init/starship.bash
@@ -139,6 +139,11 @@ fi
 # Ensure that $COLUMNS gets set
 shopt -s checkwinsize
 
+# When a command's output does not end with a newline, bash draws the prompt on the
+# same line. Dynamic prompts set via PROMPT_COMMAND can then be mis-rendered by
+# readline (notably with git modules), see #7226.
+PROMPT_EOL_MARK=$'\n'
+
 # Set up the start time and STARSHIP_SHELL, which controls shell-specific sequences
 STARSHIP_START_TIME=$(::STARSHIP:: time)
 export STARSHIP_SHELL="bash"


### PR DESCRIPTION
## Summary

Fixes #7226.

When a command prints output without a trailing newline (e.g. `curl` returning `"Hello world"`), bash draws the next prompt on the same line. Starship regenerates `PS1` in `PROMPT_COMMAND`, and readline can then mis-render the prompt (duplicate git branch segments, missing command output).

Set `PROMPT_EOL_MARK=$'\n'` during bash init so bash inserts a newline before the prompt when the previous command's output did not end with one.

## Test plan

- [x] `starship init bash --print-full-init` includes `PROMPT_EOL_MARK=$'\n'`
- [ ] Manual: in bash with a git repo in the prompt, run `curl` against a response without a trailing newline and confirm output + prompt render correctly