### PR TITLE
feat(claude_model): add thinking symbol

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -248,6 +248,7 @@
       "default": {
         "format": "[$symbol$model]($style) ",
         "symbol": "🤖 ",
+        "thinking_symbol": "💭 ",
         "style": "bold blue",
         "model_aliases": {},
         "disabled": false
@@ -2443,6 +2444,10 @@
         "symbol": {
           "type": "string",
           "default": "🤖 "
+        },
+        "thinking_symbol": {
+          "type": "string",
+          "default": "💭 "
         },
         "style": {
           "type": "string",

--- a/docs/advanced-config/README.md
+++ b/docs/advanced-config/README.md
@@ -416,23 +416,25 @@ The `claude_model` module displays the current Claude model being used in the se
 
 #### Options
 
-| Option          | Default                      | Description                                                                               |
-| --------------- | ---------------------------- | ----------------------------------------------------------------------------------------- |
-| `format`        | `'[$symbol$model]($style) '` | The format for the module.                                                                |
-| `symbol`        | `'🤖 '`                      | The symbol shown before the model name.                                                   |
-| `style`         | `'bold blue'`                | The style for the module.                                                                 |
-| `model_aliases` | `{}`                         | Map of model IDs or display names to shorter aliases. Checks ID first, then display name. |
-| `disabled`      | `false`                      | Disables the `claude_model` module.                                                       |
+| Option            | Default                      | Description                                                                               |
+| ----------------- | ---------------------------- | ----------------------------------------------------------------------------------------- |
+| `format`          | `'[$symbol$model]($style) '` | The format for the module.                                                                |
+| `symbol`          | `'🤖 '`                      | The symbol shown before the model name.                                                   |
+| `thinking_symbol` | `'💭 '`                      | The symbol shown when extended thinking is enabled.                                       |
+| `style`           | `'bold blue'`                | The style for the module.                                                                 |
+| `model_aliases`   | `{}`                         | Map of model IDs or display names to shorter aliases. Checks ID first, then display name. |
+| `disabled`        | `false`                      | Disables the `claude_model` module.                                                       |
 
 #### Variables
 
-| Variable | Example             | Description                             |
-| -------- | ------------------- | --------------------------------------- |
-| model    | `Claude 3.5 Sonnet` | The display name of the current model   |
-| model_id | `claude-3-5-sonnet` | The model ID                            |
-| effort   | `high`              | The reasoning effort level, if reported |
-| symbol   |                     | Mirrors the value of option `symbol`    |
-| style\*  |                     | Mirrors the value of option `style`     |
+| Variable        | Example             | Description                                                       |
+| --------------- | ------------------- | ----------------------------------------------------------------- |
+| model           | `Claude 3.5 Sonnet` | The display name of the current model                             |
+| model_id        | `claude-3-5-sonnet` | The model ID                                                      |
+| effort          | `high`              | The reasoning effort level; empty when not reported               |
+| symbol          |                     | Mirrors the value of option `symbol`                              |
+| thinking_symbol | `💭`                | Mirrors option `thinking_symbol`; empty when thinking is disabled |
+| style\*         |                     | Mirrors the value of option `style`                               |
 
 \*: This variable can only be used as a part of a style string
 
@@ -442,9 +444,11 @@ The `claude_model` module displays the current Claude model being used in the se
 # ~/.config/starship.toml
 
 # Basic customization
+# $thinking_symbol renders only while extended thinking is enabled
 [claude_model]
-format = "on [$symbol$model]($style) "
+format = "on [$thinking_symbol$symbol$model]($style) "
 symbol = "🧠 "
+thinking_symbol = "💭 "
 style = "bold cyan"
 
 # Using model aliases for vendor-specific model names

--- a/src/configs/claude_model.rs
+++ b/src/configs/claude_model.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 pub struct ClaudeModelConfig<'a> {
     pub format: &'a str,
     pub symbol: &'a str,
+    pub thinking_symbol: &'a str,
     pub style: &'a str,
     pub model_aliases: IndexMap<String, &'a str>,
     pub disabled: bool,
@@ -21,6 +22,7 @@ impl Default for ClaudeModelConfig<'_> {
         Self {
             format: "[$symbol$model]($style) ",
             symbol: "🤖 ",
+            thinking_symbol: "💭 ",
             style: "bold blue",
             model_aliases: IndexMap::new(),
             disabled: false,

--- a/src/context.rs
+++ b/src/context.rs
@@ -30,7 +30,7 @@ use terminal_size::terminal_size;
 
 pub use crate::utils::env::Env;
 pub use crate::utils::statusline::{
-    ClaudeCodeData, ContextWindow, CostInfo, CurrentUsage, ModelInfo, Workspace,
+    ClaudeCodeData, ContextWindow, CostInfo, CurrentUsage, ModelInfo, ThinkingInfo, Workspace,
 };
 
 /// Context contains data or common methods that may be used by multiple modules.

--- a/src/modules/claude_context.rs
+++ b/src/modules/claude_context.rs
@@ -210,6 +210,7 @@ mod tests {
             cost: None,
             workspace: None,
             effort: None,
+            thinking: None,
         }
     }
 

--- a/src/modules/claude_cost.rs
+++ b/src/modules/claude_cost.rs
@@ -180,6 +180,7 @@ mod tests {
             }),
             workspace: None,
             effort: None,
+            thinking: None,
         }
     }
 

--- a/src/modules/claude_model.rs
+++ b/src/modules/claude_model.rs
@@ -29,6 +29,11 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         formatter
             .map_meta(|variable, _| match variable {
                 "symbol" => Some(config.symbol),
+                "thinking_symbol" => claude_data
+                    .thinking
+                    .as_ref()
+                    .filter(|t| t.enabled)
+                    .map(|_| config.thinking_symbol),
                 _ => None,
             })
             .map_style(|variable| match variable {
@@ -78,6 +83,7 @@ mod tests {
             cost: None,
             workspace: None,
             effort: None,
+            thinking: None,
         };
         let actual = ModuleRenderer::new("claude_model")
             .config(toml::toml! {
@@ -101,6 +107,7 @@ mod tests {
             cost: None,
             workspace: None,
             effort: None,
+            thinking: None,
         };
 
         let actual = ModuleRenderer::new("claude_model")
@@ -129,6 +136,7 @@ mod tests {
             cost: None,
             workspace: None,
             effort: None,
+            thinking: None,
         };
 
         let actual = ModuleRenderer::new("claude_model")
@@ -160,6 +168,7 @@ mod tests {
             effort: Some(crate::utils::statusline::EffortInfo {
                 level: "high".to_string(),
             }),
+            thinking: None,
         };
 
         let actual = ModuleRenderer::new("claude_model")
@@ -187,6 +196,7 @@ mod tests {
             cost: None,
             workspace: None,
             effort: None,
+            thinking: None,
         };
 
         let actual = ModuleRenderer::new("claude_model")
@@ -194,6 +204,90 @@ mod tests {
                 [claude_model]
                 symbol = ""
                 format = "[$model( \\($effort\\))]($style)"
+            })
+            .claude_code_data(data)
+            .collect();
+
+        let expected = Some(format!("{}", Color::Blue.bold().paint("Opus 4.8")));
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_thinking_symbol_enabled() {
+        let data = crate::context::ClaudeCodeData {
+            cwd: None,
+            model: crate::context::ModelInfo {
+                id: "claude-opus-4-8".to_string(),
+                display_name: "Opus 4.8".to_string(),
+            },
+            context_window: crate::context::ContextWindow::default(),
+            cost: None,
+            workspace: None,
+            effort: None,
+            thinking: Some(crate::utils::statusline::ThinkingInfo { enabled: true }),
+        };
+
+        let actual = ModuleRenderer::new("claude_model")
+            .config(toml::toml! {
+                [claude_model]
+                thinking_symbol = "🧠 "
+                format = "[$thinking_symbol$model]($style)"
+            })
+            .claude_code_data(data)
+            .collect();
+
+        let expected = Some(format!("{}", Color::Blue.bold().paint("🧠 Opus 4.8")));
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_thinking_symbol_disabled_omits_variable() {
+        let data = crate::context::ClaudeCodeData {
+            cwd: None,
+            model: crate::context::ModelInfo {
+                id: "claude-opus-4-8".to_string(),
+                display_name: "Opus 4.8".to_string(),
+            },
+            context_window: crate::context::ContextWindow::default(),
+            cost: None,
+            workspace: None,
+            effort: None,
+            thinking: Some(crate::utils::statusline::ThinkingInfo { enabled: false }),
+        };
+
+        let actual = ModuleRenderer::new("claude_model")
+            .config(toml::toml! {
+                [claude_model]
+                thinking_symbol = "🧠 "
+                format = "[$thinking_symbol$model]($style)"
+            })
+            .claude_code_data(data)
+            .collect();
+
+        let expected = Some(format!("{}", Color::Blue.bold().paint("Opus 4.8")));
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_thinking_symbol_absent_omits_variable() {
+        let data = crate::context::ClaudeCodeData {
+            cwd: None,
+            model: crate::context::ModelInfo {
+                id: "claude-opus-4-8".to_string(),
+                display_name: "Opus 4.8".to_string(),
+            },
+            context_window: crate::context::ContextWindow::default(),
+            cost: None,
+            workspace: None,
+            effort: None,
+            thinking: None,
+        };
+
+        let actual = ModuleRenderer::new("claude_model")
+            .config(toml::toml! {
+                [claude_model]
+                thinking_symbol = "🧠 "
+                format = "[$thinking_symbol$model]($style)"
             })
             .claude_code_data(data)
             .collect();
@@ -214,6 +308,7 @@ mod tests {
             cost: None,
             workspace: None,
             effort: None,
+            thinking: None,
         };
 
         let actual = ModuleRenderer::new("claude_model")

--- a/src/utils/statusline.rs
+++ b/src/utils/statusline.rs
@@ -21,12 +21,19 @@ pub struct ClaudeCodeData {
     pub cost: Option<CostInfo>,
     pub workspace: Option<Workspace>,
     pub effort: Option<EffortInfo>,
+    pub thinking: Option<ThinkingInfo>,
 }
 
 #[derive(Deserialize, Debug, Clone, Default)]
 #[serde(default)]
 pub struct EffortInfo {
     pub level: String,
+}
+
+#[derive(Deserialize, Debug, Clone, Default)]
+#[serde(default)]
+pub struct ThinkingInfo {
+    pub enabled: bool,
 }
 
 #[derive(Deserialize, Debug, Clone, Default)]
@@ -122,6 +129,12 @@ mod tests {
                     "cache_creation_input_tokens": 10,
                     "cache_read_input_tokens": 20
                 }
+            },
+            "effort": {
+                "level": "high"
+            },
+            "thinking": {
+                "enabled": true
             }
         }"#;
 
@@ -134,6 +147,8 @@ mod tests {
             data.context_window.current_usage.cache_read_input_tokens,
             20
         );
+        assert_eq!(data.effort.expect("effort present").level, "high");
+        assert!(data.thinking.expect("thinking present").enabled);
     }
 
     #[test]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description

Expose whether extended thinking is enabled as a new $thinking_symbol format variable, sourced from the statusline payload's thinking.enabled field, along with a thinking_symbol option holding the glyph (default 💭 ). The variable resolves to the configured symbol only while thinking is enabled and is omitted when it is disabled or absent from the payload, so it can be used inside a conditional format group.


#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

add another flexibility option for claude status line

Closes #

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- Most changes do not need to be tested on multiple operating systems. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### AI-Assistance
<!-- Per our AI Policy (AI_POLICY.md), all AI usage must be declared. -->
Have you used AI-assistance to author this PR?

- [x] Yes
- [ ] No

If **yes**, describe the scope of assistance:
<!--- Describe how you used AI-Assistance -->
<!--- Disclosure is required if you have used AI-assistance -->
<!--- For example: answering project questions, writing tests, implementation, or documentation -->

I requested the change. AI implemented it. I reviewed and requested changes.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
- [x] I understand and have read the code I contribute and can answer questions about it.
