### PR TITLE
fix(golang) handle custom toolchain version suffixes

### DIFF
--- a/src/formatter/version.rs
+++ b/src/formatter/version.rs
@@ -81,7 +81,7 @@ impl<'a> VersionFormatter<'a> {
         })
     }
 
-    pub fn format_module_version_with_parsed(
+    pub(crate) fn format_module_version_with_parsed(
         module_name: &str,
         raw_version: &str,
         parsed_version: &str,

--- a/src/formatter/version.rs
+++ b/src/formatter/version.rs
@@ -28,13 +28,32 @@ impl<'a> VersionFormatter<'a> {
         Self::new(format).and_then(|formatter| formatter.format(version))
     }
 
+    /// Format version string using provided format and explicit raw/parsed inputs
+    fn format_version_with_parsed(
+        raw_version: &'a str,
+        parsed_version: &'a str,
+        format: &'a str,
+    ) -> Result<String, StringFormatterError> {
+        Self::new(format)
+            .and_then(|formatter| formatter.format_with_parsed(raw_version, parsed_version))
+    }
+
     /// Formats a version structure into a readable string
     pub fn format(self, version: &'a str) -> Result<String, StringFormatterError> {
-        let parsed = LazyLock::new(|| Versioning::new(version));
+        self.format_with_parsed(version, version)
+    }
+
+    /// Formats a version structure into a readable string using explicit raw and parsed inputs
+    fn format_with_parsed(
+        self,
+        raw_version: &'a str,
+        parsed_version: &'a str,
+    ) -> Result<String, StringFormatterError> {
+        let parsed = LazyLock::new(|| Versioning::new(parsed_version));
         let formatted = self
             .formatter
             .map(|variable| match variable {
-                "raw" => Some(Ok(version.to_string())),
+                "raw" => Some(Ok(raw_version.to_string())),
                 "major" => match parsed.deref().as_ref() {
                     Some(Versioning::Ideal(v)) => Some(Ok(v.major.to_string())),
                     Some(Versioning::General(v)) => Some(Ok(v.nth_lenient(0)?.to_string())),
@@ -62,18 +81,31 @@ impl<'a> VersionFormatter<'a> {
         })
     }
 
+    pub fn format_module_version_with_parsed(
+        module_name: &str,
+        raw_version: &str,
+        parsed_version: &str,
+        version_format: &str,
+    ) -> Option<String> {
+        match VersionFormatter::format_version_with_parsed(
+            raw_version,
+            parsed_version,
+            version_format,
+        ) {
+            Ok(formatted) => Some(formatted),
+            Err(error) => {
+                log::warn!("Error formatting `{module_name}` version:\n{error}");
+                Some(format!("v{raw_version}"))
+            }
+        }
+    }
+
     pub fn format_module_version(
         module_name: &str,
         version: &str,
         version_format: &str,
     ) -> Option<String> {
-        match VersionFormatter::format_version(version, version_format) {
-            Ok(formatted) => Some(formatted),
-            Err(error) => {
-                log::warn!("Error formatting `{module_name}` version:\n{error}");
-                Some(format!("v{version}"))
-            }
-        }
+        Self::format_module_version_with_parsed(module_name, version, version, version_format)
     }
 }
 
@@ -112,6 +144,18 @@ mod tests {
         assert_eq!(
             VersionFormatter::format_version("dummy version", VERSION_FORMAT),
             Ok("major: minor: patch: raw:dummy version".to_string())
+        );
+    }
+
+    #[test]
+    fn test_raw_and_parsed_versions() {
+        assert_eq!(
+            VersionFormatter::format_version_with_parsed(
+                "1.26.5-X:nodwarf5",
+                "1.26.5",
+                VERSION_FORMAT,
+            ),
+            Ok("major:1 minor:26 patch:5 raw:1.26.5-X:nodwarf5".to_string())
         );
     }
 }

--- a/src/modules/golang.rs
+++ b/src/modules/golang.rs
@@ -103,8 +103,6 @@ fn normalize_go_version(version: &str) -> &str {
     version.split_once('-').map(|(v, _)| v).unwrap_or(version)
 }
 
-
-
 fn get_go_mod_version(context: &Context) -> Option<String> {
     let mod_str = context.read_file_from_pwd("go.mod")?;
     let re = Regex::new(r"(?:go\s)(\d+(\.\d+)+)").unwrap();
@@ -124,7 +122,7 @@ fn check_go_version(go_version: Option<&str>, mod_version: Option<&str>) -> bool
     let Ok(r) = VersionReq::parse(mod_version) else {
         return true;
     };
-    let Ok(v) = Version::parse(go_version) else {
+    let Ok(v) = Version::parse(normalize_go_version(go_version)) else {
         return true;
     };
 
@@ -140,7 +138,6 @@ mod tests {
     use std::io;
     use std::io::Write;
 
-    
     #[test]
     fn folder_without_go_files() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
@@ -271,6 +268,16 @@ mod tests {
     #[test]
     fn normalize_go_version_with_suffix() {
         assert_eq!(normalize_go_version("1.26.5-X:nodwarf5"), "1.26.5");
+    }
+
+    #[test]
+    fn custom_go_version_matches_mod_version() {
+        assert!(check_go_version(Some("1.26.5-X:nodwarf5"), Some("1.26")));
+    }
+
+    #[test]
+    fn custom_go_version_does_not_match_newer_mod_version() {
+        assert!(!check_go_version(Some("1.26.5-X:nodwarf5"), Some("1.27")));
     }
 
     #[test]

--- a/src/modules/golang.rs
+++ b/src/modules/golang.rs
@@ -52,9 +52,10 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 "version" => {
                     let go_ver = golang_version.deref().as_ref()?;
 
-                    VersionFormatter::format_module_version(
+                    VersionFormatter::format_module_version_with_parsed(
                         module.get_name(),
                         go_ver,
+                        normalize_go_version(go_ver),
                         config.version_format,
                     )
                     .map(Ok)
@@ -133,6 +134,7 @@ fn check_go_version(go_version: Option<&str>, mod_version: Option<&str>) -> bool
 mod tests {
     use super::*;
     use crate::test::ModuleRenderer;
+    use crate::utils::CommandOutput;
     use nu_ansi_term::Color;
     use std::fs::{self, File};
     use std::io;
@@ -302,6 +304,59 @@ mod tests {
             Color::Red.bold().paint("🐹 v1.12.1 1.16 ")
         ));
 
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn custom_go_build_version_formats_without_suffix() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join("main.go"))?.sync_all()?;
+
+        let actual = ModuleRenderer::new("golang")
+            .path(dir.path())
+            .cmd(
+                "go version",
+                Some(CommandOutput {
+                    stdout: String::from("go version go1.26.5-X:nodwarf5 linux/amd64\n"),
+                    stderr: String::default(),
+                }),
+            )
+            .config(toml::toml! {
+                [golang]
+                version_format = "v${major}.${minor}.${patch}"
+            })
+            .collect();
+
+        let expected = Some(format!("via {}", Color::Cyan.bold().paint("🐹 v1.26.5 ")));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn custom_go_build_version_raw_format_with_suffix() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join("main.go"))?.sync_all()?;
+
+        let actual = ModuleRenderer::new("golang")
+            .path(dir.path())
+            .cmd(
+                "go version",
+                Some(CommandOutput {
+                    stdout: String::from("go version go1.26.5-X:nodwarf5 linux/amd64\n"),
+                    stderr: String::default(),
+                }),
+            )
+            .config(toml::toml! {
+                [golang]
+                version_format = "${raw}"
+            })
+            .collect();
+
+        let expected = Some(format!(
+            "via {}",
+            Color::Cyan.bold().paint("🐹 1.26.5-X:nodwarf5 ")
+        ));
         assert_eq!(expected, actual);
         dir.close()
     }

--- a/src/modules/golang.rs
+++ b/src/modules/golang.rs
@@ -99,6 +99,12 @@ fn parse_go_version(go_stdout: &str) -> Option<String> {
     Some(version.to_string())
 }
 
+fn normalize_go_version(version: &str) -> &str {
+    version.split_once('-').map(|(v, _)| v).unwrap_or(version)
+}
+
+
+
 fn get_go_mod_version(context: &Context) -> Option<String> {
     let mod_str = context.read_file_from_pwd("go.mod")?;
     let re = Regex::new(r"(?:go\s)(\d+(\.\d+)+)").unwrap();
@@ -134,6 +140,7 @@ mod tests {
     use std::io;
     use std::io::Write;
 
+    
     #[test]
     fn folder_without_go_files() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
@@ -254,6 +261,16 @@ mod tests {
     fn test_format_go_version() {
         let input = "go version go1.12 darwin/amd64";
         assert_eq!(parse_go_version(input), Some("1.12".to_string()));
+    }
+
+    #[test]
+    fn normalize_go_version_without_suffix() {
+        assert_eq!(normalize_go_version("1.26.5"), "1.26.5");
+    }
+
+    #[test]
+    fn normalize_go_version_with_suffix() {
+        assert_eq!(normalize_go_version("1.26.5-X:nodwarf5"), "1.26.5");
     }
 
     #[test]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
THis PR fixes handling of custom GO toolchain versions

The Go module now perserves the original fersion strin while using a normalize fersion of ${major}  ${minor} and  ${patch}. This version is also used when comparing the instaled Go version against the version declaried in go.mod.

Regressuib test were added ti verify both formatted version components  and preservation of the original raw version

#### Motivation and Context
Custom go toolchains may report versions such as: go version go1.26.5-X:nodwarf5 linux/amd64

Starship previously attempted to parse the full custom version string, casuing  ${major},  ${minor} and  ${patch} to be empty

This change separates the raw version from the version used for parsing

Closes #7645 

#### Screenshots (if appropriate):
N/A
#### How Has This Been Tested?
The change was tested with unit and module level regression test covering:
- go versions without custom sufifxes
-go versions with custom suffixes
- ${major}, ${minor} and  ${patch} formatting
- ${raw} preserving the original custom version
- go.mod compatibility
- Existing Starship test to check for regressions
Comands run: 
cargo fmt --check

cargo clippy --all-targets --all-features -- -D warnings

cargo test --lib

- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### AI-Assistance
- [x] Yes
- [ ] No

If **yes**, describe the scope of assistance:
<!--- Describe how you used AI-Assistance -->
ChatGPT was used for debugging guidance, discussing the implementation approach, explaining Rust concepts, and reviewing the changes. GitHub Copilot was also used during investigation and testing.

I reviewed, understood, and tested the contributed code myself and can explain the implementation and reasoning behind the changes.


#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
- [x] I understand and have read the code I contribute and can answer questions about it.
