### PR TITLE
feat(claude_context): add `session_id` variable

### DIFF
--- a/docs/advanced-config/README.md
+++ b/docs/advanced-config/README.md
@@ -503,19 +503,20 @@ style = "bold red"
 
 #### Variables
 
-| Variable                   | Example | Description                                           |
-| -------------------------- | ------- | ----------------------------------------------------- |
-| gauge                      | `██▒░░` | Visual representation of context usage                |
-| percentage                 | `65%`   | Context usage as a percentage                         |
-| input_tokens               | `45.2k` | Total input tokens in conversation                    |
-| output_tokens              | `12.3k` | Total output tokens in conversation                   |
-| curr_input_tokens          | `5.1k`  | Input tokens from most recent API call                |
-| curr_output_tokens         | `1.2k`  | Output tokens from most recent API call               |
-| curr_cache_creation_tokens | `1.5k`  | Cache creation tokens from most recent API call       |
-| curr_cache_read_tokens     | `23.4k` | Cache read tokens from most recent API call           |
-| total_tokens               | `200k`  | Total context window size                             |
-| symbol                     |         | Mirrors the value of option `symbol`                  |
-| style\*                    |         | Mirrors the style from the matching display threshold |
+| Variable                   | Example                                | Description                                           |
+| -------------------------- | -------------------------------------- | ----------------------------------------------------- |
+| gauge                      | `██▒░░`                                | Visual representation of context usage                |
+| percentage                 | `65%`                                  | Context usage as a percentage                         |
+| input_tokens               | `45.2k`                                | Total input tokens in conversation                    |
+| output_tokens              | `12.3k`                                | Total output tokens in conversation                   |
+| curr_input_tokens          | `5.1k`                                 | Input tokens from most recent API call                |
+| curr_output_tokens         | `1.2k`                                 | Output tokens from most recent API call               |
+| curr_cache_creation_tokens | `1.5k`                                 | Cache creation tokens from most recent API call       |
+| curr_cache_read_tokens     | `23.4k`                                | Cache read tokens from most recent API call           |
+| total_tokens               | `200k`                                 | Total context window size                             |
+| session_id                 | `9218cba7-871e-4bd8-9687-e9b902346cb3` | The ID of the current Claude Code session             |
+| symbol                     |                                        | Mirrors the value of option `symbol`                  |
+| style\*                    |                                        | Mirrors the style from the matching display threshold |
 
 \*: This variable can only be used as a part of a style string
 

--- a/src/modules/claude_context.rs
+++ b/src/modules/claude_context.rs
@@ -99,6 +99,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                             .cache_read_input_tokens,
                     ))),
                     "total_tokens" => Some(Ok(humanize_int(total_tokens))),
+                    "session_id" => claude_data.session_id.as_ref().map(|id| Ok(id.clone())),
                     _ => None,
                 })
                 .parse(None, Some(context))
@@ -167,6 +168,55 @@ mod tests {
     }
 
     #[test]
+    fn test_session_id() {
+        let mut data = get_test_claude_data(0.0);
+        data.session_id = Some("9218cba7-871e-4bd8-9687-e9b902346cb3".to_string());
+
+        let actual = ModuleRenderer::new("claude_context")
+            .config(toml::toml! {
+                [claude_context]
+                format = "[$session_id]($style) "
+                [[claude_context.display]]
+                threshold = 0
+                style = "bold green"
+            })
+            .claude_code_data(data)
+            .collect();
+
+        assert_eq!(
+            actual,
+            Some(format!(
+                "{} ",
+                Color::Green
+                    .bold()
+                    .paint("9218cba7-871e-4bd8-9687-e9b902346cb3")
+            )),
+        );
+    }
+
+    #[test]
+    fn test_session_id_absent() {
+        let data = get_test_claude_data(0.0);
+
+        let actual = ModuleRenderer::new("claude_context")
+            .config(toml::toml! {
+                [claude_context]
+                format = "[$percentage $session_id]($style) "
+                [[claude_context.display]]
+                threshold = 0
+                style = "bold green"
+            })
+            .claude_code_data(data)
+            .collect();
+
+        assert_eq!(
+            actual,
+            Some(format!("{} ", Color::Green.bold().paint("0% "))),
+            "a missing session id should render as empty"
+        );
+    }
+
+    #[test]
     fn test_zero_total_tokens() {
         let mut data = get_test_claude_data(0.0);
         data.context_window.context_window_size = 0;
@@ -190,6 +240,7 @@ mod tests {
 
     fn get_test_claude_data(used_percentage: f32) -> crate::context::ClaudeCodeData {
         crate::context::ClaudeCodeData {
+            session_id: None,
             cwd: None,
             model: crate::context::ModelInfo {
                 id: "claude-3-5-sonnet".to_string(),

--- a/src/modules/claude_cost.rs
+++ b/src/modules/claude_cost.rs
@@ -154,6 +154,7 @@ mod tests {
 
     fn get_test_claude_data(total_cost_usd: f64) -> crate::context::ClaudeCodeData {
         crate::context::ClaudeCodeData {
+            session_id: None,
             cwd: None,
             model: crate::context::ModelInfo {
                 id: "claude-3-5-sonnet".to_string(),

--- a/src/modules/claude_model.rs
+++ b/src/modules/claude_model.rs
@@ -69,6 +69,7 @@ mod tests {
     #[test]
     fn test_disabled() {
         let data = crate::context::ClaudeCodeData {
+            session_id: None,
             cwd: None,
             model: crate::context::ModelInfo {
                 id: "claude-3-5-sonnet".to_string(),
@@ -92,6 +93,7 @@ mod tests {
     #[test]
     fn test_with_model_alias() {
         let data = crate::context::ClaudeCodeData {
+            session_id: None,
             cwd: None,
             model: crate::context::ModelInfo {
                 id: "global.anthropic.claude-sonnet-4-5-20250929-v1:0".to_string(),
@@ -120,6 +122,7 @@ mod tests {
     #[test]
     fn test_without_alias_uses_display_name() {
         let data = crate::context::ClaudeCodeData {
+            session_id: None,
             cwd: None,
             model: crate::context::ModelInfo {
                 id: "claude-3-5-sonnet".to_string(),
@@ -149,6 +152,7 @@ mod tests {
     #[test]
     fn test_effort_level() {
         let data = crate::context::ClaudeCodeData {
+            session_id: None,
             cwd: None,
             model: crate::context::ModelInfo {
                 id: "claude-opus-4-8".to_string(),
@@ -178,6 +182,7 @@ mod tests {
     #[test]
     fn test_effort_absent_omits_variable() {
         let data = crate::context::ClaudeCodeData {
+            session_id: None,
             cwd: None,
             model: crate::context::ModelInfo {
                 id: "claude-opus-4-8".to_string(),
@@ -205,6 +210,7 @@ mod tests {
     #[test]
     fn test_alias_by_display_name() {
         let data = crate::context::ClaudeCodeData {
+            session_id: None,
             cwd: None,
             model: crate::context::ModelInfo {
                 id: "some-long-vendor-specific-id".to_string(),

--- a/src/utils/statusline.rs
+++ b/src/utils/statusline.rs
@@ -15,6 +15,7 @@ where
 #[derive(Deserialize, Debug, Clone, Default)]
 #[serde(default)]
 pub struct ClaudeCodeData {
+    pub session_id: Option<String>,
     pub cwd: Option<String>,
     pub model: ModelInfo,
     pub context_window: ContextWindow,
@@ -98,6 +99,7 @@ mod tests {
         let data: ClaudeCodeData =
             serde_json::from_str(payload).expect("session-start payload must deserialize");
 
+        assert_eq!(data.session_id, None);
         assert_eq!(data.model.display_name, "Opus 4.7 (1M context)");
         assert_eq!(data.context_window.context_window_size, 1_000_000);
         assert_eq!(data.context_window.used_percentage, 0.0);
@@ -107,6 +109,7 @@ mod tests {
     #[test]
     fn test_deserializes_fully_populated_payload() {
         let payload = r#"{
+            "session_id": "9218cba7-871e-4bd8-9687-e9b902346cb3",
             "model": {
                 "id": "claude-opus-4-7[1m]",
                 "display_name": "Opus 4.7 (1M context)"
@@ -128,6 +131,10 @@ mod tests {
         let data: ClaudeCodeData =
             serde_json::from_str(payload).expect("populated payload must deserialize");
 
+        assert_eq!(
+            data.session_id.as_deref(),
+            Some("9218cba7-871e-4bd8-9687-e9b902346cb3")
+        );
         assert_eq!(data.context_window.total_input_tokens, 1234);
         assert!((data.context_window.used_percentage - 12.5).abs() < f32::EPSILON);
         assert_eq!(


### PR DESCRIPTION
#### Description
Expose the Claude Code session ID, provided as a top-level `session_id` field in the statusline payload, as a `$session_id` variable on the `claude_context` module. The variable renders empty when the field is absent from the payload.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #7634

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- Most changes do not need to be tested on multiple operating systems. -->
- [X] I have tested using **MacOS**
- [X] I have tested using **Linux**
- [X] I have tested using **Windows**

#### AI-Assistance
<!-- Per our AI Policy (AI_POLICY.md), all AI usage must be declared. -->
Have you used AI-assistance to author this PR?

- [X] Yes
- [ ] No

If **yes**, describe the scope of assistance:
<!--- Describe how you used AI-Assistance -->
<!--- Disclosure is required if you have used AI-assistance -->
<!--- For example: answering project questions, writing tests, implementation, or documentation -->

Writing tests

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have updated the documentation accordingly.
- [X] I have updated the tests accordingly.
- [X] I understand and have read the code I contribute and can answer questions about it.
