### PR TITLE
fix(nodejs): replace unwrap() calls that could panic with safe pattern

### DIFF
--- a/src/modules/nodejs.rs
+++ b/src/modules/nodejs.rs
@@ -118,10 +118,11 @@ fn check_engines_version(nodejs_version: Option<&str>, engines_version: Option<&
     let re = Regex::new(r"\d+\.\d+\.\d+").unwrap();
     let version = re
         .captures(nodejs_version)
-        .unwrap()
-        .get(0)
-        .unwrap()
-        .as_str();
+        .and_then(|c| c.get(0))
+        .map(|m| m.as_str());
+    let Some(version) = version else {
+        return true;
+    };
 
     let v = match Version::parse(version) {
         Ok(v) => v,


### PR DESCRIPTION
## Description

check_engines_version in the nodejs module used three consecutive .unwrap() calls on regex captures that would **panic and crash starship** if the Node.js version string from `node --version` didn't match the expected `\d+\.\d+\.\d+` format (e.g., a 2-part version like `v21.0` from certain builds/distros).

## Fix

Replaced the three .unwrap() calls with .and_then() + .map() + let-else pattern that gracefully returns true (assume compatible) instead of crashing:

```rust
// Before (would panic):
let version = re.captures(nodejs_version).unwrap().get(0).unwrap().as_str();

// After (graceful):
let version = re.captures(nodejs_version).and_then(|c| c.get(0)).map(|m| m.as_str());
let Some(version) = version else { return true; };
```

This follows the same defensive pattern already used elsewhere in the function (`let Ok(r) = VersionReq::parse(...) else { return true; }`).

## Testing

- cargo fmt: passes
- cargo clippy -- -D warnings: passes
- cargo test nodejs::tests: 16 passed, 0 failed