### PR TITLE
docs(python): clarify python_binary arguments

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -5834,6 +5834,7 @@
           "default": "pyenv "
         },
         "python_binary": {
+          "description": "Python commands used to get the Python version. Each entry can be a\nbinary name or a command with arguments.",
           "$ref": "#/$defs/VecOr_VecOr_string",
           "default": [
             [

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -4042,9 +4042,8 @@ By default, the module will be shown if any of the following conditions are met:
 > - a list of lists of strings, representing commands with optional arguments (e.g.
 >   `[['mise', 'exec', '--', 'python'], ['python3']]`)
 >
-> Starship will try executing each configured command until it gets a result.
-> Note you can only change the binary that Starship executes to get the version
-> of Python not the arguments that are used.
+> Starship will try executing each configured command, including any configured
+> arguments, until it gets a result.
 >
 > The default values and order for `python_binary` was chosen to first identify
 > the Python version in a virtualenv/conda environments (which currently still

--- a/src/configs/python.rs
+++ b/src/configs/python.rs
@@ -12,6 +12,8 @@ use serde::{Deserialize, Serialize};
 pub struct PythonConfig<'a> {
     pub pyenv_version_name: bool,
     pub pyenv_prefix: &'a str,
+    /// Python commands used to get the Python version. Each entry can be a
+    /// binary name or a command with arguments.
     pub python_binary: VecOr<VecOr<&'a str>>,
     pub format: &'a str,
     pub version_format: &'a str,


### PR DESCRIPTION
#### Description

Clarifies that `python_binary` entries can include command arguments, not just a binary name. The previous tip contradicted the examples directly above it by saying arguments could not be changed.

This also adds a generated config-schema description for `python_binary` so editor/schema help describes the command-with-arguments form now supported by the schema shape from #7415.

#### Motivation and Context

Closes #7279.

The docs and schema now consistently describe the current `python_binary` behavior: Starship tries each configured command, including configured arguments, until it gets a Python version.

#### Screenshots (if appropriate):

N/A - documentation and generated schema metadata only.

#### How Has This Been Tested?

- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

Commands run:

- `cargo fmt --check`
- `cargo run --locked --features config-schema -- config-schema > $tmp`, then compared `$tmp` with `.github/config-schema.json`
- `cargo test --locked --features config-schema vec_or_schema_ids_distinguish_nesting`
- `cargo test --locked`
- `dprint check docs/config/README.md`
- `git diff --check`

#### AI-Assistance

Have you used AI-assistance to author this PR?

- [x] Yes
- [ ] No

If **yes**, describe the scope of assistance:

AI assistance was used to inspect the existing issue/PR history, draft and review the documentation/schema wording, run local validation commands, and prepare this PR description. The final diff was reviewed before submission.

#### Checklist:

- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I understand and have read the code I contribute and can answer questions about it.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/starship/starship/pull/7564?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

