### PR TITLE
fix(java): Capture full Java version

### DIFF
--- a/src/modules/java.rs
+++ b/src/modules/java.rs
@@ -139,10 +139,16 @@ mod tests {
     fn folder_with_java_file_preview() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("Main.java"))?.sync_all()?;
-        let actual = ModuleRenderer::new("java").cmd("java -version", Some(CommandOutput {
-            stdout: "openjdk version \"16\" 2021-01-17".to_owned(),
-            stderr: String::new()
-        })).path(dir.path()).collect();
+        let actual = ModuleRenderer::new("java")
+            .cmd(
+                "java -version",
+                Some(CommandOutput {
+                    stdout: "openjdk version \"16\" 2021-01-17".to_owned(),
+                    stderr: String::new(),
+                }),
+            )
+            .path(dir.path())
+            .collect();
         let expected = Some(format!("via {}", Color::Red.dimmed().paint("☕ v16 ")));
         assert_eq!(expected, actual);
         dir.close()
@@ -250,11 +256,13 @@ mod tests {
 
         let actual = ModuleRenderer::new("java")
             .env("JAVA_HOME", java_home.to_str().unwrap())
-            .cmd(&format!("{} -version", java_bin.to_str().unwrap()),
-            Some(CommandOutput {
-                stdout: "openjdk version \"11.0.4\" 2019-07-17".to_owned(),
-                stderr: String::new(),
-            }))
+            .cmd(
+                &format!("{} -version", java_bin.to_str().unwrap()),
+                Some(CommandOutput {
+                    stdout: "openjdk version \"11.0.4\" 2019-07-17".to_owned(),
+                    stderr: String::new(),
+                }),
+            )
             .path(dir.path())
             .collect();
         let expected = Some(format!("via {}", Color::Red.dimmed().paint("☕ v11.0.4 ")));

--- a/src/modules/java.rs
+++ b/src/modules/java.rs
@@ -107,6 +107,7 @@ mod tests {
         assert_eq!(parse_java_version_output(java_version_output), Some("25.0.4.1".to_string()));
     }
 
+    #[test]
     fn test_parse_java_version_output_oracle_jdk() {
         let java_version_output = "java version \"17.0.8\" 2023-07-18 LTS\nJava(TM) SE Runtime Environment (build 17.0.8+9-LTS-211)\nJava HotSpot(TM) 64-Bit Server VM (build 17.0.8+9-LTS-211, mixed mode, sharing)";
         assert_eq!(parse_java_version_output(java_version_output), Some("17.0.8".to_string()));

--- a/src/modules/java.rs
+++ b/src/modules/java.rs
@@ -278,7 +278,7 @@ mod tests {
             .cmd(
                 &format!("{} -version", java_bin.to_str().unwrap()),
                 Some(CommandOutput {
-                    stdout: "openjdk version \"11.0.4\" 2019-07-17".to_owned(),
+                    stdout: "openjdk version \"11.0.4\" 2019-07-16\nOpenJDK Runtime Environment (build 11.0.4+11)\nOpenJDK 64-Bit Server VM (build 11.0.4+11, mixed mode, sharing)".to_owned(),
                     stderr: String::new(),
                 }),
             )

--- a/src/modules/java.rs
+++ b/src/modules/java.rs
@@ -78,7 +78,9 @@ fn get_java_version(context: &Context) -> Option<String> {
 fn parse_java_version_output(java_version_output: &str) -> Option<String> {
     let version_line = java_version_output
         .lines()
-        .find(|line| line.contains("version \""))?;
+        .find(|line| {
+            line.starts_with("java version \"") || line.starts_with("openjdk version \"")
+        })?;
 
     parse_java_version_line(version_line)
         .map(ToString::to_string)

--- a/src/modules/java.rs
+++ b/src/modules/java.rs
@@ -102,9 +102,14 @@ mod tests {
     use std::io;
 
     #[test]
-    fn test_parse_java_version_output() {
+    fn test_parse_java_version_output_openjdk() {
         let java_version_output = "openjdk version \"25.0.4.1\" 2026-08-18 LTS\nOpenJDK Runtime Environment Zulu25.36+205-CA (build 25.0.4.1+1-LTS)\nOpenJDK 64-Bit Server VM Zulu25.36+205-CA (build 25.0.4.1+1-LTS, mixed mode, sharing)";
         assert_eq!(parse_java_version_output(java_version_output), Some("25.0.4.1".to_string()));
+    }
+
+    fn test_parse_java_version_output_oracle_jdk() {
+        let java_version_output = "java version \"17.0.8\" 2023-07-18 LTS\nJava(TM) SE Runtime Environment (build 17.0.8+9-LTS-211)\nJava HotSpot(TM) 64-Bit Server VM (build 17.0.8+9-LTS-211, mixed mode, sharing)";
+        assert_eq!(parse_java_version_output(java_version_output), Some("17.0.8".to_string()));
     }
 
     #[test]

--- a/src/modules/java.rs
+++ b/src/modules/java.rs
@@ -168,7 +168,7 @@ mod tests {
             .cmd(
                 "java -version",
                 Some(CommandOutput {
-                    stdout: "openjdk version \"16\" 2021-01-17".to_owned(),
+                    stdout: "openjdk version \"16\" 2021-03-16\nOpenJDK Runtime Environment (build 16+36)\nOpenJDK 64-Bit Server VM (build 16+36, mixed mode, sharing)".to_owned(),
                     stderr: String::new(),
                 }),
             )

--- a/src/modules/java.rs
+++ b/src/modules/java.rs
@@ -71,19 +71,18 @@ fn get_java_version(context: &Context) -> Option<String> {
 
     let output = context.exec_cmd(java_command, &["-version"])?;
     let java_version_string = get_command_string_output(output);
-    let first_line = java_version_string.lines().next()?;
+    let version_line = java_version_string
+        .lines()
+        .find(|line| line.contains("version \""))?;
 
-    parse_java_version(first_line)
+    parse_java_version_line(version_line).map(ToString::to_string)
 }
 
-fn parse_java_version(java_version_string: &str) -> Option<String> {
-    let version = java_version_string.split('"').nth(1)?;
-
-    if version.is_empty() {
-        return None;
-    }
-
-    Some(version.to_string())
+fn parse_java_version_line(java_version_line: &str) -> Option<&str> {
+    java_version_line
+        .split('"')
+        .nth(1)
+        .filter(|v| !v.is_empty())
 }
 
 #[cfg(test)]
@@ -95,25 +94,19 @@ mod tests {
     use std::io;
 
     #[test]
-    fn test_parse_java_version_openjdk() {
+    fn test_parse_java_version_line_openjdk() {
         let java_8 = "openjdk version \"1.8.0_222\"";
         let java_11 = "openjdk version \"11.0.4\" 2019-07-18";
         let java_25 = "openjdk version \"25.0.4.1\" 2026-08-18 LTS";
-        assert_eq!(parse_java_version(java_8), Some("1.8.0_222".to_string()));
-        assert_eq!(parse_java_version(java_11), Some("11.0.4".to_string()));
-        assert_eq!(parse_java_version(java_25), Some("25.0.4.1".to_string()));
+        assert_eq!(parse_java_version_line(java_8), Some("1.8.0_222"));
+        assert_eq!(parse_java_version_line(java_11), Some("11.0.4"));
+        assert_eq!(parse_java_version_line(java_25), Some("25.0.4.1"));
     }
 
     #[test]
-    fn test_parse_java_version_oracle() {
+    fn test_parse_java_version_line_oracle() {
         let java_8 = "java version \"1.8.0_65\"";
-        assert_eq!(parse_java_version(java_8), Some("1.8.0_65".to_string()));
-    }
-
-    #[test]
-    fn test_parse_java_version_unknown() {
-        let unknown_jre = "Unknown JRE";
-        assert_eq!(parse_java_version(unknown_jre), None);
+        assert_eq!(parse_java_version_line(java_8), Some("1.8.0_65"));
     }
 
     #[test]
@@ -266,6 +259,25 @@ mod tests {
             .path(dir.path())
             .collect();
         let expected = Some(format!("via {}", Color::Red.dimmed().paint("☕ v11.0.4 ")));
+        assert_eq!(expected, actual);
+        dir.close()
+    }
+
+    #[test]
+    fn java_version_not_on_first_line() -> io::Result<()> {
+        let dir = tempfile::tempdir()?;
+        File::create(dir.path().join("Main.java"))?.sync_all()?;
+        let actual = ModuleRenderer::new("java")
+            .cmd(
+                "java -version",
+                Some(CommandOutput {
+                    stdout: "Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8\nopenjdk version \"17.0.5\" 2022-10-18 LTS\nOpenJDK Runtime Environment (build 17.0.5+8)\n".to_owned(),
+                    stderr: String::new(),
+                }),
+            )
+            .path(dir.path())
+            .collect();
+        let expected = Some(format!("via {}", Color::Red.dimmed().paint("☕ v17.0.5 ")));
         assert_eq!(expected, actual);
         dir.close()
     }

--- a/src/modules/java.rs
+++ b/src/modules/java.rs
@@ -4,10 +4,6 @@ use crate::formatter::{StringFormatter, VersionFormatter};
 use crate::utils::get_command_string_output;
 use std::path::PathBuf;
 
-use regex::Regex;
-const JAVA_VERSION_PATTERN: &str =
-    "(?:JRE.*\\(|OpenJ9 )(?P<version>\\d+(?:\\.\\d+){0,2}).*, built on";
-
 /// Creates a module with the current Java version
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let mut module = context.new_module("java");
@@ -73,16 +69,19 @@ fn get_java_version(context: &Context) -> Option<String> {
         })
         .unwrap_or_else(|| String::from("java"));
 
-    let output = context.exec_cmd(java_command, &["-Xinternalversion"])?;
+    let output = context.exec_cmd(java_command, &["-version"])?;
     let java_version_string = get_command_string_output(output);
+    let first_line = java_version_string.lines().next()?;
 
-    parse_java_version(&java_version_string)
+    parse_java_version(first_line)
 }
 
 fn parse_java_version(java_version_string: &str) -> Option<String> {
-    let re = Regex::new(JAVA_VERSION_PATTERN).ok()?;
-    let captures = re.captures(java_version_string)?;
-    let version = &captures["version"];
+    let version = java_version_string.split('"').nth(1)?;
+
+    if version.is_empty() {
+        return None;
+    }
 
     Some(version.to_string())
 }
@@ -97,68 +96,18 @@ mod tests {
 
     #[test]
     fn test_parse_java_version_openjdk() {
-        let java_8 = "OpenJDK 64-Bit Server VM (25.222-b10) for linux-amd64 JRE (1.8.0_222-b10), built on Jul 11 2019 10:18:43 by \"openjdk\" with gcc 4.4.7 20120313 (Red Hat 4.4.7-23)";
-        let java_11 = "OpenJDK 64-Bit Server VM (11.0.4+11-post-Ubuntu-1ubuntu219.04) for linux-amd64 JRE (11.0.4+11-post-Ubuntu-1ubuntu219.04), built on Jul 18 2019 18:21:46 by \"build\" with gcc 8.3.0";
-        assert_eq!(parse_java_version(java_8), Some("1.8.0".to_string()));
+        let java_8 = "openjdk version \"1.8.0_222\"";
+        let java_11 = "openjdk version \"11.0.4\" 2019-07-18";
+        let java_25 = "openjdk version \"25.0.4.1\" 2026-08-18 LTS";
+        assert_eq!(parse_java_version(java_8), Some("1.8.0_222".to_string()));
         assert_eq!(parse_java_version(java_11), Some("11.0.4".to_string()));
+        assert_eq!(parse_java_version(java_25), Some("25.0.4.1".to_string()));
     }
 
     #[test]
     fn test_parse_java_version_oracle() {
-        let java_8 = "Java HotSpot(TM) Client VM (25.65-b01) for linux-arm-vfp-hflt JRE (1.8.0_65-b17), built on Oct  6 2015 16:19:04 by \"java_re\" with gcc 4.7.2 20120910 (prerelease)";
-        assert_eq!(parse_java_version(java_8), Some("1.8.0".to_string()));
-    }
-
-    #[test]
-    fn test_parse_java_version_redhat() {
-        let java_8 = "OpenJDK 64-Bit Server VM (25.222-b10) for linux-amd64 JRE (1.8.0_222-b10), built on Jul 11 2019 20:48:53 by \"root\" with gcc 7.3.1 20180303 (Red Hat 7.3.1-5)";
-        let java_12 = "OpenJDK 64-Bit Server VM (12.0.2+10) for linux-amd64 JRE (12.0.2+10), built on Jul 18 2019 14:41:47 by \"jenkins\" with gcc 7.3.1 20180303 (Red Hat 7.3.1-5)";
-        assert_eq!(parse_java_version(java_8), Some("1.8.0".to_string()));
-        assert_eq!(parse_java_version(java_12), Some("12.0.2".to_string()));
-    }
-
-    #[test]
-    fn test_parse_java_version_zulu() {
-        let java_8 = "OpenJDK 64-Bit Server VM (25.222-b10) for linux-amd64 JRE (Zulu 8.40.0.25-CA-linux64) (1.8.0_222-b10), built on Jul 11 2019 11:36:39 by \"zulu_re\" with gcc 4.4.7 20120313 (Red Hat 4.4.7-3)";
-        let java_11 = "OpenJDK 64-Bit Server VM (11.0.4+11-LTS) for linux-amd64 JRE (Zulu11.33+15-CA) (11.0.4+11-LTS), built on Jul 11 2019 21:37:17 by \"zulu_re\" with gcc 4.9.2 20150212 (Red Hat 4.9.2-6)";
-        let java_17 = "OpenJDK 64-Bit Server VM (17.0.5+8-LTS) for bsd-amd64 JRE (17.0.5+8-LTS) (Zulu17.38+21-CA), built on Oct  7 2022 06:03:12 by \"zulu_re\" with clang 4.2.1 Compatible Apple LLVM 11.0.0 (clang-1100.0.33.17)";
-        assert_eq!(parse_java_version(java_8), Some("1.8.0".to_string()));
-        assert_eq!(parse_java_version(java_11), Some("11.0.4".to_string()));
-        assert_eq!(parse_java_version(java_17), Some("17.0.5".to_string()));
-    }
-
-    #[test]
-    fn test_parse_java_version_eclipse_openj9() {
-        let java_8 = "Eclipse OpenJ9 OpenJDK 64-bit Server VM (1.8.0_222-b10) from linux-amd64 JRE with Extensions for OpenJDK for Eclipse OpenJ9 8.0.222.0, built on Jul 17 2019 21:29:18 by jenkins with g++ (GCC) 7.3.1 20180303 (Red Hat 7.3.1-5)";
-        let java_11 = "Eclipse OpenJ9 OpenJDK 64-bit Server VM (11.0.4+11) from linux-amd64 JRE with Extensions for OpenJDK for Eclipse OpenJ9 11.0.4.0, built on Jul 17 2019 21:51:37 by jenkins with g++ (GCC) 7.3.1 20180303 (Red Hat 7.3.1-5)";
-        assert_eq!(parse_java_version(java_8), Some("8.0.222".to_string()));
-        assert_eq!(parse_java_version(java_11), Some("11.0.4".to_string()));
-    }
-
-    #[test]
-    fn test_parse_java_version_graalvm() {
-        let java_8 = "OpenJDK 64-Bit GraalVM CE 19.2.0.1 (25.222-b08-jvmci-19.2-b02) for linux-amd64 JRE (8u222), built on Jul 19 2019 17:37:13 by \"buildslave\" with gcc 7.3.0";
-        assert_eq!(parse_java_version(java_8), Some("8".to_string()));
-    }
-
-    #[test]
-    fn test_parse_java_version_amazon_corretto() {
-        let java_8 = "OpenJDK 64-Bit Server VM (25.222-b10) for linux-amd64 JRE (1.8.0_222-b10), built on Jul 11 2019 20:48:53 by \"root\" with gcc 7.3.1 20180303 (Red Hat 7.3.1-5)";
-        let java_11 = "OpenJDK 64-Bit Server VM (11.0.4+11-LTS) for linux-amd64 JRE (11.0.4+11-LTS), built on Jul 11 2019 20:06:11 by \"\" with gcc 7.3.1 20180303 (Red Hat 7.3.1-5)";
-        assert_eq!(parse_java_version(java_8), Some("1.8.0".to_string()));
-        assert_eq!(parse_java_version(java_11), Some("11.0.4".to_string()));
-    }
-
-    #[test]
-    fn test_parse_java_version_sapmachine() {
-        let java_11 = "OpenJDK 64-Bit Server VM (11.0.4+11-LTS-sapmachine) for linux-amd64 JRE (11.0.4+11-LTS-sapmachine), built on Jul 17 2019 08:58:43 by \"\" with gcc 7.3.0";
-        assert_eq!(parse_java_version(java_11), Some("11.0.4".to_string()));
-    }
-
-    #[test]
-    fn test_parse_java_version_android_studio_jdk() {
-        let java_11 = "OpenJDK 64-Bit Server VM (11.0.15+0-b2043.56-8887301) for linux-amd64 JRE (11.0.15+0-b2043.56-8887301), built on Jul 29 2022 22:12:21 by \"androidbuild\" with gcc Android (7284624, based on r416183b) Clang 12.0.5 (https://android.googlesource.com/toolchain/llvm-project c935d99d7cf2016289302412d708641d52d2f7ee)}";
-        assert_eq!(parse_java_version(java_11), Some("11.0.15".to_string()));
+        let java_8 = "java version \"1.8.0_65\"";
+        assert_eq!(parse_java_version(java_8), Some("1.8.0_65".to_string()));
     }
 
     #[test]
@@ -190,8 +139,8 @@ mod tests {
     fn folder_with_java_file_preview() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("Main.java"))?.sync_all()?;
-        let actual = ModuleRenderer::new("java").cmd("java -Xinternalversion", Some(CommandOutput {
-            stdout: "OpenJDK 64-Bit Server VM (16+14) for bsd-aarch64 JRE (16+14), built on Jan 17 2021 07:19:47 by \"brew\" with clang Apple LLVM 12.0.0 (clang-1200.0.32.28)\n".to_owned(),
+        let actual = ModuleRenderer::new("java").cmd("java -version", Some(CommandOutput {
+            stdout: "openjdk version \"16\" 2021-01-17".to_owned(),
             stderr: String::new()
         })).path(dir.path()).collect();
         let expected = Some(format!("via {}", Color::Red.dimmed().paint("☕ v16 ")));
@@ -204,7 +153,7 @@ mod tests {
         let dir = tempfile::tempdir()?;
         File::create(dir.path().join("Main.java"))?.sync_all()?;
         let actual = ModuleRenderer::new("java")
-            .cmd("java -Xinternalversion", None)
+            .cmd("java -version", None)
             .path(dir.path())
             .collect();
         let expected = Some(format!("via {}", Color::Red.dimmed().paint("☕ ")));
@@ -301,9 +250,9 @@ mod tests {
 
         let actual = ModuleRenderer::new("java")
             .env("JAVA_HOME", java_home.to_str().unwrap())
-            .cmd(&format!("{} -Xinternalversion", java_bin.to_str().unwrap()),
+            .cmd(&format!("{} -version", java_bin.to_str().unwrap()),
             Some(CommandOutput {
-                stdout: "OpenJDK 64-Bit Server VM (11.0.4+11-LTS-sapmachine) for linux-amd64 JRE (11.0.4+11-LTS-sapmachine), built on Jul 17 2019 08:58:43 by \"\" with gcc 7.3.0".to_owned(),
+                stdout: "openjdk version \"11.0.4\" 2019-07-17".to_owned(),
                 stderr: String::new(),
             }))
             .path(dir.path())

--- a/src/modules/java.rs
+++ b/src/modules/java.rs
@@ -76,14 +76,11 @@ fn get_java_version(context: &Context) -> Option<String> {
 }
 
 fn parse_java_version_output(java_version_output: &str) -> Option<String> {
-    let version_line = java_version_output
-        .lines()
-        .find(|line| {
-            line.starts_with("java version \"") || line.starts_with("openjdk version \"")
-        })?;
+    let version_line = java_version_output.lines().find(|line| {
+        line.starts_with("java version \"") || line.starts_with("openjdk version \"")
+    })?;
 
-    parse_java_version_line(version_line)
-        .map(ToString::to_string)
+    parse_java_version_line(version_line).map(ToString::to_string)
 }
 
 fn parse_java_version_line(java_version_line: &str) -> Option<&str> {
@@ -104,19 +101,28 @@ mod tests {
     #[test]
     fn test_parse_java_version_output_openjdk() {
         let java_version_output = "openjdk version \"25.0.4.1\" 2026-08-18 LTS\nOpenJDK Runtime Environment Zulu25.36+205-CA (build 25.0.4.1+1-LTS)\nOpenJDK 64-Bit Server VM Zulu25.36+205-CA (build 25.0.4.1+1-LTS, mixed mode, sharing)";
-        assert_eq!(parse_java_version_output(java_version_output), Some("25.0.4.1".to_string()));
+        assert_eq!(
+            parse_java_version_output(java_version_output),
+            Some("25.0.4.1".to_string())
+        );
     }
 
     #[test]
     fn test_parse_java_version_output_oracle_jdk() {
         let java_version_output = "java version \"17.0.8\" 2023-07-18 LTS\nJava(TM) SE Runtime Environment (build 17.0.8+9-LTS-211)\nJava HotSpot(TM) 64-Bit Server VM (build 17.0.8+9-LTS-211, mixed mode, sharing)";
-        assert_eq!(parse_java_version_output(java_version_output), Some("17.0.8".to_string()));
+        assert_eq!(
+            parse_java_version_output(java_version_output),
+            Some("17.0.8".to_string())
+        );
     }
 
     #[test]
     fn test_parse_java_version_output_with_version_not_on_first_line() {
         let java_version_output = "Picked up JAVA_TOOL_OPTIONS: -Xmx2g\nopenjdk version \"25.0.4.1\" 2026-08-18 LTS\nOpenJDK Runtime Environment Zulu25.36+205-CA (build 25.0.4.1+1-LTS)\nOpenJDK 64-Bit Server VM Zulu25.36+205-CA (build 25.0.4.1+1-LTS, mixed mode, sharing)";
-        assert_eq!(parse_java_version_output(java_version_output), Some("25.0.4.1".to_string()));
+        assert_eq!(
+            parse_java_version_output(java_version_output),
+            Some("25.0.4.1".to_string())
+        );
     }
 
     #[test]

--- a/src/modules/java.rs
+++ b/src/modules/java.rs
@@ -70,12 +70,18 @@ fn get_java_version(context: &Context) -> Option<String> {
         .unwrap_or_else(|| String::from("java"));
 
     let output = context.exec_cmd(java_command, &["-version"])?;
-    let java_version_string = get_command_string_output(output);
-    let version_line = java_version_string
+    let java_version_output = get_command_string_output(output);
+
+    parse_java_version_output(&java_version_output)
+}
+
+fn parse_java_version_output(java_version_output: &str) -> Option<String> {
+    let version_line = java_version_output
         .lines()
         .find(|line| line.contains("version \""))?;
 
-    parse_java_version_line(version_line).map(ToString::to_string)
+    parse_java_version_line(version_line)
+        .map(ToString::to_string)
 }
 
 fn parse_java_version_line(java_version_line: &str) -> Option<&str> {
@@ -94,6 +100,18 @@ mod tests {
     use std::io;
 
     #[test]
+    fn test_parse_java_version_output() {
+        let java_version_output = "openjdk version \"25.0.4.1\" 2026-08-18 LTS\nOpenJDK Runtime Environment Zulu25.36+205-CA (build 25.0.4.1+1-LTS)\nOpenJDK 64-Bit Server VM Zulu25.36+205-CA (build 25.0.4.1+1-LTS, mixed mode, sharing)";
+        assert_eq!(parse_java_version_output(java_version_output), Some("25.0.4.1".to_string()));
+    }
+
+    #[test]
+    fn test_parse_java_version_output_with_version_not_on_first_line() {
+        let java_version_output = "Picked up JAVA_TOOL_OPTIONS: -Xmx2g\nopenjdk version \"25.0.4.1\" 2026-08-18 LTS\nOpenJDK Runtime Environment Zulu25.36+205-CA (build 25.0.4.1+1-LTS)\nOpenJDK 64-Bit Server VM Zulu25.36+205-CA (build 25.0.4.1+1-LTS, mixed mode, sharing)";
+        assert_eq!(parse_java_version_output(java_version_output), Some("25.0.4.1".to_string()));
+    }
+
+    #[test]
     fn test_parse_java_version_line_openjdk() {
         let java_8 = "openjdk version \"1.8.0_222\"";
         let java_11 = "openjdk version \"11.0.4\" 2019-07-18";
@@ -104,7 +122,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_java_version_line_oracle() {
+    fn test_parse_java_version_line_oracle_jdk() {
         let java_8 = "java version \"1.8.0_65\"";
         assert_eq!(parse_java_version_line(java_8), Some("1.8.0_65"));
     }
@@ -259,25 +277,6 @@ mod tests {
             .path(dir.path())
             .collect();
         let expected = Some(format!("via {}", Color::Red.dimmed().paint("☕ v11.0.4 ")));
-        assert_eq!(expected, actual);
-        dir.close()
-    }
-
-    #[test]
-    fn java_version_not_on_first_line() -> io::Result<()> {
-        let dir = tempfile::tempdir()?;
-        File::create(dir.path().join("Main.java"))?.sync_all()?;
-        let actual = ModuleRenderer::new("java")
-            .cmd(
-                "java -version",
-                Some(CommandOutput {
-                    stdout: "Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8\nopenjdk version \"17.0.5\" 2022-10-18 LTS\nOpenJDK Runtime Environment (build 17.0.5+8)\n".to_owned(),
-                    stderr: String::new(),
-                }),
-            )
-            .path(dir.path())
-            .collect();
-        let expected = Some(format!("via {}", Color::Red.dimmed().paint("☕ v17.0.5 ")));
         assert_eq!(expected, actual);
         dir.close()
     }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -392,10 +392,8 @@ Elixir 1.10 (compiled with Erlang/OTP 22)\n",
             stdout: String::from("v3.1.1+gafe7058\n"),
             stderr: String::default(),
         }),
-        s if s.ends_with("java -Xinternalversion") => Some(CommandOutput {
-            stdout: String::from(
-                "OpenJDK 64-Bit Server VM (13.0.2+8) for bsd-amd64 JRE (13.0.2+8), built on Feb  6 2020 02:07:52 by \"brew\" with clang 4.2.1 Compatible Apple LLVM 11.0.0 (clang-1100.0.33.17)",
-            ),
+        s if s.ends_with("java -version") => Some(CommandOutput {
+            stdout: String::from("openjdk version \"13.0.2\" 2020-01-14"),
             stderr: String::default(),
         }),
         "scala-cli version --scala" => Some(CommandOutput {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -393,7 +393,7 @@ Elixir 1.10 (compiled with Erlang/OTP 22)\n",
             stderr: String::default(),
         }),
         s if s.ends_with("java -version") => Some(CommandOutput {
-            stdout: String::from("openjdk version \"13.0.2\" 2020-01-14"),
+            stdout: String::from("openjdk version \"13.0.2\" 2020-01-14\nOpenJDK Runtime Environment (build 13.0.2+8)\nOpenJDK 64-Bit Server VM (build 13.0.2+8, mixed mode, sharing)"),
             stderr: String::default(),
         }),
         "scala-cli version --scala" => Some(CommandOutput {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -393,7 +393,9 @@ Elixir 1.10 (compiled with Erlang/OTP 22)\n",
             stderr: String::default(),
         }),
         s if s.ends_with("java -version") => Some(CommandOutput {
-            stdout: String::from("openjdk version \"13.0.2\" 2020-01-14\nOpenJDK Runtime Environment (build 13.0.2+8)\nOpenJDK 64-Bit Server VM (build 13.0.2+8, mixed mode, sharing)"),
+            stdout: String::from(
+                "openjdk version \"13.0.2\" 2020-01-14\nOpenJDK Runtime Environment (build 13.0.2+8)\nOpenJDK 64-Bit Server VM (build 13.0.2+8, mixed mode, sharing)",
+            ),
             stderr: String::default(),
         }),
         "scala-cli version --scala" => Some(CommandOutput {


### PR DESCRIPTION
Java's [Version-String Format](https://docs.oracle.com/en/java/javase/25/install/version-string-format.html) is `$FEATURE.$INTERIM.$UPDATE.$PATCH`, omitting trailing zero elements. So far, Starship only captured the first three version elements (`$FEATURE.$INTERIM.$UPDATE`).

#### Description

This PR drops the regular expression parsing and reports the version as `java -version` reports it itself between double quotes on the first line, which automatically omits all trailing 0 elements.

For Java 8 versions this PR also includes the update version (after the `_`), e.g. 1.8.0_504. This is relevant, because all Java 8 releases so far have started with `1.8.0_`, so the update version is actually the only discriminator.

By parsing the first line of the output of `java -version` the number of test cases can also be greatly reduced, because various distributions based on OpenJDK (Red Hat, Azul Zulu, Eclipse OpenJ9, Eclipse Temurin, GraalVM Community Edition, etc.) all use the same format for the first line of `java -version`.

#### Motivation and Context

Closes #5451

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- Most changes do not need to be tested on multiple operating systems. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### AI-Assistance
<!-- Per our AI Policy (AI_POLICY.md), all AI usage must be declared. -->
Have you used AI-assistance to author this PR?

- [x] Yes
- [ ] No

If **yes**, describe the scope of assistance:
<!--- Describe how you used AI-Assistance -->
<!--- Disclosure is required if you have used AI-assistance -->
<!--- For example: answering project questions, writing tests, implementation, or documentation -->
I've used Google Antigravity to assist with updating the implementation, because I'm a very experienced Java developer, I'm not too familiar with Rust.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
- [x] I understand and have read the code I contribute and can answer questions about it.
