### PR TITLE
feat(claude_rate_limits): add Claude Code rate limit module

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -253,6 +253,40 @@
         "disabled": false
       }
     },
+    "claude_rate_limits": {
+      "$ref": "#/$defs/ClaudeRateLimitsConfig",
+      "default": {
+        "format": "[$symbol( 5h $five_hour_percentage)( 7d $seven_day_percentage)]($style) ",
+        "symbol": "⏳",
+        "gauge_width": 5,
+        "gauge_full_symbol": "█",
+        "gauge_partial_symbol": "▒",
+        "gauge_empty_symbol": "░",
+        "display": [
+          {
+            "threshold": 0.0,
+            "style": "bold green",
+            "hidden": true
+          },
+          {
+            "threshold": 50.0,
+            "style": "bold green",
+            "hidden": false
+          },
+          {
+            "threshold": 70.0,
+            "style": "bold yellow",
+            "hidden": false
+          },
+          {
+            "threshold": 90.0,
+            "style": "bold red",
+            "hidden": false
+          }
+        ],
+        "disabled": false
+      }
+    },
     "cmake": {
       "$ref": "#/$defs/CMakeConfig",
       "default": {
@@ -2455,6 +2489,71 @@
             "type": "string"
           },
           "default": {}
+        },
+        "disabled": {
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "ClaudeRateLimitsConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "type": "string",
+          "default": "[$symbol( 5h $five_hour_percentage)( 7d $seven_day_percentage)]($style) "
+        },
+        "symbol": {
+          "type": "string",
+          "default": "⏳"
+        },
+        "gauge_width": {
+          "type": "integer",
+          "format": "uint8",
+          "minimum": 0,
+          "maximum": 255,
+          "default": 5
+        },
+        "gauge_full_symbol": {
+          "type": "string",
+          "default": "█"
+        },
+        "gauge_partial_symbol": {
+          "type": "string",
+          "default": "▒"
+        },
+        "gauge_empty_symbol": {
+          "type": "string",
+          "default": "░"
+        },
+        "display": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ClaudeDisplayConfig"
+          },
+          "default": [
+            {
+              "threshold": 0.0,
+              "style": "bold green",
+              "hidden": true
+            },
+            {
+              "threshold": 50.0,
+              "style": "bold green",
+              "hidden": false
+            },
+            {
+              "threshold": 70.0,
+              "style": "bold yellow",
+              "hidden": false
+            },
+            {
+              "threshold": 90.0,
+              "style": "bold red",
+              "hidden": false
+            }
+          ]
         },
         "disabled": {
           "type": "boolean",

--- a/docs/advanced-config/README.md
+++ b/docs/advanced-config/README.md
@@ -384,6 +384,8 @@ The default profile format is:
 claude-code = "$claude_model$git_branch$claude_context$claude_cost"
 ```
 
+An additional module, `claude_rate_limits`, shows subscription rate limit usage. It is not part of the default profile, so add it to the profile format to use it.
+
 ### Configuration
 
 You can customize the Claude Code statusline by modifying the `claude-code` profile and individual module configurations in your `~/.config/starship.toml`:
@@ -653,6 +655,100 @@ style = "bold red"
 # Show duration information
 [claude_cost]
 format = "[$symbol$cost ($duration)]($style) "
+```
+
+### Claude Rate Limits
+
+The `claude_rate_limits` module displays how much of your Claude.ai subscription rate limits the session has consumed, for both the 5-hour and the 7-day window. Like `claude_context`, it supports gauges and threshold-based styling.
+
+Claude Code only reports rate limits for Claude.ai subscriptions (Pro/Max), and only after the first API response of a session. Each window is reported separately, so the module hides the parts of the format belonging to a window that is missing.
+
+#### Options
+
+| Option                 | Default                                                                      | Description                                      |
+| ---------------------- | ---------------------------------------------------------------------------- | ------------------------------------------------ |
+| `format`               | `'[$symbol( 5h $five_hour_percentage)( 7d $seven_day_percentage)]($style) '` | The format for the module.                       |
+| `symbol`               | `'⏳'`                                                                       | The symbol shown before the usage.               |
+| `gauge_width`          | `5`                                                                          | The width of a gauge in characters.              |
+| `gauge_full_symbol`    | `'█'`                                                                        | The symbol used for filled segments of a gauge.  |
+| `gauge_partial_symbol` | `'▒'`                                                                        | The symbol used for partial segments of a gauge. |
+| `gauge_empty_symbol`   | `'░'`                                                                        | The symbol used for empty segments of a gauge.   |
+| `display`              | [see below](#display-2)                                                      | Threshold and style configurations.              |
+| `disabled`             | `false`                                                                      | Disables the `claude_rate_limits` module.        |
+
+##### Display
+
+The `display` option is an array of objects that define thresholds and styles. The thresholds are matched against the usage of the window that is closest to its limit. The module uses the style from the highest matching threshold or hides the module if `hidden` is `true`.
+
+| Option      | Default      | Description                                                         |
+| ----------- | ------------ | ------------------------------------------------------------------- |
+| `threshold` | `0.0`        | The minimum rate limit usage percentage to match this configuration |
+| `style`     | `bold green` | The value of `style` if this display configuration is matched       |
+| `hidden`    | `false`      | Hide this module if this configuration is matched.                  |
+
+**Default configuration:**
+
+```toml
+[[claude_rate_limits.display]]
+threshold = 0
+hidden = true
+
+[[claude_rate_limits.display]]
+threshold = 50
+style = "bold green"
+
+[[claude_rate_limits.display]]
+threshold = 70
+style = "bold yellow"
+
+[[claude_rate_limits.display]]
+threshold = 90
+style = "bold red"
+```
+
+#### Variables
+
+| Variable             | Example | Description                                           |
+| -------------------- | ------- | ----------------------------------------------------- |
+| five_hour_percentage | `24%`   | Usage of the 5-hour window                            |
+| five_hour_gauge      | `██▒░░` | Visual representation of the 5-hour window usage      |
+| five_hour_reset      | `1h30m` | Time until the 5-hour window resets                   |
+| seven_day_percentage | `41%`   | Usage of the 7-day window                             |
+| seven_day_gauge      | `██░░░` | Visual representation of the 7-day window usage       |
+| seven_day_reset      | `2d1h`  | Time until the 7-day window resets                    |
+| symbol               |         | Mirrors the value of option `symbol`                  |
+| style\*              |         | Mirrors the style from the matching display threshold |
+
+\*: This variable can only be used as a part of a style string
+
+Variables of a window that Claude Code did not report are unset. A reset variable is empty when the reset time is unknown, already past, or less than a minute away.
+
+#### Examples
+
+```toml
+# ~/.config/starship.toml
+
+# Add the module to the statusline
+[profiles]
+claude-code = "$claude_model$git_branch$claude_context$claude_cost$claude_rate_limits"
+
+# Gauges with the time left in each window
+[claude_rate_limits]
+format = "[$symbol( 5h $five_hour_gauge( $five_hour_reset))( 7d $seven_day_gauge( $seven_day_reset))]($style) "
+
+# Show the module at any usage, instead of only once a limit gets close.
+# A `display` array replaces the default one, so every threshold to keep has to be listed.
+[[claude_rate_limits.display]]
+threshold = 0
+style = "bold green"
+
+[[claude_rate_limits.display]]
+threshold = 70
+style = "bold yellow"
+
+[[claude_rate_limits.display]]
+threshold = 90
+style = "bold red"
 ```
 
 ## Style Strings

--- a/src/configs/claude_rate_limits.rs
+++ b/src/configs/claude_rate_limits.rs
@@ -1,0 +1,58 @@
+use serde::{Deserialize, Serialize};
+
+use crate::configs::claude_context::ClaudeDisplayConfig;
+
+#[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(
+    feature = "config-schema",
+    derive(schemars::JsonSchema),
+    schemars(deny_unknown_fields)
+)]
+#[serde(default)]
+pub struct ClaudeRateLimitsConfig<'a> {
+    pub format: &'a str,
+    pub symbol: &'a str,
+    pub gauge_width: u8,
+    pub gauge_full_symbol: &'a str,
+    pub gauge_partial_symbol: &'a str,
+    pub gauge_empty_symbol: &'a str,
+    #[serde(borrow)]
+    pub display: Vec<ClaudeDisplayConfig<'a>>,
+    pub disabled: bool,
+}
+
+impl Default for ClaudeRateLimitsConfig<'_> {
+    fn default() -> Self {
+        Self {
+            format: "[$symbol( 5h $five_hour_percentage)( 7d $seven_day_percentage)]($style) ",
+            symbol: "⏳",
+            gauge_width: 5,
+            gauge_full_symbol: "█",
+            gauge_partial_symbol: "▒",
+            gauge_empty_symbol: "░",
+            display: vec![
+                ClaudeDisplayConfig {
+                    threshold: 0.,
+                    hidden: true,
+                    ..Default::default()
+                },
+                ClaudeDisplayConfig {
+                    threshold: 50.,
+                    style: "bold green",
+                    ..Default::default()
+                },
+                ClaudeDisplayConfig {
+                    threshold: 70.,
+                    style: "bold yellow",
+                    ..Default::default()
+                },
+                ClaudeDisplayConfig {
+                    threshold: 90.,
+                    style: "bold red",
+                    ..Default::default()
+                },
+            ],
+            disabled: false,
+        }
+    }
+}

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -12,6 +12,7 @@ pub mod character;
 pub mod claude_context;
 pub mod claude_cost;
 pub mod claude_model;
+pub mod claude_rate_limits;
 pub mod cmake;
 pub mod cmd_duration;
 pub mod cobol;
@@ -147,6 +148,8 @@ pub struct FullConfig<'a> {
     claude_cost: claude_cost::ClaudeCostConfig<'a>,
     #[serde(borrow)]
     claude_model: claude_model::ClaudeModelConfig<'a>,
+    #[serde(borrow)]
+    claude_rate_limits: claude_rate_limits::ClaudeRateLimitsConfig<'a>,
     #[serde(borrow)]
     cmake: cmake::CMakeConfig<'a>,
     #[serde(borrow)]

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -29,7 +29,8 @@ use terminal_size::terminal_size;
 
 pub use crate::utils::env::Env;
 pub use crate::utils::statusline::{
-    ClaudeCodeData, ContextWindow, CostInfo, CurrentUsage, ModelInfo, Workspace,
+    ClaudeCodeData, ContextWindow, CostInfo, CurrentUsage, ModelInfo, RateLimitWindow, RateLimits,
+    Workspace,
 };
 
 mod git_repo;

--- a/src/module.rs
+++ b/src/module.rs
@@ -18,6 +18,7 @@ pub const ALL_MODULES: &[&str] = &[
     "claude_context",
     "claude_cost",
     "claude_model",
+    "claude_rate_limits",
     "cmake",
     "cmd_duration",
     "cobol",

--- a/src/modules/claude_context.rs
+++ b/src/modules/claude_context.rs
@@ -1,7 +1,7 @@
 use super::{Context, Module, ModuleConfig};
 use crate::configs::claude_context::ClaudeContextConfig;
 use crate::formatter::StringFormatter;
-use crate::utils::humanize_int;
+use crate::utils::{humanize_int, render_gauge};
 
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let mut module = context.new_module("claude_context");
@@ -45,34 +45,13 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                     _ => None,
                 })
                 .map(|variable| match variable {
-                    "gauge" => {
-                        let filled_float =
-                            (f64::from(percentage) / 100.0) * f64::from(config.gauge_width);
-                        let (filled_count, partial) = if config.gauge_partial_symbol.is_empty() {
-                            (filled_float.round() as usize, false)
-                        } else {
-                            let full = filled_float.floor() as usize;
-                            let rem = filled_float - full as f64;
-                            // Show partial block if remainder is significant enough (> 0.25)
-                            // but if it's very close to 1 (> 0.75), just round up to full (handled by empty_count check)
-                            if rem >= 0.25 {
-                                (full, true)
-                            } else {
-                                (full, false)
-                            }
-                        };
-
-                        let filled_count = filled_count.min(config.gauge_width as usize);
-                        let partial_count =
-                            usize::from(partial && filled_count < config.gauge_width as usize);
-                        let empty_count = (config.gauge_width as usize)
-                            .saturating_sub(filled_count + partial_count);
-
-                        let gauge = config.gauge_full_symbol.repeat(filled_count)
-                            + &config.gauge_partial_symbol.repeat(partial_count)
-                            + &config.gauge_empty_symbol.repeat(empty_count);
-                        Some(Ok(gauge))
-                    }
+                    "gauge" => Some(Ok(render_gauge(
+                        f64::from(percentage),
+                        config.gauge_width,
+                        config.gauge_full_symbol,
+                        config.gauge_partial_symbol,
+                        config.gauge_empty_symbol,
+                    ))),
                     "percentage" => Some(Ok(format!("{percentage}%"))),
                     "input_tokens" => Some(Ok(humanize_int(
                         claude_data.context_window.total_input_tokens,
@@ -210,6 +189,7 @@ mod tests {
             cost: None,
             workspace: None,
             effort: None,
+            rate_limits: None,
         }
     }
 

--- a/src/modules/claude_cost.rs
+++ b/src/modules/claude_cost.rs
@@ -180,6 +180,7 @@ mod tests {
             }),
             workspace: None,
             effort: None,
+            rate_limits: None,
         }
     }
 

--- a/src/modules/claude_model.rs
+++ b/src/modules/claude_model.rs
@@ -78,6 +78,7 @@ mod tests {
             cost: None,
             workspace: None,
             effort: None,
+            rate_limits: None,
         };
         let actual = ModuleRenderer::new("claude_model")
             .config(toml::toml! {
@@ -101,6 +102,7 @@ mod tests {
             cost: None,
             workspace: None,
             effort: None,
+            rate_limits: None,
         };
 
         let actual = ModuleRenderer::new("claude_model")
@@ -129,6 +131,7 @@ mod tests {
             cost: None,
             workspace: None,
             effort: None,
+            rate_limits: None,
         };
 
         let actual = ModuleRenderer::new("claude_model")
@@ -160,6 +163,7 @@ mod tests {
             effort: Some(crate::utils::statusline::EffortInfo {
                 level: "high".to_string(),
             }),
+            rate_limits: None,
         };
 
         let actual = ModuleRenderer::new("claude_model")
@@ -187,6 +191,7 @@ mod tests {
             cost: None,
             workspace: None,
             effort: None,
+            rate_limits: None,
         };
 
         let actual = ModuleRenderer::new("claude_model")
@@ -214,6 +219,7 @@ mod tests {
             cost: None,
             workspace: None,
             effort: None,
+            rate_limits: None,
         };
 
         let actual = ModuleRenderer::new("claude_model")

--- a/src/modules/claude_rate_limits.rs
+++ b/src/modules/claude_rate_limits.rs
@@ -1,0 +1,328 @@
+use super::{Context, Module, ModuleConfig};
+use crate::configs::claude_rate_limits::ClaudeRateLimitsConfig;
+use crate::context::RateLimitWindow;
+use crate::formatter::StringFormatter;
+use crate::utils::render_gauge;
+use jiff::Timestamp;
+
+/// Usage of a window, guarded against a payload reporting a percentage outside 0-100.
+fn used(window: &RateLimitWindow) -> f32 {
+    window.used_percentage.clamp(0.0, 100.0)
+}
+
+/// Time left until a window resets, as its two most significant units (`2d`, `1h30m`, `45m`).
+/// Empty when the reset time is unknown (absent from the payload), already past, or under a
+/// minute away. `utils::render_time` cannot be reused: it appends every lesser unit down to
+/// seconds, with no way to cap the output at two of them.
+fn render_reset(resets_at: i64, now: i64) -> String {
+    let minutes = u64::try_from(resets_at.saturating_sub(now)).unwrap_or(0) / 60;
+    [
+        ("d", minutes / 1440),
+        ("h", minutes / 60 % 24),
+        ("m", minutes % 60),
+    ]
+    .iter()
+    .skip_while(|(_, amount)| *amount == 0)
+    .take(2)
+    // Filtering after taking keeps `2d0h` as `2d` rather than padding it with minutes
+    .filter(|(_, amount)| *amount != 0)
+    .map(|(unit, amount)| format!("{amount}{unit}"))
+    .collect()
+}
+
+pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let mut module = context.new_module("claude_rate_limits");
+    let config = ClaudeRateLimitsConfig::try_load(module.config);
+
+    if config.disabled {
+        return None;
+    }
+
+    // Only reported for Claude.ai subscriptions, and only after the first API response
+    let rate_limits = context.claude_code_data.as_ref()?.rate_limits.as_ref()?;
+    let five_hour = rate_limits.five_hour.as_ref();
+    let seven_day = rate_limits.seven_day.as_ref();
+
+    // The window closest to its limit is the one that matters, so it picks the style
+    let percentage_float = [five_hour, seven_day]
+        .into_iter()
+        .flatten()
+        .map(used)
+        .max_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))?;
+
+    // TODO: this selection is duplicated in `claude_context` and `claude_cost`; it can be
+    // hoisted onto `ClaudeDisplayConfig`, which would also let all three use `?` and drop a
+    // level of nesting around the formatter.
+    let display_style = config
+        .display
+        .iter()
+        .filter(|s| percentage_float >= s.threshold)
+        .max_by(|a, b| {
+            a.threshold
+                .partial_cmp(&b.threshold)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+    if display_style.is_some_and(|s| s.hidden) {
+        return None;
+    }
+
+    if let Some(display_style) = display_style {
+        let now = Timestamp::now().as_second();
+        let percentage = |window: Option<&RateLimitWindow>| {
+            window.map(|w| Ok(format!("{}%", used(w).round() as u8)))
+        };
+        let gauge = |window: Option<&RateLimitWindow>| {
+            window.map(|w| {
+                Ok(render_gauge(
+                    f64::from(used(w).round()),
+                    config.gauge_width,
+                    config.gauge_full_symbol,
+                    config.gauge_partial_symbol,
+                    config.gauge_empty_symbol,
+                ))
+            })
+        };
+        let reset =
+            |window: Option<&RateLimitWindow>| window.map(|w| Ok(render_reset(w.resets_at, now)));
+
+        let parsed = StringFormatter::new(config.format).and_then(|formatter| {
+            formatter
+                .map_meta(|variable, _| match variable {
+                    "symbol" => Some(config.symbol),
+                    _ => None,
+                })
+                .map_style(|variable| match variable {
+                    "style" => Some(Ok(display_style.style)),
+                    _ => None,
+                })
+                .map(|variable| match variable {
+                    "five_hour_percentage" => percentage(five_hour),
+                    "five_hour_gauge" => gauge(five_hour),
+                    "five_hour_reset" => reset(five_hour),
+                    "seven_day_percentage" => percentage(seven_day),
+                    "seven_day_gauge" => gauge(seven_day),
+                    "seven_day_reset" => reset(seven_day),
+                    _ => None,
+                })
+                .parse(None, Some(context))
+        });
+
+        module.set_segments(match parsed {
+            Ok(segments) => segments,
+            Err(error) => {
+                log::warn!("Error in module `claude_rate_limits`: {error}");
+                return None;
+            }
+        });
+
+        Some(module)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{render_reset, used};
+    use crate::context::{ClaudeCodeData, RateLimitWindow, RateLimits};
+    use crate::test::ModuleRenderer;
+    use jiff::Timestamp;
+    use nu_ansi_term::Color;
+
+    fn get_test_claude_data(
+        five_hour: Option<RateLimitWindow>,
+        seven_day: Option<RateLimitWindow>,
+    ) -> ClaudeCodeData {
+        ClaudeCodeData {
+            rate_limits: Some(RateLimits {
+                five_hour,
+                seven_day,
+            }),
+            ..Default::default()
+        }
+    }
+
+    fn window(used_percentage: f32) -> Option<RateLimitWindow> {
+        Some(RateLimitWindow {
+            used_percentage,
+            resets_at: 0,
+        })
+    }
+
+    #[test]
+    fn test_without_data() {
+        let actual = ModuleRenderer::new("claude_rate_limits").collect();
+        assert_eq!(actual, None);
+    }
+
+    #[test]
+    fn test_without_rate_limits() {
+        let actual = ModuleRenderer::new("claude_rate_limits")
+            .claude_code_data(ClaudeCodeData::default())
+            .collect();
+        assert_eq!(
+            actual, None,
+            "module should be hidden for sessions without rate limit data"
+        );
+    }
+
+    #[test]
+    fn test_without_any_window() {
+        let actual = ModuleRenderer::new("claude_rate_limits")
+            .claude_code_data(get_test_claude_data(None, None))
+            .collect();
+        assert_eq!(actual, None);
+    }
+
+    #[test]
+    fn test_disabled() {
+        let actual = ModuleRenderer::new("claude_rate_limits")
+            .config(toml::toml! {
+                [claude_rate_limits]
+                disabled = true
+            })
+            .claude_code_data(get_test_claude_data(window(90.0), window(90.0)))
+            .collect();
+        assert_eq!(actual, None);
+    }
+
+    #[test]
+    fn test_render_with_data() {
+        let actual = ModuleRenderer::new("claude_rate_limits")
+            .claude_code_data(get_test_claude_data(window(23.5), window(72.0)))
+            .collect();
+
+        assert_eq!(
+            actual,
+            Some(format!(
+                "{} ",
+                Color::Yellow.bold().paint("⏳ 5h 24% 7d 72%")
+            )),
+            "the busier window should pick the style"
+        );
+    }
+
+    #[test]
+    fn test_hidden_below_threshold() {
+        let actual = ModuleRenderer::new("claude_rate_limits")
+            .claude_code_data(get_test_claude_data(window(23.5), window(41.2)))
+            .collect();
+        assert_eq!(
+            actual, None,
+            "module should be hidden below the 50% threshold"
+        );
+    }
+
+    #[test]
+    fn test_missing_window_drops_its_group() {
+        let actual = ModuleRenderer::new("claude_rate_limits")
+            .claude_code_data(get_test_claude_data(None, window(55.0)))
+            .collect();
+
+        assert_eq!(
+            actual,
+            Some(format!("{} ", Color::Green.bold().paint("⏳ 7d 55%")))
+        );
+    }
+
+    // Reads the clock twice, as `aws::tests::expiration_date_set` does; the 30s of slack before
+    // the rendered `1h` would tick down to `59m` is ample for an in-process render
+    #[test]
+    fn test_gauge_and_reset() {
+        let data = get_test_claude_data(
+            Some(RateLimitWindow {
+                used_percentage: 55.0,
+                resets_at: Timestamp::now().as_second() + 3630,
+            }),
+            window(20.0),
+        );
+
+        let actual = ModuleRenderer::new("claude_rate_limits")
+            .config(toml::toml! {
+                [claude_rate_limits]
+                format = "[$five_hour_gauge $five_hour_reset|$seven_day_gauge $seven_day_reset]($style) "
+            })
+            .claude_code_data(data)
+            .collect();
+
+        assert_eq!(
+            actual,
+            Some(format!("{} ", Color::Green.bold().paint("██▒░░ 1h|█░░░░ "))),
+            "an unknown reset time should render as nothing"
+        );
+    }
+
+    #[test]
+    fn test_render_with_full_window() {
+        let actual = ModuleRenderer::new("claude_rate_limits")
+            .claude_code_data(get_test_claude_data(window(95.0), window(20.0)))
+            .collect();
+
+        assert_eq!(
+            actual,
+            Some(format!("{} ", Color::Red.bold().paint("⏳ 5h 95% 7d 20%")))
+        );
+    }
+
+    #[test]
+    fn test_threshold_is_inclusive() {
+        for (used, color) in [
+            (50.0, Color::Green),
+            (70.0, Color::Yellow),
+            (90.0, Color::Red),
+        ] {
+            let actual = ModuleRenderer::new("claude_rate_limits")
+                .claude_code_data(get_test_claude_data(window(used), None))
+                .collect();
+
+            assert_eq!(
+                actual,
+                Some(format!(
+                    "{} ",
+                    color.bold().paint(format!("⏳ 5h {used:.0}%"))
+                )),
+                "usage at exactly {used} should match the {used} threshold"
+            );
+        }
+    }
+
+    #[test]
+    fn test_render_reset_days() {
+        let data = get_test_claude_data(
+            window(20.0),
+            Some(RateLimitWindow {
+                used_percentage: 55.0,
+                resets_at: Timestamp::now().as_second() + 176_400,
+            }),
+        );
+
+        let actual = ModuleRenderer::new("claude_rate_limits")
+            .config(toml::toml! {
+                [claude_rate_limits]
+                format = "[7d $seven_day_reset]($style) "
+            })
+            .claude_code_data(data)
+            .collect();
+
+        assert_eq!(
+            actual,
+            Some(format!("{} ", Color::Green.bold().paint("7d 2d1h")))
+        );
+    }
+
+    #[test]
+    fn test_used_clamps_out_of_range_percentages() {
+        assert_eq!(used(&RateLimitWindow::default()), 0.0);
+        assert_eq!(used(&window(-5.0).unwrap()), 0.0);
+        assert_eq!(used(&window(150.0).unwrap()), 100.0);
+    }
+
+    #[test]
+    fn test_render_reset() {
+        assert_eq!(render_reset(1_000_000, 1_000_000 - 5_400), "1h30m");
+        assert_eq!(render_reset(1_000_000, 1_000_000 - 176_400), "2d1h");
+        assert_eq!(render_reset(1_000_000, 1_000_000 - 174_600), "2d");
+        assert_eq!(render_reset(1_000_000, 1_000_000 - 59), "");
+        assert_eq!(render_reset(1_000_000, 1_000_001), "");
+    }
+}

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -9,6 +9,7 @@ mod character;
 mod claude_context;
 mod claude_cost;
 mod claude_model;
+mod claude_rate_limits;
 mod cmake;
 mod cmd_duration;
 mod cobol;
@@ -135,6 +136,7 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
             "claude_context" => claude_context::module(context),
             "claude_cost" => claude_cost::module(context),
             "claude_model" => claude_model::module(context),
+            "claude_rate_limits" => claude_rate_limits::module(context),
             "cmake" => cmake::module(context),
             "cmd_duration" => cmd_duration::module(context),
             "cobol" => cobol::module(context),
@@ -272,6 +274,7 @@ pub fn description(module: &str) -> &'static str {
         "claude_context" => "Context window usage for Claude Code session",
         "claude_cost" => "Cost info for Claude Code session",
         "claude_model" => "AI model name for Claude Code session",
+        "claude_rate_limits" => "Subscription rate limit usage for Claude Code session",
         "cmake" => "The currently installed version of CMake",
         "cmd_duration" => "How long the last command took to execute",
         "cobol" => "The currently installed version of COBOL/GNUCOBOL",

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -834,6 +834,26 @@ pub fn humanize_int(n: u64) -> String {
     }
 }
 
+/// Renders a fixed-width gauge for a percentage between 0 and 100.
+///
+/// The cell straddling the boundary is drawn with `partial` once at least a
+/// quarter of it is used; an empty `partial` rounds to whole cells instead.
+pub fn render_gauge(percentage: f64, width: u8, full: &str, partial: &str, empty: &str) -> String {
+    let width = usize::from(width);
+    let filled = percentage / 100.0 * width as f64;
+    let (filled_count, show_partial) = if partial.is_empty() {
+        (filled.round() as usize, false)
+    } else {
+        (filled.floor() as usize, filled.fract() >= 0.25)
+    };
+
+    let filled_count = filled_count.min(width);
+    let partial_count = usize::from(show_partial && filled_count < width);
+    let empty_count = width.saturating_sub(filled_count + partial_count);
+
+    full.repeat(filled_count) + &partial.repeat(partial_count) + &empty.repeat(empty_count)
+}
+
 pub fn home_dir() -> Option<PathBuf> {
     dirs::home_dir()
 }
@@ -930,6 +950,24 @@ mod tests {
         assert_eq!(humanize_int(100000), "100k");
         assert_eq!(humanize_int(1000000), "1M");
         assert_eq!(humanize_int(1500000), "1.5M");
+    }
+
+    #[test]
+    fn test_render_gauge() {
+        let gauge = |percentage, width| render_gauge(percentage, width, "█", "▒", "░");
+        assert_eq!(gauge(0.0, 5), "░░░░░");
+        assert_eq!(gauge(100.0, 5), "█████");
+        assert_eq!(gauge(50.0, 5), "██▒░░");
+        // A cell is drawn as partial from a quarter of it onwards
+        assert_eq!(gauge(44.0, 5), "██░░░");
+        assert_eq!(gauge(45.0, 5), "██▒░░");
+        // The partial cell never pushes the gauge past its width
+        assert_eq!(gauge(99.0, 5), "████▒");
+        assert_eq!(gauge(50.0, 0), "");
+
+        // An empty partial symbol rounds to whole cells instead
+        assert_eq!(render_gauge(44.0, 5, "█", "", "░"), "██░░░");
+        assert_eq!(render_gauge(50.0, 5, "█", "", "░"), "███░░");
     }
 
     #[test]

--- a/src/utils/statusline.rs
+++ b/src/utils/statusline.rs
@@ -21,6 +21,25 @@ pub struct ClaudeCodeData {
     pub cost: Option<CostInfo>,
     pub workspace: Option<Workspace>,
     pub effort: Option<EffortInfo>,
+    pub rate_limits: Option<RateLimits>,
+}
+
+/// Subscription rate limit usage. Each window is reported independently.
+#[derive(Deserialize, Debug, Clone, Default)]
+#[serde(default)]
+pub struct RateLimits {
+    pub five_hour: Option<RateLimitWindow>,
+    pub seven_day: Option<RateLimitWindow>,
+}
+
+#[derive(Deserialize, Debug, Clone, Default)]
+#[serde(default)]
+pub struct RateLimitWindow {
+    #[serde(deserialize_with = "deserialize_null_default")]
+    pub used_percentage: f32,
+    /// Unix epoch seconds at which the window resets.
+    #[serde(deserialize_with = "deserialize_null_default")]
+    pub resets_at: i64,
 }
 
 #[derive(Deserialize, Debug, Clone, Default)]
@@ -134,6 +153,74 @@ mod tests {
             data.context_window.current_usage.cache_read_input_tokens,
             20
         );
+    }
+
+    #[test]
+    fn test_deserializes_rate_limits_with_one_window() {
+        let payload = r#"{
+            "rate_limits": {
+                "five_hour": {
+                    "used_percentage": 23.5,
+                    "resets_at": 1738425600
+                }
+            }
+        }"#;
+
+        let data: ClaudeCodeData =
+            serde_json::from_str(payload).expect("rate limit payload must deserialize");
+
+        let rate_limits = data.rate_limits.expect("rate_limits must be present");
+        let five_hour = rate_limits.five_hour.expect("five_hour must be present");
+        assert!((five_hour.used_percentage - 23.5).abs() < f32::EPSILON);
+        assert_eq!(five_hour.resets_at, 1_738_425_600);
+        assert!(
+            rate_limits.seven_day.is_none(),
+            "windows are reported independently"
+        );
+    }
+
+    #[test]
+    fn test_deserializes_rate_limits_with_null_window_fields() {
+        let payload = r#"{
+            "model": {
+                "id": "claude-opus-4-7[1m]",
+                "display_name": "Opus 4.7 (1M context)"
+            },
+            "rate_limits": {
+                "five_hour": {
+                    "used_percentage": null,
+                    "resets_at": null
+                },
+                "seven_day": null
+            }
+        }"#;
+
+        let data: ClaudeCodeData =
+            serde_json::from_str(payload).expect("session-start payload must deserialize");
+
+        // A null anywhere in `rate_limits` must not discard the whole payload
+        assert_eq!(data.model.display_name, "Opus 4.7 (1M context)");
+        let rate_limits = data.rate_limits.expect("rate_limits must be present");
+        let five_hour = rate_limits.five_hour.expect("five_hour must be present");
+        assert_eq!(five_hour.used_percentage, 0.0);
+        assert_eq!(five_hour.resets_at, 0);
+        assert!(rate_limits.seven_day.is_none());
+    }
+
+    #[test]
+    fn test_missing_rate_limit_window_fields_default() {
+        let payload = r#"{ "rate_limits": { "five_hour": {} } }"#;
+
+        let data: ClaudeCodeData =
+            serde_json::from_str(payload).expect("rate limit payload must deserialize");
+
+        let five_hour = data
+            .rate_limits
+            .expect("rate_limits must be present")
+            .five_hour
+            .expect("five_hour must be present");
+        assert_eq!(five_hour.used_percentage, 0.0);
+        assert_eq!(five_hour.resets_at, 0);
     }
 
     #[test]


### PR DESCRIPTION
#### Description

Adds a `claude_rate_limits` module for the `claude-code` statusline profile. It displays how much of the Claude.ai subscription rate limits the session has consumed, for the 5-hour and the 7-day window, from the `rate_limits` object in the [statusline payload](https://code.claude.com/docs/en/statusline).

- Variables per window: `five_hour_percentage`, `five_hour_gauge`, `five_hour_reset`, `five_hour_style` and the `seven_day_*` equivalents. Claude Code reports each window independently, so the default format wraps each window in a conditional group and a missing window simply drops out of the output.
- Thresholds and styles reuse `ClaudeDisplayConfig` from `claude_context`. The two windows share one `display` array but are matched against it separately, on their own usage, so each takes its own style: the 5-hour window can be red while the 7-day window is yellow, or hidden while the 7-day window still shows. `$style` covers whatever sits outside both groups and follows the busier of the windows being shown. The defaults hide a window below 50% usage and style it green/yellow/red at 50/70/90; the module disappears once neither window is left.
- `$five_hour_reset` / `$seven_day_reset` render the time left as its two most significant non-zero units (`2d1h`, `2d30m`, `1h30m`, `45m`), and are empty when the payload carries no reset time. `render_time` was not usable here because it pads trailing zero units (`1h0m0s`).
- The gauge drawing that lived inline in `claude_context` moved to `utils::render_gauge` and is now shared by both modules. Behaviour is unchanged: the existing `claude_context` tests pass untouched.
- The module is deliberately **not** part of the default `claude-code` profile, so the default statusline output is unchanged. The docs show the `[profiles]` line needed to enable it.

Regarding the New Module Checklist: like the other `claude_*` modules, this one is a statusline module rather than a prompt module, so it has no `PROMPT_ORDER` entry and no preset entries, and it is documented in `docs/advanced-config/README.md` next to `claude_context` and `claude_cost` rather than in `docs/config/README.md`.

Since the first push, a review pass over the diff produced a handful of changes: `RateLimitWindow`'s scalars now use `deserialize_null_default`, matching `ContextWindow` after #7533 — without it a single `null` under `rate_limits` fails the whole payload parse, which degrades every Claude module's output, including for users who never enabled this one. The reset arithmetic uses `saturating_sub`. The `display` example in the docs now re-supplies every threshold, since a user-supplied array replaces the default rather than merging with it. Tests were added for the threshold boundaries, the multi-day reset, null and missing window fields, and `render_gauge` itself, which had no direct tests. The display-threshold selection is now duplicated a third time (it already was between `claude_context` and `claude_cost`); I left it alone to keep this diff focused and added a `TODO` — happy to hoist it onto `ClaudeDisplayConfig` here or in a follow-up, whichever you prefer.

Two later commits change behaviour, so they are worth reviewing on their own: the reset time now skips zero units instead of truncating at them (`2d30m` where it previously rendered `2d`), and each window is now styled by its own usage rather than both taking the style of the busier one.

#### Motivation and Context

The 5-hour and weekly limits are the numbers a subscriber most wants at a glance during a session. Claude Code publishes them in the statusline payload, but starship had no way to surface them.

No open issue.

#### Screenshots (if appropriate):

<img width="2660" height="448" alt="claude_rate_limits" src="https://github.com/user-attachments/assets/c54804a0-2693-4a70-98a7-618a46251dd4" />

Each threshold tier, a window hidden on its own, two windows styled differently at once, and the opt-in gauge/reset format — rendered by `starship statusline claude-code` from crafted payloads.

Default format, with the 5-hour window green and the 7-day window red:

```
🤖 Opus 5 on  main ███▒░ 45% 💰 $2.50 ⏳ 5h 55% 7d 92%
```

#### How Has This Been Tested?

- `cargo test`, `cargo clippy --all-targets --all-features`, `cargo fmt --check` and `dprint check` all clean; `.github/config-schema.json` regenerated.
- Unit tests cover the new module (rendering, thresholds and their boundaries, a missing window, a window hidden on its own, each window taking its own style, gauges, reset formatting) and the deserialization of the `rate_limits` payload.
- Manually exercised by piping payloads into `starship statusline claude-code`: both windows present, only one window present, and `rate_limits` absent entirely (as it is for non-subscription sessions and before the first API response).

- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### AI-Assistance

Have you used AI-assistance to author this PR?

- [x] Yes
- [ ] No

If **yes**, describe the scope of assistance:

The implementation, tests and documentation in this PR were written with Claude Code (Opus 5), working from the Claude Code statusline documentation and the existing `claude_context` / `claude_cost` modules as the pattern to follow.

The diff was then reviewed with Claude Code as well, which is where the null-payload handling, the `saturating_sub`, the corrected `display` example and several of the added tests came from. Each finding was checked against the code, and a few were discarded as wrong before anything was applied. The screenshot was regenerated with Claude Code after the per-window styling change.

Before taking the PR out of draft, I (the human) reviewed every line of code myself. I feel confident I can answer questions about it.

#### Checklist:

- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
- [x] I understand and have read the code I contribute and can answer questions about it.


