### PR TITLE
fix(cmd_duration): round duration display to nearest second

### DIFF
--- a/src/modules/cmd_duration.rs
+++ b/src/modules/cmd_duration.rs
@@ -27,6 +27,13 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         return None;
     }
 
+    let display_duration = if config.show_milliseconds {
+        elapsed
+    } else {
+        // Round to the nearest second before hiding milliseconds.
+        elapsed.saturating_add(500)
+    };
+
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter
             .map_style(|variable| match variable {
@@ -34,7 +41,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 _ => None,
             })
             .map(|variable| match variable {
-                "duration" => Some(Ok(render_time(elapsed, config.show_milliseconds))),
+                "duration" => Some(Ok(render_time(display_duration, config.show_milliseconds))),
                 _ => None,
             })
             .parse(None, Some(context))
@@ -163,6 +170,16 @@ mod tests {
             .collect();
 
         let expected = Some(format!("took {} ", Color::Yellow.bold().paint("10s")));
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn rounds_duration_to_nearest_second_when_milliseconds_are_hidden() {
+        let actual = ModuleRenderer::new("cmd_duration")
+            .cmd_duration(12807)
+            .collect();
+
+        let expected = Some(format!("took {} ", Color::Yellow.bold().paint("13s")));
         assert_eq!(expected, actual);
     }
 


### PR DESCRIPTION
#### Description

Round `cmd_duration` to the nearest second before rendering when `show_milliseconds` is disabled. Millisecond output still uses the original elapsed duration.

#### Motivation and Context

Fixes #7479.

A command duration such as `12807ms` was rendered as `12s` because the module discarded milliseconds before formatting. With this change, hidden-millisecond output matches the reported expectation and renders `13s` for that case.

#### Screenshots (if appropriate):

N/A

#### How Has This Been Tested?

- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

Commands run:

- `~/.cargo/bin/cargo test rounds_duration_to_nearest_second_when_milliseconds_are_hidden` (failed before the production fix, passed after)
- `~/.cargo/bin/cargo test cmd_duration`
- `~/.cargo/bin/cargo fmt --check`
- `~/.cargo/bin/cargo clippy --workspace --locked -- -D warnings`
- `TERM=xterm-256color ~/.cargo/bin/cargo test --lib`
- `git diff --check`

Local notes:

- `~/.cargo/bin/cargo test --lib` without `TERM=xterm-256color` fails because this non-interactive shell has `TERM=dumb`; rerunning the same suite with `TERM=xterm-256color` passed.
- `~/.cargo/bin/cargo clippy --all-targets --all-features` currently fails in an unrelated `src/modules/os.rs` test-target lint (`clippy::wildcard_enum_match_arm`) under Rust 1.95.0; the CI clippy command from `.github/workflows/workflow.yml` passed.

#### Checklist:

- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
