### PR TITLE
fix(config): prevent concurrent writes from losing changes

### DIFF
--- a/src/configure.rs
+++ b/src/configure.rs
@@ -1,4 +1,5 @@
 use std::fmt::Write as _;
+use std::fs::File;
 use std::process;
 use std::process::Stdio;
 use std::str::FromStr;
@@ -17,6 +18,14 @@ const STD_EDITOR: &str = "vi";
 const STD_EDITOR: &str = "notepad.exe";
 
 pub fn update_configuration(context: &Context, name: &str, value: &str) {
+    // Acquire an exclusive lock on a sibling lockfile before the read-modify-write
+    // cycle. Without this, concurrent `starship config` calls race: both read the
+    // same TOML, both modify independently, and the second write silently overwrites
+    // the first. See #7688.
+    let _lock = context
+        .get_config_path_os()
+        .and_then(|p| acquire_config_lock(&PathBuf::from(p)));
+
     let mut doc = get_configuration_edit(context);
 
     match handle_update_configuration(&mut doc, name, value) {
@@ -26,6 +35,23 @@ pub fn update_configuration(context: &Context, name: &str, value: &str) {
         }
         _ => write_configuration(context, &doc),
     }
+    // _lock is dropped here, releasing the file lock
+}
+
+/// Acquire an exclusive advisory lock on `{config_path}.lock`.
+/// Returns `None` (and logs a warning) if the lock cannot be acquired — the
+/// caller proceeds without locking rather than failing, keeping the old
+/// behavior for edge cases (read-only filesystem, permission issues).
+fn acquire_config_lock(config_path: &PathBuf) -> Option<File> {
+    let lock_path = config_path.with_extension("toml.lock");
+    let file = File::create(&lock_path).ok()?;
+    // File::lock_exclusive is stable since Rust 1.83 — blocks until the lock
+    // is available, then returns. The lock is released when the File is dropped.
+    if let Err(e) = file.lock_exclusive() {
+        log::warn!("Failed to acquire config lock on {lock_path:?}: {e}");
+        return None;
+    }
+    Some(file)
 }
 
 fn handle_update_configuration(
@@ -182,6 +208,10 @@ fn extract_toml_paths(mut config: toml::Value, paths: &[String]) -> toml::Value 
 }
 
 pub fn toggle_configuration(context: &Context, name: &str, key: &str) {
+    let _lock = context
+        .get_config_path_os()
+        .and_then(|p| acquire_config_lock(&PathBuf::from(p)));
+
     let mut doc = get_configuration_edit(context);
 
     match handle_toggle_configuration(&mut doc, name, key) {


### PR DESCRIPTION
## Summary

Fixes #7688 — concurrent `starship config` calls race on the read-modify-write cycle, silently dropping changes.

## Root cause

`update_configuration()` and `toggle_configuration()` both do:
1. **Read** the config (`get_configuration_edit`)
2. **Modify** in memory
3. **Write** atomically (`write_file_atomic`)

The write is atomic (temp + persist), but the **cycle** is not. Two concurrent calls both read the same TOML, modify independently, and the second persist overwrites the first.

## Fix

Wrap each read-modify-write cycle with an exclusive advisory lock on `{config_path}.toml.lock` using `File::lock_exclusive()` (stable since Rust 1.83, starship MSRV 1.95). The lock blocks until acquired, so concurrent calls serialize.

- **No new dependencies** — `File::lock_exclusive` is `std`
- **Cross-platform** (Unix `flock`, Windows `LockFileEx` under the hood)
- **Fail-open**: if the lockfile can't be created, proceeds without locking (preserves existing behavior for read-only filesystems)
- **Lock released on drop** when the guard goes out of scope

## Changes

`src/configure.rs` — 30 lines added:
- `acquire_config_lock()` helper returns `Option<File>` guard
- Lock guard in `update_configuration()` and `toggle_configuration()`