### PR TITLE
feat(directory): add `use_osc8_url` option

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -451,7 +451,8 @@
         "read_only_style": "red",
         "truncation_symbol": "",
         "home_symbol": "~",
-        "use_os_path_sep": true
+        "use_os_path_sep": true,
+        "use_osc8_url": false
       }
     },
     "direnv": {
@@ -2970,6 +2971,10 @@
         "use_os_path_sep": {
           "type": "boolean",
           "default": true
+        },
+        "use_osc8_url": {
+          "type": "boolean",
+          "default": false
         }
       },
       "additionalProperties": false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -774,6 +774,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "dlv-list"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -953,6 +964,15 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "fragile"
@@ -1934,6 +1954,110 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
+
+[[package]]
+name = "icu_properties"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
+
+[[package]]
+name = "icu_provider"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2121,6 +2245,12 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "lock_api"
@@ -2770,6 +2900,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "potential_utf"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3381,6 +3520,7 @@ dependencies = [
  "toml_edit",
  "unicode-segmentation",
  "unicode-width",
+ "url",
  "urlencoding",
  "versions",
  "which",
@@ -3446,6 +3586,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3635,6 +3786,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
  "crunchy",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -3832,10 +3993,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
 name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -4273,6 +4452,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
+name = "writeable"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
+
+[[package]]
 name = "yaml-rust2"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4281,6 +4466,29 @@ dependencies = [
  "arraydeque",
  "encoding_rs",
  "hashlink",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
 ]
 
 [[package]]
@@ -4371,6 +4579,60 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ toml = { version = "1.1.4", features = ["preserve_order"] }
 toml_edit = "0.25.13"
 unicode-segmentation = "1.13.3"
 unicode-width = "0.2.2"
+url = "2.5.8"
 urlencoding = "2.1.3"
 versions = "7.0.0"
 which = "8.0.5"

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1215,6 +1215,7 @@ it would have been `nixpkgs/pkgs`.
 | `substitutions`             |         | An Array or table of substitutions to be made to the path.                                                                                                             |
 | `fish_style_pwd_dir_length` | `0`     | The number of characters to use when applying fish shell pwd path logic.                                                                                               |
 | `use_logical_path`          | `true`  | If `true` render the logical path sourced from the shell via `PWD` or `--logical-path`. If `false` instead render the physical filesystem path with symlinks resolved. |
+| `use_osc8_url`              | `false` | If `true` the `directory` component of the prompt will become a hyperlink to `file://$path` via [OSC 8](https://github.com/Alhadis/OSC8-Adoption) escape sequence.     |
 
 `substitutions` allows you to define arbitrary replacements for literal strings that occur in the path, for example long network
 prefixes or development directories of Java. Note that this will disable the fish style PWD. It takes an array of the following

--- a/src/configs/directory.rs
+++ b/src/configs/directory.rs
@@ -39,6 +39,7 @@ pub struct DirectoryConfig<'a> {
     pub truncation_symbol: &'a str,
     pub home_symbol: &'a str,
     pub use_os_path_sep: bool,
+    pub use_osc8_url: bool,
 }
 
 impl DirectoryConfig<'_> {
@@ -69,6 +70,7 @@ impl Default for DirectoryConfig<'_> {
             truncation_symbol: "",
             home_symbol: "~",
             use_os_path_sep: true,
+            use_osc8_url: false,
         }
     }
 }

--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -10,6 +10,7 @@ use std::borrow::Cow;
 use std::iter::FromIterator;
 use std::path::{Path, PathBuf};
 use unicode_segmentation::UnicodeSegmentation;
+use url::Url;
 
 use super::{Context, Module};
 
@@ -110,6 +111,18 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         String::new()
     };
 
+    let (prefix, osc8_suffix) = if config.use_osc8_url {
+        match Url::from_directory_path(physical_dir) {
+            Ok(url) => (
+                format!("\u{001B}]8;;{url}\u{001B}\\{prefix}"),
+                "\u{001B}]8;;\u{001B}\\",
+            ),
+            Err(_) => (prefix, ""), // Completely skip OSC 8 if path conversion fails
+        }
+    } else {
+        (prefix, "")
+    };
+
     let path_vec = match &repo.and_then(|r| r.workdir.as_ref()) {
         Some(repo_root) if config.repo_root_style.is_some() => {
             let contracted_path = contract_repo_path(display_dir, repo_root)?;
@@ -122,12 +135,24 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             {
                 let root = repo_path_vec[0];
                 let before = before_root_dir(&dir_string, &contracted_path);
-                [prefix + before, root.to_string(), after_repo_root]
+                [
+                    prefix + before,
+                    root.to_string(),
+                    after_repo_root + osc8_suffix,
+                ]
             } else {
-                [String::new(), String::new(), prefix + dir_string.as_str()]
+                [
+                    String::new(),
+                    String::new(),
+                    prefix + dir_string.as_str() + osc8_suffix,
+                ]
             }
         }
-        _ => [String::new(), String::new(), prefix + dir_string.as_str()],
+        _ => [
+            String::new(),
+            String::new(),
+            prefix + dir_string.as_str() + osc8_suffix,
+        ],
     };
 
     let path_vec = if config.use_os_path_sep {

--- a/src/print.rs
+++ b/src/print.rs
@@ -38,10 +38,18 @@ pub trait UnicodeWidthGraphemes {
     fn width_graphemes(&self) -> usize;
 }
 
-static ANSI_REGEX: OnceLock<Regex> = OnceLock::new();
+static ESCAPE_REGEX: OnceLock<Regex> = OnceLock::new();
 
-fn ansi_strip() -> &'static Regex {
-    ANSI_REGEX.get_or_init(|| Regex::new(r"\x1B\[[0-9;]*m").unwrap())
+fn strip_escapes() -> &'static Regex {
+    ESCAPE_REGEX.get_or_init(|| {
+        // Define each pattern group individually for readability
+        let patterns = [
+            r"\x1B\[[0-9;]*m",                // SGR sequences
+            r"\x1B\].*?(?:\x1B\\|\x9C|\x07)", // OSC sequences
+        ];
+
+        Regex::new(&patterns.join("|")).unwrap()
+    })
 }
 
 impl<T> UnicodeWidthGraphemes for T
@@ -49,7 +57,7 @@ where
     T: AsRef<str>,
 {
     fn width_graphemes(&self) -> usize {
-        ansi_strip()
+        strip_escapes()
             .replace_all(self.as_ref(), "")
             .into_owned()
             .graphemes(true)
@@ -67,6 +75,26 @@ fn test_grapheme_aware_width() {
     assert_eq!(11, "normal text".width_graphemes());
     // Magenta string test
     assert_eq!(11, "\x1B[35;6mnormal text".width_graphemes());
+    let (osc8_start, osc8_end) = ("\x1B]8;;", "\x1B\\");
+    // OSC 8 hyperlink test
+    assert_eq!(
+        9,
+        format!("{0}file:///{1}Link text{0}{1}", osc8_start, osc8_end).width_graphemes()
+    );
+    // Link with newline
+    assert_eq!(
+        11,
+        format!("{0}file:///{1}With\nnewline{0}{1}", osc8_start, osc8_end).width_graphemes()
+    );
+    // Colorized link
+    assert_eq!(
+        10,
+        format!(
+            "{0}file:///{1}\x1B[35;6mPink blink{0}{1}",
+            osc8_start, osc8_end
+        )
+        .width_graphemes()
+    );
 }
 
 pub fn prompt(args: Properties, target: Target) {

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -86,11 +86,19 @@ mod fill_seg_tests {
     }
 }
 
+/// Type that holds control sequences
+#[derive(Clone)]
+pub struct ControlSegment {
+    /// The string value of the current segment.
+    value: String,
+}
+
 /// A segment is a styled text chunk ready for printing.
 #[derive(Clone)]
 pub enum Segment {
     Text(TextSegment),
     Fill(FillSegment),
+    Control(ControlSegment),
     LineTerm,
 }
 
@@ -128,7 +136,7 @@ impl Segment {
         match self {
             Self::Fill(fs) => fs.style.map(|cs| cs.to_ansi_style(None)),
             Self::Text(ts) => ts.style.map(|cs| cs.to_ansi_style(None)),
-            Self::LineTerm => None,
+            Self::Control(_) | Self::LineTerm => None,
         }
     }
 
@@ -144,7 +152,7 @@ impl Segment {
                     ts.style = style;
                 }
             }
-            Self::LineTerm => {}
+            Self::Control(_) | Self::LineTerm => {}
         }
     }
 
@@ -152,6 +160,7 @@ impl Segment {
         match self {
             Self::Fill(fs) => &fs.value,
             Self::Text(ts) => &ts.value,
+            Self::Control(cs) => &cs.value,
             Self::LineTerm => LINE_TERMINATOR_STRING,
         }
     }
@@ -161,6 +170,7 @@ impl Segment {
         match self {
             Self::Fill(fs) => fs.ansi_string(None, prev),
             Self::Text(ts) => ts.ansi_string(prev),
+            Self::Control(cs) => AnsiString::from(&cs.value),
             Self::LineTerm => AnsiString::from(LINE_TERMINATOR_STRING),
         }
     }
@@ -169,7 +179,7 @@ impl Segment {
         match self {
             Self::Fill(fs) => fs.value.width_graphemes(),
             Self::Text(ts) => ts.value.width_graphemes(),
-            Self::LineTerm => 0,
+            Self::Control(_) | Self::LineTerm => 0,
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

This PR adds a setting to the `[directory]` module to allow optionally turning the output of the [directory] module into an interactable hyperlink in terminals
supporting the OSC 8 sequence.
For spec details and implementation status see:
https://github.com/Alhadis/OSC8-Adoption

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Resolves #3036
- Resolves #4685
- Partially addresses #7296

<details><summary>I have also been toying around with this as an ad-hoc feature via an [env] module for a while now.<br>
But due to the prompt length calculation issues I never put it into permanent use in my config.</summary>
<p>

```toml
# example config snippet of ad-hoc OSC 8 support
format = """\
    ${env_var.pwd}\
    $directory\
    [\u001B\\]8;;\u001B\\\\]()\
"""


# OSC 8 file:// URI embedding
[env_var.pwd]
disabled = true
variable = "PWD"
format = """\
    [\u001B\\]8;;]()\
    [file://$env_value]()\
    [\u001B\\\\]()\
"""
```

</p>
</details>

#### Screenshots (if appropriate):

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- Most changes do not need to be tested on multiple operating systems. -->
- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
  - I am aware of the currently unaccounted for prompt-length discrepancy issue,
as described in [`#7296`](https://github.com/starship/starship/issues/7296).
I haven't been able to track down where that would need to be accounted for yet.
- [ ] I have tested using **Windows**

#### AI-Assistance
<!-- Per our AI Policy (AI_POLICY.md), all AI usage must be declared. -->
Have you used AI-assistance to author this PR?

- [ ] Yes
- [x] No

If **yes**, describe the scope of assistance:
<!--- Describe how you used AI-Assistance -->
<!--- Disclosure is required if you have used AI-assistance -->
<!--- For example: answering project questions, writing tests, implementation, or documentation -->
N/A

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
  - I'm not entirely sure what tests would make sense for this feature,
  so I wanted to get feedback on the general approach I have taken to implement it first.
  At the very least we *should* test that `right_format` behaves correctly.
  e.g. that the OSC 8 sequence is correctly removed from the prompt length calculation.
  As also described in [`#7296`](https://github.com/starship/starship/issues/7296).
  And related to that probably also checks against the `[fill]` module,
  and some of the more esoteric `[directory]` options I didn't use in my local testing.
  I don't yet know the codebase well enough yet from the development side to tell where special attention may be needed with testing this feature.
- [x] I understand and have read the code I contribute and can answer questions about it.

<h1><em></em></h1> <!-- thin separator -->

It may make sense to extend this feature to additional modules such as the `git_branch` or `git_commit` for example, to allow them to be interacted with to open the branch/tag/commit they point at on the remote in the browser.
If this makes sense for inclusion in other modules it would probably be best to implement "`OSC 8`-ification" as general a formatting function that modules can `use`.