### PR TITLE
perf(windows/scoop): Resolve scoop shim paths on Windows

### DIFF
--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -3,7 +3,7 @@ use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 use std::{env, io};
 
-use which::which;
+use crate::utils::which::which;
 
 /* We use a two-phase init here: the first phase gives a simple command to the
 shell. This command evaluates a more complicated script using `source` and

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -3,7 +3,7 @@ use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 use std::{env, io};
 
-use crate::utils::which::which;
+use crate::utils::which;
 
 /* We use a two-phase init here: the first phase gives a simple command to the
 shell. This command evaluates a more complicated script using `source` and

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,7 +1,8 @@
 pub mod env;
 pub mod serde;
 pub mod statusline;
-pub mod which;
+#[cfg(windows)]
+mod which;
 
 use process_control::{ChildExt, Control};
 use std::ffi::OsStr;
@@ -14,6 +15,11 @@ use std::time::{Duration, Instant};
 
 use crate::context::Context;
 use crate::context::Shell;
+
+#[cfg(windows)]
+pub use self::which::which;
+#[cfg(not(windows))]
+pub use which::which;
 
 /// Default timeout for command execution in milliseconds
 pub const DEFAULT_COMMAND_TIMEOUT_MS: u64 = 500;
@@ -170,7 +176,7 @@ pub fn create_command<T: AsRef<OsStr>>(binary_name: T) -> Result<Command> {
     let binary_name = binary_name.as_ref();
     log::trace!("Creating Command for binary {binary_name:?}");
 
-    let full_path = match self::which::which(binary_name) {
+    let full_path = match which(binary_name) {
         Ok(full_path) => {
             log::trace!("Using {full_path:?} as {binary_name:?}");
             full_path

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,6 +1,7 @@
 pub mod env;
 pub mod serde;
 pub mod statusline;
+pub mod which;
 
 use process_control::{ChildExt, Control};
 use std::ffi::OsStr;
@@ -169,7 +170,7 @@ pub fn create_command<T: AsRef<OsStr>>(binary_name: T) -> Result<Command> {
     let binary_name = binary_name.as_ref();
     log::trace!("Creating Command for binary {binary_name:?}");
 
-    let full_path = match which::which(binary_name) {
+    let full_path = match self::which::which(binary_name) {
         Ok(full_path) => {
             log::trace!("Using {full_path:?} as {binary_name:?}");
             full_path

--- a/src/utils/which.rs
+++ b/src/utils/which.rs
@@ -236,9 +236,11 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_scoop_shim_with_args() {
+    fn test_resolve_scoop_shim_with_args() -> std::io::Result<()> {
         let dir = tempdir().unwrap();
-        let shims_dir = dir.path().to_path_buf();
+        let root_dir = dir.path();
+        let shims_dir = root_dir.join("shims");
+        fs::create_dir_all(&shims_dir).unwrap();
 
         let shim_exe = write_shim(
             &shims_dir,
@@ -247,23 +249,27 @@ mod tests {
         );
 
         assert_eq!(
-            resolve_scoop_shim_in(&shim_exe, &[shims_dir]),
+            resolve_scoop_shim_in(&shim_exe, &[PathBuf::from(root_dir)]),
             None,
             "The shim forwards extra arguments, so it is not resolved to the target"
         );
+        dir.close()
     }
 
     #[test]
-    fn test_resolve_scoop_shim_missing_target() {
+    fn test_resolve_scoop_shim_missing_target() -> std::io::Result<()> {
         let dir = tempdir().unwrap();
-        let shims_dir = dir.path().to_path_buf();
+        let root_dir = dir.path();
+        let shims_dir = root_dir.join("shims");
+        fs::create_dir_all(&shims_dir).unwrap();
 
         let shim_exe = write_shim(&shims_dir, "git", "path = ../apps/git/git.exe\n");
 
         assert_eq!(
-            resolve_scoop_shim_in(&shim_exe, &[shims_dir]),
+            resolve_scoop_shim_in(&shim_exe, &[PathBuf::from(root_dir)]),
             None,
             "The shim target does not exist, so it is not resolved to the target"
         );
+        dir.close()
     }
 }

--- a/src/utils/which.rs
+++ b/src/utils/which.rs
@@ -28,11 +28,11 @@ pub fn resolve_scoop_shim(path: PathBuf) -> PathBuf {
 }
 
 /// Resolve a Scoop shim executable to its target executable, if applicable.
-fn resolve_scoop_shim_in(path: &Path, shims_dirs: &[PathBuf]) -> Option<PathBuf> {
+fn resolve_scoop_shim_in(path: &Path, scoop_roots: &[PathBuf]) -> Option<PathBuf> {
     let is_exe = path
         .extension()
         .is_some_and(|ext| ext.eq_ignore_ascii_case("exe"));
-    if !is_exe || !is_in_dirs(path, shims_dirs) {
+    if !is_exe || !is_scoop_shim_directory(path, scoop_roots) {
         return None;
     }
 
@@ -56,8 +56,8 @@ fn scoop_shims_dirs() -> Vec<PathBuf> {
     [user_root, global_root].into_iter().flatten().collect()
 }
 
-/// Check if a path resides directly inside one of the given directories.
-fn is_in_dirs(path: &Path, dirs: &[PathBuf]) -> bool {
+/// Check if a path resides directly inside one of the given scoop roots' `shims` directories.
+fn is_scoop_shim_directory(path: &Path, dirs: &[PathBuf]) -> bool {
     let Some(parent) = path.parent() else {
         return false;
     };
@@ -72,7 +72,7 @@ fn is_in_dirs(path: &Path, dirs: &[PathBuf]) -> bool {
     };
 
     dirs.iter()
-        .any(|root_candidate| root_candidate == &potential_root)
+        .any(|root_candidate| root_candidate == potential_root)
 }
 
 /// Parse a Scoop `.shim` file and return the target path.
@@ -107,7 +107,7 @@ mod tests {
     use crate::utils;
 
     use super::*;
-    use std::fs::{self, File};
+    use std::fs;
     use tempfile::tempdir;
 
     fn write_shim(dir: &Path, name: &str, content: &str) -> PathBuf {
@@ -119,8 +119,8 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_shim_file_simple_path() {
-        let dir = tempdir().unwrap();
+    fn test_parse_shim_file_simple_path() -> std::io::Result<()> {
+        let dir = tempdir()?;
         let shim_path = dir.path().join("test.shim");
         fs::write(
             &shim_path,
@@ -131,11 +131,12 @@ mod tests {
             parse_shim_file(&shim_path),
             Some(PathBuf::from("C:\\scoop\\apps\\git\\current\\bin\\git.exe"))
         );
+        dir.close()
     }
 
     #[test]
-    fn test_parse_shim_file_quotes() {
-        let dir = tempdir().unwrap();
+    fn test_parse_shim_file_quotes() -> std::io::Result<()> {
+        let dir = tempdir()?;
         let shim_path = dir.path().join("test.shim");
         for quote in ["\"", "'"] {
             fs::write(
@@ -148,11 +149,12 @@ mod tests {
                 Some(PathBuf::from("C:\\scoop\\apps\\git\\current\\bin\\git.exe"))
             );
         }
+        dir.close()
     }
 
     #[test]
-    fn test_parse_shim_file_non_empty_args() {
-        let dir = tempdir().unwrap();
+    fn test_parse_shim_file_non_empty_args() -> std::io::Result<()> {
+        let dir = tempdir()?;
         let shim_path = dir.path().join("test.shim");
         fs::write(
             &shim_path,
@@ -160,11 +162,12 @@ mod tests {
         )
         .unwrap();
         assert_eq!(parse_shim_file(&shim_path), None);
+        dir.close()
     }
 
     #[test]
-    fn test_parse_shim_file_other_directives() {
-        let dir = tempdir().unwrap();
+    fn test_parse_shim_file_other_directives() -> std::io::Result<()> {
+        let dir = tempdir()?;
         let shim_path = dir.path().join("test.shim");
         for directive in ["args = ", "args = \"\"", "workingdir = C:\\somewhere"] {
             fs::write(
@@ -174,11 +177,12 @@ mod tests {
             .unwrap();
             assert_eq!(parse_shim_file(&shim_path), None);
         }
+        dir.close()
     }
 
     #[test]
-    fn test_parse_shim_file_comments_and_spaces() {
-        let dir = tempdir().unwrap();
+    fn test_parse_shim_file_comments_and_spaces() -> std::io::Result<()> {
+        let dir = tempdir()?;
         let shim_path = dir.path().join("test.shim");
         fs::write(
             &shim_path,
@@ -189,10 +193,11 @@ mod tests {
             parse_shim_file(&shim_path),
             Some(PathBuf::from("C:\\test.exe"))
         );
+        dir.close()
     }
 
     #[test]
-    fn test_resolve_scoop_shim() {
+    fn test_resolve_scoop_shim() -> std::io::Result<()> {
         let dir = tempdir().unwrap();
 
         // Mock a Scoop-like directory structure:
@@ -203,28 +208,31 @@ mod tests {
         //   apps/
         //     git/
         //       git.exe (empty placeholder)
-        let shims_dir = dir.path().join("shims");
-        let apps_dir = dir.path().join("apps").join("git");
-        fs::create_dir_all(&shims_dir).unwrap();
-        fs::create_dir_all(&apps_dir).unwrap();
+        let root_dir = dir.path();
+        let shims_dir = root_dir.join("shims");
+        let apps_dir = root_dir.join("apps").join("git");
+        fs::create_dir_all(&shims_dir)?;
+        fs::create_dir_all(&apps_dir)?;
 
         let shim_exe = write_shim(&shims_dir, "git", "path = ../apps/git/git.exe\n");
         let target_exe = apps_dir.join("git.exe");
-        File::create(&target_exe).unwrap();
+        utils::write_file(&target_exe, "").unwrap();
 
-        let shims_dirs = [shims_dir];
-        let resolved = resolve_scoop_shim_in(&shim_exe, &shims_dirs)
+        let scoop_roots = [PathBuf::from(root_dir)];
+        let resolved = resolve_scoop_shim_in(&shim_exe, &scoop_roots)
             .expect("The shim should resolve to the target executable");
         assert_eq!(
             dunce::canonicalize(&resolved).unwrap(),
-            dunce::canonicalize(&target_exe).unwrap()
+            dunce::canonicalize(&target_exe).unwrap(),
+            "The resolved path ({resolved:?}) should match the target executable ({target_exe:?})"
         );
 
         assert_eq!(
-            resolve_scoop_shim_in(&target_exe, &shims_dirs),
+            resolve_scoop_shim_in(&target_exe, &scoop_roots),
             None,
             "A non-shim executable should not be resolved"
         );
+        dir.close()
     }
 
     #[test]

--- a/src/utils/which.rs
+++ b/src/utils/which.rs
@@ -53,11 +53,7 @@ fn scoop_shims_dirs() -> Vec<PathBuf> {
         .map(PathBuf::from)
         .or_else(|| Some(PathBuf::from(env::var_os("ProgramData")?).join("scoop")));
 
-    [user_root, global_root]
-        .into_iter()
-        .flatten()
-        .map(|root| root.join("shims"))
-        .collect()
+    [user_root, global_root].into_iter().flatten().collect()
 }
 
 /// Check if a path resides directly inside one of the given directories.
@@ -71,8 +67,12 @@ fn is_in_dirs(path: &Path, dirs: &[PathBuf]) -> bool {
     {
         return false;
     }
+    let Some(potential_root) = parent.parent() else {
+        return false;
+    };
 
-    dirs.iter().any(|dir| dir == parent)
+    dirs.iter()
+        .any(|root_candidate| root_candidate == &potential_root)
 }
 
 /// Parse a Scoop `.shim` file and return the target path.

--- a/src/utils/which.rs
+++ b/src/utils/which.rs
@@ -1,8 +1,5 @@
-#[cfg(windows)]
 use std::env;
-#[cfg(windows)]
 use std::ffi::OsStr;
-#[cfg(windows)]
 use std::path::{Path, PathBuf};
 
 #[cfg(not(windows))]
@@ -11,7 +8,6 @@ pub use which::which;
 /// A wrapper around `which::which` that resolves Scoop shim executables on
 /// Windows to their actual target executables, avoiding the overhead of
 /// launching the shim process.
-#[cfg(windows)]
 pub fn which<T: AsRef<OsStr>>(binary_name: T) -> Result<PathBuf, which::Error> {
     which::which(binary_name).map(resolve_scoop_shim)
 }
@@ -21,7 +17,6 @@ pub fn which<T: AsRef<OsStr>>(binary_name: T) -> Result<PathBuf, which::Error> {
 /// The path is returned unchanged unless it is an `.exe` inside a Scoop shims
 /// directory whose `.shim` file points to an existing target and forwards no
 /// extra arguments (a shim with `args` has to run as-is).
-#[cfg(windows)]
 pub fn resolve_scoop_shim(path: PathBuf) -> PathBuf {
     if let Some(resolved) = resolve_scoop_shim_in(&path, &scoop_shims_dirs()) {
         log::trace!("Resolved Scoop shim executable {path:?} to target {resolved:?}");
@@ -33,7 +28,6 @@ pub fn resolve_scoop_shim(path: PathBuf) -> PathBuf {
 }
 
 /// Resolve a Scoop shim executable to its target executable, if applicable.
-#[cfg(windows)]
 fn resolve_scoop_shim_in(path: &Path, shims_dirs: &[PathBuf]) -> Option<PathBuf> {
     let is_exe = path
         .extension()
@@ -43,12 +37,11 @@ fn resolve_scoop_shim_in(path: &Path, shims_dirs: &[PathBuf]) -> Option<PathBuf>
     }
 
     parse_shim_file(&path.with_extension("shim"))
-        .and_then(|path| dunce::canonicalize(&path).ok())
+        // Not running canonicalize here as which::which should already return an absolute path.
         .filter(|target| target.is_file())
 }
 
 /// Retrieve the possible Scoop shims directories on the system.
-#[cfg(windows)]
 fn scoop_shims_dirs() -> Vec<PathBuf> {
     let user_root = env::var_os("SCOOP")
         .filter(|v| !v.is_empty())
@@ -68,23 +61,24 @@ fn scoop_shims_dirs() -> Vec<PathBuf> {
 }
 
 /// Check if a path resides directly inside one of the given directories.
-#[cfg(windows)]
 fn is_in_dirs(path: &Path, dirs: &[PathBuf]) -> bool {
     let Some(parent) = path.parent() else {
         return false;
     };
-    let Ok(parent) = dunce::canonicalize(parent) else {
+    if parent
+        .file_name()
+        .is_none_or(|name| !name.eq_ignore_ascii_case("shims"))
+    {
         return false;
-    };
-    dirs.iter()
-        .any(|dir| dunce::canonicalize(dir).is_ok_and(|dir| dir == parent))
+    }
+
+    dirs.iter().any(|dir| dir == parent)
 }
 
 /// Parse a Scoop `.shim` file and return the target path.
 ///
 /// Returns `None` if the shim forwards extra arguments or contains any
 /// other unsupported directives.
-#[cfg(windows)]
 fn parse_shim_file(shim_path: &Path) -> Option<PathBuf> {
     let content = std::fs::read_to_string(shim_path).ok()?;
     let mut target_path = None;
@@ -108,7 +102,7 @@ fn parse_shim_file(shim_path: &Path) -> Option<PathBuf> {
     Some(parent.join(target_path?))
 }
 
-#[cfg(all(test, windows))]
+#[cfg(test)]
 mod tests {
     use crate::utils;
 

--- a/src/utils/which.rs
+++ b/src/utils/which.rs
@@ -1,0 +1,267 @@
+#[cfg(windows)]
+use std::env;
+#[cfg(windows)]
+use std::ffi::OsStr;
+#[cfg(windows)]
+use std::path::{Path, PathBuf};
+
+#[cfg(not(windows))]
+pub use which::which;
+
+/// A wrapper around `which::which` that resolves Scoop shim executables on
+/// Windows to their actual target executables, avoiding the overhead of
+/// launching the shim process.
+#[cfg(windows)]
+pub fn which<T: AsRef<OsStr>>(binary_name: T) -> Result<PathBuf, which::Error> {
+    which::which(binary_name).map(resolve_scoop_shim)
+}
+
+/// Resolve a Scoop shim executable to its target executable.
+///
+/// The path is returned unchanged unless it is an `.exe` inside a Scoop shims
+/// directory whose `.shim` file points to an existing target and forwards no
+/// extra arguments (a shim with `args` has to run as-is).
+#[cfg(windows)]
+pub fn resolve_scoop_shim(path: PathBuf) -> PathBuf {
+    if let Some(resolved) = resolve_scoop_shim_in(&path, &scoop_shims_dirs()) {
+        log::trace!("Resolved Scoop shim executable {path:?} to target {resolved:?}");
+        resolved
+    } else {
+        log::trace!("No Scoop shim resolution for {path:?}");
+        path
+    }
+}
+
+/// Resolve a Scoop shim executable to its target executable, if applicable.
+#[cfg(windows)]
+fn resolve_scoop_shim_in(path: &Path, shims_dirs: &[PathBuf]) -> Option<PathBuf> {
+    let is_exe = path
+        .extension()
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("exe"));
+    if !is_exe || !is_in_dirs(path, shims_dirs) {
+        return None;
+    }
+
+    parse_shim_file(&path.with_extension("shim"))
+        .and_then(|path| dunce::canonicalize(&path).ok())
+        .filter(|target| target.is_file())
+}
+
+/// Retrieve the possible Scoop shims directories on the system.
+#[cfg(windows)]
+fn scoop_shims_dirs() -> Vec<PathBuf> {
+    let user_root = env::var_os("SCOOP")
+        .filter(|v| !v.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| Some(PathBuf::from(env::var_os("USERPROFILE")?).join("scoop")));
+
+    let global_root = env::var_os("SCOOP_GLOBAL")
+        .filter(|v| !v.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| Some(PathBuf::from(env::var_os("ProgramData")?).join("scoop")));
+
+    [user_root, global_root]
+        .into_iter()
+        .flatten()
+        .map(|root| root.join("shims"))
+        .collect()
+}
+
+/// Check if a path resides directly inside one of the given directories.
+#[cfg(windows)]
+fn is_in_dirs(path: &Path, dirs: &[PathBuf]) -> bool {
+    let Some(parent) = path.parent() else {
+        return false;
+    };
+    let Ok(parent) = dunce::canonicalize(parent) else {
+        return false;
+    };
+    dirs.iter()
+        .any(|dir| dunce::canonicalize(dir).is_ok_and(|dir| dir == parent))
+}
+
+/// Parse a Scoop `.shim` file and return the target path.
+///
+/// Returns `None` if the shim forwards extra arguments or contains any
+/// other unsupported directives.
+#[cfg(windows)]
+fn parse_shim_file(shim_path: &Path) -> Option<PathBuf> {
+    let content = std::fs::read_to_string(shim_path).ok()?;
+    let mut target_path = None;
+
+    for line in content.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') || line.starts_with(';') {
+            continue;
+        }
+        let (key, val) = line.split_once('=')?;
+        let key = key.trim();
+        let val = val.trim().trim_matches(['"', '\'']).trim();
+        if key.eq_ignore_ascii_case("path") {
+            target_path = Some(PathBuf::from(val));
+        } else {
+            return None;
+        }
+    }
+
+    let parent = shim_path.parent()?;
+    Some(parent.join(target_path?))
+}
+
+#[cfg(all(test, windows))]
+mod tests {
+    use crate::utils;
+
+    use super::*;
+    use std::fs::{self, File};
+    use tempfile::tempdir;
+
+    fn write_shim(dir: &Path, name: &str, content: &str) -> PathBuf {
+        let shim_exe = dir.join(name).with_extension("exe");
+        utils::write_file(&shim_exe, "").unwrap();
+        let shim_config = dir.join(name).with_extension("shim");
+        utils::write_file(&shim_config, content).unwrap();
+        shim_exe
+    }
+
+    #[test]
+    fn test_parse_shim_file_simple_path() {
+        let dir = tempdir().unwrap();
+        let shim_path = dir.path().join("test.shim");
+        fs::write(
+            &shim_path,
+            "path = C:\\scoop\\apps\\git\\current\\bin\\git.exe\n",
+        )
+        .unwrap();
+        assert_eq!(
+            parse_shim_file(&shim_path),
+            Some(PathBuf::from("C:\\scoop\\apps\\git\\current\\bin\\git.exe"))
+        );
+    }
+
+    #[test]
+    fn test_parse_shim_file_quotes() {
+        let dir = tempdir().unwrap();
+        let shim_path = dir.path().join("test.shim");
+        for quote in ["\"", "'"] {
+            fs::write(
+                &shim_path,
+                format!("path = {quote}C:\\scoop\\apps\\git\\current\\bin\\git.exe{quote}\n"),
+            )
+            .unwrap();
+            assert_eq!(
+                parse_shim_file(&shim_path),
+                Some(PathBuf::from("C:\\scoop\\apps\\git\\current\\bin\\git.exe"))
+            );
+        }
+    }
+
+    #[test]
+    fn test_parse_shim_file_non_empty_args() {
+        let dir = tempdir().unwrap();
+        let shim_path = dir.path().join("test.shim");
+        fs::write(
+            &shim_path,
+            "path = C:\\scoop\\apps\\git\\current\\bin\\git.exe\nargs = --version\n",
+        )
+        .unwrap();
+        assert_eq!(parse_shim_file(&shim_path), None);
+    }
+
+    #[test]
+    fn test_parse_shim_file_other_directives() {
+        let dir = tempdir().unwrap();
+        let shim_path = dir.path().join("test.shim");
+        for directive in ["args = ", "args = \"\"", "workingdir = C:\\somewhere"] {
+            fs::write(
+                &shim_path,
+                format!("path = C:\\scoop\\apps\\git\\current\\bin\\git.exe\n{directive}\n"),
+            )
+            .unwrap();
+            assert_eq!(parse_shim_file(&shim_path), None);
+        }
+    }
+
+    #[test]
+    fn test_parse_shim_file_comments_and_spaces() {
+        let dir = tempdir().unwrap();
+        let shim_path = dir.path().join("test.shim");
+        fs::write(
+            &shim_path,
+            "# This is a comment\n  ; Another comment\npath   =   C:\\test.exe  \n",
+        )
+        .unwrap();
+        assert_eq!(
+            parse_shim_file(&shim_path),
+            Some(PathBuf::from("C:\\test.exe"))
+        );
+    }
+
+    #[test]
+    fn test_resolve_scoop_shim() {
+        let dir = tempdir().unwrap();
+
+        // Mock a Scoop-like directory structure:
+        // dir/
+        //   shims/
+        //     git.exe (empty placeholder)
+        //     git.shim (path = ../apps/git/git.exe)
+        //   apps/
+        //     git/
+        //       git.exe (empty placeholder)
+        let shims_dir = dir.path().join("shims");
+        let apps_dir = dir.path().join("apps").join("git");
+        fs::create_dir_all(&shims_dir).unwrap();
+        fs::create_dir_all(&apps_dir).unwrap();
+
+        let shim_exe = write_shim(&shims_dir, "git", "path = ../apps/git/git.exe\n");
+        let target_exe = apps_dir.join("git.exe");
+        File::create(&target_exe).unwrap();
+
+        let shims_dirs = [shims_dir];
+        let resolved = resolve_scoop_shim_in(&shim_exe, &shims_dirs)
+            .expect("The shim should resolve to the target executable");
+        assert_eq!(
+            dunce::canonicalize(&resolved).unwrap(),
+            dunce::canonicalize(&target_exe).unwrap()
+        );
+
+        assert_eq!(
+            resolve_scoop_shim_in(&target_exe, &shims_dirs),
+            None,
+            "A non-shim executable should not be resolved"
+        );
+    }
+
+    #[test]
+    fn test_resolve_scoop_shim_with_args() {
+        let dir = tempdir().unwrap();
+        let shims_dir = dir.path().to_path_buf();
+
+        let shim_exe = write_shim(
+            &shims_dir,
+            "git",
+            "path = ../apps/git/git.exe\nargs = status\n",
+        );
+
+        assert_eq!(
+            resolve_scoop_shim_in(&shim_exe, &[shims_dir]),
+            None,
+            "The shim forwards extra arguments, so it is not resolved to the target"
+        );
+    }
+
+    #[test]
+    fn test_resolve_scoop_shim_missing_target() {
+        let dir = tempdir().unwrap();
+        let shims_dir = dir.path().to_path_buf();
+
+        let shim_exe = write_shim(&shims_dir, "git", "path = ../apps/git/git.exe\n");
+
+        assert_eq!(
+            resolve_scoop_shim_in(&shim_exe, &[shims_dir]),
+            None,
+            "The shim target does not exist, so it is not resolved to the target"
+        );
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Resolve shimmed binaries on Windows as they can have overheads of 30ms.
Try to only handle simple shim files and ignore anything more complex.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- Most changes do not need to be tested on multiple operating systems. -->
- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### AI-Assistance
<!-- Per our AI Policy (AI_POLICY.md), all AI usage must be declared. -->
Have you used AI-assistance to author this PR?

- [x] Yes
- [ ] No

If **yes**, describe the scope of assistance:
<!--- Describe how you used AI-Assistance -->
<!--- Disclosure is required if you have used AI-assistance -->
<!--- For example: answering project questions, writing tests, implementation, or documentation -->
Original base implementation was generated, I've now refactored it to follow project standards.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
- [x] I understand and have read the code I contribute and can answer questions about it.
