### PR TITLE
feat(init): add brush shell support

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,17 @@ eval "$(starship init bash)"
 </details>
 
 <details>
+<summary>Brush</summary>
+
+[Brush](https://github.com/reubeno/brush) is a bash-compatible shell. Add the following to the end of `~/.bashrc` or `~/.brushrc`:
+
+```sh
+eval "$(starship init brush)"
+```
+
+</details>
+
+<details>
 <summary>Cmd</summary>
 
 You need to use [Clink](https://chrisant996.github.io/clink/clink.html) (v1.2.30+) with Cmd.

--- a/docs/README.md
+++ b/docs/README.md
@@ -85,6 +85,14 @@ onMounted(() => {
    eval "$(starship init bash)"
    ```
 
+   #### Brush
+
+   [Brush](https://github.com/reubeno/brush) is a bash-compatible shell. Add the following to the end of `~/.bashrc` or `~/.brushrc`:
+
+   ```sh
+   eval "$(starship init brush)"
+   ```
+
    #### Fish
 
    Add the following to the end of `~/.config/fish/config.fish`:

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -115,7 +115,7 @@ pub fn init_stub(shell_name: &str) -> io::Result<()> {
     let starship = StarshipPath::init()?;
 
     match shell_basename {
-        "bash" => print!(
+        "bash" | "brush" => print!(
             /* We now use the following bootstrap:
              *      `eval -- "$(starship init bash --print-full-init)"`
              * which works in any version of Bash from 3.2 to the latest
@@ -162,8 +162,9 @@ pub fn init_stub(shell_name: &str) -> io::Result<()> {
              * https://github.com/starship/starship/pull/5020
              * https://github.com/starship/starship/issues/5382
              */
-            r#"eval -- "$({0} init bash --print-full-init)""#,
-            starship.sprint_posix()?
+            r#"eval -- "$({0} init {1} --print-full-init)""#,
+            starship.sprint_posix()?,
+            shell_basename
         ),
         "zsh" => print_script(ZSH_INIT, &starship.sprint_posix()?),
         "fish" => print!(
@@ -195,6 +196,7 @@ pub fn init_stub(shell_name: &str) -> io::Result<()> {
                 "{shell_basename} is not yet supported by starship.\n\
                  For the time being, we support the following shells:\n\
                  * bash\n\
+                 * brush\n\
                  * elvish\n\
                  * fish\n\
                  * ion\n\
@@ -220,7 +222,7 @@ pub fn init_main(shell_name: &str) -> io::Result<()> {
     let starship_path = StarshipPath::init()?;
 
     match shell_name {
-        "bash" => print_script(BASH_INIT, &starship_path.sprint_posix()?),
+        "bash" | "brush" => print_script(BASH_INIT, &starship_path.sprint_posix()?),
         "zsh" => print_script(ZSH_INIT, &starship_path.sprint_posix()?),
         "fish" => print_script(FISH_INIT, &starship_path.sprint_posix()?),
         "powershell" => print_script(PWSH_INIT, &starship_path.sprint_pwsh()?),


### PR DESCRIPTION
## Summary

- Route `starship init brush` to the existing bash init script (Brush is bash-compatible and supports `PS1`/`PROMPT_COMMAND`)
- Document setup in the English README and installation guide

Fixes #7455

## Test plan

- [x] `./target/debug/starship init brush` prints the expected bootstrap command
- [x] `./target/debug/starship init brush --print-full-init` emits the bash init script
- [x] `cargo test init::`