### PR TITLE
fix(terraform): trim workspace name from environment file

### DIFF
--- a/src/modules/terraform.rs
+++ b/src/modules/terraform.rs
@@ -81,7 +81,7 @@ fn get_terraform_workspace(context: &Context) -> Option<String> {
     };
     match utils::read_file(datadir.join("environment")) {
         Err(ref e) if e.kind() == io::ErrorKind::NotFound => Some("default".to_string()),
-        Ok(s) => Some(s),
+        Ok(s) => Some(s.trim().to_string()),
         _ => None,
     }
 }


### PR DESCRIPTION
## Description

get_terraform_workspace was returning raw file content from .terraform/environment without trimming trailing whitespace/newlines. If the file has a trailing newline (common when created by text editors), the workspace name would include it in the prompt, causing display issues.

This is inconsistent with how other file-reading code in the codebase handles content (e.g., git_state.rs uses .trim() before parsing).

## Fix

Changed `Ok(s) => Some(s)` to `Ok(s) => Some(s.trim().to_string())` in get_terraform_workspace.

## Testing

- cargo fmt: passes
- cargo clippy -- -D warnings: passes
- cargo test terraform::tests: 15 passed, 0 failed