### PR TITLE
docs(presets): add Clean Text preset

### DIFF
--- a/docs/presets/README.md
+++ b/docs/presets/README.md
@@ -83,3 +83,10 @@ This is a pseudo minimalist preset inspired by the [geometry](https://github.com
 This preset is a minimally modified version of [Gruvbox Rainbow](./gruvbox-rainbow.md) using the [Catppuccin](https://github.com/catppuccin/catppuccin) theme palette.
 
 [![Screenshot of Catppuccin Powerline preset](/presets/img/catppuccin-powerline.png "Click to view Catppuccin Powerline preset")](./catppuccin-powerline)
+
+
+## [Clean Text](./clean-text.md)
+
+This preset provides a clean, two-line developer prompt with runtime version tracking that requires no Nerd Fonts or unicode symbols. Great for stock terminal environments, remote SSH sessions, and containers.
+
+[Click to view Clean Text preset](./clean-text.md)

--- a/docs/presets/clean-text.md
+++ b/docs/presets/clean-text.md
@@ -1,0 +1,111 @@
+# Clean Text
+
+A two-line prompt designed for environments where **Nerd Fonts or patched icon fonts are not available**—such as stock Windows Terminal, remote SSH sessions, minimal Linux servers, or CI/CD containers.
+
+It keeps full runtime visibility and Git tracking using standard ASCII character labels instead of unicode symbols.
+
+## Preview
+
+```text
+pwsh in ~/projects/backend on git:main took 2s [ERR 1]
+via Node v20.11.0 via Py v3.12.1 ❯
+```
+
+## Configuration
+
+Add the following to your `~/.config/starship.toml`:
+
+```toml
+# Starship Configuration - Clean Text (No Nerd Fonts Required)
+"$schema" = '[https://starship.rs/config-schema.json](https://starship.rs/config-schema.json)'
+
+add_newline = true
+
+format = """
+$shell$directory$git_branch$git_status$git_state$cmd_duration$status
+$dotnet$nodejs$python$golang$rust$java$docker_context$character"""
+
+[shell]
+disabled = false
+powershell_indicator = 'pwsh'
+style = 'bold blue'
+format = '[$indicator]($style) '
+
+[directory]
+truncation_length = 4
+truncation_symbol = '.../'
+home_symbol = '~'
+style = 'bold cyan'
+read_only = ' [RO]'
+format = 'in [$path]($style)[$read_only]($read_only_style) '
+
+[git_branch]
+symbol = 'git:'
+style = 'bold purple'
+format = 'on [$symbol$branch]($style) '
+
+[git_status]
+style = 'bold red'
+format = '([$all_status$ahead_behind]($style) )'
+conflicted = '='
+ahead = '>'
+behind = '<'
+diverged = '<>'
+untracked = '?'
+stashed = '$'
+modified = '!'
+staged = '+'
+renamed = 'r'
+deleted = 'x'
+
+[cmd_duration]
+min_time = 2_000
+style = 'bold yellow'
+format = 'took [$duration]($style) '
+
+[status]
+disabled = false
+symbol = '[ERR]'
+style = 'bold red'
+format = '[$symbol $code]($style) '
+
+[dotnet]
+symbol = '.NET '
+style = 'bold blue'
+format = 'via [$symbol$version]($style) '
+
+[nodejs]
+symbol = 'Node '
+style = 'bold green'
+format = 'via [$symbol$version]($style) '
+
+[python]
+symbol = 'Py '
+style = 'bold yellow'
+format = 'via [$symbol$version]($style) '
+
+[golang]
+symbol = 'Go '
+style = 'bold cyan'
+format = 'via [$symbol$version]($style) '
+
+[rust]
+symbol = 'Rust '
+style = 'bold red'
+format = 'via [$symbol$version]($style) '
+
+[java]
+symbol = 'Java '
+style = 'bold red'
+format = 'via [$symbol$version]($style) '
+
+[docker_context]
+symbol = 'Docker '
+style = 'bold blue'
+format = 'on [$symbol$context]($style) '
+
+[character]
+success_symbol = '[❯](bold green)'
+error_symbol = '[❯](bold red)'
+vimcmd_symbol = '[❮](bold green)'
+```


### PR DESCRIPTION
### Description
Adds a new preset called **Clean Text** to the Starship presets documentation.

### Reason for Change
Many environments (stock Windows Terminal, remote SSH sessions, minimal Linux containers, CI/CD runners) do not have Nerd Fonts or custom patched fonts installed. 

This two-line preset keeps full developer runtime visibility (.NET, Node, Python, Go, Rust, Java, Docker) and Git status tracking using clean, standard ASCII text labels instead of special unicode icons.