### PR TITLE
fix(openstack): resolve clouds.yaml from context current directory

### DIFF
--- a/src/modules/openstack.rs
+++ b/src/modules/openstack.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use yaml_rust2::YamlLoader;
 
 use super::{Context, Module, ModuleConfig};
@@ -11,15 +13,13 @@ type Project = String;
 
 fn get_osp_project_from_config(context: &Context, osp_cloud: &str) -> Option<Project> {
     // Attempt to follow OpenStack standards for clouds.yaml location:
-    // 1st = $PWD/clouds.yaml, 2nd = $HOME/.config/openstack/clouds.yaml, 3rd = /etc/openstack/clouds.yaml
+    // 1st = current directory, 2nd = $HOME/.config/openstack/clouds.yaml, 3rd = /etc/openstack/clouds.yaml
     let config = [
-        context.get_env("PWD").map(|pwd| pwd + "/clouds.yaml"),
-        context.get_home().map(|home| {
-            home.join(".config/openstack/clouds.yaml")
-                .display()
-                .to_string()
-        }),
-        Some(String::from("/etc/openstack/clouds.yaml")),
+        Some(context.current_dir.join("clouds.yaml")),
+        context
+            .get_home()
+            .map(|home| home.join(".config/openstack/clouds.yaml")),
+        Some(PathBuf::from("/etc/openstack/clouds.yaml")),
     ];
 
     config
@@ -107,7 +107,7 @@ clouds:
 ",
         )?;
         let actual = ModuleRenderer::new("openstack")
-            .env("PWD", dir.path().to_str().unwrap())
+            .path(dir.path())
             .env("OS_CLOUD", "corp")
             .config(toml::toml! {
                 [openstack]
@@ -133,7 +133,7 @@ dummy_yaml
 ",
         )?;
         let actual = ModuleRenderer::new("openstack")
-            .env("PWD", dir.path().to_str().unwrap())
+            .path(dir.path())
             .env("OS_CLOUD", "test")
             .config(toml::toml! {
                 [openstack]
@@ -153,7 +153,7 @@ dummy_yaml
         file.write_all(b"")?;
         drop(file);
         let actual = ModuleRenderer::new("openstack")
-            .env("PWD", dir.path().to_str().unwrap())
+            .path(dir.path())
             .env("OS_CLOUD", "test")
             .config(toml::toml! {
                 [openstack]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description


Use `context.current_dir` when resolving the local `clouds.yaml` file for the OpenStack module.

The module previously constructed the first candidate path directly from the `PWD` environment variable. The local candidate now uses a `PathBuf` derived from `context.current_dir`, while preserving the existing lookup order:

1. `<current_dir>/clouds.yaml`
2. `$HOME/.config/openstack/clouds.yaml`
3. `/etc/openstack/clouds.yaml`

The paths are also kept as filesystem paths instead of being converted to strings before reading them.


#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

Added/updated a regression test using `ModuleRenderer::path(...) `  without setting PWD, verifying that the OpenStack project is read from context.current_dir.join("clouds.yaml").

Tested with:
`cargo test modules::openstack`


<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- Most changes do not need to be tested on multiple operating systems. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**





#### AI-Assistance
<!-- Per our AI Policy (AI_POLICY.md), all AI usage must be declared. -->
Have you used AI-assistance to author this PR?

- [] Yes
- [x] No


<!--- Describe how you used AI-Assistance -->
<!--- Disclosure is required if you have used AI-assistance -->
<!--- For example: answering project questions, writing tests, implementation, or documentation -->
N/A

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
- [ ] I understand and have read the code I contribute and can answer questions about it.
