### PR TITLE
docs: add Lumesh to supported shell list

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,20 @@ eval $(starship init ion)
 </details>
 
 <details>
+<summary>Lumesh</summary>
+
+Lumesh has builtin support for Starship. Add the following to `~/.config/lumesh/config.lm`:
+
+```bash
+set LUME_PROMPT_SETTINGS = {
+        starship: 1,             # or `true`
+        lazy: 0,                 # 2 is ok if no duration/jobs/status needed
+}
+```
+
+</details>
+
+<details>
 <summary>Nushell</summary>
 
 Add the following to the end of your Nushell configuration (find it by running `$nu.config-path` in Nushell):

--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ eval $(starship init ion)
 <details>
 <summary>Lumesh</summary>
 
-Lumesh has builtin support for Starship. Add the following to `~/.config/lumesh/config.lm`:
+Lumesh has built-in support for Starship. Add the following to `~/.config/lumesh/config.lm`:
 
 ```bash
 set LUME_PROMPT_SETTINGS = {

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,7 @@ footer: ISC Licensed | Copyright © 2019-present Starship Contributors
 
 # Used for the description meta tag, for SEO
 metaTitle: "Starship: Cross-Shell Prompt"
-description: Starship is the minimal, blazing fast, and extremely customizable prompt for any shell! Shows the information you need, while staying sleek and minimal. Quick installation available for Bash, Fish, ZSH, Ion, Tcsh, Elvish, Nu, Xonsh, Cmd, and PowerShell.
+description: Starship is the minimal, blazing fast, and extremely customizable prompt for any shell! Shows the information you need, while staying sleek and minimal. Quick installation available for Bash, Fish, ZSH, Ion, Tcsh, Lumesh, Elvish, Nu, Xonsh, Cmd, and PowerShell.
 ---
 
 <script setup>

--- a/docs/README.md
+++ b/docs/README.md
@@ -146,6 +146,19 @@ onMounted(() => {
    eval `starship init tcsh`
    ```
 
+   #### Lumesh
+
+   Add the following to `~/.config/lumesh/config.lm`:
+
+   ```bash
+   # ~/.config/lumesh/config.lm
+
+   set LUME_PROMPT_SETTINGS = {
+           starship: 1,             # or `true`
+           lazy: 0,                 # 2 is ok if no duration/jobs/status needed
+   }
+   ```
+
    #### Nushell
    > [!WARNING]
    > This will change in the future.


### PR DESCRIPTION
Closes #7680

Adds setup instructions and configuration snippets for the Lumesh shell to `README.md` and `docs/README.md`.

#### Checklist:
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [x] I understand and have read the code I contribute and can answer questions about it.