### PR TITLE
fix(sudo): Avoid creating system error logs on every unsuccessful invocation

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -1747,7 +1747,8 @@
         "symbol": "🧙 ",
         "style": "bold blue",
         "allow_windows": false,
-        "disabled": true
+        "disabled": true,
+        "use_legacy_check": false
       }
     },
     "swift": {
@@ -6631,6 +6632,10 @@
         "disabled": {
           "type": "boolean",
           "default": true
+        },
+        "use_legacy_check": {
+          "type": "boolean",
+          "default": false
         }
       },
       "additionalProperties": false

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -4678,13 +4678,14 @@ The module will only be shown if credentials are cached.
 
 ### Options
 
-| Option          | Default                  | Description                                             |
-| --------------- | ------------------------ | ------------------------------------------------------- |
-| `format`        | `'[as $symbol]($style)'` | The format of the module                                |
-| `symbol`        | `'🧙 '`                  | The symbol displayed when credentials are cached        |
-| `style`         | `'bold blue'`            | The style for the module.                               |
-| `allow_windows` | `false`                  | Since windows has no default sudo, default is disabled. |
-| `disabled`      | `true`                   | Disables the `sudo` module.                             |
+| Option             | Default                  | Description                                                                 |
+| ------------------ | ------------------------ | --------------------------------------------------------------------------- |
+| `format`           | `'[as $symbol]($style)'` | The format of the module                                                    |
+| `symbol`           | `'🧙 '`                  | The symbol displayed when credentials are cached                            |
+| `style`            | `'bold blue'`            | The style for the module.                                                   |
+| `allow_windows`    | `false`                  | Since windows has no default sudo, default is disabled.                     |
+| `disabled`         | `true`                   | Disables the `sudo` module.                                                 |
+| `use_legacy_check` | `false`                  | Uses the legacy sudo check for compatibility with older versions of `sudo`. |
 
 ### Variables
 

--- a/src/configs/sudo.rs
+++ b/src/configs/sudo.rs
@@ -13,6 +13,7 @@ pub struct SudoConfig<'a> {
     pub style: &'a str,
     pub allow_windows: bool,
     pub disabled: bool,
+    pub use_legacy_check: bool,
 }
 
 impl Default for SudoConfig<'_> {
@@ -23,6 +24,7 @@ impl Default for SudoConfig<'_> {
             style: "bold blue",
             allow_windows: false,
             disabled: true,
+            use_legacy_check: false,
         }
     }
 }

--- a/src/modules/sudo.rs
+++ b/src/modules/sudo.rs
@@ -18,7 +18,13 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         return None;
     }
 
-    let is_sudo_cached = context.exec_cmd("sudo", &["-n", "true"]).is_some();
+    let sudo_flags = if config.use_legacy_check {
+        "-nv"
+    } else {
+        "-Nnv"
+    };
+
+    let is_sudo_cached = context.exec_cmd("sudo", &[sudo_flags]).is_some();
 
     if !is_sudo_cached {
         return None;
@@ -55,38 +61,84 @@ mod tests {
 
     #[test]
     fn test_sudo_not_cached() {
-        let actual = ModuleRenderer::new("sudo")
-            .cmd("sudo -n true", None)
-            .config(toml::toml! {
-                [sudo]
-                disabled = false
-                allow_windows = true
-            })
-            .collect();
-        let expected = None;
+        fn test_new_sudo() {
+            let actual = ModuleRenderer::new("sudo")
+                .cmd("sudo -Nnv", None)
+                .config(toml::toml! {
+                    [sudo]
+                    disabled = false
+                    allow_windows = true
+                })
+                .collect();
+            let expected = None;
 
-        assert_eq!(expected, actual);
+            assert_eq!(expected, actual);
+        }
+
+        fn test_legacy_sudo() {
+            let actual = ModuleRenderer::new("sudo")
+                .cmd("sudo -nv", None)
+                .config(toml::toml! {
+                    [sudo]
+                    disabled = false
+                    allow_windows = true
+                    use_legacy_check = true
+                })
+                .collect();
+            let expected = None;
+
+            assert_eq!(expected, actual);
+        }
+
+        test_new_sudo();
+        test_legacy_sudo();
     }
 
     #[test]
     fn test_sudo_cached() {
-        let actual = ModuleRenderer::new("sudo")
-            .cmd(
-                "sudo -n true",
-                Some(CommandOutput {
-                    stdout: String::new(),
-                    stderr: String::new(),
-                }),
-            )
-            .config(toml::toml! {
-                [sudo]
-                disabled = false
-                allow_windows = true
-            })
-            .collect();
-        let expected = Some(format!("{}", Color::Blue.bold().paint("as 🧙 ")));
+        fn test_new_sudo() {
+            let actual = ModuleRenderer::new("sudo")
+                .cmd(
+                    "sudo -Nnv",
+                    Some(CommandOutput {
+                        stdout: String::new(),
+                        stderr: String::new(),
+                    }),
+                )
+                .config(toml::toml! {
+                    [sudo]
+                    disabled = false
+                    allow_windows = true
+                })
+                .collect();
+            let expected = Some(format!("{}", Color::Blue.bold().paint("as 🧙 ")));
 
-        assert_eq!(expected, actual);
+            assert_eq!(expected, actual);
+        }
+
+        fn test_legacy_sudo() {
+            let actual = ModuleRenderer::new("sudo")
+                .cmd(
+                    "sudo -nv",
+                    Some(CommandOutput {
+                        stdout: String::new(),
+                        stderr: String::new(),
+                    }),
+                )
+                .config(toml::toml! {
+                    [sudo]
+                    disabled = false
+                    allow_windows = true
+                    use_legacy_check = true
+                })
+                .collect();
+            let expected = Some(format!("{}", Color::Blue.bold().paint("as 🧙 ")));
+
+            assert_eq!(expected, actual);
+        }
+
+        test_new_sudo();
+        test_legacy_sudo();
     }
 
     #[test]
@@ -94,7 +146,7 @@ mod tests {
     fn test_allow_windows_disabled_blocks_windows() {
         let actual = ModuleRenderer::new("sudo")
             .cmd(
-                "sudo -n true",
+                "sudo -Nnv",
                 Some(CommandOutput {
                     stdout: String::new(),
                     stderr: String::new(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
The current sudo module impl pollutes journalctl with sudo denial logs because of repeatedly launching `/usr/bin/true`. 
This change attempts to fix that.

There is also the situation where the current command extends the sudo session (via repeatedly spawning `true`) which this PR attempts to address. 

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #4538 

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- Most changes do not need to be tested on multiple operating systems. -->
- [ ] I have tested using **MacOS**
- [X] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### AI-Assistance
<!-- Per our AI Policy (AI_POLICY.md), all AI usage must be declared. -->
Have you used AI-assistance to author this PR?

- [X] Yes
- [ ] No

If **yes**, describe the scope of assistance:
<!--- Describe how you used AI-Assistance -->
<!--- Disclosure is required if you have used AI-assistance -->
<!--- For example: answering project questions, writing tests, implementation, or documentation -->
- asking general rust questions, like how do I do `X` in rust. (I am a C++ dev). 
- trying to get suggestions on the "idiomatic" rust syntax.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [X] I have updated the tests accordingly.
- [X] I understand and have read the code I contribute and can answer questions about it.

Impl: 
- The idea is essentially, check the `sudo` version, see if it supports the `-N` option or not and cache the result in the starship cache, via two empty file flags.
- Then following these cached results, decide which version of command to use, (with `-N` or without).
- update the cache on each system boot for scenarios like user upgraded / downgraded sudo.

Potential concerns:
- I can see `get_log_dir` is essentially starship cache, even all the code that attempts to use this dir expects it to contain data other than session logs, yet its name ambiguously `get_log_dir`, shouldn't this be outside the logging crate and in the utils module with the name `get_cache_dir` ? 