### PR TITLE
docs(preset): fix Pure preset formatting over SSH

### DIFF
--- a/docs/public/presets/toml/pure-preset.toml
+++ b/docs/public/presets/toml/pure-preset.toml
@@ -1,7 +1,7 @@
 "$schema" = 'https://starship.rs/config-schema.json'
 
 format = """
-[$username$hostname ]()\
+($username$hostname )\
 $directory\
 $git_branch\
 $git_state\

--- a/docs/public/presets/toml/pure-preset.toml
+++ b/docs/public/presets/toml/pure-preset.toml
@@ -1,8 +1,7 @@
 "$schema" = 'https://starship.rs/config-schema.json'
 
 format = """
-$username\
-$hostname\
+[$username$hostname ]()\
 $directory\
 $git_branch\
 $git_state\
@@ -11,6 +10,17 @@ $cmd_duration\
 $line_break\
 $python\
 $character"""
+
+[username]
+show_always = false
+format = "[$user]($style)"
+style_user = "bright-black"
+style_root = "bright-black"
+
+[hostname]
+ssh_only = true
+format = "[@$hostname]($style)"
+style = "bright-black"
 
 [directory]
 style = "blue"
@@ -48,15 +58,3 @@ format = "[$virtualenv]($style) "
 style = "bright-black"
 detect_extensions = []
 detect_files = []
-
-[username]
-show_always = false
-format = "[$user]($style)"
-style_user = "bright-black"
-style_root = "bright-black"
-
-[hostname]
-ssh_only = true
-format = "[@$hostname]($style) "
-ssh_symbol = ""
-style = "bright-black"

--- a/docs/public/presets/toml/pure-preset.toml
+++ b/docs/public/presets/toml/pure-preset.toml
@@ -14,13 +14,13 @@ $character"""
 [username]
 show_always = false
 format = "[$user]($style)"
-style_user = "bright-black"
-style_root = "bright-black"
+style_user = "242"
+style_root = ""
 
 [hostname]
 ssh_only = true
 format = "[@$hostname]($style)"
-style = "bright-black"
+style = "242"
 
 [directory]
 style = "blue"

--- a/docs/public/presets/toml/pure-preset.toml
+++ b/docs/public/presets/toml/pure-preset.toml
@@ -48,3 +48,15 @@ format = "[$virtualenv]($style) "
 style = "bright-black"
 detect_extensions = []
 detect_files = []
+
+[username]
+show_always = false
+format = "[$user]($style)"
+style_user = "bright-black"
+style_root = "bright-black"
+
+[hostname]
+ssh_only = true
+format = "[@$hostname]($style) "
+ssh_symbol = ""
+style = "bright-black"


### PR DESCRIPTION
### docs(preset): fix pure-preset formatting over SSH

#### Description
Added explicit overrides for the `[username]` and `[hostname]` modules to the `pure-preset.toml` configuration file. 
* Set `show_always = false` for the username.
* Set `ssh_only = true` for the hostname.
* Removed the default `ssh_symbol` (🌐) and formatting strings ("in", "on").

#### Motivation and Context
The current `pure-preset` does not explicitly override the `[username]` and `[hostname]` modules. When a user connects to a remote machine via SSH, Starship correctly activates these modules for security context, but falls back to its built-in default format (e.g., `user in 🌐 host`). 

This breaks the minimalist aesthetic of the prompt. This PR adds explicit overrides to the preset so that when connected via SSH, the prompt renders simply as `user@host` to maintain exact visual parity with Sindre Sorhus's original Zsh Pure prompt.

#### Screenshots (if appropriate):
*(Please see the attached screenshot below: the top prompt shows the corrected, minimal behavior over SSH, while the bottom shows the output reverting to the broken default format after running the current preset command.)*
<img width="540" height="125" alt="Screenshot_2026-06-09_12-12-29" src="https://github.com/user-attachments/assets/ae8f0812-a642-483a-9a64-fdb1d05bf939" />


#### How Has This Been Tested?
Applied the updated `pure-preset.toml` on a remote headless server accessed via SSH. Verified that the prompt rendered correctly without the globe symbol and filler words, and verified that it correctly remained hidden when tested locally.

- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### AI-Assistance
Have you used AI-assistance to author this PR?

- [x] Yes
- [ ] No

If **yes**, describe the scope of assistance:
Used Gemini to troubleshoot an issue where the remote prompt defaulted to Starship's built-in format over SSH, identify the missing overrides in the `pure-preset.toml`, and draft this PR description.

#### Checklist:
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I understand and have read the code I contribute and can answer questions about it.