### PR TITLE
feat(version): report version components for messy version strings

### DIFF
--- a/src/formatter/version.rs
+++ b/src/formatter/version.rs
@@ -38,16 +38,19 @@ impl<'a> VersionFormatter<'a> {
                 "major" => match parsed.deref().as_ref() {
                     Some(Versioning::Ideal(v)) => Some(Ok(v.major.to_string())),
                     Some(Versioning::General(v)) => Some(Ok(v.nth_lenient(0)?.to_string())),
+                    Some(Versioning::Complex(v)) => Some(Ok(v.nth(0)?.to_string())),
                     _ => None,
                 },
                 "minor" => match parsed.deref().as_ref() {
                     Some(Versioning::Ideal(v)) => Some(Ok(v.minor.to_string())),
                     Some(Versioning::General(v)) => Some(Ok(v.nth_lenient(1)?.to_string())),
+                    Some(Versioning::Complex(v)) => Some(Ok(v.nth(1)?.to_string())),
                     _ => None,
                 },
                 "patch" => match parsed.deref().as_ref() {
                     Some(Versioning::Ideal(v)) => Some(Ok(v.patch.to_string())),
                     Some(Versioning::General(v)) => Some(Ok(v.nth_lenient(2)?.to_string())),
+                    Some(Versioning::Complex(v)) => Some(Ok(v.nth(2)?.to_string())),
                     _ => None,
                 },
                 _ => None,
@@ -104,6 +107,16 @@ mod tests {
         assert_eq!(
             VersionFormatter::format_version("1.2-a.3", VERSION_FORMAT),
             Ok("major:1 minor:2 patch: raw:1.2-a.3".to_string())
+        );
+    }
+
+    #[test]
+    fn test_complex() {
+        // A Go toolchain built with an experiment reports a version that is
+        // neither semver nor a general version, e.g. `go1.26.5-X:nodwarf5`.
+        assert_eq!(
+            VersionFormatter::format_version("1.26.5-X:nodwarf5", VERSION_FORMAT),
+            Ok("major:1 minor:26 patch:5 raw:1.26.5-X:nodwarf5".to_string())
         );
     }
 

--- a/src/modules/golang.rs
+++ b/src/modules/golang.rs
@@ -257,6 +257,17 @@ mod tests {
     }
 
     #[test]
+    fn test_format_go_version_with_build_tags() {
+        // Some toolchains report build tags after the version number. The
+        // suffix is kept so `${raw}` still shows the full version.
+        let input = "go version go1.26.5-X:nodwarf5 linux/amd64";
+        assert_eq!(
+            parse_go_version(input),
+            Some("1.26.5-X:nodwarf5".to_string())
+        );
+    }
+
+    #[test]
     fn show_mod_version_if_not_matching_go_version() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         let mut file = File::create(dir.path().join("go.mod"))?;


### PR DESCRIPTION
Closes #7645

<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
`VersionFormatter` handles `Versioning::Ideal` and `Versioning::General`, but
falls through to `None` for `Versioning::Complex`. Any version string that
parses as a Mess therefore renders `${major}`, `${minor}` and `${patch}` as
empty strings.

Go toolchains that append build tags report e.g. `go version go1.26.5-X:nodwarf5
linux/amd64`. The `-X:nodwarf5` suffix is not a valid semver pre-release, so
`version_format = "v${major}.${minor}.${patch}"` renders as `v..`.

`Mess::nth` already exposes the leading numeric components, so this wires up a
`Complex` arm for each of the three variables. `${raw}` is untouched, and the
fix applies to every module rather than just `golang`.

#### Motivation and Context
Closes #7645
Closes #7654

#### Screenshots (if appropriate):
N/A

#### How Has This Been Tested?
`cargo test --lib` (1241 passed), `cargo fmt --check` and
`cargo clippy --all-targets -- -D warnings` are all clean.

Added `formatter::version::tests::test_complex`, which fails without the
change (`major: minor: patch:`) and passes with it (`major:1 minor:26
patch:5`), plus a `parse_go_version` case documenting the build-tag format.

- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### AI-Assistance
Have you used AI-assistance to author this PR?

- [ ] Yes
- [ ] No

If **yes**, describe the scope of assistance:
N/A

#### Checklist:
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
- [ ] I understand and have read the code I contribute and can answer questions about it.