### PR TITLE
fix(cmd_duration): round displayed time to nearest second

### DIFF
--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -768,6 +768,16 @@ pub fn exec_timeout(cmd: &mut Command, time_limit: Duration) -> Option<CommandOu
 
 // Render the time into a nice human-readable string
 pub fn render_time(raw_millis: u128, show_millis: bool) -> String {
+    // When milliseconds are hidden the smallest displayed unit is the second,
+    // so round to the nearest second instead of truncating the sub-second part
+    // (e.g. 12807ms is closer to 13s than to 12s). When milliseconds are shown
+    // the value is rendered in full, so no rounding is needed.
+    let raw_millis = if show_millis {
+        raw_millis
+    } else {
+        (raw_millis + 500) / 1000 * 1000
+    };
+
     // Fast returns for zero cases to render something
     match (raw_millis, show_millis) {
         (0, true) => return "0ms".into(),
@@ -901,8 +911,30 @@ mod tests {
         assert_eq!(render_time(500_u128, true), "500ms");
     }
     #[test]
+    fn render_time_test_499ms_no_millis() {
+        // Below the half-second boundary rounds down to zero.
+        assert_eq!(render_time(499_u128, false), "0s");
+    }
+    #[test]
     fn render_time_test_500ms_no_millis() {
-        assert_eq!(render_time(500_u128, false), "0s");
+        // At/above the half-second boundary rounds up to one second.
+        assert_eq!(render_time(500_u128, false), "1s");
+    }
+    #[test]
+    fn render_time_test_round_to_nearest_second() {
+        // 12.807s is closer to 13s than to 12s (issue #7479).
+        assert_eq!(render_time(12_807_u128, false), "13s");
+        // 12.499s stays at 12s.
+        assert_eq!(render_time(12_499_u128, false), "12s");
+        // Rounding still shows the exact value when millis are displayed.
+        assert_eq!(render_time(12_807_u128, true), "12s807ms");
+    }
+    #[test]
+    fn render_time_test_round_carries_into_larger_units() {
+        // 59.5s rounds up to a full minute, carrying through the breakdown.
+        assert_eq!(render_time(59_500_u128, false), "1m0s");
+        // 23h59m59.5s rounds up to a full day.
+        assert_eq!(render_time(86_399_500_u128, false), "1d0h0m0s");
     }
     #[test]
     fn render_time_test_10s() {


### PR DESCRIPTION
Closes #7479

`render_time` truncated the sub-second part when milliseconds are hidden, so a 12.807s command rendered `took 12s` instead of `took 13s`.

The smallest displayed unit in that mode is the second, so round `raw_millis` to the nearest second before the day/hour/minute/second breakdown; rounding still carries correctly into larger units (e.g. `59.5s` → `1m0s`). When milliseconds are shown the value is rendered in full and is left unchanged.

Existing `render_time(500, false)` test updated from `0s` to `1s` (the same truncation, at the half-second boundary), plus regression tests for the rounding and the carry. The other callers (`aws`, `claude_cost`) pass whole-second values, so they are unaffected.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/starship/starship/pull/7563?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

