### PR TITLE
fix(elixir): try --short-version first to avoid slow BEAM VM startup

### DIFF
--- a/src/configs/elixir.rs
+++ b/src/configs/elixir.rs
@@ -21,7 +21,7 @@ pub struct ElixirConfig<'a> {
 impl Default for ElixirConfig<'_> {
     fn default() -> Self {
         Self {
-            format: "via [$symbol($version \\(OTP $otp_version\\) )]($style)",
+            format: "via [$symbol($version )(\\(OTP $otp_version\\) )]($style)",
             version_format: "v${raw}",
             symbol: "💧 ",
             style: "bold purple",

--- a/src/modules/elixir.rs
+++ b/src/modules/elixir.rs
@@ -51,8 +51,8 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 "otp_version" => versions
                     .deref()
                     .as_ref()
-                    .map(|(otp_version, _)| otp_version.to_string())
-                    .map(Ok),
+                    .and_then(|(otp_version, _)| otp_version.as_deref())
+                    .map(|otp| Ok(otp.to_string())),
                 _ => None,
             })
             .parse(None, Some(context))
@@ -69,10 +69,30 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     Some(module)
 }
 
-fn get_elixir_version(context: &Context) -> Option<(String, String)> {
-    let output = context.exec_cmd("elixir", &["--version"])?.stdout;
+fn get_elixir_version(context: &Context) -> Option<(Option<String>, String)> {
+    // Try --short-version first (Elixir 1.13+): handled by the shell wrapper,
+    // so it never starts the BEAM VM and returns in ~9 ms instead of ~370 ms.
+    if let Some(output) = context.exec_cmd("elixir", &["--short-version"]) {
+        if let Some(version) = parse_elixir_short_version(&output.stdout) {
+            return Some((None, version));
+        }
+    }
 
-    parse_elixir_version(&output)
+    // Fall back to --version for older Elixir or when --short-version is absent.
+    let output = context.exec_cmd("elixir", &["--version"])?.stdout;
+    parse_elixir_version(&output).map(|(otp, ver)| (Some(otp), ver))
+}
+
+fn parse_elixir_short_version(output: &str) -> Option<String> {
+    let version = output.trim();
+    // Guard: must start with a digit to be a bare version string like "1.14.0".
+    // An unrecognised flag on pre-1.13 Elixir starts the VM and prints the full
+    // --version banner instead, which begins with "Erlang".
+    if version.starts_with(|c: char| c.is_ascii_digit()) {
+        Some(version.to_string())
+    } else {
+        None
+    }
 }
 
 fn parse_elixir_version(version: &str) -> Option<(String, String)> {
@@ -140,6 +160,26 @@ Elixir 1.13.0-dev (compiled with Erlang/OTP 23)
 
     #[test]
     fn test_with_mix_file() -> io::Result<()> {
+        // The global mock returns "1.13.4\n" for `elixir --short-version`,
+        // so the fast path is taken and OTP is not shown.
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join("mix.exs"))?.sync_all()?;
+
+        let expected = Some(format!(
+            "via {}",
+            Color::Purple.bold().paint("💧 v1.13.4 ")
+        ));
+        let output = ModuleRenderer::new("elixir").path(dir.path()).collect();
+
+        assert_eq!(output, expected);
+
+        dir.close()
+    }
+
+    #[test]
+    fn test_with_mix_file_version_fallback() -> io::Result<()> {
+        // Simulate pre-1.13 Elixir where --short-version is unavailable.
+        // The module should fall back to --version and show both versions.
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("mix.exs"))?.sync_all()?;
 
@@ -147,10 +187,33 @@ Elixir 1.13.0-dev (compiled with Erlang/OTP 23)
             "via {}",
             Color::Purple.bold().paint("💧 v1.10 (OTP 22) ")
         ));
-        let output = ModuleRenderer::new("elixir").path(dir.path()).collect();
+        let output = ModuleRenderer::new("elixir")
+            .path(dir.path())
+            .cmd("elixir --short-version", None) // simulate absent flag
+            .collect();
 
         assert_eq!(output, expected);
 
         dir.close()
+    }
+
+    #[test]
+    fn test_parse_elixir_short_version() {
+        assert_eq!(
+            parse_elixir_short_version("1.13.4\n"),
+            Some("1.13.4".to_string())
+        );
+        assert_eq!(
+            parse_elixir_short_version("1.14.0-rc.0\n"),
+            Some("1.14.0-rc.0".to_string())
+        );
+        // Should reject the full --version banner (pre-1.13 fallback output)
+        assert_eq!(
+            parse_elixir_short_version(
+                "Erlang/OTP 22 [erts-10.6.4]\n\nElixir 1.12.0 (compiled with Erlang/OTP 22)\n"
+            ),
+            None
+        );
+        assert_eq!(parse_elixir_short_version(""), None);
     }
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -277,6 +277,10 @@ Default target: x86_64-apple-macosx\n",
             stdout: String::from("stdout ok!\n"),
             stderr: String::from("stderr ok!\n"),
         }),
+        "elixir --short-version" => Some(CommandOutput {
+            stdout: String::from("1.13.4\n"),
+            stderr: String::default(),
+        }),
         "elixir --version" => Some(CommandOutput {
             stdout: String::from(
                 "\


### PR DESCRIPTION
## Summary

Closes #3867.

`elixir --version` starts the full Erlang VM (~370 ms). Since Elixir 1.13, the `elixir` shell script handles `--short-version` entirely before launching the VM, printing just the bare version string (e.g. `1.13.4`) in ~9 ms.

## Changes

**`src/modules/elixir.rs`**
- `get_elixir_version` now tries `elixir --short-version` first. On success it returns the Elixir version with `otp_version = None`.
- Falls back to `elixir --version` if the flag is absent or returns unexpected output (Elixir < 1.13 or unusual installs), restoring full OTP + version info.
- New `parse_elixir_short_version` validates the output starts with a digit (guards against the pre-1.13 behaviour where unrecognised flags still boot the VM and print the full banner).
- New `test_with_mix_file_version_fallback` test exercises the fallback path by disabling the `--short-version` mock.
- New `test_parse_elixir_short_version` unit tests.

**`src/configs/elixir.rs`**
- Default format changed to place each segment in its own optional group:
  ```
  before: [$symbol($version \(OTP $otp_version\) )]($style)
  after:  [$symbol($version )(\(OTP $otp_version\) )]($style)
  ```
  Visually identical when OTP is present; the OTP group is independently suppressed on the fast path.

**`src/utils/mod.rs`**
- Added `"elixir --short-version"` mock returning `"1.13.4\n"` so the existing `test_with_mix_file` exercises the fast path by default.

## Test results

```
test modules::elixir::tests::test_parse_elixir_short_version ... ok
test modules::elixir::tests::test_parse_elixir_version ... ok
test modules::elixir::tests::test_without_mix_file ... ok
test modules::elixir::tests::test_with_mix_file ... ok
test modules::elixir::tests::test_with_mix_file_version_fallback ... ok

test result: ok. 5 passed; 0 failed
```