### PR TITLE
ci: stop pinning taiki-e/install-action tool versions

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -124,16 +124,7 @@
                 'cargo install.*--version (?<currentValue>\\S+).*\\s(?<depName>\\S+)',
             ],
             datasourceTemplate: 'crate',
-        },
-        {
-            customType: 'regex',
-            managerFilePatterns: [
-                '/^(workflow-templates|\\.github\\/workflows)\\/[^/]+\\.ya?ml$/',
-            ],
-            matchStrings: [
-                '^\\s+tool: (?<depName>[\\w-]+)@(?<currentValue>[^\\s]+)',
-            ],
-            datasourceTemplate: 'crate',
+            versioningTemplate: 'semver',
         },
         {
             customType: 'regex',

--- a/.github/workflows/format-workflow.yml
+++ b/.github/workflows/format-workflow.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install | Taplo
         uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # v2.85.7
         with:
-          tool: taplo-cli@0.10.0
+          tool: taplo-cli
       - name: Presets | Validate with schema
         run: taplo lint --schema "file://${GITHUB_WORKSPACE}/.github/config-schema.json" docs/public/presets/toml/*.toml
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest' && !matrix.use_zigbuild
         uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # v2.85.7
         with:
-          tool: cross@0.2.5
+          tool: cross
 
       - name: Setup | Install Zig [riscv64]
         if: matrix.use_zigbuild

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -164,7 +164,7 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@67729d5c413db75907f0ad1e39bb04b9c868ff60 # v2.85.7
         with:
-          tool: cargo-llvm-cov@0.8.5
+          tool: cargo-llvm-cov
 
       # For windows installer test
       # On stable rust & main repo pushes only


### PR DESCRIPTION
We have two Renovate custom managers which keep our pinned tool versions current. These are used to find and bump versions in two places: the `tool: <name>@<version>` values passed to taiki-e/install-action, and the `cargo install --version` pin for cargo-wix.

Neither pin has been updated since #7390 added them. `cargo-llvm-cov` has fallen two releases behind. [Coverage jobs are now broken][job]:

```
error: failed to collect object files: not found object files (searched directories: /Users/runner/work/starship/starship/target/llvm-cov-target/debug); this may occur if show-env subcommand is used incorrectly (see docs or other warnings), or unsupported commands or configs are used
```

This is caused by two issues in the Renovate managers.

First, the `tool:` matcher was anchored with `^`. Renovate compiles `matchStrings` without the regex multiline flag. In other words, Renovate's regexes match against the _whole file_. `^` matches the start of the file, so the matcher matched nothing.

Second, both managers took their versioning from the crate datasource, which uses [`cargo` versioning][cargo-versioning]. Cargo versioning treats a bare version such as `0.8.5` as a compatible range that `0.8.7` satisfies, like `^0.8.5` in npm. Renovate won't propose a bump if the newer version satisfies the range. In both of our cases here, we use the values as exact versions.

install-action comes with its own manifest of tool versions and pins them: an unversioned `tool:` is resolved from manifests bundled with the action at release time, so the pinned action commit fully determines the tool versions and their checksums. If we drop the `@<version>` suffixes, the tools are updated whenever Renovate bumps the action pin, which its built-in github-actions manager already does, and the custom manager can be removed. The current version bumps `cargo-llvm-cov` to 0.8.7, so we will get the fixed version by unpinning.

`cargo-wix` is not covered by install-action, so we need to keep managing it with Renovate. Switch its manager to [`semver` versioning][semver-versioning], which treats bare versions as exact.

Verified with `renovate --platform=local --dry-run=lookup`, which proposes `cargo-wix` `0.3.9` and no longer extracts any `tool:` dependencies.

[cargo-versioning]: https://docs.renovatebot.com/modules/versioning/cargo/
[job]: https://github.com/starship/starship/actions/runs/31367604498/job/93389373598
[semver-versioning]: https://docs.renovatebot.com/modules/versioning/semver/
