### PR TITLE
feat(memory_usage): add show_decimals option

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -1083,6 +1083,7 @@
       "$ref": "#/$defs/MemoryConfig",
       "default": {
         "threshold": 75,
+        "show_decimals": false,
         "format": "via $symbol[$ram( | $swap)]($style) ",
         "style": "white bold dimmed",
         "symbol": "🐏 ",
@@ -4862,6 +4863,10 @@
           "type": "integer",
           "format": "int64",
           "default": 75
+        },
+        "show_decimals": {
+          "type": "boolean",
+          "default": false
         },
         "format": {
           "type": "string",

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2993,13 +2993,14 @@ By default the swap usage is displayed if the total system swap is non-zero.
 
 ### Options
 
-| Option      | Default                                        | Description                                              |
-| ----------- | ---------------------------------------------- | -------------------------------------------------------- |
-| `threshold` | `75`                                           | Hide the memory usage unless it exceeds this percentage. |
-| `format`    | `'via $symbol [${ram}( \| ${swap})]($style) '` | The format for the module.                               |
-| `symbol`    | `'🐏'`                                         | The symbol used before displaying the memory usage.      |
-| `style`     | `'bold dimmed white'`                          | The style for the module.                                |
-| `disabled`  | `true`                                         | Disables the `memory_usage` module.                      |
+| Option          | Default                                        | Description                                              |
+| --------------- | ---------------------------------------------- | -------------------------------------------------------- |
+| `threshold`     | `75`                                           | Hide the memory usage unless it exceeds this percentage. |
+| `show_decimals` | false                                          | Show decimal values in memory usage.                     |
+| `format`        | `'via $symbol [${ram}( \| ${swap})]($style) '` | The format for the module.                               |
+| `symbol`        | `'🐏'`                                         | The symbol used before displaying the memory usage.      |
+| `style`         | `'bold dimmed white'`                          | The style for the module.                                |
+| `disabled`      | `true`                                         | Disables the `memory_usage` module.                      |
 
 ### Variables
 

--- a/src/configs/memory_usage.rs
+++ b/src/configs/memory_usage.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 #[serde(default)]
 pub struct MemoryConfig<'a> {
     pub threshold: i64,
+    pub show_decimals: bool,
     pub format: &'a str,
     pub style: &'a str,
     pub symbol: &'a str,
@@ -19,6 +20,7 @@ impl Default for MemoryConfig<'_> {
     fn default() -> Self {
         Self {
             threshold: 75,
+            show_decimals: false,
             format: "via $symbol[$ram( | $swap)]($style) ",
             style: "white bold dimmed",
             symbol: "🐏 ",

--- a/src/modules/memory_usage.rs
+++ b/src/modules/memory_usage.rs
@@ -9,16 +9,16 @@ use crate::configs::memory_usage::MemoryConfig;
 use crate::formatter::StringFormatter;
 
 // Display a `ByteSize` in a human readable format.
-fn display_bs(bs: ByteSize) -> String {
+fn display_bs(bs: ByteSize, show_decimals: bool) -> String {
     let mut display_bytes = bs.to_string_as(true);
     let mut keep = true;
-    // Skip decimals and the space before the byte unit.
+    // Skip decimals (unless `show_decimals` is set) and the space before the byte unit.
     display_bytes.retain(|c| match c {
         ' ' => {
             keep = true;
             false
         }
-        '.' => {
+        '.' if !show_decimals => {
             keep = false;
             false
         }
@@ -33,11 +33,11 @@ fn pct(total: ByteSize, free: ByteSize) -> f64 {
 }
 
 // Print usage string used/total
-fn format_usage_total(total: ByteSize, free: ByteSize) -> String {
+fn format_usage_total(total: ByteSize, free: ByteSize, show_decimals: bool) -> String {
     format!(
         "{}/{}",
-        display_bs(saturating_sub_bytes(total, free)),
-        display_bs(total)
+        display_bs(saturating_sub_bytes(total, free), show_decimals),
+        display_bs(total, show_decimals)
     )
 }
 
@@ -93,11 +93,16 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 _ => None,
             })
             .map(|variable| match variable {
-                "ram" => Some(Ok(format_usage_total(memory.total, memory.free))),
+                "ram" => Some(Ok(format_usage_total(
+                    memory.total,
+                    memory.free,
+                    config.show_decimals,
+                ))),
                 "ram_pct" => Some(Ok(format!("{used_pct:.0}%"))),
                 "swap" => Some(Ok(format_usage_total(
                     swap.as_ref()?.total,
                     swap.as_ref()?.free,
+                    config.show_decimals,
                 ))),
                 "swap_pct" => Some(Ok(format!(
                     "{:.0}%",
@@ -128,19 +133,56 @@ mod test {
     #[test]
     fn test_format_usage_total() {
         assert_eq!(
-            format_usage_total(ByteSize(1024 * 1024 * 1024), ByteSize(1024 * 1024 * 1024)),
+            format_usage_total(
+                ByteSize(1024 * 1024 * 1024),
+                ByteSize(1024 * 1024 * 1024),
+                false
+            ),
             "0B/1GiB"
         );
         assert_eq!(
             format_usage_total(
                 ByteSize(1024 * 1024 * 1024),
-                ByteSize(1024 * 1024 * 1024 / 2)
+                ByteSize(1024 * 1024 * 1024),
+                true
+            ),
+            "0B/1.0GiB"
+        );
+        assert_eq!(
+            format_usage_total(
+                ByteSize(1024 * 1024 * 1024),
+                ByteSize(1024 * 1024 * 1024 / 2),
+                false
             ),
             "512MiB/1GiB"
         );
         assert_eq!(
-            format_usage_total(ByteSize(1024 * 1024 * 1024), ByteSize(0)),
+            format_usage_total(
+                ByteSize(1024 * 1024 * 1024),
+                ByteSize(1024 * 1024 * 1024 / 2),
+                true
+            ),
+            "512.0MiB/1.0GiB"
+        );
+        assert_eq!(
+            format_usage_total(ByteSize(1024 * 1024 * 1024), ByteSize(0), false),
             "1GiB/1GiB"
+        );
+        assert_eq!(
+            format_usage_total(
+                ByteSize((1024 * 1024 * 1024) + (1024 * 1024 * 512)),
+                ByteSize(0),
+                false
+            ),
+            "1GiB/1GiB"
+        );
+        assert_eq!(
+            format_usage_total(
+                ByteSize((1024 * 1024 * 1024) + (1024 * 1024 * 512)),
+                ByteSize(0),
+                true
+            ),
+            "1.5GiB/1.5GiB"
         );
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
Adds a `show_decimals` configuration flag to the `memory_usage` module, allowing for output like `1.2GiB/3.4GiB` which would otherwise be rounded to `1GiB/3GiB`. The flag is set to `false` by default as that's how the module has worked before now.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allows for more precise/detailed memory usage reporting. Nowadays, it's more important than ever to keep track of how much memory you have :wink:

Closes #6440 

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- Most changes do not need to be tested on multiple operating systems. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### AI-Assistance
<!-- Per our AI Policy (AI_POLICY.md), all AI usage must be declared. -->
Have you used AI-assistance to author this PR?

- [ ] Yes
- [x] No

If **yes**, describe the scope of assistance:
<!--- Describe how you used AI-Assistance -->
<!--- Disclosure is required if you have used AI-assistance -->
<!--- For example: answering project questions, writing tests, implementation, or documentation -->
N/A

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
- [x] I understand and have read the code I contribute and can answer questions about it.
