### PR TITLE
fix(fill): don't hang when the fill symbol is zero-width

### DIFF
--- a/src/print.rs
+++ b/src/print.rs
@@ -563,6 +563,27 @@ mod test {
     const NULL_DEVICE: &str = if cfg!(windows) { "NUL" } else { "/dev/null" };
 
     #[test]
+    fn fill_with_zero_width_symbol_terminates() {
+        // A $fill symbol made entirely of zero-width unicode (here, a ZWJ) can
+        // never reach the target width by itself; rendering it used to hang
+        // forever instead of just producing an empty fill.
+        let mut context = default_context().set_config(toml::toml! {
+                add_newline = false
+                format = "left$fill right"
+                [fill]
+                symbol = "\u{200d}"
+        });
+        context.target = Target::Main;
+        context.width = 20;
+
+        let actual = get_prompt(&context);
+        assert_eq!(
+            format!("left{} right", nu_ansi_term::Color::Black.bold().paint("")),
+            actual
+        );
+    }
+
+    #[test]
     fn main_prompt() {
         let mut context = default_context().set_config(toml::toml! {
                 add_newline=false

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -42,6 +42,12 @@ impl FillSegment {
             Some(w) => self
                 .value
                 .graphemes(true)
+                // Zero-width graphemes (e.g. a bare combining mark or ZWJ used as the fill
+                // symbol) never advance `len` below, so cycling over them would spin
+                // forever without ever reaching `w`. Drop them before cycling: they can't
+                // contribute visible width anyway, and this guarantees termination even
+                // if every grapheme in the symbol turns out to be zero-width.
+                .filter(|g| Grapheme(g).width() > 0)
                 .cycle()
                 .scan(0usize, |len, g| {
                     *len += Grapheme(g).width();
@@ -60,7 +66,7 @@ impl FillSegment {
 #[cfg(test)]
 mod fill_seg_tests {
     use super::FillSegment;
-    use nu_ansi_term::Color;
+    use nu_ansi_term::{AnsiString, Color};
 
     #[test]
     fn ansi_string_width() {
@@ -83,6 +89,33 @@ mod fill_seg_tests {
             let actual = f.ansi_string(Some(width), None);
             assert_eq!(style.paint(*expected), actual);
         }
+    }
+
+    #[test]
+    fn ansi_string_all_zero_width_symbol_does_not_hang() {
+        // A fill symbol made up entirely of zero-width graphemes (e.g. a bare
+        // combining mark or a ZWJ) can never reach the target width, so cycling
+        // over it must terminate instead of looping forever. It can't render
+        // anything visible, so the result should just be empty.
+        let f = FillSegment {
+            value: String::from("\u{0301}"), // combining acute accent, width 0
+            style: None,
+        };
+        let actual = f.ansi_string(Some(10), None);
+        assert_eq!(AnsiString::from(""), actual);
+    }
+
+    #[test]
+    fn ansi_string_mixed_zero_width_symbol() {
+        // Zero-width graphemes mixed into an otherwise-visible symbol should be
+        // skipped, filling with just the visible graphemes instead of hanging.
+        let width: usize = 4;
+        let f = FillSegment {
+            value: String::from("\u{200d}."), // ZWJ + '.'
+            style: None,
+        };
+        let actual = f.ansi_string(Some(width), None);
+        assert_eq!(AnsiString::from("...."), actual);
     }
 }
 


### PR DESCRIPTION
`FillSegment::ansi_string` cycles through the fill symbol's graphemes and stops once the accumulated width reaches the target. If every grapheme in the symbol has width 0 (a bare combining mark, a lone ZWJ, a variation selector...), the accumulated length never advances, so `.cycle()` spins forever and the whole prompt just hangs. `symbol = "‍"` in a `[fill]` config reproduces it directly.

Fix is to filter out zero-width graphemes before cycling — they can't contribute visible width anyway. As a side benefit this also stops symbols that mix zero-width and visible characters from leaking stray invisible bytes into the rendered fill.

Added a couple of unit tests around `FillSegment::ansi_string` plus an end-to-end one through `get_prompt`, all of which hang without the fix and pass with it.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/starship/starship/pull/7575?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

