### PR TITLE
fix(hostname): check SSH_CLIENT and SSH_TTY in addition to SSH_CONNECTION

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -489,6 +489,13 @@ impl<'a> Context<'a> {
     pub fn get_config_path_os(&self) -> Option<OsString> {
         get_config_path_os(&self.env)
     }
+
+    /// Checks if it is a SSH session
+    pub fn is_ssh_session(&self) -> bool {
+        ["SSH_CONNECTION", "SSH_TTY", "SSH_CLIENT"]
+            .iter()
+            .any(|s| self.get_env_os(s).is_some())
+    }
 }
 
 impl Default for Context<'_> {

--- a/src/modules/hostname.rs
+++ b/src/modules/hostname.rs
@@ -10,17 +10,17 @@ use whoami::hostname;
 ///
 /// Will display the hostname if all of the following criteria are met:
 ///     - `hostname.disabled` is absent or false
-///     - `hostname.ssh_only` is false OR the user is currently connected as an SSH session (`$SSH_CONNECTION`)
+///     - `hostname.ssh_only` is false OR the user is currently connected as an SSH session (`$SSH_CONNECTION`, `$SSH_CLIENT`, `$SSH_TTY`)
 ///     - `hostname.ssh_only` is false AND `hostname.detect_env_vars` is either empty or contains a defined environment variable
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let mut module = context.new_module("hostname");
     let config: HostnameConfig = HostnameConfig::try_load(module.config);
 
-    let ssh_connection = context.get_env("SSH_CONNECTION");
+    let is_ssh = ["SSH_CONNECTION", "SSH_TTY", "SSH_CLIENT"]
+        .iter()
+        .any(|s| context.get_env_os(s).is_some());
 
-    if (config.ssh_only && ssh_connection.is_none())
-        || !context.detect_env_vars(&config.detect_env_vars)
-    {
+    if (config.ssh_only && !is_ssh) || !context.detect_env_vars(&config.detect_env_vars) {
         return None;
     }
 
@@ -44,7 +44,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         formatter
             .map_meta(|var, _| match var {
                 "ssh_symbol" => {
-                    if ssh_connection.is_some() {
+                    if is_ssh {
                         Some(config.ssh_symbol)
                     } else {
                         None
@@ -204,7 +204,7 @@ mod tests {
     }
 
     #[test]
-    fn ssh() {
+    fn ssh_connection() {
         let hostname = get_hostname!();
         let actual = ModuleRenderer::new("hostname")
             .config(toml::toml! {
@@ -213,6 +213,44 @@ mod tests {
                 trim_at = ""
             })
             .env("SSH_CONNECTION", "something")
+            .collect();
+        let expected = Some(format!(
+            "{} in ",
+            style().paint("🌐 ".to_owned() + hostname.as_str())
+        ));
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn ssh_client() {
+        let hostname = get_hostname!();
+        let actual = ModuleRenderer::new("hostname")
+            .config(toml::toml! {
+                [hostname]
+                ssh_only = true
+                trim_at = ""
+            })
+            .env("SSH_CLIENT", "192.168.0.50 12345 67")
+            .collect();
+        let expected = Some(format!(
+            "{} in ",
+            style().paint("🌐 ".to_owned() + hostname.as_str())
+        ));
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn ssh_tty() {
+        let hostname = get_hostname!();
+        let actual = ModuleRenderer::new("hostname")
+            .config(toml::toml! {
+                [hostname]
+                ssh_only = true
+                trim_at = ""
+            })
+            .env("SSH_TTY", "dev/pts/0")
             .collect();
         let expected = Some(format!(
             "{} in ",

--- a/src/modules/hostname.rs
+++ b/src/modules/hostname.rs
@@ -16,10 +16,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let mut module = context.new_module("hostname");
     let config: HostnameConfig = HostnameConfig::try_load(module.config);
 
-    let is_ssh = ["SSH_CONNECTION", "SSH_TTY", "SSH_CLIENT"]
-        .iter()
-        .any(|s| context.get_env_os(s).is_some());
-
+    let is_ssh = context.is_ssh_session();
     if (config.ssh_only && !is_ssh) || !context.detect_env_vars(&config.detect_env_vars) {
         return None;
     }

--- a/src/modules/username.rs
+++ b/src/modules/username.rs
@@ -40,7 +40,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let show_username = config.show_always
         || is_root // [1]
         || !is_login_user(context, &username) // [2]
-        || is_ssh_session(context) // [3]
+        || context.is_ssh_session() // [3]
         || has_detected_env_var == Detected::Yes; // [4]
 
     if !show_username || has_detected_env_var == Detected::Negated {
@@ -117,11 +117,6 @@ fn is_root_user() -> bool {
 #[cfg(all(not(target_os = "windows"), not(test)))]
 fn is_root_user() -> bool {
     nix::unistd::geteuid() == nix::unistd::ROOT
-}
-
-fn is_ssh_session(context: &Context) -> bool {
-    let ssh_env = ["SSH_CONNECTION", "SSH_CLIENT", "SSH_TTY"];
-    ssh_env.iter().any(|env| context.get_env_os(env).is_some())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
#### Description
Fixes the hostname module only checking `$SSH_CONNECTION` to detect
an SSH session, missing `SSH_CLIENT` and `SSH_TTY`.

#### Motivation and Context
The `username` module already checks all three SSH-related
environment variables (`SSH_CONNECTION`, `SSH_CLIENT`, `SSH_TTY`),
but `hostname` only checked `SSH_CONNECTION`. Depending on SSH
server/client configuration, only one of these three may be set,
so `hostname` could incorrectly report "not SSH" in sessions where
`username` correctly detected one.

Closes #7207

#### Screenshots (if appropriate):

#### How Has This Been Tested?
Added three unit tests (`ssh_connection`, `ssh_client`, `ssh_tty`)
covering each of the three SSH-related environment variables.
Ran `cargo test --lib hostname::` — all 14 tests pass. Also ran
`cargo fmt` and `cargo clippy --all-targets --all-features` with
no issues.

#### AI-Assistance
- [x] Yes

I used AI assistance (Claude) to understand the codebase — comparing
`hostname.rs` and `username.rs` to identify the inconsistency, and to
learn the git/GitHub contribution workflow, since this is my first
open-source contribution. The actual fix (checking all three SSH env
vars) and the three test functions were written by me. I reviewed,
tested, and understand every part of this change and can answer
questions about it.

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
- [x] I understand and have read the code I contribute and can answer questions about it.
