### PR TITLE
fix(git_status): honor GIT_WORK_TREE for bare repositories

### DIFF
--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -357,7 +357,7 @@ impl<'a> Context<'a> {
                         ..gix::open::Permissions::default_for_level(git_sec::Trust::Full)
                     });
 
-                let shared_repo =
+                let mut shared_repo =
                     match ThreadSafeRepository::discover_with_environment_overrides_opts(
                         &self.current_dir,
                         gix::discover::upwards::Options {
@@ -372,6 +372,14 @@ impl<'a> Context<'a> {
                             return Err(Box::new(e));
                         }
                     };
+
+                // Git honors `GIT_WORK_TREE` even for a repository with `core.bare = true`,
+                // but `gix` drops the work tree it read from the environment in that case.
+                if shared_repo.work_tree.is_none()
+                    && let Some(work_tree) = self.get_env_os("GIT_WORK_TREE")
+                {
+                    shared_repo.work_tree = Some(self.current_dir.join(work_tree));
+                }
 
                 let repository = shared_repo.to_thread_local();
                 log::trace!(

--- a/src/modules/git_status.rs
+++ b/src/modules/git_status.rs
@@ -1993,6 +1993,40 @@ pub mod tests {
     }
 
     #[test]
+    fn does_generate_git_status_for_bare_repo_with_git_work_tree() -> io::Result<()> {
+        for &mode in BARE_GIT_PROVIDERS {
+            let worktree_dir = tempfile::tempdir()?;
+            let repo_dir = fixture_repo(mode)?;
+
+            create_command("git")?
+                .args([
+                    OsStr::new("--work-tree"),
+                    worktree_dir.path().as_os_str(),
+                    OsStr::new("checkout"),
+                    OsStr::new("-f"),
+                    OsStr::new("master"),
+                ])
+                .current_dir(repo_dir.path())
+                .output()?;
+
+            let mut the_file = std::fs::File::create(worktree_dir.path().join("test_file"))?;
+            writeln!(the_file, "content")?;
+            the_file.sync_all()?;
+
+            let actual = ModuleRenderer::new("git_status")
+                .path(repo_dir.path())
+                .env("GIT_WORK_TREE", worktree_dir.path().to_str().unwrap())
+                .collect();
+            let expected = format_output("?");
+
+            assert_eq!(expected, actual);
+            worktree_dir.close()?;
+            repo_dir.close()?;
+        }
+        Ok(())
+    }
+
+    #[test]
     fn does_generate_git_status_for_worktree_backed_by_bare_repo() -> io::Result<()> {
         for &mode in BARE_GIT_PROVIDERS {
             let worktree_dir = tempfile::tempdir()?;


### PR DESCRIPTION
## Description

Fixes #7609.

Using a bare repository with `GIT_DIR`/`GIT_WORK_TREE` (the common dotfiles setup) made `git_status` render nothing, while `git status` and `git_branch` worked:

```
export GIT_DIR="$HOME/.dotfiles"
export GIT_WORK_TREE="$HOME"
```

```
[TRACE] - (starship::context): Found git repo: Repository { kind: Common, git_dir: "…/.dotfiles", workdir: None }
[DEBUG] - (starship::modules::git_status): This is a bare repository, git_status is not applicable
```

### Root cause

`gix` does read `GIT_WORK_TREE` in `open_with_environment_overrides`, but `open_from_paths` then throws that work tree away when the repository's config says `core.bare = true` ([`gix-0.86.0/src/open/repository.rs`](https://github.com/GitoxideLabs/gitoxide/blob/main/gix/src/open/repository.rs), the `worktree_dir = None` arm). Git itself honors `GIT_WORK_TREE` regardless of `core.bare`, so starship ends up with `workdir: None` and `git_status` (and `git_metrics`) bail out.

Overriding `core.bare` via `open::Options::config_overrides` does not help — `is_bare` is captured in the stage-one config before API overrides are appended.

### Fix

After discovery, if the opened repository has no work tree but `GIT_WORK_TREE` is set, use it. `ThreadSafeRepository::work_tree` is public, so this needs no upstream change:

```rust
if shared_repo.work_tree.is_none()
    && let Some(work_tree) = self.get_env_os("GIT_WORK_TREE")
{
    shared_repo.work_tree = Some(self.current_dir.join(work_tree));
}
```

This only takes effect when the repository would otherwise have no work tree at all, so non-bare repositories and genuinely bare repositories (no `GIT_WORK_TREE`) are unaffected.

### Manual verification

```
$ git status --short
 M tracked.txt
?? untracked.txt

# before
$ starship module git_status
(empty)

# after
$ starship module git_status
[!?]
```

## Motivation and Context

`git_status` now reports the same working-tree state as the git CLI for bare-repo dotfile setups.

## How Has This Been Tested?

New regression test `does_generate_git_status_for_bare_repo_with_git_work_tree` in `src/modules/git_status.rs`, run against both the loose-ref and reftable bare fixtures. It exercises the `GIT_WORK_TREE` half of the setup through starship's mockable env; the `GIT_DIR` half can't be covered in-process because `gix` reads the real process environment (same limitation already noted in `src/modules/git_branch.rs`). The test fails on `main` (`left: Some("[?]")`, `right: None`) and passes with this change.

- `cargo test` — 1232 passed, 0 failed, 39 ignored
- `cargo fmt --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- Manual repro above with a real bare repo

## Checklist:

- [x] I have read the [CONTRIBUTING](https://github.com/starship/starship/blob/main/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CODE_OF_CONDUCT](https://github.com/starship/starship/blob/main/CODE_OF_CONDUCT.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

---

*Disclosure: this change was prepared with AI assistance (Claude Code). The root cause analysis, fix, and all verification commands above were run and reviewed by me.*
