### PR TITLE
feat: vcs: Added a fallback option if no repo is present

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -1865,7 +1865,8 @@
         "fossil_modules": "$fossil_branch$fossil_metrics",
         "git_modules": "$git_branch$git_commit$git_state$git_metrics$git_status",
         "hg_modules": "$hg_branch$hg_state",
-        "pijul_modules": "$pijul_channel"
+        "pijul_modules": "$pijul_channel",
+        "fallback_modules": ""
       }
     },
     "vcsh": {
@@ -6979,6 +6980,11 @@
           "description": "Modules to use when Pijul is matched.\n\nThey are configured separately at the top level.",
           "type": "string",
           "default": "$pijul_channel"
+        },
+        "fallback_modules": {
+          "description": "Modules to use when no repo is present.",
+          "type": "string",
+          "default": ""
         }
       },
       "additionalProperties": false

--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -1864,7 +1864,8 @@
         "fossil_modules": "$fossil_branch$fossil_metrics",
         "git_modules": "$git_branch$git_commit$git_state$git_metrics$git_status",
         "hg_modules": "$hg_branch$hg_state",
-        "pijul_modules": "$pijul_channel"
+        "pijul_modules": "$pijul_channel",
+        "fallback_modules": ""
       }
     },
     "vcsh": {
@@ -6974,6 +6975,11 @@
           "description": "Modules to use when Pijul is matched.\n\nThey are configured separately at the top level.",
           "type": "string",
           "default": "$pijul_channel"
+        },
+        "fallback_modules": {
+          "description": "Modules to use when no repo is present.",
+          "type": "string",
+          "default": ""
         }
       },
       "additionalProperties": false

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -5039,18 +5039,19 @@ format = 'via [V $version](blue bold) '
 > Additionally, the exact format of the module may change in the future, for example to handle right-aligned prompt.
 
 The `vcs` module displays the current active Version Control System (VCS).
-The module will be shown only if a configured VCS is currently in use.
+The module will show a configured VCS if a corresponding repo is found. Otherwise the fallback will be shown.
 
 ### Options
 
-| Option           | Default                                                     | Description                                           |
-| ---------------- | ----------------------------------------------------------- | ----------------------------------------------------- |
-| `order`          | `["git", "hg", "pijul", "fossil"]`                          | The order in which to search VCSes.                   |
-| `fossil_modules` | `"$fossil_branch$fossil_metrics"`                           | Modules to show when a Fossil repository is found.    |
-| `git_modules`    | `"$git_branch$git_commit$git_state$git_metrics$git_status"` | Modules to show when a Git repository is found.       |
-| `hg_modules`     | `"$hg_branch$hg_state"`                                     | Modules to show when a Mercurial repository is found. |
-| `pijul_modules`  | `"$pijul_channel"`                                          | Modules to show when a Pijul repository is found.     |
-| `disabled`       | `false`                                                     | Disables the `vcs` module.                            |
+| Option             | Default                                                     | Description                                           |
+| ------------------ | ----------------------------------------------------------- | ----------------------------------------------------- |
+| `order`            | `["git", "hg", "pijul", "fossil"]`                          | The order in which to search VCSes.                   |
+| `fossil_modules`   | `"$fossil_branch$fossil_metrics"`                           | Modules to show when a Fossil repository is found.    |
+| `git_modules`      | `"$git_branch$git_commit$git_state$git_metrics$git_status"` | Modules to show when a Git repository is found.       |
+| `hg_modules`       | `"$hg_branch$hg_state"`                                     | Modules to show when a Mercurial repository is found. |
+| `pijul_modules`    | `"$pijul_channel"`                                          | Modules to show when a Pijul repository is found.     |
+| `fallback_modules` | `""`                                                        | Modules to show when no repository is found.          |
+| `disabled`         | `false`                                                     | Disables the `vcs` module.                            |
 
 ### Example
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -5040,18 +5040,19 @@ format = 'via [V $version](blue bold) '
 > Additionally, the exact format of the module may change in the future, for example to handle right-aligned prompt.
 
 The `vcs` module displays the current active Version Control System (VCS).
-The module will be shown only if a configured VCS is currently in use.
+The module will show a configured VCS if a corresponding repo is found. Otherwise the fallback will be shown.
 
 ### Options
 
-| Option           | Default                                                     | Description                                           |
-| ---------------- | ----------------------------------------------------------- | ----------------------------------------------------- |
-| `order`          | `["git", "hg", "pijul", "fossil"]`                          | The order in which to search VCSes.                   |
-| `fossil_modules` | `"$fossil_branch$fossil_metrics"`                           | Modules to show when a Fossil repository is found.    |
-| `git_modules`    | `"$git_branch$git_commit$git_state$git_metrics$git_status"` | Modules to show when a Git repository is found.       |
-| `hg_modules`     | `"$hg_branch$hg_state"`                                     | Modules to show when a Mercurial repository is found. |
-| `pijul_modules`  | `"$pijul_channel"`                                          | Modules to show when a Pijul repository is found.     |
-| `disabled`       | `false`                                                     | Disables the `vcs` module.                            |
+| Option             | Default                                                     | Description                                           |
+| ------------------ | ----------------------------------------------------------- | ----------------------------------------------------- |
+| `order`            | `["git", "hg", "pijul", "fossil"]`                          | The order in which to search VCSes.                   |
+| `fossil_modules`   | `"$fossil_branch$fossil_metrics"`                           | Modules to show when a Fossil repository is found.    |
+| `git_modules`      | `"$git_branch$git_commit$git_state$git_metrics$git_status"` | Modules to show when a Git repository is found.       |
+| `hg_modules`       | `"$hg_branch$hg_state"`                                     | Modules to show when a Mercurial repository is found. |
+| `pijul_modules`    | `"$pijul_channel"`                                          | Modules to show when a Pijul repository is found.     |
+| `fallback_modules` | `""`                                                        | Modules to show when no repository is found.          |
+| `disabled`         | `false`                                                     | Disables the `vcs` module.                            |
 
 ### Example
 

--- a/src/configs/vcs.rs
+++ b/src/configs/vcs.rs
@@ -40,6 +40,8 @@ pub struct VcsConfig<'a> {
     ///
     /// They are configured separately at the top level.
     pub pijul_modules: &'a str,
+    /// Modules to use when no repo is present.
+    pub fallback_modules: &'a str,
 }
 
 impl Default for VcsConfig<'_> {
@@ -51,6 +53,7 @@ impl Default for VcsConfig<'_> {
             git_modules: "$git_branch$git_commit$git_state$git_metrics$git_status",
             hg_modules: "$hg_branch$hg_state",
             pijul_modules: "$pijul_channel",
+            fallback_modules: "",
         }
     }
 }

--- a/src/modules/vcs.rs
+++ b/src/modules/vcs.rs
@@ -19,13 +19,16 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         .order
         .into_iter()
         .filter_map(|vcs| Vcs::try_from(vcs).ok())
-        .find(|vcs| discover_repo_root(context, *vcs).is_some())?;
+        .find(|vcs| discover_repo_root(context, *vcs).is_some());
 
     let modules = match vcs {
-        Vcs::Fossil => config.fossil_modules,
-        Vcs::Git => config.git_modules,
-        Vcs::Hg => config.hg_modules,
-        Vcs::Pijul => config.pijul_modules,
+        Some(vcs) => match vcs {
+            Vcs::Fossil => config.fossil_modules,
+            Vcs::Git => config.git_modules,
+            Vcs::Hg => config.hg_modules,
+            Vcs::Pijul => config.pijul_modules,
+        },
+        None => config.fallback_modules,
     };
 
     if modules.is_empty() {
@@ -197,7 +200,33 @@ mod tests {
 
     #[test]
     fn invalid_vcs_is_none() -> io::Result<()> {
-        with_marker("does_not_exists", FixtureProvider::Fossil, None)
+        with_marker("does_not_exist", FixtureProvider::Fossil, None)
+    }
+
+    #[test]
+    fn no_vcs_is_fallback() -> io::Result<()> {
+        let repo_dir = tempfile::tempdir()?;
+
+        let config = toml::toml! {
+            [vcs]
+            fallback_modules = "${custom.fallback_test}"
+
+            [custom.fallback_test]
+            command = "echo fallback"
+            when = true
+        };
+
+        let actual = ModuleRenderer::new("vcs")
+            .config(config)
+            .path(repo_dir.path())
+            .collect();
+
+        assert_eq!(
+            actual,
+            Some(format!("{}", Color::Green.bold().paint("fallback ")))
+        );
+
+        repo_dir.close()
     }
 
     #[track_caller]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->
Added a fallback option to the vcs module to configure what's displayed when no vcs repo is found.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I currently solve this with a custom module. But it would be nice if there was a native solution for achieving this.
```toml
[custom.no_vcs]
format = "[]($style)"
style = "fg:#3C3C51 bg:#4B4B62"
when = "! git rev-parse --is-inside-work-tree > /dev/null 2>&1"
```
This can now be done like this
```toml
[vcs]
fallback_modules = "[](fg:#3C3C51 bg:#4B4B62)"
```
#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- Most changes do not need to be tested on multiple operating systems. -->
I changed the `invalid_vcs_is_none()` test to `invalid_vcs_is_default()` to test this change. I also used it with my prompt once inside a git repo where it had no impact and once outside where it displayed the content of  `default_modules`.
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### AI-Assistance
<!-- Per our AI Policy (AI_POLICY.md), all AI usage must be declared. -->
Have you used AI-assistance to author this PR?

- [ ] Yes
- [x] No

If **yes**, describe the scope of assistance:
<!--- Describe how you used AI-Assistance -->
<!--- Disclosure is required if you have used AI-assistance -->
<!--- For example: answering project questions, writing tests, implementation, or documentation -->

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
- [x] I understand and have read the code I contribute and can answer questions about it.
