### PR TITLE
fix(init): emit Unix paths for POSIX shells on Windows

### DIFF
--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -5,6 +5,10 @@ use std::{env, io};
 
 use which::which;
 
+fn quote_posix_path(path: &str) -> String {
+    shell_words::quote(path).into_owned()
+}
+
 /* We use a two-phase init here: the first phase gives a simple command to the
 shell. This command evaluates a more complicated script using `source` and
 process substitution.
@@ -70,7 +74,9 @@ impl StarshipPath {
             return self.sprint();
         }
         let str_path = self.str_path()?;
-        let res = create_command("cygpath").and_then(|mut cmd| cmd.arg(str_path).output());
+        // Ask cygpath for a Unix path explicitly. Its default output format is
+        // Windows-native, which a POSIX shell cannot execute when the path has spaces.
+        let res = create_command("cygpath").and_then(|mut cmd| cmd.args(["-u", str_path]).output());
         let output = match res {
             Ok(output) => output,
             Err(e) => {
@@ -97,7 +103,7 @@ impl StarshipPath {
                 str_path
             }
         };
-        Ok(shell_words::quote(posix_path).into_owned())
+        Ok(quote_posix_path(posix_path))
     }
 }
 
@@ -319,5 +325,13 @@ mod tests {
             r#""C:\Cool Tools\starship.exe""#
         );
         Ok(())
+    }
+
+    #[test]
+    fn escape_space_posix() {
+        assert_eq!(
+            quote_posix_path("/c/Program Files/starship.exe"),
+            "'/c/Program Files/starship.exe'"
+        );
     }
 }

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -45,7 +45,7 @@ impl StarshipPath {
 
     /// Returns POSIX quoted path to starship binary
     fn sprint(&self) -> io::Result<String> {
-        self.str_path().map(|p| shell_words::quote(p).into_owned())
+        self.str_path().map(quote_posix_path)
     }
 
     /// `PowerShell` specific path escaping


### PR DESCRIPTION
#### Description

Explicitly request Unix-style output from `cygpath` before embedding the Starship executable path in POSIX shell initialization scripts. The converted path remains shell-quoted, with a regression assertion for a path containing spaces.

#### Motivation and Context

On Windows with MSYS2 zsh, `starship init zsh` can produce an executable path that zsh splits at `Program Files`. `cygpath` defaults to Windows-style output unless asked otherwise; zsh needs the `/c/...` form.

Closes #7573

#### Screenshots (if appropriate):

N/A

#### How Has This Been Tested?

- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

- `cargo fmt --check`
- `cargo test init::tests` (5 passed)
- `cargo clippy --lib --tests -- -D warnings`

#### AI-Assistance

Have you used AI-assistance to author this PR?

- [x] Yes
- [ ] No

If **yes**, describe the scope of assistance:

Codex assisted with source investigation, the focused implementation, and the regression test. The submitted diff and validation output were reviewed line by line before submission.

#### Checklist:

- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
- [x] I understand and have read the code I contribute and can answer questions about it.
