### PR TITLE
feat(memory_usage): additional styling options

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -1100,6 +1100,7 @@
         "format": "via $symbol[$ram( | $swap)]($style) ",
         "style": "white bold dimmed",
         "symbol": "🐏 ",
+        "show_always": false,
         "disabled": true
       }
     },
@@ -4946,9 +4947,19 @@
           "type": "string",
           "default": "white bold dimmed"
         },
+        "threshold_style": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "symbol": {
           "type": "string",
           "default": "🐏 "
+        },
+        "show_always": {
+          "type": "boolean",
+          "default": false
         },
         "disabled": {
           "type": "boolean",

--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -1100,6 +1100,7 @@
         "format": "via $symbol[$ram( | $swap)]($style) ",
         "style": "white bold dimmed",
         "symbol": "🐏 ",
+        "thresholds": null,
         "show_always": false,
         "disabled": true
       }
@@ -4957,6 +4958,16 @@
           "type": "string",
           "default": "🐏 "
         },
+        "thresholds": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/$defs/ThresholdConfig"
+          },
+          "default": null
+        },
         "show_always": {
           "type": "boolean",
           "default": false
@@ -4967,6 +4978,23 @@
         }
       },
       "additionalProperties": false
+    },
+    "ThresholdConfig": {
+      "type": "object",
+      "properties": {
+        "value": {
+          "type": "integer",
+          "format": "int64"
+        },
+        "style": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "value",
+        "style"
+      ]
     },
     "MesonConfig": {
       "type": "object",

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -3037,13 +3037,15 @@ By default the swap usage is displayed if the total system swap is non-zero.
 
 ### Options
 
-| Option      | Default                                        | Description                                              |
-| ----------- | ---------------------------------------------- | -------------------------------------------------------- |
-| `threshold` | `75`                                           | Hide the memory usage unless it exceeds this percentage. |
-| `format`    | `'via $symbol [${ram}( \| ${swap})]($style) '` | The format for the module.                               |
-| `symbol`    | `'🐏'`                                         | The symbol used before displaying the memory usage.      |
-| `style`     | `'bold dimmed white'`                          | The style for the module.                                |
-| `disabled`  | `true`                                         | Disables the `memory_usage` module.                      |
+| Option            | Default                                        | Description                                                                               |
+| ------------------| ---------------------------------------------- | ------------------------------------------------------------------------------------------|
+| `threshold`       | `75`                                           | Hide the memory usage unless it exceeds this percentage.                                  |
+| `format`          | `'via $symbol [${ram}( \| ${swap})]($style) '` | The format for the module.                                                                |
+| `symbol`          | `'🐏'`                                         | The symbol used before displaying the memory usage.                                       |
+| `style`           | `'bold dimmed white'`                          | The style for the module.                                                                 |
+| `threshold_style` |                                                | The style used when the memory usage exceed the threshold (defaults to `style` if unset). |
+| `show_always`     | `false`                                        | Always shows the `memory_usage` module.                                                   |
+| `disabled`        | `true`                                         | Disables the `memory_usage` module.                                                       |
 
 ### Variables
 
@@ -3054,7 +3056,7 @@ By default the swap usage is displayed if the total system swap is non-zero.
 | swap\*\*     | `1GiB/4GiB`   | The swap memory size of the current system swap memory file.       |
 | swap_pct\*\* | `77%`         | The swap memory percentage of the current system swap memory file. |
 | symbol       | `🐏`          | Mirrors the value of option `symbol`                               |
-| style\*      |               | Mirrors the value of option `style`                                |
+| style\*      |               | Mirrors the value of option `style` and `threshold_style`          |
 
 *: This variable can only be used as a part of a style string
 *\*: The SWAP file information is only displayed if detected on the current system
@@ -3070,6 +3072,31 @@ threshold = -1
 symbol = ' '
 style = 'bold dimmed green'
 ```
+
+### Additional thresholds
+
+When `show_always` is set to `true`, the `thresholds` configuration can be used to add additional memory usage thresholds and styles.
+
+| Option            | Example                     | Description                                |
+| ----------------- | --------------------------- | ------------------------------------------ |
+| `value`           | `50`                        | **Required** The memory usage percentage.  |
+| `style`           | `'fg:yellow'`               | **Required** The style for the module.     |
+
+#### Example
+
+```toml
+# ~/.config/starship.toml
+
+[[memory_usage.thresholds]]
+value = 50
+style = "fg:yellow"
+
+[[memory_usage.thresholds]]
+value = 25
+style = "fg:blue"
+```
+
+When the memory usage exceeds one of the specified percentages, the value of the option `style` will be mirrored to the `style` variable of the format string.
 
 ## Meson
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -3037,26 +3037,26 @@ By default the swap usage is displayed if the total system swap is non-zero.
 
 ### Options
 
-| Option            | Default                                        | Description                                                                               |
-| ------------------| ---------------------------------------------- | ------------------------------------------------------------------------------------------|
-| `threshold`       | `75`                                           | Hide the memory usage unless it exceeds this percentage.                                  |
-| `format`          | `'via $symbol [${ram}( \| ${swap})]($style) '` | The format for the module.                                                                |
-| `symbol`          | `'🐏'`                                         | The symbol used before displaying the memory usage.                                       |
-| `style`           | `'bold dimmed white'`                          | The style for the module.                                                                 |
-| `threshold_style` |                                                | The style used when the memory usage exceed the threshold (defaults to `style` if unset). |
-| `show_always`     | `false`                                        | Always shows the `memory_usage` module.                                                   |
-| `disabled`        | `true`                                         | Disables the `memory_usage` module.                                                       |
+| Option            | Default                                        | Description                                                                                |
+| ----------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `threshold`       | `75`                                           | Hide the memory usage unless it exceeds this percentage.                                   |
+| `format`          | `'via $symbol [${ram}( \| ${swap})]($style) '` | The format for the module.                                                                 |
+| `symbol`          | `'🐏'`                                         | The symbol used before displaying the memory usage.                                        |
+| `style`           | `'bold dimmed white'`                          | The style for the module.                                                                  |
+| `threshold_style` |                                                | The style used when the memory usage exceeds the threshold (defaults to `style` if unset). |
+| `show_always`     | `false`                                        | Always shows the `memory_usage` module.                                                    |
+| `disabled`        | `true`                                         | Disables the `memory_usage` module.                                                        |
 
 ### Variables
 
-| Variable     | Example       | Description                                                        |
-| ------------ | ------------- | ------------------------------------------------------------------ |
-| ram          | `31GiB/65GiB` | The usage/total RAM of the current system memory.                  |
-| ram_pct      | `48%`         | The percentage of the current system memory.                       |
-| swap\*\*     | `1GiB/4GiB`   | The swap memory size of the current system swap memory file.       |
-| swap_pct\*\* | `77%`         | The swap memory percentage of the current system swap memory file. |
-| symbol       | `🐏`          | Mirrors the value of option `symbol`                               |
-| style\*      |               | Mirrors the value of option `style` and `threshold_style`          |
+| Variable     | Example       | Description                                                                                |
+| ------------ | ------------- | ------------------------------------------------------------------------------------------ |
+| ram          | `31GiB/65GiB` | The usage/total RAM of the current system memory.                                          |
+| ram_pct      | `48%`         | The percentage of the current system memory.                                               |
+| swap\*\*     | `1GiB/4GiB`   | The swap memory size of the current system swap memory file.                               |
+| swap_pct\*\* | `77%`         | The swap memory percentage of the current system swap memory file.                         |
+| symbol       | `🐏`          | Mirrors the value of option `symbol`                                                       |
+| style\*      |               | Mirrors the value of option `style`, `threshold_style`, or the matched `thresholds` entry. |
 
 *: This variable can only be used as a part of a style string
 *\*: The SWAP file information is only displayed if detected on the current system
@@ -3077,10 +3077,10 @@ style = 'bold dimmed green'
 
 When `show_always` is set to `true`, the `thresholds` configuration can be used to add additional memory usage thresholds and styles.
 
-| Option            | Example                     | Description                                |
-| ----------------- | --------------------------- | ------------------------------------------ |
-| `value`           | `50`                        | **Required** The memory usage percentage.  |
-| `style`           | `'fg:yellow'`               | **Required** The style for the module.     |
+| Option  | Example       | Description                               |
+| ------- | ------------- | ----------------------------------------- |
+| `value` | `50`          | **Required** The memory usage percentage. |
+| `style` | `'fg:yellow'` | **Required** The style for the module.    |
 
 #### Example
 

--- a/src/configs/memory_usage.rs
+++ b/src/configs/memory_usage.rs
@@ -11,7 +11,10 @@ pub struct MemoryConfig<'a> {
     pub threshold: i64,
     pub format: &'a str,
     pub style: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub threshold_style: Option<&'a str>,
     pub symbol: &'a str,
+    pub show_always: bool,
     pub disabled: bool,
 }
 
@@ -21,7 +24,9 @@ impl Default for MemoryConfig<'_> {
             threshold: 75,
             format: "via $symbol[$ram( | $swap)]($style) ",
             style: "white bold dimmed",
+            threshold_style: None,
             symbol: "🐏 ",
+            show_always: false,
             disabled: true,
         }
     }

--- a/src/configs/memory_usage.rs
+++ b/src/configs/memory_usage.rs
@@ -14,6 +14,7 @@ pub struct MemoryConfig<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub threshold_style: Option<&'a str>,
     pub symbol: &'a str,
+    pub thresholds: Option<Vec<ThresholdConfig<'a>>>,
     pub show_always: bool,
     pub disabled: bool,
 }
@@ -26,8 +27,20 @@ impl Default for MemoryConfig<'_> {
             style: "white bold dimmed",
             threshold_style: None,
             symbol: "🐏 ",
+            thresholds: None,
             show_always: false,
             disabled: true,
         }
     }
+}
+
+#[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(
+    feature = "config-schema",
+    derive(schemars::JsonSchema),
+    schemars(deny_unknown_fields)
+)]
+pub struct ThresholdConfig<'a> {
+    pub value: i64,
+    pub style: &'a str,
 }

--- a/src/modules/memory_usage.rs
+++ b/src/modules/memory_usage.rs
@@ -5,7 +5,7 @@ use systemstat::{
 
 use super::{Context, Module, ModuleConfig};
 
-use crate::configs::memory_usage::MemoryConfig;
+use crate::configs::memory_usage::{MemoryConfig, ThresholdConfig};
 use crate::formatter::StringFormatter;
 
 // Display a `ByteSize` in a human readable format.
@@ -83,6 +83,25 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         return None;
     }
 
+    let style = config
+        .threshold_style
+        .map(|style| ThresholdConfig {
+            value: config.threshold,
+            style,
+        })
+        .iter()
+        .chain(
+            config
+                .thresholds
+                .filter(|_| config.show_always)
+                .iter()
+                .flat_map(|ts| ts.iter()),
+        )
+        .filter(|t| t.value <= used_rounded)
+        .max_by_key(|t| t.value)
+        .map(|t| t.style)
+        .unwrap_or(config.style);
+
     let parsed = StringFormatter::new(config.format).and_then(|formatter| {
         formatter
             .map_meta(|var, _| match var {
@@ -90,11 +109,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 _ => None,
             })
             .map_style(|variable| match variable {
-                "style" => Some(Ok(if used_rounded < config.threshold {
-                    config.style
-                } else {
-                    config.threshold_style.unwrap_or(config.style)
-                })),
+                "style" => Some(Ok(style)),
                 _ => None,
             })
             .map(|variable| match variable {
@@ -198,7 +213,6 @@ mod test {
             .config(toml::toml! {
                 [memory_usage]
                 disabled = false
-                show_always = false
                 threshold = 101
             })
             .collect();
@@ -217,7 +231,7 @@ mod test {
 
     #[test]
     fn threshold_styling() {
-        // RAM usage exceeds the threshold, `threshold_style` is not set
+        // Usage exceeds the threshold, `threshold_style` is not set, so `style` is used instead
         let expected = Some(format!("{}", Color::Green.paint("RAM")));
         let actual = ModuleRenderer::new("memory_usage")
             .config(toml::toml! {
@@ -230,7 +244,7 @@ mod test {
             .collect();
         assert_eq!(expected, actual);
 
-        // RAM usage exceeds the threshold, `threshold_style` is set
+        // Usage exceeds the threshold, `threshold_style` is set
         let expected = Some(format!("{}", Color::Red.paint("RAM")));
         let actual = ModuleRenderer::new("memory_usage")
             .config(toml::toml! {
@@ -244,7 +258,7 @@ mod test {
             .collect();
         assert_eq!(expected, actual);
 
-        // RAM usage is below the threshold, `threshold_style` is set
+        // Usage is below the threshold, `show_always` is true, `threshold_style` is set
         let expected = Some(format!("{}", Color::Green.paint("RAM")));
         let actual = ModuleRenderer::new("memory_usage")
             .config(toml::toml! {
@@ -255,6 +269,186 @@ mod test {
                 threshold = 101
                 threshold_style = "fg:red"
                 format = "[RAM]($style)"
+            })
+            .collect();
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn optional_thresholds_missing_fields() {
+        // Both `value` and `style` must be set
+        let output = ModuleRenderer::new("memory_usage")
+            .config(toml::toml! {
+                [memory_usage]
+                disabled = false
+                show_always = true
+
+                [[memory_usage.thresholds]]
+                value = 0
+            })
+            .collect();
+        assert!(output.is_none());
+
+        let output = ModuleRenderer::new("memory_usage")
+            .config(toml::toml! {
+                [memory_usage]
+                disabled = false
+                show_always = true
+
+                [[memory_usage.thresholds]]
+                style = "fg:red"
+            })
+            .collect();
+        assert!(output.is_none());
+
+        let output = ModuleRenderer::new("memory_usage")
+            .config(toml::toml! {
+                [memory_usage]
+                disabled = false
+                show_always = true
+
+                [[memory_usage.thresholds]]
+                value = 0
+                style = "fg:red"
+            })
+            .collect();
+        assert!(output.is_some());
+    }
+
+    #[test]
+    fn optional_thresholds() {
+        // Usage is below the main threshold, optional thresholds are set,
+        // `show_always` is false, so we don't expect any output
+        let output = ModuleRenderer::new("memory_usage")
+            .config(toml::toml! {
+                [memory_usage]
+                disabled = false
+                style = "fg:green"
+                threshold = 101
+                threshold_style = "fg:red"
+                format = "[RAM]($style)"
+
+                [[memory_usage.thresholds]]
+                value = -7
+                style = "fg:purple"
+            })
+            .collect();
+        assert!(output.is_none());
+
+        // Usage is below the main threshold, optional thresholds are set, `show_always` is true
+        let expected = Some(format!("{}", Color::Cyan.paint("RAM")));
+        let actual = ModuleRenderer::new("memory_usage")
+            .config(toml::toml! {
+                [memory_usage]
+                disabled = false
+                show_always = true
+                style = "fg:green"
+                threshold = 101
+                threshold_style = "fg:red"
+                format = "[RAM]($style)"
+
+                [[memory_usage.thresholds]]
+                value = -7
+                style = "fg:purple"
+
+                [[memory_usage.thresholds]]
+                value = -5
+                style = "fg:cyan"
+            })
+            .collect();
+        assert_eq!(expected, actual);
+
+        // Usage exceeds some thresholds, optional thresholds are set, `show_always` is true
+        // We expect to see the style from the greatest exceeded threshold
+        let expected = Some(format!("{}", Color::Red.paint("RAM")));
+        let actual = ModuleRenderer::new("memory_usage")
+            .config(toml::toml! {
+                [memory_usage]
+                disabled = false
+                show_always = true
+                style = "fg:green"
+                threshold = -1
+                threshold_style = "fg:red"
+                format = "[RAM]($style)"
+
+                [[memory_usage.thresholds]]
+                value = 101
+                style = "fg:purple"
+
+                [[memory_usage.thresholds]]
+                value = -5
+                style = "fg:cyan"
+            })
+            .collect();
+        assert_eq!(expected, actual);
+
+        // Usage exceeds all threshold, `show_always` is true
+        // We expect to see the style from the greatest exceeded threshold
+        let expected = Some(format!("{}", Color::Purple.paint("RAM")));
+        let actual = ModuleRenderer::new("memory_usage")
+            .config(toml::toml! {
+                [memory_usage]
+                disabled = false
+                show_always = true
+                style = "fg:green"
+                threshold = -3
+                threshold_style = "fg:red"
+                format = "[RAM]($style)"
+
+                [[memory_usage.thresholds]]
+                value = -1
+                style = "fg:purple"
+
+                [[memory_usage.thresholds]]
+                value = -5
+                style = "fg:cyan"
+            })
+            .collect();
+        assert_eq!(expected, actual);
+
+        // Usage exceeds the main and some optional thresholds,
+        // `show_always` is true, `threshold_style` is not set,
+        // we expect an appropriate style from one of the optional thresholds
+        let expected = Some(format!("{}", Color::Cyan.paint("RAM")));
+        let actual = ModuleRenderer::new("memory_usage")
+            .config(toml::toml! {
+                [memory_usage]
+                disabled = false
+                show_always = true
+                style = "fg:green"
+                threshold = -1
+                format = "[RAM]($style)"
+
+                [[memory_usage.thresholds]]
+                value = 101
+                style = "fg:purple"
+
+                [[memory_usage.thresholds]]
+                value = -5
+                style = "fg:cyan"
+            })
+            .collect();
+        assert_eq!(expected, actual);
+
+        // Usage exceeds the main threshold, `show_always` is true
+        // `threshold_style` is not set, we expect the default style
+        let expected = Some(format!("{}", Color::Green.paint("RAM")));
+        let actual = ModuleRenderer::new("memory_usage")
+            .config(toml::toml! {
+                [memory_usage]
+                disabled = false
+                show_always = true
+                style = "fg:green"
+                threshold = -1
+                format = "[RAM]($style)"
+
+                [[memory_usage.thresholds]]
+                value = 101
+                style = "fg:purple"
+
+                [[memory_usage.thresholds]]
+                value = 102
+                style = "fg:cyan"
             })
             .collect();
         assert_eq!(expected, actual);

--- a/src/modules/memory_usage.rs
+++ b/src/modules/memory_usage.rs
@@ -77,8 +77,9 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
     };
 
     let used_pct = pct(memory.total, memory.free);
+    let used_rounded = used_pct.round() as i64;
 
-    if (used_pct.round() as i64) < config.threshold {
+    if !config.show_always && used_rounded < config.threshold {
         return None;
     }
 
@@ -89,7 +90,11 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 _ => None,
             })
             .map_style(|variable| match variable {
-                "style" => Some(Ok(config.style)),
+                "style" => Some(Ok(if used_rounded < config.threshold {
+                    config.style
+                } else {
+                    config.threshold_style.unwrap_or(config.style)
+                })),
                 _ => None,
             })
             .map(|variable| match variable {
@@ -124,6 +129,7 @@ mod test {
     use super::*;
 
     use crate::test::ModuleRenderer;
+    use nu_ansi_term::Color;
 
     #[test]
     fn test_format_usage_total() {
@@ -184,5 +190,73 @@ mod test {
             .collect();
 
         assert!(output.is_none());
+    }
+
+    #[test]
+    fn show_always() {
+        let output = ModuleRenderer::new("memory_usage")
+            .config(toml::toml! {
+                [memory_usage]
+                disabled = false
+                show_always = false
+                threshold = 101
+            })
+            .collect();
+        assert!(output.is_none());
+
+        let output = ModuleRenderer::new("memory_usage")
+            .config(toml::toml! {
+                [memory_usage]
+                disabled = false
+                show_always = true
+                threshold = 101
+            })
+            .collect();
+        assert!(output.is_some());
+    }
+
+    #[test]
+    fn threshold_styling() {
+        // RAM usage exceeds the threshold, `threshold_style` is not set
+        let expected = Some(format!("{}", Color::Green.paint("RAM")));
+        let actual = ModuleRenderer::new("memory_usage")
+            .config(toml::toml! {
+                [memory_usage]
+                disabled = false
+                style = "fg:green"
+                threshold = -1
+                format = "[RAM]($style)"
+            })
+            .collect();
+        assert_eq!(expected, actual);
+
+        // RAM usage exceeds the threshold, `threshold_style` is set
+        let expected = Some(format!("{}", Color::Red.paint("RAM")));
+        let actual = ModuleRenderer::new("memory_usage")
+            .config(toml::toml! {
+                [memory_usage]
+                disabled = false
+                style = "fg:green"
+                threshold = -1
+                threshold_style = "fg:red"
+                format = "[RAM]($style)"
+            })
+            .collect();
+        assert_eq!(expected, actual);
+
+        // RAM usage is below the threshold, `threshold_style` is set
+        let expected = Some(format!("{}", Color::Green.paint("RAM")));
+        let actual = ModuleRenderer::new("memory_usage")
+            .config(toml::toml! {
+                [memory_usage]
+                disabled = false
+                show_always = true
+                style = "fg:green"
+                threshold = 101
+                threshold_style = "fg:red"
+                format = "[RAM]($style)"
+            })
+            .collect();
+        assert_eq!(expected, actual);
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
Adds additional configuration options to the `memory_usage` module:
- `show_always`: when set to `true`, the module will be displayed at all times;
- `threshold_style`: optional style that will be used when the usage exceeds the threshold percentage;
- `thresholds`: optional thresholds values and styles.

These new optional parameters will make the module a little more customizable without huge performance costs.

#### Motivation and Context
A dedicated `show_always` flag is a more convenient way to always display this module.
Numbers and units are well and good, but visual cues like color are a great way to convey something like RAM usage level. With multiple thresholds and stylings the message will be even clearer.

#### Screenshots (if appropriate):
Here's an example of a configuration that uses the new options:
```toml
[memory_usage]
disabled = false
style = "fg:green"
show_always = true
threshold = 50
threshold_style = "fg:bold red"
symbol = "🐏"
format = "$symbol( [$ram $ram_pct]($style))"

[[memory_usage.thresholds]]
value = 40
style = "fg:blue"

[[memory_usage.thresholds]]
value = 45
style = "fg:yellow"
```

With this configuration the module's output looks like this:
<img width="544" height="437" alt="image" src="https://github.com/user-attachments/assets/a7a9c98d-21ed-4753-ad33-1a50134eba0e" />


#### How Has This Been Tested?
New tests check the new configuration options, and ensure that the original logic is preserved. I couldn't figure out how to simulate the RAM usage in tests (like the battery level in the `battery` module, and without moving too much stuff around), so I just use different threshold values.

- [ ] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [x] I have tested using **Windows**

#### AI-Assistance
<!-- Per our AI Policy (AI_POLICY.md), all AI usage must be declared. -->
Have you used AI-assistance to author this PR?

- [ ] Yes
- [x] No

If **yes**, describe the scope of assistance:
<!--- Describe how you used AI-Assistance -->
<!--- Disclosure is required if you have used AI-assistance -->
<!--- For example: answering project questions, writing tests, implementation, or documentation -->
N/A

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
- [x] I understand and have read the code I contribute and can answer questions about it.
