### PR TITLE
fix(cmd_duration): strip private-use glyphs from notifications

### DIFF
--- a/src/modules/cmd_duration.rs
+++ b/src/modules/cmd_duration.rs
@@ -116,6 +116,7 @@ fn undistract_me<'a>(
 
 #[cfg(feature = "notify")]
 fn sanitize_notification_text(text: &str) -> String {
+    // Private-use glyphs depend on terminal fonts and render as tofu in desktop notifications.
     text.chars()
         .filter(|character| {
             !matches!(

--- a/src/modules/cmd_duration.rs
+++ b/src/modules/cmd_duration.rs
@@ -88,9 +88,10 @@ fn undistract_me<'a>(
         #[cfg(target_os = "macos")]
         let _ = notify_rust::set_application("com.apple.Terminal");
 
+        let module_text = unstyle(&AnsiStrings(&module.ansi_strings()));
         let body = format!(
             "Command execution {}",
-            unstyle(&AnsiStrings(&module.ansi_strings()))
+            sanitize_notification_text(&module_text)
         );
 
         let timeout = match config.notification_timeout {
@@ -113,8 +114,26 @@ fn undistract_me<'a>(
     module
 }
 
+#[cfg(feature = "notify")]
+fn sanitize_notification_text(text: &str) -> String {
+    text.chars()
+        .filter(|character| {
+            !matches!(
+                *character,
+                '\u{E000}'..='\u{F8FF}'
+                    | '\u{F0000}'..='\u{FFFFD}'
+                    | '\u{100000}'..='\u{10FFFD}'
+            )
+        })
+        .collect::<String>()
+        .trim()
+        .to_owned()
+}
+
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "notify")]
+    use super::sanitize_notification_text;
     use crate::test::ModuleRenderer;
     use nu_ansi_term::Color;
 
@@ -192,5 +211,19 @@ mod tests {
 
         let expected = Some(format!("underwent {} ", Color::Yellow.bold().paint("5s")));
         assert_eq!(expected, actual);
+    }
+
+    #[cfg(feature = "notify")]
+    #[test]
+    fn private_use_characters_are_removed_from_notifications() {
+        let text = "\u{EAF4} took 5s \u{F0000}\u{100000}";
+        assert_eq!(sanitize_notification_text(text), "took 5s");
+    }
+
+    #[cfg(feature = "notify")]
+    #[test]
+    fn standard_unicode_is_preserved_in_notifications() {
+        let text = "Command finished: 你好 🚀";
+        assert_eq!(sanitize_notification_text(text), text);
     }
 }


### PR DESCRIPTION
#### Description

Remove Unicode Private Use Area characters from the unstyled `cmd_duration` text before using it as a desktop notification body. This covers the BMP and both supplementary private-use ranges while preserving ordinary Unicode text.

#### Motivation and Context

Desktop notification fonts do not generally include terminal Nerd Font glyphs. Passing those private-use characters to the notification API therefore renders tofu instead of readable text.

This implements the first suggested solution from the issue: sanitize the notification text after ANSI styling is removed. It keeps the terminal output unchanged and avoids adding a second format option solely for notifications.

Closes #7464

#### Screenshots (if appropriate):

N/A

#### How Has This Been Tested?

- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

Commands run:

- `cargo test modules::cmd_duration` (8 passed)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo test --all-features` (1,226 passed; 9 unrelated Windows environment failures involving symlink privileges and `cmd.exe` Unicode handling)

GitHub Actions also passed the stable and nightly test suites on Ubuntu, macOS, and Windows.

#### AI-Assistance

Have you used AI-assistance to author this PR?

- [x] Yes
- [ ] No

If **yes**, describe the scope of assistance:

AI assistance was used to inspect the relevant module, implement the focused sanitizer and regression tests, and run the documented validation commands. I reviewed and understand every submitted line and can explain the implementation choices.

#### Checklist:

- [ ] I have updated the documentation accordingly. (No user-facing configuration or behavior documentation is affected.)
- [x] I have updated the tests accordingly.
- [x] I understand and have read the code I contribute and can answer questions about it.
