### PR TITLE
fix(statusline): handle null context_window fields at session start

### DIFF
--- a/src/utils/statusline.rs
+++ b/src/utils/statusline.rs
@@ -1,5 +1,15 @@
 /// Claude Code session data structures for statusline integration
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
+
+/// Deserialize a field, treating explicit `null` the same as a missing field.
+/// `#[serde(default)]` alone only covers missing fields, not explicit `null`.
+fn deserialize_null_default<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    T: Default + Deserialize<'de>,
+    D: Deserializer<'de>,
+{
+    Ok(Option::<T>::deserialize(deserializer)?.unwrap_or_default())
+}
 
 /// Claude Code session data
 #[derive(Deserialize, Debug, Clone, Default)]
@@ -25,9 +35,9 @@ pub struct ContextWindow {
     pub context_window_size: u64,
     pub total_input_tokens: u64,
     pub total_output_tokens: u64,
-    /// Pre-computed usage percentage (0–100) provided by Claude Code
+    #[serde(deserialize_with = "deserialize_null_default")]
     pub used_percentage: f32,
-    /// Usage of the most recent API call
+    #[serde(deserialize_with = "deserialize_null_default")]
     pub current_usage: CurrentUsage,
 }
 
@@ -55,4 +65,94 @@ pub struct CostInfo {
 pub struct Workspace {
     pub current_dir: String,
     pub project_dir: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_deserializes_session_start_payload_with_null_context_window_fields() {
+        let payload = r#"{
+            "model": {
+                "id": "claude-opus-4-7[1m]",
+                "display_name": "Opus 4.7 (1M context)"
+            },
+            "context_window": {
+                "total_input_tokens": 0,
+                "total_output_tokens": 0,
+                "context_window_size": 1000000,
+                "current_usage": null,
+                "used_percentage": null,
+                "remaining_percentage": null
+            }
+        }"#;
+
+        let data: ClaudeCodeData =
+            serde_json::from_str(payload).expect("session-start payload must deserialize");
+
+        assert_eq!(data.model.display_name, "Opus 4.7 (1M context)");
+        assert_eq!(data.context_window.context_window_size, 1_000_000);
+        assert_eq!(data.context_window.used_percentage, 0.0);
+        assert_eq!(data.context_window.current_usage.input_tokens, 0);
+    }
+
+    #[test]
+    fn test_deserializes_fully_populated_payload() {
+        let payload = r#"{
+            "model": {
+                "id": "claude-opus-4-7[1m]",
+                "display_name": "Opus 4.7 (1M context)"
+            },
+            "context_window": {
+                "total_input_tokens": 1234,
+                "total_output_tokens": 567,
+                "context_window_size": 1000000,
+                "used_percentage": 12.5,
+                "current_usage": {
+                    "input_tokens": 100,
+                    "output_tokens": 50,
+                    "cache_creation_input_tokens": 10,
+                    "cache_read_input_tokens": 20
+                }
+            }
+        }"#;
+
+        let data: ClaudeCodeData =
+            serde_json::from_str(payload).expect("populated payload must deserialize");
+
+        assert_eq!(data.context_window.total_input_tokens, 1234);
+        assert!((data.context_window.used_percentage - 12.5).abs() < f32::EPSILON);
+        assert_eq!(
+            data.context_window.current_usage.cache_read_input_tokens,
+            20
+        );
+    }
+
+    #[test]
+    fn test_missing_context_window_fields_default() {
+        let payload = r#"{ "context_window": {} }"#;
+        let data: ClaudeCodeData =
+            serde_json::from_str(payload).expect("missing fields must default");
+        assert_eq!(data.context_window.context_window_size, 0);
+        assert_eq!(data.context_window.used_percentage, 0.0);
+        assert_eq!(data.context_window.current_usage.input_tokens, 0);
+    }
+
+    #[test]
+    fn test_wrong_type_still_errors() {
+        let payload = r#"{
+            "context_window": {
+                "used_percentage": "not a number"
+            }
+        }"#;
+
+        let err = serde_json::from_str::<ClaudeCodeData>(payload)
+            .expect_err("wrong-type field must not be silently defaulted");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("invalid type") && msg.contains("f32"),
+            "error should be a serde type error, got: {msg}"
+        );
+    }
 }


### PR DESCRIPTION
#### Description

I'm loving the new support for Claude Code statuslines but noticed that rendered variables are initially empty when starting a new session and only populate after sending the first message. It looks like this can be traced to an issue with `null` value handling in the JSON payload.

At session start, Claude Code's initial JSON payload contains `null` for several `context_window` fields:

```json
"context_window": {
  "total_input_tokens": 0,
  "total_output_tokens": 0,
  "context_window_size": 1000000,
  "current_usage": null,
  "used_percentage": null,
  "remaining_percentage": null
}
```

This is documented in the [statusline data reference section](https://code.claude.com/docs/en/statusline#available-data) of the Claude Code docs.

It looks like serde treats `null` as an explicit value rather than a missing field, so the `default` attribute is not applied to these fields and deserialization of the whole `ClaudeCodeData` payload fails with:

```log
(starship::print): Failed to read Claude Code JSON from stdin: invalid type: null, expected struct CurrentUsage at line 31 column 25
```

The result is `model.display_name` ends up as `""`. After the first turn, Claude Code populates the previously `null` fields with real numbers, deserialization succeeds, and the statusline renders as expected.

#### Motivation and Context

Inititally came across this issue while testing with a real Claude Code session on macOS using the `claude-code` profile setup from the [Starship docs](https://starship.rs/advanced-config/#setup).

However, the bug can be reproduced without Claude Code by piping a session-start payload directly into the subcommand. The payload must be captured *before* the first user message so `current_usage`, `used_percentage`, and `remaining_percentage` are all `null`.

The payload I captured is [here](https://gist.github.com/aaronwolen/002c891be8aed0a5f75933ba867ef3b6) and was stored locally in `claude-code-payload.json`. Then just pipe it into the `claude-code` module:

```sh
# Use a unique session key to avoid log deduplication
STARSHIP_SESSION_KEY=$(date +%s) &&
cat /tmp/claude-code-payload.json | starship statusline claude-code
```

This outputs:

```sh
[ERROR] - (starship::print): Failed to read Claude Code JSON from stdin: invalid type: null, expected struct CurrentUsage at line 31 column 25

🤖
```

I ran the same repro in a clean `node:22-slim` Docker container with the same version of Starship and got the same result.

#### Fix

Added a small `deserialize_null_default` helper and apply `#[serde(deserialize_with = ...)]` to the two `ContextWindow` fields that Claude Code documents as nullable.

The helper treats `null` and missing identically so both cases fall back to `Default`. I left the other numeric fields (`context_window_size`, `total_input_tokens`, `total_output_tokens`) as is. It seemed safer to let the deserialization fail if they ever come through as `null` to surface the upstream change from Claude.

After the fix, the repro successfully deserializes the payload and renders the full statusline with all variables populated:

```text

🤖 Opus 4.7 (1M context)
```

#### How Has This Been Tested?

Tested with the above repro on both macOS and Linux. Also added unit tests to cover the new helper and guard against regressions in both the explicit `null` and missing-field cases, as well as a negative test to confirm that type errors still throw as expected.

*New tests:*

- `test_deserializes_session_start_payload_with_null_context_window_fields` deserializes the exact session-start payload and asserts `model.display_name == "Opus 4.7 (1M context)"`, plus that the nullable fields fall back to `Default`. This is the regression test. This fails without the fix and passes with it.
- `test_deserializes_fully_populated_payload` confirms the post-first-message payload still deserializes correctly.
- `test_missing_context_window_fields_default` confirms that missing fields (not just explicit `null`) still fall back to `Default`.
- `test_wrong_type_still_errors` guards against the "null becomes default" helper silently passing a malformed JSON payload. The test uses a string where an `f32` is expected and verifies the expected serde type error.

*Existing tests:*

- All 26 existing `claude_*` module tests still pass (`cargo test --lib claude_`).
- `cargo fmt --check` and `cargo clippy --lib -- -D warnings` both pass clean.

- [x] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows** (I don't have access to a Windows machine)

#### AI-Assistance

Have you used AI-assistance to author this PR?

- [x] Yes
- [ ] No

Claude Code was used to diagnose the issue, review the fix, and round out test coverage.

#### Checklist:

- [x] I have updated the documentation accordingly. *(no user-facing behavior change)*
- [x] I have updated the tests accordingly.
- [x] I understand and have read the code I contribute and can answer questions about it.
