### PR TITLE
fix(hg_branch): trim whitespace from bookmark names

### DIFF
--- a/src/modules/hg_branch.rs
+++ b/src/modules/hg_branch.rs
@@ -80,7 +80,7 @@ fn get_hg_branch_name(hg_root: &Path) -> Result<String, Error> {
 }
 
 fn get_hg_current_bookmark(hg_root: &Path) -> Result<String, Error> {
-    read_file(hg_root.join(".hg").join("bookmarks.current"))
+    read_file(hg_root.join(".hg").join("bookmarks.current")).map(|s| s.trim().to_string())
 }
 
 fn get_hg_topic_name(hg_root: &Path) -> Result<String, Error> {


### PR DESCRIPTION
## Description

get_hg_current_bookmark was returning raw file content from .hg/bookmarks.current without trimming trailing whitespace/newlines. The other functions in the same module (get_hg_branch_name, get_hg_topic_name) already correctly trim their results.

This caused Mercurial bookmark names to display with trailing newlines in the prompt.

## Fix

Added .map(|s| s.trim().to_string()) to match the behavior of the other file-reading functions in this module.

## Testing

- cargo fmt: passes
- cargo clippy -- -D warnings: passes  
- cargo test hg_branch::tests: 1 passed, 8 ignored (same as before)