### PR TITLE
Publish the latest release documentation

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -6,8 +6,18 @@ jobs:
     name: Publish docs to Netlify
     runs-on: ubuntu-latest
     steps:
+      - name : Setup | The latest release
+        id: latest_release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG=$(gh api repos/${{ github.repository }}/releases/latest --jq .tag_name)
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
       - name: Setup | Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ steps.latest_release.outputs.tag }}
 
       - name: Setup | Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0


### PR DESCRIPTION
#### Description

Currently, since no release tag is specified, that is published the HEAD of the main branch at any point in time when it performed. I think there are some benefits to ensuring that the documentation remains consistent with the content at the time of release.

#### Motivation and Context

In this case, the documentation for the HEAD of the main branch -— which includes the changes in 1.26.0 —- resulted in a build error and was not published, making it difficult to notice the changes. If the documentation were for the latest release version, I think it would be easier to spot build errors during release workflow verification, for example.

##### Refs.

- https://github.com/starship/starship/actions/runs/28329579211/job/83925316178

#### How Has This Been Tested?

- [x] I have tested using **MacOS**
  - I've only tested the command snippets locally
  - I haven't tested the entire workflow
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### AI-Assistance

Have you used AI-assistance to author this PR?

- [x] Yes
- [ ] No

If **yes**, describe the scope of assistance:
I used GitHub Copilot for code snippet autocompletion.

#### Checklist:

- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I understand and have read the code I contribute and can answer questions about it.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/starship/starship/pull/7578?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

