### PR TITLE
feat: add `jj_change` module

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -979,6 +979,18 @@
         "disabled": false
       }
     },
+    "jj_change": {
+      "$ref": "#/$defs/JJChangeConfig",
+      "default": {
+        "format": "$change ",
+        "prefix_style": "green bold",
+        "suffix_style": "dimmed",
+        "change_offset_style": "bold",
+        "change_hash_length": 7,
+        "commit_hash_length": 7,
+        "disabled": false
+      }
+    },
     "jobs": {
       "$ref": "#/$defs/JobsConfig",
       "default": {
@@ -4520,6 +4532,53 @@
             "type": "string"
           },
           "default": []
+        },
+        "disabled": {
+          "description": "Disable the module",
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "JJChangeConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "description": "Format string for the module",
+          "type": "string",
+          "default": "$change "
+        },
+        "prefix_style": {
+          "description": "Value of the `$prefix_style` variable in the format string",
+          "type": "string",
+          "default": "green bold"
+        },
+        "suffix_style": {
+          "description": "Value of the `$suffix_style` variable in the format string",
+          "type": "string",
+          "default": "dimmed"
+        },
+        "change_offset_style": {
+          "description": "Value of the `$change_offset_style` variable in the format string",
+          "type": "string",
+          "default": "bold"
+        },
+        "change_hash_length": {
+          "description": "The max length of the displayed change hash, when combining prefix and suffix\n\nThe actual length of the displayed value will be `max(prefix.len(), change_hash_length)`",
+          "type": "integer",
+          "format": "uint8",
+          "minimum": 0,
+          "maximum": 255,
+          "default": 7
+        },
+        "commit_hash_length": {
+          "description": "The max length of the displayed commit hash, when combining prefix and suffix\n\nThe actual length of the displayed value will be `max(prefix.len(), commit_hash_length)`",
+          "type": "integer",
+          "format": "uint8",
+          "minimum": 0,
+          "maximum": 255,
+          "default": 7
         },
         "disabled": {
           "description": "Disable the module",

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2608,6 +2608,51 @@ ignore_names = ["main", "master"]
 diverged_symbol = "⇕"
 ```
 
+## JJ Change
+
+The `jj_change` module shows the current [Jujutsu](https://docs.jj-vcs.dev/) change and optionally the underlying commit when the current directory is in a Jujutsu repository.
+
+### Options
+
+| Option                | Default      | Description                                                               |
+| --------------------- | ------------ | ------------------------------------------------------------------------- |
+| `format`              | `"$change "` | Format string for the module                                              |
+| `prefix_style`        | `bold green` | Value of the `$prefix_style` variable in the format string                |
+| `suffix_style`        | `dimmed`     | Value of the `$suffix_style` variable in the format string                |
+| `change_offset_style` | `bold`       | Value of the `$change_offset_style` variable in the format string         |
+| `change_hash_length`* | `7`          | The length of the displayed change hash, when combining prefix and suffix |
+| `commit_hash_length`* | `7`          | The length of the displayed commit hash, when combining prefix and suffix |
+| `disabled`            | `false`      | Disable the module                                                        |
+
+*: The length of `$<id>_prefix` will be `max(<id>_prefix.len(), <id>_hash_length)`, to ensure the shortest unique
+prefix is always correctly displayed
+
+### Variables
+
+| Variable              | Example | Description                                                                                                                               |
+| --------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| change                |         | The full styled change at once: `[$change_prefix]($prefix_style)[$change_suffix]($suffix_style)([/$change_offset]($change_offset_style))` |
+| change_prefix         | `vpo`   | Current change hash shortest unique prefix                                                                                                |
+| change_suffix         | `vrqx`  | Current change hash, truncated to `change_hash_length` and after removing `change_prefix`                                                 |
+| change_offset         | `2`     | Offset of the current change, if it is divergent                                                                                          |
+| commit                |         | The full styled commit at once: `[$commit_prefix]($prefix_style)[$commit_suffix]($suffix_style)`                                          |
+| commit_prefix         | `303`   | Current commit hash shortest unique prefix                                                                                                |
+| commit_suffix         | `63e4`  | Current commit hash, truncated to `commit_hash_length` and after removing `commit_prefix`                                                 |
+| prefix_style\*        |         | Mirrors the value of option `prefix_style`                                                                                                |
+| suffix_style\*        |         | Mirrors the value of option `suffix_style`                                                                                                |
+| change_offset_style\* |         | Mirrors the value of option `change_offset_style`                                                                                         |
+
+*: This variable can only be used as a part of a style string
+
+### Example
+
+```toml
+# ~/.config/starship.toml
+
+[jj_change]
+format = "($change:$commit) "
+```
+
 ## Jobs
 
 The `jobs` module shows the current number of jobs running.

--- a/docs/public/presets/toml/bracketed-segments.toml
+++ b/docs/public/presets/toml/bracketed-segments.toml
@@ -129,6 +129,9 @@ format = '\[[$symbol($version)]($style)\]'
 [jj_bookmark]
 format = '\[[$symbol$bookmark(@$remote)$diverged( \(+$overflow_count others\))]($style)\]'
 
+[jj_change]
+format = '\[[\($change\)]($style)\]'
+
 [jobs]
 format = '\[[$symbol$number]($style)\]'
 

--- a/src/configs/jj_change.rs
+++ b/src/configs/jj_change.rs
@@ -1,0 +1,43 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(
+    feature = "config-schema",
+    derive(schemars::JsonSchema),
+    schemars(deny_unknown_fields)
+)]
+#[serde(default)]
+pub struct JJChangeConfig<'a> {
+    /// Format string for the module
+    pub format: &'a str,
+    /// Value of the `$prefix_style` variable in the format string
+    pub prefix_style: &'a str,
+    /// Value of the `$suffix_style` variable in the format string
+    pub suffix_style: &'a str,
+    /// Value of the `$change_offset_style` variable in the format string
+    pub change_offset_style: &'a str,
+    /// The max length of the displayed change hash, when combining prefix and suffix
+    ///
+    /// The actual length of the displayed value will be `max(prefix.len(), change_hash_length)`
+    pub change_hash_length: u8,
+    /// The max length of the displayed commit hash, when combining prefix and suffix
+    ///
+    /// The actual length of the displayed value will be `max(prefix.len(), commit_hash_length)`
+    pub commit_hash_length: u8,
+    /// Disable the module
+    pub disabled: bool,
+}
+
+impl Default for JJChangeConfig<'_> {
+    fn default() -> Self {
+        Self {
+            format: "$change ",
+            prefix_style: "green bold",
+            suffix_style: "dimmed",
+            change_offset_style: "bold",
+            change_hash_length: 7,
+            commit_hash_length: 7,
+            disabled: false,
+        }
+    }
+}

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -54,6 +54,7 @@ pub mod hg_state;
 pub mod hostname;
 pub mod java;
 pub mod jj_bookmark;
+pub mod jj_change;
 pub mod jobs;
 pub mod julia;
 pub mod kotlin;
@@ -230,6 +231,8 @@ pub struct FullConfig<'a> {
     java: java::JavaConfig<'a>,
     #[serde(borrow)]
     jj_bookmark: jj_bookmark::JJBookmarkConfig<'a>,
+    #[serde(borrow)]
+    jj_change: jj_change::JJChangeConfig<'a>,
     #[serde(borrow)]
     jobs: jobs::JobsConfig<'a>,
     #[serde(borrow)]

--- a/src/context/jj_repo.rs
+++ b/src/context/jj_repo.rs
@@ -13,10 +13,14 @@ pub struct JJRepo {
 #[derive(Debug)]
 pub struct CurrentChange {
     /// JJ change ID
+    ///
+    /// Checked to be ASCII at construction
     pub change: Box<str>,
     /// Size of the shortest unique prefix for the change ID
     pub change_shortest: u8,
     /// Underlying VCS commit ID (most often Git)
+    ///
+    /// Checked to be ASCII at construction
     pub commit: Box<str>,
     /// Size of the shortest unique prefix for the commit ID
     pub commit_shortest: u8,
@@ -147,14 +151,14 @@ impl JJRepo {
                 // A full JJ change ID is always `[k-z]{32}`,
                 // so we do a quick sanity check on it just to confirm it looks ok
                 let change = lines.next()?;
-                if change.len() != 32 {
+                if change.len() != 32 || !change.is_ascii() {
                     return None;
                 }
 
                 Some(CurrentChange {
                     change: Box::from(change),
                     change_shortest: lines.next()?.parse().ok()?,
-                    commit: Box::from(lines.next()?),
+                    commit: Box::from(lines.next().filter(|s| s.is_ascii())?),
                     commit_shortest: lines.next()?.parse().ok()?,
                     change_offset,
                     bookmarks: parse_bookmark_lines(lines.next()?, lines.next()?),

--- a/src/context/jj_repo.rs
+++ b/src/context/jj_repo.rs
@@ -315,6 +315,9 @@ impl JJRepo {
 
     pub const BOOKMARK_NO_CURRENT: &str = "/jj/bookmarks/no-current";
 
+    pub const CHANGE_DIVERGENT: &str = "/jj/change/divergent";
+    pub const CHANGE_NOT_ASCII: &str = "/jj/change/not-ascii";
+
     pub const NONE: &str = "/jj/no-repo";
 }
 
@@ -421,6 +424,20 @@ pub fn mock_jj_cmd(s: &str) -> Option<crate::utils::CommandOutput> {
             JJRepo::BOOKMARK_NO_CURRENT,
             || output([
                 (BOOKMARKS_CUR, ""),
+            ]),
+        ),
+        // Repos testing jj_change rendering
+        (
+            JJRepo::CHANGE_DIVERGENT,
+            || output([
+                (DIVERGENT, "true"),
+                (CHANGE_OFFSET, "2"),
+            ]),
+        ),
+        (
+            JJRepo::CHANGE_NOT_ASCII,
+            || output([
+                (CHANGE, "Étxwmvtttmrkkoqkutlystlnozssmnk"),
             ]),
         ),
         // Used to test the parsing will correctly fail on empty stdout

--- a/src/module.rs
+++ b/src/module.rs
@@ -58,6 +58,7 @@ pub const ALL_MODULES: &[&str] = &[
     "hostname",
     "java",
     "jj_bookmark",
+    "jj_change",
     "jobs",
     "julia",
     "kotlin",

--- a/src/modules/jj_change.rs
+++ b/src/modules/jj_change.rs
@@ -1,0 +1,77 @@
+use std::borrow::Cow;
+
+use super::{Context, Module, ModuleConfig};
+
+use crate::configs::jj_change::JJChangeConfig;
+use crate::formatter::StringFormatter;
+
+/// Creates a module with the JJ change and commit in the current directory
+///
+/// Will display the JJ change hash truncated by default if the current directory is a JJ repo
+pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let mut module = context.new_module("jj_change");
+    let config = JJChangeConfig::try_load(module.config);
+
+    if config.disabled {
+        return None;
+    }
+
+    let current = context.get_jj_repo()?.current_change(context)?;
+
+    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
+        formatter
+            .map_meta(|variable, _| match variable {
+                "change" => Some("[$change_prefix]($prefix_style)[$change_suffix]($suffix_style)([/$change_offset]($change_offset_style))"),
+                "commit" => Some("[$commit_prefix]($prefix_style)[$commit_suffix]($suffix_style)"),
+                _ => None,
+            })
+            .map_style(|variable| match variable {
+                "prefix_style" => Some(Ok(config.prefix_style)),
+                "suffix_style" => Some(Ok(config.suffix_style)),
+                "change_offset_style" => Some(Ok(config.change_offset_style)),
+                _ => None,
+            })
+            .map(|variable| match variable {
+                "change_offset" => current.change_offset.map(|o| Ok(o.to_string().into())),
+                "change_prefix" => prefix(current.change.as_ref(), current.change_shortest).map(Ok),
+                "change_suffix" => suffix(
+                    current.change.as_ref(),
+                    current.change_shortest,
+                    config.change_hash_length,
+                )
+                .map(Ok),
+                "commit_prefix" => prefix(current.commit.as_ref(), current.commit_shortest).map(Ok),
+                "commit_suffix" => suffix(
+                    current.commit.as_ref(),
+                    current.commit_shortest,
+                    config.commit_hash_length,
+                )
+                .map(Ok),
+                _ => None,
+            })
+            .parse(None, Some(context))
+    });
+
+    module.set_segments(match parsed {
+        Ok(segments) => segments,
+        Err(error) => {
+            log::warn!("Error in module `jj_change`:\n{error}");
+            return None;
+        }
+    });
+
+    Some(module)
+}
+
+fn prefix(id: &str, prefix_size: u8) -> Option<Cow<'_, str>> {
+    let end = id.len().min(prefix_size.into());
+    id.get(..end).filter(|s| !s.is_empty()).map(Cow::Borrowed)
+}
+
+fn suffix(id: &str, prefix_size: u8, hash_length: u8) -> Option<Cow<'_, str>> {
+    let start = id.len().min(prefix_size.into());
+    let end = id.len().min(prefix_size.max(hash_length).into());
+    id.get(start..end)
+        .filter(|s| !s.is_empty())
+        .map(Cow::Borrowed)
+}

--- a/src/modules/jj_change.rs
+++ b/src/modules/jj_change.rs
@@ -75,3 +75,162 @@ fn suffix(id: &str, prefix_size: u8, hash_length: u8) -> Option<Cow<'_, str>> {
         .filter(|s| !s.is_empty())
         .map(Cow::Borrowed)
 }
+
+#[cfg(test)]
+mod tests {
+    use nu_ansi_term::{Color, Style};
+    use toml::toml;
+
+    use super::{prefix, suffix};
+    use crate::context::JJRepo;
+    use crate::test::JJTester;
+
+    // == Helper tests ==
+
+    #[test]
+    fn test_prefix() {
+        assert_eq!(prefix("", 42), None);
+        assert_eq!(prefix("abc", 0), None);
+
+        assert_eq!(prefix("12345678", 4), Some("1234".into()));
+        // When asked for length is bigger than slice, give out the full slice
+        assert_eq!(prefix("123", 12), Some("123".into()));
+    }
+
+    #[test]
+    fn test_suffix() {
+        assert_eq!(suffix("", 24, 42), None);
+        assert_eq!(suffix("", 42, 24), None);
+        assert_eq!(suffix("abc", 4, 3), None);
+        assert_eq!(suffix("123", 2, 2), None);
+
+        assert_eq!(suffix("12345678", 4, 7), Some("567".into()));
+        // When asked for length is bigger than slice, give out the full slice minus the prefix
+        assert_eq!(suffix("12345678", 4, 15), Some("5678".into()));
+    }
+
+    // == Render tests ==
+
+    fn tester(repo: &'static str) -> JJTester {
+        JJTester::new("jj_change").repo(repo)
+    }
+
+    #[test]
+    fn test_render_basics() {
+        JJTester::basic_tests("jj_change");
+    }
+
+    #[test]
+    fn test_render_default_config() {
+        tester(JJRepo::BASE)
+            .expected(format!(
+                "{}{} ",
+                Color::Green.bold().paint("pvt"),
+                Style::new().dimmed().paint("xwmv"),
+            ))
+            .render();
+    }
+
+    #[test]
+    fn test_render_style() {
+        tester(JJRepo::BASE)
+            .options(toml! {
+                prefix_style = "italic red"
+                suffix_style = "blue bold"
+            })
+            .expected(format!(
+                "{}{} ",
+                Color::Red.italic().paint("pvt"),
+                Color::Blue.bold().paint("xwmv"),
+            ))
+            .render();
+    }
+
+    #[test]
+    fn test_render_format() {
+        tester(JJRepo::BASE)
+            .options(toml! {
+                format = "$change \\($commit\\)"
+                prefix_style = ""
+                suffix_style = ""
+            })
+            .expected("pvtxwmv (30363e4)")
+            .render();
+    }
+
+    #[test]
+    fn test_render_variables() {
+        tester(JJRepo::BASE)
+            .options(toml! {
+                format = "$change_prefix $change_suffix \\($commit_prefix $commit_suffix\\)"
+            })
+            .expected("pvt xwmv (3036 3e4)")
+            .render();
+    }
+
+    #[test]
+    fn test_render_modified_change_hash_length() {
+        tester(JJRepo::BASE)
+            .options(toml! {
+                format = "$change_prefix $change_suffix"
+                change_hash_length = 10
+            })
+            .expected("pvt xwmvttt")
+            .render();
+
+        tester(JJRepo::BASE)
+            .options(toml! {
+                format = "$change_prefix $change_suffix"
+                change_hash_length = 2
+            })
+            .expected("pvt ")
+            .render();
+
+        tester(JJRepo::BASE)
+            .options(toml! {
+                format = "$change_prefix $change_suffix"
+                change_hash_length = 255
+            })
+            .expected("pvt xwmvtttmrkkoqkutlystlnozssmnk")
+            .render();
+    }
+
+    #[test]
+    fn test_render_modified_commit_hash_length() {
+        tester(JJRepo::BASE)
+            .options(toml! {
+                format = "$commit_prefix $commit_suffix"
+                commit_hash_length = 12
+            })
+            .expected("3036 3e463b3a")
+            .render();
+
+        tester(JJRepo::BASE)
+            .options(toml! {
+                format = "$commit_prefix $commit_suffix"
+                commit_hash_length = 2
+            })
+            .expected("3036 ")
+            .render();
+
+        tester(JJRepo::BASE)
+            .options(toml! {
+                format = "$commit_prefix $commit_suffix"
+                commit_hash_length = 255
+            })
+            .expected("3036 3e463b3a5c87ad352b2d342f7408e3c2dda8")
+            .render();
+    }
+
+    #[test]
+    fn test_render_divergent_change() {
+        tester(JJRepo::CHANGE_DIVERGENT)
+            .expected(format!(
+                "{}{}{} ",
+                Color::Green.bold().paint("pvt"),
+                Style::new().dimmed().paint("xwmv"),
+                Style::new().bold().paint("/2"),
+            ))
+            .render();
+    }
+}

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -51,6 +51,7 @@ mod hg_state;
 mod hostname;
 mod java;
 mod jj_bookmark;
+mod jj_change;
 mod jobs;
 mod julia;
 mod kotlin;
@@ -176,6 +177,7 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
             "hostname" => hostname::module(context),
             "java" => java::module(context),
             "jj_bookmark" => jj_bookmark::module(context),
+            "jj_change" => jj_change::module(context),
             "jobs" => jobs::module(context),
             "julia" => julia::module(context),
             "kotlin" => kotlin::module(context),
@@ -316,6 +318,7 @@ pub fn description(module: &str) -> &'static str {
         "hostname" => "The system hostname",
         "java" => "The currently installed version of Java",
         "jj_bookmark" => "The closest ancestor bookmark in Jujutsu",
+        "jj_change" => "The current change in Jujutsu",
         "jobs" => "The current number of jobs running",
         "julia" => "The currently installed version of Julia",
         "kotlin" => "The currently installed version of Kotlin",

--- a/src/test/jj_tester.rs
+++ b/src/test/jj_tester.rs
@@ -75,6 +75,8 @@ impl JJTester {
         Self::new(module).repo(JJRepo::EMPTY_OUTPUT).render();
         // JJ repo and invalid output -> parsing fails
         Self::new(module).repo(JJRepo::INVALID_OUTPUT).render();
+        // JJ repo with invalid change hash format -> no output
+        Self::new(module).repo(JJRepo::CHANGE_NOT_ASCII).render();
         // Invalid format
         Self::new(module)
             .repo(JJRepo::BASE)


### PR DESCRIPTION
**See https://github.com/starship/starship/pull/7612 for the full MR with every changes, this MR has been extracted from it to make review easier.**

Adds `jj_change` in two commits, one for the module implementation and one for the rendering tests

Each commit can be reviewed on its own, they all pass tests and formatting.

We start using the test infrastructure introduced in `src/test/jj_tester.rs` in the previous extracted MR, #7643.