### PR TITLE
(feat) added doas as a option in the installer

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -177,7 +177,7 @@ elevate_priv() {
 		info "If you are on Windows, please run your shell as an administrator, then"
 		info "rerun this script. Otherwise, please run this script as root, or install"
 		info "sudo or doas."
-		exit
+		exit 1
 	fi
 	if ! sudo -v or doas; then
 		error "Superuser not granted, aborting installation"

--- a/install/install.sh
+++ b/install/install.sh
@@ -179,7 +179,7 @@ elevate_priv() {
 		info "sudo or doas."
 		exit 1
 	fi
-	if ! sudo -v or doas; then
+	if ! sudo -v && ! doas; then
 		error "Superuser not granted, aborting installation"
 		exit 1
 	fi

--- a/install/install.sh
+++ b/install/install.sh
@@ -172,7 +172,7 @@ usage() {
 }
 
 elevate_priv() {
-	if ! has sudo or doas; then
+	if ! has sudo && ! doas; then
 		error 'Could not find the command "sudo" or "doas", needed to get permissions for install.'
 		info "If you are on Windows, please run your shell as an administrator, then"
 		info "rerun this script. Otherwise, please run this script as root, or install"

--- a/install/install.sh
+++ b/install/install.sh
@@ -172,14 +172,14 @@ usage() {
 }
 
 elevate_priv() {
-	if ! has sudo; then
-		error 'Could not find the command "sudo", needed to get permissions for install.'
+	if ! has sudo or; then
+		error 'Could not find the command "sudo" or "doas", needed to get permissions for install.'
 		info "If you are on Windows, please run your shell as an administrator, then"
 		info "rerun this script. Otherwise, please run this script as root, or install"
-		info "sudo."
+		info "sudo or doas."
 		exit 1
 	fi
-	if ! sudo -v; then
+	if ! sudo -v or doas; then
 		error "Superuser not granted, aborting installation"
 		exit 1
 	fi

--- a/install/install.sh
+++ b/install/install.sh
@@ -172,12 +172,12 @@ usage() {
 }
 
 elevate_priv() {
-	if ! has sudo or; then
+	if ! has sudo or doas; then
 		error 'Could not find the command "sudo" or "doas", needed to get permissions for install.'
 		info "If you are on Windows, please run your shell as an administrator, then"
 		info "rerun this script. Otherwise, please run this script as root, or install"
 		info "sudo or doas."
-		exit 1
+		exit
 	fi
 	if ! sudo -v or doas; then
 		error "Superuser not granted, aborting installation"

--- a/install/install.sh
+++ b/install/install.sh
@@ -130,17 +130,17 @@ download() {
 unpack() {
 	archive=$1
 	bin_dir=$2
-	=${3-}
+	sudo=${3-}
 
 	case "$archive" in
 	*.tar.gz)
 		flags=$(test -n "${VERBOSE-}" && echo "-xzvof" || echo "-xzof")
-		${} tar "${flags}" "${archive}" -C "${bin_dir}"
+		${sudo} tar "${flags}" "${archive}" -C "${bin_dir}"
 		return 0
 		;;
 	*.zip)
 		flags=$(test -z "${VERBOSE-}" && echo "-qqo" || echo "-o")
-		UNZIP="${flags}" ${} unzip "${archive}" -d "${bin_dir}"
+		UNZIP="${flags}" ${sudo} unzip "${archive}" -d "${bin_dir}"
 		return 0
 		;;
 	esac
@@ -184,7 +184,6 @@ elevate_priv() {
 		exit 1
 	fi
 }
-
 
 install() {
 	ext="$1"

--- a/install/install.sh
+++ b/install/install.sh
@@ -130,17 +130,17 @@ download() {
 unpack() {
 	archive=$1
 	bin_dir=$2
-	sudo=${3-}
+	=${3-}
 
 	case "$archive" in
 	*.tar.gz)
 		flags=$(test -n "${VERBOSE-}" && echo "-xzvof" || echo "-xzof")
-		${sudo} tar "${flags}" "${archive}" -C "${bin_dir}"
+		${} tar "${flags}" "${archive}" -C "${bin_dir}"
 		return 0
 		;;
 	*.zip)
 		flags=$(test -z "${VERBOSE-}" && echo "-qqo" || echo "-o")
-		UNZIP="${flags}" ${sudo} unzip "${archive}" -d "${bin_dir}"
+		UNZIP="${flags}" ${} unzip "${archive}" -d "${bin_dir}"
 		return 0
 		;;
 	esac
@@ -172,18 +172,19 @@ usage() {
 }
 
 elevate_priv() {
-	if ! has sudo && ! doas; then
+	if ! [[ has sudo || has doas ]]; then
 		error 'Could not find the command "sudo" or "doas", needed to get permissions for install.'
 		info "If you are on Windows, please run your shell as an administrator, then"
 		info "rerun this script. Otherwise, please run this script as root, or install"
-		info "sudo or doas."
+		info "sudo."
 		exit 1
 	fi
-	if ! sudo -v && ! doas; then
+	if ! [[ has sudo || has doas ]; then
 		error "Superuser not granted, aborting installation"
 		exit 1
 	fi
 }
+
 
 install() {
 	ext="$1"

--- a/install/install.sh
+++ b/install/install.sh
@@ -172,7 +172,7 @@ usage() {
 }
 
 elevate_priv() {
-	if ! [[ has sudo || has doas ]]; then
+	if ! has [[ sudo || doas ]]; then
 		error 'Could not find the command "sudo" or "doas", needed to get permissions for install.'
 		info "If you are on Windows, please run your shell as an administrator, then"
 		info "rerun this script. Otherwise, please run this script as root, or install"


### PR DESCRIPTION
[feat] Added doas as an alternative to sudo
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
Added doas as a alternative to sudo

#### Motivation and Context
This allows for people who use doas instead of sudo to not gain a error on installing

#### Screenshots (if appropriate):

#### How Has This Been Tested?
I have tested it by running  (./install.sh) and running (doas ./install.sh), after running the second one with doas it worked.
- [ ] I have tested using **MacOS**
- [X] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### AI-Assistance
<!-- Per our AI Policy (AI_POLICY.md), all AI usage must be declared. -->
Have you used AI-assistance to author this PR?

- [ ] Yes
- [X] No

If **yes**, describe the scope of assistance:
<!--- Describe how you used AI-Assistance -->
<!--- Disclosure is required if you have used AI-assistance -->
<!--- For example: answering project questions, writing tests, implementation, or documentation -->
N/A

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation accordingly.
- [X] I have updated the tests accordingly.
- [X] I understand and have read the code I contribute and can answer questions about it.
