### PR TITLE
feat(git_branch): add `ignore_remotes` option

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -693,6 +693,7 @@
         "only_attached": false,
         "always_show_remote": false,
         "ignore_branches": [],
+        "ignore_remotes": [],
         "ignore_bare_repo": false,
         "disabled": false
       }
@@ -3667,6 +3668,13 @@
           "default": false
         },
         "ignore_branches": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": []
+        },
+        "ignore_remotes": {
           "type": "array",
           "items": {
             "type": "string"

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1916,6 +1916,7 @@ The `git_branch` module shows the active branch of the repo in your current dire
 | `truncation_symbol`  | `'…'`                                             | The symbol used to indicate a branch name was truncated. You can use `''` for no symbol. |
 | `only_attached`      | `false`                                           | Only show the branch name when not in a detached `HEAD` state.                           |
 | `ignore_branches`    | `[]`                                              | A list of names to avoid displaying. Useful for 'master' or 'main'.                      |
+| `ignore_remotes`     | `[]`                                              | A list of remotes to avoid displaying. Useful for 'origin' or fetch-only remotes.        |
 | `ignore_bare_repo`   | `false`                                           | Do not show when in a bare repo.                                                         |
 | `disabled`           | `false`                                           | Disables the `git_branch` module.                                                        |
 
@@ -1941,6 +1942,7 @@ symbol = '🌱 '
 truncation_length = 4
 truncation_symbol = ''
 ignore_branches = ['master', 'main']
+ignore_remotes = ['origin', 'upstream']
 ```
 
 ## Git Commit

--- a/src/configs/git_branch.rs
+++ b/src/configs/git_branch.rs
@@ -16,6 +16,7 @@ pub struct GitBranchConfig<'a> {
     pub only_attached: bool,
     pub always_show_remote: bool,
     pub ignore_branches: Vec<&'a str>,
+    pub ignore_remotes: Vec<&'a str>,
     pub ignore_bare_repo: bool,
     pub disabled: bool,
 }
@@ -31,6 +32,7 @@ impl Default for GitBranchConfig<'_> {
             only_attached: false,
             always_show_remote: false,
             ignore_branches: vec![],
+            ignore_remotes: vec![],
             ignore_bare_repo: false,
             disabled: false,
         }

--- a/src/modules/git_branch.rs
+++ b/src/modules/git_branch.rs
@@ -96,6 +96,11 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         return None;
     }
 
+    let is_ignored_remote = config
+        .ignore_remotes
+        .iter()
+        .any(|ignored| remote_name.as_deref() == Some(ignored));
+
     let mut graphemes: Vec<&str> = branch_name.graphemes(true).collect();
 
     let remote_branch_string = remote_branch.unwrap_or_default();
@@ -142,7 +147,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                     }
                 }
                 "remote_name" => {
-                    if show_remote && !remote_name_graphemes.is_empty() {
+                    if show_remote && !is_ignored_remote && !remote_name_graphemes.is_empty() {
                         Some(Ok(remote_name_graphemes.concat()))
                     } else {
                         None
@@ -514,6 +519,46 @@ mod tests {
 
             assert_eq!(expected, actual);
             repo_dir.close()?;
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_ignore_remotes() -> io::Result<()> {
+        for &mode in COMMON_GIT_PROVIDERS {
+            let remote_dir = fixture_repo(mode)?;
+            let repo_dir = fixture_repo(mode)?;
+
+            create_command("git")?
+                .args(["checkout", "-b", "test_branch"])
+                .current_dir(repo_dir.path())
+                .output()?;
+
+            create_command("git")?
+                .args(["remote", "add", "--fetch", "remote_repo"])
+                .arg(remote_dir.path())
+                .current_dir(repo_dir.path())
+                .output()?;
+
+            create_command("git")?
+                .args(["branch", "--set-upstream-to", "remote_repo/master"])
+                .current_dir(repo_dir.path())
+                .output()?;
+
+            let actual = ModuleRenderer::new("git_branch")
+                .path(repo_dir.path())
+                .config(toml::toml! {
+                    [git_branch]
+                        ignore_remotes = ["remote_repo"]
+                        format = "($remote_name/)$branch"
+                })
+                .collect();
+
+            let expected = Some("test_branch");
+
+            assert_eq!(expected, actual.as_deref());
+            repo_dir.close()?;
+            remote_dir.close()?;
         }
         Ok(())
     }

--- a/src/modules/git_branch.rs
+++ b/src/modules/git_branch.rs
@@ -526,8 +526,10 @@ mod tests {
     #[test]
     fn test_ignore_remotes() -> io::Result<()> {
         for &mode in COMMON_GIT_PROVIDERS {
-            let remote_dir = fixture_repo(mode)?;
-            let repo_dir = fixture_repo(mode)?;
+            // Both repos must use the same hash format; SHA1/SHA256 repos can't fetch from each other.
+            let sha256 = rand::random();
+            let remote_dir = fixture_repo_with_hash(mode, sha256)?;
+            let repo_dir = fixture_repo_with_hash(mode, sha256)?;
 
             create_command("git")?
                 .args(["checkout", "-b", "test_branch"])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

This PR adds a `ignore_remotes` key to the `[git_branch]` module.
This is an analogous counterpart to the existing `ignore_branches` key.

#### Description
<!--- Describe your changes in detail -->

The `git_branch.ignore_remotes` list is intended to let users selectively suppress the outputting of specified `$remote_name` values as part of the `[git_branch]` output.
This is intended to serve the same purpose as the existing `git_branch.ignore_branches` list,
but for remotes.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Being able to filter the default (`origin`) remote, or "fetch-only" remotes (e.g. `upstream`) from the `[git_branch]` output is a feature I have wanted to have available for a while.

In my particular usecase I often have a `origin` and `upstream` remote for my development repos,
as well as occasional additional remotes for pushing to PRs by other authors for assistance/cleanup.
Being able to tell if I'm on a branch from a different remote than my `origin` or `upstream` at a glance is quite useful in this workflow.
See also, screenshot below:

#### Screenshots (if appropriate):

<img width="1855" height="929" alt="image" src="https://github.com/user-attachments/assets/155f2b14-ce88-4800-918c-efff946aaaf4" />


#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- Most changes do not need to be tested on multiple operating systems. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

I've had some trouble getting the test case to work consistently.
*I think* it's correct as it is committed here, but it seems to fail if the remote is added via `git remote add --fetch` instead of `git remote add`.
I do not understand why this impacts the output of `ModuleRenderer::new("git_branch")` in a way that breaks `ignore_remotes`, though there may be an early return in that case that I can't seem to spot.

#### AI-Assistance
<!-- Per our AI Policy (AI_POLICY.md), all AI usage must be declared. -->
Have you used AI-assistance to author this PR?

- [ ] Yes
- [x] No

If **yes**, describe the scope of assistance:
<!--- Describe how you used AI-Assistance -->
<!--- Disclosure is required if you have used AI-assistance -->
<!--- For example: answering project questions, writing tests, implementation, or documentation -->
N/A

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
- [x] I understand and have read the code I contribute and can answer questions about it.

I do not write in Rust very often, so my code here may be a bit rough around the edges.
The implementation for `ignore_remotes` is largely a carbon copy of `ignore_branches`.
And the test case is largely based on the existing `test_remote` test cases in the `git_branch.rs` module.
It's ***very*** possible I've made mistakes here.
I need to call it a night though and the test case is passing now.