### PR TITLE
docs: guard prompt init in non-interactive shells

### DIFF
--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -162,13 +162,13 @@ pub fn init_stub(shell_name: &str) -> io::Result<()> {
              * https://github.com/starship/starship/pull/5020
              * https://github.com/starship/starship/issues/5382
              */
-            r#"eval -- "$({0} init bash --print-full-init)""#,
+            r#"if [[ $- == *i* ]]; then eval -- "$({0} init bash --print-full-init)"; fi"#,
             starship.sprint_posix()?
         ),
         "zsh" => print_script(ZSH_INIT, &starship.sprint_posix()?),
         "fish" => print!(
             // Fish does process substitution with pipes and psub instead of bash syntax
-            r"source ({} init fish --print-full-init | psub)",
+            r"if status is-interactive; source ({} init fish --print-full-init | psub); end",
             starship.sprint_posix()?
         ),
         "powershell" => print!(


### PR DESCRIPTION
#### Description

Update the shell initialization examples to avoid initializing Starship in non-interactive shells.

* Guard the Bash initialization with an interactive-shell check.
* Guard the Fish initialization with `status is-interactive`.
* Apply the same guidance to both the repository README and the documentation homepage.
* Leave Zsh unchanged, since `.zshrc` is intended for interactive shells.

#### Motivation and Context

Starship is a prompt, so initializing it in a non-interactive shell is unnecessary and can cause unexpected output.

This matters in environments such as SSH remote commands, `rsync`, CI jobs, and coding agents, where a shell startup file may still be evaluated even though no interactive prompt is needed. These environments may also use `TERM=dumb`, causing Starship to emit messages such as:

```text
[ERROR] - (starship::print): Under a 'dumb' terminal (TERM=dumb).
```

Such output can pollute command output and, in some cases, interfere with tools that expect a clean protocol stream.

Using an interactive-shell guard prevents Starship from being initialized in these cases while preserving the existing behavior for normal terminal sessions.

Related discussions:

* #1588
* #6419

#### Screenshots (if appropriate)

N/A — documentation-only change.

#### How Has This Been Tested?

* [ ] I have tested using **MacOS**

* [x] I have tested using **Linux**

* [ ] I have tested using **Windows**

#### AI-Assistance

Have you used AI-assistance to author this PR?

* [ ] Yes
* [x] No

If **yes**, describe the scope of assistance:

#### Checklist:

* [x] I have updated the documentation accordingly.
* [ ] I have updated the tests accordingly. Tests are not applicable because this is a documentation-only change.
* [x] I understand and have read the changes I contribute and can answer questions about them.
