### PR TITLE
feat: Add `jj_bookmark` module

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -965,6 +965,20 @@
         "detect_folders": []
       }
     },
+    "jj_bookmark": {
+      "$ref": "#/$defs/JJBookmarkConfig",
+      "default": {
+        "format": "on [$symbol$bookmark(@$remote)$diverged( \\(+$overflow_count others\\))]($style) ",
+        "symbol": " ",
+        "style": "bold purple",
+        "truncation_length": 65535,
+        "truncation_symbol": "…",
+        "diverged_symbol": "*",
+        "ignore_names": [],
+        "ignore_remotes": [],
+        "disabled": false
+      }
+    },
     "jobs": {
       "$ref": "#/$defs/JobsConfig",
       "default": {
@@ -4451,6 +4465,66 @@
             "type": "string"
           },
           "default": []
+        }
+      },
+      "additionalProperties": false
+    },
+    "JJBookmarkConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "description": "Format string for the module",
+          "type": "string",
+          "default": "on [$symbol$bookmark(@$remote)$diverged( \\(+$overflow_count others\\))]($style) "
+        },
+        "symbol": {
+          "description": "`$symbol` in the module's format",
+          "type": "string",
+          "default": " "
+        },
+        "style": {
+          "description": "`$style` in the module's format",
+          "type": "string",
+          "default": "bold purple"
+        },
+        "truncation_length": {
+          "description": "Truncate bookmark names and remotes if they're longer",
+          "type": "integer",
+          "format": "uint16",
+          "minimum": 0,
+          "maximum": 65535,
+          "default": 65535
+        },
+        "truncation_symbol": {
+          "description": "Symbol used to signify truncation was used",
+          "type": "string",
+          "default": "…"
+        },
+        "diverged_symbol": {
+          "description": "Symbol added at the end of a bookmark's string if it has diverged from its remote state",
+          "type": "string",
+          "default": "*"
+        },
+        "ignore_names": {
+          "description": "Ignore bookmarks with this name\n\nUseful to filter out items like `main`, `master` or `develop` that are often default\nbookmarks you don't advance manually.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        },
+        "ignore_remotes": {
+          "description": "Ignore bookmarks with this remote\n\nUseful to filter out items like `main@upstream` when you develop in a fork.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        },
+        "disabled": {
+          "description": "Disable the module",
+          "type": "boolean",
+          "default": false
         }
       },
       "additionalProperties": false

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2564,6 +2564,50 @@ By default the module will be shown if any of the following conditions are met:
 symbol = '🌟 '
 ```
 
+## JJ Bookmark
+
+The `jj_bookmark` module shows the [Jujutsu](https://docs.jj-vcs.dev/) bookmark when the current directory is in a Jujutsu repository.
+
+It looks at `@ | @-` to find bookmarks and will prioritize displaying those of `@` (after filtering has been applied).
+
+### Options
+
+| Option              | Default                                                                               | Description                                                                              |
+| ------------------- | ------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `format`            | `"on [$symbol$bookmark(@$remote)$diverged( \\(+$overflow_count others\\))]($style) "` | The format for the module.                                                               |
+| `symbol`            | `" "`                                                                                | The symbol used in the `$symbol` variable.                                               |
+| `style`             | `"bold purple"`                                                                       | The style for the module.                                                                |
+| `truncation_length` | `2^16-1`                                                                              | Truncates the bookmark's name and remote to `N` graphemes.                               |
+| `truncation_symbol` | `"…"`                                                                                 | The symbol used to indicate a branch name was truncated. You can use `''` for no symbol. |
+| `diverged_symbol`   | `"*"`                                                                                 | Symbol used in the `$diverged` variable in the local bookmark diverged from its remote.  |
+| `ignore_names`      | `[]`                                                                                  | A list of bookmark names to avoid displaying. Useful for `'master'` or `'main'`.         |
+| `ignore_remotes`    | `[]`                                                                                  | A list of bookmark remotes to avoid displaying. Useful for `'upstream'` or `'fork'`.     |
+| `disabled`          | `false`                                                                               | Disables the `jj_bookmark` module.                                                       |
+
+### Variables
+
+| Variable         | Example  | Description                                                    |
+| ---------------- | -------- | -------------------------------------------------------------- |
+| bookmark         | `main`   | The bookmark's name                                            |
+| remote           | `origin` | The bookmark's remote, if any                                  |
+| diverged\*       | `*`      | Set when the bookmark is tracked and divergent from its remote |
+| overflow_count\* | `3`      | How many other bookmarks were found (and not ignored)          |
+| symbol           |          | Mirrors the value of option `symbol`                           |
+| style\*\*        |          | Mirrors the value of option `style`                            |
+
+- *: These variables are only set if there is cause: a tracked and divergent bookmark / a non-zero overflow count
+- **: This variable can only be used as a part of a style string
+
+### Example
+
+```toml
+# ~/.config/starship.toml
+
+[jj_bookmark]
+ignore_names = ["main", "master"]
+diverged_symbol = "⇕"
+```
+
 ## Jobs
 
 The `jobs` module shows the current number of jobs running.

--- a/docs/public/presets/toml/bracketed-segments.toml
+++ b/docs/public/presets/toml/bracketed-segments.toml
@@ -126,6 +126,9 @@ format = '\[[$ssh_symbol($hostname)]($style)\] '
 [java]
 format = '\[[$symbol($version)]($style)\]'
 
+[jj_bookmark]
+format = '\[[$symbol$bookmark(@$remote)$diverged( \(+$overflow_count others\))]($style)\]'
+
 [jobs]
 format = '\[[$symbol$number]($style)\]'
 

--- a/docs/public/presets/toml/catppuccin-powerline.toml
+++ b/docs/public/presets/toml/catppuccin-powerline.toml
@@ -120,6 +120,11 @@ symbol = " "
 style = "bg:green"
 format = '[[ $symbol( $version) ](fg:crust bg:green)]($style)'
 
+[jj_bookmark]
+symbol = ""
+style = "bg:yellow"
+format = '[[ $symbol $bookmark(@$remote)$diverged( \\(+$overflow_count others\\)) ](fg:crust bg:yellow)]($style)'
+
 [kotlin]
 symbol = ""
 style = "bg:green"

--- a/docs/public/presets/toml/gruvbox-rainbow.toml
+++ b/docs/public/presets/toml/gruvbox-rainbow.toml
@@ -140,6 +140,11 @@ symbol = ""
 style = "bg:color_blue"
 format = '[[ $symbol( $version) ](fg:color_fg0 bg:color_blue)]($style)'
 
+[jj_bookmark]
+symbol = ""
+style = "bg:color_aqua"
+format = '[[ $symbol $bookmark(@$remote)$diverged( \\(+$overflow_count others\\)) ](fg:color_fg0 bg:color_aqua)]($style)'
+
 [kotlin]
 symbol = ""
 style = "bg:color_blue"

--- a/docs/public/presets/toml/jetpack.toml
+++ b/docs/public/presets/toml/jetpack.toml
@@ -309,6 +309,14 @@ format = " hs [$symbol($version )]($style)"
 symbol = "∪ "
 format = " java [${symbol}(${version} )]($style)"
 
+[jj_bookmark]
+format = " [$symbol$bookmark(@$remote)$diverged( \\(+$overflow_count others\\))]($style)"
+symbol = "[△](bold italic bright-blue)"
+style = "italic bright-blue"
+truncation_symbol = "⋯"
+truncation_length = 11
+ignore_names = ["main", "master"]
+
 [julia]
 symbol = "◎ "
 format = " jl [$symbol($version )]($style)"

--- a/docs/public/presets/toml/nerd-font-symbols.toml
+++ b/docs/public/presets/toml/nerd-font-symbols.toml
@@ -115,6 +115,9 @@ ssh_symbol = " "
 [java]
 symbol = " "
 
+[jj_bookmark]
+symbol = " "
+
 [julia]
 symbol = " "
 

--- a/docs/public/presets/toml/pastel-powerline.toml
+++ b/docs/public/presets/toml/pastel-powerline.toml
@@ -121,6 +121,11 @@ symbol = " "
 style = "bg:#86BBD8"
 format = '[ $symbol ($version) ]($style)'
 
+[jj_bookmark]
+symbol = ""
+style = "bg:#FCA17D"
+format = '[ $symbol $bookmark(@$remote)$diverged( \\(+$overflow_count others\\)) ]($style)'
+
 [julia]
 symbol = " "
 style = "bg:#86BBD8"

--- a/docs/public/presets/toml/plain-text-symbols.toml
+++ b/docs/public/presets/toml/plain-text-symbols.toml
@@ -136,6 +136,10 @@ ssh_symbol = "ssh "
 [java]
 symbol = "java "
 
+[jj_bookmark]
+symbol = "jj "
+truncation_symbol = "..."
+
 [jobs]
 symbol = "*"
 

--- a/docs/public/presets/toml/pure-preset.toml
+++ b/docs/public/presets/toml/pure-preset.toml
@@ -43,6 +43,10 @@ style = "bright-black"
 format = "[$duration]($style) "
 style = "yellow"
 
+[jj_bookmark]
+format = "[$bookmark(@$remote)$diverged( \\(+$overflow_count others\\))]($style)"
+style = "bright-black"
+
 [python]
 format = "[$virtualenv]($style) "
 style = "bright-black"

--- a/docs/public/presets/toml/tokyo-night.toml
+++ b/docs/public/presets/toml/tokyo-night.toml
@@ -40,6 +40,11 @@ format = '[[ $symbol $branch ](fg:#769ff0 bg:#394260)]($style)'
 style = "bg:#394260"
 format = '[[($all_status$ahead_behind )](fg:#769ff0 bg:#394260)]($style)'
 
+[jj_bookmark]
+symbol = ""
+style = "bg:#394260"
+format = '[[ $symbol $bookmark(@$remote)$diverged( \\(+$overflow_count others\\)) ](fg:#769ff0 bg:#394260)]($style)'
+
 [nodejs]
 symbol = ""
 style = "bg:#212736"

--- a/src/configs/jj_bookmark.rs
+++ b/src/configs/jj_bookmark.rs
@@ -1,0 +1,54 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(
+    feature = "config-schema",
+    derive(schemars::JsonSchema),
+    schemars(deny_unknown_fields)
+)]
+#[serde(default)]
+pub struct JJBookmarkConfig<'a> {
+    /// Format string for the module
+    pub format: &'a str,
+    /// `$symbol` in the module's format
+    pub symbol: &'a str,
+    /// `$style` in the module's format
+    pub style: &'a str,
+
+    /// Truncate bookmark names and remotes if they're longer
+    pub truncation_length: u16,
+    /// Symbol used to signify truncation was used
+    pub truncation_symbol: &'a str,
+
+    /// Symbol added at the end of a bookmark's string if it has diverged from its remote state
+    pub diverged_symbol: &'a str,
+
+    /// Ignore bookmarks with this name
+    ///
+    /// Useful to filter out items like `main`, `master` or `develop` that are often default
+    /// bookmarks you don't advance manually.
+    pub ignore_names: Vec<&'a str>,
+    /// Ignore bookmarks with this remote
+    ///
+    /// Useful to filter out items like `main@upstream` when you develop in a fork.
+    pub ignore_remotes: Vec<&'a str>,
+
+    /// Disable the module
+    pub disabled: bool,
+}
+
+impl Default for JJBookmarkConfig<'_> {
+    fn default() -> Self {
+        Self {
+            format: "on [$symbol$bookmark(@$remote)$diverged( \\(+$overflow_count others\\))]($style) ",
+            symbol: " ",
+            style: "bold purple",
+            truncation_length: u16::MAX,
+            truncation_symbol: "…",
+            diverged_symbol: "*",
+            ignore_names: vec![],
+            ignore_remotes: vec![],
+            disabled: false,
+        }
+    }
+}

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -53,6 +53,7 @@ pub mod hg_branch;
 pub mod hg_state;
 pub mod hostname;
 pub mod java;
+pub mod jj_bookmark;
 pub mod jobs;
 pub mod julia;
 pub mod kotlin;
@@ -227,6 +228,8 @@ pub struct FullConfig<'a> {
     hostname: hostname::HostnameConfig<'a>,
     #[serde(borrow)]
     java: java::JavaConfig<'a>,
+    #[serde(borrow)]
+    jj_bookmark: jj_bookmark::JJBookmarkConfig<'a>,
     #[serde(borrow)]
     jobs: jobs::JobsConfig<'a>,
     #[serde(borrow)]

--- a/src/context/jj_repo.rs
+++ b/src/context/jj_repo.rs
@@ -1,0 +1,16 @@
+use std::path::PathBuf;
+
+use super::Context;
+
+pub struct JJRepo {
+    #[expect(unused)] // will go away in follow up commits
+    root: PathBuf,
+}
+
+impl JJRepo {
+    pub fn discover(context: &Context) -> Option<Self> {
+        let root = context.begin_ancestor_scan().set_folders(&[".jj"]).scan()?;
+
+        Some(Self { root })
+    }
+}

--- a/src/context/jj_repo.rs
+++ b/src/context/jj_repo.rs
@@ -1,16 +1,343 @@
 use std::path::PathBuf;
+use std::sync::OnceLock;
 
 use super::Context;
 
+/// A Jujutsu (JJ) repository's data.
 pub struct JJRepo {
-    #[expect(unused)] // will go away in follow up commits
+    /// Repository root, passed as `--repository` to the JJ CLI
     root: PathBuf,
+    current_change: OnceLock<Option<CurrentChange>>,
 }
+
+#[derive(Debug)]
+pub struct CurrentChange {
+    /// JJ change ID
+    pub change: Box<str>,
+    /// Size of the shortest unique prefix for the change ID
+    pub change_shortest: u8,
+    /// Underlying VCS commit ID (most often Git)
+    pub commit: Box<str>,
+    /// Size of the shortest unique prefix for the commit ID
+    pub commit_shortest: u8,
+
+    /// `Some(_)` only if the change is [divergent][1]
+    ///
+    /// [1]: https://docs.jj-vcs.dev/latest/glossary/#divergent-change
+    pub change_offset: Option<u16>,
+
+    /// Bookmarks to consider for the current change, if any
+    pub bookmarks: Option<Vec<Bookmark>>,
+
+    /// Total lines added in this change
+    pub lines_added: u32,
+    /// Total lines removed in this change
+    pub lines_removed: u32,
+
+    /// See `impl CurrentChange` below
+    flags: u32,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Bookmark(pub Box<str>);
 
 impl JJRepo {
     pub fn discover(context: &Context) -> Option<Self> {
         let root = context.begin_ancestor_scan().set_folders(&[".jj"]).scan()?;
 
-        Some(Self { root })
+        // NOTE: we don't compute anything by default, gating everything behind `OnceLock`s
+        //       to avoid running `jj` commands for nothing if the information is never asked for.
+        Some(Self {
+            root,
+            current_change: OnceLock::new(),
+        })
+    }
+
+    /// Information about the current change's state.
+    pub fn current_change(&self, context: &Context) -> Option<&CurrentChange> {
+        self.current_change
+            .get_or_init(|| {
+                let res = context.exec_cmd("jj", &[
+                    "--color".as_ref(),
+                    "never".as_ref(),
+                    // Will search for diffs and such normally but not update the underlying repository
+                    "--no-integrate-operation".as_ref(),
+                    "--no-pager".as_ref(),
+                    "--quiet".as_ref(),
+                    "--repository".as_ref(),
+                    self.root.as_os_str(),
+                    "show".as_ref(),
+                    // Find conflicts in parents and select only one of them: we want to print
+                    // `conflict_before|` once if there is a conflict and it's not in '@'
+                    "@ | latest(heads(conflicts()::@ & conflicts()), 1)".as_ref(),
+                    "--no-patch".as_ref(),
+                    // Important to ensure `conflict_before|` is always printed first if a conflict
+                    // is present before '@' (and not in '@')
+                    "--reversed".as_ref(),
+                    "--template".as_ref(),
+                    r#"if(
+                        current_working_copy,
+                        join(
+                            "\n",
+                            conflict,
+                            description.len() > 0,
+                            hidden,
+                            immutable,
+                            divergent,
+                            change_offset,
+                            change_id,
+                            change_id.shortest().prefix().len(),
+                            commit_id,
+                            commit_id.shortest().prefix().len(),
+                            bookmarks,
+                            parents.map(|p| p.bookmarks()),
+                            diff.stat().total_added(),
+                            diff.stat().total_removed(),
+                            self
+                                .diff(".")
+                                .files()
+                                .filter(|file| !conflict || conflicted_files.all(|c| c.path().display() != file.path().display()))
+                                .map(|file| file.status_char())
+                                .join(""),
+                            "",
+                        ),
+                        "conflict_before|",
+                    )"#.as_ref(),
+                ])?;
+
+                let mut lines = res.stdout.lines();
+
+                // If the conflict is _before_ '@', the output is
+                //
+                //     conflict_before|false
+                //     <...>
+                //
+                // If the conflict is _at_ '@', the output is
+                //
+                //     true
+                //     <...>
+                let first_line = lines.next()?;
+                let has_conflict = first_line == "conflict_before|false" || read_boolean(first_line)?;
+
+                let description = read_boolean(lines.next()?)?;
+                let hidden = read_boolean(lines.next()?)?;
+                let immutable = read_boolean(lines.next()?)?;
+
+                let change_offset = {
+                    // Always advance the iterator for the two relevant lines
+                    let divergent = read_boolean(lines.next()?)?;
+                    let raw = lines.next()?;
+                    match divergent {
+                        true => Some(raw.parse().ok()?),
+                        false => None,
+                    }
+                };
+
+                // A full JJ change ID is always `[k-z]{32}`,
+                // so we do a quick sanity check on it just to confirm it looks ok
+                let change = lines.next()?;
+                if change.len() != 32 {
+                    return None;
+                }
+
+                Some(CurrentChange {
+                    change: Box::from(change),
+                    change_shortest: lines.next()?.parse().ok()?,
+                    commit: Box::from(lines.next()?),
+                    commit_shortest: lines.next()?.parse().ok()?,
+                    change_offset,
+                    bookmarks: parse_bookmark_lines(lines.next()?, lines.next()?),
+                    lines_added: lines.next()?.parse().ok()?,
+                    lines_removed: lines.next()?.parse().ok()?,
+                    flags: {
+                        let mut flags = 0;
+
+                        if has_conflict {
+                            flags |= CurrentChange::CONFLICTED;
+                        }
+                        if description {
+                            flags |= CurrentChange::DESCRIPTION;
+                        }
+                        if hidden {
+                            flags |= CurrentChange::HIDDEN;
+                        }
+                        if immutable {
+                            flags |= CurrentChange::IMMUTABLE;
+                        }
+
+                        if let Some(statuses) = lines.next() {
+                            if statuses.contains('A') {
+                                flags |= CurrentChange::STATUS_ADDED;
+                            }
+                            if statuses.contains('C') {
+                                flags |= CurrentChange::STATUS_COPIED;
+                            }
+                            if statuses.contains('D') {
+                                flags |= CurrentChange::STATUS_DELETED;
+                            }
+                            if statuses.contains('M') {
+                                flags |= CurrentChange::STATUS_MODIFIED;
+                            }
+                            if statuses.contains('R') {
+                                flags |= CurrentChange::STATUS_RENAMED;
+                            }
+                        }
+
+                        flags
+                    },
+                })
+            })
+            .as_ref()
+    }
+}
+
+impl CurrentChange {
+    const CONFLICTED: u32 = 1 << 0;
+    const DESCRIPTION: u32 = 1 << 1;
+    const HIDDEN: u32 = 1 << 2;
+    const IMMUTABLE: u32 = 1 << 3;
+
+    const STATUS_ADDED: u32 = 1 << 4;
+    const STATUS_COPIED: u32 = 1 << 5;
+    const STATUS_DELETED: u32 = 1 << 6;
+    const STATUS_MODIFIED: u32 = 1 << 7;
+    const STATUS_RENAMED: u32 = 1 << 8;
+
+    /// True if any mutable change up to the current one is conflicted
+    pub fn conflicted(&self) -> bool {
+        self.flags & Self::CONFLICTED == Self::CONFLICTED
+    }
+
+    /// True if the current change has a non-empty description
+    pub fn description(&self) -> bool {
+        self.flags & Self::DESCRIPTION == Self::DESCRIPTION
+    }
+
+    /// True if the current change is hidden
+    pub fn hidden(&self) -> bool {
+        self.flags & Self::HIDDEN == Self::HIDDEN
+    }
+
+    /// True if the current change is immutable
+    pub fn immutable(&self) -> bool {
+        self.flags & Self::IMMUTABLE == Self::IMMUTABLE
+    }
+
+    /// True if the current change includes at least one added file
+    pub fn status_added(&self) -> bool {
+        self.flags & Self::STATUS_ADDED == Self::STATUS_ADDED
+    }
+
+    /// True if the current change includes at least one copied file
+    pub fn status_copied(&self) -> bool {
+        self.flags & Self::STATUS_COPIED == Self::STATUS_COPIED
+    }
+
+    /// True if the current change includes at least one deleted file
+    pub fn status_deleted(&self) -> bool {
+        self.flags & Self::STATUS_DELETED == Self::STATUS_DELETED
+    }
+
+    /// True if the current change includes at least one modified file
+    pub fn status_modified(&self) -> bool {
+        self.flags & Self::STATUS_MODIFIED == Self::STATUS_MODIFIED
+    }
+
+    /// True if the current change includes at least one renamed file
+    pub fn status_renamed(&self) -> bool {
+        self.flags & Self::STATUS_RENAMED == Self::STATUS_RENAMED
+    }
+}
+
+impl Bookmark {
+    /// False when the bookmark is up-to-date, meaning it's either:
+    /// - Local, so logically up-to-date with itself
+    /// - Remote, in which case the comparison is made with the last fetched state
+    pub fn diverged(&self) -> bool {
+        self.0.ends_with('*')
+    }
+
+    /// Name of the bookmark
+    pub fn name(&self) -> &str {
+        let no_star = self.0.trim_end_matches('*');
+        no_star.split_once('@').map_or(no_star, |raw| raw.0)
+    }
+
+    /// Remote of the bookmark, if any
+    pub fn remote(&self) -> Option<&str> {
+        let no_star = self.0.trim_end_matches('*');
+        no_star.split_once('@').map(|raw| raw.1)
+    }
+}
+
+/// Read a single boolean
+fn read_boolean(line: &str) -> Option<bool> {
+    match line {
+        "true" => Some(true),
+        "false" => Some(false),
+        _ => None,
+    }
+}
+
+/// Select the bookmarks to save (current > parents)
+fn parse_bookmark_lines(current: &str, parents: &str) -> Option<Vec<Bookmark>> {
+    let line = if !current.is_empty() {
+        current
+    } else if !parents.is_empty() {
+        parents
+    } else {
+        return None;
+    };
+
+    Some(line.split(' ').map(|b| Bookmark(Box::from(b))).collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Bookmark, parse_bookmark_lines, read_boolean};
+
+    fn b(s: &str) -> Bookmark {
+        Bookmark(s.into())
+    }
+
+    #[test]
+    fn test_read_boolean() {
+        assert_eq!(read_boolean("true"), Some(true));
+        assert_eq!(read_boolean("false"), Some(false));
+        assert_eq!(read_boolean("falsefalse"), None);
+        assert_eq!(read_boolean("trueabcdef"), None);
+        assert_eq!(read_boolean(""), None);
+    }
+
+    #[test]
+    fn test_parse_bookmark_lines() {
+        assert_eq!(parse_bookmark_lines("", ""), None,);
+
+        assert_eq!(
+            parse_bookmark_lines("b1 b2* b3@upstream b4@origin*", "ignored"),
+            Some(vec![b("b1"), b("b2*"), b("b3@upstream"), b("b4@origin*")]),
+        );
+
+        assert_eq!(
+            parse_bookmark_lines("", "p1 p2* p3@upstream p4@origin*"),
+            Some(vec![b("p1"), b("p2*"), b("p3@upstream"), b("p4@origin*")]),
+        );
+    }
+
+    #[test]
+    fn test_bookmark_methods() {
+        #[track_caller]
+        fn check_bookmark(orig: &str, name: &str, remote: Option<&str>, diverged: bool) {
+            let bm = b(orig);
+
+            assert_eq!(bm.name(), name);
+            assert_eq!(bm.remote(), remote);
+            assert_eq!(bm.diverged(), diverged);
+        }
+
+        check_bookmark("name", "name", None, false);
+        check_bookmark("name*", "name", None, true);
+        check_bookmark("name@remote", "name", Some("remote"), false);
+        check_bookmark("name@remote*", "name", Some("remote"), true);
     }
 }

--- a/src/context/jj_repo.rs
+++ b/src/context/jj_repo.rs
@@ -42,15 +42,26 @@ pub struct CurrentChange {
 pub struct Bookmark(pub Box<str>);
 
 impl JJRepo {
+    /// Discover if we're in a JJ repo by looking for a `.jj` directory in the current directory
+    /// and its parents.
+    ///
+    /// While this is technically more error prone than `jj workspace root`, it also much faster
+    /// and subsequent JJ commands will fail fast if it's not actually a JJ repo.
     pub fn discover(context: &Context) -> Option<Self> {
-        let root = context.begin_ancestor_scan().set_folders(&[".jj"]).scan()?;
+        context
+            .begin_ancestor_scan()
+            .set_folders(&[".jj"])
+            .scan()
+            .map(Self::with_root)
+    }
 
+    pub fn with_root(root: PathBuf) -> Self {
         // NOTE: we don't compute anything by default, gating everything behind `OnceLock`s
         //       to avoid running `jj` commands for nothing if the information is never asked for.
-        Some(Self {
+        Self {
             root,
             current_change: OnceLock::new(),
-        })
+        }
     }
 
     /// Information about the current change's state.
@@ -290,6 +301,153 @@ fn parse_bookmark_lines(current: &str, parents: &str) -> Option<Vec<Bookmark>> {
     };
 
     Some(line.split(' ').map(|b| Bookmark(Box::from(b))).collect())
+}
+
+#[cfg(test)]
+impl JJRepo {
+    pub const BASE: &str = "/jj/base";
+    pub const EMPTY_OUTPUT: &str = "/jj/empty-output";
+    pub const INVALID_OUTPUT: &str = "/jj/invalid-output";
+
+    pub const BOOKMARK_NO_CURRENT: &str = "/jj/bookmarks/no-current";
+
+    pub const NONE: &str = "/jj/no-repo";
+}
+
+/// Helper function to generate mock command outputs for JJ module tests
+#[cfg(test)]
+pub fn mock_jj_cmd(s: &str) -> Option<crate::utils::CommandOutput> {
+    use crate::utils::CommandOutput;
+
+    // Constants to avoid magic numbers in `let outputs` and allow changing the indexes
+    // without having to rewrite the whole array every time.
+    // We allow unused for all of them to avoid having to add/remove/rename in commits all over.
+    #[allow(unused)]
+    const CONFLICT: usize = 0;
+    #[allow(unused)]
+    const DESC: usize = 1;
+    #[allow(unused)]
+    const HIDDEN: usize = 2;
+    #[allow(unused)]
+    const IMMUTABLE: usize = 3;
+    #[allow(unused)]
+    const DIVERGENT: usize = 4;
+    #[allow(unused)]
+    const CHANGE_OFFSET: usize = 5;
+    #[allow(unused)]
+    const CHANGE: usize = 6;
+    #[allow(unused)]
+    const CHANGE_SHORT_LENGTH: usize = 7;
+    #[allow(unused)]
+    const COMMIT: usize = 8;
+    #[allow(unused)]
+    const COMMIT_SHORT_LENGTH: usize = 9;
+    #[allow(unused)]
+    const BOOKMARKS_CUR: usize = 10;
+    #[allow(unused)]
+    const BOOKMARKS_PREV: usize = 11;
+    #[allow(unused)]
+    const LINES_A: usize = 12;
+    #[allow(unused)]
+    const LINES_D: usize = 13;
+    #[allow(unused)]
+    const FILES: usize = 14;
+
+    /// Generate output for JJ while allowing easy replacement of lines to test various valid
+    /// possibilities
+    fn output<const N: usize>(mods: [(usize, &str); N]) -> Option<CommandOutput> {
+        let mut stdout = [
+            // conflict
+            "conflict_before|false",
+            // description
+            "false",
+            // hidden
+            "false",
+            // immutable
+            "false",
+            // divergent
+            "false",
+            // change offset
+            "",
+            // change id
+            "pvtxwmvtttmrkkoqkutlystlnozssmnk",
+            // change id shortest prefix length
+            "3",
+            // commit id
+            "30363e463b3a5c87ad352b2d342f7408e3c2dda8",
+            // commit id shortest prefix length
+            "4",
+            // @ bookmarks
+            "cur_local cur_tracked* cur_modified@upstream* cur_untracked@origin",
+            // @- bookmarks
+            "par_local par_tracked* par_modified@upstream* par_untracked@origin",
+            // lines added
+            "100",
+            // lines deleted
+            "90",
+            // files status in current directory
+            "ACDMR",
+        ];
+
+        for (index, replacement) in mods {
+            stdout[index] = replacement;
+        }
+
+        Some(CommandOutput {
+            stdout: stdout.as_ref().join("\n"),
+            stderr: String::new(),
+        })
+    }
+
+    if !s.contains("show @") {
+        panic!("Found non-mocked JJ command: {s}");
+    }
+
+    // Voluntarily unformatted to allow easy modifications that don't conflict all the time
+    // and to make each outputs formatted the same for easier reading
+    #[rustfmt::skip]
+    #[expect(clippy::type_complexity)]
+    let outputs: [(_, fn() -> Option<CommandOutput>); _] = [
+        (
+            JJRepo::BASE,
+            || output([])
+        ),
+        // Repos testing jj_bookmark rendering
+        (
+            JJRepo::BOOKMARK_NO_CURRENT,
+            || output([
+                (BOOKMARKS_CUR, ""),
+            ]),
+        ),
+        // Used to test the parsing will correctly fail on empty stdout
+        (
+            JJRepo::EMPTY_OUTPUT,
+            || {
+                Some(CommandOutput {
+                    stdout: String::new(),
+                    stderr: String::new(),
+                })
+            },
+        ),
+        // Used to test the parsing will correctly fail on invalid stdout
+        (
+            JJRepo::INVALID_OUTPUT,
+            || {
+                Some(CommandOutput {
+                    stdout: String::from("invalid output"),
+                    stderr: String::new(),
+                })
+            },
+        ),
+    ];
+
+    for (key, closure) in outputs {
+        if s.contains(key) {
+            return (closure)();
+        }
+    }
+
+    None
 }
 
 #[cfg(test)]

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -33,8 +33,10 @@ pub use crate::utils::statusline::{
 };
 
 mod git_repo;
+mod jj_repo;
 
 pub use git_repo::{GitRemote, GitRepo};
+pub use jj_repo::JJRepo;
 
 /// Context contains data or common methods that may be used by multiple modules.
 /// The data contained within Context will be relevant to this particular rendering
@@ -59,6 +61,9 @@ pub struct Context<'a> {
 
     /// Private field to store Git information for modules who need it
     git_repo: OnceLock<Result<GitRepo, Box<gix::discover::Error>>>,
+
+    /// Private field to store JJ information for modules who need it
+    jj_repo: OnceLock<Option<JJRepo>>,
 
     /// The shell the user is assumed to be running
     pub shell: Shell,
@@ -179,6 +184,7 @@ impl<'a> Context<'a> {
             logical_dir,
             dir_contents: OnceLock::new(),
             git_repo: OnceLock::new(),
+            jj_repo: OnceLock::new(),
             shell,
             target,
             width,
@@ -401,6 +407,11 @@ impl<'a> Context<'a> {
             })
             .as_ref()
             .map_err(std::convert::AsRef::as_ref)
+    }
+
+    /// Will lazily discover Jujutsu repo root when a module requests it.
+    pub fn get_jj_repo(&self) -> Option<&JJRepo> {
+        self.jj_repo.get_or_init(|| JJRepo::discover(self)).as_ref()
     }
 
     pub fn dir_contents(&self) -> Result<&DirContents, &std::io::Error> {

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -37,6 +37,8 @@ mod jj_repo;
 
 pub use git_repo::{GitRemote, GitRepo};
 pub use jj_repo::JJRepo;
+#[cfg(test)]
+pub use jj_repo::mock_jj_cmd;
 
 /// Context contains data or common methods that may be used by multiple modules.
 /// The data contained within Context will be relevant to this particular rendering
@@ -412,6 +414,11 @@ impl<'a> Context<'a> {
     /// Will lazily discover Jujutsu repo root when a module requests it.
     pub fn get_jj_repo(&self) -> Option<&JJRepo> {
         self.jj_repo.get_or_init(|| JJRepo::discover(self)).as_ref()
+    }
+
+    #[cfg(test)]
+    pub fn set_jj_repo(&mut self, repo: JJRepo) {
+        self.jj_repo = OnceLock::from(Some(repo));
     }
 
     pub fn dir_contents(&self) -> Result<&DirContents, &std::io::Error> {

--- a/src/module.rs
+++ b/src/module.rs
@@ -57,6 +57,7 @@ pub const ALL_MODULES: &[&str] = &[
     "hg_state",
     "hostname",
     "java",
+    "jj_bookmark",
     "jobs",
     "julia",
     "kotlin",

--- a/src/modules/jj_bookmark.rs
+++ b/src/modules/jj_bookmark.rs
@@ -70,3 +70,171 @@ fn format_item(config: &JJBookmarkConfig, item: &str) -> String {
         config.truncation_symbol,
     )
 }
+
+#[cfg(test)]
+pub mod tests {
+    use nu_ansi_term::Color;
+    use toml::toml;
+
+    use crate::context::JJRepo;
+    use crate::test::JJTester;
+
+    fn tester(repo: &'static str) -> JJTester {
+        JJTester::new("jj_bookmark").repo(repo)
+    }
+
+    #[test]
+    fn test_render_basics() {
+        JJTester::basic_tests("jj_bookmark");
+    }
+
+    #[test]
+    fn test_render_default_config() {
+        tester(JJRepo::BASE)
+            .expected(format!(
+                "on {} ",
+                Color::Purple.bold().paint("\u{e0a0} cur_local (+3 others)")
+            ))
+            .render();
+    }
+
+    #[test]
+    fn test_render_no_current() {
+        tester(JJRepo::BOOKMARK_NO_CURRENT)
+            .expected(format!(
+                "on {} ",
+                Color::Purple.bold().paint("\u{e0a0} par_local (+3 others)")
+            ))
+            .render();
+    }
+
+    #[test]
+    fn test_render_truncated() {
+        tester(JJRepo::BASE)
+            .options(toml! {
+                truncation_length = 7
+                truncation_symbol = "#"
+            })
+            .expected(format!(
+                "on {} ",
+                Color::Purple.bold().paint("\u{e0a0} cur_loc# (+3 others)")
+            ))
+            .render();
+    }
+
+    #[test]
+    fn test_render_style() {
+        tester(JJRepo::BASE)
+            .options(toml! { style = "italic red" })
+            .expected(format!(
+                "on {} ",
+                Color::Red.italic().paint("\u{e0a0} cur_local (+3 others)")
+            ))
+            .render();
+    }
+
+    #[test]
+    fn test_render_format() {
+        tester(JJRepo::BASE)
+            .options(toml! { format = "$bookmark(@$remote)$diverged" })
+            .expected("cur_local")
+            .render();
+    }
+
+    #[test]
+    fn test_render_ignore_names() {
+        tester(JJRepo::BASE)
+            .options(toml! {
+                format = "$bookmark(@$remote)$diverged( \\(+$overflow_count\\))"
+                ignore_names = [ "cur_local", "cur_tracked" ]
+            })
+            .expected("cur_modified@upstream* (+1)")
+            .render();
+
+        tester(JJRepo::BASE)
+            .options(toml! {
+                format = "$bookmark(@$remote)$diverged( \\(+$overflow_count\\))"
+                ignore_names = [ "cur_local", "cur_tracked", "cur_untracked" ]
+            })
+            .expected("cur_modified@upstream*")
+            .render();
+
+        tester(JJRepo::BASE)
+            .options(toml! {
+                format = "$bookmark(@$remote)$diverged( \\(+$overflow_count\\))"
+                ignore_names = [ "cur_local", "cur_tracked", "cur_modified", "cur_untracked" ]
+            })
+            .render();
+    }
+
+    #[test]
+    fn test_render_diverged_symbol() {
+        tester(JJRepo::BASE)
+            .options(toml! {
+                format = "$bookmark(@$remote)$diverged( \\(+$overflow_count\\))"
+                ignore_names = [ "cur_local", "cur_tracked" ]
+                diverged_symbol = "#"
+            })
+            .expected("cur_modified@upstream# (+1)")
+            .render();
+    }
+
+    #[test]
+    fn test_render_ignore_remotes() {
+        tester(JJRepo::BASE)
+            .options(toml! {
+                format = "$bookmark(@$remote)$diverged( \\(+$overflow_count\\))"
+                ignore_names = [ "cur_local", "cur_tracked" ]
+                ignore_remotes = [ "upstream" ]
+            })
+            .expected("cur_untracked@origin")
+            .render();
+
+        tester(JJRepo::BASE)
+            .options(toml! {
+                format = "$bookmark(@$remote)$diverged( \\(+$overflow_count\\))"
+                ignore_names = [ "cur_local", "cur_tracked" ]
+                ignore_remotes = [ "origin" ]
+            })
+            .expected("cur_modified@upstream*")
+            .render();
+
+        tester(JJRepo::BASE)
+            .options(toml! {
+                format = "$bookmark(@$remote)$diverged"
+                ignore_names = [ "cur_local", "cur_tracked" ]
+                ignore_remotes = [ "upstream", "origin" ]
+            })
+            .render();
+    }
+
+    #[test]
+    fn test_render_remote_with_local() {
+        tester(JJRepo::BASE)
+            .options(toml! { format = "$remote" })
+            .render();
+    }
+
+    #[test]
+    fn test_render_remote_with_remote() {
+        tester(JJRepo::BASE)
+            .options(toml! {
+                format = "$remote"
+                ignore_names = [ "cur_local", "cur_tracked" ]
+            })
+            .expected("upstream")
+            .render();
+    }
+    #[test]
+    fn test_render_remote_truncated() {
+        tester(JJRepo::BASE)
+            .options(toml! {
+                format = "$remote"
+                ignore_names = [ "cur_local", "cur_tracked" ]
+                truncation_length = 3
+                truncation_symbol = "#"
+            })
+            .expected("ups#")
+            .render();
+    }
+}

--- a/src/modules/jj_bookmark.rs
+++ b/src/modules/jj_bookmark.rs
@@ -1,0 +1,72 @@
+use crate::configs::jj_bookmark::JJBookmarkConfig;
+use crate::formatter::StringFormatter;
+use crate::modules::utils::truncate::truncate_text;
+
+use super::{Context, Module, ModuleConfig};
+
+/// Creates a module with the JJ bookmark in the current repository
+pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let mut module = context.new_module("jj_bookmark");
+    let config = JJBookmarkConfig::try_load(module.config);
+
+    if config.disabled {
+        return None;
+    }
+
+    let current_change = context.get_jj_repo()?.current_change(context)?;
+    let bookmarks = current_change.bookmarks.as_deref()?;
+
+    // The overflow count filters out ignored bookmarks
+    let ((name, remote, diverged), overflow_count) = {
+        let mut iter = bookmarks.iter().filter_map(|b| {
+            let name = b.name();
+            let remote = b.remote();
+            let ignored = config.ignore_names.contains(&name)
+                || remote
+                    .map(|r| config.ignore_remotes.contains(&r))
+                    .unwrap_or_default();
+
+            (!ignored).then_some((name, remote, b.diverged()))
+        });
+
+        (iter.next()?, iter.count())
+    };
+
+    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
+        formatter
+            .map_meta(|variable, _| match variable {
+                "symbol" => Some(config.symbol),
+                "diverged" => diverged.then_some(config.diverged_symbol),
+                _ => None,
+            })
+            .map_style(|variable| match variable {
+                "style" => Some(Ok(config.style)),
+                _ => None,
+            })
+            .map(move |variable| match variable {
+                "bookmark" => Some(Ok(format_item(&config, name))),
+                "remote" => remote.map(|s| Ok(format_item(&config, s))),
+                "overflow_count" => (overflow_count > 0).then(|| Ok(overflow_count.to_string())),
+                _ => None,
+            })
+            .parse(None, Some(context))
+    });
+
+    module.set_segments(match parsed {
+        Ok(segments) => segments,
+        Err(error) => {
+            log::warn!("Error in module `jj_bookmark`: \n{error}");
+            return None;
+        }
+    });
+
+    Some(module)
+}
+
+fn format_item(config: &JJBookmarkConfig, item: &str) -> String {
+    truncate_text(
+        item,
+        config.truncation_length.into(),
+        config.truncation_symbol,
+    )
+}

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -50,6 +50,7 @@ mod hg_branch;
 mod hg_state;
 mod hostname;
 mod java;
+mod jj_bookmark;
 mod jobs;
 mod julia;
 mod kotlin;
@@ -174,6 +175,7 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
             "hg_state" => hg_state::module(context),
             "hostname" => hostname::module(context),
             "java" => java::module(context),
+            "jj_bookmark" => jj_bookmark::module(context),
             "jobs" => jobs::module(context),
             "julia" => julia::module(context),
             "kotlin" => kotlin::module(context),
@@ -313,6 +315,7 @@ pub fn description(module: &str) -> &'static str {
         "hg_state" => "The current hg operation",
         "hostname" => "The system hostname",
         "java" => "The currently installed version of Java",
+        "jj_bookmark" => "The closest ancestor bookmark in Jujutsu",
         "jobs" => "The current number of jobs running",
         "julia" => "The currently installed version of Julia",
         "kotlin" => "The currently installed version of Kotlin",

--- a/src/test/jj_tester.rs
+++ b/src/test/jj_tester.rs
@@ -1,0 +1,100 @@
+use toml::{Table, Value, toml};
+
+use crate::context::JJRepo;
+use crate::test::ModuleRenderer;
+
+/// Helper to test JJ modules
+#[must_use]
+pub struct JJTester {
+    /// JJ module being tested
+    module: &'static str,
+    /// 'Repo' (see `JJ_REPO` constants) to test in
+    repo: &'static str,
+    /// Options to add to the module's config, if any
+    options: Option<Table>,
+    /// Expected output, None by default
+    expected: Option<String>,
+}
+
+impl JJTester {
+    pub fn new(module: &'static str) -> Self {
+        Self {
+            module,
+            repo: "",
+            options: None,
+            expected: None,
+        }
+    }
+
+    pub fn repo(mut self, repo: &'static str) -> Self {
+        self.repo = repo;
+        self
+    }
+
+    pub fn options(mut self, options: Table) -> Self {
+        self.options = Some(options);
+        self
+    }
+
+    pub fn expected(mut self, expected: impl Into<String>) -> Self {
+        self.expected = Some(expected.into());
+        self
+    }
+
+    /// Test rendering against `self.expected`
+    #[track_caller]
+    pub fn render(self) {
+        assert_ne!(
+            self.repo, "",
+            "You forgot to set a repository for this `Tester` instance"
+        );
+
+        let rendered_output = ModuleRenderer::new(self.module)
+            .jj_repo(self.repo)
+            .config({
+                let mut config = Table::with_capacity(1);
+                if let Some(options) = self.options {
+                    config.insert(self.module.into(), Value::Table(options));
+                }
+                config
+            })
+            .collect();
+
+        assert_eq!(rendered_output, self.expected);
+    }
+
+    /// A collection of basic tests, usually run in a `fn test_render_basics()` that will ensure
+    /// some sane defaults are respected, like actually disabling on `disabled = true` in the
+    /// config or not rendering anything when an unknown var is used or no output is produced
+    /// by the `jj` command.
+    #[track_caller]
+    pub fn basic_tests(module: &'static str) {
+        // No JJ repo -> no command output to parse
+        Self::new(module).repo(JJRepo::NONE).render();
+        // JJ repo but empty output -> nothing to parse
+        Self::new(module).repo(JJRepo::EMPTY_OUTPUT).render();
+        // JJ repo and invalid output -> parsing fails
+        Self::new(module).repo(JJRepo::INVALID_OUTPUT).render();
+        // Invalid format
+        Self::new(module)
+            .repo(JJRepo::BASE)
+            .options(toml! { format = "[" })
+            .render();
+        // Non existent variable
+        Self::new(module)
+            .repo(JJRepo::BASE)
+            .options(toml! { format = "$not_a_valid_jj_variable_in_any_module" })
+            .render();
+        // Non existent style
+        Self::new(module)
+            .repo(JJRepo::BASE)
+            .options(toml! { format = "[*]($not_a_valid_jj_style_variable_in_any_module)" })
+            .expected("*")
+            .render();
+        // Disabled module
+        Self::new(module)
+            .repo(JJRepo::BASE)
+            .options(toml! { disabled = true })
+            .render();
+    }
+}

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -1,4 +1,4 @@
-use crate::context::{Context, Env, Properties, Shell, Target};
+use crate::context::{Context, Env, JJRepo, Properties, Shell, Target};
 use crate::logger::StarshipLogger;
 use crate::{
     config::StarshipConfig,
@@ -12,6 +12,9 @@ use std::process::Command;
 use std::sync::LazyLock;
 use std::sync::Once;
 use tempfile::TempDir;
+
+mod jj_tester;
+pub(crate) use jj_tester::JJTester;
 
 static FIXTURE_DIR: LazyLock<PathBuf> =
     LazyLock::new(|| PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src/test/fixtures/"));
@@ -112,6 +115,16 @@ impl<'a> ModuleRenderer<'a> {
         T: Into<PathBuf>,
     {
         self.context.logical_dir = path.into();
+        self
+    }
+
+    /// Init at `JJRepo` with a mocked path, allowing to test JJ modules in several situations:
+    /// valid repo, invalid repo, no repo at all.
+    pub fn jj_repo<T>(mut self, path: T) -> Self
+    where
+        T: Into<PathBuf>,
+    {
+        self.context.set_jj_repo(JJRepo::with_root(path.into()));
         self
     }
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -640,6 +640,7 @@ CMake suite maintained and supported by Kitware (kitware.com/cmake).\n",
             stdout: String::from("22.1.3\n"),
             stderr: String::default(),
         }),
+        s if s.starts_with("jj --color never") => crate::context::mock_jj_cmd(s),
         _ => return None,
     };
     Some(out)


### PR DESCRIPTION
**See https://github.com/starship/starship/pull/7612 for the full MR with every changes, this MR has been extracted from it to make review easier.**

- Following the refactor in #7626, add `src/context/jj_repo.rs` with two commits, the second being the main of it
- Add `jj_bookmark` in another two commits, one for the module implementation and one for the rendering tests

Each commit can be reviewed on its own, they all pass tests and formatting.

Some of the test infrastructure in `src/test/jj_tester.rs` will only make sense once later JJ module come up, it reduces duplicated lines a lot and allows tests to be short and to the point with little boilerplate.