### PR TITLE
fix(preset): make OS symbol dynamic in Tokyo Night theme

### DIFF
--- a/docs/public/presets/toml/tokyo-night.toml
+++ b/docs/public/presets/toml/tokyo-night.toml
@@ -2,7 +2,7 @@
 
 format = """
 [░▒▓](#a3aed2)\
-[  ](bg:#a3aed2 fg:#090c0c)\
+$os\
 [](bg:#769ff0 fg:#a3aed2)\
 $directory\
 [](fg:#769ff0 bg:#394260)\
@@ -70,3 +70,32 @@ disabled = false
 time_format = "%R" # Hour:Minute Format
 style = "bg:#1d2230"
 format = '[[  $time ](fg:#a0a9cb bg:#1d2230)]($style)'
+
+[os]
+style = "bg:#a3aed2 fg:#090c0c"
+format = "[ $symbol ]($style)"
+disabled = false
+
+[os.symbols]
+Windows = "󰍲"
+Ubuntu = "󰕈"
+SUSE = ""
+Raspbian = "󰐿"
+Mint = "󰣭"
+Macos = "󰀵"
+Manjaro = ""
+Linux = "󰌽"
+Gentoo = "󰣨"
+Fedora = "󰣛"
+Alpine = ""
+Amazon = ""
+Android = ""
+AOSC = ""
+Arch = "󰣇"
+Artix = "󰣇"
+EndeavourOS = ""
+CentOS = ""
+Debian = "󰣚"
+Redhat = "󱄛"
+RedHatEnterprise = "󱄛"
+Pop = ""


### PR DESCRIPTION
### Summary

This PR replaces the hardcoded macOS Apple symbol in the **Tokyo Night** preset (tokyo-night.toml) with the dynamic **$os** module. This allows the prompt to automatically adapt and display the correct icon depending on the operating system the user is running.

### Details

- Replaced the hardcoded macOS symbol in the prompt's format with **$os**.
- Added the **[os]** module configuration, matching the style and padding of the original preset header.
- Populated the **[os.symbols]** table using the modern Nerd Font  icons matching the  **gruvbox** and **catppuccin** presets.

### Screenshots :

<img width="419" height="85" alt="Screenshot from 2026-06-17 01-55-00" src="https://github.com/user-attachments/assets/59640ad9-1b02-4cea-8eaa-1a58b57f8315" />
<img width="420" height="85" alt="Screenshot from 2026-06-17 02-04-36" src="https://github.com/user-attachments/assets/f190e1ec-3181-49df-8c0d-d6e0af9ca28b" />
<img width="420" height="85" alt="Screenshot from 2026-06-17 02-05-03" src="https://github.com/user-attachments/assets/3a35a2a5-1446-4f09-852e-503680c10717" />
<img width="420" height="85" alt="Screenshot from 2026-06-17 02-05-16" src="https://github.com/user-attachments/assets/76b7da0d-e45d-4ba9-bcf2-b48ca502f403" />
<img width="420" height="85" alt="Screenshot from 2026-06-17 02-06-28" src="https://github.com/user-attachments/assets/4a1ad8ff-0e63-419b-89b0-ccaef3351cdd" />

### How Has This Been Tested?

- Verified correct visual rendering natively on Windows, Fedora, and Arch Linux.
- Tested distro rendering (Debian, Ubuntu, CentOS) in Docker by overriding /etc/os-release.
- Confirmed the preset loads and compiles without syntax or schema warnings.
---
- [x] I have tested using **Linux**
- [x] I have tested using **Windows**
- [ ] I have tested using **MacOS**

#### AI-Assistance
<!-- Per our AI Policy (AI_POLICY.md), all AI usage must be declared. -->
Have you used AI-assistance to author this PR?

- [ ] Yes
- [x] No

If **yes**, describe the scope of assistance:
<!--- Describe how you used AI-Assistance -->
<!--- Disclosure is required if you have used AI-assistance -->
<!--- For example: answering project questions, writing tests, implementation, or documentation -->
N/A

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
- [x] I understand and have read the code I contribute and can answer questions about it.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/starship/starship/pull/7555?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

