### PR TITLE
fix(package): support build.gradle.kts in gradle version detection

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -3712,7 +3712,7 @@ package, and shows its current version. The module currently supports `npm`, `ni
 - [**Python**](https://www.python.org) - The `python` package version is extracted from a [PEP 621](https://peps.python.org/pep-0621/) compliant `pyproject.toml` or a `setup.cfg` present in the current directory
 - [**Composer**](https://getcomposer.org/) – The `composer` package version is extracted from the `composer.json` present
   in the current directory
-- [**Gradle**](https://gradle.org/) – The `gradle` package version is extracted from the `build.gradle` present in the current directory
+- [**Gradle**](https://gradle.org/) – The `gradle` package version is extracted from the `build.gradle` or `build.gradle.kts` present in the current directory
 - [**Julia**](https://docs.julialang.org/en/v1/stdlib/Pkg/) - The package version is extracted from the `Project.toml` present in the current directory
 - [**Mix**](https://hexdocs.pm/mix/) - The `mix` package version is extracted from the `mix.exs` present in the current directory
 - [**Helm**](https://helm.sh/docs/helm/helm_package/) - The `helm` chart version is extracted from the `Chart.yaml` present in the current directory

--- a/src/modules/package.rs
+++ b/src/modules/package.rs
@@ -180,7 +180,9 @@ fn get_gradle_version(context: &Context, config: &PackageConfig) -> Option<Strin
             let caps = re.captures(&contents)?;
             format_version(&caps["version"], config.version_format)
         }).or_else(|| {
-            let build_file_contents = context.read_file_from_pwd("build.gradle")?;
+            let build_file_contents = context
+                .read_file_from_pwd("build.gradle")
+                .or_else(|| context.read_file_from_pwd("build.gradle.kts"))?;
             let re = Regex::new(r#"(?m)^version( |\s*=\s*)['"](?P<version>[^'"]+)['"]$"#).unwrap(); /*dark magic*/
             let caps = re.captures(&build_file_contents)?;
             format_version(&caps["version"], config.version_format)
@@ -1204,6 +1206,25 @@ java {
         expect_output(&project_dir, None, None);
         project_dir.close()
     }
+    #[test]
+    fn test_extract_gradle_version_kotlin_dsl() -> io::Result<()> {
+        let config_name = "build.gradle.kts";
+        let config_content = "plugins {
+    id(\"java\")
+    id(\"test.plugin\") version \"0.2.0\"
+}
+version = \"0.1.0\"
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}";
+
+        let project_dir = create_project_dir()?;
+        fill_config(&project_dir, config_name, Some(config_content))?;
+        expect_output(&project_dir, Some("v0.1.0"), None);
+        project_dir.close()
+    }
+
     #[test]
     fn test_extract_grade_version_from_properties() -> io::Result<()> {
         let config_name = "gradle.properties";

--- a/src/modules/package.rs
+++ b/src/modules/package.rs
@@ -1206,6 +1206,7 @@ java {
         expect_output(&project_dir, None, None);
         project_dir.close()
     }
+
     #[test]
     fn test_extract_gradle_version_kotlin_dsl() -> io::Result<()> {
         let config_name = "build.gradle.kts";


### PR DESCRIPTION
## Summary

`get_gradle_version` in the `package` module only looked for a file named `build.gradle`, so projects using the Kotlin DSL variant (`build.gradle.kts`) never had their package version detected — the module simply reported nothing for those projects.

Fixes #7561.

## Root cause

The existing version regex (`^version( |\s*=\s*)['"]...`) already matches Kotlin DSL syntax like `version = "1.0.0"` — the issue reporter confirmed this themselves by renaming `build.gradle.kts` to `build.gradle`, which "did the trick". The only actual gap was that the code never looked for the `build.gradle.kts` filename at all.

## Fix

Fall back to reading `build.gradle.kts` when `build.gradle` isn't present, reusing the same regex-based extraction logic.

## Test plan

- [x] Added `test_extract_gradle_version_kotlin_dsl`, mirroring the existing `build.gradle` tests, using Kotlin DSL syntax (`id("java")`, `version = "0.1.0"`)
- [x] `cargo test --lib modules::package` — all 67 tests pass, including the new one
- [x] `cargo fmt --check`