### PR TITLE
fix(hostname): detect SSH session using SSH_CLIENT and SSH_TTY

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2468,6 +2468,11 @@ format = 'via [⎈ $version](bold white) '
 
 The `hostname` module shows the system hostname.
 
+> [!TIP]
+> SSH connection is detected by checking environment variables
+> `SSH_CONNECTION`, `SSH_CLIENT`, and `SSH_TTY`. If your SSH host does not set up
+> these variables, one workaround is to set one of them with a dummy value.
+
 ### Options
 
 | Option            | Default                                | Description                                                                                                                           |

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -235,6 +235,14 @@ impl<'a> Context<'a> {
         self.env.get_env_os(key)
     }
 
+    /// Returns true if the user is currently connected in an SSH session
+    /// (checks `SSH_CONNECTION`, `SSH_CLIENT`, and `SSH_TTY`).
+    #[inline]
+    pub fn is_ssh_session(&self) -> bool {
+        const SSH_ENV: [&str; 3] = ["SSH_CONNECTION", "SSH_CLIENT", "SSH_TTY"];
+        SSH_ENV.iter().any(|env| self.get_env_os(env).is_some())
+    }
+
     /// Convert a `~` in a path to the home directory
     pub fn expand_tilde(dir: PathBuf) -> PathBuf {
         if dir.starts_with("~") {

--- a/src/modules/hostname.rs
+++ b/src/modules/hostname.rs
@@ -10,17 +10,15 @@ use whoami::hostname;
 ///
 /// Will display the hostname if all of the following criteria are met:
 ///     - `hostname.disabled` is absent or false
-///     - `hostname.ssh_only` is false OR the user is currently connected as an SSH session (`$SSH_CONNECTION`)
+///     - `hostname.ssh_only` is false OR the user is currently connected as an SSH session (`$SSH_CONNECTION`, `$SSH_CLIENT`, or `$SSH_TTY`)
 ///     - `hostname.ssh_only` is false AND `hostname.detect_env_vars` is either empty or contains a defined environment variable
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let mut module = context.new_module("hostname");
     let config: HostnameConfig = HostnameConfig::try_load(module.config);
 
-    let ssh_connection = context.get_env("SSH_CONNECTION");
+    let is_ssh = context.is_ssh_session();
 
-    if (config.ssh_only && ssh_connection.is_none())
-        || !context.detect_env_vars(&config.detect_env_vars)
-    {
+    if (config.ssh_only && !is_ssh) || !context.detect_env_vars(&config.detect_env_vars) {
         return None;
     }
 
@@ -44,7 +42,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         formatter
             .map_meta(|var, _| match var {
                 "ssh_symbol" => {
-                    if ssh_connection.is_some() {
+                    if is_ssh {
                         Some(config.ssh_symbol)
                     } else {
                         None
@@ -213,6 +211,44 @@ mod tests {
                 trim_at = ""
             })
             .env("SSH_CONNECTION", "something")
+            .collect();
+        let expected = Some(format!(
+            "{} in ",
+            style().paint("🌐 ".to_owned() + hostname.as_str())
+        ));
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn ssh_client() {
+        let hostname = get_hostname!();
+        let actual = ModuleRenderer::new("hostname")
+            .config(toml::toml! {
+                [hostname]
+                ssh_only = true
+                trim_at = ""
+            })
+            .env("SSH_CLIENT", "192.168.0.101 39323 22")
+            .collect();
+        let expected = Some(format!(
+            "{} in ",
+            style().paint("🌐 ".to_owned() + hostname.as_str())
+        ));
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn ssh_tty() {
+        let hostname = get_hostname!();
+        let actual = ModuleRenderer::new("hostname")
+            .config(toml::toml! {
+                [hostname]
+                ssh_only = true
+                trim_at = ""
+            })
+            .env("SSH_TTY", "/dev/pts/0")
             .collect();
         let expected = Some(format!(
             "{} in ",

--- a/src/modules/hostname.rs
+++ b/src/modules/hostname.rs
@@ -11,7 +11,7 @@ use whoami::hostname;
 /// Will display the hostname if all of the following criteria are met:
 ///     - `hostname.disabled` is absent or false
 ///     - `hostname.ssh_only` is false OR the user is currently connected as an SSH session (`$SSH_CONNECTION`, `$SSH_CLIENT`, or `$SSH_TTY`)
-///     - `hostname.ssh_only` is false AND `hostname.detect_env_vars` is either empty or contains a defined environment variable
+///     - `hostname.detect_env_vars` is either empty or contains a defined environment variable
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let mut module = context.new_module("hostname");
     let config: HostnameConfig = HostnameConfig::try_load(module.config);

--- a/src/modules/username.rs
+++ b/src/modules/username.rs
@@ -14,7 +14,7 @@ const USERNAME_ENV_VAR: &str = "USERNAME";
 /// Will display the username if any of the following criteria are met:
 ///     - The current user is root (UID = 0) [1]
 ///     - The current user isn't the same as the one that is logged in (`$LOGNAME` != `$USER`) [2]
-///     - The user is currently connected as an SSH session (`$SSH_CONNECTION`) [3]
+///     - The user is currently connected as an SSH session (`$SSH_CONNECTION`, `$SSH_CLIENT`, or `$SSH_TTY`) [3]
 ///     - The option `username.detect_env_vars` is set with a not negated environment variable [4]
 /// Does not display the username:
 ///     - If the option `username.detect_env_vars` is set with a negated environment variable [A]
@@ -40,7 +40,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     let show_username = config.show_always
         || is_root // [1]
         || !is_login_user(context, &username) // [2]
-        || is_ssh_session(context) // [3]
+        || context.is_ssh_session() // [3]
         || has_detected_env_var == Detected::Yes; // [4]
 
     if !show_username || has_detected_env_var == Detected::Negated {
@@ -117,11 +117,6 @@ fn is_root_user() -> bool {
 #[cfg(all(not(target_os = "windows"), not(test)))]
 fn is_root_user() -> bool {
     nix::unistd::geteuid() == nix::unistd::ROOT
-}
-
-fn is_ssh_session(context: &Context) -> bool {
-    let ssh_env = ["SSH_CONNECTION", "SSH_CLIENT", "SSH_TTY"];
-    ssh_env.iter().any(|env| context.get_env_os(env).is_some())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #7207

The `hostname` module previously only checked `$SSH_CONNECTION` to detect SSH sessions, whereas the `username` module checks `$SSH_CONNECTION`, `$SSH_CLIENT`, and `$SSH_TTY`. This PR adds `Context::is_ssh_session()` to unify SSH detection across modules and adds tests for `$SSH_CLIENT` and `$SSH_TTY`.

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
- [x] I understand and have read the code I contribute and can answer questions about it.