### PR TITLE
fix(package): support build.gradle.kts in gradle version detection

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -3712,7 +3712,7 @@ package, and shows its current version. The module currently supports `npm`, `ni
 - [**Python**](https://www.python.org) - The `python` package version is extracted from a [PEP 621](https://peps.python.org/pep-0621/) compliant `pyproject.toml` or a `setup.cfg` present in the current directory
 - [**Composer**](https://getcomposer.org/) – The `composer` package version is extracted from the `composer.json` present
   in the current directory
-- [**Gradle**](https://gradle.org/) – The `gradle` package version is extracted from the `build.gradle` present in the current directory
+- [**Gradle**](https://gradle.org/) – The `gradle` package version is extracted from the `build.gradle` or `build.gradle.kts` present in the current directory
 - [**Julia**](https://docs.julialang.org/en/v1/stdlib/Pkg/) - The package version is extracted from the `Project.toml` present in the current directory
 - [**Mix**](https://hexdocs.pm/mix/) - The `mix` package version is extracted from the `mix.exs` present in the current directory
 - [**Helm**](https://helm.sh/docs/helm/helm_package/) - The `helm` chart version is extracted from the `Chart.yaml` present in the current directory

--- a/src/modules/package.rs
+++ b/src/modules/package.rs
@@ -180,7 +180,9 @@ fn get_gradle_version(context: &Context, config: &PackageConfig) -> Option<Strin
             let caps = re.captures(&contents)?;
             format_version(&caps["version"], config.version_format)
         }).or_else(|| {
-            let build_file_contents = context.read_file_from_pwd("build.gradle")?;
+            let build_file_contents = context
+                .read_file_from_pwd("build.gradle")
+                .or_else(|| context.read_file_from_pwd("build.gradle.kts"))?;
             let re = Regex::new(r#"(?m)^version( |\s*=\s*)['"](?P<version>[^'"]+)['"]$"#).unwrap(); /*dark magic*/
             let caps = re.captures(&build_file_contents)?;
             format_version(&caps["version"], config.version_format)
@@ -1204,6 +1206,25 @@ java {
         expect_output(&project_dir, None, None);
         project_dir.close()
     }
+    #[test]
+    fn test_extract_gradle_version_kotlin_dsl() -> io::Result<()> {
+        let config_name = "build.gradle.kts";
+        let config_content = "plugins {
+    id(\"java\")
+    id(\"test.plugin\") version \"0.2.0\"
+}
+version = \"0.1.0\"
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}";
+
+        let project_dir = create_project_dir()?;
+        fill_config(&project_dir, config_name, Some(config_content))?;
+        expect_output(&project_dir, Some("v0.1.0"), None);
+        project_dir.close()
+    }
+
     #[test]
     fn test_extract_grade_version_from_properties() -> io::Result<()> {
         let config_name = "gradle.properties";

--- a/src/modules/package.rs
+++ b/src/modules/package.rs
@@ -1206,6 +1206,7 @@ java {
         expect_output(&project_dir, None, None);
         project_dir.close()
     }
+
     #[test]
     fn test_extract_gradle_version_kotlin_dsl() -> io::Result<()> {
         let config_name = "build.gradle.kts";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
`get_gradle_version` only looked for a file named `build.gradle`, so projects using the Kotlin DSL (`build.gradle.kts`) never had their package version detected.

This change falls back to reading `build.gradle.kts` when `build.gradle` is absent, reusing the same version regex (which already matches Kotlin DSL `version = "..."` syntax). Documentation is updated accordingly, and a unit test covers the Kotlin DSL case.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #7561

Previous PR #7619 was closed for not using this template; this is the same fix with the required template filled in.

#### Screenshots (if appropriate):

N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- Most changes do not need to be tested on multiple operating systems. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

- Added `test_extract_gradle_version_kotlin_dsl` mirroring existing `build.gradle` tests
- `cargo test --lib modules::package` — all tests pass, including the new one
- `cargo fmt --check`

#### AI-Assistance
<!-- Per our AI Policy (AI_POLICY.md), all AI usage must be declared. -->
Have you used AI-assistance to author this PR?

- [x] Yes
- [ ] No

If **yes**, describe the scope of assistance:
Assistance with locating the `build.gradle`-only path, drafting the Kotlin DSL fallback and unit test, and filling this PR template. Changes were reviewed and verified locally before submission.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
- [x] I understand and have read the code I contribute and can answer questions about it.