### PR TITLE
fix(git_status): respect GIT_WORK_TREE for bare repositories

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -370,6 +370,21 @@ impl<'a> Context<'a> {
                         }
                     };
 
+                let mut repository = shared_repo.to_thread_local();
+                if repository.workdir().is_none()
+                    && let Some(worktree) = self.get_env_os("GIT_WORK_TREE")
+                {
+                    let worktree = PathBuf::from(worktree);
+                    let worktree = if worktree.is_absolute() {
+                        worktree
+                    } else {
+                        self.current_dir.join(worktree)
+                    };
+                    if let Err(error) = repository.set_workdir(worktree) {
+                        log::debug!("Failed to apply GIT_WORK_TREE: {error}");
+                    }
+                }
+                let shared_repo = repository.into_sync();
                 let repository = shared_repo.to_thread_local();
                 log::trace!(
                     "Found git repo: {repository:?}, (trust: {:?})",

--- a/src/modules/git_status.rs
+++ b/src/modules/git_status.rs
@@ -2024,6 +2024,45 @@ pub mod tests {
         Ok(())
     }
 
+    #[test]
+    fn does_generate_git_status_for_explicit_worktree_of_bare_repo() -> io::Result<()> {
+        for &mode in BARE_GIT_PROVIDERS {
+            let worktree_dir = tempfile::tempdir()?;
+            let repo_dir = fixture_repo(mode)?;
+
+            create_command("git")?
+                .args([
+                    OsStr::new("--git-dir"),
+                    repo_dir.path().as_os_str(),
+                    OsStr::new("--work-tree"),
+                    worktree_dir.path().as_os_str(),
+                    OsStr::new("checkout"),
+                    OsStr::new("-f"),
+                ])
+                .output()?;
+
+            let mut the_file = std::fs::File::create(worktree_dir.path().join("test_file"))?;
+            writeln!(the_file, "content")?;
+            the_file.sync_all()?;
+
+            let actual = ModuleRenderer::new("git_status")
+                .path(repo_dir.path())
+                .env("GIT_WORK_TREE", worktree_dir.path().to_string_lossy())
+                .config(toml::toml! {
+                    [git_status]
+                    format = "$all_status"
+                    style = ""
+                })
+                .collect();
+            let expected = Some("?".to_string());
+
+            assert_eq!(expected, actual);
+            worktree_dir.close()?;
+            repo_dir.close()?;
+        }
+        Ok(())
+    }
+
     fn ahead(repo_dir: &Path) -> io::Result<()> {
         File::create(repo_dir.join("readme.md"))?.sync_all()?;
 


### PR DESCRIPTION
#### Description

Apply the explicit `GIT_WORK_TREE` environment override when repository discovery identifies a bare repository without a worktree.

This allows the `git_status` module to report modified, staged, and untracked files for workflows that use a bare repository together with an external worktree.

#### Motivation and Context

Git itself honors `GIT_DIR` and `GIT_WORK_TREE` in this configuration, and `git_branch` already works, but Starship previously treated the repository as having no worktree and skipped `git_status`.

The repository discovered through gix retained `workdir: None` because `core.bare=true`. This change applies the explicit environment override before the repository is used by Git modules.

Closes #7609

#### Screenshots (if appropriate):

N/A

#### How Has This Been Tested?

- Added a regression test using a bare repository and a separate explicit worktree.
- Verified the test with both supported bare Git status providers.
- Reproduced the original behavior using Starship 1.26.0.
- Verified the patched binary reports modified and untracked files.
- Ran the complete test suite: 1,237 passed, 0 failed, 39 ignored.
- Ran the `git_status` module suite: 49 passed.
- Ran strict Clippy and formatting checks.

- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### AI-Assistance

Have you used AI-assistance to author this PR?

- [x] Yes
- [ ] No

If **yes**, describe the scope of assistance:

AI assistance was used to investigate repository discovery behavior, implement the focused change, write the regression test, and run validation. I reviewed and verified the resulting code and behavior locally.

#### Checklist:

- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
- [x] I understand and have read the code I contribute and can answer questions about it.
