### PR TITLE
feat(claude_model): add effort variable

### DIFF
--- a/docs/advanced-config/README.md
+++ b/docs/advanced-config/README.md
@@ -426,12 +426,13 @@ The `claude_model` module displays the current Claude model being used in the se
 
 #### Variables
 
-| Variable | Example             | Description                           |
-| -------- | ------------------- | ------------------------------------- |
-| model    | `Claude 3.5 Sonnet` | The display name of the current model |
-| model_id | `claude-3-5-sonnet` | The model ID                          |
-| symbol   |                     | Mirrors the value of option `symbol`  |
-| style\*  |                     | Mirrors the value of option `style`   |
+| Variable | Example             | Description                             |
+| -------- | ------------------- | --------------------------------------- |
+| model    | `Claude 3.5 Sonnet` | The display name of the current model   |
+| model_id | `claude-3-5-sonnet` | The model ID                            |
+| effort   | `high`              | The reasoning effort level, if reported |
+| symbol   |                     | Mirrors the value of option `symbol`    |
+| style\*  |                     | Mirrors the value of option `style`     |
 
 \*: This variable can only be used as a part of a style string
 

--- a/src/modules/claude_context.rs
+++ b/src/modules/claude_context.rs
@@ -209,6 +209,7 @@ mod tests {
             },
             cost: None,
             workspace: None,
+            effort: None,
         }
     }
 

--- a/src/modules/claude_cost.rs
+++ b/src/modules/claude_cost.rs
@@ -179,6 +179,7 @@ mod tests {
                 total_lines_removed: 500,
             }),
             workspace: None,
+            effort: None,
         }
     }
 

--- a/src/modules/claude_model.rs
+++ b/src/modules/claude_model.rs
@@ -38,6 +38,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             .map(|variable| match variable {
                 "model" => Some(Ok(model_display)),
                 "model_id" => Some(Ok(claude_data.model.id.as_str())),
+                "effort" => claude_data.effort.as_ref().map(|e| Ok(e.level.as_str())),
                 _ => None,
             })
             .parse(None, Some(context))
@@ -76,6 +77,7 @@ mod tests {
             context_window: crate::context::ContextWindow::default(),
             cost: None,
             workspace: None,
+            effort: None,
         };
         let actual = ModuleRenderer::new("claude_model")
             .config(toml::toml! {
@@ -98,6 +100,7 @@ mod tests {
             context_window: crate::context::ContextWindow::default(),
             cost: None,
             workspace: None,
+            effort: None,
         };
 
         let actual = ModuleRenderer::new("claude_model")
@@ -125,6 +128,7 @@ mod tests {
             context_window: crate::context::ContextWindow::default(),
             cost: None,
             workspace: None,
+            effort: None,
         };
 
         let actual = ModuleRenderer::new("claude_model")
@@ -143,6 +147,62 @@ mod tests {
     }
 
     #[test]
+    fn test_effort_level() {
+        let data = crate::context::ClaudeCodeData {
+            cwd: None,
+            model: crate::context::ModelInfo {
+                id: "claude-opus-4-8".to_string(),
+                display_name: "Opus 4.8".to_string(),
+            },
+            context_window: crate::context::ContextWindow::default(),
+            cost: None,
+            workspace: None,
+            effort: Some(crate::utils::statusline::EffortInfo {
+                level: "high".to_string(),
+            }),
+        };
+
+        let actual = ModuleRenderer::new("claude_model")
+            .config(toml::toml! {
+                [claude_model]
+                symbol = ""
+                format = "[$model $effort]($style)"
+            })
+            .claude_code_data(data)
+            .collect();
+
+        let expected = Some(format!("{}", Color::Blue.bold().paint("Opus 4.8 high")));
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_effort_absent_omits_variable() {
+        let data = crate::context::ClaudeCodeData {
+            cwd: None,
+            model: crate::context::ModelInfo {
+                id: "claude-opus-4-8".to_string(),
+                display_name: "Opus 4.8".to_string(),
+            },
+            context_window: crate::context::ContextWindow::default(),
+            cost: None,
+            workspace: None,
+            effort: None,
+        };
+
+        let actual = ModuleRenderer::new("claude_model")
+            .config(toml::toml! {
+                [claude_model]
+                symbol = ""
+                format = "[$model( \\($effort\\))]($style)"
+            })
+            .claude_code_data(data)
+            .collect();
+
+        let expected = Some(format!("{}", Color::Blue.bold().paint("Opus 4.8")));
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
     fn test_alias_by_display_name() {
         let data = crate::context::ClaudeCodeData {
             cwd: None,
@@ -153,6 +213,7 @@ mod tests {
             context_window: crate::context::ContextWindow::default(),
             cost: None,
             workspace: None,
+            effort: None,
         };
 
         let actual = ModuleRenderer::new("claude_model")

--- a/src/utils/statusline.rs
+++ b/src/utils/statusline.rs
@@ -20,6 +20,13 @@ pub struct ClaudeCodeData {
     pub context_window: ContextWindow,
     pub cost: Option<CostInfo>,
     pub workspace: Option<Workspace>,
+    pub effort: Option<EffortInfo>,
+}
+
+#[derive(Deserialize, Debug, Clone, Default)]
+#[serde(default)]
+pub struct EffortInfo {
+    pub level: String,
 }
 
 #[derive(Deserialize, Debug, Clone, Default)]


### PR DESCRIPTION
#### Description

Expose the Claude Code reasoning effort level (low/medium/high/xhigh/max) as a new `$effort` format variable, sourced from the statusline payload's `effort.level` field. The variable is omitted when the model does not report an effort level, so it can be used inside a conditional format group. The default format is unchanged.

#### Motivation and Context

add another flexibility option for claude status line

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- Most changes do not need to be tested on multiple operating systems. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### AI-Assistance
<!-- Per our AI Policy (AI_POLICY.md), all AI usage must be declared. -->
Have you used AI-assistance to author this PR?

- [x] Yes
- [ ] No

If **yes**, describe the scope of assistance:
<!--- Describe how you used AI-Assistance -->
<!--- Disclosure is required if you have used AI-assistance -->
<!--- For example: answering project questions, writing tests, implementation, or documentation -->
I requested the change.  AI implemented it.  I reviewed and requested changes.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
- [x] I understand and have read the code I contribute and can answer questions about it.
