### PR TITLE
fix(bash): Support PROMPT_COMMAND array in bash integration script

### DIFF
--- a/src/init/starship.bash
+++ b/src/init/starship.bash
@@ -124,15 +124,28 @@ else
 
     # Finally, prepare the precmd function and set up the start time. We will avoid to
     # add multiple instances of the starship function and keep other user functions if any.
-    if [[ -z "${PROMPT_COMMAND-}" ]]; then
-        PROMPT_COMMAND="starship_precmd"
-    elif [[ "$PROMPT_COMMAND" != *"starship_precmd"* ]]; then
-        # Appending to PROMPT_COMMAND breaks exit status ($?) checking.
-        # Prepending to PROMPT_COMMAND breaks "command duration" module.
-        # So, we are preserving the existing PROMPT_COMMAND
-        # which will be executed later in the starship_precmd function
-        STARSHIP_PROMPT_COMMAND="$PROMPT_COMMAND"
-        PROMPT_COMMAND="starship_precmd"
+    if ((BASH_VERSINFO[0] < 5 || BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] < 1)); then
+        if [[ -z "${PROMPT_COMMAND-}" ]]; then
+            PROMPT_COMMAND="starship_precmd"
+        elif [[ "$PROMPT_COMMAND" != *"starship_precmd"* ]]; then
+            # Appending to PROMPT_COMMAND breaks exit status ($?) checking.
+            # Prepending to PROMPT_COMMAND breaks "command duration" module.
+            # So, we are preserving the existing PROMPT_COMMAND
+            # which will be executed later in the starship_precmd function
+            STARSHIP_PROMPT_COMMAND="$PROMPT_COMMAND"
+            PROMPT_COMMAND="starship_precmd"
+        fi
+    else
+        # In Bash 5.1+, the type of PROMPT_COMMAND can be 'array'. Old assignment
+        # commands will work with the first element instead of the full PROMPT_COMMAND.
+        \builtin declare -- __starship_prompt_command_cand="$(IFS=';'; \builtin printf '%s\n' "${PROMPT_COMMAND[*]-}")"
+        if [[ ";${__starship_prompt_command_cand};" != *";starship_precmd;"* ]]; then
+            PROMPT_COMMAND=("starship_precmd")
+            if [[ -n "${__starship_prompt_command_cand}" ]]; then
+                STARSHIP_PROMPT_COMMAND="${__starship_prompt_command_cand}"
+            fi
+        fi
+        \builtin unset -- __starship_prompt_command_cand
     fi
 fi
 

--- a/src/init/starship.bash
+++ b/src/init/starship.bash
@@ -141,7 +141,9 @@ else
         # Even so, when 'string' PROMPT_COMMAND is detected when `Starship` is triggered,
         # use old fallback logic.
         # PR: https://github.com/starship/starship/pull/7603
-        \builtin declare __starship_ifs="${IFS-}"  # Cause we use empty IFS to figure out if array is empty
+        if [[ -v IFS ]]; then
+            \builtin declare __starship_ifs="${IFS}"  # Cause we use empty IFS to figure out if array is empty
+        fi
         \builtin unset IFS
         \builtin declare -a STARSHIP_PROMPT_COMMAND
         if [[ -z "${STARSHIP_PROMPT_COMMAND[*]}" ]]; then  # Fix: Reenter this line should not overwrite STARSHIP_PROMPT_COMMAND
@@ -168,7 +170,7 @@ else
         fi
         \builtin unset __prompt_subcommand
 
-        if [[ -n "${__starship_ifs}" ]]; then  # Recover IFS
+        if [[ -v __starship_ifs ]]; then  # Recover IFS
             IFS="${__starship_ifs}"
         fi
         \builtin unset __starship_ifs

--- a/src/init/starship.bash
+++ b/src/init/starship.bash
@@ -70,11 +70,10 @@ starship_precmd() {
             # Extended `STARSHIP_PROMPT_COMMAND` array usage
             # If Bash 5.1+ and `STARSHIP_PROMPT_COMMAND` is non-empty array
             # PR: https://github.com/starship/starship/pull/7603
-            \builtin declare __starship_prompt_subcommand
+            \builtin local __starship_prompt_subcommand
             for __starship_prompt_subcommand in "${STARSHIP_PROMPT_COMMAND[@]}"; do
                 eval "${__starship_prompt_subcommand}"
             done
-            \builtin unset __starship_prompt_subcommand
         else
             eval "$STARSHIP_PROMPT_COMMAND"
         fi
@@ -135,7 +134,7 @@ else
 
     # Finally, prepare the precmd function and set up the start time. We will avoid to
     # add multiple instances of the starship function and keep other user functions if any.
-    if ((BASH_VERSINFO[0] > 5 || BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] >= 1)) && [[ -v PROMPT_COMMAND ]] && [[ "${PROMPT_COMMAND@a}" == "a" ]]; then
+    if ((BASH_VERSINFO[0] > 5 || BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] >= 1)) && [[ -v PROMPT_COMMAND && "${PROMPT_COMMAND@a}" == "a" ]]; then
         # In Bash 5.1+, the type of PROMPT_COMMAND can be 'array'. Old assignment
         # commands will work with the first element instead of the full PROMPT_COMMAND.
         # Even so, when 'string' PROMPT_COMMAND is detected when `Starship` is triggered,
@@ -147,7 +146,7 @@ else
             \builtin unset __starship_ifs
         fi
         \builtin declare IFS=''  # Use empty IFS to figure out if array is empty
-        \builtin declare -a STARSHIP_PROMPT_COMMAND
+        \builtin declare -ag STARSHIP_PROMPT_COMMAND  # Force global variable
         if [[ -z "${STARSHIP_PROMPT_COMMAND[*]}" ]]; then  # Fix: Reenter this line should not overwrite STARSHIP_PROMPT_COMMAND
             STARSHIP_PROMPT_COMMAND=()
         fi
@@ -173,6 +172,7 @@ else
         \builtin unset __prompt_subcommand
 
         if [[ -v __starship_ifs ]]; then  # If detect IFS defined
+            # TODO: Maybe we can remove IFS when declared in a function
             IFS="${__starship_ifs}" # Recover IFS
             \builtin unset __starship_ifs
         else
@@ -206,4 +206,3 @@ export STARSHIP_SESSION_KEY=${STARSHIP_SESSION_KEY:0:16}; # Trim to 16-digits if
 
 # Set the continuation prompt
 PS2="$(::STARSHIP:: prompt --continuation)"
-

--- a/src/init/starship.bash
+++ b/src/init/starship.bash
@@ -142,9 +142,11 @@ else
         # use old fallback logic.
         # PR: https://github.com/starship/starship/pull/7603
         if [[ -v IFS ]]; then
-            \builtin declare __starship_ifs="${IFS}"  # Cause we use empty IFS to figure out if array is empty
+            \builtin declare __starship_ifs="${IFS}"
+        else
+            \builtin unset __starship_ifs
         fi
-        \builtin unset IFS
+        \builtin declare IFS=''  # Use empty IFS to figure out if array is empty
         \builtin declare -a STARSHIP_PROMPT_COMMAND
         if [[ -z "${STARSHIP_PROMPT_COMMAND[*]}" ]]; then  # Fix: Reenter this line should not overwrite STARSHIP_PROMPT_COMMAND
             STARSHIP_PROMPT_COMMAND=()
@@ -170,10 +172,12 @@ else
         fi
         \builtin unset __prompt_subcommand
 
-        if [[ -v __starship_ifs ]]; then  # Recover IFS
-            IFS="${__starship_ifs}"
+        if [[ -v __starship_ifs ]]; then  # If detect IFS defined
+            IFS="${__starship_ifs}" # Recover IFS
+            \builtin unset __starship_ifs
+        else
+            \builtin unset IFS  # Remove definition of IFS
         fi
-        \builtin unset __starship_ifs
     else
         if [[ -z "${PROMPT_COMMAND-}" ]]; then
             PROMPT_COMMAND="starship_precmd"

--- a/src/init/starship.bash
+++ b/src/init/starship.bash
@@ -66,7 +66,16 @@ starship_precmd() {
     _starship_set_return "$STARSHIP_CMD_STATUS"
 
     if [[ -n "${STARSHIP_PROMPT_COMMAND-}" ]]; then
-        eval "$STARSHIP_PROMPT_COMMAND"
+        if ((BASH_VERSINFO[0] > 5 || BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] >= 1)) && [[ "${STARSHIP_PROMPT_COMMAND@a}" == "a" ]]; then
+            # PR: https://github.com/starship/starship/pull/7603
+            \builtin declare -- __starship_prompt_subcommand
+            for __starship_prompt_subcommand in "${STARSHIP_PROMPT_COMMAND[@]}"; do
+                eval "${__starship_prompt_subcommand}"
+            done
+            \builtin unset -- __starship_prompt_subcommand
+        else
+            eval "$STARSHIP_PROMPT_COMMAND"
+        fi
     fi
 
     local -a ARGS=(--terminal-width="${COLUMNS}" --status="${STARSHIP_CMD_STATUS}" --pipestatus="${STARSHIP_PIPE_STATUS[*]}" --jobs="${NUM_JOBS}" --shlvl="${SHLVL}")
@@ -127,14 +136,21 @@ else
     if ((BASH_VERSINFO[0] > 5 || BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] >= 1)) && [[ "${PROMPT_COMMAND@a}" == "a" ]]; then
         # In Bash 5.1+, the type of PROMPT_COMMAND can be 'array'. Old assignment
         # commands will work with the first element instead of the full PROMPT_COMMAND.
-        \builtin declare -- __starship_prompt_command_cand="$(IFS=';'; \builtin printf '%s\n' "${PROMPT_COMMAND[*]-}")"
-        if [[ ";${__starship_prompt_command_cand};" != *";starship_precmd;"* ]]; then
-            PROMPT_COMMAND=("starship_precmd")
-            if [[ -n "${__starship_prompt_command_cand}" ]]; then
-                STARSHIP_PROMPT_COMMAND="${__starship_prompt_command_cand}"
+        # PR: https://github.com/starship/starship/pull/7603
+        \builtin declare -- __prompt_subcommand="" __make_starship_precmd=1
+        for __prompt_subcommand in "${PROMPT_COMMAND[@]}"; do
+            if [[ "${__prompt_subcommand}" == *"starship_precmd"* ]]; then  # If modify this, modify line 157 as well
+                __make_starship_precmd=""
+                \builtin break
             fi
+        done
+        if [[ -n "${__make_starship_precmd}" ]]; then
+            if ((${#PROMPT_COMMAND[@]} > 0)); then
+                STARSHIP_PROMPT_COMMAND=("${PROMPT_COMMAND[@]}")
+            fi
+            PROMPT_COMMAND=("starship_precmd")
         fi
-        \builtin unset -- __starship_prompt_command_cand
+        \builtin unset -- __prompt_subcommand __make_starship_precmd
     else
         if [[ -z "${PROMPT_COMMAND-}" ]]; then
             PROMPT_COMMAND="starship_precmd"

--- a/src/init/starship.bash
+++ b/src/init/starship.bash
@@ -124,18 +124,7 @@ else
 
     # Finally, prepare the precmd function and set up the start time. We will avoid to
     # add multiple instances of the starship function and keep other user functions if any.
-    if ((BASH_VERSINFO[0] < 5 || BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] < 1)); then
-        if [[ -z "${PROMPT_COMMAND-}" ]]; then
-            PROMPT_COMMAND="starship_precmd"
-        elif [[ "$PROMPT_COMMAND" != *"starship_precmd"* ]]; then
-            # Appending to PROMPT_COMMAND breaks exit status ($?) checking.
-            # Prepending to PROMPT_COMMAND breaks "command duration" module.
-            # So, we are preserving the existing PROMPT_COMMAND
-            # which will be executed later in the starship_precmd function
-            STARSHIP_PROMPT_COMMAND="$PROMPT_COMMAND"
-            PROMPT_COMMAND="starship_precmd"
-        fi
-    else
+    if ((BASH_VERSINFO[0] > 5 || BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] >= 1)) && [[ "${PROMPT_COMMAND@a}" == "a" ]]; then
         # In Bash 5.1+, the type of PROMPT_COMMAND can be 'array'. Old assignment
         # commands will work with the first element instead of the full PROMPT_COMMAND.
         \builtin declare -- __starship_prompt_command_cand="$(IFS=';'; \builtin printf '%s\n' "${PROMPT_COMMAND[*]-}")"
@@ -146,6 +135,17 @@ else
             fi
         fi
         \builtin unset -- __starship_prompt_command_cand
+    else
+        if [[ -z "${PROMPT_COMMAND-}" ]]; then
+            PROMPT_COMMAND="starship_precmd"
+        elif [[ "$PROMPT_COMMAND" != *"starship_precmd"* ]]; then
+            # Appending to PROMPT_COMMAND breaks exit status ($?) checking.
+            # Prepending to PROMPT_COMMAND breaks "command duration" module.
+            # So, we are preserving the existing PROMPT_COMMAND
+            # which will be executed later in the starship_precmd function
+            STARSHIP_PROMPT_COMMAND="$PROMPT_COMMAND"
+            PROMPT_COMMAND="starship_precmd"
+        fi
     fi
 fi
 

--- a/src/init/starship.bash
+++ b/src/init/starship.bash
@@ -67,12 +67,13 @@ starship_precmd() {
 
     if [[ -n "${STARSHIP_PROMPT_COMMAND-}" ]]; then
         if ((BASH_VERSINFO[0] > 5 || BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] >= 1)) && [[ "${STARSHIP_PROMPT_COMMAND@a}" == "a" ]]; then
+            # Extended `STARSHIP_PROMPT_COMMAND` array usage
             # PR: https://github.com/starship/starship/pull/7603
-            \builtin declare -- __starship_prompt_subcommand
+            \builtin declare __starship_prompt_subcommand
             for __starship_prompt_subcommand in "${STARSHIP_PROMPT_COMMAND[@]}"; do
                 eval "${__starship_prompt_subcommand}"
             done
-            \builtin unset -- __starship_prompt_subcommand
+            \builtin unset __starship_prompt_subcommand
         else
             eval "$STARSHIP_PROMPT_COMMAND"
         fi
@@ -137,20 +138,23 @@ else
         # In Bash 5.1+, the type of PROMPT_COMMAND can be 'array'. Old assignment
         # commands will work with the first element instead of the full PROMPT_COMMAND.
         # PR: https://github.com/starship/starship/pull/7603
-        \builtin declare -- __prompt_subcommand="" __make_starship_precmd=1
+        \builtin declare -a STARSHIP_PROMPT_COMMAND=()
+        \builtin declare __prompt_subcommand
         for __prompt_subcommand in "${PROMPT_COMMAND[@]}"; do
-            if [[ "${__prompt_subcommand}" == *"starship_precmd"* ]]; then  # If modify this, modify line 157 as well
-                __make_starship_precmd=""
+            if [[ "${__prompt_subcommand}" == *"starship_precmd"* ]]; then  # If modify this line, modify line 161 as well
+                \builtin unset STARSHIP_PROMPT_COMMAND
                 \builtin break
+            elif [[ -n "${__prompt_subcommand}" ]]; then
+                STARSHIP_PROMPT_COMMAND+=("${__prompt_subcommand}")
             fi
         done
-        if [[ -n "${__make_starship_precmd}" ]]; then
-            if ((${#PROMPT_COMMAND[@]} > 0)); then
-                STARSHIP_PROMPT_COMMAND=("${PROMPT_COMMAND[@]}")
-            fi
+        \builtin unset __prompt_subcommand
+        if \builtin declare -p STARSHIP_PROMPT_COMMAND 1> /dev/null 2>&1; then  # If no `starship_precmd` exists
             PROMPT_COMMAND=("starship_precmd")
+            if [[ -z "${STARSHIP_PROMPT_COMMAND[*]}" ]]; then  # If `STARSHIP_PROMPT_COMMAND` is empty
+                \builtin unset STARSHIP_PROMPT_COMMAND
+            fi
         fi
-        \builtin unset -- __prompt_subcommand __make_starship_precmd
     else
         if [[ -z "${PROMPT_COMMAND-}" ]]; then
             PROMPT_COMMAND="starship_precmd"

--- a/src/init/starship.bash
+++ b/src/init/starship.bash
@@ -68,6 +68,7 @@ starship_precmd() {
     if [[ -n "${STARSHIP_PROMPT_COMMAND-}" ]]; then
         if ((BASH_VERSINFO[0] > 5 || BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] >= 1)) && [[ "${STARSHIP_PROMPT_COMMAND@a}" == "a" ]]; then
             # Extended `STARSHIP_PROMPT_COMMAND` array usage
+            # If Bash 5.1+ and `STARSHIP_PROMPT_COMMAND` is non-empty array
             # PR: https://github.com/starship/starship/pull/7603
             \builtin declare __starship_prompt_subcommand
             for __starship_prompt_subcommand in "${STARSHIP_PROMPT_COMMAND[@]}"; do
@@ -84,7 +85,7 @@ starship_precmd() {
     if [[ -n "${STARSHIP_START_TIME-}" ]]; then
         STARSHIP_END_TIME=$(::STARSHIP:: time)
         STARSHIP_DURATION=$((STARSHIP_END_TIME - STARSHIP_START_TIME))
-        ARGS+=( --cmd-duration="${STARSHIP_DURATION}")
+        ARGS+=("--cmd-duration=${STARSHIP_DURATION}")
         STARSHIP_START_TIME=""
     fi
     PS1="$(::STARSHIP:: prompt "${ARGS[@]}")"
@@ -137,24 +138,40 @@ else
     if ((BASH_VERSINFO[0] > 5 || BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] >= 1)) && [[ "${PROMPT_COMMAND@a}" == "a" ]]; then
         # In Bash 5.1+, the type of PROMPT_COMMAND can be 'array'. Old assignment
         # commands will work with the first element instead of the full PROMPT_COMMAND.
+        # Even so, when 'string' PROMPT_COMMAND is detected when `Starship` is triggered,
+        # use old fallback logic.
         # PR: https://github.com/starship/starship/pull/7603
-        \builtin declare -a STARSHIP_PROMPT_COMMAND=()
+        \builtin declare __starship_ifs="${IFS-}"  # Cause we use empty IFS to figure out if array is empty
+        \builtin unset IFS
+        \builtin declare -a STARSHIP_PROMPT_COMMAND
+        if [[ -z "${STARSHIP_PROMPT_COMMAND[*]}" ]]; then  # Fix: Reenter this line should not overwrite STARSHIP_PROMPT_COMMAND
+            STARSHIP_PROMPT_COMMAND=()
+        fi
+
         \builtin declare __prompt_subcommand
-        for __prompt_subcommand in "${PROMPT_COMMAND[@]}"; do
-            if [[ "${__prompt_subcommand}" == *"starship_precmd"* ]]; then  # If modify this line, modify line 161 as well
-                \builtin unset STARSHIP_PROMPT_COMMAND
+        for __prompt_subcommand in "${PROMPT_COMMAND[@]}"; do  # Test if PROMPT_COMMAND contains 'starship_precmd'
+            if [[ "${__prompt_subcommand}" == *"starship_precmd"* ]]; then  # If modify this line, modify line 158,178 as well
                 \builtin break
-            elif [[ -n "${__prompt_subcommand}" ]]; then
-                STARSHIP_PROMPT_COMMAND+=("${__prompt_subcommand}")
             fi
         done
-        \builtin unset __prompt_subcommand
-        if \builtin declare -p STARSHIP_PROMPT_COMMAND 1> /dev/null 2>&1; then  # If no `starship_precmd` exists
+
+        if [[ "${__prompt_subcommand}" != *"starship_precmd"* ]]; then  # If not contain 'starship_precmd' (first initialization)
+            for __prompt_subcommand in "${PROMPT_COMMAND[@]}"; do  # Join non-empty STARSHIP_PROMPT_COMMAND array
+                if [[ -n "${__prompt_subcommand}" ]]; then
+                    STARSHIP_PROMPT_COMMAND+=("${__prompt_subcommand}")
+                fi
+            done
             PROMPT_COMMAND=("starship_precmd")
-            if [[ -z "${STARSHIP_PROMPT_COMMAND[*]}" ]]; then  # If `STARSHIP_PROMPT_COMMAND` is empty
-                \builtin unset STARSHIP_PROMPT_COMMAND
+            if [[ -z "${STARSHIP_PROMPT_COMMAND[*]}" ]]; then  # If STARSHIP_PROMPT_COMMAND is empty
+                \builtin unset STARSHIP_PROMPT_COMMAND  # Unset STARSHIP_PROMPT_COMMAND
             fi
         fi
+        \builtin unset __prompt_subcommand
+
+        if [[ -n "${__starship_ifs}" ]]; then  # Recover IFS
+            IFS="${__starship_ifs}"
+        fi
+        \builtin unset __starship_ifs
     else
         if [[ -z "${PROMPT_COMMAND-}" ]]; then
             PROMPT_COMMAND="starship_precmd"

--- a/src/init/starship.bash
+++ b/src/init/starship.bash
@@ -135,7 +135,7 @@ else
 
     # Finally, prepare the precmd function and set up the start time. We will avoid to
     # add multiple instances of the starship function and keep other user functions if any.
-    if ((BASH_VERSINFO[0] > 5 || BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] >= 1)) && [[ "${PROMPT_COMMAND@a}" == "a" ]]; then
+    if ((BASH_VERSINFO[0] > 5 || BASH_VERSINFO[0] == 5 && BASH_VERSINFO[1] >= 1)) && [[ -v PROMPT_COMMAND ]] && [[ "${PROMPT_COMMAND@a}" == "a" ]]; then
         # In Bash 5.1+, the type of PROMPT_COMMAND can be 'array'. Old assignment
         # commands will work with the first element instead of the full PROMPT_COMMAND.
         # Even so, when 'string' PROMPT_COMMAND is detected when `Starship` is triggered,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
- Modify `src/init/starship.bash`:
Add `PROMPT_COMMAND` array support by comparing subcommands in for-loop. The remaining content is an imitation of the previous logic.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes https://github.com/starship/starship/issues/7602

#### Screenshots (if appropriate):

<img width="1754" height="1153" alt="image" src="https://github.com/user-attachments/assets/eb298004-4e66-40cc-9680-83fe02d92ab7" />
<img width="572" height="121" alt="image" src="https://github.com/user-attachments/assets/5b45dbbd-f241-42cb-bf66-86d943c52fff" />


#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- Most changes do not need to be tested on multiple operating systems. -->
- [x] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [x] I have tested using **Windows**

This PR has been tested with the following test scripts from Bash 3.1 to 5.3.
The authors make no guarantees on their test scripts.
[test-starship-bash-integration.sh](https://github.com/user-attachments/files/30129881/test-starship-bash-integration.sh)
[interaction.sh](https://github.com/user-attachments/files/30129908/interaction.sh)
[run-test.sh](https://github.com/user-attachments/files/30129909/run-test.sh)

```Dockerfile
## @file Dockerfile.template
## @comments  Gh prevents me from uploading this file ...
FROM alpine:latest AS builder
RUN apk add --no-cache git curl build-base
RUN sh <(curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs) -y --no-modify-path --profile minimal
ENV PATH="/root/.cargo/bin:${PATH}"
RUN rustup target add x86_64-unknown-linux-musl
ENV RUSTFLAGS="-C target-feature=+crt-static -C link-arg=-static"
ENV STARSHIP_CARGO_BUILD_FEATURES="rustls"
WORKDIR /build
RUN git clone --branch=fix/declare-empty-array --single-branch --depth=1 https://github.com/amas127/starship.git .
RUN git checkout fix/declare-empty-array
RUN cargo build --release --target=x86_64-unknown-linux-musl

FROM bash:*.*
COPY --from=builder /build/target/x86_64-unknown-linux-musl/release/starship /usr/local/bin/starship
RUN chmod +x /usr/local/bin/starship
COPY test-starship-bash-integration.sh /test.sh
RUN chmod +x /test.sh
```

#### AI-Assistance
<!-- Per our AI Policy (AI_POLICY.md), all AI usage must be declared. -->
Have you used AI-assistance to author this PR?

- [x] Yes
- [ ] No

If **yes**, describe the scope of assistance:
<!--- Describe how you used AI-Assistance -->
<!--- Disclosure is required if you have used AI-assistance -->
<!--- For example: answering project questions, writing tests, implementation, or documentation -->
Basic sanity check.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
- [x] I understand and have read the code I contribute and can answer questions about it.

Edit-1: Modify script logic.
Edit-2: Add my test scripts and screenshots.