### PR TITLE
docs(python): fix outdated python_binary documentation

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -4040,9 +4040,9 @@ By default, the module will be shown if any of the following conditions are met:
 > - a list of lists of strings, representing commands with optional arguments (e.g.
 >   `[['mise', 'exec', '--', 'python'], ['python3']]`)
 >
-> Starship will try executing each configured command until it gets a result.
-> Note you can only change the binary that Starship executes to get the version
-> of Python not the arguments that are used.
+> Starship tries each configured command in order until one returns a version.
+> Each entry can be a command name (e.g. `'python3'`) or an argv prefix array
+> (e.g. `['mise', 'exec', '--', 'python']`).
 >
 > The default values and order for `python_binary` was chosen to first identify
 > the Python version in a virtualenv/conda environments (which currently still


### PR DESCRIPTION
## Summary

Fixes #7279.

The English config docs still claimed that `python_binary` cannot use command arguments, which contradicts support added in #6523. The page already documented argv-prefix arrays in the list above that note; this removes the outdated sentence and clarifies how entries are tried.

Schema documentation is handled separately in #7517.

## Test plan

- [x] Documentation review only