### PR TITLE
feat: bash streaming, validated by a real-shell pty harness

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,10 @@
+[test-groups]
+# Each test spawns a real shell in a pseudo-terminal and polls its output;
+# running many at once on a shared CI runner starves them of CPU and turns
+# the poll timeouts flaky, so parallelism is capped rather than serialized.
+pty = { max-threads = 2 }
+
+[[profile.default.overrides]]
+filter = 'binary(init_async)'
+test-group = 'pty'
+platform = 'cfg(unix)'

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,8 +1,10 @@
 [test-groups]
 # Each test spawns a real shell in a pseudo-terminal and polls its output;
-# running many at once on a shared CI runner starves them of CPU and turns
-# the poll timeouts flaky, so parallelism is capped rather than serialized.
-pty = { max-threads = 2 }
+# running two at once on a shared CI runner still starves them of CPU often
+# enough to turn the poll timeouts flaky (seen concurrently failing bash
+# and Nushell pty tests on ubuntu-latest's coverage-instrumented leg), so
+# they're fully serialized.
+pty = { max-threads = 1 }
 
 [[profile.default.overrides]]
 filter = 'binary(init_async)'

--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -31,6 +31,21 @@
       "minimum": 0,
       "default": 500
     },
+    "async": {
+      "description": "How a streaming prompt paces itself: whether it streams at all, how\nlong it collects reflowing refinements before redrawing, and how often\neach module whose value goes stale on its own is renewed. See\n[`AsynchronousConfig`].",
+      "$ref": "#/$defs/AsynchronousConfig",
+      "default": {
+        "enabled": true,
+        "bus": 100,
+        "adaptive": true,
+        "dynamic": {
+          "time": 1000,
+          "battery": 30000,
+          "memory_usage": 5000,
+          "localip": 30000
+        }
+      }
+    },
     "add_newline": {
       "type": "boolean",
       "default": true
@@ -1950,6 +1965,77 @@
   },
   "additionalProperties": false,
   "$defs": {
+    "AsynchronousConfig": {
+      "description": "Streaming prompt timing settings.",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Enables refinements after the first paint.",
+          "type": "boolean",
+          "default": true
+        },
+        "bus": {
+          "description": "Maximum refinement batching delay in milliseconds.",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0,
+          "default": 100
+        },
+        "adaptive": {
+          "description": "Batches refinements using session timing estimates.",
+          "type": "boolean",
+          "default": true
+        },
+        "dynamic": {
+          "description": "Refresh periods for dynamic modules.",
+          "$ref": "#/$defs/DynamicPeriodsConfig",
+          "default": {
+            "time": 1000,
+            "battery": 30000,
+            "memory_usage": 5000,
+            "localip": 30000
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "DynamicPeriodsConfig": {
+      "description": "Dynamic module refresh periods.",
+      "type": "object",
+      "properties": {
+        "time": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 1,
+          "maximum": 86400000
+        },
+        "battery": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 1,
+          "maximum": 86400000
+        },
+        "memory_usage": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 1,
+          "maximum": 86400000
+        },
+        "localip": {
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 1,
+          "maximum": 86400000
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "time",
+        "battery",
+        "memory_usage",
+        "localip"
+      ]
+    },
     "AwsConfig": {
       "title": "AWS",
       "description": "The `aws` module shows the current AWS region and profile and an expiration timer when using temporary credentials.\nThe output of the module uses the `AWS_REGION`, `AWS_DEFAULT_REGION`, and `AWS_PROFILE` env vars and the `~/.aws/config` and `~/.aws/credentials` files as required.\n\nThe module will display a profile only if its credentials are present in `~/.aws/credentials` or if a `credential_process` or `sso_start_url` are defined in `~/.aws/config`. Alternatively, having any of the `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, or `AWS_SESSION_TOKEN` env vars defined will also suffice.\nIf the option `force_display` is set to `true`, all available information will be displayed even if no credentials per the conditions above are detected.\n\nWhen using [aws-vault](https://github.com/99designs/aws-vault) the profile\nis read from the `AWS_VAULT` env var and the credentials expiration date\nis read from the `AWS_SESSION_EXPIRATION` or `AWS_CREDENTIAL_EXPIRATION`\nvar.\n\nWhen using [awsu](https://github.com/kreuzwerker/awsu) the profile\nis read from the `AWSU_PROFILE` env var.\n\nWhen using [`AWSume`](https://awsu.me) the profile\nis read from the `AWSUME_PROFILE` env var and the credentials expiration\ndate is read from the `AWSUME_EXPIRATION` env var.\n\nWhen using [aws-sso-cli](https://github.com/synfinatic/aws-sso-cli) the profile\nis read from the `AWS_SSO_PROFILE` env var.",

--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -2007,34 +2007,32 @@
           "type": "integer",
           "format": "uint64",
           "minimum": 1,
-          "maximum": 86400000
+          "maximum": 86400000,
+          "default": 1000
         },
         "battery": {
           "type": "integer",
           "format": "uint64",
           "minimum": 1,
-          "maximum": 86400000
+          "maximum": 86400000,
+          "default": 30000
         },
         "memory_usage": {
           "type": "integer",
           "format": "uint64",
           "minimum": 1,
-          "maximum": 86400000
+          "maximum": 86400000,
+          "default": 5000
         },
         "localip": {
           "type": "integer",
           "format": "uint64",
           "minimum": 1,
-          "maximum": 86400000
+          "maximum": 86400000,
+          "default": 30000
         }
       },
-      "additionalProperties": false,
-      "required": [
-        "time",
-        "battery",
-        "memory_usage",
-        "localip"
-      ]
+      "additionalProperties": false
     },
     "AwsConfig": {
       "title": "AWS",

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -210,7 +210,16 @@ jobs:
 
       # Run the ignored tests that expect the above setup.
       # `--run-ignored all` is nextest's spelling of `--include-ignored`.
+      #
+      # Coverage instrumentation is stable-only: cargo-llvm-cov's pinned
+      # release periodically falls out of sync with nightly rust's own
+      # ABI/codegen churn, which surfaces as every test passing and then
+      # object-file collection failing outright — a tool-compatibility
+      # failure, not a real test one. Nightly's purpose in this matrix is
+      # to catch compiler regressions in pass/fail, not to contribute a
+      # coverage number.
       - name: Build | Test
+        if: matrix.rust == 'stable'
         run: "cargo llvm-cov nextest
           --all-features
           --locked
@@ -218,10 +227,21 @@ jobs:
           --lcov --output-path lcov.info
           --run-ignored all"
         env:
-          # Avoid -D warnings on nightly builds
-          CARGO_BUILD_WARNINGS: ${{ matrix.rust == 'stable' && 'deny' || 'allow' }}
+          CARGO_BUILD_WARNINGS: deny
           # Snapshot mismatches must fail the run rather than writing
           # `.snap.new` files nobody will look at on a CI runner.
+          INSTA_UPDATE: "no"
+
+      - name: Build | Test [Nightly]
+        if: matrix.rust == 'nightly'
+        run: "cargo nextest run
+          --all-features
+          --locked
+          --workspace
+          --run-ignored all"
+        env:
+          # Nightly's own warnings are not this project's to fix.
+          CARGO_BUILD_WARNINGS: allow
           INSTA_UPDATE: "no"
 
       - name: Build | Installer [Windows]
@@ -273,7 +293,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
-        if: github.repository == 'starship/starship'
+        if: github.repository == 'starship/starship' && matrix.rust == 'stable'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -10,6 +10,8 @@ on:
       - "**.md"
 
 concurrency:
+  # The source repository distinguishes identically named branches in forks;
+  # the branch name lets a newer push cancel its superseded workflow run.
   group: ${{ github.workflow }}-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -138,28 +138,55 @@ jobs:
             exit 1
           fi
 
-  # Run tests on Linux, macOS, and Windows
-  # On both Rust stable and Rust nightly
-  #
-  # The suite is executed with `cargo-nextest` rather than the built-in test
-  # harness. `cargo test` runs every test in a crate inside a single process
-  # and a shared thread pool; nextest runs each test in its own process.
-  # That isolation matters here because the integration tests under
-  # `src/test/init_async/` spawn real shells (bash, zsh, fish, PowerShell,
-  # elvish, xonsh) inside real pseudo-terminals. A shell that hangs, aborts,
-  # or wedges its pty takes down only its own test process instead of
-  # stalling or aborting the whole test binary, so the remaining tests still
-  # run and still report. Nextest also reports each test individually as it
-  # completes, so a wedged shell is identifiable by name rather than showing
-  # up as a silent suite-wide stall.
-  #
-  # The project has no doctests (nextest does not run those), so nothing is
-  # lost relative to `cargo test`.
+  streaming_shells:
+    name: Streaming Shells
+    needs: cargo_check
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Setup | Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup | Rust
+        run: rustup toolchain install stable --profile minimal --no-self-update
+
+      - name: Setup | Cache
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - name: Setup | Shells
+        run: sudo apt-get update && sudo apt-get install --yes bash fish gawk make zsh
+
+      - name: Setup | ble.sh
+        run: |
+          git clone --depth 1 --branch v0.4.0-devel3 https://github.com/akinomyoga/ble.sh.git "$RUNNER_TEMP/ble.sh"
+          make -C "$RUNNER_TEMP/ble.sh"
+
+      - name: Build | Nushell main
+        run: |
+          git init "$RUNNER_TEMP/nushell"
+          git -C "$RUNNER_TEMP/nushell" remote add origin https://github.com/nushell/nushell.git
+          git -C "$RUNNER_TEMP/nushell" fetch --depth 1 origin 5d80505557115920993296600f57233c30a4248b
+          git -C "$RUNNER_TEMP/nushell" checkout --detach FETCH_HEAD
+          cargo build --locked --manifest-path "$RUNNER_TEMP/nushell/Cargo.toml" --bin nu
+        env:
+          RUSTFLAGS: ""
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
+        with:
+          tool: cargo-nextest@0.9.140
+
+      - name: Test
+        run: cargo nextest run --all-features --locked --test init_async --run-ignored all --test-threads 1
+        env:
+          BASH: /usr/bin/bash
+          BLE_SH: ${{ runner.temp }}/ble.sh/out/ble.sh
+          NUSHELL_MAIN: ${{ runner.temp }}/nushell/target/debug/nu
+
   test:
     name: Test Suite
     runs-on: ${{ matrix.os }}
     needs: cargo_check # First check then run expansive tests
-    # A shell wedged in a pseudo-terminal cannot block the runner forever.
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -226,6 +253,7 @@ jobs:
           --all-features
           --locked
           --workspace
+          -E 'not binary(init_async)'
           --lcov --output-path lcov.info
           --run-ignored all"
         env:

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -9,6 +9,10 @@ on:
       - "docs/**"
       - "**.md"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
@@ -134,10 +138,27 @@ jobs:
 
   # Run tests on Linux, macOS, and Windows
   # On both Rust stable and Rust nightly
+  #
+  # The suite is executed with `cargo-nextest` rather than the built-in test
+  # harness. `cargo test` runs every test in a crate inside a single process
+  # and a shared thread pool; nextest runs each test in its own process.
+  # That isolation matters here because the integration tests under
+  # `src/test/init_async/` spawn real shells (bash, zsh, fish, PowerShell,
+  # elvish, xonsh) inside real pseudo-terminals. A shell that hangs, aborts,
+  # or wedges its pty takes down only its own test process instead of
+  # stalling or aborting the whole test binary, so the remaining tests still
+  # run and still report. Nextest also reports each test individually as it
+  # completes, so a wedged shell is identifiable by name rather than showing
+  # up as a silent suite-wide stall.
+  #
+  # The project has no doctests (nextest does not run those), so nothing is
+  # lost relative to `cargo test`.
   test:
     name: Test Suite
     runs-on: ${{ matrix.os }}
     needs: cargo_check # First check then run expansive tests
+    # A shell wedged in a pseudo-terminal cannot block the runner forever.
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -161,10 +182,10 @@ jobs:
       - name: Setup | Cache
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
 
-      - name: Install cargo-llvm-cov
+      - name: Install cargo-llvm-cov and cargo-nextest
         uses: taiki-e/install-action@b20dedce73af6905cdc30d6611090c9b67557c8d # v2.85.12
         with:
-          tool: cargo-llvm-cov
+          tool: cargo-llvm-cov,cargo-nextest@0.9.140
 
       # For windows installer test
       # On stable rust & main repo pushes only
@@ -187,17 +208,21 @@ jobs:
           winget install --id Mercurial.Mercurial --silent --exact --disable-interactivity --accept-source-agreements
           Add-Content -Path $env:GITHUB_PATH -Value "C:\Program Files\Mercurial" -Encoding utf8
 
-      # Run the ignored tests that expect the above setup
+      # Run the ignored tests that expect the above setup.
+      # `--run-ignored all` is nextest's spelling of `--include-ignored`.
       - name: Build | Test
-        run: "cargo llvm-cov
+        run: "cargo llvm-cov nextest
           --all-features
           --locked
           --workspace
           --lcov --output-path lcov.info
-          -- --include-ignored"
+          --run-ignored all"
         env:
           # Avoid -D warnings on nightly builds
           CARGO_BUILD_WARNINGS: ${{ matrix.rust == 'stable' && 'deny' || 'allow' }}
+          # Snapshot mismatches must fail the run rather than writing
+          # `.snap.new` files nobody will look at on a CI runner.
+          INSTA_UPDATE: "no"
 
       - name: Build | Installer [Windows]
         continue-on-error: true

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -245,13 +245,15 @@ jobs:
           BLE_SH: ${{ (matrix.os == 'ubuntu-latest' && matrix.rust == 'stable') && format('{0}/ble.sh/out/ble.sh', runner.temp) || '' }}
           NUSHELL_MAIN: ${{ (matrix.os == 'ubuntu-latest' && matrix.rust == 'stable') && format('{0}/nushell/target/debug/nu', runner.temp) || '' }}
 
+      # Nightly has no shell-streaming setup (see the comment on the stable
+      # `Build | Test` step above), so it only needs the non-init_async slice.
       - name: Build | Test [Nightly]
         if: matrix.rust == 'nightly'
         run: "cargo nextest run
           --all-features
           --locked
           --workspace
-          --run-ignored all"
+          -E 'not binary(init_async)'"
         env:
           # Nightly's own warnings are not this project's to fix.
           CARGO_BUILD_WARNINGS: allow

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -138,51 +138,6 @@ jobs:
             exit 1
           fi
 
-  streaming_shells:
-    name: Streaming Shells
-    needs: cargo_check
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    steps:
-      - name: Setup | Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Setup | Rust
-        run: rustup toolchain install stable --profile minimal --no-self-update
-
-      - name: Setup | Cache
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-
-      - name: Setup | Shells
-        run: sudo apt-get update && sudo apt-get install --yes bash fish gawk make zsh
-
-      - name: Setup | ble.sh
-        run: |
-          git clone --depth 1 --branch v0.4.0-devel3 https://github.com/akinomyoga/ble.sh.git "$RUNNER_TEMP/ble.sh"
-          make -C "$RUNNER_TEMP/ble.sh"
-
-      - name: Build | Nushell main
-        run: |
-          git init "$RUNNER_TEMP/nushell"
-          git -C "$RUNNER_TEMP/nushell" remote add origin https://github.com/nushell/nushell.git
-          git -C "$RUNNER_TEMP/nushell" fetch --depth 1 origin 5d80505557115920993296600f57233c30a4248b
-          git -C "$RUNNER_TEMP/nushell" checkout --detach FETCH_HEAD
-          cargo build --locked --manifest-path "$RUNNER_TEMP/nushell/Cargo.toml" --bin nu
-        env:
-          RUSTFLAGS: ""
-
-      - name: Install cargo-nextest
-        uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
-        with:
-          tool: cargo-nextest@0.9.140
-
-      - name: Test
-        run: cargo nextest run --all-features --locked --test init_async --run-ignored all --test-threads 1
-        env:
-          BASH: /usr/bin/bash
-          BLE_SH: ${{ runner.temp }}/ble.sh/out/ble.sh
-          NUSHELL_MAIN: ${{ runner.temp }}/nushell/target/debug/nu
-
   test:
     name: Test Suite
     runs-on: ${{ matrix.os }}
@@ -237,6 +192,31 @@ jobs:
           winget install --id Mercurial.Mercurial --silent --exact --disable-interactivity --accept-source-agreements
           Add-Content -Path $env:GITHUB_PATH -Value "C:\Program Files\Mercurial" -Encoding utf8
 
+      # The pseudo-terminal shell tests (tests/init_async.rs) need real shell
+      # binaries and drive them from an actual terminal, so they only run on
+      # one matrix leg — running them across every OS x Rust channel would be
+      # both wasteful and, on Windows/macOS runners, impossible regardless.
+      - name: Setup | Streaming shells
+        if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable'
+        run: sudo apt-get update && sudo apt-get install --yes bash fish gawk make zsh
+
+      - name: Setup | ble.sh
+        if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable'
+        run: |
+          git clone --depth 1 --branch v0.4.0-devel3 https://github.com/akinomyoga/ble.sh.git "$RUNNER_TEMP/ble.sh"
+          make -C "$RUNNER_TEMP/ble.sh"
+
+      - name: Build | Nushell main
+        if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable'
+        run: |
+          git init "$RUNNER_TEMP/nushell"
+          git -C "$RUNNER_TEMP/nushell" remote add origin https://github.com/nushell/nushell.git
+          git -C "$RUNNER_TEMP/nushell" fetch --depth 1 origin 5d80505557115920993296600f57233c30a4248b
+          git -C "$RUNNER_TEMP/nushell" checkout --detach FETCH_HEAD
+          cargo build --locked --manifest-path "$RUNNER_TEMP/nushell/Cargo.toml" --bin nu
+        env:
+          RUSTFLAGS: ""
+
       # Run the ignored tests that expect the above setup.
       # `--run-ignored all` is nextest's spelling of `--include-ignored`.
       #
@@ -253,7 +233,7 @@ jobs:
           --all-features
           --locked
           --workspace
-          -E 'not binary(init_async)'
+          -E '${{ (matrix.os == 'ubuntu-latest' && matrix.rust == 'stable') && 'all()' || 'not binary(init_async)' }}'
           --lcov --output-path lcov.info
           --run-ignored all"
         env:
@@ -261,6 +241,9 @@ jobs:
           # Snapshot mismatches must fail the run rather than writing
           # `.snap.new` files nobody will look at on a CI runner.
           INSTA_UPDATE: "no"
+          BASH: ${{ (matrix.os == 'ubuntu-latest' && matrix.rust == 'stable') && '/usr/bin/bash' || '' }}
+          BLE_SH: ${{ (matrix.os == 'ubuntu-latest' && matrix.rust == 'stable') && format('{0}/ble.sh/out/ble.sh', runner.temp) || '' }}
+          NUSHELL_MAIN: ${{ (matrix.os == 'ubuntu-latest' && matrix.rust == 'stable') && format('{0}/nushell/target/debug/nu', runner.temp) || '' }}
 
       - name: Build | Test [Nightly]
         if: matrix.rust == 'nightly'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -479,6 +479,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -792,6 +803,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -974,10 +991,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "futures-task"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
@@ -986,6 +1020,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-task",
  "pin-project-lite",
  "slab",
@@ -1840,6 +1875,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
+
+[[package]]
 name = "guess_host_triple"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1953,6 +1994,20 @@ dependencies = [
  "hashbrown 0.17.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "insta"
+version = "1.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86f0f8fee8c926415c58d6ae43a08523a26faccb2323f5e6b644fe7dd4ef6b82"
+dependencies = [
+ "console",
+ "once_cell",
+ "regex",
+ "similar",
+ "strip-ansi-escapes",
+ "tempfile",
 ]
 
 [[package]]
@@ -3040,6 +3095,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
+name = "rstest"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn 2.0.118",
+ "unicode-ident",
+]
+
+[[package]]
 name = "rust-ini"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3047,6 +3137,15 @@ checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
 dependencies = [
  "cfg-if",
  "ordered-multimap",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver 1.0.28",
 ]
 
 [[package]]
@@ -3328,6 +3427,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3365,6 +3470,7 @@ dependencies = [
  "guess_host_triple",
  "home",
  "indexmap",
+ "insta",
  "jiff",
  "jsonc-parser",
  "log",
@@ -3383,6 +3489,7 @@ dependencies = [
  "rand 0.10.2",
  "rayon",
  "regex",
+ "rstest",
  "rust-ini",
  "schemars",
  "semver 1.0.28",
@@ -3426,6 +3533,15 @@ dependencies = [
  "plist",
  "uom",
  "windows-sys",
+]
+
+[[package]]
+name = "strip-ansi-escapes"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8f8038e7e7969abb3f1b7c2a811225e9296da208539e0f79c5251d6cac0025"
+dependencies = [
+ "vte",
 ]
 
 [[package]]
@@ -3879,6 +3995,15 @@ checksum = "80a7e511ce1795821207a837b7b1c8d8aca0c648810966ad200446ae58f6667f"
 dependencies = [
  "itertools",
  "nom 8.0.0",
+]
+
+[[package]]
+name = "vte"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "alacritty_terminal"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda177466b9524d59f1b12f0dd30b68696788e9992a7e959021c4a0ed96fcf59"
+dependencies = [
+ "base64 0.22.1",
+ "bitflags 2.13.1",
+ "home",
+ "libc",
+ "log",
+ "miow",
+ "parking_lot",
+ "piper",
+ "polling",
+ "regex-automata",
+ "rustix",
+ "rustix-openpty",
+ "serde",
+ "signal-hook 0.4.4",
+ "unicode-width",
+ "vte 0.15.0",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -62,7 +87,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -73,7 +98,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -156,7 +181,7 @@ dependencies = [
  "polling",
  "rustix",
  "slab",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -214,7 +239,7 @@ dependencies = [
  "rustix",
  "signal-hook-registry",
  "slab",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -265,6 +290,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -275,6 +315,9 @@ name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "block-buffer"
@@ -486,7 +529,7 @@ checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -623,6 +666,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cursor-icon"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
+
+[[package]]
 name = "dashmap"
 version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -755,7 +804,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -868,7 +917,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -992,13 +1041,13 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1049,13 +1098,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "rand_core 0.10.1",
 ]
 
@@ -1684,7 +1745,7 @@ dependencies = [
  "bitflags 2.13.1",
  "gix-path",
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1722,7 +1783,7 @@ dependencies = [
  "hashbrown 0.16.1",
  "portable-atomic",
  "thiserror 2.0.20",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1972,7 +2033,7 @@ version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1986,9 +2047,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
@@ -2259,6 +2320,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miow"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "536bfad37a309d62069485248eeaba1e8d9853aaf951caaeaed0585a95346f08"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "mockall"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2351,7 +2421,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2641,7 +2711,7 @@ dependencies = [
  "objc2-ui-kit",
  "schemars",
  "serde",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2816,7 +2886,7 @@ dependencies = [
  "hermit-abi",
  "pin-project-lite",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2902,7 +2972,7 @@ dependencies = [
  "attr_alias",
  "libc",
  "signal-hook 0.3.18",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2913,6 +2983,40 @@ checksum = "962200e2d7d551451297d9fdce85138374019ada198e30ea9ede38034e27604c"
 dependencies = [
  "parking_lot",
 ]
+
+[[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.13.1",
+ "num-traits",
+ "rand 0.9.5",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "proptest-state-machine"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1675727965d66ff6f335e7d398e477184da08f4bed22f1a7f0dbf2f077f56f2e"
+dependencies = [
+ "proptest",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
@@ -2943,6 +3047,12 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
@@ -2954,8 +3064,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e058c7de0b26af77780c769414d6257830bb240f3c38477dbc2c16e5f54d6d4c"
 dependencies = [
  "libc",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2980,6 +3100,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2990,9 +3120,27 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "rayon"
@@ -3125,7 +3273,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.118",
+ "syn 2.0.119",
  "unicode-ident",
 ]
 
@@ -3158,7 +3306,18 @@ dependencies = [
  "errno 0.3.14",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustix-openpty"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de16c7c59892b870a6336f185dc10943517f1327447096bbb7bb32cd85e2393"
+dependencies = [
+ "errno 0.3.14",
+ "libc",
+ "rustix",
 ]
 
 [[package]]
@@ -3166,6 +3325,18 @@ name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "same-file"
@@ -3417,6 +3588,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a0c28ca5908dbdbcd52e6fdaa00358ab88637f8ab33e1f188dd510eb44b53d"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3460,6 +3641,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 name = "starship"
 version = "1.26.0"
 dependencies = [
+ "alacritty_terminal",
  "clap",
  "clap_complete",
  "clap_complete_nushell",
@@ -3485,6 +3667,8 @@ dependencies = [
  "pest",
  "pest_derive",
  "process_control",
+ "proptest",
+ "proptest-state-machine",
  "quick-xml 0.42.0",
  "rand 0.10.2",
  "rayon",
@@ -3532,7 +3716,7 @@ dependencies = [
  "objc2-io-kit",
  "plist",
  "uom",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3541,7 +3725,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a8f8038e7e7969abb3f1b7c2a811225e9296da208539e0f79c5251d6cac0025"
 dependencies = [
- "vte",
+ "vte 0.14.1",
 ]
 
 [[package]]
@@ -3620,7 +3804,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3630,7 +3814,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3890,7 +4074,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3901,6 +4085,12 @@ checksum = "7c8a2469e56e6e5095c82ccd3afb98dad95f7af7929aab6d8ba8d6e0f73657da"
 dependencies = [
  "arrayvec",
 ]
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicase"
@@ -4007,12 +4197,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "vte"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5924018406ce0063cd67f8e008104968b74b563ee1b85dde3ed1f7cb87d3dbd"
+dependencies = [
+ "arrayvec",
+ "bitflags 2.13.1",
+ "cursor-icon",
+ "log",
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "vtparse"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
 dependencies = [
  "utf8parse",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -4157,7 +4370,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4349,11 +4562,36 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -4382,6 +4620,54 @@ checksum = "e4060a1da109b9d0326b7262c8e12c84df67cc0dbc9e33cf49e01ccc2eb63631"
 dependencies = [
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
@@ -4447,7 +4733,7 @@ dependencies = [
  "tracing",
  "uds_windows",
  "uuid",
- "windows-sys",
+ "windows-sys 0.61.2",
  "winnow",
  "zbus_macros",
  "zbus_names",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,12 +124,28 @@ dunce = "1.0.5"
 winresource = "0.1.31"
 
 [dev-dependencies]
+# Pinned: the pty-backed shell integration tests under `src/test/init_async/`
+# depend on this crate answering cursor-position-report queries (`ESC[6n`)
+# natively via `Term::device_status`, which real line editors require in order
+# not to stall. Do not swap this for another pseudo-terminal crate.
+alacritty_terminal = "0.26.0"
 # Snapshot assertions for rendered module output. The `filters` feature lets a
 # snapshot redact the randomly named temporary directories that some module
 # tests necessarily render. Note that insta's ANSI-escape-stripping support is
 # deliberately NOT enabled: the ANSI styling is part of the contract under test.
 insta = { version = "1.48.0", features = ["filters"] }
 mockall = "=0.15.0"
+# Property-based testing for the incremental repaint algorithm in
+# `src/damage/`. Its central invariant -- that replaying the emitted damage
+# yields the same terminal grid as a full render -- is universally quantified
+# over prompts, so it is stated as a property rather than as examples.
+proptest = "1.11.0"
+# Drives that invariant over *sequences* of prompt updates rather than single
+# pairs, because incremental repaint is stateful: a wrong repaint only shows up
+# once a later update stops on top of the residue the earlier one left behind.
+# Shrinking a failing sequence down to a minimal reproduction is the reason for
+# the state-machine layer specifically.
+proptest-state-machine = "0.8.0"
 # Parameterized tests and fixtures, replacing hand-rolled `for` loops over
 # cases: every case becomes its own named test, so one failing case neither
 # hides the others nor loses the identity of the case that broke.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,16 @@ dunce = "1.0.5"
 winresource = "0.1.31"
 
 [dev-dependencies]
+# Snapshot assertions for rendered module output. The `filters` feature lets a
+# snapshot redact the randomly named temporary directories that some module
+# tests necessarily render. Note that insta's ANSI-escape-stripping support is
+# deliberately NOT enabled: the ANSI styling is part of the contract under test.
+insta = { version = "1.48.0", features = ["filters"] }
 mockall = "=0.15.0"
+# Parameterized tests and fixtures, replacing hand-rolled `for` loops over
+# cases: every case becomes its own named test, so one failing case neither
+# hides the others nor loses the identity of the case that broke.
+rstest = "0.26.1"
 
 [profile.release]
 codegen-units = 1

--- a/README.md
+++ b/README.md
@@ -360,7 +360,8 @@ mkdir ($nu.data-dir | path join "vendor/autoload")
 starship init nu | save -f ($nu.data-dir | path join "vendor/autoload/starship.nu")
 ```
 
-Note: Only Nushell v0.96+ is supported
+> Requires a Nushell main build with `commandline set-prompt`; no release has
+> this API yet.
 
 </details>
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -149,7 +149,8 @@ onMounted(() => {
    #### Nushell
    > [!WARNING]
    > This will change in the future.
-   > Only Nushell v0.96+ is supported.
+   > Requires a Nushell main build with `commandline set-prompt`; no release has
+   > this API yet.
 
    Add the following to the end of your Nushell configuration (find it by running `$nu.config-path` in Nushell):
 

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -373,6 +373,46 @@ modules you explicitly add to the format will not be duplicated. Eg.
 format = '$all$directory$character'
 ```
 
+## Async
+
+Starship can draw available modules first and refine the prompt as slower
+modules resolve. The final prompt is identical to a synchronous render.
+
+| Shell | Refinement |
+| --- | --- |
+| zsh | Changed cells are repainted in place. |
+| fish | The complete prompt is replaced. |
+| Nushell main | The complete prompt is replaced with its unreleased async prompt API. |
+| bash with [ble.sh](https://github.com/akinomyoga/ble.sh) | The complete prompt is replaced. |
+| Stock Bash and other shells | The prompt remains synchronous. |
+
+`bus` batches width-changing refinements for up to its configured delay;
+`adaptive` places those batches using timings from the current shell session.
+Width-stable changes apply immediately.
+
+`time`, `battery`, `memory_usage`, and `localip` refresh on these intervals,
+but only while visible and included in the prompt's format.
+
+### Options
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `enabled` | `true` | Enable streaming refinements. |
+| `bus` | `100` | Maximum grouping delay in milliseconds. |
+| `adaptive` | `true` | Group refinements from session timings. |
+
+### `[async.dynamic]`
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `time` | `1000` | Clock refresh interval in milliseconds. |
+| `battery` | `30000` | Battery refresh interval in milliseconds. |
+| `memory_usage` | `5000` | Memory refresh interval in milliseconds. |
+| `localip` | `30000` | Address refresh interval in milliseconds. |
+
+Intervals must be between 1 and 86,400,000 milliseconds. Invalid values retain
+their defaults. Disable a dynamic module with its own `disabled = true`.
+
 ## AWS
 
 The `aws` module shows the current AWS region and profile and an expiration timer when using temporary credentials.

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -378,13 +378,13 @@ format = '$all$directory$character'
 Starship can draw available modules first and refine the prompt as slower
 modules resolve. The final prompt is identical to a synchronous render.
 
-| Shell | Refinement |
-| --- | --- |
-| zsh | Changed cells are repainted in place. |
-| fish | The complete prompt is replaced. |
-| Nushell main | The complete prompt is replaced with its unreleased async prompt API. |
-| bash with [ble.sh](https://github.com/akinomyoga/ble.sh) | The complete prompt is replaced. |
-| Stock Bash and other shells | The prompt remains synchronous. |
+| Shell                                                    | Refinement                                                            |
+| -------------------------------------------------------- | --------------------------------------------------------------------- |
+| zsh                                                      | Changed cells are repainted in place.                                 |
+| fish                                                     | The complete prompt is replaced.                                      |
+| Nushell main                                             | The complete prompt is replaced with its unreleased async prompt API. |
+| bash with [ble.sh](https://github.com/akinomyoga/ble.sh) | The complete prompt is replaced.                                      |
+| Stock Bash and other shells                              | The prompt remains synchronous.                                       |
 
 `bus` batches width-changing refinements for up to its configured delay;
 `adaptive` places those batches using timings from the current shell session.
@@ -395,20 +395,20 @@ but only while visible and included in the prompt's format.
 
 ### Options
 
-| Option | Default | Description |
-| --- | --- | --- |
-| `enabled` | `true` | Enable streaming refinements. |
-| `bus` | `100` | Maximum grouping delay in milliseconds. |
-| `adaptive` | `true` | Group refinements from session timings. |
+| Option     | Default | Description                             |
+| ---------- | ------- | --------------------------------------- |
+| `enabled`  | `true`  | Enable streaming refinements.           |
+| `bus`      | `100`   | Maximum grouping delay in milliseconds. |
+| `adaptive` | `true`  | Group refinements from session timings. |
 
 ### `[async.dynamic]`
 
-| Option | Default | Description |
-| --- | --- | --- |
-| `time` | `1000` | Clock refresh interval in milliseconds. |
-| `battery` | `30000` | Battery refresh interval in milliseconds. |
-| `memory_usage` | `5000` | Memory refresh interval in milliseconds. |
-| `localip` | `30000` | Address refresh interval in milliseconds. |
+| Option         | Default | Description                               |
+| -------------- | ------- | ----------------------------------------- |
+| `time`         | `1000`  | Clock refresh interval in milliseconds.   |
+| `battery`      | `30000` | Battery refresh interval in milliseconds. |
+| `memory_usage` | `5000`  | Memory refresh interval in milliseconds.  |
+| `localip`      | `30000` | Address refresh interval in milliseconds. |
 
 Intervals must be between 1 and 86,400,000 milliseconds. Invalid values retain
 their defaults. Disable a dynamic module with its own `disabled = true`.

--- a/examples/streaming-demo/starship.toml
+++ b/examples/streaming-demo/starship.toml
@@ -1,0 +1,63 @@
+# Streaming-prompt demo configuration.
+#
+# Shows all three cadences at once:
+#   - $directory is Instant: painted synchronously, in the very first frame.
+#   - $git_branch / $git_status are Deferred: blank on the first paint, then
+#     stream in as their own frame once the git subprocess resolves.
+#   - $time is Dynamic: painted immediately like an Instant module, then kept
+#     current by re-polling on its own schedule (see [async.dynamic.time]
+#     below) without waiting for you to press Enter.
+#
+# Run `examples/streaming-demo/try.sh` from the repo root to try it live.
+
+"$schema" = 'https://starship.rs/config-schema.json'
+
+add_newline = true
+
+format = """
+$directory\
+$git_branch\
+$git_status\
+$character"""
+
+right_format = "$time"
+
+# Streaming is on by default; spelled out here so the knobs are visible.
+[async]
+enabled = true
+# How long a batch of refinements is allowed to collect before it repaints,
+# so near-simultaneous updates (e.g. git_branch and git_status resolving a
+# few milliseconds apart) land as one repaint instead of two.
+bus = 100
+# Widen or shrink that window using this session's own measured module
+# latencies instead of the fixed 100ms above.
+adaptive = true
+
+[async.dynamic]
+# Re-poll the clock every second. This is also the built-in default —
+# spelled out here so it's the first knob you reach for.
+time = 1000
+
+[directory]
+style = "bold cyan"
+truncation_length = 3
+truncate_to_repo = true
+
+[git_branch]
+symbol = " "
+style = "bold purple"
+format = "on [$symbol$branch]($style) "
+
+[git_status]
+style = "bold red"
+format = '([\[$all_status$ahead_behind\]]($style)) '
+
+[time]
+disabled = false
+time_format = "%H:%M:%S"
+format = "[$time]($style)"
+style = "bold yellow"
+
+[character]
+success_symbol = "[❯](bold green)"
+error_symbol = "[❯](bold red)"

--- a/examples/streaming-demo/try.sh
+++ b/examples/streaming-demo/try.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Drops you into an interactive shell running the streaming-demo prompt
+# (examples/streaming-demo/starship.toml) against a debug build of this
+# checkout's starship binary.
+#
+# Usage: examples/streaming-demo/try.sh [zsh|fish]
+# Defaults to zsh, the only shell that reaches Tier::CellPrecise, so
+# git_branch/git_status visibly repaint in place once they resolve and the
+# clock ticks without a cell-width reflow.
+#
+# Self-contained: builds its own throwaway rc file rather than relying on
+# your personal dotfiles, so it works even if your zsh/fish config isn't set
+# up on this machine (or isn't what you normally use day to day).
+
+set -euo pipefail
+
+script_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repository_root="$(cd "$script_directory/../.." && pwd)"
+shell_name="${1:-zsh}"
+
+case "$shell_name" in
+zsh | fish) ;;
+*)
+    echo "error: try.sh supports zsh or fish (got '$shell_name')" >&2
+    echo "  zsh reaches Tier::CellPrecise; fish reaches Tier::PromptReplace." >&2
+    exit 1
+    ;;
+esac
+
+if ! command -v "$shell_name" >/dev/null 2>&1; then
+    echo "error: $shell_name is not on PATH" >&2
+    exit 1
+fi
+
+echo "Building starship..." >&2
+cargo build --manifest-path "$repository_root/Cargo.toml" --quiet
+
+export STARSHIP_CONFIG="$script_directory/starship.toml"
+
+demo_rc_directory="$(mktemp -d)"
+trap 'rm -rf "$demo_rc_directory"' EXIT
+
+echo "Starting $shell_name with the streaming demo prompt (STARSHIP_CONFIG=$STARSHIP_CONFIG)." >&2
+echo "Watch \$git_branch/\$git_status pop in after \$directory, and the clock tick on its own." >&2
+
+debug_bin_directory="$repository_root/target/debug"
+
+if [ "$shell_name" = zsh ]; then
+    # Re-assert PATH here rather than trusting the inherited one: on this
+    # machine /etc/zshenv sources nix-darwin's set-environment, which
+    # re-prepends the Nix profile's own (older, non-streaming) starship
+    # *after* zsh starts, silently shadowing the one built above.
+    cat >"$demo_rc_directory/.zshrc" <<EOF
+export PATH="$debug_bin_directory:\$PATH"
+eval "\$(starship init zsh)"
+EOF
+    ZDOTDIR="$demo_rc_directory" zsh -i
+else
+    cat >"$demo_rc_directory/config.fish" <<EOF
+set -gx PATH "$debug_bin_directory" \$PATH
+starship init fish | source
+EOF
+    fish -i -C "source $demo_rc_directory/config.fish"
+fi

--- a/proptest-regressions/plan/property_tests.txt
+++ b/proptest-regressions/plan/property_tests.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc d363fdd45851ecd3b047fc9a81ee8d7625b28962b480132fdd7458d150970410 # shrinks to document = [Group([Variable("directory"), Text])]

--- a/proptest-regressions/plan/property_tests.txt
+++ b/proptest-regressions/plan/property_tests.txt
@@ -1,7 +1,0 @@
-# Seeds for failure cases proptest has generated in the past. It is
-# automatically read and these particular cases re-run before any
-# novel cases are generated.
-#
-# It is recommended to check this file in to source control so that
-# everyone who runs the test benefits from these saved cases.
-cc d363fdd45851ecd3b047fc9a81ee8d7625b28962b480132fdd7458d150970410 # shrinks to document = [Group([Variable("directory"), Text])]

--- a/src/config.rs
+++ b/src/config.rs
@@ -355,6 +355,26 @@ impl From<nu_ansi_term::Color> for Style {
  - '<color>'       (see the `parse_color_string` doc for valid color strings)
 */
 pub fn parse_style_string(style_string: &str, context: Option<&Context>) -> Option<Style> {
+    parse_style_string_with_palette(
+        style_string,
+        context.and_then(|context| {
+            get_palette(
+                &context.root_config.palettes,
+                context.root_config.palette.as_deref(),
+            )
+        }),
+    )
+}
+
+/// Parse a style string against an explicit palette rather than a [`Context`].
+///
+/// The palette is the only thing a style string depends on beyond itself, so
+/// this is style resolution without a running prompt; [`parse_style_string`]
+/// is this function with the palette read out of a context.
+pub fn parse_style_string_with_palette(
+    style_string: &str,
+    palette: Option<&Palette>,
+) -> Option<Style> {
     style_string
         .split_whitespace()
         .try_fold(Style::default(), |style, token| {
@@ -393,15 +413,7 @@ pub fn parse_style_string(style_string: &str, context: Option<&Context>) -> Opti
                         None // fg:none yields no style.
                     } else {
                         // Either bg or valid color or both.
-                        let parsed = parse_color_string(
-                            color_string,
-                            context.and_then(|x| {
-                                get_palette(
-                                    &x.root_config.palettes,
-                                    x.root_config.palette.as_deref(),
-                                )
-                            }),
-                        );
+                        let parsed = parse_color_string(color_string, palette);
                         // bg + invalid color = reset the background to default.
                         if !col_fg && parsed.is_none() {
                             let mut new_style = style;
@@ -490,7 +502,8 @@ fn parse_color_string(
     predefined_color
 }
 
-fn get_palette<'a>(
+/// Look up the palette a configuration selects, if it selects one that exists.
+pub fn get_palette<'a>(
     palettes: &'a HashMap<String, Palette>,
     palette_name: Option<&str>,
 ) -> Option<&'a Palette> {

--- a/src/configs/asynchronous.rs
+++ b/src/configs/asynchronous.rs
@@ -1,0 +1,261 @@
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::time::Duration;
+
+/// Streaming prompt timing settings.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(
+    feature = "config-schema",
+    derive(schemars::JsonSchema),
+    schemars(deny_unknown_fields)
+)]
+#[serde(default)]
+pub struct AsynchronousConfig {
+    /// Enables refinements after the first paint.
+    pub enabled: bool,
+    /// Maximum refinement batching delay in milliseconds.
+    pub bus: u64,
+    /// Batches refinements using session timing estimates.
+    pub adaptive: bool,
+    /// Refresh periods for dynamic modules.
+    pub dynamic: DynamicPeriodsConfig,
+}
+
+impl Default for AsynchronousConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            bus: 100,
+            adaptive: true,
+            dynamic: DynamicPeriodsConfig::default(),
+        }
+    }
+}
+
+macro_rules! dynamic_periods {
+    ($(
+        $(#[$attribute:meta])*
+        $module:ident;
+    )+) => {
+        /// Dynamic module refresh periods.
+        #[derive(Clone, Debug, PartialEq, Serialize)]
+        #[cfg_attr(
+            feature = "config-schema",
+            derive(schemars::JsonSchema),
+            schemars(deny_unknown_fields)
+        )]
+        pub struct DynamicPeriodsConfig {
+            $(
+                $(#[$attribute])*
+                #[cfg_attr(
+                    feature = "config-schema",
+                    schemars(with = "u64", range(min = 1, max = 86_400_000))
+                )]
+                pub $module: RefreshPeriod,
+            )+
+        }
+
+        impl Default for DynamicPeriodsConfig {
+            fn default() -> Self {
+                Self {
+                    $($(#[$attribute])* $module: default_period(stringify!($module)),)+
+                }
+            }
+        }
+
+        impl DynamicPeriodsConfig {
+            /// Returns a module's refresh period.
+            #[must_use]
+            pub fn period_for(&self, module: &str) -> Option<Duration> {
+                match module {
+                    $($(#[$attribute])* stringify!($module) => Some(self.$module.get()),)+
+                    _ => None,
+                }
+            }
+        }
+
+        impl<'de> Deserialize<'de> for DynamicPeriodsConfig {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                #[derive(Default, Deserialize)]
+                #[serde(default)]
+                struct Unvalidated {
+                    $($(#[$attribute])* $module: Option<u64>,)+
+                }
+
+                let configured = Unvalidated::deserialize(deserializer)?;
+                let defaults = DynamicPeriodsConfig::default();
+
+                Ok(Self {
+                    $($(#[$attribute])* $module: configured.$module.map_or(defaults.$module, |milliseconds| {
+                        RefreshPeriod::try_from(milliseconds).unwrap_or_else(|reason| {
+                            log::warn!(
+                                "[async.dynamic] {}: {reason} — keeping the default of {}ms",
+                                stringify!($module),
+                                defaults.$module.get().as_millis(),
+                            );
+                            defaults.$module
+                        })
+                    }),)+
+                })
+            }
+        }
+    };
+}
+
+dynamic_periods! {
+    time;
+    #[cfg(feature = "battery")]
+    battery;
+    memory_usage;
+    localip;
+}
+
+fn default_period(module: &str) -> RefreshPeriod {
+    let Some(crate::modules::Cadence::Dynamic { period }) = crate::modules::cadence(module) else {
+        panic!("{module} is configured as dynamic without a dynamic cadence")
+    };
+    RefreshPeriod(period)
+}
+
+const MAX_REFRESH_PERIOD_MILLISECONDS: u64 = 86_400_000;
+
+/// A dynamic-module refresh period of at most one day.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct RefreshPeriod(Duration);
+
+impl RefreshPeriod {
+    /// Returns the interval.
+    #[must_use]
+    pub const fn get(self) -> Duration {
+        self.0
+    }
+}
+
+impl TryFrom<u64> for RefreshPeriod {
+    type Error = &'static str;
+
+    fn try_from(milliseconds: u64) -> Result<Self, Self::Error> {
+        if milliseconds == 0 {
+            return Err("a refresh period must be nonzero");
+        }
+        if milliseconds > MAX_REFRESH_PERIOD_MILLISECONDS {
+            return Err("a refresh period must be at most one day");
+        }
+        Ok(Self(Duration::from_millis(milliseconds)))
+    }
+}
+
+impl Serialize for RefreshPeriod {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let milliseconds = u64::try_from(self.0.as_millis())
+            .expect("a refresh period always originates as u64 milliseconds");
+        milliseconds.serialize(serializer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::modules::{Cadence, cadence};
+
+    #[test]
+    fn every_dynamic_module_can_be_given_a_period() {
+        for module in crate::module::ALL_MODULES {
+            if matches!(cadence(module), Some(Cadence::Dynamic { .. })) {
+                assert!(
+                    DynamicPeriodsConfig::default().period_for(module).is_some(),
+                    "{module} is dynamic but has no configurable period"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn a_module_that_is_not_dynamic_has_no_period() {
+        for module in ["git_status", "character", "custom.anything", "nonsense"] {
+            assert_eq!(None, DynamicPeriodsConfig::default().period_for(module));
+        }
+    }
+
+    #[test]
+    fn streaming_is_on_by_default_and_paces_itself_over_a_tenth_of_a_second() {
+        let configuration = AsynchronousConfig::default();
+
+        assert!(configuration.enabled);
+        assert!(configuration.adaptive);
+        assert_eq!(100, configuration.bus);
+    }
+
+    #[test]
+    fn an_unusable_period_falls_back_to_the_default_for_that_module_alone() {
+        let periods = toml::from_str::<DynamicPeriodsConfig>("time = 0\nlocalip = 7000")
+            .expect("an unusable period is warned about, not propagated");
+
+        assert_eq!(DynamicPeriodsConfig::default().time, periods.time);
+        assert_eq!(
+            Some(Duration::from_millis(7_000)),
+            periods.period_for("localip")
+        );
+    }
+
+    #[test]
+    fn an_unusable_period_does_not_discard_the_rest_of_the_root_table() {
+        use crate::config::ModuleConfig;
+
+        let table = toml::toml! {
+            add_newline = false
+            format = "$directory$character"
+            [async.dynamic]
+            time = 0
+        };
+        let root = crate::configs::StarshipRootConfig::load(&table);
+
+        assert_eq!(
+            "$directory$character", root.format,
+            "an unusable period must not discard the configured format"
+        );
+        assert!(
+            !root.add_newline,
+            "an unusable period must not discard the other root settings"
+        );
+        assert_eq!(
+            DynamicPeriodsConfig::default().time,
+            root.asynchronous.dynamic.time,
+            "the unusable period itself falls back to its default"
+        );
+    }
+
+    #[test]
+    fn refresh_period_requires_a_value_within_one_day() {
+        assert!(RefreshPeriod::try_from(0).is_err());
+        assert!(RefreshPeriod::try_from(MAX_REFRESH_PERIOD_MILLISECONDS + 1).is_err());
+    }
+
+    #[test]
+    fn refresh_period_accepts_one_day() {
+        assert_eq!(
+            Ok(RefreshPeriod(Duration::from_millis(
+                MAX_REFRESH_PERIOD_MILLISECONDS
+            ))),
+            RefreshPeriod::try_from(MAX_REFRESH_PERIOD_MILLISECONDS)
+        );
+    }
+
+    #[test]
+    fn refresh_period_round_trips_through_serialization() {
+        let original = DynamicPeriodsConfig {
+            time: RefreshPeriod::try_from(12_345).expect("in range"),
+            ..DynamicPeriodsConfig::default()
+        };
+
+        let serialized = toml::to_string(&original).expect("a config table serializes");
+        let deserialized: DynamicPeriodsConfig =
+            toml::from_str(&serialized).expect("what was just written must parse back");
+        assert_eq!(original, deserialized);
+    }
+}

--- a/src/configs/asynchronous.rs
+++ b/src/configs/asynchronous.rs
@@ -43,6 +43,7 @@ macro_rules! dynamic_periods {
             derive(schemars::JsonSchema),
             schemars(deny_unknown_fields)
         )]
+        #[serde(default)]
         pub struct DynamicPeriodsConfig {
             $(
                 $(#[$attribute])*
@@ -81,23 +82,30 @@ macro_rules! dynamic_periods {
                 #[derive(Default, Deserialize)]
                 #[serde(default)]
                 struct Unvalidated {
-                    $($(#[$attribute])* $module: Option<u64>,)+
+                    $($(#[$attribute])* $module: Option<toml::Value>,)+
                 }
 
                 let configured = Unvalidated::deserialize(deserializer)?;
                 let defaults = DynamicPeriodsConfig::default();
 
                 Ok(Self {
-                    $($(#[$attribute])* $module: configured.$module.map_or(defaults.$module, |milliseconds| {
-                        RefreshPeriod::try_from(milliseconds).unwrap_or_else(|reason| {
+                    $($(#[$attribute])* $module: {
+                        let value = configured.$module.as_ref();
+                        value
+                            .and_then(toml::Value::as_integer)
+                            .and_then(|milliseconds| u64::try_from(milliseconds).ok())
+                            .and_then(|milliseconds| RefreshPeriod::try_from(milliseconds).ok())
+                            .unwrap_or_else(|| {
+                                if value.is_some() {
                             log::warn!(
-                                "[async.dynamic] {}: {reason} — keeping the default of {}ms",
+                                "[async.dynamic] {}: invalid interval — keeping the default of {}ms",
                                 stringify!($module),
                                 defaults.$module.get().as_millis(),
                             );
-                            defaults.$module
-                        })
-                    }),)+
+                                }
+                                defaults.$module
+                            })
+                    }),+
                 })
             }
         }

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -1,6 +1,7 @@
 use indexmap::IndexMap;
 use serde::{self, Deserialize, Serialize};
 
+pub mod asynchronous;
 pub mod aws;
 pub mod azure;
 pub mod battery;

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -2,6 +2,8 @@ use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+use super::asynchronous::AsynchronousConfig;
+
 pub fn default_profiles() -> IndexMap<String, String> {
     IndexMap::from_iter([(
         "claude-code".to_string(),
@@ -24,6 +26,12 @@ pub struct StarshipRootConfig {
     pub continuation_prompt: String,
     pub scan_timeout: u64,
     pub command_timeout: u64,
+    /// How a streaming prompt paces itself: whether it streams at all, how
+    /// long it collects reflowing refinements before redrawing, and how often
+    /// each module whose value goes stale on its own is renewed. See
+    /// [`AsynchronousConfig`].
+    #[serde(rename = "async")]
+    pub asynchronous: AsynchronousConfig,
     pub add_newline: bool,
     pub follow_symlinks: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -60,6 +68,7 @@ impl Default for StarshipRootConfig {
             internal_profiles: default_profiles(),
             scan_timeout: 30,
             command_timeout: 500,
+            asynchronous: AsynchronousConfig::default(),
             add_newline: true,
             follow_symlinks: true,
             palette: None,

--- a/src/configs/starship_root.rs
+++ b/src/configs/starship_root.rs
@@ -38,116 +38,15 @@ pub struct StarshipRootConfig {
 
 pub type Palette = HashMap<String, String>;
 
-// List of default prompt order
-// NOTE: If this const value is changed then Default prompt order subheading inside
-// prompt heading of config docs needs to be updated according to changes made here.
-pub const PROMPT_ORDER: &[&str] = &[
-    "username",
-    "hostname",
-    "localip",
-    "shlvl",
-    "singularity",
-    "kubernetes",
-    "nats",
-    "directory",
-    "vcsh",
-    "fossil_branch",
-    "fossil_metrics",
-    "git_branch",
-    "git_commit",
-    "git_state",
-    "git_metrics",
-    "git_status",
-    "hg_branch",
-    "hg_state",
-    "pijul_channel",
-    "docker_context",
-    "package",
-    // ↓ Toolchain version modules ↓
-    // (Let's keep these sorted alphabetically)
-    "bun",
-    "c",
-    "cmake",
-    "cobol",
-    "cpp",
-    "daml",
-    "dart",
-    "deno",
-    "dotnet",
-    "elixir",
-    "elm",
-    "erlang",
-    "fennel",
-    "fortran",
-    "gleam",
-    "golang",
-    "gradle",
-    "haskell",
-    "haxe",
-    "helm",
-    "java",
-    "julia",
-    "kotlin",
-    "lua",
-    "maven",
-    "mojo",
-    "nim",
-    "nodejs",
-    "ocaml",
-    "odin",
-    "opa",
-    "perl",
-    "php",
-    "pulumi",
-    "purescript",
-    "python",
-    "quarto",
-    "raku",
-    "rlang",
-    "red",
-    "ruby",
-    "rust",
-    "scala",
-    "solidity",
-    "swift",
-    "terraform",
-    "typst",
-    "vlang",
-    "vagrant",
-    "xmake",
-    "zig",
-    // ↑ Toolchain version modules ↑
-    "buf",
-    "guix_shell",
-    "nix_shell",
-    "conda",
-    "pixi",
-    "meson",
-    "spack",
-    "memory_usage",
-    "aws",
-    "gcloud",
-    "openstack",
-    "azure",
-    "direnv",
-    "env_var",
-    "mise",
-    "crystal",
-    "custom",
-    "sudo",
-    "cmd_duration",
-    "line_break",
-    "jobs",
-    #[cfg(feature = "battery")]
-    "battery",
-    "time",
-    "status",
-    "container",
-    "netns",
-    "os",
-    "shell",
-    "character",
-];
+/// The default order modules are drawn in, and what `$all` expands to.
+///
+/// Generated from the module registry — see [`crate::modules::registry`] —
+/// rather than hand-maintained here; each module's place in this ordering is
+/// declared next to the rest of what the registry says about it.
+///
+/// NOTE: If this ordering changes, the default prompt order subheading inside
+/// the prompt heading of the config docs needs to be updated to match.
+pub use crate::modules::registry::PROMPT_ORDER;
 
 // On changes please also update `Default` for the `FullConfig` struct in `mod.rs`
 impl Default for StarshipRootConfig {

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -71,6 +71,16 @@ pub struct Context<'a> {
     /// The shell the user is assumed to be running
     pub shell: Shell,
 
+    /// An explicit statement of where the prompt rendered from this context is
+    /// going, or `None` to take the answer from [`Self::shell`].
+    ///
+    /// Kept as an override rather than as a second field of record so that the
+    /// two can never drift apart: a context whose shell is changed and whose
+    /// destination is not still escapes for the shell it now has. Only a
+    /// streaming prompt sets it, and only ever to
+    /// [`Destination::RawTerminal`], which depends on no shell at all.
+    destination_override: Option<Destination>,
+
     /// Which prompt to print (main, right, ...)
     pub target: Target,
 
@@ -239,6 +249,7 @@ impl<'a> Context<'a> {
             git_repo: OnceLock::new(),
             jj_repo: OnceLock::new(),
             shell,
+            destination_override: None,
             target,
             width,
             env,
@@ -259,7 +270,22 @@ impl<'a> Context<'a> {
     /// Defaults to the prompt variable of [`Self::shell`], because that is
     /// where every prompt starship has ever printed goes.
     pub fn destination(&self) -> Destination {
-        Destination::shell_prompt_variable(self.shell)
+        self.destination_override
+            .unwrap_or_else(|| Destination::shell_prompt_variable(self.shell))
+    }
+
+    /// Renders this context's prompt for the terminal rather than for a shell's
+    /// prompt variable.
+    ///
+    /// Only a streaming prompt has any reason to ask for this: it renders once
+    /// for the terminal, so that an incremental repaint is written exactly as
+    /// it stands, and escapes those finished bytes only where it hands a whole
+    /// prompt to the shell. Rendering twice instead would let the repaint and
+    /// the prompt assignment disagree about what is on screen.
+    #[must_use]
+    pub fn rendering_for_the_terminal(mut self) -> Self {
+        self.destination_override = Some(Destination::RawTerminal);
+        self
     }
 
     /// Sets the context config, overwriting the existing config
@@ -960,7 +986,7 @@ pub enum Target {
 }
 
 /// Properties as passed on from the shell as arguments
-#[derive(Parser, Debug)]
+#[derive(Parser, Clone, Debug)]
 pub struct Properties {
     /// The status code of the previously run command as an unsigned or signed 32bit integer
     #[clap(short = 's', long = "status")]

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -1,5 +1,6 @@
 use crate::config::{ModuleConfig, StarshipConfig};
 use crate::configs::StarshipRootConfig;
+use crate::escaping::Destination;
 use crate::module::Module;
 use crate::utils::{CommandOutput, PathExt, create_command, exec_timeout, read_file};
 
@@ -251,6 +252,14 @@ impl<'a> Context<'a> {
             claude_code_data: None,
             _marker: PhantomData,
         }
+    }
+
+    /// Where the prompt rendered from this context is going.
+    ///
+    /// Defaults to the prompt variable of [`Self::shell`], because that is
+    /// where every prompt starship has ever printed goes.
+    pub fn destination(&self) -> Destination {
+        Destination::shell_prompt_variable(self.shell)
     }
 
     /// Sets the context config, overwriting the existing config

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -140,8 +140,9 @@ impl<'a> Context<'a> {
     /// Create a new instance of Context for the provided directory, loading the
     /// configuration the environment points at.
     ///
-    /// In a test build there is no ambient configuration to load: see
-    /// [`Self::ambient_config`].
+    /// Unit tests in this crate do not load ambient configuration; external
+    /// test harnesses should use [`Self::new_with_config`] to supply an
+    /// explicit, hermetic configuration.
     pub fn new_with_shell_and_path(
         properties: Properties,
         shell: Shell,
@@ -166,13 +167,12 @@ impl<'a> Context<'a> {
     /// help either, because `Env` is a mock in test builds and never forwards
     /// it.
     ///
-    /// So in a test build this is not "a read that is skipped" but a read that
-    /// does not exist: there is no code path from a test to the filesystem
-    /// configuration. Tests that need a configuration hand one to
-    /// [`Self::new_with_config`] or [`Self::set_config`], which is also what
-    /// guarantees everything derived from configuration — `root_config` today,
-    /// whatever is added tomorrow — is derived from *that* configuration and
-    /// not from a half-reset leftover.
+    /// Unit tests in this crate have no code path to filesystem configuration.
+    /// External test harnesses use [`Self::new_with_config`] to make the same
+    /// hermetic guarantee. That constructor also ensures everything derived
+    /// from configuration — `root_config` today, whatever is added tomorrow —
+    /// comes from the supplied configuration rather than a leftover ambient
+    /// setting.
     fn ambient_config(env: &Env<'a>) -> StarshipConfig {
         #[cfg(test)]
         {

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -136,17 +136,67 @@ impl<'a> Context<'a> {
         )
     }
 
-    /// Create a new instance of Context for the provided directory
+    /// Create a new instance of Context for the provided directory, loading the
+    /// configuration the environment points at.
+    ///
+    /// In a test build there is no ambient configuration to load: see
+    /// [`Self::ambient_config`].
     pub fn new_with_shell_and_path(
-        mut properties: Properties,
+        properties: Properties,
         shell: Shell,
         target: Target,
         path: PathBuf,
         logical_path: PathBuf,
         env: Env<'a>,
     ) -> Self {
-        let config = StarshipConfig::initialize(get_config_path_os(&env).as_deref());
+        let config = Self::ambient_config(&env);
+        Self::new_with_config(properties, shell, target, path, logical_path, env, config)
+    }
 
+    /// The configuration the ambient environment points at.
+    ///
+    /// The filesystem read only exists in a non-test build. A test build that
+    /// could reach the developer's own `~/.config/starship.toml` would report
+    /// results that depend on their personal dotfiles: a `palette` alone
+    /// redefines every named color a module renders, so a test asserting on
+    /// ANSI yellow sees the palette's truecolor yellow instead. Worse, a
+    /// personal configuration can coincidentally make a genuinely broken module
+    /// render the expected output. Pointing `STARSHIP_CONFIG` elsewhere does not
+    /// help either, because `Env` is a mock in test builds and never forwards
+    /// it.
+    ///
+    /// So in a test build this is not "a read that is skipped" but a read that
+    /// does not exist: there is no code path from a test to the filesystem
+    /// configuration. Tests that need a configuration hand one to
+    /// [`Self::new_with_config`] or [`Self::set_config`], which is also what
+    /// guarantees everything derived from configuration — `root_config` today,
+    /// whatever is added tomorrow — is derived from *that* configuration and
+    /// not from a half-reset leftover.
+    fn ambient_config(env: &Env<'a>) -> StarshipConfig {
+        #[cfg(test)]
+        {
+            let _ = env;
+            StarshipConfig { config: None }
+        }
+        #[cfg(not(test))]
+        StarshipConfig::initialize(get_config_path_os(env).as_deref())
+    }
+
+    /// Create a new instance of Context for the provided directory from an
+    /// explicitly supplied, fully owned configuration.
+    ///
+    /// Everything the context derives from configuration is derived here, so a
+    /// caller that supplies a configuration gets a context consistent with it —
+    /// there is no second step to forget.
+    pub fn new_with_config(
+        mut properties: Properties,
+        shell: Shell,
+        target: Target,
+        path: PathBuf,
+        logical_path: PathBuf,
+        env: Env<'a>,
+        config: StarshipConfig,
+    ) -> Self {
         // If the vector is zero-length, we should pretend that we didn't get a
         // pipestatus at all (since this is the input `--pipestatus=""`)
         if properties

--- a/src/damage/cursor.rs
+++ b/src/damage/cursor.rs
@@ -1,0 +1,118 @@
+//! Cursor-neutral terminal writes.
+
+use std::fmt;
+use std::io::Write;
+
+use nu_ansi_term::ansi::RESET;
+
+use super::Column;
+use crate::module::painted::ResolvedStyle;
+
+const SAVE_CURSOR: &[u8] = b"\x1b7";
+const RESTORE_CURSOR: &[u8] = b"\x1b8";
+const ERASE_TO_END_OF_LINE: &[u8] = b"\x1b[K";
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct RowsAbove(pub usize);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CursorSafeText<'a>(&'a str);
+
+impl<'a> CursorSafeText<'a> {
+    pub fn new(text: &'a str) -> Option<Self> {
+        text.chars()
+            .all(|character| !character.is_control())
+            .then_some(Self(text))
+    }
+}
+
+pub struct CursorNeutralBody {
+    bytes: Vec<u8>,
+    style: Option<ResolvedStyle>,
+}
+
+impl CursorNeutralBody {
+    fn new() -> Self {
+        Self {
+            bytes: Vec::new(),
+            style: None,
+        }
+    }
+
+    pub fn move_to(&mut self, rows: RowsAbove, column: Column) {
+        if rows.0 != 0 {
+            write!(self.bytes, "\x1b[{}A", rows.0).expect("a vector is writable");
+        }
+        write!(self.bytes, "\x1b[{}G", column.0 + 1).expect("a vector is writable");
+    }
+
+    pub fn select_style(&mut self, style: ResolvedStyle) {
+        if self.style == Some(style) {
+            return;
+        }
+        self.bytes.extend_from_slice(RESET.as_bytes());
+        write!(self.bytes, "{}", style.as_ansi_style().prefix()).expect("a vector is writable");
+        self.style = Some(style);
+    }
+
+    pub fn write_text(&mut self, text: CursorSafeText<'_>) {
+        self.bytes.extend_from_slice(text.0.as_bytes());
+    }
+
+    pub fn erase_to_end_of_line(&mut self) {
+        self.select_style(ResolvedStyle::plain());
+        self.bytes.extend_from_slice(ERASE_TO_END_OF_LINE);
+    }
+}
+
+/// A terminal write that restores the cursor.
+#[derive(Clone, PartialEq, Eq)]
+pub struct CursorNeutral(Vec<u8>);
+
+impl CursorNeutral {
+    pub fn around(build: impl FnOnce(&mut CursorNeutralBody)) -> Self {
+        let mut body = CursorNeutralBody::new();
+        build(&mut body);
+
+        let mut bytes =
+            Vec::with_capacity(SAVE_CURSOR.len() + body.bytes.len() + RESTORE_CURSOR.len());
+        bytes.extend_from_slice(SAVE_CURSOR);
+        bytes.extend_from_slice(&body.bytes);
+        bytes.extend_from_slice(RESTORE_CURSOR);
+        Self(bytes)
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl fmt::Debug for CursorNeutral {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "CursorNeutral({:?})",
+            String::from_utf8_lossy(&self.0)
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builder_cannot_emit_a_control_character_as_text() {
+        assert!(CursorSafeText::new("ok\n").is_none());
+    }
+
+    #[test]
+    fn every_write_restores_the_saved_cursor() {
+        let repaint = CursorNeutral::around(|body| {
+            body.move_to(RowsAbove(1), Column(2));
+            body.write_text(CursorSafeText::new("ok").unwrap());
+        });
+        assert!(repaint.as_bytes().starts_with(SAVE_CURSOR));
+        assert!(repaint.as_bytes().ends_with(RESTORE_CURSOR));
+    }
+}

--- a/src/damage/mod.rs
+++ b/src/damage/mod.rs
@@ -1,0 +1,320 @@
+//! Incremental, cursor-neutral prompt repainting.
+
+pub mod cursor;
+#[cfg(test)]
+mod property_tests;
+#[cfg(test)]
+pub mod terminal;
+
+use cursor::{CursorNeutral, CursorSafeText, RowsAbove};
+use unicode_segmentation::UnicodeSegmentation;
+
+use crate::module::painted::{LineIndex, Painted, ResolvedStyle, Run, RunKind, TerminalWidth};
+use crate::print::Grapheme;
+
+/// A zero-based display column.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Column(pub usize);
+
+/// The result of comparing two painted prompts.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Damage {
+    None,
+    Repaint(CursorNeutral),
+    Full,
+}
+
+impl Damage {
+    pub fn between(previous: &Painted, next: &Painted, terminal_width: TerminalWidth) -> Self {
+        let previous_cursor = cursor_row(previous);
+        let next_cursor = cursor_row(next);
+        if previous.line_count() != next.line_count() || previous_cursor != next_cursor {
+            return Self::Full;
+        }
+
+        let mut changed = None;
+        for (index, (previous, next)) in previous.lines().zip(next.lines()).enumerate() {
+            let previous = Line::new(previous);
+            let next = Line::new(next);
+            if previous.width() > terminal_width || next.width() > terminal_width {
+                return Self::Full;
+            }
+
+            let Some(span) = Span::between(previous, next) else {
+                continue;
+            };
+            if changed.replace((LineIndex(index), span, next)).is_some() {
+                return Self::Full;
+            }
+        }
+
+        let Some((line, span, next)) = changed else {
+            return Self::None;
+        };
+        if line.0 == next_cursor && span.erases_tail {
+            return Self::Full;
+        }
+
+        let rows = RowsAbove(previous_cursor - line.0);
+        span.paint(rows, next).map_or(Self::Full, Self::Repaint)
+    }
+}
+
+fn cursor_row(painted: &Painted) -> usize {
+    let last = painted.line_count().saturating_sub(1);
+    if painted
+        .line(LineIndex(last))
+        .and_then(<[_]>::last)
+        .is_some_and(|run| run.kind() == RunKind::LineTerminator)
+    {
+        painted.line_count()
+    } else {
+        last
+    }
+}
+
+#[derive(Clone, Copy)]
+struct Line<'a> {
+    runs: &'a [Run],
+    width: TerminalWidth,
+}
+
+impl<'a> Line<'a> {
+    fn new(runs: &'a [Run]) -> Self {
+        let width = runs
+            .iter()
+            .filter(|run| run.kind() != RunKind::LineTerminator)
+            .flat_map(|run| run.text().graphemes(true))
+            .map(Grapheme)
+            .map(|grapheme| grapheme.width())
+            .sum();
+        Self {
+            runs,
+            width: TerminalWidth(width),
+        }
+    }
+
+    fn width(self) -> TerminalWidth {
+        self.width
+    }
+
+    fn cells(self) -> impl Iterator<Item = Cell<'a>> {
+        self.runs
+            .iter()
+            .filter(|run| run.kind() != RunKind::LineTerminator)
+            .flat_map(|run| {
+                let style = run.style();
+                run.text().graphemes(true).map(move |text| (text, style))
+            })
+            .scan(Column::default(), |column, (text, style)| {
+                let cell = Cell {
+                    text,
+                    style,
+                    column: *column,
+                };
+                column.0 += Grapheme(text).width();
+                Some(cell)
+            })
+    }
+
+    fn cells_from_end(self) -> impl Iterator<Item = Cell<'a>> {
+        self.runs
+            .iter()
+            .rev()
+            .filter(|run| run.kind() != RunKind::LineTerminator)
+            .flat_map(|run| {
+                let style = run.style();
+                run.text()
+                    .graphemes(true)
+                    .rev()
+                    .map(move |text| (text, style))
+            })
+            .scan(self.width.0, |column, (text, style)| {
+                *column -= Grapheme(text).width();
+                Some(Cell {
+                    text,
+                    style,
+                    column: Column(*column),
+                })
+            })
+    }
+
+    fn cell_count(self) -> usize {
+        self.cells().count()
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct Cell<'a> {
+    text: &'a str,
+    style: ResolvedStyle,
+    column: Column,
+}
+
+#[derive(Clone, Copy)]
+struct Span {
+    first: usize,
+    last: usize,
+    column: Column,
+    erases_tail: bool,
+}
+
+impl Span {
+    fn between(previous: Line<'_>, next: Line<'_>) -> Option<Self> {
+        let first = previous
+            .cells()
+            .zip(next.cells())
+            .take_while(|(previous, next)| previous == next)
+            .count();
+        let previous_count = previous.cell_count();
+        let next_count = next.cell_count();
+        if first == previous_count && first == next_count {
+            return None;
+        }
+
+        let suffix = if previous_count == next_count {
+            previous
+                .cells_from_end()
+                .zip(next.cells_from_end())
+                .take(previous_count - first)
+                .take_while(|(previous, next)| previous == next)
+                .count()
+        } else {
+            0
+        };
+
+        Some(Self {
+            first,
+            last: next_count - suffix,
+            column: next
+                .cells()
+                .nth(first)
+                .map_or(Column(next.width().0), |cell| cell.column),
+            erases_tail: previous.width() != next.width(),
+        })
+    }
+
+    fn paint(self, rows: RowsAbove, line: Line<'_>) -> Option<CursorNeutral> {
+        let span = || line.cells().skip(self.first).take(self.last - self.first);
+        span()
+            .all(|cell| CursorSafeText::new(cell.text).is_some())
+            .then(|| {
+                CursorNeutral::around(|body| {
+                    body.move_to(rows, self.column);
+                    for cell in span() {
+                        body.select_style(cell.style);
+                        body.write_text(CursorSafeText::new(cell.text).unwrap());
+                    }
+                    body.select_style(ResolvedStyle::plain());
+                    self.erases_tail.then(|| body.erase_to_end_of_line());
+                })
+            })
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use crate::config::{Style, parse_style_string};
+    use crate::formatter::StringFormatter;
+    use crate::segment::Segment;
+
+    fn parsed_style(value: &str) -> Option<Style> {
+        (!value.is_empty()).then(|| parse_style_string(value, None).unwrap())
+    }
+
+    pub fn text(style: &str, value: &str) -> Segment {
+        Segment::from_text(parsed_style(style), value).remove(0)
+    }
+
+    pub fn segments(format: &str) -> Vec<Segment> {
+        StringFormatter::new(format)
+            .unwrap()
+            .parse(None, None)
+            .unwrap()
+    }
+
+    pub fn painted(segments: &[Segment], width: usize) -> Painted {
+        Painted::paint(segments, Some(TerminalWidth(width)))
+    }
+
+    fn with_cursor_line(segments: &[Segment]) -> Vec<Segment> {
+        let mut prompt = segments.to_vec();
+        prompt.extend([Segment::LineTerm, text("", "> ")]);
+        prompt
+    }
+
+    fn assert_replays(previous: Painted, next: Painted, width: TerminalWidth) {
+        let mut terminal = crate::damage::terminal::EmulatedTerminal::blank(width);
+        terminal.feed(&previous.to_bytes());
+        match Damage::between(&previous, &next, width) {
+            Damage::None => {}
+            Damage::Repaint(bytes) => terminal.feed(bytes.as_bytes()),
+            Damage::Full => terminal.redraw(&next.to_bytes()),
+        }
+        assert_eq!(
+            crate::damage::terminal::fully_rendered(&next, width),
+            terminal.screen()
+        );
+    }
+
+    #[test]
+    fn unchanged_paint_is_empty_damage() {
+        let prompt = painted(&with_cursor_line(&segments("[main](red)")), 40);
+        assert_eq!(
+            Damage::None,
+            Damage::between(&prompt, &prompt, TerminalWidth(40))
+        );
+    }
+
+    #[test]
+    fn repaint_touches_one_changed_run() {
+        let previous = painted(&with_cursor_line(&segments("[main](red)")), 40);
+        let next = painted(&with_cursor_line(&segments("[work](red)")), 40);
+        let Damage::Repaint(bytes) = Damage::between(&previous, &next, TerminalWidth(40)) else {
+            panic!("same-shape edit should repaint");
+        };
+        assert!(String::from_utf8_lossy(bytes.as_bytes()).contains("work"));
+        assert_replays(previous, next, TerminalWidth(40));
+    }
+
+    #[test]
+    fn a_fill_resynchronizes_after_a_width_change() {
+        let previous = painted(&with_cursor_line(&segments("a$fill>b")), 20);
+        let next = painted(&with_cursor_line(&segments("long$fill>b")), 20);
+        assert_replays(previous, next, TerminalWidth(20));
+    }
+
+    #[test]
+    fn a_width_change_on_the_cursor_row_requires_a_redraw() {
+        let previous = painted(&segments("main >"), 40);
+        let next = painted(&segments("workspace >"), 40);
+        assert_eq!(
+            Damage::Full,
+            Damage::between(&previous, &next, TerminalWidth(40))
+        );
+    }
+
+    #[test]
+    fn two_changed_lines_require_a_redraw() {
+        let previous = painted(&segments("one\ntwo\n> "), 40);
+        let next = painted(&segments("uno\ndos\n> "), 40);
+        assert_eq!(
+            Damage::Full,
+            Damage::between(&previous, &next, TerminalWidth(40))
+        );
+    }
+
+    #[test]
+    fn repaint_reproduces_styled_cells() {
+        let previous = painted(
+            &with_cursor_line(&segments("[one](red)[ two](fg:prev_fg)")),
+            40,
+        );
+        let next = painted(
+            &with_cursor_line(&segments("[one](green)[ two](fg:prev_fg)")),
+            40,
+        );
+        assert_replays(previous, next, TerminalWidth(40));
+    }
+}

--- a/src/damage/mod.rs
+++ b/src/damage/mod.rs
@@ -26,76 +26,74 @@ pub enum Damage {
 
 impl Damage {
     pub fn between(previous: &Painted, next: &Painted, terminal_width: TerminalWidth) -> Self {
-        let previous_cursor = cursor_row(previous);
-        let next_cursor = cursor_row(next);
+        let previous_cursor = compute_cursor_row(previous);
+        let next_cursor = compute_cursor_row(next);
+
         if previous.line_count() != next.line_count() || previous_cursor != next_cursor {
             return Self::Full;
         }
 
-        let mut changed = None;
-        for (index, (previous, next)) in previous.lines().zip(next.lines()).enumerate() {
-            let previous = Line::new(previous);
-            let next = Line::new(next);
-            if previous.width() > terminal_width || next.width() > terminal_width {
+        let mut changed_line_data = None;
+
+        for (line_index, (previous_runs, next_runs)) in
+            previous.lines().zip(next.lines()).enumerate()
+        {
+            let previous_line = Line::new(previous_runs);
+            let next_line = Line::new(next_runs);
+
+            if previous_line.exceeds_width(terminal_width)
+                || next_line.exceeds_width(terminal_width)
+            {
                 return Self::Full;
             }
 
-            let Some(span) = Span::between(previous, next) else {
-                continue;
-            };
-            if changed.replace((LineIndex(index), span, next)).is_some() {
-                return Self::Full;
+            if let Some(span) = Span::compare(previous_line, next_line) {
+                // Only one changed line is repaintable incrementally.
+                if changed_line_data.is_some() {
+                    return Self::Full;
+                }
+                changed_line_data = Some((LineIndex(line_index), span, next_line));
             }
         }
 
-        let Some((line, span, next)) = changed else {
+        let Some((changed_index, span, next_line)) = changed_line_data else {
             return Self::None;
         };
-        if line.0 == next_cursor && span.erases_tail {
+
+        if changed_index.0 == next_cursor && span.erases_tail {
             return Self::Full;
         }
 
-        let rows = RowsAbove(previous_cursor - line.0);
-        span.paint(rows, next).map_or(Self::Full, Self::Repaint)
+        let rows_above = RowsAbove(previous_cursor.saturating_sub(changed_index.0));
+        span.paint(rows_above, next_line)
+            .map_or(Self::Full, Self::Repaint)
     }
 }
 
-fn cursor_row(painted: &Painted) -> usize {
-    let last = painted.line_count().saturating_sub(1);
-    if painted
-        .line(LineIndex(last))
-        .and_then(<[_]>::last)
-        .is_some_and(|run| run.kind() == RunKind::LineTerminator)
-    {
-        painted.line_count()
+fn compute_cursor_row(painted: &Painted) -> usize {
+    let total_lines = painted.line_count();
+    let last_index = total_lines.saturating_sub(1);
+
+    let has_trailing_terminator = painted
+        .line(LineIndex(last_index))
+        .and_then(|runs| runs.last())
+        .is_some_and(|run| run.kind() == RunKind::LineTerminator);
+
+    if has_trailing_terminator {
+        total_lines
     } else {
-        last
+        last_index
     }
 }
 
 #[derive(Clone, Copy)]
 struct Line<'a> {
     runs: &'a [Run],
-    width: TerminalWidth,
 }
 
 impl<'a> Line<'a> {
     fn new(runs: &'a [Run]) -> Self {
-        let width = runs
-            .iter()
-            .filter(|run| run.kind() != RunKind::LineTerminator)
-            .flat_map(|run| run.text().graphemes(true))
-            .map(Grapheme)
-            .map(|grapheme| grapheme.width())
-            .sum();
-        Self {
-            runs,
-            width: TerminalWidth(width),
-        }
-    }
-
-    fn width(self) -> TerminalWidth {
-        self.width
+        Self { runs }
     }
 
     fn cells(self) -> impl Iterator<Item = Cell<'a>> {
@@ -104,16 +102,9 @@ impl<'a> Line<'a> {
             .filter(|run| run.kind() != RunKind::LineTerminator)
             .flat_map(|run| {
                 let style = run.style();
-                run.text().graphemes(true).map(move |text| (text, style))
-            })
-            .scan(Column::default(), |column, (text, style)| {
-                let cell = Cell {
-                    text,
-                    style,
-                    column: *column,
-                };
-                column.0 += Grapheme(text).width();
-                Some(cell)
+                run.text()
+                    .graphemes(true)
+                    .map(move |text| Cell { text, style })
             })
     }
 
@@ -127,20 +118,21 @@ impl<'a> Line<'a> {
                 run.text()
                     .graphemes(true)
                     .rev()
-                    .map(move |text| (text, style))
-            })
-            .scan(self.width.0, |column, (text, style)| {
-                *column -= Grapheme(text).width();
-                Some(Cell {
-                    text,
-                    style,
-                    column: Column(*column),
-                })
+                    .map(move |text| Cell { text, style })
             })
     }
 
     fn cell_count(self) -> usize {
         self.cells().count()
+    }
+
+    fn width(self) -> TerminalWidth {
+        let total_width = self.cells().map(|cell| Grapheme(cell.text).width()).sum();
+        TerminalWidth(total_width)
+    }
+
+    fn exceeds_width(self, max_width: TerminalWidth) -> bool {
+        self.width() > max_width
     }
 }
 
@@ -148,70 +140,99 @@ impl<'a> Line<'a> {
 struct Cell<'a> {
     text: &'a str,
     style: ResolvedStyle,
-    column: Column,
 }
 
 #[derive(Clone, Copy)]
 struct Span {
-    first: usize,
-    last: usize,
-    column: Column,
+    start_index: usize,
+    end_index: usize,
+    start_column: Column,
     erases_tail: bool,
 }
 
 impl Span {
-    fn between(previous: Line<'_>, next: Line<'_>) -> Option<Self> {
-        let first = previous
-            .cells()
-            .zip(next.cells())
-            .take_while(|(previous, next)| previous == next)
-            .count();
+    fn compare(previous: Line<'_>, next: Line<'_>) -> Option<Self> {
+        let (start_index, start_column) = Self::find_divergence(previous, next)?;
+
         let previous_count = previous.cell_count();
         let next_count = next.cell_count();
-        if first == previous_count && first == next_count {
-            return None;
-        }
 
-        let suffix = if previous_count == next_count {
-            previous
-                .cells_from_end()
-                .zip(next.cells_from_end())
-                .take(previous_count - first)
-                .take_while(|(previous, next)| previous == next)
-                .count()
+        // Suffix matching only makes sense when the lengths match.
+        let suffix_length = if previous_count == next_count {
+            Self::match_suffix_length(previous, next, previous_count.saturating_sub(start_index))
         } else {
-            0
+            usize::default()
         };
 
         Some(Self {
-            first,
-            last: next_count - suffix,
-            column: next
-                .cells()
-                .nth(first)
-                .map_or(Column(next.width().0), |cell| cell.column),
+            start_index,
+            end_index: next_count.saturating_sub(suffix_length),
+            start_column,
             erases_tail: previous.width() != next.width(),
         })
     }
 
-    fn paint(self, rows: RowsAbove, line: Line<'_>) -> Option<CursorNeutral> {
-        let span = || line.cells().skip(self.first).take(self.last - self.first);
-        span()
-            .all(|cell| CursorSafeText::new(cell.text).is_some())
-            .then(|| {
-                CursorNeutral::around(|body| {
-                    body.move_to(rows, self.column);
-                    for cell in span() {
-                        body.select_style(cell.style);
-                        body.write_text(CursorSafeText::new(cell.text).unwrap());
-                    }
-                    body.select_style(ResolvedStyle::plain());
-                    self.erases_tail.then(|| body.erase_to_end_of_line());
-                })
-            })
+    // Single pass, tracking column alongside index.
+    fn find_divergence(previous: Line<'_>, next: Line<'_>) -> Option<(usize, Column)> {
+        let mut current_column = Column::default();
+        let mut current_index = usize::default();
+
+        let mut previous_cells = previous.cells();
+        let mut next_cells = next.cells();
+
+        loop {
+            match (previous_cells.next(), next_cells.next()) {
+                (Some(previous_cell), Some(next_cell)) if previous_cell == next_cell => {
+                    current_column.0 += Grapheme(next_cell.text).width();
+                    current_index += 1;
+                }
+                (Some(_), Some(_)) | (Some(_), None) | (None, Some(_)) => {
+                    return Some((current_index, current_column));
+                }
+                (None, None) => return None,
+            }
+        }
+    }
+
+    fn match_suffix_length(previous: Line<'_>, next: Line<'_>, max_search_length: usize) -> usize {
+        previous
+            .cells_from_end()
+            .zip(next.cells_from_end())
+            .take(max_search_length)
+            .take_while(|(previous_cell, next_cell)| previous_cell == next_cell)
+            .count()
+    }
+
+    fn paint(self, rows_above: RowsAbove, next_line: Line<'_>) -> Option<CursorNeutral> {
+        // A closure avoids allocating twice below.
+        let cell_iterator = || {
+            next_line
+                .cells()
+                .skip(self.start_index)
+                .take(self.end_index.saturating_sub(self.start_index))
+        };
+
+        let is_cursor_safe = cell_iterator().all(|cell| CursorSafeText::new(cell.text).is_some());
+        if !is_cursor_safe {
+            return None;
+        }
+
+        Some(CursorNeutral::around(|terminal| {
+            terminal.move_to(rows_above, self.start_column);
+
+            for cell in cell_iterator() {
+                terminal.select_style(cell.style);
+                terminal.write_text(CursorSafeText::new(cell.text).unwrap()); // checked above
+            }
+
+            terminal.select_style(ResolvedStyle::plain());
+
+            if self.erases_tail {
+                terminal.erase_to_end_of_line();
+            }
+        }))
     }
 }
-
 #[cfg(test)]
 pub mod tests {
     use super::*;

--- a/src/damage/mod.rs
+++ b/src/damage/mod.rs
@@ -43,6 +43,8 @@ impl Damage {
 
             if previous_line.exceeds_width(terminal_width)
                 || next_line.exceeds_width(terminal_width)
+                || previous_line.has_zero_width_cell()
+                || next_line.has_zero_width_cell()
             {
                 return Self::Full;
             }
@@ -134,6 +136,10 @@ impl<'a> Line<'a> {
     fn exceeds_width(self, max_width: TerminalWidth) -> bool {
         self.width() > max_width
     }
+
+    fn has_zero_width_cell(self) -> bool {
+        self.cells().any(|cell| Grapheme(cell.text).width() == 0)
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -158,7 +164,7 @@ impl Span {
         let next_count = next.cell_count();
 
         // Suffix matching only makes sense when the lengths match.
-        let suffix_length = if previous_count == next_count {
+        let suffix_length = if previous_count == next_count && previous.width() == next.width() {
             Self::match_suffix_length(previous, next, previous_count.saturating_sub(start_index))
         } else {
             usize::default()

--- a/src/damage/property_tests.rs
+++ b/src/damage/property_tests.rs
@@ -1,0 +1,49 @@
+use proptest::prelude::*;
+
+use super::{Damage, terminal};
+use crate::config::parse_style_string;
+use crate::module::painted::{Painted, TerminalWidth};
+use crate::segment::Segment;
+
+fn prompt(parts: &[(bool, String)]) -> Painted {
+    let mut segments: Vec<_> = parts
+        .iter()
+        .map(|(green, text)| {
+            let style = green.then(|| parse_style_string("green", None).unwrap());
+            Segment::from_text(style, text).remove(0)
+        })
+        .collect();
+    segments.extend([Segment::LineTerm, Segment::from_text(None, "> ").remove(0)]);
+    Painted::paint(&segments, Some(TerminalWidth(32)))
+}
+
+fn apply(terminal: &mut terminal::EmulatedTerminal, previous: &Painted, next: &Painted) {
+    match Damage::between(previous, next, TerminalWidth(32)) {
+        Damage::None => {}
+        Damage::Repaint(repaint) => terminal.feed(repaint.as_bytes()),
+        Damage::Full => terminal.redraw(&next.to_bytes()),
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    #[test]
+    fn a_sequence_of_single_line_refinements_matches_full_rendering(
+        updates in prop::collection::vec(
+            prop::collection::vec((any::<bool>(), "[a-z]{0,6}"), 1..4),
+            2..8,
+        ),
+    ) {
+        let mut previous = prompt(&updates[0]);
+        let mut terminal = terminal::EmulatedTerminal::blank(TerminalWidth(32));
+        terminal.feed(&previous.to_bytes());
+
+        for update in &updates[1..] {
+            let next = prompt(update);
+            apply(&mut terminal, &previous, &next);
+            prop_assert_eq!(terminal::fully_rendered(&next, TerminalWidth(32)), terminal.screen());
+            previous = next;
+        }
+    }
+}

--- a/src/damage/property_tests.rs
+++ b/src/damage/property_tests.rs
@@ -41,6 +41,10 @@ proptest! {
 
         for update in &updates[1..] {
             let next = prompt(update);
+            prop_assert!(
+                !matches!(Damage::between(&previous, &next, TerminalWidth(32)), Damage::Full),
+                "single-line ASCII refinements must exercise incremental damage"
+            );
             apply(&mut terminal, &previous, &next);
             prop_assert_eq!(terminal::fully_rendered(&next, TerminalWidth(32)), terminal.screen());
             previous = next;

--- a/src/damage/terminal.rs
+++ b/src/damage/terminal.rs
@@ -26,11 +26,9 @@ impl Dimensions for ScreenSize {
     fn total_lines(&self) -> usize {
         SCREEN_ROWS
     }
-
     fn screen_lines(&self) -> usize {
         SCREEN_ROWS
     }
-
     fn columns(&self) -> usize {
         self.columns
     }
@@ -44,12 +42,8 @@ pub struct CellSnapshot {
     flags: Flags,
 }
 
-impl CellSnapshot {
-    fn is_blank(&self) -> bool {
-        *self == Self::blank()
-    }
-
-    fn blank() -> Self {
+impl Default for CellSnapshot {
+    fn default() -> Self {
         Self {
             character: ' ',
             foreground: TerminalColor::Named(NamedColor::Foreground),
@@ -59,17 +53,24 @@ impl CellSnapshot {
     }
 }
 
+impl CellSnapshot {
+    fn is_blank(&self) -> bool {
+        *self == Self::default()
+    }
+}
+
 impl std::fmt::Debug for CellSnapshot {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(formatter, "{:?}", self.character)?;
-        if self.foreground != Self::blank().foreground {
-            write!(formatter, "/fg:{:?}", self.foreground)?;
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let default = Self::default();
+        write!(f, "{:?}", self.character)?;
+        if self.foreground != default.foreground {
+            write!(f, "/fg:{:?}", self.foreground)?;
         }
-        if self.background != Self::blank().background {
-            write!(formatter, "/bg:{:?}", self.background)?;
+        if self.background != default.background {
+            write!(f, "/bg:{:?}", self.background)?;
         }
         if !self.flags.is_empty() {
-            write!(formatter, "/{:?}", self.flags)?;
+            write!(f, "/{:?}", self.flags)?;
         }
         Ok(())
     }
@@ -81,31 +82,38 @@ pub struct Screen {
     cursor: Point,
 }
 
-impl Screen {
-    fn of(terminal: &Term<DiscardEvents>) -> Self {
+impl From<&Term<DiscardEvents>> for Screen {
+    fn from(terminal: &Term<DiscardEvents>) -> Self {
         let grid = terminal.grid();
-        let mut rows = Vec::with_capacity(grid.screen_lines());
 
-        for row in 0..grid.screen_lines() {
-            let mut cells: Vec<CellSnapshot> = grid[Line(row as i32)]
-                .into_iter()
-                .map(|cell| CellSnapshot {
-                    character: cell.c,
-                    foreground: cell.fg,
-                    background: cell.bg,
-                    // `WRAPLINE` is transport history, not screen state.
-                    flags: cell.flags.difference(Flags::WRAPLINE),
-                })
-                .collect();
-            while cells.last().is_some_and(CellSnapshot::is_blank) {
-                cells.pop();
-            }
-            rows.push(cells);
-        }
+        let mut rows: Vec<Vec<CellSnapshot>> = (0..grid.screen_lines())
+            .map(|row| {
+                let mut cells: Vec<_> = grid[Line(row as i32)]
+                    .into_iter()
+                    .map(|cell| CellSnapshot {
+                        character: cell.c,
+                        foreground: cell.fg,
+                        background: cell.bg,
+                        flags: cell.flags.difference(Flags::WRAPLINE),
+                    })
+                    .collect();
 
-        while rows.last().is_some_and(Vec::is_empty) {
-            rows.pop();
-        }
+                cells.truncate(
+                    cells
+                        .iter()
+                        .rposition(|c| !c.is_blank())
+                        .map_or(0, |i| i + 1),
+                );
+                cells
+            })
+            .collect();
+
+        // Same trick, for trailing empty rows.
+        rows.truncate(
+            rows.iter()
+                .rposition(|r| !r.is_empty())
+                .map_or(0, |i| i + 1),
+        );
 
         Self {
             rows,
@@ -115,11 +123,11 @@ impl Screen {
 }
 
 impl std::fmt::Debug for Screen {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        writeln!(formatter, "cursor at {:?}", self.cursor)?;
-        for (index, row) in self.rows.iter().enumerate() {
-            let text: String = row.iter().map(|cell| cell.character).collect();
-            writeln!(formatter, "  row {index}: {text:?} {row:?}")?;
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "cursor at {:?}", self.cursor)?;
+        for (i, row) in self.rows.iter().enumerate() {
+            let text: String = row.iter().map(|c| c.character).collect();
+            writeln!(f, "  row {i}: {text:?} {row:?}")?;
         }
         Ok(())
     }
@@ -146,13 +154,16 @@ impl EmulatedTerminal {
 
     /// Applies the tty's `ONLCR` translation (`\n` becomes `\r\n`) before feeding.
     pub fn feed(&mut self, bytes: &[u8]) {
-        let mut translated = Vec::with_capacity(bytes.len());
-        for &byte in bytes {
-            if byte == b'\n' {
-                translated.push(b'\r');
-            }
-            translated.push(byte);
-        }
+        let translated: Vec<u8> = bytes
+            .iter()
+            .flat_map(|&b| {
+                (b == b'\n')
+                    .then_some(b'\r')
+                    .into_iter()
+                    .chain(std::iter::once(b))
+            })
+            .collect();
+
         self.parser.advance(&mut self.terminal, &translated);
     }
 
@@ -162,7 +173,7 @@ impl EmulatedTerminal {
     }
 
     pub fn screen(&self) -> Screen {
-        Screen::of(&self.terminal)
+        Screen::from(&self.terminal)
     }
 }
 

--- a/src/damage/terminal.rs
+++ b/src/damage/terminal.rs
@@ -1,0 +1,173 @@
+//! Terminal-emulator support for repaint tests.
+
+use alacritty_terminal::event::{Event, EventListener};
+use alacritty_terminal::grid::Dimensions;
+use alacritty_terminal::index::{Line, Point};
+use alacritty_terminal::term::cell::Flags;
+use alacritty_terminal::term::{Config, Term};
+use alacritty_terminal::vte::ansi::{Color as TerminalColor, NamedColor, Processor};
+
+use crate::module::painted::{Painted, TerminalWidth};
+
+pub const SCREEN_ROWS: usize = 16;
+
+#[derive(Clone)]
+struct DiscardEvents;
+
+impl EventListener for DiscardEvents {
+    fn send_event(&self, _: Event) {}
+}
+
+struct ScreenSize {
+    columns: usize,
+}
+
+impl Dimensions for ScreenSize {
+    fn total_lines(&self) -> usize {
+        SCREEN_ROWS
+    }
+
+    fn screen_lines(&self) -> usize {
+        SCREEN_ROWS
+    }
+
+    fn columns(&self) -> usize {
+        self.columns
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct CellSnapshot {
+    character: char,
+    foreground: TerminalColor,
+    background: TerminalColor,
+    flags: Flags,
+}
+
+impl CellSnapshot {
+    fn is_blank(&self) -> bool {
+        *self == Self::blank()
+    }
+
+    fn blank() -> Self {
+        Self {
+            character: ' ',
+            foreground: TerminalColor::Named(NamedColor::Foreground),
+            background: TerminalColor::Named(NamedColor::Background),
+            flags: Flags::empty(),
+        }
+    }
+}
+
+impl std::fmt::Debug for CellSnapshot {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "{:?}", self.character)?;
+        if self.foreground != Self::blank().foreground {
+            write!(formatter, "/fg:{:?}", self.foreground)?;
+        }
+        if self.background != Self::blank().background {
+            write!(formatter, "/bg:{:?}", self.background)?;
+        }
+        if !self.flags.is_empty() {
+            write!(formatter, "/{:?}", self.flags)?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(PartialEq, Eq)]
+pub struct Screen {
+    rows: Vec<Vec<CellSnapshot>>,
+    cursor: Point,
+}
+
+impl Screen {
+    fn of(terminal: &Term<DiscardEvents>) -> Self {
+        let grid = terminal.grid();
+        let mut rows = Vec::with_capacity(grid.screen_lines());
+
+        for row in 0..grid.screen_lines() {
+            let mut cells: Vec<CellSnapshot> = grid[Line(row as i32)]
+                .into_iter()
+                .map(|cell| CellSnapshot {
+                    character: cell.c,
+                    foreground: cell.fg,
+                    background: cell.bg,
+                    // `WRAPLINE` is transport history, not screen state.
+                    flags: cell.flags.difference(Flags::WRAPLINE),
+                })
+                .collect();
+            while cells.last().is_some_and(CellSnapshot::is_blank) {
+                cells.pop();
+            }
+            rows.push(cells);
+        }
+
+        while rows.last().is_some_and(Vec::is_empty) {
+            rows.pop();
+        }
+
+        Self {
+            rows,
+            cursor: grid.cursor.point,
+        }
+    }
+}
+
+impl std::fmt::Debug for Screen {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(formatter, "cursor at {:?}", self.cursor)?;
+        for (index, row) in self.rows.iter().enumerate() {
+            let text: String = row.iter().map(|cell| cell.character).collect();
+            writeln!(formatter, "  row {index}: {text:?} {row:?}")?;
+        }
+        Ok(())
+    }
+}
+
+pub struct EmulatedTerminal {
+    terminal: Term<DiscardEvents>,
+    parser: Processor,
+    width: TerminalWidth,
+}
+
+impl EmulatedTerminal {
+    pub fn blank(width: TerminalWidth) -> Self {
+        Self {
+            terminal: Term::new(
+                Config::default(),
+                &ScreenSize { columns: width.0 },
+                DiscardEvents,
+            ),
+            parser: Processor::new(),
+            width,
+        }
+    }
+
+    /// Applies the tty's `ONLCR` translation (`\n` becomes `\r\n`) before feeding.
+    pub fn feed(&mut self, bytes: &[u8]) {
+        let mut translated = Vec::with_capacity(bytes.len());
+        for &byte in bytes {
+            if byte == b'\n' {
+                translated.push(b'\r');
+            }
+            translated.push(byte);
+        }
+        self.parser.advance(&mut self.terminal, &translated);
+    }
+
+    pub fn redraw(&mut self, bytes: &[u8]) {
+        *self = Self::blank(self.width);
+        self.feed(bytes);
+    }
+
+    pub fn screen(&self) -> Screen {
+        Screen::of(&self.terminal)
+    }
+}
+
+pub fn fully_rendered(painted: &Painted, width: TerminalWidth) -> Screen {
+    let mut terminal = EmulatedTerminal::blank(width);
+    terminal.feed(&painted.to_bytes());
+    terminal.screen()
+}

--- a/src/escaping.rs
+++ b/src/escaping.rs
@@ -43,6 +43,7 @@ where
             escaped
         }
         Shell::Zsh => text.into().replace('%', "%%"),
+        Shell::Tcsh => text.into().replace('%', "%%").replace('!', r"\!"),
         _ => text.into(),
     }
 }
@@ -101,7 +102,6 @@ mod tests {
             Shell::Pwsh,
             Shell::PowerShell,
             Shell::Elvish,
-            Shell::Tcsh,
             Shell::Nu,
             Shell::Xonsh,
             Shell::Cmd,
@@ -110,5 +110,10 @@ mod tests {
             let destination = Destination::shell_prompt_variable(shell);
             assert_eq!(text, destination.escape(text), "for {shell:?}");
         }
+    }
+
+    #[test]
+    fn a_tcsh_prompt_variable_escapes_prompt_and_history_tokens() {
+        assert_eq!("100%% \\!", shell_prompt_escape("100% !", Shell::Tcsh));
     }
 }

--- a/src/escaping.rs
+++ b/src/escaping.rs
@@ -1,0 +1,106 @@
+//! Prompt output destinations.
+
+use crate::context::Shell;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Destination {
+    ShellPromptVariable(Shell),
+    RawTerminal,
+}
+
+impl Destination {
+    pub const fn shell_prompt_variable(shell: Shell) -> Self {
+        Self::ShellPromptVariable(shell)
+    }
+
+    pub fn escape<T>(self, text: T) -> String
+    where
+        T: Into<String>,
+    {
+        match self {
+            Self::ShellPromptVariable(shell) => shell_prompt_escape(text, shell),
+            Self::RawTerminal => text.into(),
+        }
+    }
+}
+
+pub fn shell_prompt_escape<T>(text: T, shell: Shell) -> String
+where
+    T: Into<String>,
+{
+    match shell {
+        Shell::Bash => text
+            .into()
+            .replace('\\', r"\\")
+            .replace('$', r"\$")
+            .replace('`', r"\`"),
+        Shell::Zsh => text.into().replace('%', "%%"),
+        _ => text.into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_raw_terminal_destination_never_rewrites_anything() {
+        for text in ["10% $ `tick` back\\slash", "", "%%%", "$$$"] {
+            assert_eq!(text, Destination::RawTerminal.escape(text));
+        }
+    }
+
+    #[test]
+    fn a_zsh_prompt_variable_doubles_every_percent() {
+        assert_eq!(
+            "10%% off",
+            Destination::shell_prompt_variable(Shell::Zsh).escape("10% off")
+        );
+    }
+
+    #[test]
+    fn a_bash_prompt_variable_escapes_what_bash_would_expand() {
+        assert_eq!(
+            r"\$HOME \`date\` back\\slash",
+            Destination::shell_prompt_variable(Shell::Bash).escape(r"$HOME `date` back\slash")
+        );
+    }
+
+    #[test]
+    fn bash_escaping_covers_every_character_bash_would_expand() {
+        for (text, expected) in [
+            ("$(echo a)", r"\$(echo a)"),
+            (r"\$(echo a)", r"\\\$(echo a)"),
+            (r"`echo a`", r"\`echo a\`"),
+        ] {
+            assert_eq!(expected, shell_prompt_escape(text, Shell::Bash));
+            assert_eq!(text, shell_prompt_escape(text, Shell::PowerShell));
+        }
+    }
+
+    #[test]
+    fn zsh_escaping_covers_the_one_character_zsh_would_expand() {
+        assert_eq!("10%%", shell_prompt_escape("10%", Shell::Zsh));
+        assert_eq!("10%", shell_prompt_escape("10%", Shell::PowerShell));
+    }
+
+    #[test]
+    fn shells_that_expand_nothing_agree_with_the_raw_terminal() {
+        let text = "10% $ `tick` back\\slash";
+        for shell in [
+            Shell::Fish,
+            Shell::Ion,
+            Shell::Pwsh,
+            Shell::PowerShell,
+            Shell::Elvish,
+            Shell::Tcsh,
+            Shell::Nu,
+            Shell::Xonsh,
+            Shell::Cmd,
+            Shell::Unknown,
+        ] {
+            let destination = Destination::shell_prompt_variable(shell);
+            assert_eq!(text, destination.escape(text), "for {shell:?}");
+        }
+    }
+}

--- a/src/escaping.rs
+++ b/src/escaping.rs
@@ -29,11 +29,19 @@ where
     T: Into<String>,
 {
     match shell {
-        Shell::Bash => text
-            .into()
-            .replace('\\', r"\\")
-            .replace('$', r"\$")
-            .replace('`', r"\`"),
+        Shell::Bash => {
+            let text = text.into();
+            let mut escaped = String::with_capacity(text.len());
+            for character in text.chars() {
+                match character {
+                    '\\' => escaped.push_str(r"\\"),
+                    '$' => escaped.push_str(r"\$"),
+                    '`' => escaped.push_str(r"\`"),
+                    character => escaped.push(character),
+                }
+            }
+            escaped
+        }
         Shell::Zsh => text.into().replace('%', "%%"),
         _ => text.into(),
     }

--- a/src/formatter/mod.rs
+++ b/src/formatter/mod.rs
@@ -4,5 +4,5 @@ pub mod string_formatter;
 mod version;
 
 pub use model::{StyleVariableHolder, VariableHolder};
-pub use string_formatter::StringFormatter;
+pub use string_formatter::{StringFormatter, parse_format_string};
 pub use version::VersionFormatter;

--- a/src/formatter/string_formatter.rs
+++ b/src/formatter/string_formatter.rs
@@ -6,7 +6,8 @@ use std::error::Error;
 use std::fmt;
 
 use crate::config::{Style, parse_style_string};
-use crate::context::{Context, Shell};
+use crate::context::Context;
+use crate::escaping::Destination;
 use crate::segment::Segment;
 
 use super::model::*;
@@ -28,6 +29,16 @@ impl Default for VariableValue<'_> {
 
 type VariableMapType<'a> =
     BTreeMap<String, Option<Result<VariableValue<'a>, StringFormatterError>>>;
+
+/// Where the text this formatter produces is going.
+///
+/// A format string parsed without a context belongs to no prompt and so is
+/// bound for nothing that expands it — the same answer a context whose prompt
+/// is written straight to the terminal gives.
+fn destination(context: Option<&Context>) -> Destination {
+    context.map_or(Destination::RawTerminal, Context::destination)
+}
+
 type StyleVariableMapType<'a> =
     BTreeMap<String, Option<Result<Cow<'a, str>, StringFormatterError>>>;
 
@@ -60,12 +71,22 @@ pub struct StringFormatter<'a> {
     style_variables: StyleVariableMapType<'a>,
 }
 
+/// Parses a format string into the elements it is built from.
+///
+/// This is the front half of [`StringFormatter::new`], exposed on its own for
+/// callers that want the syntax tree rather than a formatter — notably
+/// [`crate::plan::Plan`], which turns the tree into a representation of the
+/// prompt that carries no variable values at all.
+pub fn parse_format_string(format: &str) -> Result<Vec<FormatElement<'_>>, StringFormatterError> {
+    parse(format).map_err(StringFormatterError::Parse)
+}
+
 impl<'a> StringFormatter<'a> {
     /// Creates an instance of `StringFormatter` from a format string
     ///
     /// This method will throw an Error when the given format string fails to parse.
     pub fn new(format: &'a str) -> Result<Self, StringFormatterError> {
-        let format = parse(format).map_err(StringFormatterError::Parse)?;
+        let format = parse_format_string(format)?;
 
         // Cache all variables
         let variables = format
@@ -291,16 +312,9 @@ impl<'a> StringFormatter<'a> {
                 .into_iter()
                 .map(|el| {
                     match el {
-                        FormatElement::Text(text) => Ok(Segment::from_text(
-                            style,
-                            shell_prompt_escape(
-                                text,
-                                match context {
-                                    None => Shell::Unknown,
-                                    Some(c) => c.shell,
-                                },
-                            ),
-                        )),
+                        FormatElement::Text(text) => {
+                            Ok(Segment::from_text(style, destination(context).escape(text)))
+                        }
                         FormatElement::TextGroup(textgroup) => {
                             parse_textgroup(textgroup, variables, style_variables, context)
                         }
@@ -321,13 +335,7 @@ impl<'a> StringFormatter<'a> {
                                         .collect()),
                                     VariableValue::Plain(text) => Ok(Segment::from_text(
                                         style,
-                                        shell_prompt_escape(
-                                            text,
-                                            match context {
-                                                None => Shell::Unknown,
-                                                Some(c) => c.shell,
-                                            },
-                                        ),
+                                        destination(context).escape(text),
                                     )),
                                     VariableValue::NoEscapingPlain(text) => {
                                         Ok(Segment::from_text(style, text))
@@ -435,28 +443,6 @@ fn clone_without_meta<'a>(variables: &VariableMapType<'a>) -> VariableMapType<'a
             (key.clone(), value)
         })
         .collect()
-}
-
-/// Escape interpretable characters for the shell prompt
-pub fn shell_prompt_escape<T>(text: T, shell: Shell) -> String
-where
-    T: Into<String>,
-{
-    // Handle other interpretable characters
-    match shell {
-        // Bash might interpret backslashes, backticks and $
-        // see #658 for more details
-        Shell::Bash => text
-            .into()
-            .replace('\\', r"\\")
-            .replace('$', r"\$")
-            .replace('`', r"\`"),
-        Shell::Zsh => {
-            // % is an escape in zsh, see PROMPT in `man zshmisc`
-            text.into().replace('%', "%%")
-        }
-        _ => text.into(),
-    }
 }
 
 #[cfg(test)]
@@ -853,47 +839,5 @@ mod tests {
                 .parse(None, None)
         });
         assert!(segments.is_err());
-    }
-
-    #[test]
-    fn test_bash_escape() {
-        let test = "$(echo a)";
-        assert_eq!(
-            shell_prompt_escape(test.to_owned(), Shell::Bash),
-            r"\$(echo a)"
-        );
-        assert_eq!(
-            shell_prompt_escape(test.to_owned(), Shell::PowerShell),
-            test
-        );
-
-        let test = r"\$(echo a)";
-        assert_eq!(
-            shell_prompt_escape(test.to_owned(), Shell::Bash),
-            r"\\\$(echo a)"
-        );
-        assert_eq!(
-            shell_prompt_escape(test.to_owned(), Shell::PowerShell),
-            test
-        );
-
-        let test = r"`echo a`";
-        assert_eq!(
-            shell_prompt_escape(test.to_owned(), Shell::Bash),
-            r"\`echo a\`"
-        );
-        assert_eq!(
-            shell_prompt_escape(test.to_owned(), Shell::PowerShell),
-            test
-        );
-    }
-    #[test]
-    fn test_zsh_escape() {
-        let test = "10%";
-        assert_eq!(shell_prompt_escape(test.to_owned(), Shell::Zsh), "10%%");
-        assert_eq!(
-            shell_prompt_escape(test.to_owned(), Shell::PowerShell),
-            test
-        );
     }
 }

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -15,7 +15,15 @@ use crate::escaping::shell_prompt_escape;
 use crate::module::painted::Painted;
 use crate::utils::wrap_colorseq_for_shell;
 
-/// Streaming event encoding.
+const NULL_BYTE: u8 = b'\0';
+const NEWLINE: &[u8] = b"\n";
+const EMPTY_SLICE: &[u8] = &[];
+
+const EVENT_READY: &[u8] = b"READY";
+const EVENT_PATCH: &[u8] = b"PATCH";
+const EVENT_COMPLETE: &[u8] = b"COMPLETE";
+const EVENT_HEARTBEAT: &[u8] = b"HEARTBEAT";
+
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, ValueEnum)]
 pub enum FrameEncoding {
     #[default]
@@ -30,16 +38,14 @@ pub struct RawTerminalPayload(String);
 
 impl RawTerminalPayload {
     pub fn repaint(repaint: &CursorNeutral) -> Self {
-        let repaint =
+        let repaint_string =
             String::from_utf8(repaint.as_bytes().to_vec()).expect("repaints are valid UTF-8");
-        debug_assert!(!repaint.contains('\0'));
-        Self(repaint)
+        debug_assert!(!repaint_string.contains(char::from(NULL_BYTE)));
+        Self(repaint_string)
     }
 
     pub fn prompt(painted: &Painted) -> Self {
-        let mut prompt = painted.to_string();
-        prompt.retain(|character| character != '\0');
-        Self(prompt)
+        Self(painted.to_string().replace(char::from(NULL_BYTE), ""))
     }
 
     pub fn as_bytes(&self) -> &[u8] {
@@ -63,26 +69,32 @@ impl PromptVariablePayload {
 
     #[cfg(test)]
     pub fn as_terminal_bytes_under(&self, shell: Shell) -> RawTerminalPayload {
-        let expansion = match shell {
+        let escape_tokens = match shell {
             Shell::Bash => Some(('\\', '[', ']')),
             Shell::Zsh | Shell::Tcsh => Some(('%', '{', '}')),
             _ => None,
         };
-        let Some((introducer, zero_width_start, zero_width_end)) = expansion else {
+
+        let Some((intro, start, end)) = escape_tokens else {
             return RawTerminalPayload(self.0.clone());
         };
 
         let mut expanded = String::with_capacity(self.0.len());
         let mut characters = self.0.chars();
+
         while let Some(character) = characters.next() {
-            if character != introducer {
+            if character != intro {
                 expanded.push(character);
                 continue;
             }
+
             match characters.next() {
-                Some(next) if next == zero_width_start || next == zero_width_end => {}
+                Some(next) if next == start || next == end => continue,
                 Some(next) => expanded.push(next),
-                None => expanded.push(introducer),
+                None => {
+                    expanded.push(intro);
+                    break;
+                }
             }
         }
         RawTerminalPayload(expanded)
@@ -99,23 +111,26 @@ pub enum Patch {
 }
 
 impl Patch {
-    pub fn whole_prompt(prompt: PromptVariablePayload) -> Self {
+    pub const fn whole_prompt(prompt: PromptVariablePayload) -> Self {
         Self::Replace(prompt)
     }
 
-    pub fn repainting_cells(prompt: PromptVariablePayload, repaint: RawTerminalPayload) -> Self {
+    pub const fn repainting_cells(
+        prompt: PromptVariablePayload,
+        repaint: RawTerminalPayload,
+    ) -> Self {
         Self::Repaint { prompt, repaint }
     }
 
     #[cfg(test)]
-    pub fn prompt(&self) -> &PromptVariablePayload {
+    pub const fn prompt(&self) -> &PromptVariablePayload {
         match self {
             Self::Replace(prompt) | Self::Repaint { prompt, .. } => prompt,
         }
     }
 
     #[cfg(test)]
-    pub fn repaint(&self) -> Option<&RawTerminalPayload> {
+    pub const fn repaint(&self) -> Option<&RawTerminalPayload> {
         match self {
             Self::Replace(_) => None,
             Self::Repaint { repaint, .. } => Some(repaint),
@@ -135,6 +150,55 @@ impl ProcessId {
     #[must_use]
     pub const fn get(self) -> u32 {
         self.0
+    }
+}
+
+/// Module resolution timings.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Timings(BTreeMap<String, u64>);
+
+impl Timings {
+    /// An empty set of timings, usable in a `const` context.
+    #[must_use]
+    pub const fn empty() -> Self {
+        Self(BTreeMap::new())
+    }
+
+    pub fn record(&mut self, module: &str, elapsed: Duration) {
+        let elapsed_microseconds = u64::try_from(elapsed.as_micros()).unwrap_or(u64::MAX);
+        self.0
+            .entry(module.to_owned())
+            .and_modify(|recorded| *recorded = (*recorded).max(elapsed_microseconds))
+            .or_insert(elapsed_microseconds);
+    }
+
+    pub fn set(&mut self, module: &str, cost_microseconds: u64) {
+        self.0.insert(module.to_owned(), cost_microseconds);
+    }
+
+    pub fn get(&self, module: &str) -> Option<u64> {
+        self.0.get(module).copied()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&str, u64)> {
+        self.0.iter().map(|(module, cost)| (module.as_str(), *cost))
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    fn to_json_bytes(&self) -> Vec<u8> {
+        serde_json::to_vec(self).expect("a map of strings to integers always serializes")
+    }
+
+    pub fn from_json(payload: &[u8]) -> Option<Self> {
+        serde_json::from_slice(payload).ok()
     }
 }
 
@@ -167,29 +231,70 @@ impl ServerEvent {
     }
 
     fn write_compact(&self, writer: &mut impl Write) -> io::Result<()> {
-        const NOTHING: &[u8] = &[];
         match self {
             Self::Ready { prompt, process_id } => {
-                let process_id = process_id.get().to_string();
-                write_frame(writer, "READY", prompt.as_bytes(), process_id.as_bytes())
+                let process_id_string = process_id.get().to_string();
+                write_frame(
+                    writer,
+                    EVENT_READY,
+                    prompt.as_bytes(),
+                    process_id_string.as_bytes(),
+                )
             }
             Self::Patch(Patch::Replace(prompt)) => {
-                write_frame(writer, "PATCH", prompt.as_bytes(), NOTHING)
+                write_frame(writer, EVENT_PATCH, prompt.as_bytes(), EMPTY_SLICE)
             }
             Self::Patch(Patch::Repaint { prompt, repaint }) => {
-                write_frame(writer, "PATCH", prompt.as_bytes(), repaint.as_bytes())
+                write_frame(writer, EVENT_PATCH, prompt.as_bytes(), repaint.as_bytes())
             }
-            Self::Complete(timings) => {
-                let timings = timings.to_json_bytes();
-                write_frame(writer, "COMPLETE", &timings, NOTHING)
-            }
-            Self::Heartbeat => write_frame(writer, "HEARTBEAT", NOTHING, NOTHING),
+            Self::Complete(timings) => write_frame(
+                writer,
+                EVENT_COMPLETE,
+                &timings.to_json_bytes(),
+                EMPTY_SLICE,
+            ),
+            Self::Heartbeat => write_frame(writer, EVENT_HEARTBEAT, EMPTY_SLICE, EMPTY_SLICE),
         }
     }
 
     fn write_json(&self, writer: &mut impl Write) -> io::Result<()> {
-        serde_json::to_writer(&mut *writer, &JsonEvent::from(self))?;
-        writer.write_all(b"\n")?;
+        #[derive(Serialize)]
+        #[serde(tag = "kind", rename_all = "SCREAMING_SNAKE_CASE")]
+        enum JsonView<'a> {
+            Ready {
+                prompt: &'a str,
+                process_id: u32,
+            },
+            Patch {
+                prompt: &'a str,
+                #[serde(skip_serializing_if = "Option::is_none")]
+                repaint: Option<&'a str>,
+            },
+            Complete {
+                timings: &'a Timings,
+            },
+            Heartbeat,
+        }
+
+        let payload = match self {
+            Self::Ready { prompt, process_id } => JsonView::Ready {
+                prompt: &prompt.0,
+                process_id: process_id.get(),
+            },
+            Self::Patch(Patch::Replace(prompt)) => JsonView::Patch {
+                prompt: &prompt.0,
+                repaint: None,
+            },
+            Self::Patch(Patch::Repaint { prompt, repaint }) => JsonView::Patch {
+                prompt: &prompt.0,
+                repaint: Some(&repaint.0),
+            },
+            Self::Complete(timings) => JsonView::Complete { timings },
+            Self::Heartbeat => JsonView::Heartbeat,
+        };
+
+        serde_json::to_writer(&mut *writer, &payload)?;
+        writer.write_all(NEWLINE)?;
         writer.flush()
     }
 
@@ -200,88 +305,61 @@ impl ServerEvent {
         };
         let first = read_field(reader)?.ok_or(io::ErrorKind::UnexpectedEof)?;
         let second = read_field(reader)?.ok_or(io::ErrorKind::UnexpectedEof)?;
-        let malformed = |message| io::Error::new(io::ErrorKind::InvalidData, message);
 
-        match keyword.as_slice() {
-            b"READY" => Ok(Some(Self::Ready {
-                prompt: PromptVariablePayload(text(first)?),
-                process_id: ProcessId(
-                    std::str::from_utf8(&second)
-                        .ok()
-                        .and_then(|field| field.parse().ok())
-                        .ok_or_else(|| malformed("invalid process id"))?,
-                ),
-            })),
-            b"PATCH" => {
-                let prompt = PromptVariablePayload(text(first)?);
-                Ok(Some(Self::Patch(if second.is_empty() {
+        Self::parse_event(&keyword, first, second)
+            .map_err(|message| io::Error::new(io::ErrorKind::InvalidData, message))
+    }
+
+    #[cfg(test)]
+    fn parse_event(
+        keyword: &[u8],
+        first: Vec<u8>,
+        second: Vec<u8>,
+    ) -> Result<Option<Self>, &'static str> {
+        match keyword {
+            EVENT_READY => {
+                let prompt = PromptVariablePayload(parse_text(first)?);
+                let process_id = std::str::from_utf8(&second)
+                    .ok()
+                    .and_then(|string| string.parse().ok())
+                    .map(ProcessId)
+                    .ok_or("invalid process id")?;
+
+                Ok(Some(Self::Ready { prompt, process_id }))
+            }
+            EVENT_PATCH => {
+                let prompt = PromptVariablePayload(parse_text(first)?);
+                let patch = if second.is_empty() {
                     Patch::Replace(prompt)
                 } else {
                     Patch::Repaint {
                         prompt,
-                        repaint: RawTerminalPayload(text(second)?),
+                        repaint: RawTerminalPayload(parse_text(second)?),
                     }
-                })))
+                };
+
+                Ok(Some(Self::Patch(patch)))
             }
-            b"COMPLETE" if second.is_empty() => Timings::from_json(&first)
+            EVENT_COMPLETE if second.is_empty() => Timings::from_json(&first)
                 .map(Self::Complete)
                 .map(Some)
-                .ok_or_else(|| malformed("invalid timings")),
-            b"HEARTBEAT" if first.is_empty() && second.is_empty() => Ok(Some(Self::Heartbeat)),
-            _ => Err(malformed("invalid event")),
-        }
-    }
-}
-
-#[derive(Serialize)]
-#[serde(tag = "kind", rename_all = "SCREAMING_SNAKE_CASE")]
-enum JsonEvent<'a> {
-    Ready {
-        prompt: &'a str,
-        process_id: u32,
-    },
-    Patch {
-        prompt: &'a str,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        repaint: Option<&'a str>,
-    },
-    Complete {
-        timings: &'a Timings,
-    },
-    Heartbeat,
-}
-
-impl<'a> From<&'a ServerEvent> for JsonEvent<'a> {
-    fn from(event: &'a ServerEvent) -> Self {
-        match event {
-            ServerEvent::Ready { prompt, process_id } => Self::Ready {
-                prompt: &prompt.0,
-                process_id: process_id.get(),
-            },
-            ServerEvent::Patch(Patch::Replace(prompt)) => Self::Patch {
-                prompt: &prompt.0,
-                repaint: None,
-            },
-            ServerEvent::Patch(Patch::Repaint { prompt, repaint }) => Self::Patch {
-                prompt: &prompt.0,
-                repaint: Some(&repaint.0),
-            },
-            ServerEvent::Complete(timings) => Self::Complete { timings },
-            ServerEvent::Heartbeat => Self::Heartbeat,
+                .ok_or("invalid timings"),
+            EVENT_HEARTBEAT if first.is_empty() && second.is_empty() => Ok(Some(Self::Heartbeat)),
+            _ => Err("invalid event"),
         }
     }
 }
 
 fn write_frame(
     writer: &mut impl Write,
-    keyword: &str,
+    keyword: &[u8],
     first: &[u8],
     second: &[u8],
 ) -> io::Result<()> {
-    for field in [keyword.as_bytes(), first, second] {
-        debug_assert!(!field.contains(&0));
+    for field in [keyword, first, second] {
+        debug_assert!(!field.contains(&NULL_BYTE));
         writer.write_all(field)?;
-        writer.write_all(b"\0")?;
+        writer.write_all(&[NULL_BYTE])?;
     }
     writer.flush()
 }
@@ -289,75 +367,23 @@ fn write_frame(
 #[cfg(test)]
 fn read_field(reader: &mut impl BufRead) -> io::Result<Option<Vec<u8>>> {
     let mut field = Vec::new();
-    match reader.read_until(0, &mut field)? {
-        0 => Ok(None),
-        _ if field.pop() == Some(0) => Ok(Some(field)),
-        _ => Err(io::ErrorKind::UnexpectedEof.into()),
+    let bytes_read = reader.read_until(NULL_BYTE, &mut field)?;
+
+    if bytes_read == 0 {
+        return Ok(None);
+    }
+
+    if field.ends_with(&[NULL_BYTE]) {
+        field.pop();
+        Ok(Some(field))
+    } else {
+        Err(io::ErrorKind::UnexpectedEof.into())
     }
 }
 
 #[cfg(test)]
-fn text(field: Vec<u8>) -> io::Result<String> {
-    String::from_utf8(field).map_err(|_| io::ErrorKind::InvalidData.into())
-}
-
-/// A module resolution latency.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-#[serde(transparent)]
-pub struct Microseconds(pub u64);
-
-impl Microseconds {
-    #[must_use]
-    pub fn duration(self) -> Duration {
-        Duration::from_micros(self.0)
-    }
-}
-
-impl From<Duration> for Microseconds {
-    fn from(duration: Duration) -> Self {
-        Self(u64::try_from(duration.as_micros()).unwrap_or(u64::MAX))
-    }
-}
-
-/// Module resolution timings.
-#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(transparent)]
-pub struct Timings(BTreeMap<String, Microseconds>);
-
-impl Timings {
-    pub fn record(&mut self, module: &str, elapsed: Duration) {
-        let elapsed = Microseconds::from(elapsed);
-        let recorded = self.0.entry(module.to_owned()).or_default();
-        *recorded = (*recorded).max(elapsed);
-    }
-
-    pub fn set(&mut self, module: &str, cost: Microseconds) {
-        self.0.insert(module.to_owned(), cost);
-    }
-
-    pub fn get(&self, module: &str) -> Option<Microseconds> {
-        self.0.get(module).copied()
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = (&str, Microseconds)> {
-        self.0.iter().map(|(module, cost)| (module.as_str(), *cost))
-    }
-
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
-    fn to_json_bytes(&self) -> Vec<u8> {
-        serde_json::to_vec(self).expect("a map of strings and integers always serializes")
-    }
-
-    pub fn from_json(payload: &[u8]) -> Option<Self> {
-        serde_json::from_slice(payload).ok()
-    }
+fn parse_text(field: Vec<u8>) -> Result<String, &'static str> {
+    String::from_utf8(field).map_err(|_| "invalid utf-8 text")
 }
 
 #[cfg(test)]
@@ -499,8 +525,8 @@ mod tests {
         let read = Timings::from_json(&fields[1]).expect("timings are JSON");
 
         assert_eq!(timings, read);
-        assert_eq!(Some(Microseconds(12)), read.get("character"));
-        assert_eq!(Some(Microseconds(180_000)), read.get("git_status"));
+        assert_eq!(Some(12), read.get("character"));
+        assert_eq!(Some(180_000), read.get("git_status"));
         assert_eq!(2, read.len());
     }
 
@@ -512,7 +538,7 @@ mod tests {
         timings.record("directory", Duration::from_millis(9));
         timings.record("directory", Duration::from_micros(50));
 
-        assert_eq!(Some(Microseconds(9_000)), timings.get("directory"));
+        assert_eq!(Some(9_000), timings.get("directory"));
     }
 
     #[test]

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -1,0 +1,525 @@
+//! Streaming prompt frames.
+
+use std::collections::BTreeMap;
+#[cfg(test)]
+use std::io::BufRead;
+use std::io::{self, Write};
+use std::time::Duration;
+
+use clap::ValueEnum;
+use serde::{Deserialize, Serialize};
+
+use crate::context::Shell;
+use crate::damage::cursor::CursorNeutral;
+use crate::escaping::shell_prompt_escape;
+use crate::module::painted::Painted;
+use crate::utils::wrap_colorseq_for_shell;
+
+/// Streaming event encoding.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, ValueEnum)]
+pub enum FrameEncoding {
+    #[default]
+    Compact,
+    #[value(name = "json")]
+    JsonLines,
+}
+
+/// Bytes written directly to the terminal.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RawTerminalPayload(String);
+
+impl RawTerminalPayload {
+    pub fn repaint(repaint: &CursorNeutral) -> Self {
+        let repaint =
+            String::from_utf8(repaint.as_bytes().to_vec()).expect("repaints are valid UTF-8");
+        debug_assert!(!repaint.contains('\0'));
+        Self(repaint)
+    }
+
+    pub fn prompt(painted: &Painted) -> Self {
+        let mut prompt = painted.to_string();
+        prompt.retain(|character| character != '\0');
+        Self(prompt)
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        self.0.as_bytes()
+    }
+}
+
+/// Bytes assigned to a shell prompt variable.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PromptVariablePayload(String);
+
+impl PromptVariablePayload {
+    pub fn escaped_for(payload: &RawTerminalPayload, shell: Shell) -> Self {
+        let escaped = shell_prompt_escape(payload.0.as_str(), shell);
+        Self(wrap_colorseq_for_shell(escaped, shell))
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        self.0.as_bytes()
+    }
+
+    #[cfg(test)]
+    pub fn as_terminal_bytes_under(&self, shell: Shell) -> RawTerminalPayload {
+        let expansion = match shell {
+            Shell::Bash => Some(('\\', '[', ']')),
+            Shell::Zsh | Shell::Tcsh => Some(('%', '{', '}')),
+            _ => None,
+        };
+        let Some((introducer, zero_width_start, zero_width_end)) = expansion else {
+            return RawTerminalPayload(self.0.clone());
+        };
+
+        let mut expanded = String::with_capacity(self.0.len());
+        let mut characters = self.0.chars();
+        while let Some(character) = characters.next() {
+            if character != introducer {
+                expanded.push(character);
+                continue;
+            }
+            match characters.next() {
+                Some(next) if next == zero_width_start || next == zero_width_end => {}
+                Some(next) => expanded.push(next),
+                None => expanded.push(introducer),
+            }
+        }
+        RawTerminalPayload(expanded)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Patch {
+    Replace(PromptVariablePayload),
+    Repaint {
+        prompt: PromptVariablePayload,
+        repaint: RawTerminalPayload,
+    },
+}
+
+impl Patch {
+    pub fn whole_prompt(prompt: PromptVariablePayload) -> Self {
+        Self::Replace(prompt)
+    }
+
+    pub fn repainting_cells(prompt: PromptVariablePayload, repaint: RawTerminalPayload) -> Self {
+        Self::Repaint { prompt, repaint }
+    }
+
+    #[cfg(test)]
+    pub fn prompt(&self) -> &PromptVariablePayload {
+        match self {
+            Self::Replace(prompt) | Self::Repaint { prompt, .. } => prompt,
+        }
+    }
+
+    #[cfg(test)]
+    pub fn repaint(&self) -> Option<&RawTerminalPayload> {
+        match self {
+            Self::Replace(_) => None,
+            Self::Repaint { repaint, .. } => Some(repaint),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ProcessId(u32);
+
+impl ProcessId {
+    #[must_use]
+    pub fn of_this_process() -> Self {
+        Self(std::process::id())
+    }
+
+    #[must_use]
+    pub const fn get(self) -> u32 {
+        self.0
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ServerEvent {
+    /// The first prompt paint.
+    Ready {
+        prompt: PromptVariablePayload,
+        /// Lets the shell stop a stream blocked in a module.
+        process_id: ProcessId,
+    },
+    Patch(Patch),
+    /// Initial rendering completed.
+    Complete(Timings),
+    /// Keeps an idle pipe observable.
+    Heartbeat,
+}
+
+impl ServerEvent {
+    #[cfg(test)]
+    pub fn write_to(&self, writer: &mut impl Write) -> io::Result<()> {
+        self.write(FrameEncoding::Compact, writer)
+    }
+
+    pub fn write(&self, encoding: FrameEncoding, writer: &mut impl Write) -> io::Result<()> {
+        match encoding {
+            FrameEncoding::Compact => self.write_compact(writer),
+            FrameEncoding::JsonLines => self.write_json(writer),
+        }
+    }
+
+    fn write_compact(&self, writer: &mut impl Write) -> io::Result<()> {
+        const NOTHING: &[u8] = &[];
+        match self {
+            Self::Ready { prompt, process_id } => {
+                let process_id = process_id.get().to_string();
+                write_frame(writer, "READY", prompt.as_bytes(), process_id.as_bytes())
+            }
+            Self::Patch(Patch::Replace(prompt)) => {
+                write_frame(writer, "PATCH", prompt.as_bytes(), NOTHING)
+            }
+            Self::Patch(Patch::Repaint { prompt, repaint }) => {
+                write_frame(writer, "PATCH", prompt.as_bytes(), repaint.as_bytes())
+            }
+            Self::Complete(timings) => {
+                let timings = timings.to_json_bytes();
+                write_frame(writer, "COMPLETE", &timings, NOTHING)
+            }
+            Self::Heartbeat => write_frame(writer, "HEARTBEAT", NOTHING, NOTHING),
+        }
+    }
+
+    fn write_json(&self, writer: &mut impl Write) -> io::Result<()> {
+        serde_json::to_writer(&mut *writer, &JsonEvent::from(self))?;
+        writer.write_all(b"\n")?;
+        writer.flush()
+    }
+
+    #[cfg(test)]
+    pub fn read_from(reader: &mut impl BufRead) -> io::Result<Option<Self>> {
+        let Some(keyword) = read_field(reader)? else {
+            return Ok(None);
+        };
+        let first = read_field(reader)?.ok_or(io::ErrorKind::UnexpectedEof)?;
+        let second = read_field(reader)?.ok_or(io::ErrorKind::UnexpectedEof)?;
+        let malformed = |message| io::Error::new(io::ErrorKind::InvalidData, message);
+
+        match keyword.as_slice() {
+            b"READY" => Ok(Some(Self::Ready {
+                prompt: PromptVariablePayload(text(first)?),
+                process_id: ProcessId(
+                    std::str::from_utf8(&second)
+                        .ok()
+                        .and_then(|field| field.parse().ok())
+                        .ok_or_else(|| malformed("invalid process id"))?,
+                ),
+            })),
+            b"PATCH" => {
+                let prompt = PromptVariablePayload(text(first)?);
+                Ok(Some(Self::Patch(if second.is_empty() {
+                    Patch::Replace(prompt)
+                } else {
+                    Patch::Repaint {
+                        prompt,
+                        repaint: RawTerminalPayload(text(second)?),
+                    }
+                })))
+            }
+            b"COMPLETE" if second.is_empty() => Timings::from_json(&first)
+                .map(Self::Complete)
+                .map(Some)
+                .ok_or_else(|| malformed("invalid timings")),
+            b"HEARTBEAT" if first.is_empty() && second.is_empty() => Ok(Some(Self::Heartbeat)),
+            _ => Err(malformed("invalid event")),
+        }
+    }
+}
+
+#[derive(Serialize)]
+#[serde(tag = "kind", rename_all = "SCREAMING_SNAKE_CASE")]
+enum JsonEvent<'a> {
+    Ready {
+        prompt: &'a str,
+        process_id: u32,
+    },
+    Patch {
+        prompt: &'a str,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        repaint: Option<&'a str>,
+    },
+    Complete {
+        timings: &'a Timings,
+    },
+    Heartbeat,
+}
+
+impl<'a> From<&'a ServerEvent> for JsonEvent<'a> {
+    fn from(event: &'a ServerEvent) -> Self {
+        match event {
+            ServerEvent::Ready { prompt, process_id } => Self::Ready {
+                prompt: &prompt.0,
+                process_id: process_id.get(),
+            },
+            ServerEvent::Patch(Patch::Replace(prompt)) => Self::Patch {
+                prompt: &prompt.0,
+                repaint: None,
+            },
+            ServerEvent::Patch(Patch::Repaint { prompt, repaint }) => Self::Patch {
+                prompt: &prompt.0,
+                repaint: Some(&repaint.0),
+            },
+            ServerEvent::Complete(timings) => Self::Complete { timings },
+            ServerEvent::Heartbeat => Self::Heartbeat,
+        }
+    }
+}
+
+fn write_frame(
+    writer: &mut impl Write,
+    keyword: &str,
+    first: &[u8],
+    second: &[u8],
+) -> io::Result<()> {
+    for field in [keyword.as_bytes(), first, second] {
+        debug_assert!(!field.contains(&0));
+        writer.write_all(field)?;
+        writer.write_all(b"\0")?;
+    }
+    writer.flush()
+}
+
+#[cfg(test)]
+fn read_field(reader: &mut impl BufRead) -> io::Result<Option<Vec<u8>>> {
+    let mut field = Vec::new();
+    match reader.read_until(0, &mut field)? {
+        0 => Ok(None),
+        _ if field.pop() == Some(0) => Ok(Some(field)),
+        _ => Err(io::ErrorKind::UnexpectedEof.into()),
+    }
+}
+
+#[cfg(test)]
+fn text(field: Vec<u8>) -> io::Result<String> {
+    String::from_utf8(field).map_err(|_| io::ErrorKind::InvalidData.into())
+}
+
+/// A module resolution latency.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Microseconds(pub u64);
+
+impl Microseconds {
+    #[must_use]
+    pub fn duration(self) -> Duration {
+        Duration::from_micros(self.0)
+    }
+}
+
+impl From<Duration> for Microseconds {
+    fn from(duration: Duration) -> Self {
+        Self(u64::try_from(duration.as_micros()).unwrap_or(u64::MAX))
+    }
+}
+
+/// Module resolution timings.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Timings(BTreeMap<String, Microseconds>);
+
+impl Timings {
+    pub fn record(&mut self, module: &str, elapsed: Duration) {
+        let elapsed = Microseconds::from(elapsed);
+        let recorded = self.0.entry(module.to_owned()).or_default();
+        *recorded = (*recorded).max(elapsed);
+    }
+
+    pub fn set(&mut self, module: &str, cost: Microseconds) {
+        self.0.insert(module.to_owned(), cost);
+    }
+
+    pub fn get(&self, module: &str) -> Option<Microseconds> {
+        self.0.get(module).copied()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&str, Microseconds)> {
+        self.0.iter().map(|(module, cost)| (module.as_str(), *cost))
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    fn to_json_bytes(&self) -> Vec<u8> {
+        serde_json::to_vec(self).expect("a map of strings and integers always serializes")
+    }
+
+    pub fn from_json(payload: &[u8]) -> Option<Self> {
+        serde_json::from_slice(payload).ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::context::Shell;
+    use crate::damage::Column;
+    use crate::damage::cursor::{CursorNeutral, CursorSafeText, RowsAbove};
+    use crate::module::painted::TerminalWidth;
+    use crate::segment::Segment;
+
+    fn ready(prompt: PromptVariablePayload) -> ServerEvent {
+        ServerEvent::Ready {
+            prompt,
+            process_id: ProcessId::of_this_process(),
+        }
+    }
+
+    fn painted(text: &str) -> Painted {
+        Painted::paint(&Segment::from_text(None, text), Some(TerminalWidth(80)))
+    }
+
+    fn prompt_payload(text: &str) -> PromptVariablePayload {
+        PromptVariablePayload::escaped_for(
+            &RawTerminalPayload::prompt(&painted(text)),
+            Shell::Unknown,
+        )
+    }
+
+    fn repaint_payload() -> RawTerminalPayload {
+        RawTerminalPayload::repaint(&CursorNeutral::around(|body| {
+            body.move_to(RowsAbove(1), Column(4));
+            body.write_text(CursorSafeText::new("main").expect("plain text is cursor safe"));
+        }))
+    }
+
+    fn compact_fields(event: &ServerEvent) -> Vec<Vec<u8>> {
+        let mut bytes = Vec::new();
+        event
+            .write_to(&mut bytes)
+            .expect("writing to a vector cannot fail");
+        assert_eq!(Some(&0), bytes.last());
+        let mut fields: Vec<_> = bytes.split(|byte| *byte == 0).map(<[u8]>::to_vec).collect();
+        assert_eq!(4, fields.len());
+        assert!(fields.pop().expect("trailing field").is_empty());
+        fields
+    }
+
+    #[test]
+    fn json_lines_are_typed_and_self_delimiting() {
+        let event = ServerEvent::Patch(Patch::repainting_cells(
+            prompt_payload("10% off"),
+            repaint_payload(),
+        ));
+        let mut bytes = Vec::new();
+        event
+            .write(FrameEncoding::JsonLines, &mut bytes)
+            .expect("a vector is writable");
+
+        assert_eq!(Some(&b'\n'), bytes.last());
+        let json: serde_json::Value = serde_json::from_slice(&bytes).expect("one JSON object");
+        assert_eq!("PATCH", json["kind"]);
+        assert_eq!("10% off", json["prompt"]);
+        assert!(json["repaint"].as_str().is_some());
+    }
+
+    #[test]
+    fn compact_events_are_three_nul_delimited_fields() {
+        let mut timings = Timings::default();
+        timings.record("git_status", Duration::from_millis(180));
+
+        let cases = [
+            (ready(prompt_payload("> ")), b"READY".as_slice()),
+            (
+                ServerEvent::Patch(Patch::whole_prompt(prompt_payload("> "))),
+                b"PATCH",
+            ),
+            (
+                ServerEvent::Patch(Patch::repainting_cells(
+                    prompt_payload("> "),
+                    repaint_payload(),
+                )),
+                b"PATCH",
+            ),
+            (ServerEvent::Complete(timings), b"COMPLETE"),
+            (ServerEvent::Heartbeat, b"HEARTBEAT"),
+        ];
+
+        for (event, keyword) in cases {
+            let fields = compact_fields(&event);
+            assert_eq!(3, fields.len());
+            assert_eq!(keyword, fields[0]);
+        }
+    }
+
+    #[test]
+    fn compact_payloads_preserve_newlines() {
+        let two_lines = Painted::paint(
+            &[
+                Segment::from_text(None, "first").remove(0),
+                Segment::LineTerm,
+                Segment::from_text(None, "second").remove(0),
+            ],
+            None,
+        );
+        let event = ready(PromptVariablePayload::escaped_for(
+            &RawTerminalPayload::prompt(&two_lines),
+            Shell::Unknown,
+        ));
+
+        assert_eq!(compact_fields(&event)[1], b"first\nsecond");
+    }
+
+    #[test]
+    fn terminal_payloads_discard_nul() {
+        let payload = RawTerminalPayload::prompt(&painted("a\0b"));
+        assert_eq!(b"ab", payload.as_bytes());
+    }
+
+    #[test]
+    fn compact_events_preserve_empty_fields() {
+        let event = ready(PromptVariablePayload::escaped_for(
+            &RawTerminalPayload::prompt(&Painted::default()),
+            Shell::Unknown,
+        ));
+
+        let fields = compact_fields(&event);
+        assert!(fields[1].is_empty());
+        assert!(!fields[2].is_empty());
+    }
+
+    #[test]
+    fn timings_round_trip_through_their_event() {
+        let mut timings = Timings::default();
+        timings.record("character", Duration::from_micros(12));
+        timings.record("git_status", Duration::from_millis(180));
+
+        let fields = compact_fields(&ServerEvent::Complete(timings.clone()));
+        let read = Timings::from_json(&fields[1]).expect("timings are JSON");
+
+        assert_eq!(timings, read);
+        assert_eq!(Some(Microseconds(12)), read.get("character"));
+        assert_eq!(Some(Microseconds(180_000)), read.get("git_status"));
+        assert_eq!(2, read.len());
+    }
+
+    #[test]
+    fn a_module_recorded_twice_keeps_the_longer_latency() {
+        // `directory` renders twice (instant estimate, then real); keep the real one.
+        let mut timings = Timings::default();
+        timings.record("directory", Duration::from_micros(40));
+        timings.record("directory", Duration::from_millis(9));
+        timings.record("directory", Duration::from_micros(50));
+
+        assert_eq!(Some(Microseconds(9_000)), timings.get("directory"));
+    }
+
+    #[test]
+    fn empty_timings_are_still_valid_json() {
+        let timings = Timings::default();
+
+        assert!(timings.is_empty());
+        assert_eq!(compact_fields(&ServerEvent::Complete(timings))[1], b"{}");
+    }
+}

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -38,8 +38,7 @@ pub struct RawTerminalPayload(String);
 
 impl RawTerminalPayload {
     pub fn repaint(repaint: &CursorNeutral) -> Self {
-        let repaint_string =
-            String::from_utf8(repaint.as_bytes().to_vec()).expect("repaints are valid UTF-8");
+        let repaint_string = String::from_utf8_lossy(repaint.as_bytes()).into_owned();
         debug_assert!(!repaint_string.contains(char::from(NULL_BYTE)));
         Self(repaint_string)
     }
@@ -340,10 +339,14 @@ impl ServerEvent {
 
                 Ok(Some(Self::Patch(patch)))
             }
-            EVENT_COMPLETE if second.is_empty() => Timings::from_json(&first)
-                .map(Self::Complete)
-                .map(Some)
-                .ok_or("invalid timings"),
+            EVENT_COMPLETE if second.is_empty() => {
+                let timings = if first.is_empty() {
+                    Timings::empty()
+                } else {
+                    Timings::from_json(&first).ok_or("invalid timings")?
+                };
+                Ok(Some(Self::Complete(timings)))
+            }
             EVENT_HEARTBEAT if first.is_empty() && second.is_empty() => Ok(Some(Self::Heartbeat)),
             _ => Err("invalid event"),
         }

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -227,7 +227,9 @@ pub fn init_main(shell_name: &str) -> io::Result<()> {
         "ion" => print_script(ION_INIT, &starship_path.sprint()?),
         "elvish" => print_script(ELVISH_INIT, &starship_path.sprint_elv()?),
         "tcsh" => print_script(TCSH_INIT, &starship_path.sprint_posix()?),
+        "nu" => print_script(NU_INIT, &starship_path.sprint()?),
         "xonsh" => print_script(XONSH_INIT, &starship_path.sprint_posix()?),
+        "cmd" => print_script(CMDEXE_INIT, &starship_path.sprint_cmdexe()?),
         _ => {
             println!(
                 "printf \"Shell name detection failed on phase two init.\\n\

--- a/src/init/starship.bash
+++ b/src/init/starship.bash
@@ -15,10 +15,108 @@
 # A way to set '$?', since bash does not allow assigning to '$?' directly
 function _starship_set_return() { return "${1:-0}"; }
 
+STARSHIP_STREAM_DESCRIPTOR=
+STARSHIP_STREAM_PROCESS=
+STARSHIP_STREAM_COMPLETE=
+STARSHIP_BLE_ENABLED=
+STARSHIP_TIMINGS=
+STARSHIP_PROMPT=
+STARSHIP_RIGHT_PROMPT=
+STARSHIP_PROMPT_ARGUMENTS=()
+STARSHIP_FRAME=()
+
+function ble/prompt/backslash:starship {
+    ble/prompt/unit/add-hash '$STARSHIP_PROMPT'
+    ble/prompt/process-prompt-string "$STARSHIP_PROMPT"
+}
+
+starship_ble_read_frame() {
+    local descriptor=$1 kind first second
+    IFS= read -r -d '' -u "$descriptor" kind &&
+        IFS= read -r -d '' -u "$descriptor" first &&
+        IFS= read -r -d '' -u "$descriptor" second || return
+    STARSHIP_FRAME=("$kind" "$first" "$second")
+}
+
+starship_ble_set_prompt() {
+    STARSHIP_PROMPT=$1
+    local lines=${STARSHIP_PROMPT//[!$'\n']}
+    bleopt prompt_rps1="$lines$STARSHIP_RIGHT_PROMPT"
+}
+
+starship_ble_stream_stop() {
+    ble/util/idle.cancel starship_ble_stream_step 2>/dev/null || :
+    if [[ $STARSHIP_STREAM_DESCRIPTOR ]]; then
+        exec {STARSHIP_STREAM_DESCRIPTOR}<&-
+        STARSHIP_STREAM_DESCRIPTOR=
+    fi
+    if [[ $STARSHIP_STREAM_PROCESS ]]; then
+        kill "$STARSHIP_STREAM_PROCESS" 2>/dev/null || :
+        STARSHIP_STREAM_PROCESS=
+    fi
+    STARSHIP_STREAM_COMPLETE=
+}
+
+starship_ble_stream_end() {
+    local complete=$STARSHIP_STREAM_COMPLETE
+    starship_ble_stream_stop
+    if [[ ! $complete ]]; then
+        starship_ble_set_prompt "$(::STARSHIP:: prompt "${STARSHIP_PROMPT_ARGUMENTS[@]}")"
+        ble/textarea#redraw
+    fi
+}
+
+starship_ble_stream_step() {
+    if read -t 0 -u "$STARSHIP_STREAM_DESCRIPTOR"; then
+        if ! starship_ble_read_frame "$STARSHIP_STREAM_DESCRIPTOR"; then
+            starship_ble_stream_end
+            return
+        else
+            case ${STARSHIP_FRAME[0]} in
+                PATCH)
+                    starship_ble_set_prompt "${STARSHIP_FRAME[1]}"
+                    ble/textarea#redraw
+                    ;;
+                COMPLETE)
+                    STARSHIP_TIMINGS=${STARSHIP_FRAME[1]}
+                    STARSHIP_STREAM_COMPLETE=1
+                    ;;
+            esac
+        fi
+    elif ! kill -0 "$STARSHIP_STREAM_PROCESS" 2>/dev/null; then
+        starship_ble_stream_end
+        return
+    fi
+
+    ble/util/idle.sleep 51
+}
+
+starship_ble_stream_start() {
+    starship_ble_stream_stop
+    STARSHIP_PROMPT_ARGUMENTS=("$@")
+
+    exec {STARSHIP_STREAM_DESCRIPTOR}< <(
+        ::STARSHIP:: stream --transport ble "$@" --timings="$STARSHIP_TIMINGS" 2>/dev/null
+    )
+    if [[ -z $STARSHIP_STREAM_DESCRIPTOR ]] ||
+       ! starship_ble_read_frame "$STARSHIP_STREAM_DESCRIPTOR" ||
+       [[ ${STARSHIP_FRAME[0]} != READY ]]; then
+        starship_ble_stream_stop
+        starship_ble_set_prompt "$(::STARSHIP:: prompt "$@")"
+        return
+    fi
+
+    STARSHIP_STREAM_PROCESS=${STARSHIP_FRAME[2]}
+    starship_ble_set_prompt "${STARSHIP_FRAME[1]}"
+    ble/util/idle.push starship_ble_stream_step
+}
+
 # Will be run before *every* command (even ones in pipes!)
 starship_preexec() {
     # Save previous command's last argument, otherwise it will be set to "starship_preexec"
     local PREV_LAST_ARG=$1
+
+    [[ $STARSHIP_BLE_ENABLED ]] && starship_ble_stream_stop
 
     # Avoid restarting the timer for commands in the same pipeline
     if [ "${STARSHIP_PREEXEC_READY:-}" = "true" ]; then
@@ -77,10 +175,12 @@ starship_precmd() {
         ARGS+=( --cmd-duration="${STARSHIP_DURATION}")
         STARSHIP_START_TIME=""
     fi
-    PS1="$(::STARSHIP:: prompt "${ARGS[@]}")"
-    if [[ ${BLE_ATTACHED-} ]]; then
-        local nlns=${PS1//[!$'\n']}
-        bleopt prompt_rps1="$nlns$(::STARSHIP:: prompt --right "${ARGS[@]}")"
+    if [[ $STARSHIP_BLE_ENABLED ]]; then
+        STARSHIP_RIGHT_PROMPT="$(::STARSHIP:: prompt --right "${ARGS[@]}")"
+        starship_ble_stream_start "${ARGS[@]}"
+        PS1='\q{starship}'
+    else
+        PS1="$(::STARSHIP:: prompt "${ARGS[@]}")"
     fi
     STARSHIP_PREEXEC_READY=true  # Signal that we can safely restart the timer
 }
@@ -88,6 +188,7 @@ starship_precmd() {
 # If the user appears to be using https://github.com/akinomyoga/ble.sh,
 # then hook our functions into their framework.
 if [[ ${BLE_VERSION-} && _ble_version -ge 400 ]]; then
+    STARSHIP_BLE_ENABLED=1
     blehook PREEXEC!='starship_preexec "$_"'
     blehook PRECMD!='starship_precmd'
 # If the user appears to be using https://github.com/rcaloras/bash-preexec,
@@ -152,4 +253,3 @@ export STARSHIP_SESSION_KEY=${STARSHIP_SESSION_KEY:0:16}; # Trim to 16-digits if
 
 # Set the continuation prompt
 PS2="$(::STARSHIP:: prompt --continuation)"
-

--- a/src/init/starship.bash
+++ b/src/init/starship.bash
@@ -18,12 +18,18 @@ function _starship_set_return() { return "${1:-0}"; }
 STARSHIP_STREAM_DESCRIPTOR=
 STARSHIP_STREAM_PROCESS=
 STARSHIP_STREAM_COMPLETE=
+STARSHIP_STREAM_RIGHT_DESCRIPTOR=
+STARSHIP_STREAM_RIGHT_PROCESS=
+STARSHIP_STREAM_RIGHT_COMPLETE=
 STARSHIP_BLE_ENABLED=
 STARSHIP_TIMINGS=
+STARSHIP_RIGHT_TIMINGS=
 STARSHIP_PROMPT=
 STARSHIP_RIGHT_PROMPT=
 STARSHIP_PROMPT_ARGUMENTS=()
+STARSHIP_RIGHT_PROMPT_ARGUMENTS=()
 STARSHIP_FRAME=()
+STARSHIP_RIGHT_FRAME=()
 
 function ble/prompt/backslash:starship {
     ble/prompt/unit/add-hash '$STARSHIP_PROMPT'
@@ -38,10 +44,30 @@ starship_ble_read_frame() {
     STARSHIP_FRAME=("$kind" "$first" "$second")
 }
 
-starship_ble_set_prompt() {
-    STARSHIP_PROMPT=$1
+starship_ble_read_right_frame() {
+    local descriptor=$1 kind first second
+    IFS= read -r -d '' -u "$descriptor" kind &&
+        IFS= read -r -d '' -u "$descriptor" first &&
+        IFS= read -r -d '' -u "$descriptor" second || return
+    STARSHIP_RIGHT_FRAME=("$kind" "$first" "$second")
+}
+
+# ble.sh's `prompt_rps1` carries the right prompt, but it is drawn on the line
+# holding the left prompt's final row, so it is padded with the left prompt's
+# newlines. Either stream recomputes it from the latest left and right values.
+starship_ble_refresh_rps1() {
     local lines=${STARSHIP_PROMPT//[!$'\n']}
     bleopt prompt_rps1="$lines$STARSHIP_RIGHT_PROMPT"
+}
+
+starship_ble_set_prompt() {
+    STARSHIP_PROMPT=$1
+    starship_ble_refresh_rps1
+}
+
+starship_ble_set_right_prompt() {
+    STARSHIP_RIGHT_PROMPT=$1
+    starship_ble_refresh_rps1
 }
 
 starship_ble_stream_stop() {
@@ -57,11 +83,35 @@ starship_ble_stream_stop() {
     STARSHIP_STREAM_COMPLETE=
 }
 
+# The right prompt streams independently, so it stops and fails on its own
+# without discarding the left prompt's in-flight progress.
+starship_ble_stream_right_stop() {
+    ble/util/idle.cancel starship_ble_stream_right_step 2>/dev/null || :
+    if [[ $STARSHIP_STREAM_RIGHT_DESCRIPTOR ]]; then
+        exec {STARSHIP_STREAM_RIGHT_DESCRIPTOR}<&-
+        STARSHIP_STREAM_RIGHT_DESCRIPTOR=
+    fi
+    if [[ $STARSHIP_STREAM_RIGHT_PROCESS ]]; then
+        kill "$STARSHIP_STREAM_RIGHT_PROCESS" 2>/dev/null || :
+        STARSHIP_STREAM_RIGHT_PROCESS=
+    fi
+    STARSHIP_STREAM_RIGHT_COMPLETE=
+}
+
 starship_ble_stream_end() {
     local complete=$STARSHIP_STREAM_COMPLETE
     starship_ble_stream_stop
     if [[ ! $complete ]]; then
         starship_ble_set_prompt "$(::STARSHIP:: prompt "${STARSHIP_PROMPT_ARGUMENTS[@]}")"
+        ble/textarea#redraw
+    fi
+}
+
+starship_ble_stream_right_end() {
+    local complete=$STARSHIP_STREAM_RIGHT_COMPLETE
+    starship_ble_stream_right_stop
+    if [[ ! $complete ]]; then
+        starship_ble_set_right_prompt "$(::STARSHIP:: prompt --right "${STARSHIP_RIGHT_PROMPT_ARGUMENTS[@]}")"
         ble/textarea#redraw
     fi
 }
@@ -91,6 +141,31 @@ starship_ble_stream_step() {
     ble/util/idle.sleep 51
 }
 
+starship_ble_stream_right_step() {
+    if read -t 0 -u "$STARSHIP_STREAM_RIGHT_DESCRIPTOR"; then
+        if ! starship_ble_read_right_frame "$STARSHIP_STREAM_RIGHT_DESCRIPTOR"; then
+            starship_ble_stream_right_end
+            return
+        else
+            case ${STARSHIP_RIGHT_FRAME[0]} in
+                PATCH)
+                    starship_ble_set_right_prompt "${STARSHIP_RIGHT_FRAME[1]}"
+                    ble/textarea#redraw
+                    ;;
+                COMPLETE)
+                    STARSHIP_RIGHT_TIMINGS=${STARSHIP_RIGHT_FRAME[1]}
+                    STARSHIP_STREAM_RIGHT_COMPLETE=1
+                    ;;
+            esac
+        fi
+    elif ! kill -0 "$STARSHIP_STREAM_RIGHT_PROCESS" 2>/dev/null; then
+        starship_ble_stream_right_end
+        return
+    fi
+
+    ble/util/idle.sleep 51
+}
+
 starship_ble_stream_start() {
     starship_ble_stream_stop
     STARSHIP_PROMPT_ARGUMENTS=("$@")
@@ -111,12 +186,35 @@ starship_ble_stream_start() {
     ble/util/idle.push starship_ble_stream_step
 }
 
+starship_ble_stream_right_start() {
+    starship_ble_stream_right_stop
+    STARSHIP_RIGHT_PROMPT_ARGUMENTS=("$@")
+
+    exec {STARSHIP_STREAM_RIGHT_DESCRIPTOR}< <(
+        ::STARSHIP:: stream --right --transport ble "$@" --timings="$STARSHIP_RIGHT_TIMINGS" 2>/dev/null
+    )
+    if [[ -z $STARSHIP_STREAM_RIGHT_DESCRIPTOR ]] ||
+       ! starship_ble_read_right_frame "$STARSHIP_STREAM_RIGHT_DESCRIPTOR" ||
+       [[ ${STARSHIP_RIGHT_FRAME[0]} != READY ]]; then
+        starship_ble_stream_right_stop
+        starship_ble_set_right_prompt "$(::STARSHIP:: prompt --right "$@")"
+        return
+    fi
+
+    STARSHIP_STREAM_RIGHT_PROCESS=${STARSHIP_RIGHT_FRAME[2]}
+    starship_ble_set_right_prompt "${STARSHIP_RIGHT_FRAME[1]}"
+    ble/util/idle.push starship_ble_stream_right_step
+}
+
 # Will be run before *every* command (even ones in pipes!)
 starship_preexec() {
     # Save previous command's last argument, otherwise it will be set to "starship_preexec"
     local PREV_LAST_ARG=$1
 
-    [[ $STARSHIP_BLE_ENABLED ]] && starship_ble_stream_stop
+    if [[ $STARSHIP_BLE_ENABLED ]]; then
+        starship_ble_stream_stop
+        starship_ble_stream_right_stop
+    fi
 
     # Avoid restarting the timer for commands in the same pipeline
     if [ "${STARSHIP_PREEXEC_READY:-}" = "true" ]; then
@@ -176,7 +274,7 @@ starship_precmd() {
         STARSHIP_START_TIME=""
     fi
     if [[ $STARSHIP_BLE_ENABLED ]]; then
-        STARSHIP_RIGHT_PROMPT="$(::STARSHIP:: prompt --right "${ARGS[@]}")"
+        starship_ble_stream_right_start "${ARGS[@]}"
         starship_ble_stream_start "${ARGS[@]}"
         PS1='\q{starship}'
     else

--- a/src/init/starship.fish
+++ b/src/init/starship.fish
@@ -77,7 +77,11 @@ function __starship_stream_start --argument-names terminal_width keymap command_
         return
     end
 
-    ::STARSHIP:: stream $arguments --timings="$STARSHIP_TIMINGS" | $__fish_bin_dir/fish -c '
+    # `< /dev/null`: this renderer is backgrounded and outlives the prompt
+    # that launched it, but nothing here ever reads stdin. Left inherited,
+    # it would be the shell's own pty, and a renderer still alive when the
+    # shell exits would keep that pty from ever reporting end-of-file.
+    ::STARSHIP:: stream $arguments --timings="$STARSHIP_TIMINGS" < /dev/null | $__fish_bin_dir/fish -c '
         set -l state_name $argv[1]
         set -l ready_fifo $argv[2]
         set -l arguments $argv[3..]

--- a/src/init/starship.fish
+++ b/src/init/starship.fish
@@ -10,6 +10,136 @@ function __starship_set_job_count --description 'Set STARSHIP_JOBS using fish jo
     end    
 end
 
+set -g STARSHIP_PROMPT ''
+set -g STARSHIP_TIMINGS ''
+set -g __starship_stream_active_for_current_line 0
+set -g __starship_stream_processes
+set -g __starship_stream_state_name __starship_stream_state_$fish_pid
+set -g __starship_stream_directory (mktemp -d 2>/dev/null)
+set -e -U $__starship_stream_state_name 2>/dev/null
+
+# Variable events may coalesce, so publish complete snapshots.
+function __starship_stream_apply --on-variable $__starship_stream_state_name
+    test $__starship_stream_active_for_current_line -eq 1; or return
+    set -l state $$__starship_stream_state_name
+    test (count $state) -ge 4; or return
+    set -g STARSHIP_TIMINGS $state[4]
+
+    contains -- $state[1] READY PATCH REPAIR; or return
+    set -g STARSHIP_PROMPT $state[2]
+    if test "$TRANSIENT" != 1; and test "$RIGHT_TRANSIENT" != 1
+        commandline -f repaint
+    end
+end
+
+function __starship_stream_stop
+    for process in $__starship_stream_processes
+        command kill $process 2>/dev/null
+    end
+    set -g __starship_stream_processes
+    set -g __starship_stream_active_for_current_line 0
+end
+
+function __starship_stream_cleanup --on-event fish_exit
+    __starship_stream_stop
+    set -e -U $__starship_stream_state_name 2>/dev/null
+    if test -n "$__starship_stream_directory"
+        command rm -rf -- "$__starship_stream_directory" 2>/dev/null
+    end
+end
+
+function __starship_stream_start --argument-names terminal_width keymap command_status command_pipestatus command_duration jobs
+    __starship_stream_stop
+    set -g __starship_stream_active_for_current_line 1
+
+    if set -q $__starship_stream_state_name
+        set -l previous $$__starship_stream_state_name
+        test (count $previous) -ge 4; and set -g STARSHIP_TIMINGS $previous[4]
+    end
+    set -e -U $__starship_stream_state_name 2>/dev/null
+
+    set -l arguments \
+        --terminal-width="$terminal_width" \
+        --keymap="$keymap" \
+        --status="$command_status" \
+        --pipestatus="$command_pipestatus" \
+        --cmd-duration="$command_duration" \
+        --jobs="$jobs"
+
+    if test -z "$__starship_stream_directory"
+        ::STARSHIP:: prompt $arguments | read -gz STARSHIP_PROMPT
+        return
+    end
+
+    set -l ready_fifo "$__starship_stream_directory/"(random)
+    command mkfifo "$ready_fifo" 2>/dev/null; or begin
+        ::STARSHIP:: prompt $arguments | read -gz STARSHIP_PROMPT
+        return
+    end
+
+    ::STARSHIP:: stream $arguments --timings="$STARSHIP_TIMINGS" | $__fish_bin_dir/fish -c '
+        set -l state_name $argv[1]
+        set -l ready_fifo $argv[2]
+        set -l arguments $argv[3..]
+        set -l prompt ""
+        set -l process ""
+        set -l timings ""
+        set -l ready 0
+        set -l complete 0
+
+        while read -z kind
+            read -z first; and read -z second; or break
+
+            switch $kind
+                case READY
+                    set prompt "$first"
+                    set process "$second"
+                    set -U $state_name READY "$prompt" "$process" "$timings"
+                    echo READY > "$ready_fifo"
+                    set ready 1
+                case PATCH
+                    set prompt "$first"
+                    set -U $state_name PATCH "$prompt" "$process" "$timings"
+                case COMPLETE
+                    set timings "$first"
+                    set complete 1
+                    set -U $state_name COMPLETE "$prompt" "$process" "$timings"
+            end
+        end
+
+        if test $complete -eq 0
+            ::STARSHIP:: prompt $arguments | read -z prompt
+            set -U $state_name REPAIR "$prompt" "$process" "$timings"
+            test $ready -eq 1; or echo READY > "$ready_fifo"
+        end
+    ' -- $__starship_stream_state_name "$ready_fifo" $arguments &
+    set -g __starship_stream_processes (jobs --last --pid)
+
+    read < "$ready_fifo"
+    command rm -f -- "$ready_fifo" 2>/dev/null
+
+    if set -q $__starship_stream_state_name
+        set -l state $$__starship_stream_state_name
+        if test (count $state) -ge 4
+            set -g STARSHIP_PROMPT $state[2]
+            set -g STARSHIP_TIMINGS $state[4]
+            if test -n "$state[3]"; and not contains -- $state[3] $__starship_stream_processes
+                set -a __starship_stream_processes $state[3]
+            end
+            return
+        end
+    end
+
+    __starship_stream_stop
+    set -g __starship_stream_active_for_current_line 1
+    ::STARSHIP:: prompt $arguments | read -gz STARSHIP_PROMPT
+end
+
+function __starship_stream_preexec --on-event fish_preexec
+    __starship_stream_stop
+    set -g STARSHIP_PROMPT ''
+end
+
 function fish_prompt
     switch "$fish_key_bindings"
         case fish_hybrid_key_bindings fish_vi_key_bindings fish_helix_key_bindings
@@ -38,7 +168,10 @@ function fish_prompt
             printf "\e[1;32m❯\e[0m "
         end
     else
-        ::STARSHIP:: prompt --terminal-width="$COLUMNS" --status=$STARSHIP_CMD_STATUS --pipestatus="$STARSHIP_CMD_PIPESTATUS" --keymap=$STARSHIP_KEYMAP --cmd-duration=$STARSHIP_DURATION --jobs=$STARSHIP_JOBS
+        if test "$__starship_stream_active_for_current_line" = 0
+            __starship_stream_start "$COLUMNS" "$STARSHIP_KEYMAP" "$STARSHIP_CMD_STATUS" "$STARSHIP_CMD_PIPESTATUS" "$STARSHIP_DURATION" "$STARSHIP_JOBS"
+        end
+        printf '%s' "$STARSHIP_PROMPT"
     end
 end
 

--- a/src/init/starship.fish
+++ b/src/init/starship.fish
@@ -11,52 +11,102 @@ function __starship_set_job_count --description 'Set STARSHIP_JOBS using fish jo
 end
 
 set -g STARSHIP_PROMPT ''
+set -g STARSHIP_RIGHT_PROMPT ''
 set -g STARSHIP_TIMINGS ''
+set -g STARSHIP_RIGHT_TIMINGS ''
 set -g __starship_stream_active_for_current_line 0
+set -g __starship_stream_right_active_for_current_line 0
 set -g __starship_stream_processes
+set -g __starship_stream_right_processes
 set -g __starship_stream_state_name __starship_stream_state_$fish_pid
+set -g __starship_stream_right_state_name __starship_stream_right_state_$fish_pid
 set -g __starship_stream_directory (mktemp -d 2>/dev/null)
 set -e -U $__starship_stream_state_name 2>/dev/null
+set -e -U $__starship_stream_right_state_name 2>/dev/null
 
-# Variable events may coalesce, so publish complete snapshots.
-function __starship_stream_apply --on-variable $__starship_stream_state_name
-    test $__starship_stream_active_for_current_line -eq 1; or return
-    set -l state $$__starship_stream_state_name
+# Variable events may coalesce, so publish complete snapshots. The left and
+# right prompts each stream into their own universal variable; a redraw
+# re-issues both `fish_prompt` and `fish_right_prompt`, so either side's patch
+# repaints the whole prompt.
+function __starship_stream_apply_target --argument-names state_name_variable active_variable prompt_variable timings_variable
+    test $$active_variable -eq 1; or return
+    set -l state_name $$state_name_variable
+    set -l state $$state_name
     test (count $state) -ge 4; or return
-    set -g STARSHIP_TIMINGS $state[4]
+    set -g $timings_variable $state[4]
 
     contains -- $state[1] READY PATCH REPAIR; or return
-    set -g STARSHIP_PROMPT $state[2]
+    set -g $prompt_variable $state[2]
     if test "$TRANSIENT" != 1; and test "$RIGHT_TRANSIENT" != 1
         commandline -f repaint
     end
 end
 
-function __starship_stream_stop
-    for process in $__starship_stream_processes
+function __starship_stream_apply --on-variable $__starship_stream_state_name
+    __starship_stream_apply_target __starship_stream_state_name __starship_stream_active_for_current_line STARSHIP_PROMPT STARSHIP_TIMINGS
+end
+
+function __starship_stream_right_apply --on-variable $__starship_stream_right_state_name
+    __starship_stream_apply_target __starship_stream_right_state_name __starship_stream_right_active_for_current_line STARSHIP_RIGHT_PROMPT STARSHIP_RIGHT_TIMINGS
+end
+
+function __starship_stream_stop --argument-names target
+    set -l processes_variable __starship_stream_processes
+    set -l active_variable __starship_stream_active_for_current_line
+    if test "$target" = right
+        set processes_variable __starship_stream_right_processes
+        set active_variable __starship_stream_right_active_for_current_line
+    end
+    for process in $$processes_variable
         command kill $process 2>/dev/null
     end
-    set -g __starship_stream_processes
-    set -g __starship_stream_active_for_current_line 0
+    set -g $processes_variable
+    set -g $active_variable 0
+end
+
+function __starship_stream_stop_all
+    __starship_stream_stop main
+    __starship_stream_stop right
 end
 
 function __starship_stream_cleanup --on-event fish_exit
-    __starship_stream_stop
+    __starship_stream_stop_all
     set -e -U $__starship_stream_state_name 2>/dev/null
+    set -e -U $__starship_stream_right_state_name 2>/dev/null
     if test -n "$__starship_stream_directory"
         command rm -rf -- "$__starship_stream_directory" 2>/dev/null
     end
 end
 
-function __starship_stream_start --argument-names terminal_width keymap command_status command_pipestatus command_duration jobs
-    __starship_stream_stop
-    set -g __starship_stream_active_for_current_line 1
-
-    if set -q $__starship_stream_state_name
-        set -l previous $$__starship_stream_state_name
-        test (count $previous) -ge 4; and set -g STARSHIP_TIMINGS $previous[4]
+# The `target` argument selects the left prompt (`main`) or the right prompt
+# (`right`); the two differ only in which universal variable they publish into
+# and whether `--right` is threaded through to Starship.
+function __starship_stream_start --argument-names target terminal_width keymap command_status command_pipestatus command_duration jobs
+    set -l state_name_variable __starship_stream_state_name
+    set -l active_variable __starship_stream_active_for_current_line
+    set -l processes_variable __starship_stream_processes
+    set -l prompt_variable STARSHIP_PROMPT
+    set -l timings_variable STARSHIP_TIMINGS
+    set -l stream_target
+    if test "$target" = right
+        set state_name_variable __starship_stream_right_state_name
+        set active_variable __starship_stream_right_active_for_current_line
+        set processes_variable __starship_stream_right_processes
+        set prompt_variable STARSHIP_RIGHT_PROMPT
+        set timings_variable STARSHIP_RIGHT_TIMINGS
+        set stream_target --right
     end
-    set -e -U $__starship_stream_state_name 2>/dev/null
+
+    __starship_stream_stop $target
+    set -g $active_variable 1
+
+    set -l state_name $$state_name_variable
+
+    if set -q $state_name
+        set -l previous $$state_name
+        test (count $previous) -ge 4; and set -g $timings_variable $previous[4]
+    end
+    set -e -U $state_name 2>/dev/null
 
     set -l arguments \
         --terminal-width="$terminal_width" \
@@ -66,14 +116,16 @@ function __starship_stream_start --argument-names terminal_width keymap command_
         --cmd-duration="$command_duration" \
         --jobs="$jobs"
 
+    set -l timings_value $$timings_variable
+
     if test -z "$__starship_stream_directory"
-        ::STARSHIP:: prompt $arguments | read -gz STARSHIP_PROMPT
+        ::STARSHIP:: prompt $stream_target $arguments | read -gz $prompt_variable
         return
     end
 
     set -l ready_fifo "$__starship_stream_directory/"(random)
     command mkfifo "$ready_fifo" 2>/dev/null; or begin
-        ::STARSHIP:: prompt $arguments | read -gz STARSHIP_PROMPT
+        ::STARSHIP:: prompt $stream_target $arguments | read -gz $prompt_variable
         return
     end
 
@@ -81,7 +133,7 @@ function __starship_stream_start --argument-names terminal_width keymap command_
     # that launched it, but nothing here ever reads stdin. Left inherited,
     # it would be the shell's own pty, and a renderer still alive when the
     # shell exits would keep that pty from ever reporting end-of-file.
-    ::STARSHIP:: stream $arguments --timings="$STARSHIP_TIMINGS" < /dev/null | $__fish_bin_dir/fish -c '
+    ::STARSHIP:: stream $stream_target $arguments --timings="$timings_value" < /dev/null | $__fish_bin_dir/fish -c '
         set -l state_name $argv[1]
         set -l ready_fifo $argv[2]
         set -l arguments $argv[3..]
@@ -116,32 +168,33 @@ function __starship_stream_start --argument-names terminal_width keymap command_
             set -U $state_name REPAIR "$prompt" "$process" "$timings"
             test $ready -eq 1; or echo READY > "$ready_fifo"
         end
-    ' -- $__starship_stream_state_name "$ready_fifo" $arguments &
-    set -g __starship_stream_processes (jobs --last --pid)
+    ' -- $state_name "$ready_fifo" $stream_target $arguments &
+    set -g $processes_variable (jobs --last --pid)
 
     read < "$ready_fifo"
     command rm -f -- "$ready_fifo" 2>/dev/null
 
-    if set -q $__starship_stream_state_name
-        set -l state $$__starship_stream_state_name
+    if set -q $state_name
+        set -l state $$state_name
         if test (count $state) -ge 4
-            set -g STARSHIP_PROMPT $state[2]
-            set -g STARSHIP_TIMINGS $state[4]
-            if test -n "$state[3]"; and not contains -- $state[3] $__starship_stream_processes
-                set -a __starship_stream_processes $state[3]
+            set -g $prompt_variable $state[2]
+            set -g $timings_variable $state[4]
+            if test -n "$state[3]"; and not contains -- $state[3] $$processes_variable
+                set -a $processes_variable $state[3]
             end
             return
         end
     end
 
-    __starship_stream_stop
-    set -g __starship_stream_active_for_current_line 1
-    ::STARSHIP:: prompt $arguments | read -gz STARSHIP_PROMPT
+    __starship_stream_stop $target
+    set -g $active_variable 1
+    ::STARSHIP:: prompt $stream_target $arguments | read -gz $prompt_variable
 end
 
 function __starship_stream_preexec --on-event fish_preexec
-    __starship_stream_stop
+    __starship_stream_stop_all
     set -g STARSHIP_PROMPT ''
+    set -g STARSHIP_RIGHT_PROMPT ''
 end
 
 function fish_prompt
@@ -173,7 +226,7 @@ function fish_prompt
         end
     else
         if test "$__starship_stream_active_for_current_line" = 0
-            __starship_stream_start "$COLUMNS" "$STARSHIP_KEYMAP" "$STARSHIP_CMD_STATUS" "$STARSHIP_CMD_PIPESTATUS" "$STARSHIP_DURATION" "$STARSHIP_JOBS"
+            __starship_stream_start main "$COLUMNS" "$STARSHIP_KEYMAP" "$STARSHIP_CMD_STATUS" "$STARSHIP_CMD_PIPESTATUS" "$STARSHIP_DURATION" "$STARSHIP_JOBS"
         end
         printf '%s' "$STARSHIP_PROMPT"
     end
@@ -181,7 +234,7 @@ end
 
 function fish_right_prompt
     switch "$fish_key_bindings"
-        case fish_hybrid_key_bindings fish_vi_key_bindings fish_helix_keybindings
+        case fish_hybrid_key_bindings fish_vi_key_bindings fish_helix_key_bindings
             set STARSHIP_KEYMAP "$fish_bind_mode"
         case '*'
             set STARSHIP_KEYMAP insert
@@ -203,7 +256,10 @@ function fish_right_prompt
             printf ""
         end
     else
-        ::STARSHIP:: prompt --right --terminal-width="$COLUMNS" --status=$STARSHIP_CMD_STATUS --pipestatus="$STARSHIP_CMD_PIPESTATUS" --keymap=$STARSHIP_KEYMAP --cmd-duration=$STARSHIP_DURATION --jobs=$STARSHIP_JOBS
+        if test "$__starship_stream_right_active_for_current_line" = 0
+            __starship_stream_start right "$COLUMNS" "$STARSHIP_KEYMAP" "$STARSHIP_CMD_STATUS" "$STARSHIP_CMD_PIPESTATUS" "$STARSHIP_DURATION" "$STARSHIP_JOBS"
+        end
+        printf '%s' "$STARSHIP_RIGHT_PROMPT"
     end
 end
 

--- a/src/init/starship.nu
+++ b/src/init/starship.nu
@@ -1,57 +1,123 @@
-# this file is both a valid
-# - overlay which can be loaded with `overlay use starship.nu`
-# - module which can be used with `use starship.nu`
-# - script which can be used with `source starship.nu`
-export-env { $env.STARSHIP_SHELL = "nu"; load-env {
-    STARSHIP_SESSION_KEY: (random chars -l 16)
-    PROMPT_MULTILINE_INDICATOR: (
-        ^::STARSHIP:: prompt --continuation
+# Requires `commandline set-prompt`.
+
+const STARSHIP_JOB = "starship-stream"
+
+def starship-stream-jobs [] {
+    job list | where description == $STARSHIP_JOB
+}
+
+def starship-stream-stop [] {
+    starship-stream-jobs | each {|job| try { job kill $job.id }} | ignore
+}
+
+def starship-command-duration [] {
+    if $env.CMD_DURATION_MS == "0823" { 0 } else { $env.CMD_DURATION_MS }
+}
+
+def starship-prompt-arguments []: nothing -> list<string> {
+    [
+        "--cmd-duration"
+        (starship-command-duration | into string)
+        $"--status=($env.LAST_EXIT_CODE)"
+        "--terminal-width"
+        ((term size).columns | into string)
+        "--jobs"
+        (job list | where description != $STARSHIP_JOB | length | into string)
+    ]
+}
+
+def starship-render [arguments: list<string>] {
+    ^::STARSHIP:: prompt ...$arguments
+}
+
+def starship-stream-apply [frame: record, complete: bool]: nothing -> bool {
+    match $frame.kind {
+        "READY" => {
+            $frame.prompt | job send 0 --tag $env.STARSHIP_READY_TAG
+            $complete
+        }
+        "PATCH" => {
+            commandline set-prompt $frame.prompt
+            $complete
+        }
+        "COMPLETE" => {
+            $frame.timings | to json --raw | job send 0 --tag $env.STARSHIP_TIMINGS_TAG
+            true
+        }
+        _ => $complete
+    }
+}
+
+def starship-stream-read [arguments: list<string>, timings: string] {
+    let complete = try {
+        ^::STARSHIP:: stream --frames json ...$arguments $"--timings=($timings)"
+        | from json --objects
+        | generate {|frame, complete = false|
+            let complete = starship-stream-apply $frame $complete
+            {out: $complete, next: $complete}
+        }
+        | last
+        | default false
+    } catch {
+        false
+    }
+
+    if not $complete {
+        let prompt = starship-render $arguments
+        commandline set-prompt $prompt
+        $prompt | job send 0 --tag $env.STARSHIP_READY_TAG
+    }
+}
+
+def starship-stream-start [arguments: list<string>] {
+    starship-stream-stop
+    job flush --tag $env.STARSHIP_READY_TAG
+
+    let timings = try {
+        job recv --tag $env.STARSHIP_TIMINGS_TAG --timeout 0sec
+    } catch {
+        ""
+    }
+
+    job spawn --description $STARSHIP_JOB {
+        starship-stream-read $arguments $timings
+    } | ignore
+
+    try {
+        job recv --tag $env.STARSHIP_READY_TAG --timeout 2sec
+    } catch {
+        starship-stream-stop
+        starship-render $arguments
+    }
+}
+
+export-env {
+    $env.STARSHIP_SHELL = "nu"
+    let mailbox = random int 1..9223372036854775806
+
+    let hooks = $env.config?.hooks? | default {}
+    let pre_execution = $hooks.pre_execution? | default [] | append {||
+        job list
+        | where description == $STARSHIP_JOB
+        | each {|job| try { job kill $job.id }}
+        | ignore
+    }
+    $env.config = (
+        $env.config?
+        | default {}
+        | merge {render_right_prompt_on_last_line: true}
+        | upsert hooks ($hooks | upsert pre_execution $pre_execution)
     )
 
-    # Does not play well with default character module.
-    # TODO: Also Use starship vi mode indicators?
-    PROMPT_INDICATOR: ""
-
-    PROMPT_COMMAND: {||
-        (
-            # The initial value of `$env.CMD_DURATION_MS` is always `0823`, which is an official setting.
-            # See https://github.com/nushell/nushell/discussions/6402#discussioncomment-3466687.
-            let cmd_duration = if $env.CMD_DURATION_MS == "0823" { 0 } else { $env.CMD_DURATION_MS };
-            ^::STARSHIP:: prompt
-                --cmd-duration $cmd_duration
-                $"--status=($env.LAST_EXIT_CODE)"
-                --terminal-width (term size).columns
-                ...(
-                    if (which "job list" | where type == built-in | is-not-empty) {
-                        ["--jobs", (job list | length)]
-                    } else {
-                        []
-                    }
-                )
-        )
+    load-env {
+        STARSHIP_SESSION_KEY: (random chars -l 16)
+        STARSHIP_READY_TAG: $mailbox
+        STARSHIP_TIMINGS_TAG: ($mailbox + 1)
+        PROMPT_MULTILINE_INDICATOR: (^::STARSHIP:: prompt --continuation)
+        PROMPT_INDICATOR: ""
+        PROMPT_COMMAND: {|| starship-stream-start (starship-prompt-arguments) }
+        PROMPT_COMMAND_RIGHT: {||
+            ^::STARSHIP:: prompt --right ...(starship-prompt-arguments)
+        }
     }
-
-    config: ($env.config? | default {} | merge {
-        render_right_prompt_on_last_line: true
-    })
-
-    PROMPT_COMMAND_RIGHT: {||
-        (
-            # The initial value of `$env.CMD_DURATION_MS` is always `0823`, which is an official setting.
-            # See https://github.com/nushell/nushell/discussions/6402#discussioncomment-3466687.
-            let cmd_duration = if $env.CMD_DURATION_MS == "0823" { 0 } else { $env.CMD_DURATION_MS };
-            ^::STARSHIP:: prompt
-                --right
-                --cmd-duration $cmd_duration
-                $"--status=($env.LAST_EXIT_CODE)"
-                --terminal-width (term size).columns
-                ...(
-                    if (which "job list" | where type == built-in | is-not-empty) {
-                        ["--jobs", (job list | length)]
-                    } else {
-                        []
-                    }
-                )
-        )
-    }
-}}
+}

--- a/src/init/starship.zsh
+++ b/src/init/starship.zsh
@@ -73,6 +73,9 @@ add-zsh-hook zshexit starship_stream_stop
 STARSHIP_STREAM_DESCRIPTOR=
 STARSHIP_STREAM_PROCESS=
 STARSHIP_STREAM_COMPLETE=
+STARSHIP_STREAM_RIGHT_DESCRIPTOR=
+STARSHIP_STREAM_RIGHT_PROCESS=
+STARSHIP_STREAM_RIGHT_COMPLETE=
 STARSHIP_TIMINGS=
 
 starship_prompt_arguments() {
@@ -94,7 +97,7 @@ starship_read_frame() {
     reply=("$kind" "$first" "$second")
 }
 
-starship_stream_stop() {
+starship_stream_stop_left() {
     if [[ -n $STARSHIP_STREAM_DESCRIPTOR ]]; then
         zle -F "$STARSHIP_STREAM_DESCRIPTOR" 2>/dev/null
         { exec {STARSHIP_STREAM_DESCRIPTOR}<&- } 2>/dev/null
@@ -105,6 +108,26 @@ starship_stream_stop() {
         STARSHIP_STREAM_PROCESS=
     fi
     STARSHIP_STREAM_COMPLETE=
+}
+
+starship_stream_stop_right() {
+    if [[ -n $STARSHIP_STREAM_RIGHT_DESCRIPTOR ]]; then
+        zle -F "$STARSHIP_STREAM_RIGHT_DESCRIPTOR" 2>/dev/null
+        { exec {STARSHIP_STREAM_RIGHT_DESCRIPTOR}<&- } 2>/dev/null
+        STARSHIP_STREAM_RIGHT_DESCRIPTOR=
+    fi
+    if [[ -n $STARSHIP_STREAM_RIGHT_PROCESS ]]; then
+        kill "$STARSHIP_STREAM_RIGHT_PROCESS" 2>/dev/null
+        STARSHIP_STREAM_RIGHT_PROCESS=
+    fi
+    STARSHIP_STREAM_RIGHT_COMPLETE=
+}
+
+# Stops both streams; each also stops independently on its own failure so one
+# side dying does not discard the other's in-flight progress.
+starship_stream_stop() {
+    starship_stream_stop_left
+    starship_stream_stop_right
 }
 
 starship_editor_is_busy() {
@@ -132,9 +155,10 @@ starship_apply_prompt() {
 starship_stream_readable() {
     if [[ -n ${2-} ]] || ! starship_read_frame "$1"; then
         local complete=$STARSHIP_STREAM_COMPLETE
-        starship_stream_stop
+        starship_stream_stop_left
         if [[ ! $complete ]]; then
-            starship_render_synchronously
+            starship_prompt_arguments
+            STARSHIP_PROMPT="$(::STARSHIP:: prompt "${reply[@]}")"
             zle reset-prompt
         fi
         return
@@ -151,12 +175,32 @@ starship_stream_readable() {
     esac
 }
 
-starship_render_synchronously() {
-    starship_stream_stop
-    starship_prompt_arguments
-    local -a arguments=("${reply[@]}")
-    STARSHIP_PROMPT="$(::STARSHIP:: prompt "${arguments[@]}")"
-    STARSHIP_RIGHT_PROMPT="$(::STARSHIP:: prompt --right "${arguments[@]}")"
+# The right prompt's own callback, separate from starship_stream_readable:
+# its cursor sits nowhere near where zle would rest for a cell-precise
+# repaint, so unlike the left prompt it always redraws with a full
+# `zle reset-prompt` rather than ever touching a PATCH's repaint bytes.
+starship_stream_right_readable() {
+    if [[ -n ${2-} ]] || ! starship_read_frame "$1"; then
+        local complete=$STARSHIP_STREAM_RIGHT_COMPLETE
+        starship_stream_stop_right
+        if [[ ! $complete ]]; then
+            starship_prompt_arguments
+            STARSHIP_RIGHT_PROMPT="$(::STARSHIP:: prompt --right "${reply[@]}")"
+            zle reset-prompt
+        fi
+        return
+    fi
+
+    case $reply[1] in
+        PATCH)
+            STARSHIP_RIGHT_PROMPT=$reply[2]
+            starship_editor_is_busy || zle reset-prompt
+            ;;
+        COMPLETE)
+            STARSHIP_TIMINGS=$reply[2]
+            STARSHIP_STREAM_RIGHT_COMPLETE=1
+            ;;
+    esac
 }
 
 starship_stream_start() {
@@ -164,19 +208,29 @@ starship_stream_start() {
     starship_prompt_arguments
     local -a arguments=("${reply[@]}")
 
-    STARSHIP_RIGHT_PROMPT="$(::STARSHIP:: prompt --right "${arguments[@]}")"
     exec {STARSHIP_STREAM_DESCRIPTOR}< <(::STARSHIP:: stream "${arguments[@]}" --timings="$STARSHIP_TIMINGS" 2>/dev/null)
-
     if [[ -z $STARSHIP_STREAM_DESCRIPTOR ]] ||
        ! starship_read_frame "$STARSHIP_STREAM_DESCRIPTOR" ||
        [[ $reply[1] != READY ]]; then
-        starship_render_synchronously
-        return
+        starship_stream_stop_left
+        STARSHIP_PROMPT="$(::STARSHIP:: prompt "${arguments[@]}")"
+    else
+        STARSHIP_PROMPT=$reply[2]
+        STARSHIP_STREAM_PROCESS=$reply[3]
+        zle -F "$STARSHIP_STREAM_DESCRIPTOR" starship_stream_readable
     fi
 
-    STARSHIP_PROMPT=$reply[2]
-    STARSHIP_STREAM_PROCESS=$reply[3]
-    zle -F "$STARSHIP_STREAM_DESCRIPTOR" starship_stream_readable
+    exec {STARSHIP_STREAM_RIGHT_DESCRIPTOR}< <(::STARSHIP:: stream --right "${arguments[@]}" --timings="$STARSHIP_TIMINGS" 2>/dev/null)
+    if [[ -z $STARSHIP_STREAM_RIGHT_DESCRIPTOR ]] ||
+       ! starship_read_frame "$STARSHIP_STREAM_RIGHT_DESCRIPTOR" ||
+       [[ $reply[1] != READY ]]; then
+        starship_stream_stop_right
+        STARSHIP_RIGHT_PROMPT="$(::STARSHIP:: prompt --right "${arguments[@]}")"
+    else
+        STARSHIP_RIGHT_PROMPT=$reply[2]
+        STARSHIP_STREAM_RIGHT_PROCESS=$reply[3]
+        zle -F "$STARSHIP_STREAM_RIGHT_DESCRIPTOR" starship_stream_right_readable
+    fi
 }
 
 # Set up a function to redraw the prompt if the user switches vi modes

--- a/src/init/starship.zsh
+++ b/src/init/starship.zsh
@@ -51,11 +51,15 @@ prompt_starship_precmd() {
     # Use length of jobstates array as number of jobs. Expansion fails inside
     # quotes so we set it here and then use the value later on.
     STARSHIP_JOBS_COUNT="${#jobstates[*]}"
+
+    starship_stream_start
 }
 
 # Runs after the user submits the command line, but before it is executed and
 # only if there's an actual command to run
 prompt_starship_preexec() {
+    # Stop the stream now — the line it was rendering into is about to be replaced.
+    starship_stream_stop
     __starship_get_time && STARSHIP_START_TIME=$STARSHIP_CAPTURED_TIME
 }
 
@@ -64,8 +68,121 @@ autoload -Uz add-zsh-hook
 add-zsh-hook precmd prompt_starship_precmd
 add-zsh-hook preexec prompt_starship_preexec
 
+add-zsh-hook zshexit starship_stream_stop
+
+STARSHIP_STREAM_DESCRIPTOR=
+STARSHIP_STREAM_PROCESS=
+STARSHIP_STREAM_COMPLETE=
+STARSHIP_TIMINGS=
+
+starship_prompt_arguments() {
+    reply=(
+        --terminal-width="$COLUMNS"
+        --keymap="${KEYMAP:-}"
+        --status="${STARSHIP_CMD_STATUS:-}"
+        --pipestatus="${STARSHIP_PIPE_STATUS[*]:-}"
+        --cmd-duration="${STARSHIP_DURATION:-}"
+        --jobs="${STARSHIP_JOBS_COUNT:-0}"
+    )
+}
+
+starship_read_frame() {
+    local descriptor=$1 kind first second
+    IFS= read -r -d '' -u "$descriptor" kind &&
+        IFS= read -r -d '' -u "$descriptor" first &&
+        IFS= read -r -d '' -u "$descriptor" second || return
+    reply=("$kind" "$first" "$second")
+}
+
+starship_stream_stop() {
+    if [[ -n $STARSHIP_STREAM_DESCRIPTOR ]]; then
+        zle -F "$STARSHIP_STREAM_DESCRIPTOR" 2>/dev/null
+        { exec {STARSHIP_STREAM_DESCRIPTOR}<&- } 2>/dev/null
+        STARSHIP_STREAM_DESCRIPTOR=
+    fi
+    if [[ -n $STARSHIP_STREAM_PROCESS ]]; then
+        kill "$STARSHIP_STREAM_PROCESS" 2>/dev/null
+        STARSHIP_STREAM_PROCESS=
+    fi
+    STARSHIP_STREAM_COMPLETE=
+}
+
+starship_editor_is_busy() {
+    [[ ${WIDGET-} == *complete* || ${WIDGET-} == *search* ||
+       ${LASTWIDGET-} == *complete* || ${LASTWIDGET-} == *search* ]]
+}
+
+starship_editor_is_at_prompt() {
+    [[ -z ${BUFFER-}${PREDISPLAY-}${POSTDISPLAY-} ]]
+}
+
+starship_apply_prompt() {
+    local prompt=$1 repaint=$2
+    STARSHIP_PROMPT=$prompt
+    starship_editor_is_busy && return
+
+    if [[ -n $repaint ]] && starship_editor_is_at_prompt; then
+        zle -I
+        print -rn -- "$repaint"
+    else
+        zle reset-prompt
+    fi
+}
+
+starship_stream_readable() {
+    if [[ -n ${2-} ]] || ! starship_read_frame "$1"; then
+        local complete=$STARSHIP_STREAM_COMPLETE
+        starship_stream_stop
+        if [[ ! $complete ]]; then
+            starship_render_synchronously
+            zle reset-prompt
+        fi
+        return
+    fi
+
+    case $reply[1] in
+        PATCH)
+            starship_apply_prompt "$reply[2]" "$reply[3]"
+            ;;
+        COMPLETE)
+            STARSHIP_TIMINGS=$reply[2]
+            STARSHIP_STREAM_COMPLETE=1
+            ;;
+    esac
+}
+
+starship_render_synchronously() {
+    starship_stream_stop
+    starship_prompt_arguments
+    local -a arguments=("${reply[@]}")
+    STARSHIP_PROMPT="$(::STARSHIP:: prompt "${arguments[@]}")"
+    STARSHIP_RIGHT_PROMPT="$(::STARSHIP:: prompt --right "${arguments[@]}")"
+}
+
+starship_stream_start() {
+    starship_stream_stop
+    starship_prompt_arguments
+    local -a arguments=("${reply[@]}")
+
+    STARSHIP_RIGHT_PROMPT="$(::STARSHIP:: prompt --right "${arguments[@]}")"
+    exec {STARSHIP_STREAM_DESCRIPTOR}< <(::STARSHIP:: stream "${arguments[@]}" --timings="$STARSHIP_TIMINGS" 2>/dev/null)
+
+    if [[ -z $STARSHIP_STREAM_DESCRIPTOR ]] ||
+       ! starship_read_frame "$STARSHIP_STREAM_DESCRIPTOR" ||
+       [[ $reply[1] != READY ]]; then
+        starship_render_synchronously
+        return
+    fi
+
+    STARSHIP_PROMPT=$reply[2]
+    STARSHIP_STREAM_PROCESS=$reply[3]
+    zle -F "$STARSHIP_STREAM_DESCRIPTOR" starship_stream_readable
+}
+
 # Set up a function to redraw the prompt if the user switches vi modes
 starship_zle-keymap-select() {
+    # Keymap changes require a new render.
+    starship_stream_start
     zle reset-prompt
 }
 
@@ -86,6 +203,22 @@ else
     zle -N zle-keymap-select starship_zle-keymap-select-wrapped;
 fi
 
+if (( ${+functions[TRAPWINCH]} )); then
+    functions[starship_preserved_winch_handler]=$functions[TRAPWINCH]
+elif [[ -n ${traps[WINCH]-} ]]; then
+    eval "starship_preserved_winch_handler() { ${traps[WINCH]} }"
+fi
+
+TRAPWINCH() {
+    if (( ${+functions[starship_preserved_winch_handler]} )); then
+        starship_preserved_winch_handler "$@"
+    fi
+    if zle; then
+        starship_stream_start
+        zle reset-prompt
+    fi
+}
+
 export STARSHIP_SHELL="zsh"
 
 # Set up the session key that will be used to store logs
@@ -97,6 +230,7 @@ VIRTUAL_ENV_DISABLE_PROMPT=1
 
 setopt promptsubst
 
-PROMPT='$('::STARSHIP::' prompt --terminal-width="$COLUMNS" --keymap="${KEYMAP:-}" --status="${STARSHIP_CMD_STATUS:-}" --pipestatus="${STARSHIP_PIPE_STATUS[*]:-}" --cmd-duration="${STARSHIP_DURATION:-}" --jobs="$STARSHIP_JOBS_COUNT")'
-RPROMPT='$('::STARSHIP::' prompt --right --terminal-width="$COLUMNS" --keymap="${KEYMAP:-}" --status="${STARSHIP_CMD_STATUS:-}" --pipestatus="${STARSHIP_PIPE_STATUS[*]:-}" --cmd-duration="${STARSHIP_DURATION:-}" --jobs="$STARSHIP_JOBS_COUNT")'
+# A variable, not a command substitution, so a redraw re-expands the stored prompt without rerunning starship (needs promptsubst).
+PROMPT='${STARSHIP_PROMPT}'
+RPROMPT='${STARSHIP_RIGHT_PROMPT}'
 PROMPT2="$(::STARSHIP:: prompt --continuation)"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,12 +13,15 @@ pub mod config;
 pub mod configs;
 pub mod configure;
 pub mod context;
+pub mod escaping;
 pub mod formatter;
 pub mod init;
 pub mod logger;
 pub mod module;
 mod modules;
+mod plan;
 pub mod print;
+mod render;
 mod segment;
 mod utils;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 #[macro_use]
 extern crate shadow_rs;
 
+use std::num::NonZeroUsize;
 use std::thread::available_parallelism;
 
 shadow!(shadow);
@@ -18,15 +19,78 @@ pub mod formatter;
 pub mod init;
 pub mod logger;
 pub mod module;
+pub mod print;
+pub mod stream;
+pub use frame::FrameEncoding;
+pub use transport::{StreamingTransport, TransportMismatch};
+
+// `stream` is the only part of the streaming prompt anything outside this
+// crate needs to name — a prompt is served by one call — so the protocol,
+// plan and repaint diff stay private and free to change shape without that
+// being a breaking change.
+mod damage;
+mod frame;
 mod modules;
 mod plan;
-pub mod print;
 mod render;
 mod segment;
+mod transport;
 mod utils;
 
 #[cfg(test)]
 mod test;
+
+/// A validated count of worker threads.
+///
+/// Guaranteed to be at least one, so a thread pool can never be built with no
+/// workers at all.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ThreadCount(NonZeroUsize);
+
+impl ThreadCount {
+    /// Build a count from an arbitrary number, raising zero to one.
+    ///
+    /// Zero is not a usable pool size, and it is reachable both from a
+    /// user-supplied `STARSHIP_NUM_THREADS=0` and from arithmetic on a
+    /// processor count, so it is corrected rather than rejected.
+    const fn at_least_one(requested: usize) -> Self {
+        match NonZeroUsize::new(requested) {
+            Some(count) => Self(count),
+            None => Self(NonZeroUsize::MIN),
+        }
+    }
+
+    /// The count as a plain number, for interfaces that take one.
+    #[must_use]
+    pub const fn get(self) -> usize {
+        self.0.get()
+    }
+}
+
+/// Blocking threads to allocate for every logical processor.
+///
+/// Module rendering is I/O-bound (waiting on subprocesses up to
+/// `command_timeout`), so the classic `processors * (1 + waiting/computing)`
+/// sizing rule argues for a much higher multiplier than four; four is a
+/// deliberately conservative choice, paired with the floor and ceiling below.
+const BLOCKING_THREADS_PER_PROCESSOR: usize = 4;
+
+/// The fewest blocking threads to allocate, whatever the processor count.
+///
+/// A low processor count says nothing about how many subprocess waits can
+/// usefully overlap; sixteen covers the modules that typically reach a
+/// subprocess in one prompt, so their timeouts run concurrently instead of
+/// queueing behind one another.
+const MINIMUM_BLOCKING_THREADS: usize = 16;
+
+/// The most blocking threads to allocate, whatever the processor count.
+///
+/// The pool is built eagerly on every prompt, so each thread costs startup
+/// time (measured: 8 to 44 threads added ~1ms on an 11-processor machine) —
+/// cheap against what a slow module saves, but not free. Sixty-four also
+/// exceeds the number of modules a single prompt could plausibly block on, so
+/// raising it further would only add startup cost.
+const MAXIMUM_BLOCKING_THREADS: usize = 64;
 
 /// Return the number of threads starship should use, if configured.
 pub fn num_configured_starship_threads() -> Option<usize> {
@@ -35,10 +99,80 @@ pub fn num_configured_starship_threads() -> Option<usize> {
         .and_then(|s| s.parse().ok())
 }
 
+/// The number of logical processors, or one if it cannot be determined.
+fn processor_count() -> usize {
+    available_parallelism().map_or(1, usize::from)
+}
+
+/// The sizing policy, as a pure function of its two inputs.
+fn thread_count_from(configured: Option<usize>, processors: usize) -> ThreadCount {
+    if let Some(configured) = configured {
+        return ThreadCount::at_least_one(configured);
+    }
+
+    ThreadCount::at_least_one(
+        processors
+            .saturating_mul(BLOCKING_THREADS_PER_PROCESSOR)
+            .clamp(MINIMUM_BLOCKING_THREADS, MAXIMUM_BLOCKING_THREADS),
+    )
+}
+
+fn thread_count() -> ThreadCount {
+    thread_count_from(num_configured_starship_threads(), processor_count())
+}
+
 /// Return the maximum number of threads for the global thread-pool.
+///
+/// Module rendering is overwhelmingly blocking I/O (only 26 of 104 modules are
+/// [`Cadence::Instant`]), so sizing the pool to the processor count would force
+/// a prompt with more deferred modules than cores through several rounds of
+/// `command_timeout` in sequence; it is sized for blocking work instead.
 pub fn num_rayon_threads() -> usize {
-    num_configured_starship_threads()
-        // Default to the number of logical cores,
-        // but restrict the number of threads to 8
-        .unwrap_or_else(|| available_parallelism().map_or(1, usize::from).min(8))
+    thread_count().get()
+}
+
+#[cfg(test)]
+mod thread_pool_tests {
+    use super::*;
+
+    #[test]
+    fn the_ceiling_binds_above_the_uncapped_range() {
+        for processors in (MAXIMUM_BLOCKING_THREADS / BLOCKING_THREADS_PER_PROCESSOR)..=1024 {
+            assert_eq!(
+                thread_count_from(None, processors).get(),
+                MAXIMUM_BLOCKING_THREADS,
+                "the module pool must stop growing with {processors} processors"
+            );
+        }
+    }
+
+    #[test]
+    fn the_module_pool_stays_within_its_bounds() {
+        for processors in 1..=256 {
+            let blocking = thread_count_from(None, processors).get();
+            assert!(
+                (MINIMUM_BLOCKING_THREADS..=MAXIMUM_BLOCKING_THREADS).contains(&blocking),
+                "with {processors} processors, blocking got {blocking} threads"
+            );
+        }
+    }
+
+    #[test]
+    fn a_configured_thread_count_overrides_the_policy() {
+        assert_eq!(thread_count_from(Some(3), 64).get(), 3);
+    }
+
+    #[test]
+    fn a_pool_always_has_at_least_one_thread() {
+        assert_eq!(thread_count_from(Some(0), 0).get(), 1);
+        assert!(thread_count_from(None, 0).get() >= 1);
+    }
+
+    #[test]
+    fn the_environment_variable_is_still_honoured_end_to_end() {
+        assert_eq!(
+            thread_count(),
+            thread_count_from(num_configured_starship_threads(), processor_count())
+        );
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,7 +124,7 @@ fn thread_count() -> ThreadCount {
 /// Return the maximum number of threads for the global thread-pool.
 ///
 /// Module rendering is overwhelmingly blocking I/O (only 26 of 104 modules are
-/// [`Cadence::Instant`]), so sizing the pool to the processor count would force
+/// `Cadence::Instant`), so sizing the pool to the processor count would force
 /// a prompt with more deferred modules than cores through several rounds of
 /// `command_timeout` in sequence; it is sized for blocking work instead.
 pub fn num_rayon_threads() -> usize {
@@ -168,11 +168,4 @@ mod thread_pool_tests {
         assert!(thread_count_from(None, 0).get() >= 1);
     }
 
-    #[test]
-    fn the_environment_variable_is_still_honoured_end_to_end() {
-        assert_eq!(
-            thread_count(),
-            thread_count_from(num_configured_starship_threads(), processor_count())
-        );
-    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,5 +167,4 @@ mod thread_pool_tests {
         assert_eq!(thread_count_from(Some(0), 0).get(), 1);
         assert!(thread_count_from(None, 0).get() >= 1);
     }
-
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,11 @@ use clap_complete::generate;
 use rand::RngExt;
 use starship::context::{Context, Properties, Target};
 use starship::module::ALL_MODULES;
-use starship::{bug_report, configure, init, logger, num_rayon_threads, print, shadow};
+use starship::stream::LatencyEstimates;
+use starship::{
+    FrameEncoding, StreamingTransport, bug_report, configure, init, logger, num_rayon_threads,
+    print, shadow, stream,
+};
 
 #[derive(Parser, Debug)]
 #[clap(
@@ -136,6 +140,28 @@ enum Commands {
         #[clap(flatten)]
         properties: Properties,
     },
+    /// Prints the prompt as a stream of frames: an immediate first paint,
+    /// then incremental repaints as slow modules resolve
+    Stream {
+        /// Stream the right prompt (instead of the standard left prompt)
+        #[clap(long)]
+        right: bool,
+        /// What earlier prompts of this shell session measured each module to
+        /// cost, as the payload of the last TIMING frame. Chooses how repaints
+        /// are grouped and nothing else; a shell that keeps none of it, or
+        /// hands back something malformed, gets a prompt that draws to a fixed
+        /// window instead.
+        #[clap(long, default_value = "", value_parser = LatencyEstimates::parse_argument)]
+        timings: LatencyEstimates,
+        /// Shell transport for refinements. `ble` enables the ble.sh hook in bash.
+        #[clap(long, value_enum, default_value_t)]
+        transport: StreamingTransport,
+        /// Event encoding. `json` emits one structured event per line.
+        #[clap(long, value_enum, default_value_t)]
+        frames: FrameEncoding,
+        #[clap(flatten)]
+        properties: Properties,
+    },
     /// Generate random session key
     Session,
     /// Prints the statusline with a specific profile
@@ -237,6 +263,22 @@ fn main() {
                 (_, _, _) => Target::Main,
             };
             print::prompt(properties, target);
+        }
+        Commands::Stream {
+            right,
+            timings,
+            transport,
+            frames,
+            properties,
+        } => {
+            let target = if right { Target::Right } else { Target::Main };
+            // A closed pipe just means the shell stopped wanting this prompt.
+            if let Err(error) = stream::stream(properties, target, &timings, transport, frames)
+                && !error.is_broken_pipe()
+            {
+                eprintln!("Error streaming the prompt: {error}");
+                std::process::exit(1);
+            }
         }
         Commands::Module {
             name,

--- a/src/module.rs
+++ b/src/module.rs
@@ -1,119 +1,15 @@
+pub mod painted;
+
 use crate::segment;
-use crate::segment::{FillSegment, Segment};
-use nu_ansi_term::{AnsiString, AnsiStrings, Style as AnsiStyle};
+use crate::segment::Segment;
+use nu_ansi_term::AnsiString;
+use painted::{Painted, TerminalWidth};
 use std::fmt;
 use std::time::Duration;
 
 // List of all modules
 // Default ordering is handled in configs/starship_root.rs
-pub const ALL_MODULES: &[&str] = &[
-    "aws",
-    "azure",
-    #[cfg(feature = "battery")]
-    "battery",
-    "buf",
-    "bun",
-    "c",
-    "character",
-    "claude_context",
-    "claude_cost",
-    "claude_model",
-    "cmake",
-    "cmd_duration",
-    "cobol",
-    "conda",
-    "container",
-    "cpp",
-    "crystal",
-    "daml",
-    "dart",
-    "deno",
-    "directory",
-    "direnv",
-    "docker_context",
-    "dotnet",
-    "elixir",
-    "elm",
-    "erlang",
-    "fennel",
-    "fill",
-    "fortran",
-    "fossil_branch",
-    "fossil_metrics",
-    "gcloud",
-    "git_branch",
-    "git_commit",
-    "git_metrics",
-    "git_state",
-    "git_status",
-    "gleam",
-    "golang",
-    "gradle",
-    "guix_shell",
-    "haskell",
-    "haxe",
-    "helm",
-    "hg_branch",
-    "hg_state",
-    "hostname",
-    "java",
-    "jj_bookmark",
-    "jobs",
-    "julia",
-    "kotlin",
-    "kubernetes",
-    "line_break",
-    "localip",
-    "lua",
-    "maven",
-    "memory_usage",
-    "meson",
-    "mise",
-    "mojo",
-    "nats",
-    "netns",
-    "nim",
-    "nix_shell",
-    "nodejs",
-    "ocaml",
-    "odin",
-    "opa",
-    "openstack",
-    "os",
-    "package",
-    "perl",
-    "php",
-    "pijul_channel",
-    "pixi",
-    "pulumi",
-    "purescript",
-    "python",
-    "quarto",
-    "raku",
-    "red",
-    "rlang",
-    "ruby",
-    "rust",
-    "scala",
-    "shell",
-    "shlvl",
-    "singularity",
-    "solidity",
-    "spack",
-    "status",
-    "sudo",
-    "swift",
-    "terraform",
-    "time",
-    "typst",
-    "username",
-    "vagrant",
-    "vcs",
-    "vcsh",
-    "vlang",
-    "xmake",
-    "zig",
-];
+pub const ALL_MODULES: &[&str] = crate::modules::registry::ALL_MODULES;
 
 /// A module is a collection of segments showing data for a single integration
 /// (e.g. The git module shows the current git branch and status)
@@ -178,73 +74,30 @@ impl<'a> Module<'a> {
         self.segments.iter().map(segment::Segment::value).collect()
     }
 
-    /// Returns a vector of colored `AnsiString` elements to be later used with
-    /// `AnsiStrings()` to optimize ANSI codes
-    pub fn ansi_strings(&self) -> Vec<AnsiString<'_>> {
-        self.ansi_strings_for_width(None)
+    /// Resolves this module's segments into their final painted form, with
+    /// fills left at their natural width.
+    pub fn paint(&self) -> Painted {
+        self.paint_for_width(None)
     }
 
-    pub fn ansi_strings_for_width(&self, width: Option<usize>) -> Vec<AnsiString<'_>> {
-        let mut iter = self.segments.iter().peekable();
-        let mut ansi_strings: Vec<AnsiString> = Vec::new();
-        while iter.peek().is_some() {
-            ansi_strings.extend(ansi_line(&mut iter, width));
-        }
-        ansi_strings
+    /// Resolves this module's segments into their final painted form, stretching
+    /// fills to take up the width left over on each line.
+    pub fn paint_for_width(&self, available_width: Option<TerminalWidth>) -> Painted {
+        Painted::paint(&self.segments, available_width)
+    }
+
+    pub fn ansi_strings(&self) -> Vec<AnsiString<'static>> {
+        self.paint()
+            .runs()
+            .iter()
+            .map(|run| run.style().as_ansi_style().paint(run.text().to_owned()))
+            .collect()
     }
 }
 
 impl fmt::Display for Module<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let ansi_strings = self.ansi_strings();
-        write!(f, "{}", AnsiStrings(&ansi_strings))
-    }
-}
-
-fn ansi_line<'a, I>(segments: &mut I, term_width: Option<usize>) -> Vec<AnsiString<'a>>
-where
-    I: Iterator<Item = &'a Segment>,
-{
-    let mut used = 0usize;
-    let mut current: Vec<AnsiString> = Vec::new();
-    let mut chunks: Vec<(Vec<AnsiString>, &FillSegment)> = Vec::new();
-    let mut prev_style: Option<AnsiStyle> = None;
-
-    for segment in segments {
-        if let Segment::Fill(fs) = segment {
-            chunks.push((current, fs));
-            current = Vec::new();
-            prev_style = None;
-        } else {
-            used += segment.width_graphemes();
-            let current_segment_string = segment.ansi_string(prev_style.as_ref());
-
-            prev_style = Some(*current_segment_string.style_ref());
-            current.push(current_segment_string);
-        }
-
-        if matches!(segment, Segment::LineTerm) {
-            break;
-        }
-    }
-
-    if chunks.is_empty() {
-        current
-    } else {
-        let fill_size = term_width
-            .and_then(|tw| if tw > used { Some(tw - used) } else { None })
-            .map(|remaining| remaining / chunks.len());
-        chunks
-            .into_iter()
-            .flat_map(|(strs, fill)| {
-                let fill_string = fill.ansi_string(
-                    fill_size,
-                    strs.last().map(nu_ansi_term::AnsiGenericString::style_ref),
-                );
-                strs.into_iter().chain(std::iter::once(fill_string))
-            })
-            .chain(current)
-            .collect::<Vec<AnsiString>>()
+        write!(f, "{}", self.paint())
     }
 }
 

--- a/src/module/painted.rs
+++ b/src/module/painted.rs
@@ -1,0 +1,938 @@
+//! A painted prompt.
+
+use std::fmt;
+use std::ops::Range;
+
+use nu_ansi_term::{Color, Style as AnsiStyle, ansi::RESET};
+
+use crate::config::Style;
+use crate::segment::{FillSegment, Segment};
+
+/// A width, measured in terminal cells, that a prompt line may occupy.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct TerminalWidth(pub usize);
+
+/// The position of a visual line within a [`Painted`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct LineIndex(pub usize);
+
+/// A style in which every symbolic colour reference has already been replaced by
+/// a concrete colour.
+///
+/// The wrapped [`nu_ansi_term::Style`] has no representation for the `prev_fg`
+/// and `prev_bg` specifiers, and the field is private, so the only way to obtain
+/// a `ResolvedStyle` is [`ResolvedStyle::resolve`] — which demands the style of
+/// the left neighbour at the same time. A `ResolvedStyle` that still holds a
+/// symbolic reference is therefore not constructible.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ResolvedStyle(AnsiStyle);
+
+impl ResolvedStyle {
+    /// The style that emits no escape sequences at all.
+    pub fn plain() -> Self {
+        Self(AnsiStyle::new())
+    }
+
+    /// Resolves a symbolic style against the already resolved style of the run
+    /// to its left.
+    ///
+    /// `previous` is `None` wherever there is no left neighbour to inherit from:
+    /// at the start of a visual line, and immediately after a fill.
+    pub fn resolve(symbolic: Option<Style>, previous: Option<Self>) -> Self {
+        match symbolic {
+            Some(symbolic) => {
+                Self(symbolic.to_ansi_style(previous.map(|Self(style)| style).as_ref()))
+            }
+            None => Self::plain(),
+        }
+    }
+
+    /// Whether this style is the absence of styling.
+    pub fn is_plain(&self) -> bool {
+        self.0.is_plain()
+    }
+
+    /// The concrete terminal style that this resolves to.
+    pub fn as_ansi_style(&self) -> AnsiStyle {
+        self.0
+    }
+}
+
+/// What produced a [`Run`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RunKind {
+    /// Literal text emitted by a module.
+    Text,
+    /// Padding produced by expanding a [`Segment::Fill`] to its final width.
+    Fill,
+    /// The structural end of a visual line. Newlines are never part of a
+    /// [`RunKind::Text`] run.
+    LineTerminator,
+}
+
+/// A contiguous piece of text that carries a single fully resolved style.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Run {
+    text: String,
+    style: ResolvedStyle,
+    kind: RunKind,
+}
+
+impl Run {
+    /// The literal text of this run. A [`RunKind::LineTerminator`] run is
+    /// exactly one newline, and a [`RunKind::Text`] run never contains one.
+    pub fn text(&self) -> &str {
+        &self.text
+    }
+
+    /// The style this run is drawn with.
+    pub fn style(&self) -> ResolvedStyle {
+        self.style
+    }
+
+    /// What produced this run.
+    pub fn kind(&self) -> RunKind {
+        self.kind
+    }
+}
+
+/// A prompt whose styles are all resolved and whose fills are all expanded.
+///
+/// The runs are stored in output order. `lines` partitions them into visual
+/// lines, so a caller can ask which runs belong to which line without scanning
+/// for newlines again.
+#[derive(Clone, Default, PartialEq, Eq)]
+pub struct Painted {
+    runs: Vec<Run>,
+    lines: Vec<Range<usize>>,
+}
+
+impl Painted {
+    /// Pass 2: resolves `segments` into their final painted form.
+    ///
+    /// `available_width` is the width that each visual line may occupy. When it
+    /// is `None`, or when a line is already at least that wide, fills are
+    /// emitted at their natural width rather than being stretched.
+    pub fn paint(segments: &[Segment], available_width: Option<TerminalWidth>) -> Self {
+        let mut runs: Vec<Run> = Vec::new();
+        let mut lines: Vec<Range<usize>> = Vec::new();
+
+        let mut next_segment = 0;
+        while next_segment < segments.len() {
+            if next_segment + 1 == segments.len()
+                && matches!(segments.get(next_segment), Some(Segment::Text(text)) if text.value().is_empty())
+                && matches!(runs.last(), Some(run) if run.kind() == RunKind::LineTerminator)
+            {
+                break;
+            }
+
+            let line_start = runs.len();
+            next_segment = paint_line(segments, next_segment, available_width, &mut runs);
+            lines.push(line_start..runs.len());
+        }
+
+        Self { runs, lines }
+    }
+
+    /// Every run, in output order.
+    pub fn runs(&self) -> &[Run] {
+        &self.runs
+    }
+
+    /// Whether this prompt has no runs at all.
+    pub fn is_empty(&self) -> bool {
+        self.runs.is_empty()
+    }
+
+    /// How many visual lines this prompt occupies.
+    pub fn line_count(&self) -> usize {
+        self.lines.len()
+    }
+
+    /// The runs belonging to one visual line, or `None` if the line does not
+    /// exist.
+    pub fn line(&self, line: LineIndex) -> Option<&[Run]> {
+        self.line_range(line).map(|range| &self.runs[range])
+    }
+
+    /// The range of [`Painted::runs`] belonging to one visual line, or `None` if
+    /// the line does not exist.
+    pub fn line_range(&self, line: LineIndex) -> Option<Range<usize>> {
+        self.lines.get(line.0).cloned()
+    }
+
+    /// Every visual line, in output order.
+    pub fn lines(&self) -> impl ExactSizeIterator<Item = &[Run]> {
+        self.lines.iter().map(|range| &self.runs[range.clone()])
+    }
+
+    /// Pass 3: the exact bytes to write to the terminal, with the escape
+    /// sequences of adjacent runs collapsed down to the attributes that change.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        self.to_string().into_bytes()
+    }
+
+    /// Renders the prompt as legible markup rather than escape sequences, in the
+    /// spirit of starship's own format strings — for example
+    /// `via [ v12.0.0 ](green bold)`.
+    ///
+    /// Styled runs are wrapped in `[text](style)` and unstyled runs are written
+    /// bare; `\`, `[` and `]` in the text are backslash-escaped. Line
+    /// terminators appear as real newlines. This is a diagnostic form meant for
+    /// reading and for snapshot tests: a few styles that the configuration
+    /// parser cannot produce have no format-string spelling, and are rendered
+    /// with the closest descriptive token instead.
+    pub fn to_markup(&self) -> String {
+        let mut markup = String::new();
+        for run in &self.runs {
+            let text = escape_markup_text(&run.text);
+            if run.style.is_plain() {
+                markup.push_str(&text);
+            } else {
+                markup.push('[');
+                markup.push_str(&text);
+                markup.push_str("](");
+                markup.push_str(&style_markup(run.style.0));
+                markup.push(')');
+            }
+        }
+        markup
+    }
+}
+
+/// Writes the prompt as the bytes a terminal should receive.
+impl fmt::Display for Painted {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut remaining = self.runs.iter();
+        let Some(first) = remaining.next() else {
+            return Ok(());
+        };
+
+        write!(formatter, "{}", first.style.0.prefix())?;
+        formatter.write_str(&first.text)?;
+
+        let mut previous = first;
+        for run in remaining {
+            match StyleTransition::between(previous.style.0, run.style.0) {
+                StyleTransition::AddAttributes(added) => write!(formatter, "{}", added.prefix())?,
+                StyleTransition::ResetFirst => {
+                    write!(formatter, "{RESET}{}", run.style.0.prefix())?;
+                }
+                StyleTransition::Nothing => {}
+            }
+            formatter.write_str(&run.text)?;
+            previous = run;
+        }
+
+        // The trailing reset is only needed when the last run left attributes
+        // switched on.
+        if !previous.style.is_plain() {
+            formatter.write_str(RESET)?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Writes the prompt as legible markup; see [`Painted::to_markup`].
+impl fmt::Debug for Painted {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.to_markup())
+    }
+}
+
+/// Paints one visual line, appending its runs to `runs`, and returns the index
+/// of the first segment of the next line.
+fn paint_line(
+    segments: &[Segment],
+    line_start: usize,
+    available_width: Option<TerminalWidth>,
+    runs: &mut Vec<Run>,
+) -> usize {
+    // Runs since the last fill; claimed into `chunks` once the next fill is hit.
+    let mut pending: Vec<Run> = Vec::new();
+    let mut chunks: Vec<(Vec<Run>, &FillSegment)> = Vec::new();
+    let mut used_width = 0;
+    // A fill resets the inheritance chain, so nothing after it can see across.
+    let mut previous_style: Option<ResolvedStyle> = None;
+
+    let mut next_segment = line_start;
+    while let Some(segment) = segments.get(next_segment) {
+        next_segment += 1;
+
+        match segment {
+            Segment::Fill(fill) => {
+                chunks.push((std::mem::take(&mut pending), fill));
+                previous_style = None;
+            }
+            Segment::Text(text) => {
+                used_width += segment.width_graphemes();
+                let style = ResolvedStyle::resolve(text.symbolic_style(), previous_style);
+                previous_style = Some(style);
+                pending.push(Run {
+                    text: segment.value().to_owned(),
+                    style,
+                    kind: RunKind::Text,
+                });
+            }
+            Segment::LineTerm => {
+                // Nothing follows a line terminator, so inheritance simply ends here.
+                pending.push(Run {
+                    text: segment.value().to_owned(),
+                    style: ResolvedStyle::plain(),
+                    kind: RunKind::LineTerminator,
+                });
+                break;
+            }
+        }
+    }
+
+    if !chunks.is_empty() {
+        let fill_count = chunks.len();
+
+        for (index, (chunk, fill)) in chunks.into_iter().enumerate() {
+            let fill_width = available_width.and_then(|TerminalWidth(available)| {
+                (available > used_width).then(|| {
+                    let leftover = available - used_width;
+                    leftover / fill_count + usize::from(index < leftover % fill_count)
+                })
+            });
+            let preceding_style = chunk.last().map(Run::style);
+            let style = ResolvedStyle::resolve(fill.symbolic_style(), preceding_style);
+            let text = fill.expand(fill_width);
+            runs.extend(chunk);
+            runs.push(Run {
+                text,
+                style,
+                kind: RunKind::Fill,
+            });
+        }
+    }
+
+    runs.append(&mut pending);
+    next_segment
+}
+
+/// The escape sequences needed to get from one resolved style to the next.
+///
+/// This mirrors the collapsing that `nu_ansi_term::AnsiStrings` performs, which
+/// is not reachable as a library function.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum StyleTransition {
+    /// The next style only adds attributes; emit just those.
+    AddAttributes(AnsiStyle),
+    /// Attributes have to be switched off, which is only possible by resetting
+    /// everything and starting the next style from scratch.
+    ResetFirst,
+    /// The styles are identical; emit nothing.
+    Nothing,
+}
+
+impl StyleTransition {
+    fn between(first: AnsiStyle, next: AnsiStyle) -> Self {
+        if first == next {
+            return Self::Nothing;
+        }
+
+        // None of these attributes can be switched off on its own.
+        let switched_off = (first.is_bold && !next.is_bold)
+            || (first.is_dimmed && !next.is_dimmed)
+            || (first.is_italic && !next.is_italic)
+            || (first.is_underline && !next.is_underline)
+            || (first.is_blink && !next.is_blink)
+            || (first.is_reverse && !next.is_reverse)
+            || (first.is_hidden && !next.is_hidden)
+            || (first.is_strikethrough && !next.is_strikethrough)
+            || (first.foreground.is_some() && next.foreground.is_none())
+            || (first.background.is_some() && next.background.is_none());
+
+        if switched_off {
+            return Self::ResetFirst;
+        }
+
+        let mut added = AnsiStyle::new();
+        added.is_bold = first.is_bold != next.is_bold;
+        added.is_dimmed = first.is_dimmed != next.is_dimmed;
+        added.is_italic = first.is_italic != next.is_italic;
+        added.is_underline = first.is_underline != next.is_underline;
+        added.is_blink = first.is_blink != next.is_blink;
+        added.is_reverse = first.is_reverse != next.is_reverse;
+        added.is_hidden = first.is_hidden != next.is_hidden;
+        added.is_strikethrough = first.is_strikethrough != next.is_strikethrough;
+        if first.foreground != next.foreground {
+            added.foreground = next.foreground;
+        }
+        if first.background != next.background {
+            added.background = next.background;
+        }
+
+        Self::AddAttributes(added)
+    }
+}
+
+/// Escapes the characters that would otherwise be read as markup delimiters.
+fn escape_markup_text(text: &str) -> String {
+    let mut escaped = String::with_capacity(text.len());
+    for character in text.chars() {
+        if matches!(character, '\\' | '[' | ']') {
+            escaped.push('\\');
+        }
+        escaped.push(character);
+    }
+    escaped
+}
+
+/// Spells a resolved style the way a starship format string would.
+fn style_markup(style: AnsiStyle) -> String {
+    let mut tokens: Vec<String> = Vec::new();
+
+    if style.prefix_with_reset {
+        // Not expressible in a format string; the configuration parser never
+        // produces it, but the markup should not silently drop it either.
+        tokens.push(String::from("reset"));
+    }
+    if let Some(color) = style.foreground {
+        tokens.push(color_markup(color));
+    }
+    if let Some(color) = style.background {
+        tokens.push(format!("bg:{}", color_markup(color)));
+    }
+    for (is_set, token) in [
+        (style.is_bold, "bold"),
+        (style.is_dimmed, "dimmed"),
+        (style.is_italic, "italic"),
+        (style.is_underline, "underline"),
+        (style.is_blink, "blink"),
+        (style.is_reverse, "inverted"),
+        (style.is_hidden, "hidden"),
+        (style.is_strikethrough, "strikethrough"),
+    ] {
+        if is_set {
+            tokens.push(String::from(token));
+        }
+    }
+
+    tokens.join(" ")
+}
+
+/// Spells a colour the way a starship format string would.
+fn color_markup(color: Color) -> String {
+    let named = match color {
+        Color::Black => "black",
+        Color::DarkGray => "bright-black",
+        Color::Red => "red",
+        Color::LightRed => "bright-red",
+        Color::Green => "green",
+        Color::LightGreen => "bright-green",
+        Color::Yellow => "yellow",
+        Color::LightYellow => "bright-yellow",
+        Color::Blue => "blue",
+        Color::LightBlue => "bright-blue",
+        Color::Purple => "purple",
+        Color::LightPurple => "bright-purple",
+        Color::Cyan => "cyan",
+        Color::LightCyan => "bright-cyan",
+        Color::White => "white",
+        Color::LightGray => "bright-white",
+        Color::Magenta => "magenta",
+        Color::LightMagenta => "bright-magenta",
+        Color::Default => "default",
+        // Fixed and Rgb have no named spelling; write them out directly instead.
+        Color::Fixed(number) => return number.to_string(),
+        Color::Rgb(red, green, blue) => return format!("#{red:02X}{green:02X}{blue:02X}"),
+    };
+    String::from(named)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::parse_style_string;
+    use crate::formatter::StringFormatter;
+    use nu_ansi_term::{AnsiString, AnsiStrings};
+
+    /// Parses a style string the way a module's configuration would.
+    fn style(style_string: &str) -> Option<Style> {
+        if style_string.is_empty() {
+            return None;
+        }
+        Some(parse_style_string(style_string, None).expect("style string should parse"))
+    }
+
+    /// One text segment. The value must not contain a newline: newlines are
+    /// structural and are written as [`Segment::LineTerm`] instead.
+    fn text(style_string: &str, value: &str) -> Segment {
+        let mut segments = Segment::from_text(style(style_string), value);
+        assert_eq!(1, segments.len(), "text segments cannot span lines");
+        segments.remove(0)
+    }
+
+    /// One fill segment.
+    fn fill(style_string: &str, value: &str) -> Segment {
+        Segment::fill(style(style_string), value)
+    }
+
+    /// Parses a starship format string into the segments a module would emit.
+    fn segments(format: &str) -> Vec<Segment> {
+        StringFormatter::new(format)
+            .expect("format string should parse")
+            .parse(None, None)
+            .expect("format string should evaluate")
+    }
+
+    /// The concrete style of every run, in order.
+    fn styles(painted: &Painted) -> Vec<AnsiStyle> {
+        painted
+            .runs()
+            .iter()
+            .map(|run| run.style().as_ansi_style())
+            .collect()
+    }
+
+    /// The bytes `nu_ansi_term` produces for the same runs. This is exactly what
+    /// starship emitted before painting was made an explicit pass, so it is the
+    /// reference that the output has to stay identical to.
+    fn reference_bytes(painted: &Painted) -> String {
+        let ansi_strings: Vec<AnsiString> = painted
+            .runs()
+            .iter()
+            .map(|run| run.style().as_ansi_style().paint(run.text().to_owned()))
+            .collect();
+        AnsiStrings(&ansi_strings).to_string()
+    }
+
+    fn assert_matches_reference(painted: &Painted) {
+        assert_eq!(reference_bytes(painted), painted.to_string());
+    }
+
+    #[test]
+    fn empty_input_paints_nothing() {
+        let painted = Painted::paint(&[], None);
+
+        assert!(painted.is_empty());
+        assert_eq!(0, painted.line_count());
+        assert_eq!(String::new(), painted.to_string());
+        assert_eq!(String::new(), painted.to_markup());
+        assert_eq!(Vec::<u8>::new(), painted.to_bytes());
+    }
+
+    #[test]
+    fn plain_text_is_emitted_without_escape_sequences() {
+        let painted = Painted::paint(&[text("", "❯ ")], None);
+
+        assert_eq!("❯ ", painted.to_string());
+        assert_eq!("❯ ", painted.to_markup());
+        assert_matches_reference(&painted);
+    }
+
+    #[test]
+    fn previous_foreground_and_background_are_resolved_left_to_right() {
+        let painted = Painted::paint(
+            &segments("[a](fg:red bg:blue)[b](fg:prev_bg bg:prev_fg)"),
+            None,
+        );
+
+        assert_eq!(
+            vec![
+                AnsiStyle::new().fg(Color::Red).on(Color::Blue),
+                AnsiStyle::new().fg(Color::Blue).on(Color::Red),
+            ],
+            styles(&painted)
+        );
+        assert_eq!("[a](red bg:blue)[b](blue bg:red)", painted.to_markup());
+        assert_matches_reference(&painted);
+    }
+
+    #[test]
+    fn previous_colors_chain_across_many_segments() {
+        let painted = Painted::paint(
+            &segments("[a](fg:red)[b](fg:prev_fg)[c](fg:prev_fg)[d](bg:prev_fg)"),
+            None,
+        );
+
+        assert_eq!(
+            vec![
+                AnsiStyle::new().fg(Color::Red),
+                AnsiStyle::new().fg(Color::Red),
+                AnsiStyle::new().fg(Color::Red),
+                AnsiStyle::new().on(Color::Red),
+            ],
+            styles(&painted)
+        );
+        assert_matches_reference(&painted);
+    }
+
+    #[test]
+    fn previous_colors_see_through_empty_segments() {
+        let painted = Painted::paint(&segments("[](bg:#9A348E)[X](bg:prev_bg)"), None);
+
+        assert_eq!(
+            Some(Color::Rgb(0x9A, 0x34, 0x8E)),
+            painted.runs()[1].style().as_ansi_style().background
+        );
+        assert_eq!("[](bg:#9A348E)[X](bg:#9A348E)", painted.to_markup());
+        assert_matches_reference(&painted);
+    }
+
+    #[test]
+    fn previous_colors_do_not_reach_across_a_line_terminator() {
+        let prompt = vec![
+            text("fg:red", "a"),
+            Segment::LineTerm,
+            text("fg:prev_fg", "b"),
+        ];
+
+        let painted = Painted::paint(&prompt, None);
+
+        assert_eq!(2, painted.line_count());
+        // With no left neighbour on its own line, the reference resolves to no
+        // colour at all.
+        assert_eq!(None, painted.runs()[2].style().as_ansi_style().foreground);
+        assert_matches_reference(&painted);
+    }
+
+    #[test]
+    fn lines_partition_the_runs() {
+        let prompt = vec![
+            text("red", "a"),
+            Segment::LineTerm,
+            text("green", "b"),
+            Segment::LineTerm,
+            text("", "c"),
+        ];
+
+        let painted = Painted::paint(&prompt, None);
+
+        assert_eq!(3, painted.line_count());
+        assert_eq!(Some(0..2), painted.line_range(LineIndex(0)));
+        assert_eq!(Some(2..4), painted.line_range(LineIndex(1)));
+        assert_eq!(Some(4..5), painted.line_range(LineIndex(2)));
+        assert_eq!(None, painted.line_range(LineIndex(3)));
+
+        assert_eq!(
+            painted.line(LineIndex(1)),
+            Some(&painted.runs()[2..4]),
+            "line() and line_range() must agree"
+        );
+
+        let line_texts: Vec<String> = painted
+            .lines()
+            .map(|line| line.iter().map(Run::text).collect())
+            .collect();
+        assert_eq!(vec!["a\n", "b\n", "c"], line_texts);
+    }
+
+    #[test]
+    fn line_terminators_are_structural_not_text() {
+        let prompt = vec![text("", "a"), Segment::LineTerm, text("", "b")];
+
+        let painted = Painted::paint(&prompt, None);
+
+        assert_eq!(
+            vec![RunKind::Text, RunKind::LineTerminator, RunKind::Text],
+            painted.runs().iter().map(Run::kind).collect::<Vec<_>>()
+        );
+        for run in painted.runs() {
+            if run.kind() == RunKind::Text {
+                assert!(!run.text().contains('\n'));
+            }
+        }
+        assert_eq!("a\nb", painted.to_string());
+        assert_eq!("a\nb", painted.to_markup());
+    }
+
+    #[test]
+    fn a_trailing_line_terminator_does_not_open_a_new_line() {
+        let painted = Painted::paint(&[text("", "a"), Segment::LineTerm], None);
+
+        assert_eq!(1, painted.line_count());
+        assert_eq!(Some(0..2), painted.line_range(LineIndex(0)));
+    }
+
+    #[test]
+    fn a_trailing_empty_text_segment_after_a_line_terminator_does_not_open_a_new_line() {
+        let painted = Painted::paint(&Segment::from_text(None, "a\n"), None);
+
+        assert_eq!(1, painted.line_count());
+        assert_eq!("a\n", painted.to_string());
+    }
+
+    #[test]
+    fn a_fill_absorbs_the_leftover_width() {
+        let prompt = vec![text("red", "a"), fill("", "."), text("green", "b")];
+
+        let painted = Painted::paint(&prompt, Some(TerminalWidth(10)));
+
+        assert_eq!("........", painted.runs()[1].text());
+        assert_matches_reference(&painted);
+    }
+
+    #[test]
+    fn several_fills_share_the_leftover_width() {
+        let prompt = vec![
+            text("", "a"),
+            fill("", "."),
+            text("", "b"),
+            fill("", "."),
+            text("", "c"),
+        ];
+
+        let painted = Painted::paint(&prompt, Some(TerminalWidth(11)));
+
+        assert_eq!("a....b....c", painted.to_string());
+    }
+
+    #[test]
+    fn a_fill_keeps_its_natural_width_when_the_line_is_already_full() {
+        let prompt = vec![text("", "abcdef"), fill("", "-:-")];
+
+        let painted = Painted::paint(&prompt, Some(TerminalWidth(3)));
+
+        assert_eq!("abcdef-:-", painted.to_string());
+    }
+
+    #[test]
+    fn a_fill_keeps_its_natural_width_when_no_width_is_available() {
+        let prompt = vec![text("", "a"), fill("", "-:-")];
+
+        let painted = Painted::paint(&prompt, None);
+
+        assert_eq!("a-:-", painted.to_string());
+    }
+
+    #[test]
+    fn a_fill_inherits_from_the_run_to_its_left() {
+        let prompt = vec![text("fg:red bg:blue", "a"), fill("fg:prev_bg", ".")];
+
+        let painted = Painted::paint(&prompt, Some(TerminalWidth(5)));
+
+        assert_eq!(
+            Some(Color::Blue),
+            painted.runs()[1].style().as_ansi_style().foreground
+        );
+        assert_matches_reference(&painted);
+    }
+
+    #[test]
+    fn a_fill_breaks_the_inheritance_chain() {
+        let prompt = vec![text("fg:red", "a"), fill("", "."), text("fg:prev_fg", "b")];
+
+        let painted = Painted::paint(&prompt, Some(TerminalWidth(6)));
+
+        // The run after the fill has no left neighbour it may inherit from.
+        assert_eq!(None, painted.runs()[2].style().as_ansi_style().foreground);
+        assert_matches_reference(&painted);
+    }
+
+    #[test]
+    fn fills_are_measured_per_line() {
+        let prompt = vec![
+            text("", "a"),
+            fill("", "."),
+            Segment::LineTerm,
+            text("", "bb"),
+            fill("", "."),
+        ];
+
+        let painted = Painted::paint(&prompt, Some(TerminalWidth(6)));
+
+        assert_eq!(2, painted.line_count());
+        assert_eq!("a.....\nbb....", painted.to_string());
+    }
+
+    #[test]
+    fn a_line_terminator_after_a_fill_still_ends_the_line() {
+        let prompt = vec![
+            text("", "a"),
+            fill("", "."),
+            text("", "b"),
+            Segment::LineTerm,
+            text("", "c"),
+        ];
+
+        let painted = Painted::paint(&prompt, Some(TerminalWidth(6)));
+
+        assert_eq!(2, painted.line_count());
+        assert_eq!("a....b\nc", painted.to_string());
+    }
+
+    #[test]
+    fn wide_and_emoji_graphemes_are_measured_by_display_width() {
+        let prompt = vec![text("", "👩‍👩‍👦‍👦"), fill("", "🟦")];
+
+        let painted = Painted::paint(&prompt, Some(TerminalWidth(10)));
+
+        // The family emoji occupies two cells, leaving eight for four blocks.
+        assert_eq!("🟦🟦🟦🟦", painted.runs()[1].text());
+        assert_eq!("👩‍👩‍👦‍👦🟦🟦🟦🟦", painted.to_string());
+    }
+
+    #[test]
+    fn a_fill_never_overshoots_a_partially_filled_cell() {
+        let prompt = vec![text("", "a"), fill("", "🟢🔵🟡")];
+
+        let painted = Painted::paint(&prompt, Some(TerminalWidth(6)));
+
+        // Five cells remain, so the third emoji would not fit.
+        assert_eq!("🟢🔵", painted.runs()[1].text());
+    }
+
+    #[test]
+    fn wide_graphemes_survive_serialising_unchanged() {
+        let prompt = vec![text("red", "👩‍👩‍👦‍👦"), text("", "Ü")];
+
+        let painted = Painted::paint(&prompt, None);
+
+        assert_eq!("\u{1b}[31m👩‍👩‍👦‍👦\u{1b}[0mÜ", painted.to_string());
+        assert_matches_reference(&painted);
+    }
+
+    #[test]
+    fn adjacent_identical_styles_are_not_repeated() {
+        let painted = Painted::paint(&[text("red", "a"), text("red", "b")], None);
+
+        assert_eq!("\u{1b}[31mab\u{1b}[0m", painted.to_string());
+        assert_matches_reference(&painted);
+    }
+
+    #[test]
+    fn added_attributes_are_emitted_without_a_reset() {
+        let painted = Painted::paint(&[text("green", "a"), text("green bold", "b")], None);
+
+        assert_eq!("\u{1b}[32ma\u{1b}[1mb\u{1b}[0m", painted.to_string());
+        assert_matches_reference(&painted);
+    }
+
+    #[test]
+    fn removed_attributes_force_a_reset() {
+        let painted = Painted::paint(&[text("green bold", "a"), text("green", "b")], None);
+
+        assert_eq!(
+            "\u{1b}[1;32ma\u{1b}[0m\u{1b}[32mb\u{1b}[0m",
+            painted.to_string()
+        );
+        assert_matches_reference(&painted);
+    }
+
+    #[test]
+    fn escape_sequence_collapsing_matches_nu_ansi_term_for_every_pair_of_styles() {
+        let attribute_setters: [fn(&AnsiStyle) -> AnsiStyle; 8] = [
+            AnsiStyle::bold,
+            AnsiStyle::dimmed,
+            AnsiStyle::italic,
+            AnsiStyle::underline,
+            AnsiStyle::blink,
+            AnsiStyle::reverse,
+            AnsiStyle::hidden,
+            AnsiStyle::strikethrough,
+        ];
+        let colors = [
+            None,
+            Some(Color::Red),
+            Some(Color::Fixed(120)),
+            Some(Color::Rgb(1, 2, 3)),
+        ];
+
+        let mut attribute_sets: Vec<AnsiStyle> = vec![AnsiStyle::new()];
+        for setter in attribute_setters {
+            attribute_sets.push(setter(&AnsiStyle::new()));
+            attribute_sets.push(setter(&AnsiStyle::new().bold()));
+        }
+        let mut candidates: Vec<AnsiStyle> = Vec::new();
+        for attributes in attribute_sets {
+            for foreground in colors {
+                for background in colors {
+                    let mut candidate = attributes;
+                    candidate.foreground = foreground;
+                    candidate.background = background;
+                    candidates.push(candidate);
+                }
+            }
+        }
+
+        for &first in &candidates {
+            for &second in &candidates {
+                let painted = Painted::paint(
+                    &[
+                        text_with_ansi_style(first, "first"),
+                        text_with_ansi_style(second, "second"),
+                    ],
+                    None,
+                );
+                assert_eq!(
+                    reference_bytes(&painted),
+                    painted.to_string(),
+                    "collapsing {first:?} into {second:?}"
+                );
+            }
+        }
+    }
+
+    /// A text segment carrying a concrete style. Concrete styles hold no
+    /// symbolic reference, so painting reproduces them exactly.
+    fn text_with_ansi_style(style: AnsiStyle, value: &str) -> Segment {
+        let mut segments = Segment::from_text(Some(Style::from(style)), value);
+        assert_eq!(1, segments.len(), "text segments cannot span lines");
+        segments.remove(0)
+    }
+
+    #[test]
+    fn markup_spells_out_colors_and_attributes() {
+        let painted = Painted::paint(
+            &segments("via [ v12.0.0 ](green bold)[x](fg:120 bg:#0A0B0C italic underline)"),
+            None,
+        );
+
+        assert_eq!(
+            "via [ v12.0.0 ](green bold)[x](120 bg:#0A0B0C italic underline)",
+            painted.to_markup()
+        );
+        assert_eq!(painted.to_markup(), format!("{painted:?}"));
+    }
+
+    #[test]
+    fn markup_shows_fills_and_line_terminators() {
+        let prompt = vec![
+            text("red", "a"),
+            fill("blue", "."),
+            Segment::LineTerm,
+            text("", "b"),
+        ];
+
+        let painted = Painted::paint(&prompt, Some(TerminalWidth(5)));
+
+        assert_eq!("[a](red)[....](blue)\nb", painted.to_markup());
+    }
+
+    #[test]
+    fn markup_escapes_its_own_delimiters() {
+        let painted = Painted::paint(&[text("red", "[a]"), text("", "back\\slash")], None);
+
+        assert_eq!("[\\[a\\]](red)back\\\\slash", painted.to_markup());
+    }
+
+    #[test]
+    fn markup_names_every_attribute() {
+        let painted = Painted::paint(
+            &[text(
+                "bold dimmed italic underline blink inverted hidden strikethrough",
+                "a",
+            )],
+            None,
+        );
+
+        assert_eq!(
+            "[a](bold dimmed italic underline blink inverted hidden strikethrough)",
+            painted.to_markup()
+        );
+    }
+
+    #[test]
+    fn to_bytes_agrees_with_the_display_form() {
+        let prompt = vec![text("red bold", "a"), Segment::LineTerm, text("blue", "b")];
+
+        let painted = Painted::paint(&prompt, None);
+
+        assert_eq!(painted.to_string().into_bytes(), painted.to_bytes());
+    }
+}

--- a/src/module/painted.rs
+++ b/src/module/painted.rs
@@ -120,7 +120,7 @@ impl Painted {
         let mut next_segment = 0;
         while next_segment < segments.len() {
             if next_segment + 1 == segments.len()
-                && matches!(segments.get(next_segment), Some(Segment::Text(text)) if text.value().is_empty())
+                && matches!(segments.get(next_segment), Some(Segment::Text(text)) if text.is_empty())
                 && matches!(runs.last(), Some(run) if run.kind() == RunKind::LineTerminator)
             {
                 break;

--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -19,11 +19,19 @@ use crate::configs::directory::{DirectoryConfig, SubstitutionConfig};
 use crate::formatter::StringFormatter;
 
 /// The `directory` module's renderer.
+///
+/// Reaches the filesystem in two places — repository discovery and the
+/// `$read_only` `stat` — both unbounded on a slow or network mount, so the
+/// instant approximation skips them; see [`UnboundedWork`].
 pub struct Directory;
 
 impl Render for Directory {
     fn full<'context>(&self, context: &'context Context<'_>) -> Option<Module<'context>> {
         render(context, UnboundedWork::Allowed)
+    }
+
+    fn instant<'context>(&self, context: &'context Context<'_>) -> Option<Module<'context>> {
+        render(context, UnboundedWork::Forbidden)
     }
 }
 
@@ -32,6 +40,7 @@ impl Render for Directory {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum UnboundedWork {
     Allowed,
+    Forbidden,
 }
 
 /// Creates a module with the current logical or physical directory
@@ -642,6 +651,49 @@ mod tests {
 
             assert_eq!(expected, actual);
         }
+    }
+
+    /// The instant approximation must never `stat` for `$read_only`, unlike the full render.
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn the_instant_approximation_never_shows_read_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        if nix::unistd::Uid::effective().is_root() {
+            return;
+        }
+
+        let home = tempfile::tempdir().expect("a temporary directory");
+        let working = home.path().join("locked");
+        std::fs::create_dir_all(&working).expect("a working directory");
+        let mut permissions = std::fs::metadata(&working)
+            .expect("the directory was just created")
+            .permissions();
+        permissions.set_mode(0o555);
+        std::fs::set_permissions(&working, permissions).expect("removing the write bit");
+
+        let mut context = crate::test::default_context().set_config(toml::toml! {
+            [directory]
+            format = "[$read_only]($read_only_style)"
+        });
+        context.current_dir = working.clone();
+        context.logical_dir = working;
+        context
+            .env
+            .insert("HOME", home.path().display().to_string());
+
+        let full = Directory.full(&context).expect("a full render");
+        assert!(
+            !full.get_segments().join("").is_empty(),
+            "a genuinely read-only directory must show `$read_only` in the full render"
+        );
+
+        let instant = Directory.instant(&context);
+        assert!(
+            instant.is_none_or(|module| module.get_segments().join("").is_empty()),
+            "the instant approximation must never show `$read_only`, since answering it \
+             would need a `stat` that a first paint may not perform"
+        );
     }
 
     #[test]

--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -1051,6 +1051,7 @@ mod tests {
             .renderer("directory")
             .config(toml::toml! {
                 [directory]
+                use_os_path_sep = false
                 // Don't truncate the path at all.
                 truncation_length = 5
                 truncate_to_repo = false
@@ -1073,7 +1074,6 @@ mod tests {
             .renderer("directory")
             .config(toml::toml! {
                 [directory]
-                use_os_path_sep = false
                 // Don't truncate the path at all.
                 truncation_length = 5
                 truncate_to_repo = false
@@ -1221,6 +1221,7 @@ mod tests {
             .renderer("directory")
             .config(toml::toml! {
                 [directory]
+                use_os_path_sep = false
                 // Don't truncate the path at all.
                 truncation_length = 5
                 truncate_to_repo = false
@@ -1248,7 +1249,6 @@ mod tests {
             .renderer("directory")
             .config(toml::toml! {
                 [directory]
-                use_os_path_sep = false
                 // Don't truncate the path at all.
                 truncation_length = 5
                 truncate_to_repo = false

--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -672,6 +672,7 @@ mod tests {
             .path(home_dir().unwrap().join("path/subpath"))
             .config(toml::toml! {
                 [directory]
+                use_os_path_sep = false
                 home_symbol = "🚀"
             })
             .collect();
@@ -685,6 +686,7 @@ mod tests {
             .path("/some/long/network/path/workspace/a/b/c/dev")
             .config(toml::toml! {
                 [directory]
+                use_os_path_sep = false
                 truncation_length = 4
                 [directory.substitutions]
                 "/some/long/network/path" = "/some/net"
@@ -700,6 +702,8 @@ mod tests {
         let rendered = ModuleRenderer::new("directory")
             .path("/path/to/sub")
             .config(toml::toml! {
+                [directory]
+                use_os_path_sep = false
                 [directory.substitutions]
                 "/path/to/sub" = "/correct/order"
                 "/to/sub" = "/wrong/order"
@@ -716,6 +720,7 @@ mod tests {
             .path("/foo/bar/regular/path")
             .config(toml::toml! {
                 [directory]
+                use_os_path_sep = false
                 truncation_length = 0
                 fish_style_pwd_dir_length = 2 // Overridden by substitutions
                 [directory.substitutions]
@@ -732,6 +737,7 @@ mod tests {
             .path(path)
             .config(toml::toml! {
                 [directory]
+                use_os_path_sep = false
                 format = "[$path]($style)"
                 substitutions = [
                     { from = "~/Documents", to = "docs"},
@@ -760,6 +766,7 @@ mod tests {
             .path("/var/log")
             .config(toml::toml! {
                 [directory]
+                use_os_path_sep = false
                 format = "[$path]($style)"
                 substitutions = [
                     { from = "~/Documents", to = "docs"},
@@ -777,6 +784,10 @@ mod tests {
 
         let rendered = home_project
             .renderer("directory")
+            .config(toml::toml! {
+                [directory]
+                use_os_path_sep = false
+            })
             .path(home_project.path().join("starship"))
             .collect();
 
@@ -789,6 +800,10 @@ mod tests {
 
         let rendered = home_project
             .renderer("directory")
+            .config(toml::toml! {
+                [directory]
+                use_os_path_sep = false
+            })
             .path(home_project.path().join("engine/schematics"))
             .collect();
 
@@ -827,6 +842,7 @@ mod tests {
         let rendered = ModuleRenderer::new("directory")
             .config(toml::toml! {
                 [directory]
+                use_os_path_sep = false
                 read_only = ""
                 read_only_style = ""
             })
@@ -843,6 +859,10 @@ mod tests {
 
         let rendered = project
             .renderer("directory")
+            .config(toml::toml! {
+                [directory]
+                use_os_path_sep = false
+            })
             .path(project.path().join("thrusters/rocket"))
             .collect();
 
@@ -911,6 +931,7 @@ mod tests {
             .renderer("directory")
             .config(toml::toml! {
                 [directory]
+                use_os_path_sep = false
                 truncation_length = 2
             })
             .path(project.path().join("rocket"))
@@ -990,6 +1011,10 @@ mod tests {
 
         let rendered = project
             .renderer("directory")
+            .config(toml::toml! {
+                [directory]
+                use_os_path_sep = false
+            })
             .path(repo_dir.join("src"))
             .collect();
 
@@ -1005,6 +1030,10 @@ mod tests {
 
         let rendered = project
             .renderer("directory")
+            .config(toml::toml! {
+                [directory]
+                use_os_path_sep = false
+            })
             .path(repo_dir.join("src/meters/fuel-gauge"))
             .collect();
 
@@ -1044,6 +1073,7 @@ mod tests {
             .renderer("directory")
             .config(toml::toml! {
                 [directory]
+                use_os_path_sep = false
                 // Don't truncate the path at all.
                 truncation_length = 5
                 truncate_to_repo = false
@@ -1104,6 +1134,7 @@ mod tests {
             .renderer("directory")
             .config(toml::toml! {
                 [directory]
+                use_os_path_sep = false
                 // `truncate_to_repo = true` should display the truncated path
                 truncation_length = 5
                 truncate_to_repo = true
@@ -1141,6 +1172,10 @@ mod tests {
 
         let rendered = project
             .renderer("directory")
+            .config(toml::toml! {
+                [directory]
+                use_os_path_sep = false
+            })
             .path(symlink_dir.join("src"))
             .collect();
 
@@ -1159,6 +1194,10 @@ mod tests {
 
         let rendered = project
             .renderer("directory")
+            .config(toml::toml! {
+                [directory]
+                use_os_path_sep = false
+            })
             .path(symlink_dir.join("src/meters/fuel-gauge"))
             .collect();
 
@@ -1209,6 +1248,7 @@ mod tests {
             .renderer("directory")
             .config(toml::toml! {
                 [directory]
+                use_os_path_sep = false
                 // Don't truncate the path at all.
                 truncation_length = 5
                 truncate_to_repo = false
@@ -1279,6 +1319,7 @@ mod tests {
             .renderer("directory")
             .config(toml::toml! {
                 [directory]
+                use_os_path_sep = false
                 // `truncate_to_repo = true` should display the truncated path
                 truncation_length = 5
                 truncate_to_repo = true
@@ -1302,6 +1343,7 @@ mod tests {
             .renderer("directory")
             .config(toml::toml! {
                 [directory]
+                use_os_path_sep = false
                 // `truncate_to_repo = true` should display the truncated path
                 truncation_length = 5
                 truncate_to_repo = true
@@ -1317,6 +1359,7 @@ mod tests {
         let rendered = ModuleRenderer::new("directory")
             .config(toml::toml! {
                 [directory]
+                use_os_path_sep = false
                 truncation_length = 3
                 truncation_symbol = "…/"
             })
@@ -1331,6 +1374,7 @@ mod tests {
         let rendered = ModuleRenderer::new("directory")
             .config(toml::toml! {
                 [directory]
+                use_os_path_sep = false
                 truncation_length = 4
                 truncation_symbol = "…/"
             })
@@ -1348,6 +1392,7 @@ mod tests {
             .renderer("directory")
             .config(toml::toml! {
                 [directory]
+                use_os_path_sep = false
                 truncation_length = 3
                 truncation_symbol = "…/"
             })
@@ -1365,6 +1410,7 @@ mod tests {
             .renderer("directory")
             .config(toml::toml! {
                 [directory]
+                use_os_path_sep = false
                 truncate_to_repo = false // Necessary if homedir is a git repo
                 truncation_length = 4
                 truncation_symbol = "…/"
@@ -1386,6 +1432,7 @@ mod tests {
             .renderer("directory")
             .config(toml::toml! {
                 [directory]
+                use_os_path_sep = false
                 truncation_length = 3
                 truncation_symbol = "…/"
             })
@@ -1406,6 +1453,7 @@ mod tests {
             .renderer("directory")
             .config(toml::toml! {
                 [directory]
+                use_os_path_sep = false
                 truncation_length = 5
                 truncation_symbol = "…/"
                 truncate_to_repo = true
@@ -1481,6 +1529,7 @@ mod tests {
             .renderer("directory")
             .config(toml::toml! {
                 [directory]
+                use_os_path_sep = false
                 use_logical_path = true
                 truncation_length = 3
             })
@@ -1499,6 +1548,7 @@ mod tests {
             .renderer("directory")
             .config(toml::toml! {
                 [directory]
+                use_os_path_sep = false
                 use_logical_path = false
                 truncation_length = 3
             })
@@ -1579,6 +1629,7 @@ mod tests {
             .renderer("directory")
             .config(toml::toml! {
                 [directory]
+                use_os_path_sep = false
                 truncation_length = 5
                 truncate_to_repo = true
                 repo_root_style = "bold red"
@@ -1600,6 +1651,7 @@ mod tests {
             .renderer("directory")
             .config(toml::toml! {
                 [directory]
+                use_os_path_sep = false
                 truncation_length = 5
                 truncation_symbol = "…/"
                 truncate_to_repo = false

--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -19,19 +19,11 @@ use crate::configs::directory::{DirectoryConfig, SubstitutionConfig};
 use crate::formatter::StringFormatter;
 
 /// The `directory` module's renderer.
-///
-/// Reaches the filesystem in two places — repository discovery and the
-/// `$read_only` `stat` — both unbounded on a slow or network mount, so the
-/// instant approximation skips them; see [`UnboundedWork`].
 pub struct Directory;
 
 impl Render for Directory {
     fn full<'context>(&self, context: &'context Context<'_>) -> Option<Module<'context>> {
         render(context, UnboundedWork::Allowed)
-    }
-
-    fn instant<'context>(&self, context: &'context Context<'_>) -> Option<Module<'context>> {
-        render(context, UnboundedWork::Forbidden)
     }
 }
 
@@ -40,7 +32,6 @@ impl Render for Directory {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum UnboundedWork {
     Allowed,
-    Forbidden,
 }
 
 /// Creates a module with the current logical or physical directory
@@ -651,49 +642,6 @@ mod tests {
 
             assert_eq!(expected, actual);
         }
-    }
-
-    /// The instant approximation must never `stat` for `$read_only`, unlike the full render.
-    #[cfg(not(target_os = "windows"))]
-    #[test]
-    fn the_instant_approximation_never_shows_read_only() {
-        use std::os::unix::fs::PermissionsExt;
-
-        if nix::unistd::Uid::effective().is_root() {
-            return;
-        }
-
-        let home = tempfile::tempdir().expect("a temporary directory");
-        let working = home.path().join("locked");
-        std::fs::create_dir_all(&working).expect("a working directory");
-        let mut permissions = std::fs::metadata(&working)
-            .expect("the directory was just created")
-            .permissions();
-        permissions.set_mode(0o555);
-        std::fs::set_permissions(&working, permissions).expect("removing the write bit");
-
-        let mut context = crate::test::default_context().set_config(toml::toml! {
-            [directory]
-            format = "[$read_only]($read_only_style)"
-        });
-        context.current_dir = working.clone();
-        context.logical_dir = working;
-        context
-            .env
-            .insert("HOME", home.path().display().to_string());
-
-        let full = Directory.full(&context).expect("a full render");
-        assert!(
-            !full.get_segments().join("").is_empty(),
-            "a genuinely read-only directory must show `$read_only` in the full render"
-        );
-
-        let instant = Directory.instant(&context);
-        assert!(
-            instant.is_none_or(|module| module.get_segments().join("").is_empty()),
-            "the instant approximation must never show `$read_only`, since answering it \
-             would need a `stat` that a first paint may not perform"
-        );
     }
 
     #[test]

--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -11,12 +11,37 @@ use std::iter::FromIterator;
 use std::path::{Path, PathBuf};
 use unicode_segmentation::UnicodeSegmentation;
 
-use super::{Context, Module};
+use super::{Context, Module, Render};
 
 use super::utils::directory::truncate;
 use crate::config::{Either, ModuleConfig};
 use crate::configs::directory::{DirectoryConfig, SubstitutionConfig};
 use crate::formatter::StringFormatter;
+
+/// The `directory` module's renderer.
+///
+/// Reaches the filesystem in two places — repository discovery and the
+/// `$read_only` `stat` — both unbounded on a slow or network mount, so the
+/// instant approximation skips them; see [`UnboundedWork`].
+pub struct Directory;
+
+impl Render for Directory {
+    fn full<'context>(&self, context: &'context Context<'_>) -> Option<Module<'context>> {
+        render(context, UnboundedWork::Allowed)
+    }
+
+    fn instant<'context>(&self, context: &'context Context<'_>) -> Option<Module<'context>> {
+        render(context, UnboundedWork::Forbidden)
+    }
+}
+
+/// Whether a render may discover the repository and `stat` the working
+/// directory to answer `$read_only`, or must skip both for an instant render.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum UnboundedWork {
+    Allowed,
+    Forbidden,
+}
 
 /// Creates a module with the current logical or physical directory
 ///
@@ -33,6 +58,10 @@ use crate::formatter::StringFormatter;
 /// **Truncation**
 /// Paths will be limited in length to `3` path components by default.
 pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    render(context, UnboundedWork::Allowed)
+}
+
+fn render<'a>(context: &'a Context, discovery: UnboundedWork) -> Option<Module<'a>> {
     let mut module = context.new_module("directory");
     let config: DirectoryConfig = DirectoryConfig::try_load(module.config);
 
@@ -52,7 +81,9 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
     // Attempt repository path contraction (if we are in a git repository)
     // Otherwise use the logical path, automatically contracting
-    let repo = if config.truncate_to_repo || config.repo_root_style.is_some() {
+    let repo = if discovery == UnboundedWork::Allowed
+        && (config.truncate_to_repo || config.repo_root_style.is_some())
+    {
         context.get_git_repo().ok()
     } else {
         None
@@ -157,8 +188,9 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                 "path" => Some(Ok(path_vec[2].as_str())),
                 "before_root_path" => Some(Ok(path_vec[0].as_str())),
                 "repo_root" => Some(Ok(path_vec[1].as_str())),
+                // `is_readonly_dir` stats the filesystem; see `UnboundedWork`.
                 "read_only" => {
-                    if is_readonly_dir(physical_dir) {
+                    if discovery == UnboundedWork::Allowed && is_readonly_dir(physical_dir) {
                         Some(Ok(config.read_only))
                     } else {
                         None
@@ -381,17 +413,46 @@ fn before_root_dir<'a>(path: &'a str, repo: &'a str) -> &'a str {
 mod tests {
     use super::*;
     use crate::config::Either::First;
-    use crate::test::ModuleRenderer;
+    use crate::test::{
+        FixtureProvider, ModuleRenderer, Project, RenderedModule, home_project, project,
+    };
     use crate::utils::create_command;
     use crate::utils::home_dir;
+    use insta::assert_snapshot;
     use nu_ansi_term::Color;
+    use rstest::rstest;
     #[cfg(not(target_os = "windows"))]
     use std::os::unix::fs::symlink;
     #[cfg(target_os = "windows")]
     use std::os::windows::fs::symlink_dir as symlink;
     use std::path::Path;
-    use std::{fs, io};
-    use tempfile::TempDir;
+
+    /// Outside the home directory, so its path is not contracted to `~`.
+    const KNOWN_ROOT: &str = "/tmp";
+
+    /// Replaces a project's randomly generated directory name in a snapshot.
+    const PROJECT_NAME_PLACEHOLDER: &str = "[PROJECT]";
+
+    fn redact_project_name(project: &Project, rendered: RenderedModule) -> String {
+        rendered
+            .to_string()
+            .replace(&project.directory_name(), PROJECT_NAME_PLACEHOLDER)
+    }
+
+    /// Panics on failure: a test cannot proceed once its fixture doesn't exist.
+    fn init_repo(path: &Path) {
+        let output = create_command("git")
+            .and_then(|mut command| command.args(["init"]).current_dir(path).output())
+            .unwrap_or_else(|error| {
+                panic!("failed to run `git init` in {}: {error}", path.display())
+            });
+        assert!(
+            output.status.success(),
+            "`git init` failed in {}: {}",
+            path.display(),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
 
     #[test]
     fn contract_home_directory() {
@@ -402,13 +463,12 @@ mod tests {
         assert_eq!(output, "~/schematics/rocket");
     }
 
-    #[test]
-    fn contract_repo_directory() -> io::Result<()> {
-        let tmp_dir = TempDir::new_in(home_dir().unwrap().as_path())?;
-        let repo_dir = tmp_dir.path().join("dev").join("rocket-controls");
+    #[rstest]
+    fn contract_repo_directory(home_project: Project) {
+        let repo_dir = home_project.path().join("dev").join("rocket-controls");
         let src_dir = repo_dir.join("src");
-        fs::create_dir_all(&src_dir)?;
-        init_repo(&repo_dir)?;
+        home_project.create_directory("dev/rocket-controls/src");
+        init_repo(&repo_dir);
 
         let src_variations = [src_dir.clone(), dunce::canonicalize(src_dir).unwrap()];
         let repo_variations = [repo_dir.clone(), dunce::canonicalize(repo_dir).unwrap()];
@@ -418,8 +478,6 @@ mod tests {
                 assert_eq!(output, Some("rocket-controls/src".to_string()));
             }
         }
-
-        tmp_dir.close()
     }
 
     #[test]
@@ -490,107 +548,81 @@ mod tests {
         assert_eq!(output, "/foo/baz");
     }
 
-    #[test]
-    fn fish_style_with_user_home_contracted_path() {
-        let path = "~/starship/engines/booster/rocket";
-        let output = to_fish_style(1, path, "engines/booster/rocket");
-        assert_eq!(output, "~/s/");
-    }
-
-    #[test]
-    fn fish_style_with_user_home_contracted_path_and_dot_dir() {
-        let path = "~/.starship/engines/booster/rocket";
-        let output = to_fish_style(1, path, "engines/booster/rocket");
-        assert_eq!(output, "~/.s/");
-    }
-
-    #[test]
-    fn fish_style_with_no_contracted_path() {
-        // `truncation_length = 2`
-        let path = "/absolute/Path/not/in_a/repo/but_nested";
-        let output = to_fish_style(1, path, "repo/but_nested");
-        assert_eq!(output, "/a/P/n/i/");
-    }
-
-    #[test]
-    fn fish_style_with_pwd_dir_len_no_contracted_path() {
-        // `truncation_length = 2`
-        let path = "/absolute/Path/not/in_a/repo/but_nested";
-        let output = to_fish_style(2, path, "repo/but_nested");
-        assert_eq!(output, "/ab/Pa/no/in/");
-    }
-
-    #[test]
-    fn fish_style_with_duplicate_directories() {
-        let path = "~/starship/tmp/C++/C++/C++";
-        let output = to_fish_style(1, path, "C++");
-        assert_eq!(output, "~/s/t/C/C/");
-    }
-
-    #[test]
-    fn fish_style_with_unicode() {
-        let path = "~/starship/tmp/目录/a̐éö̲/目录";
-        let output = to_fish_style(1, path, "目录");
-        assert_eq!(output, "~/s/t/目/a̐/");
-    }
-
-    fn init_repo(path: &Path) -> io::Result<()> {
-        create_command("git")?
-            .args(["init"])
-            .current_dir(path)
-            .output()
-            .map(|_| ())
-    }
-
-    fn make_known_tempdir(root: &Path) -> io::Result<(TempDir, String)> {
-        fs::create_dir_all(root)?;
-        let dir = TempDir::new_in(root)?;
-        // the .to_string_lossy().to_string() here looks weird but is required
-        // to convert it from a Cow.
-        let path = dir
-            .path()
-            .file_name()
-            .unwrap()
-            .to_string_lossy()
-            .to_string();
-        Ok((dir, path))
+    /// One case per shortening rule, so a broken rule is named by the failing test.
+    #[rstest]
+    #[case::user_home_contracted_path(
+        1,
+        "~/starship/engines/booster/rocket",
+        "engines/booster/rocket",
+        "~/s/"
+    )]
+    #[case::user_home_contracted_path_with_dot_directory(
+        1,
+        "~/.starship/engines/booster/rocket",
+        "engines/booster/rocket",
+        "~/.s/"
+    )]
+    #[case::no_contracted_path(
+        1,
+        "/absolute/Path/not/in_a/repo/but_nested",
+        "repo/but_nested",
+        "/a/P/n/i/"
+    )]
+    #[case::two_character_components(
+        2,
+        "/absolute/Path/not/in_a/repo/but_nested",
+        "repo/but_nested",
+        "/ab/Pa/no/in/"
+    )]
+    #[case::duplicate_directories(1, "~/starship/tmp/C++/C++/C++", "C++", "~/s/t/C/C/")]
+    #[case::unicode(1, "~/starship/tmp/目录/a̐éö̲/目录", "目录", "~/s/t/目/a̐/")]
+    fn fish_style(
+        #[case] pwd_dir_length: usize,
+        #[case] dir_string: &str,
+        #[case] truncated_suffix: &str,
+        #[case] expected: &str,
+    ) {
+        assert_eq!(
+            to_fish_style(pwd_dir_length, dir_string, truncated_suffix),
+            expected
+        );
     }
 
     #[cfg(not(target_os = "windows"))]
     mod linux {
         use super::*;
 
-        #[test]
+        #[rstest]
         #[ignore]
-        fn symlinked_subdirectory_git_repo_out_of_tree() -> io::Result<()> {
-            let tmp_dir = TempDir::new_in(home_dir().unwrap().as_path())?;
-            let repo_dir = tmp_dir.path().join("above-repo").join("rocket-controls");
+        fn symlinked_subdirectory_git_repo_out_of_tree(home_project: Project) {
+            let repo_dir = home_project
+                .path()
+                .join("above-repo")
+                .join("rocket-controls");
             let src_dir = repo_dir.join("src/meters/fuel-gauge");
-            let symlink_dir = tmp_dir.path().join("fuel-gauge");
-            fs::create_dir_all(&src_dir)?;
-            init_repo(&repo_dir)?;
-            symlink(&src_dir, &symlink_dir)?;
+            let symlink_dir = home_project.path().join("fuel-gauge");
+            home_project.create_directory("above-repo/rocket-controls/src/meters/fuel-gauge");
+            init_repo(&repo_dir);
+            symlink(&src_dir, &symlink_dir).unwrap();
 
-            let actual = ModuleRenderer::new("directory")
-                .env("HOME", tmp_dir.path().to_str().unwrap())
+            let rendered = home_project
+                .renderer("directory")
+                .env("HOME", home_project.path().to_str().unwrap())
                 .path(symlink_dir)
                 .collect();
-            let expected = Some(format!("{} ", Color::Cyan.bold().paint("~/fuel-gauge")));
 
-            assert_eq!(expected, actual);
-
-            tmp_dir.close()
+            assert_snapshot!(RenderedModule::from(rendered), @r#""\u{1b}[1;36m~/fuel-gauge\u{1b}[0m ""#);
         }
 
-        #[test]
+        #[rstest]
         #[ignore]
-        fn git_repo_in_home_directory_truncate_to_repo_true() -> io::Result<()> {
-            let tmp_dir = TempDir::new_in(home_dir().unwrap().as_path())?;
-            let dir = tmp_dir.path().join("src/fuel-gauge");
-            fs::create_dir_all(&dir)?;
-            init_repo(tmp_dir.path())?;
+        fn git_repo_in_home_directory_truncate_to_repo_true(home_project: Project) {
+            let dir = home_project.path().join("src/fuel-gauge");
+            home_project.create_directory("src/fuel-gauge");
+            init_repo(home_project.path());
 
-            let actual = ModuleRenderer::new("directory")
+            let rendered = home_project
+                .renderer("directory")
                 .config(toml::toml! {
                     [directory]
                     // `truncate_to_repo = true` should attempt to display the truncated path
@@ -598,15 +630,15 @@ mod tests {
                     truncation_length = 5
                 })
                 .path(dir)
-                .env("HOME", tmp_dir.path().to_str().unwrap())
+                .env("HOME", home_project.path().to_str().unwrap())
                 .collect();
-            let expected = Some(format!("{} ", Color::Cyan.bold().paint("~/src/fuel-gauge")));
 
-            assert_eq!(expected, actual);
-
-            tmp_dir.close()
+            assert_snapshot!(RenderedModule::from(rendered), @r#""\u{1b}[1;36m~/src/fuel-gauge\u{1b}[0m ""#);
         }
 
+        /// Not snapshotted: whether `/etc` is reported read-only, and whether
+        /// it canonicalizes to itself, both depend on the host, so the
+        /// expectation is composed rather than recorded.
         #[test]
         #[ignore]
         fn directory_in_root() {
@@ -621,55 +653,87 @@ mod tests {
         }
     }
 
+    /// The instant approximation must never `stat` for `$read_only`, unlike the full render.
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn the_instant_approximation_never_shows_read_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        if nix::unistd::Uid::effective().is_root() {
+            return;
+        }
+
+        let home = tempfile::tempdir().expect("a temporary directory");
+        let working = home.path().join("locked");
+        std::fs::create_dir_all(&working).expect("a working directory");
+        let mut permissions = std::fs::metadata(&working)
+            .expect("the directory was just created")
+            .permissions();
+        permissions.set_mode(0o555);
+        std::fs::set_permissions(&working, permissions).expect("removing the write bit");
+
+        let mut context = crate::test::default_context().set_config(toml::toml! {
+            [directory]
+            format = "[$read_only]($read_only_style)"
+        });
+        context.current_dir = working.clone();
+        context.logical_dir = working;
+        context
+            .env
+            .insert("HOME", home.path().display().to_string());
+
+        let full = Directory.full(&context).expect("a full render");
+        assert!(
+            !full.get_segments().join("").is_empty(),
+            "a genuinely read-only directory must show `$read_only` in the full render"
+        );
+
+        let instant = Directory.instant(&context);
+        assert!(
+            instant.is_none_or(|module| module.get_segments().join("").is_empty()),
+            "the instant approximation must never show `$read_only`, since answering it \
+             would need a `stat` that a first paint may not perform"
+        );
+    }
+
     #[test]
     fn home_directory_default_home_symbol() {
-        let actual = ModuleRenderer::new("directory")
+        let rendered = ModuleRenderer::new("directory")
             .path(home_dir().unwrap())
             .collect();
-        let expected = Some(format!("{} ", Color::Cyan.bold().paint("~")));
 
-        assert_eq!(expected, actual);
+        assert_snapshot!(RenderedModule::from(rendered), @r#""\u{1b}[1;36m~\u{1b}[0m ""#);
     }
 
     #[test]
     fn home_directory_custom_home_symbol() {
-        let actual = ModuleRenderer::new("directory")
+        let rendered = ModuleRenderer::new("directory")
             .path(home_dir().unwrap())
             .config(toml::toml! {
                 [directory]
                 home_symbol = "🚀"
             })
             .collect();
-        let expected = Some(format!(
-            "{} ",
-            Color::Cyan.bold().paint(convert_path_sep("🚀"))
-        ));
 
-        assert_eq!(expected, actual);
+        assert_snapshot!(RenderedModule::from(rendered), @r#""\u{1b}[1;36m🚀\u{1b}[0m ""#);
     }
 
     #[test]
     fn home_directory_custom_home_symbol_subdirectories() {
-        let actual = ModuleRenderer::new("directory")
+        let rendered = ModuleRenderer::new("directory")
             .path(home_dir().unwrap().join("path/subpath"))
             .config(toml::toml! {
                 [directory]
                 home_symbol = "🚀"
             })
             .collect();
-        let expected = Some(format!(
-            "{} ",
-            Color::Cyan
-                .bold()
-                .paint(convert_path_sep("🚀/path/subpath"))
-        ));
 
-        assert_eq!(expected, actual);
+        assert_snapshot!(RenderedModule::from(rendered), @r#""\u{1b}[1;36m🚀/path/subpath\u{1b}[0m ""#);
     }
 
     #[test]
     fn substituted_truncated_path() {
-        let actual = ModuleRenderer::new("directory")
+        let rendered = ModuleRenderer::new("directory")
             .path("/some/long/network/path/workspace/a/b/c/dev")
             .config(toml::toml! {
                 [directory]
@@ -679,19 +743,13 @@ mod tests {
                 "a/b/c" = "d"
             })
             .collect();
-        let expected = Some(format!(
-            "{} ",
-            Color::Cyan
-                .bold()
-                .paint(convert_path_sep("net/workspace/d/dev"))
-        ));
 
-        assert_eq!(expected, actual);
+        assert_snapshot!(RenderedModule::from(rendered), @r#""\u{1b}[1;36mnet/workspace/d/dev\u{1b}[0m ""#);
     }
 
     #[test]
     fn substitution_order() {
-        let actual = ModuleRenderer::new("directory")
+        let rendered = ModuleRenderer::new("directory")
             .path("/path/to/sub")
             .config(toml::toml! {
                 [directory.substitutions]
@@ -699,18 +757,14 @@ mod tests {
                 "/to/sub" = "/wrong/order"
             })
             .collect();
-        let expected = Some(format!(
-            "{} ",
-            Color::Cyan.bold().paint(convert_path_sep("/correct/order"))
-        ));
 
-        assert_eq!(expected, actual);
+        assert_snapshot!(RenderedModule::from(rendered), @r#""\u{1b}[1;36m/correct/order\u{1b}[0m ""#);
     }
 
     #[test]
     fn strange_substitution() {
         let strange_sub = "/\\/;,!";
-        let actual = ModuleRenderer::new("directory")
+        let rendered = ModuleRenderer::new("directory")
             .path("/foo/bar/regular/path")
             .config(toml::toml! {
                 [directory]
@@ -720,66 +774,42 @@ mod tests {
                 "regular" = strange_sub
             })
             .collect();
-        let expected = Some(format!(
-            "{} ",
-            Color::Cyan
-                .bold()
-                .paint(convert_path_sep(&format!("/foo/bar/{strange_sub}/path")))
-        ));
 
-        assert_eq!(expected, actual);
+        assert_snapshot!(RenderedModule::from(rendered), @r#""\u{1b}[1;36m/foo/bar//\\/;,!/path\u{1b}[0m ""#);
+    }
+
+    /// Split into one test per starting path so a break in one doesn't hide the other.
+    fn render_with_regex_substitutions(path: &str) -> RenderedModule {
+        ModuleRenderer::new("directory")
+            .path(path)
+            .config(toml::toml! {
+                [directory]
+                format = "[$path]($style)"
+                substitutions = [
+                    { from = "~/Documents", to = "docs"},
+                    { from = "^/", to = "<root>/", regex = true},
+                    { from = "/", to = " | "},
+                    { from = "^<root>", to = "/", regex = true},
+                ]
+            })
+            .collect()
+            .into()
     }
 
     #[test]
-    fn regex_substitution() {
-        let actual = ModuleRenderer::new("directory")
-            .path("/var/log")
-            .config(toml::toml! {
-                [directory]
-                format = "[$path]($style)"
-                substitutions = [
-                    { from = "~/Documents", to = "docs"},
-                    { from = "^/", to = "<root>/", regex = true},
-                    { from = "/", to = " | "},
-                    { from = "^<root>", to = "/", regex = true},
-                ]
-            })
-            .collect();
-        let expected = Some(format!(
-            "{}",
-            Color::Cyan.bold().paint(convert_path_sep("/ | var | log"))
-        ));
+    fn regex_substitution_on_absolute_path() {
+        assert_snapshot!(render_with_regex_substitutions("/var/log"), @r#""\u{1b}[1;36m/ | var | log\u{1b}[0m""#);
+    }
 
-        assert_eq!(expected, actual);
-
-        let actual = ModuleRenderer::new("directory")
-            .path("~/Documents/var/log")
-            .config(toml::toml! {
-                [directory]
-                format = "[$path]($style)"
-                substitutions = [
-                    { from = "~/Documents", to = "docs"},
-                    { from = "^/", to = "<root>/", regex = true},
-                    { from = "/", to = " | "},
-                    { from = "^<root>", to = "/", regex = true},
-                ]
-            })
-            .collect();
-        let expected = Some(format!(
-            "{}",
-            Color::Cyan
-                .bold()
-                .paint(convert_path_sep("docs | var | log"))
-        ));
-
-        assert_eq!(expected, actual);
+    #[test]
+    fn regex_substitution_on_home_relative_path() {
+        assert_snapshot!(render_with_regex_substitutions("~/Documents/var/log"), @r#""\u{1b}[1;36mdocs | var | log\u{1b}[0m""#);
     }
 
     #[test]
     fn bad_regex_substitution_leaves_path_untouched() {
-        let path = "/var/log";
-        let actual = ModuleRenderer::new("directory")
-            .path(path)
+        let rendered = ModuleRenderer::new("directory")
+            .path("/var/log")
             .config(toml::toml! {
                 [directory]
                 format = "[$path]($style)"
@@ -789,81 +819,64 @@ mod tests {
                 ]
             })
             .collect();
-        let expected = Some(format!(
-            "{}",
-            Color::Cyan.bold().paint(convert_path_sep(path))
-        ));
 
-        assert_eq!(expected, actual);
+        assert_snapshot!(RenderedModule::from(rendered), @r#""\u{1b}[1;36m/var/log\u{1b}[0m""#);
     }
 
-    #[test]
-    fn directory_in_home() -> io::Result<()> {
-        let (tmp_dir, name) = make_known_tempdir(home_dir().unwrap().as_path())?;
-        let dir = tmp_dir.path().join("starship");
-        fs::create_dir_all(&dir)?;
+    #[rstest]
+    fn directory_in_home(home_project: Project) {
+        home_project.create_directory("starship");
 
-        let actual = ModuleRenderer::new("directory").path(dir).collect();
-        let expected = Some(format!(
-            "{} ",
-            Color::Cyan
-                .bold()
-                .paint(convert_path_sep(&format!("~/{name}/starship")))
-        ));
+        let rendered = home_project
+            .renderer("directory")
+            .path(home_project.path().join("starship"))
+            .collect();
 
-        assert_eq!(expected, actual);
-        tmp_dir.close()
+        assert_snapshot!(redact_project_name(&home_project, rendered.into()), @r#""\u{1b}[1;36m~/[PROJECT]/starship\u{1b}[0m ""#);
     }
 
-    #[test]
-    fn truncated_directory_in_home() -> io::Result<()> {
-        let (tmp_dir, name) = make_known_tempdir(home_dir().unwrap().as_path())?;
-        let dir = tmp_dir.path().join("engine/schematics");
-        fs::create_dir_all(&dir)?;
+    #[rstest]
+    fn truncated_directory_in_home(home_project: Project) {
+        home_project.create_directory("engine/schematics");
 
-        let actual = ModuleRenderer::new("directory").path(dir).collect();
-        let expected = Some(format!(
-            "{} ",
-            Color::Cyan
-                .bold()
-                .paint(convert_path_sep(&format!("{name}/engine/schematics")))
-        ));
+        let rendered = home_project
+            .renderer("directory")
+            .path(home_project.path().join("engine/schematics"))
+            .collect();
 
-        assert_eq!(expected, actual);
-        tmp_dir.close()
+        assert_snapshot!(redact_project_name(&home_project, rendered.into()), @r#""\u{1b}[1;36m[PROJECT]/engine/schematics\u{1b}[0m ""#);
     }
 
-    #[test]
-    fn fish_directory_in_home() -> io::Result<()> {
-        let (tmp_dir, name) = make_known_tempdir(home_dir().unwrap().as_path())?;
-        let dir = tmp_dir.path().join("starship/schematics");
-        fs::create_dir_all(&dir)?;
+    /// The project's directory name is itself shortened, so redaction can't apply here.
+    #[rstest]
+    fn fish_directory_in_home(home_project: Project) {
+        home_project.create_directory("starship/schematics");
 
-        let actual = ModuleRenderer::new("directory")
+        let actual = home_project
+            .renderer("directory")
             .config(toml::toml! {
                 [directory]
                 truncation_length = 1
                 fish_style_pwd_dir_length = 2
             })
-            .path(&dir)
+            .path(home_project.path().join("starship/schematics"))
             .collect();
         let expected = Some(format!(
             "{} ",
             Color::Cyan.bold().paint(convert_path_sep(&format!(
                 "~/{}/st/schematics",
-                name.split_at(3).0
+                home_project.directory_name().split_at(3).0
             )))
         ));
 
         assert_eq!(expected, actual);
-        tmp_dir.close()
     }
 
     #[test]
     fn root_directory() {
         // Note: We have disable the read_only settings here due to false positives when running
         // the tests on Windows as a non-admin.
-        let actual = ModuleRenderer::new("directory")
+        let rendered = ModuleRenderer::new("directory")
             .config(toml::toml! {
                 [directory]
                 read_only = ""
@@ -871,39 +884,32 @@ mod tests {
             })
             .path("/")
             .collect();
-        let expected = Some(format!(
-            "{} ",
-            Color::Cyan.bold().paint(convert_path_sep("/"))
-        ));
 
-        assert_eq!(expected, actual);
+        assert_snapshot!(RenderedModule::from(rendered), @r#""\u{1b}[1;36m/\u{1b}[0m ""#);
     }
 
     #[test]
-    fn truncated_directory_in_root() -> io::Result<()> {
-        let (tmp_dir, name) = make_known_tempdir(Path::new("/tmp"))?;
-        let dir = tmp_dir.path().join("thrusters/rocket");
-        fs::create_dir_all(&dir)?;
+    fn truncated_directory_in_root() {
+        let project = Project::inside(Path::new(KNOWN_ROOT));
+        project.create_directory("thrusters/rocket");
 
-        let actual = ModuleRenderer::new("directory").path(dir).collect();
-        let expected = Some(format!(
-            "{} ",
-            Color::Cyan
-                .bold()
-                .paint(convert_path_sep(&format!("{name}/thrusters/rocket")))
-        ));
+        let rendered = project
+            .renderer("directory")
+            .path(project.path().join("thrusters/rocket"))
+            .collect();
 
-        assert_eq!(expected, actual);
-        tmp_dir.close()
+        assert_snapshot!(redact_project_name(&project, rendered.into()), @r#""\u{1b}[1;36m[PROJECT]/thrusters/rocket\u{1b}[0m ""#);
     }
 
+    /// The project's absolute path isn't knowable ahead of time, so derive the expectation.
     #[test]
-    fn truncated_directory_config_large() -> io::Result<()> {
-        let (tmp_dir, _) = make_known_tempdir(Path::new("/tmp"))?;
-        let dir = tmp_dir.path().join("thrusters/rocket");
-        fs::create_dir_all(&dir)?;
+    fn truncated_directory_config_large() {
+        let project = Project::inside(Path::new(KNOWN_ROOT));
+        project.create_directory("thrusters/rocket");
+        let dir = project.path().join("thrusters/rocket");
 
-        let actual = ModuleRenderer::new("directory")
+        let actual = project
+            .renderer("directory")
             .config(toml::toml! {
                 [directory]
                 truncation_length = 100
@@ -919,16 +925,16 @@ mod tests {
         ));
 
         assert_eq!(expected, actual);
-        tmp_dir.close()
     }
 
     #[test]
-    fn fish_style_directory_config_large() -> io::Result<()> {
-        let (tmp_dir, _) = make_known_tempdir(Path::new("/tmp"))?;
-        let dir = tmp_dir.path().join("thrusters/rocket");
-        fs::create_dir_all(&dir)?;
+    fn fish_style_directory_config_large() {
+        let project = Project::inside(Path::new(KNOWN_ROOT));
+        project.create_directory("thrusters/rocket");
+        let dir = project.path().join("thrusters/rocket");
 
-        let actual = ModuleRenderer::new("directory")
+        let actual = project
+            .renderer("directory")
             .config(toml::toml! {
                 [directory]
                 truncation_length = 1
@@ -946,40 +952,33 @@ mod tests {
         ));
 
         assert_eq!(expected, actual);
-        tmp_dir.close()
     }
 
     #[test]
-    fn truncated_directory_config_small() -> io::Result<()> {
-        let (tmp_dir, name) = make_known_tempdir(Path::new("/tmp"))?;
-        let dir = tmp_dir.path().join("rocket");
-        fs::create_dir_all(&dir)?;
+    fn truncated_directory_config_small() {
+        let project = Project::inside(Path::new(KNOWN_ROOT));
+        project.create_directory("rocket");
 
-        let actual = ModuleRenderer::new("directory")
+        let rendered = project
+            .renderer("directory")
             .config(toml::toml! {
                 [directory]
                 truncation_length = 2
             })
-            .path(dir)
+            .path(project.path().join("rocket"))
             .collect();
-        let expected = Some(format!(
-            "{} ",
-            Color::Cyan
-                .bold()
-                .paint(convert_path_sep(&format!("{name}/rocket")))
-        ));
 
-        assert_eq!(expected, actual);
-        tmp_dir.close()
+        assert_snapshot!(redact_project_name(&project, rendered.into()), @r#""\u{1b}[1;36m[PROJECT]/rocket\u{1b}[0m ""#);
     }
 
     #[test]
-    fn fish_directory_config_small() -> io::Result<()> {
-        let (tmp_dir, _) = make_known_tempdir(Path::new("/tmp"))?;
-        let dir = tmp_dir.path().join("thrusters/rocket");
-        fs::create_dir_all(&dir)?;
+    fn fish_directory_config_small() {
+        let project = Project::inside(Path::new(KNOWN_ROOT));
+        project.create_directory("thrusters/rocket");
+        let dir = project.path().join("thrusters/rocket");
 
-        let actual = ModuleRenderer::new("directory")
+        let actual = project
+            .renderer("directory")
             .config(toml::toml! {
                 [directory]
                 truncation_length = 2
@@ -996,110 +995,105 @@ mod tests {
         ));
 
         assert_eq!(expected, actual);
-        tmp_dir.close()
     }
 
-    #[test]
-    #[ignore]
-    fn git_repo_root() -> io::Result<()> {
-        let tmp_dir = TempDir::new()?;
-        let repo_dir = tmp_dir.path().join("rocket-controls");
-        fs::create_dir(&repo_dir)?;
-        init_repo(&repo_dir).unwrap();
+    /// One case per reference backend, so an unrecognized one is named by the failing test.
+    #[rstest]
+    fn directory_in_repository_fixture_contracts_to_repository_root(
+        #[values(FixtureProvider::GIT, FixtureProvider::GIT_REFTABLE)] provider: FixtureProvider,
+    ) {
+        let repository = Project::from_repository_fixture(provider);
+        repository.create_directory("meters/fuel-gauge");
 
-        let actual = ModuleRenderer::new("directory").path(repo_dir).collect();
-        let expected = Some(format!(
+        let rendered = repository
+            .renderer("directory")
+            .path(repository.path().join("meters/fuel-gauge"))
+            .collect();
+
+        let expected = RenderedModule::Styled(format!(
             "{} ",
-            Color::Cyan
-                .bold()
-                .paint(convert_path_sep("rocket-controls"))
+            Color::Cyan.bold().paint(convert_path_sep(&format!(
+                "{}/meters/fuel-gauge",
+                repository.directory_name()
+            )))
         ));
 
-        assert_eq!(expected, actual);
-        tmp_dir.close()
+        assert_eq!(RenderedModule::from(rendered), expected);
     }
 
-    #[test]
+    #[rstest]
     #[ignore]
-    fn directory_in_git_repo() -> io::Result<()> {
-        let tmp_dir = TempDir::new()?;
-        let repo_dir = tmp_dir.path().join("rocket-controls");
-        let dir = repo_dir.join("src");
-        fs::create_dir_all(&dir)?;
-        init_repo(&repo_dir).unwrap();
+    fn git_repo_root(project: Project) {
+        let repo_dir = project.path().join("rocket-controls");
+        project.create_directory("rocket-controls");
+        init_repo(&repo_dir);
 
-        let actual = ModuleRenderer::new("directory").path(dir).collect();
-        let expected = Some(format!(
-            "{} ",
-            Color::Cyan
-                .bold()
-                .paint(convert_path_sep("rocket-controls/src"))
-        ));
+        let rendered = project.renderer("directory").path(repo_dir).collect();
 
-        assert_eq!(expected, actual);
-        tmp_dir.close()
+        assert_snapshot!(RenderedModule::from(rendered), @r#""\u{1b}[1;36mrocket-controls\u{1b}[0m ""#);
     }
 
-    #[test]
+    #[rstest]
     #[ignore]
-    fn truncated_directory_in_git_repo() -> io::Result<()> {
-        let tmp_dir = TempDir::new()?;
-        let repo_dir = tmp_dir.path().join("rocket-controls");
-        let dir = repo_dir.join("src/meters/fuel-gauge");
-        fs::create_dir_all(&dir)?;
-        init_repo(&repo_dir).unwrap();
+    fn directory_in_git_repo(project: Project) {
+        let repo_dir = project.path().join("rocket-controls");
+        project.create_directory("rocket-controls/src");
+        init_repo(&repo_dir);
 
-        let actual = ModuleRenderer::new("directory").path(dir).collect();
-        let expected = Some(format!(
-            "{} ",
-            Color::Cyan
-                .bold()
-                .paint(convert_path_sep("src/meters/fuel-gauge"))
-        ));
+        let rendered = project
+            .renderer("directory")
+            .path(repo_dir.join("src"))
+            .collect();
 
-        assert_eq!(expected, actual);
-        tmp_dir.close()
+        assert_snapshot!(RenderedModule::from(rendered), @r#""\u{1b}[1;36mrocket-controls/src\u{1b}[0m ""#);
     }
 
-    #[test]
+    #[rstest]
     #[ignore]
-    fn directory_in_git_repo_truncate_to_repo_false() -> io::Result<()> {
-        let tmp_dir = TempDir::new()?;
-        let repo_dir = tmp_dir.path().join("above-repo").join("rocket-controls");
-        let dir = repo_dir.join("src/meters/fuel-gauge");
-        fs::create_dir_all(&dir)?;
-        init_repo(&repo_dir).unwrap();
+    fn truncated_directory_in_git_repo(project: Project) {
+        let repo_dir = project.path().join("rocket-controls");
+        project.create_directory("rocket-controls/src/meters/fuel-gauge");
+        init_repo(&repo_dir);
 
-        let actual = ModuleRenderer::new("directory")
+        let rendered = project
+            .renderer("directory")
+            .path(repo_dir.join("src/meters/fuel-gauge"))
+            .collect();
+
+        assert_snapshot!(RenderedModule::from(rendered), @r#""\u{1b}[1;36msrc/meters/fuel-gauge\u{1b}[0m ""#);
+    }
+
+    #[rstest]
+    #[ignore]
+    fn directory_in_git_repo_truncate_to_repo_false(project: Project) {
+        let repo_dir = project.path().join("above-repo").join("rocket-controls");
+        project.create_directory("above-repo/rocket-controls/src/meters/fuel-gauge");
+        init_repo(&repo_dir);
+
+        let rendered = project
+            .renderer("directory")
             .config(toml::toml! {
                 [directory]
                 // Don't truncate the path at all.
                 truncation_length = 5
                 truncate_to_repo = false
             })
-            .path(dir)
+            .path(repo_dir.join("src/meters/fuel-gauge"))
             .collect();
-        let expected = Some(format!(
-            "{} ",
-            Color::Cyan.bold().paint(convert_path_sep(
-                "above-repo/rocket-controls/src/meters/fuel-gauge"
-            ))
-        ));
 
-        assert_eq!(expected, actual);
-        tmp_dir.close()
+        assert_snapshot!(RenderedModule::from(rendered), @r#""\u{1b}[1;36mabove-repo/rocket-controls/src/meters/fuel-gauge\u{1b}[0m ""#);
     }
 
     #[test]
     #[ignore]
-    fn fish_path_directory_in_git_repo_truncate_to_repo_false() -> io::Result<()> {
-        let (tmp_dir, _) = make_known_tempdir(Path::new("/tmp"))?;
-        let repo_dir = tmp_dir.path().join("above-repo").join("rocket-controls");
-        let dir = repo_dir.join("src/meters/fuel-gauge");
-        fs::create_dir_all(&dir)?;
-        init_repo(&repo_dir).unwrap();
+    fn fish_path_directory_in_git_repo_truncate_to_repo_false() {
+        let project = Project::inside(Path::new(KNOWN_ROOT));
+        let repo_dir = project.path().join("above-repo").join("rocket-controls");
+        project.create_directory("above-repo/rocket-controls/src/meters/fuel-gauge");
+        init_repo(&repo_dir);
 
-        let actual = ModuleRenderer::new("directory")
+        let actual = project
+            .renderer("directory")
             .config(toml::toml! {
                 [directory]
                 // Don't truncate the path at all.
@@ -1107,30 +1101,29 @@ mod tests {
                 truncate_to_repo = false
                 fish_style_pwd_dir_length = 1
             })
-            .path(dir)
+            .path(repo_dir.join("src/meters/fuel-gauge"))
             .collect();
         let expected = Some(format!(
             "{} ",
             Color::Cyan.bold().paint(convert_path_sep(&format!(
                 "{}/above-repo/rocket-controls/src/meters/fuel-gauge",
-                to_fish_style(1, &tmp_dir.path().to_slash_lossy(), "")
+                to_fish_style(1, &project.path().to_slash_lossy(), "")
             )))
         ));
 
         assert_eq!(expected, actual);
-        tmp_dir.close()
     }
 
     #[test]
     #[ignore]
-    fn fish_path_directory_in_git_repo_truncate_to_repo_true() -> io::Result<()> {
-        let (tmp_dir, _) = make_known_tempdir(Path::new("/tmp"))?;
-        let repo_dir = tmp_dir.path().join("above-repo").join("rocket-controls");
-        let dir = repo_dir.join("src/meters/fuel-gauge");
-        fs::create_dir_all(&dir)?;
-        init_repo(&repo_dir).unwrap();
+    fn fish_path_directory_in_git_repo_truncate_to_repo_true() {
+        let project = Project::inside(Path::new(KNOWN_ROOT));
+        let repo_dir = project.path().join("above-repo").join("rocket-controls");
+        project.create_directory("above-repo/rocket-controls/src/meters/fuel-gauge");
+        init_repo(&repo_dir);
 
-        let actual = ModuleRenderer::new("directory")
+        let actual = project
+            .renderer("directory")
             .config(toml::toml! {
                 [directory]
                 // `truncate_to_repo = true` should display the truncated path
@@ -1138,174 +1131,134 @@ mod tests {
                 truncate_to_repo = true
                 fish_style_pwd_dir_length = 1
             })
-            .path(dir)
+            .path(repo_dir.join("src/meters/fuel-gauge"))
             .collect();
         let expected = Some(format!(
             "{} ",
             Color::Cyan.bold().paint(convert_path_sep(&format!(
                 "{}/rocket-controls/src/meters/fuel-gauge",
-                to_fish_style(1, &tmp_dir.path().join("above-repo").to_slash_lossy(), "")
+                to_fish_style(1, &project.path().join("above-repo").to_slash_lossy(), "")
             )))
         ));
 
         assert_eq!(expected, actual);
-        tmp_dir.close()
     }
 
     #[test]
     #[ignore]
-    fn directory_in_git_repo_truncate_to_repo_true() -> io::Result<()> {
-        let (tmp_dir, _) = make_known_tempdir(Path::new("/tmp"))?;
-        let repo_dir = tmp_dir.path().join("above-repo").join("rocket-controls");
-        let dir = repo_dir.join("src/meters/fuel-gauge");
-        fs::create_dir_all(&dir)?;
-        init_repo(&repo_dir).unwrap();
+    fn directory_in_git_repo_truncate_to_repo_true() {
+        let project = Project::inside(Path::new(KNOWN_ROOT));
+        let repo_dir = project.path().join("above-repo").join("rocket-controls");
+        project.create_directory("above-repo/rocket-controls/src/meters/fuel-gauge");
+        init_repo(&repo_dir);
 
-        let actual = ModuleRenderer::new("directory")
+        let rendered = project
+            .renderer("directory")
             .config(toml::toml! {
                 [directory]
                 // `truncate_to_repo = true` should display the truncated path
                 truncation_length = 5
                 truncate_to_repo = true
             })
-            .path(dir)
+            .path(repo_dir.join("src/meters/fuel-gauge"))
             .collect();
-        let expected = Some(format!(
-            "{} ",
-            Color::Cyan
-                .bold()
-                .paint(convert_path_sep("rocket-controls/src/meters/fuel-gauge"))
-        ));
 
-        assert_eq!(expected, actual);
-        tmp_dir.close()
+        assert_snapshot!(RenderedModule::from(rendered), @r#""\u{1b}[1;36mrocket-controls/src/meters/fuel-gauge\u{1b}[0m ""#);
     }
 
     #[test]
     #[ignore]
-    fn symlinked_git_repo_root() -> io::Result<()> {
-        let (tmp_dir, _) = make_known_tempdir(Path::new("/tmp"))?;
-        let repo_dir = tmp_dir.path().join("rocket-controls");
-        let symlink_dir = tmp_dir.path().join("rocket-controls-symlink");
-        fs::create_dir(&repo_dir)?;
-        init_repo(&repo_dir).unwrap();
-        symlink(&repo_dir, &symlink_dir)?;
+    fn symlinked_git_repo_root() {
+        let project = Project::inside(Path::new(KNOWN_ROOT));
+        let repo_dir = project.path().join("rocket-controls");
+        let symlink_dir = project.path().join("rocket-controls-symlink");
+        project.create_directory("rocket-controls");
+        init_repo(&repo_dir);
+        symlink(&repo_dir, &symlink_dir).unwrap();
 
-        let actual = ModuleRenderer::new("directory").path(symlink_dir).collect();
-        let expected = Some(format!(
-            "{} ",
-            Color::Cyan
-                .bold()
-                .paint(convert_path_sep("rocket-controls-symlink"))
-        ));
+        let rendered = project.renderer("directory").path(symlink_dir).collect();
 
-        assert_eq!(expected, actual);
-        tmp_dir.close()
+        assert_snapshot!(RenderedModule::from(rendered), @r#""\u{1b}[1;36mrocket-controls-symlink\u{1b}[0m ""#);
     }
 
     #[test]
     #[ignore]
-    fn directory_in_symlinked_git_repo() -> io::Result<()> {
-        let (tmp_dir, _) = make_known_tempdir(Path::new("/tmp"))?;
-        let repo_dir = tmp_dir.path().join("rocket-controls");
-        let src_dir = repo_dir.join("src");
-        let symlink_dir = tmp_dir.path().join("rocket-controls-symlink");
-        let symlink_src_dir = symlink_dir.join("src");
-        fs::create_dir_all(src_dir)?;
-        init_repo(&repo_dir).unwrap();
-        symlink(&repo_dir, &symlink_dir)?;
+    fn directory_in_symlinked_git_repo() {
+        let project = Project::inside(Path::new(KNOWN_ROOT));
+        let repo_dir = project.path().join("rocket-controls");
+        let symlink_dir = project.path().join("rocket-controls-symlink");
+        project.create_directory("rocket-controls/src");
+        init_repo(&repo_dir);
+        symlink(&repo_dir, &symlink_dir).unwrap();
 
-        let actual = ModuleRenderer::new("directory")
-            .path(symlink_src_dir)
+        let rendered = project
+            .renderer("directory")
+            .path(symlink_dir.join("src"))
             .collect();
-        let expected = Some(format!(
-            "{} ",
-            Color::Cyan
-                .bold()
-                .paint(convert_path_sep("rocket-controls-symlink/src"))
-        ));
 
-        assert_eq!(expected, actual);
-        tmp_dir.close()
+        assert_snapshot!(RenderedModule::from(rendered), @r#""\u{1b}[1;36mrocket-controls-symlink/src\u{1b}[0m ""#);
     }
 
     #[test]
     #[ignore]
-    fn truncated_directory_in_symlinked_git_repo() -> io::Result<()> {
-        let (tmp_dir, _) = make_known_tempdir(Path::new("/tmp"))?;
-        let repo_dir = tmp_dir.path().join("rocket-controls");
-        let src_dir = repo_dir.join("src/meters/fuel-gauge");
-        let symlink_dir = tmp_dir.path().join("rocket-controls-symlink");
-        let symlink_src_dir = symlink_dir.join("src/meters/fuel-gauge");
-        fs::create_dir_all(src_dir)?;
-        init_repo(&repo_dir).unwrap();
-        symlink(&repo_dir, &symlink_dir)?;
+    fn truncated_directory_in_symlinked_git_repo() {
+        let project = Project::inside(Path::new(KNOWN_ROOT));
+        let repo_dir = project.path().join("rocket-controls");
+        let symlink_dir = project.path().join("rocket-controls-symlink");
+        project.create_directory("rocket-controls/src/meters/fuel-gauge");
+        init_repo(&repo_dir);
+        symlink(&repo_dir, &symlink_dir).unwrap();
 
-        let actual = ModuleRenderer::new("directory")
-            .path(symlink_src_dir)
+        let rendered = project
+            .renderer("directory")
+            .path(symlink_dir.join("src/meters/fuel-gauge"))
             .collect();
-        let expected = Some(format!(
-            "{} ",
-            Color::Cyan
-                .bold()
-                .paint(convert_path_sep("src/meters/fuel-gauge"))
-        ));
 
-        assert_eq!(expected, actual);
-        tmp_dir.close()
+        assert_snapshot!(RenderedModule::from(rendered), @r#""\u{1b}[1;36msrc/meters/fuel-gauge\u{1b}[0m ""#);
     }
 
     #[test]
     #[ignore]
-    fn directory_in_symlinked_git_repo_truncate_to_repo_false() -> io::Result<()> {
-        let (tmp_dir, _) = make_known_tempdir(Path::new("/tmp"))?;
-        let repo_dir = tmp_dir.path().join("above-repo").join("rocket-controls");
-        let src_dir = repo_dir.join("src/meters/fuel-gauge");
-        let symlink_dir = tmp_dir
+    fn directory_in_symlinked_git_repo_truncate_to_repo_false() {
+        let project = Project::inside(Path::new(KNOWN_ROOT));
+        let repo_dir = project.path().join("above-repo").join("rocket-controls");
+        let symlink_dir = project
             .path()
             .join("above-repo")
             .join("rocket-controls-symlink");
-        let symlink_src_dir = symlink_dir.join("src/meters/fuel-gauge");
-        fs::create_dir_all(src_dir)?;
-        init_repo(&repo_dir).unwrap();
-        symlink(&repo_dir, &symlink_dir)?;
+        project.create_directory("above-repo/rocket-controls/src/meters/fuel-gauge");
+        init_repo(&repo_dir);
+        symlink(&repo_dir, &symlink_dir).unwrap();
 
-        let actual = ModuleRenderer::new("directory")
+        let rendered = project
+            .renderer("directory")
             .config(toml::toml! {
                 [directory]
                 // Don't truncate the path at all.
                 truncation_length = 5
                 truncate_to_repo = false
             })
-            .path(symlink_src_dir)
+            .path(symlink_dir.join("src/meters/fuel-gauge"))
             .collect();
-        let expected = Some(format!(
-            "{} ",
-            Color::Cyan.bold().paint(convert_path_sep(
-                "above-repo/rocket-controls-symlink/src/meters/fuel-gauge"
-            ))
-        ));
 
-        assert_eq!(expected, actual);
-        tmp_dir.close()
+        assert_snapshot!(RenderedModule::from(rendered), @r#""\u{1b}[1;36mabove-repo/rocket-controls-symlink/src/meters/fuel-gauge\u{1b}[0m ""#);
     }
 
     #[test]
     #[ignore]
-    fn fish_path_directory_in_symlinked_git_repo_truncate_to_repo_false() -> io::Result<()> {
-        let (tmp_dir, _) = make_known_tempdir(Path::new("/tmp"))?;
-        let repo_dir = tmp_dir.path().join("above-repo").join("rocket-controls");
-        let src_dir = repo_dir.join("src/meters/fuel-gauge");
-        let symlink_dir = tmp_dir
+    fn fish_path_directory_in_symlinked_git_repo_truncate_to_repo_false() {
+        let project = Project::inside(Path::new(KNOWN_ROOT));
+        let repo_dir = project.path().join("above-repo").join("rocket-controls");
+        let symlink_dir = project
             .path()
             .join("above-repo")
             .join("rocket-controls-symlink");
-        let symlink_src_dir = symlink_dir.join("src/meters/fuel-gauge");
-        fs::create_dir_all(src_dir)?;
-        init_repo(&repo_dir).unwrap();
-        symlink(&repo_dir, &symlink_dir)?;
+        project.create_directory("above-repo/rocket-controls/src/meters/fuel-gauge");
+        init_repo(&repo_dir);
+        symlink(&repo_dir, &symlink_dir).unwrap();
 
-        let actual = ModuleRenderer::new("directory")
+        let actual = project
+            .renderer("directory")
             .config(toml::toml! {
                 [directory]
                 // Don't truncate the path at all.
@@ -1313,36 +1266,34 @@ mod tests {
                 truncate_to_repo = false
                 fish_style_pwd_dir_length = 1
             })
-            .path(symlink_src_dir)
+            .path(symlink_dir.join("src/meters/fuel-gauge"))
             .collect();
         let expected = Some(format!(
             "{} ",
             Color::Cyan.bold().paint(convert_path_sep(&format!(
                 "{}/above-repo/rocket-controls-symlink/src/meters/fuel-gauge",
-                to_fish_style(1, &tmp_dir.path().to_slash_lossy(), "")
+                to_fish_style(1, &project.path().to_slash_lossy(), "")
             )))
         ));
 
         assert_eq!(expected, actual);
-        tmp_dir.close()
     }
 
     #[test]
     #[ignore]
-    fn fish_path_directory_in_symlinked_git_repo_truncate_to_repo_true() -> io::Result<()> {
-        let (tmp_dir, _) = make_known_tempdir(Path::new("/tmp"))?;
-        let repo_dir = tmp_dir.path().join("above-repo").join("rocket-controls");
-        let src_dir = repo_dir.join("src/meters/fuel-gauge");
-        let symlink_dir = tmp_dir
+    fn fish_path_directory_in_symlinked_git_repo_truncate_to_repo_true() {
+        let project = Project::inside(Path::new(KNOWN_ROOT));
+        let repo_dir = project.path().join("above-repo").join("rocket-controls");
+        let symlink_dir = project
             .path()
             .join("above-repo")
             .join("rocket-controls-symlink");
-        let symlink_src_dir = symlink_dir.join("src/meters/fuel-gauge");
-        fs::create_dir_all(src_dir)?;
-        init_repo(&repo_dir).unwrap();
-        symlink(&repo_dir, &symlink_dir)?;
+        project.create_directory("above-repo/rocket-controls/src/meters/fuel-gauge");
+        init_repo(&repo_dir);
+        symlink(&repo_dir, &symlink_dir).unwrap();
 
-        let actual = ModuleRenderer::new("directory")
+        let actual = project
+            .renderer("directory")
             .config(toml::toml! {
                 [directory]
                 // `truncate_to_repo = true` should display the truncated path
@@ -1350,66 +1301,57 @@ mod tests {
                 truncate_to_repo = true
                 fish_style_pwd_dir_length = 1
             })
-            .path(symlink_src_dir)
+            .path(symlink_dir.join("src/meters/fuel-gauge"))
             .collect();
         let expected = Some(format!(
             "{} ",
             Color::Cyan.bold().paint(convert_path_sep(&format!(
                 "{}/rocket-controls-symlink/src/meters/fuel-gauge",
-                to_fish_style(1, &tmp_dir.path().join("above-repo").to_slash_lossy(), "")
+                to_fish_style(1, &project.path().join("above-repo").to_slash_lossy(), "")
             )))
         ));
 
         assert_eq!(expected, actual);
-        tmp_dir.close()
     }
 
     #[test]
     #[ignore]
-    fn directory_in_symlinked_git_repo_truncate_to_repo_true() -> io::Result<()> {
-        let (tmp_dir, _) = make_known_tempdir(Path::new("/tmp"))?;
-        let repo_dir = tmp_dir.path().join("above-repo").join("rocket-controls");
-        let src_dir = repo_dir.join("src/meters/fuel-gauge");
-        let symlink_dir = tmp_dir
+    fn directory_in_symlinked_git_repo_truncate_to_repo_true() {
+        let project = Project::inside(Path::new(KNOWN_ROOT));
+        let repo_dir = project.path().join("above-repo").join("rocket-controls");
+        let symlink_dir = project
             .path()
             .join("above-repo")
             .join("rocket-controls-symlink");
-        let symlink_src_dir = symlink_dir.join("src/meters/fuel-gauge");
-        fs::create_dir_all(src_dir)?;
-        init_repo(&repo_dir).unwrap();
-        symlink(&repo_dir, &symlink_dir)?;
+        project.create_directory("above-repo/rocket-controls/src/meters/fuel-gauge");
+        init_repo(&repo_dir);
+        symlink(&repo_dir, &symlink_dir).unwrap();
 
-        let actual = ModuleRenderer::new("directory")
+        let rendered = project
+            .renderer("directory")
             .config(toml::toml! {
                 [directory]
                 // `truncate_to_repo = true` should display the truncated path
                 truncation_length = 5
                 truncate_to_repo = true
             })
-            .path(symlink_src_dir)
+            .path(symlink_dir.join("src/meters/fuel-gauge"))
             .collect();
-        let expected = Some(format!(
-            "{} ",
-            Color::Cyan.bold().paint(convert_path_sep(
-                "rocket-controls-symlink/src/meters/fuel-gauge"
-            ))
-        ));
 
-        assert_eq!(expected, actual);
-        tmp_dir.close()
+        assert_snapshot!(RenderedModule::from(rendered), @r#""\u{1b}[1;36mrocket-controls-symlink/src/meters/fuel-gauge\u{1b}[0m ""#);
     }
 
     #[test]
     #[ignore]
-    fn symlinked_directory_in_git_repo() -> io::Result<()> {
-        let (tmp_dir, _) = make_known_tempdir(Path::new("/tmp"))?;
-        let repo_dir = tmp_dir.path().join("rocket-controls");
-        let dir = repo_dir.join("src");
-        fs::create_dir_all(&dir)?;
-        init_repo(&repo_dir).unwrap();
-        symlink(&dir, repo_dir.join("src/loop"))?;
+    fn symlinked_directory_in_git_repo() {
+        let project = Project::inside(Path::new(KNOWN_ROOT));
+        let repo_dir = project.path().join("rocket-controls");
+        project.create_directory("rocket-controls/src");
+        init_repo(&repo_dir);
+        symlink(repo_dir.join("src"), repo_dir.join("src/loop")).unwrap();
 
-        let actual = ModuleRenderer::new("directory")
+        let rendered = project
+            .renderer("directory")
             .config(toml::toml! {
                 [directory]
                 // `truncate_to_repo = true` should display the truncated path
@@ -1418,20 +1360,13 @@ mod tests {
             })
             .path(repo_dir.join("src/loop/loop"))
             .collect();
-        let expected = Some(format!(
-            "{} ",
-            Color::Cyan
-                .bold()
-                .paint(convert_path_sep("rocket-controls/src/loop/loop"))
-        ));
 
-        assert_eq!(expected, actual);
-        tmp_dir.close()
+        assert_snapshot!(RenderedModule::from(rendered), @r#""\u{1b}[1;36mrocket-controls/src/loop/loop\u{1b}[0m ""#);
     }
 
     #[test]
     fn truncation_symbol_truncated_root() {
-        let actual = ModuleRenderer::new("directory")
+        let rendered = ModuleRenderer::new("directory")
             .config(toml::toml! {
                 [directory]
                 truncation_length = 3
@@ -1439,18 +1374,13 @@ mod tests {
             })
             .path(Path::new("/a/four/element/path"))
             .collect();
-        let expected = Some(format!(
-            "{} ",
-            Color::Cyan
-                .bold()
-                .paint(convert_path_sep("…/four/element/path"))
-        ));
-        assert_eq!(expected, actual);
+
+        assert_snapshot!(RenderedModule::from(rendered), @r#""\u{1b}[1;36m…/four/element/path\u{1b}[0m ""#);
     }
 
     #[test]
     fn truncation_symbol_not_truncated_root() {
-        let actual = ModuleRenderer::new("directory")
+        let rendered = ModuleRenderer::new("directory")
             .config(toml::toml! {
                 [directory]
                 truncation_length = 4
@@ -1458,113 +1388,84 @@ mod tests {
             })
             .path(Path::new("/a/four/element/path"))
             .collect();
-        let expected = Some(format!(
-            "{} ",
-            Color::Cyan
-                .bold()
-                .paint(convert_path_sep("/a/four/element/path"))
-        ));
-        assert_eq!(expected, actual);
+
+        assert_snapshot!(RenderedModule::from(rendered), @r#""\u{1b}[1;36m/a/four/element/path\u{1b}[0m ""#);
     }
 
-    #[test]
-    fn truncation_symbol_truncated_home() -> io::Result<()> {
-        let (tmp_dir, name) = make_known_tempdir(home_dir().unwrap().as_path())?;
-        let dir = tmp_dir.path().join("a/subpath");
-        fs::create_dir_all(&dir)?;
+    #[rstest]
+    fn truncation_symbol_truncated_home(home_project: Project) {
+        home_project.create_directory("a/subpath");
 
-        let actual = ModuleRenderer::new("directory")
+        let rendered = home_project
+            .renderer("directory")
             .config(toml::toml! {
                 [directory]
                 truncation_length = 3
                 truncation_symbol = "…/"
             })
-            .path(dir)
+            .path(home_project.path().join("a/subpath"))
             .collect();
-        let expected = Some(format!(
-            "{} ",
-            Color::Cyan
-                .bold()
-                .paint(convert_path_sep(&format!("…/{name}/a/subpath")))
-        ));
-        assert_eq!(expected, actual);
-        tmp_dir.close()
+
+        assert_snapshot!(redact_project_name(&home_project, rendered.into()), @r#""\u{1b}[1;36m…/[PROJECT]/a/subpath\u{1b}[0m ""#);
     }
 
-    #[test]
-    fn truncation_symbol_not_truncated_home() -> io::Result<()> {
-        let (tmp_dir, name) = make_known_tempdir(home_dir().unwrap().as_path())?;
-        let dir = tmp_dir.path().join("a/subpath");
-        fs::create_dir_all(&dir)?;
+    #[rstest]
+    fn truncation_symbol_not_truncated_home(home_project: Project) {
+        home_project.create_directory("a/subpath");
 
-        let actual = ModuleRenderer::new("directory")
+        let rendered = home_project
+            .renderer("directory")
             .config(toml::toml! {
                 [directory]
                 truncate_to_repo = false // Necessary if homedir is a git repo
                 truncation_length = 4
                 truncation_symbol = "…/"
             })
-            .path(dir)
+            .path(home_project.path().join("a/subpath"))
             .collect();
-        let expected = Some(format!(
-            "{} ",
-            Color::Cyan
-                .bold()
-                .paint(convert_path_sep(&format!("~/{name}/a/subpath")))
-        ));
-        assert_eq!(expected, actual);
-        tmp_dir.close()
+
+        assert_snapshot!(redact_project_name(&home_project, rendered.into()), @r#""\u{1b}[1;36m~/[PROJECT]/a/subpath\u{1b}[0m ""#);
     }
 
     #[test]
-    fn truncation_symbol_truncated_in_repo() -> io::Result<()> {
-        let (tmp_dir, _) = make_known_tempdir(Path::new("/tmp"))?;
-        let repo_dir = tmp_dir.path().join("above").join("repo");
-        let dir = repo_dir.join("src/sub/path");
-        fs::create_dir_all(&dir)?;
-        init_repo(&repo_dir).unwrap();
+    fn truncation_symbol_truncated_in_repo() {
+        let project = Project::inside(Path::new(KNOWN_ROOT));
+        let repo_dir = project.path().join("above").join("repo");
+        project.create_directory("above/repo/src/sub/path");
+        init_repo(&repo_dir);
 
-        let actual = ModuleRenderer::new("directory")
+        let rendered = project
+            .renderer("directory")
             .config(toml::toml! {
                 [directory]
                 truncation_length = 3
                 truncation_symbol = "…/"
             })
-            .path(dir)
+            .path(repo_dir.join("src/sub/path"))
             .collect();
-        let expected = Some(format!(
-            "{} ",
-            Color::Cyan.bold().paint(convert_path_sep("…/src/sub/path"))
-        ));
-        assert_eq!(expected, actual);
-        tmp_dir.close()
+
+        assert_snapshot!(RenderedModule::from(rendered), @r#""\u{1b}[1;36m…/src/sub/path\u{1b}[0m ""#);
     }
 
     #[test]
-    fn truncation_symbol_not_truncated_in_repo() -> io::Result<()> {
-        let (tmp_dir, _) = make_known_tempdir(Path::new("/tmp"))?;
-        let repo_dir = tmp_dir.path().join("above").join("repo");
-        let dir = repo_dir.join("src/sub/path");
-        fs::create_dir_all(&dir)?;
-        init_repo(&repo_dir).unwrap();
+    fn truncation_symbol_not_truncated_in_repo() {
+        let project = Project::inside(Path::new(KNOWN_ROOT));
+        let repo_dir = project.path().join("above").join("repo");
+        project.create_directory("above/repo/src/sub/path");
+        init_repo(&repo_dir);
 
-        let actual = ModuleRenderer::new("directory")
+        let rendered = project
+            .renderer("directory")
             .config(toml::toml! {
                 [directory]
                 truncation_length = 5
                 truncation_symbol = "…/"
                 truncate_to_repo = true
             })
-            .path(dir)
+            .path(repo_dir.join("src/sub/path"))
             .collect();
-        let expected = Some(format!(
-            "{} ",
-            Color::Cyan
-                .bold()
-                .paint(convert_path_sep("…/repo/src/sub/path"))
-        ));
-        assert_eq!(expected, actual);
-        tmp_dir.close()
+
+        assert_snapshot!(RenderedModule::from(rendered), @r#""\u{1b}[1;36m…/repo/src/sub/path\u{1b}[0m ""#);
     }
 
     #[test]
@@ -1624,60 +1525,41 @@ mod tests {
         assert_eq!(expected, actual);
     }
 
-    #[test]
-    fn use_logical_path_true_should_render_logical_dir_path() -> io::Result<()> {
-        let tmp_dir = TempDir::new()?;
-        let path = tmp_dir.path().join("src/meters/fuel-gauge");
-        fs::create_dir_all(&path)?;
-        let logical_path = "Logical:/fuel-gauge";
+    #[rstest]
+    fn use_logical_path_true_should_render_logical_dir_path(project: Project) {
+        project.create_directory("src/meters/fuel-gauge");
 
-        let expected = Some(format!(
-            "{} ",
-            Color::Cyan
-                .bold()
-                .paint(convert_path_sep("Logical:/fuel-gauge"))
-        ));
-
-        let actual = ModuleRenderer::new("directory")
+        let rendered = project
+            .renderer("directory")
             .config(toml::toml! {
                 [directory]
                 use_logical_path = true
                 truncation_length = 3
             })
-            .path(path)
-            .logical_path(logical_path)
+            .path(project.path().join("src/meters/fuel-gauge"))
+            .logical_path("Logical:/fuel-gauge")
             .collect();
 
-        assert_eq!(expected, actual);
-        tmp_dir.close()
+        assert_snapshot!(RenderedModule::from(rendered), @r#""\u{1b}[1;36mLogical:/fuel-gauge\u{1b}[0m ""#);
     }
 
-    #[test]
-    fn use_logical_path_false_should_render_current_dir_path() -> io::Result<()> {
-        let tmp_dir = TempDir::new()?;
-        let path = tmp_dir.path().join("src/meters/fuel-gauge");
-        fs::create_dir_all(&path)?;
-        let logical_path = "Logical:/fuel-gauge";
+    #[rstest]
+    fn use_logical_path_false_should_render_current_dir_path(project: Project) {
+        project.create_directory("src/meters/fuel-gauge");
 
-        let expected = Some(format!(
-            "{} ",
-            Color::Cyan
-                .bold()
-                .paint(convert_path_sep("src/meters/fuel-gauge"))
-        ));
-
-        let actual = ModuleRenderer::new("directory")
+        let rendered = project
+            .renderer("directory")
             .config(toml::toml! {
                 [directory]
                 use_logical_path = false
                 truncation_length = 3
             })
-            .path(path)
-            .logical_path(logical_path) // logical_path should be ignored
+            .path(project.path().join("src/meters/fuel-gauge"))
+            // The logical path should be ignored.
+            .logical_path("Logical:/fuel-gauge")
             .collect();
 
-        assert_eq!(expected, actual);
-        tmp_dir.close()
+        assert_snapshot!(RenderedModule::from(rendered), @r#""\u{1b}[1;36msrc/meters/fuel-gauge\u{1b}[0m ""#);
     }
 
     #[test]
@@ -1739,41 +1621,35 @@ mod tests {
     }
 
     #[test]
-    fn highlight_git_root_dir() -> io::Result<()> {
-        let (tmp_dir, _) = make_known_tempdir(Path::new("/tmp"))?;
-        let repo_dir = tmp_dir.path().join("above").join("repo");
-        let dir = repo_dir.join("src/sub/path");
-        fs::create_dir_all(&dir)?;
-        init_repo(&repo_dir).unwrap();
+    fn highlight_git_root_dir() {
+        let project = Project::inside(Path::new(KNOWN_ROOT));
+        let repo_dir = project.path().join("above").join("repo");
+        project.create_directory("above/repo/src/sub/path");
+        init_repo(&repo_dir);
 
-        let actual = ModuleRenderer::new("directory")
+        let rendered = project
+            .renderer("directory")
             .config(toml::toml! {
                 [directory]
                 truncation_length = 5
                 truncate_to_repo = true
                 repo_root_style = "bold red"
             })
-            .path(dir)
+            .path(repo_dir.join("src/sub/path"))
             .collect();
-        let expected = Some(format!(
-            "{}{}repo{} ",
-            Color::Cyan.bold().prefix(),
-            Color::Red.prefix(),
-            Color::Cyan.paint(convert_path_sep("/src/sub/path"))
-        ));
-        assert_eq!(expected, actual);
-        tmp_dir.close()
+
+        assert_snapshot!(RenderedModule::from(rendered), @r#""\u{1b}[1;36m\u{1b}[31mrepo\u{1b}[36m/src/sub/path\u{1b}[0m ""#);
     }
 
     #[test]
-    fn highlight_git_root_dir_config_change() -> io::Result<()> {
-        let (tmp_dir, _) = make_known_tempdir(Path::new("/tmp"))?;
-        let repo_dir = tmp_dir.path().join("above").join("repo");
-        let dir = repo_dir.join("src/sub/path");
-        fs::create_dir_all(&dir)?;
-        init_repo(&repo_dir).unwrap();
+    fn highlight_git_root_dir_config_change() {
+        let project = Project::inside(Path::new(KNOWN_ROOT));
+        let repo_dir = project.path().join("above").join("repo");
+        project.create_directory("above/repo/src/sub/path");
+        init_repo(&repo_dir);
 
-        let actual = ModuleRenderer::new("directory")
+        let rendered = project
+            .renderer("directory")
             .config(toml::toml! {
                 [directory]
                 truncation_length = 5
@@ -1782,46 +1658,40 @@ mod tests {
                 repo_root_style = "green"
                 before_repo_root_style = "blue"
             })
-            .path(dir)
+            .path(repo_dir.join("src/sub/path"))
             .collect();
-        let expected = Some(format!(
-            "{}{}{}repo{} ",
-            Color::Blue.prefix(),
-            convert_path_sep("…/above/"),
-            Color::Green.prefix(),
-            Color::Cyan.bold().paint(convert_path_sep("/src/sub/path"))
-        ));
-        assert_eq!(expected, actual);
-        tmp_dir.close()
+
+        assert_snapshot!(RenderedModule::from(rendered), @r#""\u{1b}[34m…/above/\u{1b}[32mrepo\u{1b}[1;36m/src/sub/path\u{1b}[0m ""#);
     }
 
+    /// The project's absolute path isn't knowable ahead of time, so it can't be snapshotted.
     #[test]
-    fn highlight_git_root_dir_zero_truncation_length() -> io::Result<()> {
-        let (tmp_dir, _) = make_known_tempdir(Path::new("/tmp"))?;
-        let repo_dir = tmp_dir.path().join("above").join("repo");
-        let dir = repo_dir.join("src/sub/path");
-        fs::create_dir_all(&dir)?;
-        init_repo(&repo_dir).unwrap();
+    fn highlight_git_root_dir_zero_truncation_length() {
+        let project = Project::inside(Path::new(KNOWN_ROOT));
+        let repo_dir = project.path().join("above").join("repo");
+        project.create_directory("above/repo/src/sub/path");
+        init_repo(&repo_dir);
 
-        let actual = ModuleRenderer::new("directory")
+        let actual = project
+            .renderer("directory")
             .config(toml::toml! {
                 [directory]
                 truncation_length = 0
                 truncate_to_repo = false
                 repo_root_style = "green"
             })
-            .path(dir)
+            .path(repo_dir.join("src/sub/path"))
             .collect();
         let expected = Some(format!(
             "{}{}repo{} ",
             Color::Cyan.bold().paint(convert_path_sep(
-                tmp_dir.path().join("above/").to_str().unwrap()
+                project.path().join("above/").to_str().unwrap()
             )),
             Color::Green.prefix(),
             Color::Cyan.bold().paint(convert_path_sep("/src/sub/path"))
         ));
+
         assert_eq!(expected, actual);
-        tmp_dir.close()
     }
 
     // sample for invalid unicode from https://doc.rust-lang.org/std/ffi/struct.OsStr.html#method.to_string_lossy
@@ -1867,43 +1737,32 @@ mod tests {
         assert_eq!(expected, actual);
     }
 
-    #[test]
-    fn use_os_path_sep_false() -> io::Result<()> {
-        let (tmp_dir, name) = make_known_tempdir(home_dir().unwrap().as_path())?;
-        let dir = tmp_dir.path().join("starship");
-        fs::create_dir_all(&dir)?;
+    #[rstest]
+    fn use_os_path_sep_false(home_project: Project) {
+        home_project.create_directory("starship");
 
-        let actual = ModuleRenderer::new("directory")
+        let rendered = home_project
+            .renderer("directory")
             .config(toml::toml! {
                 [directory]
                 use_os_path_sep = false
             })
-            .path(dir)
+            .path(home_project.path().join("starship"))
             .collect();
-        let expected = Some(format!(
-            "{} ",
-            Color::Cyan.bold().paint(format!("~/{name}/starship"))
-        ));
 
-        assert_eq!(expected, actual);
-        tmp_dir.close()
+        assert_snapshot!(redact_project_name(&home_project, rendered.into()), @r#""\u{1b}[1;36m~/[PROJECT]/starship\u{1b}[0m ""#);
     }
 
-    #[test]
-    fn parent_and_sub_git_repo_are_in_same_name_folder() {
-        assert_eq!(
-            before_root_dir("~/user/gitrepo/gitrepo", "gitrepo"),
-            "~/user/gitrepo/".to_string()
-        );
-
-        assert_eq!(
-            before_root_dir("~/user/gitrepo-diff/gitrepo", "gitrepo"),
-            "~/user/gitrepo-diff/".to_string()
-        );
-
-        assert_eq!(
-            before_root_dir("~/user/gitrepo-diff/gitrepo", "aaa"),
-            "~/user/gitrepo-diff/gitrepo".to_string()
-        );
+    /// A repository nested in a same-named directory must not confuse the search.
+    #[rstest]
+    #[case::same_name_parent("~/user/gitrepo/gitrepo", "gitrepo", "~/user/gitrepo/")]
+    #[case::similar_name_parent("~/user/gitrepo-diff/gitrepo", "gitrepo", "~/user/gitrepo-diff/")]
+    #[case::absent_root_dir("~/user/gitrepo-diff/gitrepo", "aaa", "~/user/gitrepo-diff/gitrepo")]
+    fn parent_and_sub_git_repo_are_in_same_name_folder(
+        #[case] path: &str,
+        #[case] root_dir: &str,
+        #[case] expected: &str,
+    ) {
+        assert_eq!(before_root_dir(path, root_dir), expected.to_string());
     }
 }

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -118,106 +118,15 @@ pub use self::battery::{BatteryInfoProvider, BatteryInfoProviderImpl};
 use crate::config::ModuleConfig;
 use crate::context::{Context, Detected, Shell};
 use crate::module::Module;
-use std::time::{Duration, Instant};
-
-/// How a module behaves over time, and how expensive it is to produce.
-///
-/// The prompt is rendered incrementally: cheap modules are painted immediately
-/// and expensive ones stream in afterwards. Every module therefore has to
-/// declare which of these it is, so the renderer can decide what to wait for.
-/// See [`cadence`] for the classification of each module.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Cadence {
-    /// No unbounded input/output: no subprocess, no repository discovery, no
-    /// directory scan. Cheap system calls such as `gethostname` are
-    /// acceptable, and so is reading a single file whose path is already
-    /// known *and* is guaranteed to resolve fast — a virtual filesystem such
-    /// as `/proc` or `/run`. A path under the user's home directory is not
-    /// guaranteed fast: it may be a slow or network mount (NFS, SMB, a
-    /// stalled FUSE mount), and a single `open` or `stat` against one can
-    /// block for as long as the mount is stuck, unbounded in exactly the way
-    /// this variant promises not to be.
-    ///
-    /// These modules can be rendered on the critical path of the first paint.
-    Instant,
-    /// Performs unbounded input/output: spawns a subprocess, discovers a
-    /// repository, or scans a directory. The cost is set by the machine and the
-    /// working directory rather than by the module, and a subprocess may run
-    /// all the way to `command_timeout`.
-    Deferred,
-    /// Intrinsically time-varying; a rendered value goes stale on its own and
-    /// must be re-polled to stay correct, even when nothing else changed.
-    Dynamic {
-        /// How long a rendered value stays correct.
-        period: Duration,
-    },
-}
-
-/// The clock shown by the `time` module advances every second at its default
-/// (and finest useful) granularity.
-const TIME_PERIOD: Duration = Duration::from_secs(1);
-
-/// Battery charge moves by well under a percentage point in thirty seconds, and
-/// polling the platform battery service is not free.
-const BATTERY_PERIOD: Duration = Duration::from_secs(30);
-
-/// Memory pressure is the fastest-moving of these values: it can swing across a
-/// configured threshold within seconds of a build starting.
-const MEMORY_USAGE_PERIOD: Duration = Duration::from_secs(5);
-
-/// The local address changes only when the machine changes network, which is
-/// rare but must not go unnoticed for the length of a shell session.
-const LOCALIP_PERIOD: Duration = Duration::from_secs(30);
-
-/// The [`Cadence`] of a module, or `None` if the module is unknown.
-///
-/// A module missing from the registry table has no declared cadence and the
-/// renderer cannot schedule it; `all_modules_have_a_cadence` fails if a module
-/// is added to `ALL_MODULES` without being classified there.
-///
-/// The names accepted here are exactly the names accepted by [`handle`],
-/// including the `env_var.` and `custom.` prefixed forms. See
-/// [`registry::entry_for`] for the classification of each built-in module and
-/// why it is what it is.
-#[must_use]
-pub fn cadence(module: &str) -> Option<Cadence> {
-    registry::cadence(module)
-}
+use std::time::Instant;
 
 /// How a module produces its output.
-///
-/// Most modules produce one value: the value they exist to show, however long
-/// it takes to work out. A module whose real value needs unbounded work may
-/// additionally offer an *instant* one — a value that is correct as far as it
-/// goes, cheap enough to appear in the very first paint, and replaced by the
-/// real value as soon as that resolves.
-///
-/// The default [`Render::instant`] returns nothing, which is what "this module
-/// contributes nothing until it has really resolved" means. Overriding it is
-/// only worthwhile where a blank would be conspicuous; today that is
-/// [`directory::Directory`] alone, because a first paint with no path in it is
-/// not a prompt anyone would recognise.
 pub trait Render {
     /// The module's real value.
     fn full<'context>(&self, context: &'context Context<'_>) -> Option<Module<'context>>;
-
-    /// A value cheap enough to paint before anything slow has resolved, or
-    /// nothing if the module has no such value.
-    ///
-    /// An implementation must not perform unbounded input/output — no
-    /// subprocess, no repository discovery, no directory scan — since this runs
-    /// on the critical path between starting the process and drawing a prompt.
-    fn instant<'context>(&self, context: &'context Context<'_>) -> Option<Module<'context>> {
-        let _ = context;
-        None
-    }
 }
 
-/// The renderer of a module that has no instant approximation of its own.
-///
-/// It inherits [`Render::instant`]'s default. There is deliberately no way to
-/// give a module an instant approximation from here: a module that wants one
-/// declares it next to the rest of its own code, the way `directory` does.
+/// The renderer of a module dispatched purely by name.
 struct DispatchedByName<'name>(&'name str);
 
 impl Render for DispatchedByName<'_> {
@@ -238,18 +147,6 @@ fn with_renderer<T>(module: &str, action: impl FnOnce(&dyn Render) -> T) -> T {
 pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
     timed(module, context, || {
         with_renderer(module, |renderer| renderer.full(context))
-    })
-}
-
-/// Renders `module`'s instant approximation, if it has one, recording how long
-/// it took.
-///
-/// Returns `None` both for a module with no approximation and for one whose
-/// approximation resolved to nothing; the two are the same thing to a caller
-/// painting a prompt, which is why they are not distinguished.
-pub fn instant<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
-    timed(module, context, || {
-        with_renderer(module, |renderer| renderer.instant(context))
     })
 }
 
@@ -312,49 +209,6 @@ mod test {
         for module in ALL_MODULES {
             println!("Checking if {module:?} has a description");
             assert_ne!(description(module), "<no description>");
-        }
-    }
-
-    #[test]
-    fn all_modules_have_a_cadence() {
-        // A module the renderer cannot classify is a module it cannot schedule,
-        // so adding one to `ALL_MODULES` without a cadence must fail here rather
-        // than silently fall back to some default.
-        for module in ALL_MODULES {
-            assert!(
-                cadence(module).is_some(),
-                "module {module:?} has no declared cadence; add it to `cadence`"
-            );
-        }
-    }
-
-    #[test]
-    fn dynamically_named_modules_have_a_cadence() {
-        // These two are dispatched by prefix rather than by name, so they never
-        // appear in `ALL_MODULES` and the check above cannot see them.
-        assert_eq!(cadence("env_var"), Some(Cadence::Instant));
-        assert_eq!(cadence("env_var.SHELL"), Some(Cadence::Instant));
-        assert_eq!(cadence("custom.git_hash"), Some(Cadence::Deferred));
-    }
-
-    #[test]
-    fn an_unknown_module_has_no_cadence() {
-        assert_eq!(cadence("not_a_module"), None);
-        // The prefixed forms only classify the prefixed forms.
-        assert_eq!(cadence("custom"), None);
-    }
-
-    #[test]
-    fn every_dynamic_period_is_usable() {
-        // A zero period would ask the renderer to re-poll without ever making
-        // progress.
-        for module in ALL_MODULES {
-            if let Some(Cadence::Dynamic { period }) = cadence(module) {
-                assert!(
-                    !period.is_zero(),
-                    "module {module:?} declares a zero refresh period"
-                );
-            }
         }
     }
 }

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -50,7 +50,6 @@ mod hg_branch;
 mod hg_state;
 mod hostname;
 mod java;
-mod jj_bookmark;
 mod jobs;
 mod julia;
 mod kotlin;
@@ -111,272 +110,196 @@ mod zig;
 mod battery;
 mod typst;
 
+pub(crate) mod registry;
+
 #[cfg(feature = "battery")]
 pub use self::battery::{BatteryInfoProvider, BatteryInfoProviderImpl};
 
 use crate::config::ModuleConfig;
 use crate::context::{Context, Detected, Shell};
 use crate::module::Module;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
-pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
-    let start: Instant = Instant::now();
-    let mut m: Option<Module> = {
-        match module {
-            // Keep these ordered alphabetically.
-            // Default ordering is handled in configs/starship_root.rs
-            "aws" => aws::module(context),
-            "azure" => azure::module(context),
-            #[cfg(feature = "battery")]
-            "battery" => battery::module(context),
-            "buf" => buf::module(context),
-            "bun" => bun::module(context),
-            "c" => c::module(context),
-            "character" => character::module(context),
-            "claude_context" => claude_context::module(context),
-            "claude_cost" => claude_cost::module(context),
-            "claude_model" => claude_model::module(context),
-            "cmake" => cmake::module(context),
-            "cmd_duration" => cmd_duration::module(context),
-            "cobol" => cobol::module(context),
-            "conda" => conda::module(context),
-            "container" => container::module(context),
-            "cpp" => cpp::module(context),
-            "daml" => daml::module(context),
-            "dart" => dart::module(context),
-            "deno" => deno::module(context),
-            "directory" => directory::module(context),
-            "direnv" => direnv::module(context),
-            "docker_context" => docker_context::module(context),
-            "dotnet" => dotnet::module(context),
-            "elixir" => elixir::module(context),
-            "elm" => elm::module(context),
-            "erlang" => erlang::module(context),
-            "env_var" => env_var::module(None, context),
-            "fennel" => fennel::module(context),
-            "fill" => fill::module(context),
-            "fortran" => fortran::module(context),
-            "fossil_branch" => fossil_branch::module(context),
-            "fossil_metrics" => fossil_metrics::module(context),
-            "gcloud" => gcloud::module(context),
-            "git_branch" => git_branch::module(context),
-            "git_commit" => git_commit::module(context),
-            "git_metrics" => git_metrics::module(context),
-            "git_state" => git_state::module(context),
-            "git_status" => git_status::module(context),
-            "gleam" => gleam::module(context),
-            "golang" => golang::module(context),
-            "gradle" => gradle::module(context),
-            "guix_shell" => guix_shell::module(context),
-            "haskell" => haskell::module(context),
-            "haxe" => haxe::module(context),
-            "helm" => helm::module(context),
-            "hg_branch" => hg_branch::module(context),
-            "hg_state" => hg_state::module(context),
-            "hostname" => hostname::module(context),
-            "java" => java::module(context),
-            "jj_bookmark" => jj_bookmark::module(context),
-            "jobs" => jobs::module(context),
-            "julia" => julia::module(context),
-            "kotlin" => kotlin::module(context),
-            "kubernetes" => kubernetes::module(context),
-            "line_break" => line_break::module(context),
-            "localip" => localip::module(context),
-            "lua" => lua::module(context),
-            "maven" => maven::module(context),
-            "memory_usage" => memory_usage::module(context),
-            "meson" => meson::module(context),
-            "mise" => mise::module(context),
-            "mojo" => mojo::module(context),
-            "nats" => nats::module(context),
-            "netns" => netns::module(context),
-            "nim" => nim::module(context),
-            "nix_shell" => nix_shell::module(context),
-            "nodejs" => nodejs::module(context),
-            "ocaml" => ocaml::module(context),
-            "odin" => odin::module(context),
-            "opa" => opa::module(context),
-            "openstack" => openstack::module(context),
-            "os" => os::module(context),
-            "package" => package::module(context),
-            "perl" => perl::module(context),
-            "php" => php::module(context),
-            "pijul_channel" => pijul_channel::module(context),
-            "pixi" => pixi::module(context),
-            "pulumi" => pulumi::module(context),
-            "purescript" => purescript::module(context),
-            "python" => python::module(context),
-            "quarto" => quarto::module(context),
-            "raku" => raku::module(context),
-            "rlang" => rlang::module(context),
-            "red" => red::module(context),
-            "ruby" => ruby::module(context),
-            "rust" => rust::module(context),
-            "scala" => scala::module(context),
-            "shell" => shell::module(context),
-            "shlvl" => shlvl::module(context),
-            "singularity" => singularity::module(context),
-            "solidity" => solidity::module(context),
-            "spack" => spack::module(context),
-            "swift" => swift::module(context),
-            "status" => status::module(context),
-            "sudo" => sudo::module(context),
-            "terraform" => terraform::module(context),
-            "time" => time::module(context),
-            "typst" => typst::module(context),
-            "crystal" => crystal::module(context),
-            "username" => username::module(context),
-            "vlang" => vlang::module(context),
-            "vagrant" => vagrant::module(context),
-            "vcs" => vcs::module(context),
-            "vcsh" => vcsh::module(context),
-            "xmake" => xmake::module(context),
-            "zig" => zig::module(context),
-            env if env.starts_with("env_var.") => {
-                env_var::module(env.strip_prefix("env_var."), context)
-            }
-            custom if custom.starts_with("custom.") => {
-                // SAFETY: We just checked that the module starts with "custom."
-                custom::module(custom.strip_prefix("custom.").unwrap(), context)
-            }
-            _ => {
-                eprintln!(
-                    "Error: Unknown module {module}. Use starship module --list to list out all supported modules."
-                );
-                None
-            }
-        }
-    };
-
-    let elapsed = start.elapsed();
-    log::trace!("Took {elapsed:?} to compute module {module:?}");
-    if elapsed.as_millis() >= 1 {
-        // If we take less than 1ms to compute a None, then we will not return a module at all
-        // if we have a module: default duration is 0 so no need to change it
-        // if we took more than 1ms we want to report that and so--in case we have None currently--
-        // need to create an empty module just to hold the duration for that case
-        m.get_or_insert_with(|| context.new_module(module)).duration = elapsed;
-    }
-    m
+/// How a module behaves over time, and how expensive it is to produce.
+///
+/// The prompt is rendered incrementally: cheap modules are painted immediately
+/// and expensive ones stream in afterwards. Every module therefore has to
+/// declare which of these it is, so the renderer can decide what to wait for.
+/// See [`cadence`] for the classification of each module.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Cadence {
+    /// No unbounded input/output: no subprocess, no repository discovery, no
+    /// directory scan. Cheap system calls such as `gethostname` are
+    /// acceptable, and so is reading a single file whose path is already
+    /// known *and* is guaranteed to resolve fast — a virtual filesystem such
+    /// as `/proc` or `/run`. A path under the user's home directory is not
+    /// guaranteed fast: it may be a slow or network mount (NFS, SMB, a
+    /// stalled FUSE mount), and a single `open` or `stat` against one can
+    /// block for as long as the mount is stuck, unbounded in exactly the way
+    /// this variant promises not to be.
+    ///
+    /// These modules can be rendered on the critical path of the first paint.
+    Instant,
+    /// Performs unbounded input/output: spawns a subprocess, discovers a
+    /// repository, or scans a directory. The cost is set by the machine and the
+    /// working directory rather than by the module, and a subprocess may run
+    /// all the way to `command_timeout`.
+    Deferred,
+    /// Intrinsically time-varying; a rendered value goes stale on its own and
+    /// must be re-polled to stay correct, even when nothing else changed.
+    Dynamic {
+        /// How long a rendered value stays correct.
+        period: Duration,
+    },
 }
 
-pub fn description(module: &str) -> &'static str {
-    match module {
-        "aws" => "The current AWS region and profile",
-        "azure" => "The current Azure subscription",
-        "battery" => "The current charge of the device's battery and its current charging status",
-        "buf" => "The currently installed version of the Buf CLI",
-        "bun" => "The currently installed version of the Bun",
-        "c" => "Your C compiler type",
-        "character" => {
-            "A character (usually an arrow) beside where the text is entered in your terminal"
-        }
-        "claude_context" => "Context window usage for Claude Code session",
-        "claude_cost" => "Cost info for Claude Code session",
-        "claude_model" => "AI model name for Claude Code session",
-        "cmake" => "The currently installed version of CMake",
-        "cmd_duration" => "How long the last command took to execute",
-        "cobol" => "The currently installed version of COBOL/GNUCOBOL",
-        "conda" => "The current conda environment, if $CONDA_DEFAULT_ENV is set",
-        "container" => "The container indicator, if inside a container.",
-        "cpp" => "your cpp compiler type",
-        "crystal" => "The currently installed version of Crystal",
-        "daml" => "The Daml SDK version of your project",
-        "dart" => "The currently installed version of Dart",
-        "deno" => "The currently installed version of Deno",
-        "directory" => "The current working directory",
-        "direnv" => "The currently applied direnv file",
-        "docker_context" => "The current docker context",
-        "dotnet" => "The relevant version of the .NET Core SDK for the current directory",
-        "elixir" => "The currently installed versions of Elixir and OTP",
-        "elm" => "The currently installed version of Elm",
-        "erlang" => "Current OTP version",
-        "fennel" => "The currently installed version of Fennel",
-        "fill" => "Fills the remaining space on the line with a pad string",
-        "fortran" => "The currently used version of Fortran",
-        "fossil_branch" => "The active branch of the check-out in your current directory",
-        "fossil_metrics" => "The currently added/deleted lines in your check-out",
-        "gcloud" => "The current GCP client configuration",
-        "git_branch" => "The active branch of the current Git repo",
-        "git_commit" => "The active commit (and tag if any) of the current Git repo",
-        "git_metrics" => "The currently added/deleted lines in your Git repo",
-        "git_state" => "The current Git operation, and it's progress",
-        "git_status" => {
-            "Symbols representing the state of the current Git repo, filtered to your current directory"
-        }
-        "gleam" => "The currently installed version of Gleam",
-        "golang" => "The currently installed version of Golang",
-        "gradle" => "The currently installed version of Gradle",
-        "guix_shell" => "The guix-shell environment",
-        "haskell" => "The selected version of the Haskell toolchain",
-        "haxe" => "The currently installed version of Haxe",
-        "helm" => "The currently installed version of Helm",
-        "hg_branch" => "The active branch and topic of the repo in your current directory",
-        "hg_state" => "The current hg operation",
-        "hostname" => "The system hostname",
-        "java" => "The currently installed version of Java",
-        "jj_bookmark" => "The closest ancestor bookmark in Jujutsu",
-        "jobs" => "The current number of jobs running",
-        "julia" => "The currently installed version of Julia",
-        "kotlin" => "The currently installed version of Kotlin",
-        "kubernetes" => "The current Kubernetes context name and, if set, the namespace",
-        "line_break" => "Separates the prompt into two lines",
-        "localip" => "The currently assigned ipv4 address",
-        "lua" => "The currently installed version of Lua",
-        "maven" => "The Maven Wrapper version of the current project",
-        "memory_usage" => "Current system memory and swap usage",
-        "meson" => {
-            "The current Meson environment, if $MESON_DEVENV and $MESON_PROJECT_NAME are set"
-        }
-        "mise" => "The current mise status",
-        "mojo" => "The currently installed version of Mojo",
-        "nats" => "The current NATS context",
-        "netns" => "The current network namespace",
-        "nim" => "The currently installed version of Nim",
-        "nix_shell" => "The nix-shell environment",
-        "nodejs" => "The currently installed version of NodeJS",
-        "ocaml" => "The currently installed version of OCaml",
-        "odin" => "The currently installed version of Odin",
-        "opa" => "The currently installed version of Open Platform Agent",
-        "openstack" => "The current OpenStack cloud and project",
-        "os" => "The current operating system",
-        "package" => "The package version of the current directory's project",
-        "perl" => "The currently installed version of Perl",
-        "php" => "The currently installed version of PHP",
-        "pijul_channel" => "The current channel of the repo in the current directory",
-        "pixi" => {
-            "The currently installed version of Pixi, and the active environment if $PIXI_ENVIRONMENT_NAME is set"
-        }
-        "pulumi" => "The current username, stack, and installed version of Pulumi",
-        "purescript" => "The currently installed version of PureScript",
-        "python" => "The currently installed version of Python",
-        "quarto" => "The current installed version of quarto",
-        "raku" => "The currently installed version of Raku",
-        "red" => "The currently installed version of Red",
-        "rlang" => "The currently installed version of R",
-        "ruby" => "The currently installed version of Ruby",
-        "rust" => "The currently installed version of Rust",
-        "scala" => "The currently installed version of Scala",
-        "shell" => "The currently used shell indicator",
-        "shlvl" => "The current value of SHLVL",
-        "singularity" => "The currently used Singularity image",
-        "solidity" => "The current installed version of Solidity",
-        "spack" => "The current spack environment, if $SPACK_ENV is set",
-        "status" => "The status of the last command",
-        "sudo" => "The sudo credentials are currently cached",
-        "swift" => "The currently installed version of Swift",
-        "terraform" => "The currently selected terraform workspace and version",
-        "time" => "The current local time",
-        "typst" => "The current installed version of typst",
-        "username" => "The active user's username",
-        "vagrant" => "The currently installed version of Vagrant",
-        "vcs" => "The currently active VCS repository (first one matching)",
-        "vcsh" => "The currently active VCSH repository",
-        "vlang" => "The currently installed version of V",
-        "xmake" => "The currently installed version of XMake",
-        "zig" => "The currently installed version of Zig",
-        _ => "<no description>",
+/// The clock shown by the `time` module advances every second at its default
+/// (and finest useful) granularity.
+const TIME_PERIOD: Duration = Duration::from_secs(1);
+
+/// Battery charge moves by well under a percentage point in thirty seconds, and
+/// polling the platform battery service is not free.
+const BATTERY_PERIOD: Duration = Duration::from_secs(30);
+
+/// Memory pressure is the fastest-moving of these values: it can swing across a
+/// configured threshold within seconds of a build starting.
+const MEMORY_USAGE_PERIOD: Duration = Duration::from_secs(5);
+
+/// The local address changes only when the machine changes network, which is
+/// rare but must not go unnoticed for the length of a shell session.
+const LOCALIP_PERIOD: Duration = Duration::from_secs(30);
+
+/// The [`Cadence`] of a module, or `None` if the module is unknown.
+///
+/// A module missing from the registry table has no declared cadence and the
+/// renderer cannot schedule it; `all_modules_have_a_cadence` fails if a module
+/// is added to `ALL_MODULES` without being classified there.
+///
+/// The names accepted here are exactly the names accepted by [`handle`],
+/// including the `env_var.` and `custom.` prefixed forms. See
+/// [`registry::entry_for`] for the classification of each built-in module and
+/// why it is what it is.
+#[must_use]
+pub fn cadence(module: &str) -> Option<Cadence> {
+    registry::cadence(module)
+}
+
+/// How a module produces its output.
+///
+/// Most modules produce one value: the value they exist to show, however long
+/// it takes to work out. A module whose real value needs unbounded work may
+/// additionally offer an *instant* one — a value that is correct as far as it
+/// goes, cheap enough to appear in the very first paint, and replaced by the
+/// real value as soon as that resolves.
+///
+/// The default [`Render::instant`] returns nothing, which is what "this module
+/// contributes nothing until it has really resolved" means. Overriding it is
+/// only worthwhile where a blank would be conspicuous; today that is
+/// [`directory::Directory`] alone, because a first paint with no path in it is
+/// not a prompt anyone would recognise.
+pub trait Render {
+    /// The module's real value.
+    fn full<'context>(&self, context: &'context Context<'_>) -> Option<Module<'context>>;
+
+    /// A value cheap enough to paint before anything slow has resolved, or
+    /// nothing if the module has no such value.
+    ///
+    /// An implementation must not perform unbounded input/output — no
+    /// subprocess, no repository discovery, no directory scan — since this runs
+    /// on the critical path between starting the process and drawing a prompt.
+    fn instant<'context>(&self, context: &'context Context<'_>) -> Option<Module<'context>> {
+        let _ = context;
+        None
     }
+}
+
+/// The renderer of a module that has no instant approximation of its own.
+///
+/// It inherits [`Render::instant`]'s default. There is deliberately no way to
+/// give a module an instant approximation from here: a module that wants one
+/// declares it next to the rest of its own code, the way `directory` does.
+struct DispatchedByName<'name>(&'name str);
+
+impl Render for DispatchedByName<'_> {
+    fn full<'context>(&self, context: &'context Context<'_>) -> Option<Module<'context>> {
+        dispatch(self.0, context)
+    }
+}
+
+/// Runs `action` with the renderer of `module`.
+fn with_renderer<T>(module: &str, action: impl FnOnce(&dyn Render) -> T) -> T {
+    match module {
+        "directory" => action(&directory::Directory),
+        other => action(&DispatchedByName(other)),
+    }
+}
+
+/// Renders `module` in full, recording how long it took.
+pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
+    timed(module, context, || {
+        with_renderer(module, |renderer| renderer.full(context))
+    })
+}
+
+/// Renders `module`'s instant approximation, if it has one, recording how long
+/// it took.
+///
+/// Returns `None` both for a module with no approximation and for one whose
+/// approximation resolved to nothing; the two are the same thing to a caller
+/// painting a prompt, which is why they are not distinguished.
+pub fn instant<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
+    timed(module, context, || {
+        with_renderer(module, |renderer| renderer.instant(context))
+    })
+}
+
+/// Runs one rendering of `module` and records its duration on the result.
+///
+/// A module that took less than a millisecond keeps the default duration of
+/// zero, and one that produced nothing in under a millisecond stays `None`
+/// rather than becoming an empty module that exists only to carry a duration.
+fn timed<'context>(
+    module: &str,
+    context: &'context Context<'_>,
+    render: impl FnOnce() -> Option<Module<'context>>,
+) -> Option<Module<'context>> {
+    let start: Instant = Instant::now();
+    let mut rendered = render();
+    let elapsed = start.elapsed();
+
+    log::trace!("Took {elapsed:?} to compute module {module:?}");
+    if elapsed.as_millis() >= 1 {
+        rendered
+            .get_or_insert_with(|| context.new_module(module))
+            .duration = elapsed;
+    }
+
+    rendered
+}
+
+/// Dispatches a module by the name a format string spells it with.
+///
+/// What `module` dispatches to is decided entirely by [`registry::ModuleId`]:
+/// a name that does not parse as one is not a module at all, and everything
+/// else — the closed set of built-ins and the two open-ended prefixed
+/// families — is [`registry::render`]'s job.
+fn dispatch<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
+    match registry::render(module, context) {
+        Some(rendered) => rendered,
+        None => {
+            eprintln!(
+                "Error: Unknown module {module}. Use starship module --list to list out all supported modules."
+            );
+            None
+        }
+    }
+}
+
+/// `module`'s description, as shown by `starship module --list` and in the
+/// generated configuration schema.
+#[must_use]
+pub fn description(module: &str) -> &'static str {
+    registry::description(module)
 }
 
 #[cfg(test)]
@@ -389,6 +312,49 @@ mod test {
         for module in ALL_MODULES {
             println!("Checking if {module:?} has a description");
             assert_ne!(description(module), "<no description>");
+        }
+    }
+
+    #[test]
+    fn all_modules_have_a_cadence() {
+        // A module the renderer cannot classify is a module it cannot schedule,
+        // so adding one to `ALL_MODULES` without a cadence must fail here rather
+        // than silently fall back to some default.
+        for module in ALL_MODULES {
+            assert!(
+                cadence(module).is_some(),
+                "module {module:?} has no declared cadence; add it to `cadence`"
+            );
+        }
+    }
+
+    #[test]
+    fn dynamically_named_modules_have_a_cadence() {
+        // These two are dispatched by prefix rather than by name, so they never
+        // appear in `ALL_MODULES` and the check above cannot see them.
+        assert_eq!(cadence("env_var"), Some(Cadence::Instant));
+        assert_eq!(cadence("env_var.SHELL"), Some(Cadence::Instant));
+        assert_eq!(cadence("custom.git_hash"), Some(Cadence::Deferred));
+    }
+
+    #[test]
+    fn an_unknown_module_has_no_cadence() {
+        assert_eq!(cadence("not_a_module"), None);
+        // The prefixed forms only classify the prefixed forms.
+        assert_eq!(cadence("custom"), None);
+    }
+
+    #[test]
+    fn every_dynamic_period_is_usable() {
+        // A zero period would ask the renderer to re-poll without ever making
+        // progress.
+        for module in ALL_MODULES {
+            if let Some(Cadence::Dynamic { period }) = cadence(module) {
+                assert!(
+                    !period.is_zero(),
+                    "module {module:?} declares a zero refresh period"
+                );
+            }
         }
     }
 }

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -184,12 +184,39 @@ pub fn cadence(module: &str) -> Option<Cadence> {
 }
 
 /// How a module produces its output.
+///
+/// Most modules produce one value: the value they exist to show, however long
+/// it takes to work out. A module whose real value needs unbounded work may
+/// additionally offer an *instant* one — a value that is correct as far as it
+/// goes, cheap enough to appear in the very first paint, and replaced by the
+/// real value as soon as that resolves.
+///
+/// The default [`Render::instant`] returns nothing, which is what "this module
+/// contributes nothing until it has really resolved" means. Overriding it is
+/// only worthwhile where a blank would be conspicuous; today that is
+/// [`directory::Directory`] alone, because a first paint with no path in it is
+/// not a prompt anyone would recognise.
 pub trait Render {
     /// The module's real value.
     fn full<'context>(&self, context: &'context Context<'_>) -> Option<Module<'context>>;
+
+    /// A value cheap enough to paint before anything slow has resolved, or
+    /// nothing if the module has no such value.
+    ///
+    /// An implementation must not perform unbounded input/output — no
+    /// subprocess, no repository discovery, no directory scan — since this runs
+    /// on the critical path between starting the process and drawing a prompt.
+    fn instant<'context>(&self, context: &'context Context<'_>) -> Option<Module<'context>> {
+        let _ = context;
+        None
+    }
 }
 
-/// The renderer of a module dispatched purely by name.
+/// The renderer of a module that has no instant approximation of its own.
+///
+/// It inherits [`Render::instant`]'s default. There is deliberately no way to
+/// give a module an instant approximation from here: a module that wants one
+/// declares it next to the rest of its own code, the way `directory` does.
 struct DispatchedByName<'name>(&'name str);
 
 impl Render for DispatchedByName<'_> {
@@ -210,6 +237,18 @@ fn with_renderer<T>(module: &str, action: impl FnOnce(&dyn Render) -> T) -> T {
 pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
     timed(module, context, || {
         with_renderer(module, |renderer| renderer.full(context))
+    })
+}
+
+/// Renders `module`'s instant approximation, if it has one, recording how long
+/// it took.
+///
+/// Returns `None` both for a module with no approximation and for one whose
+/// approximation resolved to nothing; the two are the same thing to a caller
+/// painting a prompt, which is why they are not distinguished.
+pub fn instant<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
+    timed(module, context, || {
+        with_renderer(module, |renderer| renderer.instant(context))
     })
 }
 
@@ -272,6 +311,49 @@ mod test {
         for module in ALL_MODULES {
             println!("Checking if {module:?} has a description");
             assert_ne!(description(module), "<no description>");
+        }
+    }
+
+    #[test]
+    fn all_modules_have_a_cadence() {
+        // A module the renderer cannot classify is a module it cannot schedule,
+        // so adding one to `ALL_MODULES` without a cadence must fail here rather
+        // than silently fall back to some default.
+        for module in ALL_MODULES {
+            assert!(
+                cadence(module).is_some(),
+                "module {module:?} has no declared cadence; add it to `cadence`"
+            );
+        }
+    }
+
+    #[test]
+    fn dynamically_named_modules_have_a_cadence() {
+        // These two are dispatched by prefix rather than by name, so they never
+        // appear in `ALL_MODULES` and the check above cannot see them.
+        assert_eq!(cadence("env_var"), Some(Cadence::Instant));
+        assert_eq!(cadence("env_var.SHELL"), Some(Cadence::Instant));
+        assert_eq!(cadence("custom.git_hash"), Some(Cadence::Deferred));
+    }
+
+    #[test]
+    fn an_unknown_module_has_no_cadence() {
+        assert_eq!(cadence("not_a_module"), None);
+        // The prefixed forms only classify the prefixed forms.
+        assert_eq!(cadence("custom"), None);
+    }
+
+    #[test]
+    fn every_dynamic_period_is_usable() {
+        // A zero period would ask the renderer to re-poll without ever making
+        // progress.
+        for module in ALL_MODULES {
+            if let Some(Cadence::Dynamic { period }) = cadence(module) {
+                assert!(
+                    !period.is_zero(),
+                    "module {module:?} declares a zero refresh period"
+                );
+            }
         }
     }
 }

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -1,4 +1,3 @@
-// While adding out new module add out module to src/module.rs ALL_MODULES const array also.
 mod aws;
 mod azure;
 mod buf;
@@ -119,7 +118,70 @@ pub use self::battery::{BatteryInfoProvider, BatteryInfoProviderImpl};
 use crate::config::ModuleConfig;
 use crate::context::{Context, Detected, Shell};
 use crate::module::Module;
-use std::time::Instant;
+use std::time::{Duration, Instant};
+
+/// How a module behaves over time, and how expensive it is to produce.
+///
+/// The prompt is rendered incrementally: cheap modules are painted immediately
+/// and expensive ones stream in afterwards. Every module therefore has to
+/// declare which of these it is, so the renderer can decide what to wait for.
+/// See [`cadence`] for the classification of each module.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Cadence {
+    /// No unbounded input/output: no subprocess, no repository discovery, no
+    /// directory scan. Cheap system calls such as `gethostname` are
+    /// acceptable, and so is reading a single file whose path is already
+    /// known *and* is guaranteed to resolve fast — a virtual filesystem such
+    /// as `/proc` or `/run`. A path under the user's home directory is not
+    /// guaranteed fast: it may be a slow or network mount (NFS, SMB, a
+    /// stalled FUSE mount), and a single `open` or `stat` against one can
+    /// block for as long as the mount is stuck, unbounded in exactly the way
+    /// this variant promises not to be.
+    ///
+    /// These modules can be rendered on the critical path of the first paint.
+    Instant,
+    /// Performs unbounded input/output: spawns a subprocess, discovers a
+    /// repository, or scans a directory. The cost is set by the machine and the
+    /// working directory rather than by the module, and a subprocess may run
+    /// all the way to `command_timeout`.
+    Deferred,
+    /// Intrinsically time-varying; a rendered value goes stale on its own and
+    /// must be re-polled to stay correct, even when nothing else changed.
+    Dynamic {
+        /// How long a rendered value stays correct.
+        period: Duration,
+    },
+}
+
+/// The clock shown by the `time` module advances every second at its default
+/// (and finest useful) granularity.
+const TIME_PERIOD: Duration = Duration::from_secs(1);
+
+#[cfg(feature = "battery")]
+const BATTERY_PERIOD: Duration = Duration::from_secs(30);
+
+/// Memory pressure is the fastest-moving of these values: it can swing across a
+/// configured threshold within seconds of a build starting.
+const MEMORY_USAGE_PERIOD: Duration = Duration::from_secs(5);
+
+/// The local address changes only when the machine changes network, which is
+/// rare but must not go unnoticed for the length of a shell session.
+const LOCALIP_PERIOD: Duration = Duration::from_secs(30);
+
+/// The [`Cadence`] of a module, or `None` if the module is unknown.
+///
+/// A module missing from the registry table has no declared cadence and the
+/// renderer cannot schedule it; `all_modules_have_a_cadence` fails if a module
+/// is added to `ALL_MODULES` without being classified there.
+///
+/// The names accepted here are exactly the names accepted by [`handle`],
+/// including the `env_var.` and `custom.` prefixed forms. See
+/// [`registry::entry_for`] for the classification of each built-in module and
+/// why it is what it is.
+#[must_use]
+pub fn cadence(module: &str) -> Option<Cadence> {
+    registry::cadence(module)
+}
 
 /// How a module produces its output.
 pub trait Render {

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -50,6 +50,7 @@ mod hg_branch;
 mod hg_state;
 mod hostname;
 mod java;
+mod jj_bookmark;
 mod jobs;
 mod julia;
 mod kotlin;

--- a/src/modules/nodejs.rs
+++ b/src/modules/nodejs.rs
@@ -132,244 +132,165 @@ fn check_engines_version(nodejs_version: Option<&str>, engines_version: Option<&
 
 #[cfg(test)]
 mod tests {
-    use crate::test::ModuleRenderer;
-    use nu_ansi_term::Color;
-    use std::fs::{self, File};
-    use std::io;
-    use std::io::Write;
+    use crate::test::{Project, RenderedModule, project};
+    use insta::assert_snapshot;
+    use rstest::rstest;
 
-    #[test]
-    fn folder_without_node_files() -> io::Result<()> {
-        let dir = tempfile::tempdir()?;
-        let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
-        let expected = None;
-        assert_eq!(expected, actual);
-        dir.close()
+    /// The `format` that also surfaces the `engines` requirement, used by the
+    /// checks that care about how a mismatch is reported.
+    const FORMAT_WITH_ENGINES_VERSION: &str = "via [$symbol($version )($engines_version )]($style)";
+
+    /// A filesystem artifact that on its own must make the `nodejs` module
+    /// treat a directory as a Node.js project.
+    ///
+    /// Each variant becomes its own independently named, independently reported
+    /// test case, so a detection rule that regresses is identified by name
+    /// rather than hidden behind whichever rule happens to fail first.
+    #[derive(Clone, Copy, Debug)]
+    enum NodeProjectMarker {
+        PackageManifest,
+        NodeVersionFile,
+        NodeVersionManagerFile,
+        JavaScriptFile,
+        EcmaScriptModuleFile,
+        CommonJsModuleFile,
+        TypeScriptFile,
+        InstalledDependenciesDirectory,
     }
 
-    #[test]
-    fn folder_with_package_json() -> io::Result<()> {
-        let dir = tempfile::tempdir()?;
-        File::create(dir.path().join("package.json"))?.sync_all()?;
-
-        let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Green.bold().paint(" v12.0.0 ")));
-        assert_eq!(expected, actual);
-        dir.close()
+    impl NodeProjectMarker {
+        /// Materializes this marker inside `project`.
+        fn create_in(self, project: &Project) {
+            match self {
+                Self::PackageManifest => project.create_file("package.json"),
+                Self::NodeVersionFile => project.create_file(".node-version"),
+                Self::NodeVersionManagerFile => project.create_file(".nvmrc"),
+                Self::JavaScriptFile => project.create_file("index.js"),
+                Self::EcmaScriptModuleFile => project.create_file("index.mjs"),
+                Self::CommonJsModuleFile => project.create_file("index.cjs"),
+                Self::TypeScriptFile => project.create_file("index.ts"),
+                Self::InstalledDependenciesDirectory => project.create_directory("node_modules"),
+            };
+        }
     }
 
-    #[test]
-    fn folder_with_package_json_and_esy_lock() -> io::Result<()> {
-        let dir = tempfile::tempdir()?;
-        File::create(dir.path().join("package.json"))?.sync_all()?;
-        let esy_lock = dir.path().join("esy.lock");
-        fs::create_dir_all(esy_lock)?;
-
-        let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
-        let expected = None;
-        assert_eq!(expected, actual);
-        dir.close()
+    /// A `package.json` declaring `engines.node` as `requirement`.
+    fn package_manifest_requiring_node(requirement: &str) -> String {
+        format!("{{\n  \"engines\": {{\n    \"node\": \"{requirement}\"\n  }}\n}}")
     }
 
-    #[test]
-    fn folder_with_node_version() -> io::Result<()> {
-        let dir = tempfile::tempdir()?;
-        File::create(dir.path().join(".node-version"))?.sync_all()?;
-
-        let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Green.bold().paint(" v12.0.0 ")));
-        assert_eq!(expected, actual);
-        dir.close()
+    #[rstest]
+    fn folder_without_node_files(project: Project) {
+        assert_eq!(project.render("nodejs"), RenderedModule::Empty);
     }
 
-    #[test]
-    fn folder_with_nvmrc() -> io::Result<()> {
-        let dir = tempfile::tempdir()?;
-        File::create(dir.path().join(".nvmrc"))?.sync_all()?;
+    #[rstest]
+    fn folder_with_node_project_marker(
+        project: Project,
+        #[values(
+            NodeProjectMarker::PackageManifest,
+            NodeProjectMarker::NodeVersionFile,
+            NodeProjectMarker::NodeVersionManagerFile,
+            NodeProjectMarker::JavaScriptFile,
+            NodeProjectMarker::EcmaScriptModuleFile,
+            NodeProjectMarker::CommonJsModuleFile,
+            NodeProjectMarker::TypeScriptFile,
+            NodeProjectMarker::InstalledDependenciesDirectory
+        )]
+        marker: NodeProjectMarker,
+    ) {
+        marker.create_in(&project);
 
-        let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Green.bold().paint(" v12.0.0 ")));
-        assert_eq!(expected, actual);
-        dir.close()
+        // Every marker must produce the very same rendering, so all cases share
+        // one inline snapshot. `allow_duplicates!` tells insta that repeated
+        // assertions against this location are intentional: under `cargo test`
+        // all cases run in one process, and insta otherwise rejects the second
+        // assertion at a given inline location as an accidental loop.
+        insta::allow_duplicates! {
+            assert_snapshot!(project.render("nodejs"), @r#""via \u{1b}[1;32m\u{e718} v12.0.0 \u{1b}[0m""#);
+        }
     }
 
-    #[test]
-    fn folder_with_js_file() -> io::Result<()> {
-        let dir = tempfile::tempdir()?;
-        File::create(dir.path().join("index.js"))?.sync_all()?;
+    /// An `esy` project happens to carry a `package.json`, but belongs to the
+    /// `ocaml` module rather than to this one.
+    #[rstest]
+    fn folder_with_package_json_and_esy_lock(project: Project) {
+        project.create_file("package.json");
+        project.create_directory("esy.lock");
 
-        let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Green.bold().paint(" v12.0.0 ")));
-        assert_eq!(expected, actual);
-        dir.close()
+        assert_eq!(project.render("nodejs"), RenderedModule::Empty);
     }
 
-    #[test]
-    fn folder_with_mjs_file() -> io::Result<()> {
-        let dir = tempfile::tempdir()?;
-        File::create(dir.path().join("index.mjs"))?.sync_all()?;
+    #[rstest]
+    fn engines_node_version_match(project: Project) {
+        project.write_file("package.json", &package_manifest_requiring_node(">=12.0.0"));
 
-        let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Green.bold().paint(" v12.0.0 ")));
-        assert_eq!(expected, actual);
-        dir.close()
+        assert_snapshot!(project.render("nodejs"), @r#""via \u{1b}[1;32m\u{e718} v12.0.0 \u{1b}[0m""#);
     }
 
-    #[test]
-    fn folder_with_cjs_file() -> io::Result<()> {
-        let dir = tempfile::tempdir()?;
-        File::create(dir.path().join("index.cjs"))?.sync_all()?;
+    /// A version outside the declared `engines` range must switch the module
+    /// over to `not_capable_style`.
+    #[rstest]
+    fn engines_node_version_not_match(project: Project) {
+        project.write_file("package.json", &package_manifest_requiring_node("<12.0.0"));
 
-        let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Green.bold().paint(" v12.0.0 ")));
-        assert_eq!(expected, actual);
-        dir.close()
+        assert_snapshot!(project.render("nodejs"), @r#""via \u{1b}[1;31m\u{e718} v12.0.0 \u{1b}[0m""#);
     }
 
-    #[test]
-    fn folder_with_ts_file() -> io::Result<()> {
-        let dir = tempfile::tempdir()?;
-        File::create(dir.path().join("index.ts"))?.sync_all()?;
+    #[rstest]
+    fn show_expected_version_when_engines_does_not_match(project: Project) {
+        project.write_file("package.json", &package_manifest_requiring_node("<=11.0.0"));
 
-        let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Green.bold().paint(" v12.0.0 ")));
-        assert_eq!(expected, actual);
-        dir.close()
-    }
-
-    #[test]
-    fn folder_with_node_modules() -> io::Result<()> {
-        let dir = tempfile::tempdir()?;
-        let node_modules = dir.path().join("node_modules");
-        fs::create_dir_all(node_modules)?;
-
-        let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Green.bold().paint(" v12.0.0 ")));
-        assert_eq!(expected, actual);
-        dir.close()
-    }
-
-    #[test]
-    fn engines_node_version_match() -> io::Result<()> {
-        let dir = tempfile::tempdir()?;
-        let mut file = File::create(dir.path().join("package.json"))?;
-        file.write_all(
-            b"{
-            \"engines\":{
-                \"node\":\">=12.0.0\"
-            }
-        }",
-        )?;
-        file.sync_all()?;
-
-        let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Green.bold().paint(" v12.0.0 ")));
-        assert_eq!(expected, actual);
-        dir.close()
-    }
-
-    #[test]
-    fn engines_node_version_not_match() -> io::Result<()> {
-        let dir = tempfile::tempdir()?;
-        let mut file = File::create(dir.path().join("package.json"))?;
-        file.write_all(
-            b"{
-            \"engines\":{
-                \"node\":\"<12.0.0\"
-            }
-        }",
-        )?;
-        file.sync_all()?;
-
-        let actual = ModuleRenderer::new("nodejs").path(dir.path()).collect();
-        let expected = Some(format!("via {}", Color::Red.bold().paint(" v12.0.0 ")));
-        assert_eq!(expected, actual);
-        dir.close()
-    }
-
-    #[test]
-    fn show_expected_version_when_engines_does_not_match() -> io::Result<()> {
-        let dir = tempfile::tempdir()?;
-        let mut file = File::create(dir.path().join("package.json"))?;
-        file.write_all(
-            b"{
-            \"engines\":{
-                \"node\":\"<=11.0.0\"
-            }
-        }",
-        )?;
-        file.sync_all()?;
-
-        let actual = ModuleRenderer::new("nodejs")
-            .path(dir.path())
+        let rendered = project
+            .renderer("nodejs")
             .config(toml::toml! {
                 [nodejs]
-                format = "via [$symbol($version )($engines_version )]($style)"
+                format = FORMAT_WITH_ENGINES_VERSION
             })
             .collect();
-        let expected = Some(format!(
-            "via {}",
-            Color::Red.bold().paint(" v12.0.0 <=11.0.0 ")
-        ));
 
-        assert_eq!(expected, actual);
-        dir.close()
+        assert_snapshot!(RenderedModule::from(rendered), @r#""via \u{1b}[1;31m\u{e718} v12.0.0 <=11.0.0 \u{1b}[0m""#);
     }
 
-    #[test]
-    fn do_not_show_expected_version_if_engines_match() -> io::Result<()> {
-        let dir = tempfile::tempdir()?;
-        let mut file = File::create(dir.path().join("package.json"))?;
-        file.write_all(
-            b"{
-            \"engines\":{
-                \"node\":\">=12.0.0\"
-            }
-        }",
-        )?;
-        file.sync_all()?;
+    #[rstest]
+    fn do_not_show_expected_version_if_engines_match(project: Project) {
+        project.write_file("package.json", &package_manifest_requiring_node(">=12.0.0"));
 
-        let actual = ModuleRenderer::new("nodejs")
-            .path(dir.path())
-            .config(toml::toml! [
-                [nodejs]
-                format = "via [$symbol($version )($engines_version )]($style)"
-            ])
-            .collect();
-        let expected = Some(format!("via {}", Color::Green.bold().paint(" v12.0.0 ")));
-
-        assert_eq!(expected, actual);
-        dir.close()
-    }
-
-    #[test]
-    fn do_not_show_expected_version_if_no_set_engines_version() -> io::Result<()> {
-        let dir = tempfile::tempdir()?;
-        File::create(dir.path().join("package.json"))?.sync_all()?;
-
-        let actual = ModuleRenderer::new("nodejs")
-            .path(dir.path())
+        let rendered = project
+            .renderer("nodejs")
             .config(toml::toml! {
                 [nodejs]
-                format = "via [$symbol($version )($engines_version )]($style)"
+                format = FORMAT_WITH_ENGINES_VERSION
             })
             .collect();
-        let expected = Some(format!("via {}", Color::Green.bold().paint(" v12.0.0 ")));
 
-        assert_eq!(expected, actual);
-        dir.close()
+        assert_snapshot!(RenderedModule::from(rendered), @r#""via \u{1b}[1;32m\u{e718} v12.0.0 \u{1b}[0m""#);
     }
 
-    #[test]
-    fn no_node_installed() -> io::Result<()> {
-        let dir = tempfile::tempdir()?;
-        File::create(dir.path().join("index.js"))?.sync_all()?;
-        let actual = ModuleRenderer::new("nodejs")
-            .path(dir.path())
+    #[rstest]
+    fn do_not_show_expected_version_if_no_set_engines_version(project: Project) {
+        project.create_file("package.json");
+
+        let rendered = project
+            .renderer("nodejs")
+            .config(toml::toml! {
+                [nodejs]
+                format = FORMAT_WITH_ENGINES_VERSION
+            })
+            .collect();
+
+        assert_snapshot!(RenderedModule::from(rendered), @r#""via \u{1b}[1;32m\u{e718} v12.0.0 \u{1b}[0m""#);
+    }
+
+    #[rstest]
+    fn no_node_installed(project: Project) {
+        project.create_file("index.js");
+
+        let rendered = project
+            .renderer("nodejs")
             .cmd("node --version", None)
             .collect();
-        let expected = Some(format!("via {}", Color::Green.bold().paint(" ")));
-        assert_eq!(expected, actual);
-        dir.close()
+
+        assert_snapshot!(RenderedModule::from(rendered), @r#""via \u{1b}[1;32m\u{e718} \u{1b}[0m""#);
     }
 }

--- a/src/modules/nodejs.rs
+++ b/src/modules/nodejs.rs
@@ -155,6 +155,8 @@ mod tests {
         EcmaScriptModuleFile,
         CommonJsModuleFile,
         TypeScriptFile,
+        TypeScriptModuleFile,
+        CommonJsTypeScriptFile,
         InstalledDependenciesDirectory,
     }
 
@@ -169,6 +171,8 @@ mod tests {
                 Self::EcmaScriptModuleFile => project.create_file("index.mjs"),
                 Self::CommonJsModuleFile => project.create_file("index.cjs"),
                 Self::TypeScriptFile => project.create_file("index.ts"),
+                Self::TypeScriptModuleFile => project.create_file("index.mts"),
+                Self::CommonJsTypeScriptFile => project.create_file("index.cts"),
                 Self::InstalledDependenciesDirectory => project.create_directory("node_modules"),
             };
         }
@@ -195,6 +199,8 @@ mod tests {
             NodeProjectMarker::EcmaScriptModuleFile,
             NodeProjectMarker::CommonJsModuleFile,
             NodeProjectMarker::TypeScriptFile,
+            NodeProjectMarker::TypeScriptModuleFile,
+            NodeProjectMarker::CommonJsTypeScriptFile,
             NodeProjectMarker::InstalledDependenciesDirectory
         )]
         marker: NodeProjectMarker,

--- a/src/modules/registry.rs
+++ b/src/modules/registry.rs
@@ -104,6 +104,7 @@ builtin_modules! {
     HgState = "hg_state",
     Hostname = "hostname",
     Java = "java",
+    JjBookmark = "jj_bookmark",
     Jobs = "jobs",
     Julia = "julia",
     Kotlin = "kotlin",
@@ -473,6 +474,10 @@ pub const fn entry_for(module: BuiltinModule) -> ModuleEntry {
             description: "The currently installed version of Java",
             prompt_position: Some(41),
         },
+        M::JjBookmark => ModuleEntry {
+            description: "The closest ancestor bookmark in Jujutsu",
+            prompt_position: None,
+        },
         M::Julia => ModuleEntry {
             description: "The currently installed version of Julia",
             prompt_position: Some(42),
@@ -678,6 +683,7 @@ pub fn dispatch_builtin<'a>(module: BuiltinModule, context: &'a Context) -> Opti
         M::HgState => super::hg_state::module(context),
         M::Hostname => super::hostname::module(context),
         M::Java => super::java::module(context),
+        M::JjBookmark => super::jj_bookmark::module(context),
         M::Jobs => super::jobs::module(context),
         M::Julia => super::julia::module(context),
         M::Kotlin => super::kotlin::module(context),

--- a/src/modules/registry.rs
+++ b/src/modules/registry.rs
@@ -5,6 +5,10 @@ use std::sync::LazyLock;
 use crate::context::Context;
 use crate::module::Module;
 
+#[cfg(feature = "battery")]
+use super::BATTERY_PERIOD;
+use super::{Cadence, LOCALIP_PERIOD, MEMORY_USAGE_PERIOD, TIME_PERIOD};
+
 /// Declares [`BuiltinModule`] and everything that can be generated from
 /// enumerating it alone: its name in each direction, and the array of every
 /// variant. See the module-level doc comment for why this is a macro.
@@ -165,6 +169,7 @@ builtin_modules! {
 /// What the table says about a module, beyond what [`BuiltinModule`] already
 /// carries (its name).
 pub struct ModuleEntry {
+    pub cadence: Cadence,
     pub description: &'static str,
     /// This module's place in [`PROMPT_ORDER`], or `None` for a module that is
     /// not part of the default ordering — a profile-only module such as
@@ -186,88 +191,109 @@ pub const fn entry_for(module: BuiltinModule) -> ModuleEntry {
     match module {
         // Instant — a cheap system call, or reading shell-supplied or environment state. No file system traversal and no subprocess.
         M::Character => ModuleEntry {
+            cadence: Cadence::Instant,
             description: "A character (usually an arrow) beside where the text is entered in your terminal",
             prompt_position: Some(100),
         },
         M::ClaudeContext => ModuleEntry {
+            cadence: Cadence::Instant,
             description: "Context window usage for Claude Code session",
             prompt_position: None,
         },
         M::ClaudeCost => ModuleEntry {
+            cadence: Cadence::Instant,
             description: "Cost info for Claude Code session",
             prompt_position: None,
         },
         M::ClaudeModel => ModuleEntry {
+            cadence: Cadence::Instant,
             description: "AI model name for Claude Code session",
             prompt_position: None,
         },
         M::CmdDuration => ModuleEntry {
+            cadence: Cadence::Instant,
             description: "How long the last command took to execute",
             prompt_position: Some(90),
         },
         M::Conda => ModuleEntry {
+            cadence: Cadence::Instant,
             description: "The current conda environment, if $CONDA_DEFAULT_ENV is set",
             prompt_position: Some(75),
         },
         M::Fill => ModuleEntry {
+            cadence: Cadence::Instant,
             description: "Fills the remaining space on the line with a pad string",
             prompt_position: None,
         },
         M::GuixShell => ModuleEntry {
+            cadence: Cadence::Instant,
             description: "The guix-shell environment",
             prompt_position: Some(73),
         },
         M::Hostname => ModuleEntry {
+            cadence: Cadence::Instant,
             description: "The system hostname",
             prompt_position: Some(1),
         },
         M::Jobs => ModuleEntry {
+            cadence: Cadence::Instant,
             description: "The current number of jobs running",
             prompt_position: Some(92),
         },
         M::LineBreak => ModuleEntry {
+            cadence: Cadence::Instant,
             description: "Separates the prompt into two lines",
             prompt_position: Some(91),
         },
         M::Meson => ModuleEntry {
+            cadence: Cadence::Instant,
             description: "The current Meson environment, if $MESON_DEVENV and $MESON_PROJECT_NAME are set",
             prompt_position: Some(77),
         },
         M::NixShell => ModuleEntry {
+            cadence: Cadence::Instant,
             description: "The nix-shell environment",
             prompt_position: Some(74),
         },
         M::Shell => ModuleEntry {
+            cadence: Cadence::Instant,
             description: "The currently used shell indicator",
             prompt_position: Some(99),
         },
         M::Shlvl => ModuleEntry {
+            cadence: Cadence::Instant,
             description: "The current value of SHLVL",
             prompt_position: Some(3),
         },
         M::Singularity => ModuleEntry {
+            cadence: Cadence::Instant,
             description: "The currently used Singularity image",
             prompt_position: Some(4),
         },
         M::Spack => ModuleEntry {
+            cadence: Cadence::Instant,
             description: "The current spack environment, if $SPACK_ENV is set",
             prompt_position: Some(78),
         },
         M::Status => ModuleEntry {
+            cadence: Cadence::Instant,
             description: "The status of the last command",
             prompt_position: Some(95),
         },
         M::Username => ModuleEntry {
+            cadence: Cadence::Instant,
             description: "The active user's username",
             prompt_position: Some(0),
         },
         M::Vcsh => ModuleEntry {
+            cadence: Cadence::Instant,
             description: "The currently active VCSH repository",
             prompt_position: Some(8),
         },
 
         // Instant — a container marker under `/run`, a virtual filesystem backed by memory rather than a disk or a network mount: the `stat` or `open` against it cannot stall the way one against a real filesystem can.
         M::Container => ModuleEntry {
+            cadence: Cadence::Instant,
             description: "The container indicator, if inside a container.",
             prompt_position: Some(96),
         },
@@ -275,202 +301,257 @@ pub const fn entry_for(module: BuiltinModule) -> ModuleEntry {
         // Dynamic — intrinsically time-varying values, re-polled on their own period.
         #[cfg(feature = "battery")]
         M::Battery => ModuleEntry {
+            cadence: Cadence::Dynamic {
+                period: BATTERY_PERIOD,
+            },
             description: "The current charge of the device's battery and its current charging status",
             prompt_position: Some(93),
         },
         M::Localip => ModuleEntry {
+            cadence: Cadence::Dynamic {
+                period: LOCALIP_PERIOD,
+            },
             description: "The currently assigned ipv4 address",
             prompt_position: Some(2),
         },
         M::MemoryUsage => ModuleEntry {
+            cadence: Cadence::Dynamic {
+                period: MEMORY_USAGE_PERIOD,
+            },
             description: "Current system memory and swap usage",
             prompt_position: Some(79),
         },
         M::Time => ModuleEntry {
+            cadence: Cadence::Dynamic {
+                period: TIME_PERIOD,
+            },
             description: "The current local time",
             prompt_position: Some(94),
         },
 
         // Deferred — read one or more credentials or profile files under the user's home directory: `~/.aws/{config,credentials}`, `~/.azure/azureProfile.json`, `~/.config/gcloud/...`, `~/.config/openstack/clouds.yaml`. Each path is known up front, but "known up front" does not mean bounded — the directory it lives under may be a slow or network mount, and these are full file reads (parsed as INI or JSON), not a single cheap `stat`.
         M::Aws => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The current AWS region and profile",
             prompt_position: Some(80),
         },
         M::Azure => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The current Azure subscription",
             prompt_position: Some(83),
         },
         M::Gcloud => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The current GCP client configuration",
             prompt_position: Some(81),
         },
         M::Openstack => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The current OpenStack cloud and project",
             prompt_position: Some(82),
         },
 
         // Deferred — discover a repository, either by opening it through `Context::get_repo` or by walking the ancestors of the working directory looking for a control directory.
         M::Directory => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The current working directory",
             prompt_position: Some(7),
         },
         M::GitCommit => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The active commit (and tag if any) of the current Git repo",
             prompt_position: Some(12),
         },
         M::GitState => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The current Git operation and its progress",
             prompt_position: Some(13),
         },
         M::HgBranch => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The active branch and topic of the repo in your current directory",
             prompt_position: Some(16),
         },
         M::HgState => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The current hg operation",
             prompt_position: Some(17),
         },
         M::Vcs => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The currently active VCS repository (first one matching)",
             prompt_position: None,
         },
 
         // Deferred — repository discovery followed by a `git` subprocess.
         M::GitBranch => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The active branch of the current Git repo",
             prompt_position: Some(11),
         },
         M::GitMetrics => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The currently added/deleted lines in your Git repo",
             prompt_position: Some(14),
         },
         M::GitStatus => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "Symbols representing the state of the current Git repo, filtered to your current directory",
             prompt_position: Some(15),
         },
 
         // Deferred — scan the working directory for marker files. No subprocess, but the scan itself is unbounded: its cost is set by the directory it lands in, not by the module.
         M::Daml => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The Daml SDK version of your project",
             prompt_position: Some(26),
         },
         M::DockerContext => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The current docker context",
             prompt_position: Some(19),
         },
         M::Gradle => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The currently installed version of Gradle",
             prompt_position: Some(37),
         },
         M::Kubernetes => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The current Kubernetes context name and, if set, the namespace",
             prompt_position: Some(5),
         },
         M::Maven => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The Maven Wrapper version of the current project",
             prompt_position: Some(45),
         },
 
         // Deferred — `os_info` inspects the running system, which on several platforms means spawning a helper such as `sw_vers` or `lsb_release`.
         M::Os => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The current operating system",
             prompt_position: Some(98),
         },
 
         // Deferred — spawn a subprocess to ask a tool for its version or its state. Most of these gate the subprocess behind a directory scan first, which makes them cheap in an unrelated directory but does not make them bounded: the scan is itself unbounded input/output.
         M::Buf => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The currently installed version of the Buf CLI",
             prompt_position: Some(72),
         },
         M::Bun => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The currently installed version of the Bun",
             prompt_position: Some(21),
         },
         M::C => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "Your C compiler type",
             prompt_position: Some(22),
         },
         M::Cmake => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The currently installed version of CMake",
             prompt_position: Some(23),
         },
         M::Cobol => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The currently installed version of COBOL/GNUCOBOL",
             prompt_position: Some(24),
         },
         M::Cpp => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "Your C++ compiler type",
             prompt_position: Some(25),
         },
         M::Crystal => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The currently installed version of Crystal",
             prompt_position: Some(87),
         },
         M::Dart => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The currently installed version of Dart",
             prompt_position: Some(27),
         },
         M::Deno => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The currently installed version of Deno",
             prompt_position: Some(28),
         },
         M::Direnv => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The currently applied direnv file",
             prompt_position: Some(84),
         },
         M::Dotnet => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The relevant version of the .NET Core SDK for the current directory",
             prompt_position: Some(29),
         },
         M::Elixir => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The currently installed versions of Elixir and OTP",
             prompt_position: Some(30),
         },
         M::Elm => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The currently installed version of Elm",
             prompt_position: Some(31),
         },
         M::Erlang => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "Current OTP version",
             prompt_position: Some(32),
         },
         M::Fennel => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The currently installed version of Fennel",
             prompt_position: Some(33),
         },
         M::Fortran => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The currently used version of Fortran",
             prompt_position: Some(34),
         },
         M::FossilBranch => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The active branch of the check-out in your current directory",
             prompt_position: Some(9),
         },
         M::FossilMetrics => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The currently added/deleted lines in your check-out",
             prompt_position: Some(10),
         },
         M::Gleam => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The currently installed version of Gleam",
             prompt_position: Some(35),
         },
         M::Golang => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The currently installed version of Golang",
             prompt_position: Some(36),
         },
         M::Haskell => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The selected version of the Haskell toolchain",
             prompt_position: Some(38),
         },
         M::Haxe => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The currently installed version of Haxe",
             prompt_position: Some(39),
         },
         M::Helm => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The currently installed version of Helm",
             prompt_position: Some(40),
         },
         M::Java => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The currently installed version of Java",
             prompt_position: Some(41),
         },
@@ -479,146 +560,182 @@ pub const fn entry_for(module: BuiltinModule) -> ModuleEntry {
             prompt_position: None,
         },
         M::Julia => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The currently installed version of Julia",
             prompt_position: Some(42),
         },
         M::Kotlin => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The currently installed version of Kotlin",
             prompt_position: Some(43),
         },
         M::Lua => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The currently installed version of Lua",
             prompt_position: Some(44),
         },
         M::Mise => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The current mise status",
             prompt_position: Some(86),
         },
         M::Mojo => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The currently installed version of Mojo",
             prompt_position: Some(46),
         },
         M::Nats => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The current NATS context",
             prompt_position: Some(6),
         },
         M::Netns => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The current network namespace",
             prompt_position: Some(97),
         },
         M::Nim => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The currently installed version of Nim",
             prompt_position: Some(47),
         },
         M::Nodejs => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The currently installed version of NodeJS",
             prompt_position: Some(48),
         },
         M::Ocaml => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The currently installed version of OCaml",
             prompt_position: Some(49),
         },
         M::Odin => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The currently installed version of Odin",
             prompt_position: Some(50),
         },
         M::Opa => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The currently installed version of Open Platform Agent",
             prompt_position: Some(51),
         },
         M::Package => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The package version of the current directory's project",
             prompt_position: Some(20),
         },
         M::Perl => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The currently installed version of Perl",
             prompt_position: Some(52),
         },
         M::Php => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The currently installed version of PHP",
             prompt_position: Some(53),
         },
         M::PijulChannel => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The current channel of the repo in the current directory",
             prompt_position: Some(18),
         },
         M::Pixi => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The currently installed version of Pixi, and the active environment if $PIXI_ENVIRONMENT_NAME is set",
             prompt_position: Some(76),
         },
         M::Pulumi => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The current username, stack, and installed version of Pulumi",
             prompt_position: Some(54),
         },
         M::Purescript => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The currently installed version of PureScript",
             prompt_position: Some(55),
         },
         M::Python => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The currently installed version of Python",
             prompt_position: Some(56),
         },
         M::Quarto => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The currently installed version of Quarto",
             prompt_position: Some(57),
         },
         M::Raku => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The currently installed version of Raku",
             prompt_position: Some(58),
         },
         M::Red => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The currently installed version of Red",
             prompt_position: Some(60),
         },
         M::Rlang => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The currently installed version of R",
             prompt_position: Some(59),
         },
         M::Ruby => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The currently installed version of Ruby",
             prompt_position: Some(61),
         },
         M::Rust => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The currently installed version of Rust",
             prompt_position: Some(62),
         },
         M::Scala => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The currently installed version of Scala",
             prompt_position: Some(63),
         },
         M::Solidity => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The current installed version of Solidity",
             prompt_position: Some(64),
         },
         M::Sudo => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The sudo credentials are currently cached",
             prompt_position: Some(89),
         },
         M::Swift => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The currently installed version of Swift",
             prompt_position: Some(65),
         },
         M::Terraform => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The currently selected terraform workspace and version",
             prompt_position: Some(66),
         },
         M::Typst => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The currently installed version of Typst",
             prompt_position: Some(67),
         },
         M::Vagrant => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The currently installed version of Vagrant",
             prompt_position: Some(69),
         },
         M::Vlang => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The currently installed version of V",
             prompt_position: Some(68),
         },
         M::Xmake => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The currently installed version of XMake",
             prompt_position: Some(70),
         },
         M::Zig => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The currently installed version of Zig",
             prompt_position: Some(71),
         },
@@ -783,6 +900,18 @@ impl<'a> ModuleId<'a> {
             return Some(Self::Custom(suffix));
         }
         None
+    }
+}
+
+/// The [`Cadence`] of `module`, or `None` if it is not recognised at all.
+#[must_use]
+pub fn cadence(module: &str) -> Option<Cadence> {
+    match ModuleId::parse(module)? {
+        ModuleId::Builtin(builtin) => Some(entry_for(builtin).cadence),
+        // A single environment variable lookup, whichever variable was named.
+        ModuleId::EnvVar(_) => Some(Cadence::Instant),
+        // A user-supplied command line, run through a shell.
+        ModuleId::Custom(_) => Some(Cadence::Deferred),
     }
 }
 
@@ -1051,9 +1180,10 @@ mod tests {
     }
 
     #[test]
-    fn description_agrees_with_entry_for() {
+    fn cadence_and_description_agree_with_entry_for() {
         for &module in BuiltinModule::ALL {
             let entry = entry_for(module);
+            assert_eq!(Some(entry.cadence), cadence(module.name()));
             assert_eq!(entry.description, description(module.name()));
         }
     }

--- a/src/modules/registry.rs
+++ b/src/modules/registry.rs
@@ -1,0 +1,1184 @@
+//! Module registry.
+
+use std::sync::LazyLock;
+
+use crate::context::Context;
+use crate::module::Module;
+
+#[cfg(feature = "battery")]
+use super::BATTERY_PERIOD;
+use super::{Cadence, LOCALIP_PERIOD, MEMORY_USAGE_PERIOD, TIME_PERIOD};
+
+/// Declares [`BuiltinModule`] and everything that can be generated from
+/// enumerating it alone: its name in each direction, and the array of every
+/// variant. See the module-level doc comment for why this is a macro.
+macro_rules! builtin_modules {
+    ( $( $(#[$meta:meta])* $variant:ident = $name:literal ),+ $(,)? ) => {
+        /// The closed set of modules starship ships with, dispatched by exact
+        /// name — as opposed to `custom.*` and `env_var.*`, which are open-ended
+        /// families dispatched by prefix. See [`ModuleId`].
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        pub enum BuiltinModule {
+            $( $(#[$meta])* $variant, )+
+        }
+
+        impl BuiltinModule {
+            /// Every variant, exactly once, in the same order declared below.
+            ///
+            /// This is the one place a new module has to be added by hand with
+            /// nothing enforcing completeness at compile time — Rust has no way to
+            /// enumerate an enum's own variants. Everything downstream of this
+            /// array *is* enforced: [`entry_for`] and [`dispatch_builtin`] are
+            /// exhaustive matches over `BuiltinModule`, so a variant added to the
+            /// enum without a corresponding row in either fails to compile.
+            pub const ALL: &'static [BuiltinModule] = &[
+                $( $(#[$meta])* BuiltinModule::$variant, )+
+            ];
+
+            /// The name this module is configured and dispatched under.
+            #[must_use]
+            pub const fn name(self) -> &'static str {
+                match self {
+                    $( $(#[$meta])* Self::$variant => $name, )+
+                }
+            }
+
+            /// The builtin named `name`, or `None` — including when `name` names a
+            /// member of one of the prefixed families, which are not part of this
+            /// closed set at all.
+            #[must_use]
+            pub fn from_name(name: &str) -> Option<Self> {
+                match name {
+                    $( $(#[$meta])* $name => Some(Self::$variant), )+
+                    _ => None,
+                }
+            }
+        }
+    };
+}
+
+builtin_modules! {
+    Aws = "aws",
+    Azure = "azure",
+    #[cfg(feature = "battery")]
+    Battery = "battery",
+    Buf = "buf",
+    Bun = "bun",
+    C = "c",
+    Character = "character",
+    ClaudeContext = "claude_context",
+    ClaudeCost = "claude_cost",
+    ClaudeModel = "claude_model",
+    Cmake = "cmake",
+    CmdDuration = "cmd_duration",
+    Cobol = "cobol",
+    Conda = "conda",
+    Container = "container",
+    Cpp = "cpp",
+    Crystal = "crystal",
+    Daml = "daml",
+    Dart = "dart",
+    Deno = "deno",
+    Directory = "directory",
+    Direnv = "direnv",
+    DockerContext = "docker_context",
+    Dotnet = "dotnet",
+    Elixir = "elixir",
+    Elm = "elm",
+    Erlang = "erlang",
+    Fennel = "fennel",
+    Fill = "fill",
+    Fortran = "fortran",
+    FossilBranch = "fossil_branch",
+    FossilMetrics = "fossil_metrics",
+    Gcloud = "gcloud",
+    GitBranch = "git_branch",
+    GitCommit = "git_commit",
+    GitMetrics = "git_metrics",
+    GitState = "git_state",
+    GitStatus = "git_status",
+    Gleam = "gleam",
+    Golang = "golang",
+    Gradle = "gradle",
+    GuixShell = "guix_shell",
+    Haskell = "haskell",
+    Haxe = "haxe",
+    Helm = "helm",
+    HgBranch = "hg_branch",
+    HgState = "hg_state",
+    Hostname = "hostname",
+    Java = "java",
+    Jobs = "jobs",
+    Julia = "julia",
+    Kotlin = "kotlin",
+    Kubernetes = "kubernetes",
+    LineBreak = "line_break",
+    Localip = "localip",
+    Lua = "lua",
+    Maven = "maven",
+    MemoryUsage = "memory_usage",
+    Meson = "meson",
+    Mise = "mise",
+    Mojo = "mojo",
+    Nats = "nats",
+    Netns = "netns",
+    Nim = "nim",
+    NixShell = "nix_shell",
+    Nodejs = "nodejs",
+    Ocaml = "ocaml",
+    Odin = "odin",
+    Opa = "opa",
+    Openstack = "openstack",
+    Os = "os",
+    Package = "package",
+    Perl = "perl",
+    Php = "php",
+    PijulChannel = "pijul_channel",
+    Pixi = "pixi",
+    Pulumi = "pulumi",
+    Purescript = "purescript",
+    Python = "python",
+    Quarto = "quarto",
+    Raku = "raku",
+    Red = "red",
+    Rlang = "rlang",
+    Ruby = "ruby",
+    Rust = "rust",
+    Scala = "scala",
+    Shell = "shell",
+    Shlvl = "shlvl",
+    Singularity = "singularity",
+    Solidity = "solidity",
+    Spack = "spack",
+    Status = "status",
+    Sudo = "sudo",
+    Swift = "swift",
+    Terraform = "terraform",
+    Time = "time",
+    Typst = "typst",
+    Username = "username",
+    Vagrant = "vagrant",
+    Vcs = "vcs",
+    Vcsh = "vcsh",
+    Vlang = "vlang",
+    Xmake = "xmake",
+    Zig = "zig",
+}
+
+/// What the table says about a module, beyond what [`BuiltinModule`] already
+/// carries (its name).
+pub struct ModuleEntry {
+    pub cadence: Cadence,
+    pub description: &'static str,
+    /// This module's place in [`PROMPT_ORDER`], or `None` for a module that is
+    /// not part of the default ordering — a profile-only module such as
+    /// `claude_model`, or `fill` and `vcs`, which a format string must name
+    /// explicitly to use.
+    pub prompt_position: Option<u16>,
+}
+
+/// What the table says about `module`.
+///
+/// Exhaustive over [`BuiltinModule`]: adding a variant to the `builtin_modules!`
+/// table above without describing it here fails to compile, rather than leaving
+/// the new module without a cadence the way a missing `match` arm keyed by name
+/// used to. Grouped by *why* each module is classified as it is, the same
+/// grouping the hand-written `cadence` match used before this table replaced it.
+#[must_use]
+pub const fn entry_for(module: BuiltinModule) -> ModuleEntry {
+    use BuiltinModule as M;
+    match module {
+        // Instant — a cheap system call, or reading shell-supplied or environment state. No file system traversal and no subprocess.
+        M::Character => ModuleEntry {
+            cadence: Cadence::Instant,
+            description: "A character (usually an arrow) beside where the text is entered in your terminal",
+            prompt_position: Some(100),
+        },
+        M::ClaudeContext => ModuleEntry {
+            cadence: Cadence::Instant,
+            description: "Context window usage for Claude Code session",
+            prompt_position: None,
+        },
+        M::ClaudeCost => ModuleEntry {
+            cadence: Cadence::Instant,
+            description: "Cost info for Claude Code session",
+            prompt_position: None,
+        },
+        M::ClaudeModel => ModuleEntry {
+            cadence: Cadence::Instant,
+            description: "AI model name for Claude Code session",
+            prompt_position: None,
+        },
+        M::CmdDuration => ModuleEntry {
+            cadence: Cadence::Instant,
+            description: "How long the last command took to execute",
+            prompt_position: Some(90),
+        },
+        M::Conda => ModuleEntry {
+            cadence: Cadence::Instant,
+            description: "The current conda environment, if $CONDA_DEFAULT_ENV is set",
+            prompt_position: Some(75),
+        },
+        M::Fill => ModuleEntry {
+            cadence: Cadence::Instant,
+            description: "Fills the remaining space on the line with a pad string",
+            prompt_position: None,
+        },
+        M::GuixShell => ModuleEntry {
+            cadence: Cadence::Instant,
+            description: "The guix-shell environment",
+            prompt_position: Some(73),
+        },
+        M::Hostname => ModuleEntry {
+            cadence: Cadence::Instant,
+            description: "The system hostname",
+            prompt_position: Some(1),
+        },
+        M::Jobs => ModuleEntry {
+            cadence: Cadence::Instant,
+            description: "The current number of jobs running",
+            prompt_position: Some(92),
+        },
+        M::LineBreak => ModuleEntry {
+            cadence: Cadence::Instant,
+            description: "Separates the prompt into two lines",
+            prompt_position: Some(91),
+        },
+        M::Meson => ModuleEntry {
+            cadence: Cadence::Instant,
+            description: "The current Meson environment, if $MESON_DEVENV and $MESON_PROJECT_NAME are set",
+            prompt_position: Some(77),
+        },
+        M::NixShell => ModuleEntry {
+            cadence: Cadence::Instant,
+            description: "The nix-shell environment",
+            prompt_position: Some(74),
+        },
+        M::Shell => ModuleEntry {
+            cadence: Cadence::Instant,
+            description: "The currently used shell indicator",
+            prompt_position: Some(99),
+        },
+        M::Shlvl => ModuleEntry {
+            cadence: Cadence::Instant,
+            description: "The current value of SHLVL",
+            prompt_position: Some(3),
+        },
+        M::Singularity => ModuleEntry {
+            cadence: Cadence::Instant,
+            description: "The currently used Singularity image",
+            prompt_position: Some(4),
+        },
+        M::Spack => ModuleEntry {
+            cadence: Cadence::Instant,
+            description: "The current spack environment, if $SPACK_ENV is set",
+            prompt_position: Some(78),
+        },
+        M::Status => ModuleEntry {
+            cadence: Cadence::Instant,
+            description: "The status of the last command",
+            prompt_position: Some(95),
+        },
+        M::Username => ModuleEntry {
+            cadence: Cadence::Instant,
+            description: "The active user's username",
+            prompt_position: Some(0),
+        },
+        M::Vcsh => ModuleEntry {
+            cadence: Cadence::Instant,
+            description: "The currently active VCSH repository",
+            prompt_position: Some(8),
+        },
+
+        // Instant — a container marker under `/run`, a virtual filesystem backed by memory rather than a disk or a network mount: the `stat` or `open` against it cannot stall the way one against a real filesystem can.
+        M::Container => ModuleEntry {
+            cadence: Cadence::Instant,
+            description: "The container indicator, if inside a container.",
+            prompt_position: Some(96),
+        },
+
+        // Dynamic — intrinsically time-varying values, re-polled on their own period.
+        #[cfg(feature = "battery")]
+        M::Battery => ModuleEntry {
+            cadence: Cadence::Dynamic {
+                period: BATTERY_PERIOD,
+            },
+            description: "The current charge of the device's battery and its current charging status",
+            prompt_position: Some(93),
+        },
+        M::Localip => ModuleEntry {
+            cadence: Cadence::Dynamic {
+                period: LOCALIP_PERIOD,
+            },
+            description: "The currently assigned ipv4 address",
+            prompt_position: Some(2),
+        },
+        M::MemoryUsage => ModuleEntry {
+            cadence: Cadence::Dynamic {
+                period: MEMORY_USAGE_PERIOD,
+            },
+            description: "Current system memory and swap usage",
+            prompt_position: Some(79),
+        },
+        M::Time => ModuleEntry {
+            cadence: Cadence::Dynamic {
+                period: TIME_PERIOD,
+            },
+            description: "The current local time",
+            prompt_position: Some(94),
+        },
+
+        // Deferred — read one or more credentials or profile files under the user's home directory: `~/.aws/{config,credentials}`, `~/.azure/azureProfile.json`, `~/.config/gcloud/...`, `~/.config/openstack/clouds.yaml`. Each path is known up front, but "known up front" does not mean bounded — the directory it lives under may be a slow or network mount, and these are full file reads (parsed as INI or JSON), not a single cheap `stat`.
+        M::Aws => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The current AWS region and profile",
+            prompt_position: Some(80),
+        },
+        M::Azure => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The current Azure subscription",
+            prompt_position: Some(83),
+        },
+        M::Gcloud => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The current GCP client configuration",
+            prompt_position: Some(81),
+        },
+        M::Openstack => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The current OpenStack cloud and project",
+            prompt_position: Some(82),
+        },
+
+        // Deferred — discover a repository, either by opening it through `Context::get_repo` or by walking the ancestors of the working directory looking for a control directory.
+        M::Directory => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The current working directory",
+            prompt_position: Some(7),
+        },
+        M::GitCommit => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The active commit (and tag if any) of the current Git repo",
+            prompt_position: Some(12),
+        },
+        M::GitState => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The current Git operation and its progress",
+            prompt_position: Some(13),
+        },
+        M::HgBranch => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The active branch and topic of the repo in your current directory",
+            prompt_position: Some(16),
+        },
+        M::HgState => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The current hg operation",
+            prompt_position: Some(17),
+        },
+        M::Vcs => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The currently active VCS repository (first one matching)",
+            prompt_position: None,
+        },
+
+        // Deferred — repository discovery followed by a `git` subprocess.
+        M::GitBranch => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The active branch of the current Git repo",
+            prompt_position: Some(11),
+        },
+        M::GitMetrics => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The currently added/deleted lines in your Git repo",
+            prompt_position: Some(14),
+        },
+        M::GitStatus => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "Symbols representing the state of the current Git repo, filtered to your current directory",
+            prompt_position: Some(15),
+        },
+
+        // Deferred — scan the working directory for marker files. No subprocess, but the scan itself is unbounded: its cost is set by the directory it lands in, not by the module.
+        M::Daml => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The Daml SDK version of your project",
+            prompt_position: Some(26),
+        },
+        M::DockerContext => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The current docker context",
+            prompt_position: Some(19),
+        },
+        M::Gradle => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The currently installed version of Gradle",
+            prompt_position: Some(37),
+        },
+        M::Kubernetes => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The current Kubernetes context name and, if set, the namespace",
+            prompt_position: Some(5),
+        },
+        M::Maven => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The Maven Wrapper version of the current project",
+            prompt_position: Some(45),
+        },
+
+        // Deferred — `os_info` inspects the running system, which on several platforms means spawning a helper such as `sw_vers` or `lsb_release`.
+        M::Os => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The current operating system",
+            prompt_position: Some(98),
+        },
+
+        // Deferred — spawn a subprocess to ask a tool for its version or its state. Most of these gate the subprocess behind a directory scan first, which makes them cheap in an unrelated directory but does not make them bounded: the scan is itself unbounded input/output.
+        M::Buf => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The currently installed version of the Buf CLI",
+            prompt_position: Some(72),
+        },
+        M::Bun => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The currently installed version of the Bun",
+            prompt_position: Some(21),
+        },
+        M::C => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "Your C compiler type",
+            prompt_position: Some(22),
+        },
+        M::Cmake => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The currently installed version of CMake",
+            prompt_position: Some(23),
+        },
+        M::Cobol => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The currently installed version of COBOL/GNUCOBOL",
+            prompt_position: Some(24),
+        },
+        M::Cpp => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "Your C++ compiler type",
+            prompt_position: Some(25),
+        },
+        M::Crystal => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The currently installed version of Crystal",
+            prompt_position: Some(87),
+        },
+        M::Dart => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The currently installed version of Dart",
+            prompt_position: Some(27),
+        },
+        M::Deno => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The currently installed version of Deno",
+            prompt_position: Some(28),
+        },
+        M::Direnv => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The currently applied direnv file",
+            prompt_position: Some(84),
+        },
+        M::Dotnet => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The relevant version of the .NET Core SDK for the current directory",
+            prompt_position: Some(29),
+        },
+        M::Elixir => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The currently installed versions of Elixir and OTP",
+            prompt_position: Some(30),
+        },
+        M::Elm => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The currently installed version of Elm",
+            prompt_position: Some(31),
+        },
+        M::Erlang => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "Current OTP version",
+            prompt_position: Some(32),
+        },
+        M::Fennel => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The currently installed version of Fennel",
+            prompt_position: Some(33),
+        },
+        M::Fortran => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The currently used version of Fortran",
+            prompt_position: Some(34),
+        },
+        M::FossilBranch => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The active branch of the check-out in your current directory",
+            prompt_position: Some(9),
+        },
+        M::FossilMetrics => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The currently added/deleted lines in your check-out",
+            prompt_position: Some(10),
+        },
+        M::Gleam => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The currently installed version of Gleam",
+            prompt_position: Some(35),
+        },
+        M::Golang => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The currently installed version of Golang",
+            prompt_position: Some(36),
+        },
+        M::Haskell => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The selected version of the Haskell toolchain",
+            prompt_position: Some(38),
+        },
+        M::Haxe => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The currently installed version of Haxe",
+            prompt_position: Some(39),
+        },
+        M::Helm => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The currently installed version of Helm",
+            prompt_position: Some(40),
+        },
+        M::Java => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The currently installed version of Java",
+            prompt_position: Some(41),
+        },
+        M::Julia => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The currently installed version of Julia",
+            prompt_position: Some(42),
+        },
+        M::Kotlin => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The currently installed version of Kotlin",
+            prompt_position: Some(43),
+        },
+        M::Lua => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The currently installed version of Lua",
+            prompt_position: Some(44),
+        },
+        M::Mise => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The current mise status",
+            prompt_position: Some(86),
+        },
+        M::Mojo => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The currently installed version of Mojo",
+            prompt_position: Some(46),
+        },
+        M::Nats => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The current NATS context",
+            prompt_position: Some(6),
+        },
+        M::Netns => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The current network namespace",
+            prompt_position: Some(97),
+        },
+        M::Nim => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The currently installed version of Nim",
+            prompt_position: Some(47),
+        },
+        M::Nodejs => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The currently installed version of NodeJS",
+            prompt_position: Some(48),
+        },
+        M::Ocaml => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The currently installed version of OCaml",
+            prompt_position: Some(49),
+        },
+        M::Odin => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The currently installed version of Odin",
+            prompt_position: Some(50),
+        },
+        M::Opa => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The currently installed version of Open Platform Agent",
+            prompt_position: Some(51),
+        },
+        M::Package => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The package version of the current directory's project",
+            prompt_position: Some(20),
+        },
+        M::Perl => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The currently installed version of Perl",
+            prompt_position: Some(52),
+        },
+        M::Php => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The currently installed version of PHP",
+            prompt_position: Some(53),
+        },
+        M::PijulChannel => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The current channel of the repo in the current directory",
+            prompt_position: Some(18),
+        },
+        M::Pixi => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The currently installed version of Pixi, and the active environment if $PIXI_ENVIRONMENT_NAME is set",
+            prompt_position: Some(76),
+        },
+        M::Pulumi => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The current username, stack, and installed version of Pulumi",
+            prompt_position: Some(54),
+        },
+        M::Purescript => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The currently installed version of PureScript",
+            prompt_position: Some(55),
+        },
+        M::Python => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The currently installed version of Python",
+            prompt_position: Some(56),
+        },
+        M::Quarto => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The currently installed version of Quarto",
+            prompt_position: Some(57),
+        },
+        M::Raku => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The currently installed version of Raku",
+            prompt_position: Some(58),
+        },
+        M::Red => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The currently installed version of Red",
+            prompt_position: Some(60),
+        },
+        M::Rlang => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The currently installed version of R",
+            prompt_position: Some(59),
+        },
+        M::Ruby => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The currently installed version of Ruby",
+            prompt_position: Some(61),
+        },
+        M::Rust => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The currently installed version of Rust",
+            prompt_position: Some(62),
+        },
+        M::Scala => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The currently installed version of Scala",
+            prompt_position: Some(63),
+        },
+        M::Solidity => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The current installed version of Solidity",
+            prompt_position: Some(64),
+        },
+        M::Sudo => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The sudo credentials are currently cached",
+            prompt_position: Some(89),
+        },
+        M::Swift => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The currently installed version of Swift",
+            prompt_position: Some(65),
+        },
+        M::Terraform => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The currently selected terraform workspace and version",
+            prompt_position: Some(66),
+        },
+        M::Typst => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The currently installed version of Typst",
+            prompt_position: Some(67),
+        },
+        M::Vagrant => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The currently installed version of Vagrant",
+            prompt_position: Some(69),
+        },
+        M::Vlang => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The currently installed version of V",
+            prompt_position: Some(68),
+        },
+        M::Xmake => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The currently installed version of XMake",
+            prompt_position: Some(70),
+        },
+        M::Zig => ModuleEntry {
+            cadence: Cadence::Deferred,
+            description: "The currently installed version of Zig",
+            prompt_position: Some(71),
+        },
+    }
+}
+
+/// Renders a builtin module by calling its own `module` function.
+///
+/// Exhaustive over [`BuiltinModule`] for the same reason [`entry_for`] is: the
+/// dispatch table [`crate::modules::handle`] and [`crate::modules::instant`]
+/// delegate to, for anything in the closed set, cannot silently omit a variant.
+pub fn dispatch_builtin<'a>(module: BuiltinModule, context: &'a Context) -> Option<Module<'a>> {
+    use BuiltinModule as M;
+    match module {
+        M::Aws => super::aws::module(context),
+        M::Azure => super::azure::module(context),
+        #[cfg(feature = "battery")]
+        M::Battery => super::battery::module(context),
+        M::Buf => super::buf::module(context),
+        M::Bun => super::bun::module(context),
+        M::C => super::c::module(context),
+        M::Character => super::character::module(context),
+        M::ClaudeContext => super::claude_context::module(context),
+        M::ClaudeCost => super::claude_cost::module(context),
+        M::ClaudeModel => super::claude_model::module(context),
+        M::Cmake => super::cmake::module(context),
+        M::CmdDuration => super::cmd_duration::module(context),
+        M::Cobol => super::cobol::module(context),
+        M::Conda => super::conda::module(context),
+        M::Container => super::container::module(context),
+        M::Cpp => super::cpp::module(context),
+        M::Crystal => super::crystal::module(context),
+        M::Daml => super::daml::module(context),
+        M::Dart => super::dart::module(context),
+        M::Deno => super::deno::module(context),
+        M::Directory => super::directory::module(context),
+        M::Direnv => super::direnv::module(context),
+        M::DockerContext => super::docker_context::module(context),
+        M::Dotnet => super::dotnet::module(context),
+        M::Elixir => super::elixir::module(context),
+        M::Elm => super::elm::module(context),
+        M::Erlang => super::erlang::module(context),
+        M::Fennel => super::fennel::module(context),
+        M::Fill => super::fill::module(context),
+        M::Fortran => super::fortran::module(context),
+        M::FossilBranch => super::fossil_branch::module(context),
+        M::FossilMetrics => super::fossil_metrics::module(context),
+        M::Gcloud => super::gcloud::module(context),
+        M::GitBranch => super::git_branch::module(context),
+        M::GitCommit => super::git_commit::module(context),
+        M::GitMetrics => super::git_metrics::module(context),
+        M::GitState => super::git_state::module(context),
+        M::GitStatus => super::git_status::module(context),
+        M::Gleam => super::gleam::module(context),
+        M::Golang => super::golang::module(context),
+        M::Gradle => super::gradle::module(context),
+        M::GuixShell => super::guix_shell::module(context),
+        M::Haskell => super::haskell::module(context),
+        M::Haxe => super::haxe::module(context),
+        M::Helm => super::helm::module(context),
+        M::HgBranch => super::hg_branch::module(context),
+        M::HgState => super::hg_state::module(context),
+        M::Hostname => super::hostname::module(context),
+        M::Java => super::java::module(context),
+        M::Jobs => super::jobs::module(context),
+        M::Julia => super::julia::module(context),
+        M::Kotlin => super::kotlin::module(context),
+        M::Kubernetes => super::kubernetes::module(context),
+        M::LineBreak => super::line_break::module(context),
+        M::Localip => super::localip::module(context),
+        M::Lua => super::lua::module(context),
+        M::Maven => super::maven::module(context),
+        M::MemoryUsage => super::memory_usage::module(context),
+        M::Meson => super::meson::module(context),
+        M::Mise => super::mise::module(context),
+        M::Mojo => super::mojo::module(context),
+        M::Nats => super::nats::module(context),
+        M::Netns => super::netns::module(context),
+        M::Nim => super::nim::module(context),
+        M::NixShell => super::nix_shell::module(context),
+        M::Nodejs => super::nodejs::module(context),
+        M::Ocaml => super::ocaml::module(context),
+        M::Odin => super::odin::module(context),
+        M::Opa => super::opa::module(context),
+        M::Openstack => super::openstack::module(context),
+        M::Os => super::os::module(context),
+        M::Package => super::package::module(context),
+        M::Perl => super::perl::module(context),
+        M::Php => super::php::module(context),
+        M::PijulChannel => super::pijul_channel::module(context),
+        M::Pixi => super::pixi::module(context),
+        M::Pulumi => super::pulumi::module(context),
+        M::Purescript => super::purescript::module(context),
+        M::Python => super::python::module(context),
+        M::Quarto => super::quarto::module(context),
+        M::Raku => super::raku::module(context),
+        M::Red => super::red::module(context),
+        M::Rlang => super::rlang::module(context),
+        M::Ruby => super::ruby::module(context),
+        M::Rust => super::rust::module(context),
+        M::Scala => super::scala::module(context),
+        M::Shell => super::shell::module(context),
+        M::Shlvl => super::shlvl::module(context),
+        M::Singularity => super::singularity::module(context),
+        M::Solidity => super::solidity::module(context),
+        M::Spack => super::spack::module(context),
+        M::Status => super::status::module(context),
+        M::Sudo => super::sudo::module(context),
+        M::Swift => super::swift::module(context),
+        M::Terraform => super::terraform::module(context),
+        M::Time => super::time::module(context),
+        M::Typst => super::typst::module(context),
+        M::Username => super::username::module(context),
+        M::Vagrant => super::vagrant::module(context),
+        M::Vcs => super::vcs::module(context),
+        M::Vcsh => super::vcsh::module(context),
+        M::Vlang => super::vlang::module(context),
+        M::Xmake => super::xmake::module(context),
+        M::Zig => super::zig::module(context),
+    }
+}
+
+/// Identifies a module by what dispatches it.
+///
+/// `custom.<name>` and `env_var.<name>` are user-defined — a user may write
+/// `custom.anything` in their own configuration — so no closed enum could ever
+/// list them. Keeping them as a variant that carries the suffix, rather than
+/// accepting any `&str` as a module name everywhere `cadence`, `description` and
+/// dispatch are used, is what stops an arbitrary string from masquerading as a
+/// builtin: the only way to produce a `ModuleId::Builtin` is
+/// [`BuiltinModule::from_name`] recognising it exactly, and every other spelling —
+/// including one that merely *starts with* a builtin's name — falls through to
+/// one of the other two variants, or to `None` from [`ModuleId::parse`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModuleId<'a> {
+    /// One of the closed set of modules starship ships with.
+    Builtin(BuiltinModule),
+    /// `env_var` (`None`) or `env_var.<name>` (`Some`) — the bare form names no
+    /// particular variable, and is what an unqualified `$env_var` means.
+    EnvVar(Option<&'a str>),
+    /// `custom.<name>`. Bare `custom` is not a module — it never dispatched to
+    /// anything before this type existed either — so it has no representation
+    /// here at all.
+    Custom(&'a str),
+}
+
+impl<'a> ModuleId<'a> {
+    /// Classifies `name` the way [`crate::modules::handle`] would.
+    #[must_use]
+    pub fn parse(name: &'a str) -> Option<Self> {
+        if let Some(builtin) = BuiltinModule::from_name(name) {
+            return Some(Self::Builtin(builtin));
+        }
+        if name == "env_var" {
+            return Some(Self::EnvVar(None));
+        }
+        if let Some(suffix) = name.strip_prefix("env_var.") {
+            return Some(Self::EnvVar(Some(suffix)));
+        }
+        if let Some(suffix) = name.strip_prefix("custom.") {
+            return Some(Self::Custom(suffix));
+        }
+        None
+    }
+}
+
+/// The [`Cadence`] of `module`, or `None` if it is not recognised at all.
+#[must_use]
+pub fn cadence(module: &str) -> Option<Cadence> {
+    match ModuleId::parse(module)? {
+        ModuleId::Builtin(builtin) => Some(entry_for(builtin).cadence),
+        // A single environment variable lookup, whichever variable was named.
+        ModuleId::EnvVar(_) => Some(Cadence::Instant),
+        // A user-supplied command line, run through a shell.
+        ModuleId::Custom(_) => Some(Cadence::Deferred),
+    }
+}
+
+/// `module`'s description, or a placeholder for one that has none — which is
+/// every `custom.*` and `env_var.*` module, exactly as before this table existed.
+#[must_use]
+pub fn description(module: &str) -> &'static str {
+    match ModuleId::parse(module) {
+        Some(ModuleId::Builtin(builtin)) => entry_for(builtin).description,
+        _ => "<no description>",
+    }
+}
+
+/// Renders `module` by dispatching on what kind of [`ModuleId`] it parses as, or
+/// `None` if `name` is not a module starship recognises at all.
+#[must_use]
+pub fn render<'a>(module: &str, context: &'a Context) -> Option<Option<Module<'a>>> {
+    Some(match ModuleId::parse(module)? {
+        ModuleId::Builtin(builtin) => dispatch_builtin(builtin, context),
+        ModuleId::EnvVar(name) => super::env_var::module(name, context),
+        ModuleId::Custom(name) => super::custom::module(name, context),
+    })
+}
+
+const ALL_MODULE_NAME_COUNT: usize = BuiltinModule::ALL.len();
+
+const fn all_module_names() -> [&'static str; ALL_MODULE_NAME_COUNT] {
+    let mut names = [""; ALL_MODULE_NAME_COUNT];
+    let mut i = 0;
+    while i < ALL_MODULE_NAME_COUNT {
+        names[i] = BuiltinModule::ALL[i].name();
+        i += 1;
+    }
+    names
+}
+
+const ALL_MODULE_NAMES: [&str; ALL_MODULE_NAME_COUNT] = all_module_names();
+
+/// Every module starship ships with, alphabetically.
+///
+/// Alphabetical because the `builtin_modules!` invocation above is declared that
+/// way — see `test_all_modules_is_in_alphabetical_order` in `crate::module`, which
+/// this satisfies by construction rather than by a sort computed here.
+pub const ALL_MODULES: &[&str] = &ALL_MODULE_NAMES;
+
+/// Where `env_var.*` modules collectively sit in the default ordering.
+const ENV_VAR_PROMPT_POSITION: u16 = 85;
+/// Where `custom.*` modules collectively sit in the default ordering.
+const CUSTOM_PROMPT_POSITION: u16 = 88;
+
+/// The default order modules are drawn in, and what `$all` expands to.
+///
+/// Built once, from every [`BuiltinModule`] that has a
+/// [`ModuleEntry::prompt_position`], plus the two prefixed-family placeholders,
+/// sorted by that position. A `const` array would have to sort itself at compile
+/// time for no real benefit — nothing here is on a hot path, and it is computed
+/// once regardless — so this is a plain sort behind a [`LazyLock`].
+pub static PROMPT_ORDER: LazyLock<Vec<&'static str>> = LazyLock::new(|| {
+    let mut positioned: Vec<(u16, &'static str)> = BuiltinModule::ALL
+        .iter()
+        .filter_map(|&module| {
+            entry_for(module)
+                .prompt_position
+                .map(|position| (position, module.name()))
+        })
+        .collect();
+    positioned.push((ENV_VAR_PROMPT_POSITION, "env_var"));
+    positioned.push((CUSTOM_PROMPT_POSITION, "custom"));
+    positioned.sort_by_key(|&(position, _)| position);
+    positioned.into_iter().map(|(_, name)| name).collect()
+});
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The exact ordering `PROMPT_ORDER` held before this table replaced its
+    /// hand-maintained array, with `battery` included — this crate is built
+    /// `--all-features` under test, so the cfg-gated entry is always present
+    /// here.
+    ///
+    /// A golden list rather than a property (`is_sorted_by`, say) because the
+    /// property that matters is the *specific* order a hand-maintained array
+    /// used to encode by position alone: this is the one test that would have
+    /// caught the position-scale bug an earlier draft of this table had, where
+    /// builtin positions and the two placeholder positions were computed on
+    /// two different numberings and silently reordered `env_var`, `custom` and
+    /// their neighbours.
+    const ORIGINAL_PROMPT_ORDER: &[&str] = &[
+        "username",
+        "hostname",
+        "localip",
+        "shlvl",
+        "singularity",
+        "kubernetes",
+        "nats",
+        "directory",
+        "vcsh",
+        "fossil_branch",
+        "fossil_metrics",
+        "git_branch",
+        "git_commit",
+        "git_state",
+        "git_metrics",
+        "git_status",
+        "hg_branch",
+        "hg_state",
+        "pijul_channel",
+        "docker_context",
+        "package",
+        "bun",
+        "c",
+        "cmake",
+        "cobol",
+        "cpp",
+        "daml",
+        "dart",
+        "deno",
+        "dotnet",
+        "elixir",
+        "elm",
+        "erlang",
+        "fennel",
+        "fortran",
+        "gleam",
+        "golang",
+        "gradle",
+        "haskell",
+        "haxe",
+        "helm",
+        "java",
+        "julia",
+        "kotlin",
+        "lua",
+        "maven",
+        "mojo",
+        "nim",
+        "nodejs",
+        "ocaml",
+        "odin",
+        "opa",
+        "perl",
+        "php",
+        "pulumi",
+        "purescript",
+        "python",
+        "quarto",
+        "raku",
+        "rlang",
+        "red",
+        "ruby",
+        "rust",
+        "scala",
+        "solidity",
+        "swift",
+        "terraform",
+        "typst",
+        "vlang",
+        "vagrant",
+        "xmake",
+        "zig",
+        "buf",
+        "guix_shell",
+        "nix_shell",
+        "conda",
+        "pixi",
+        "meson",
+        "spack",
+        "memory_usage",
+        "aws",
+        "gcloud",
+        "openstack",
+        "azure",
+        "direnv",
+        "env_var",
+        "mise",
+        "crystal",
+        "custom",
+        "sudo",
+        "cmd_duration",
+        "line_break",
+        "jobs",
+        #[cfg(feature = "battery")]
+        "battery",
+        "time",
+        "status",
+        "container",
+        "netns",
+        "os",
+        "shell",
+        "character",
+    ];
+
+    #[test]
+    fn prompt_order_exactly_reproduces_the_ordering_it_replaced() {
+        assert_eq!(ORIGINAL_PROMPT_ORDER, PROMPT_ORDER.as_slice());
+    }
+
+    #[test]
+    fn all_modules_is_alphabetical_and_agrees_with_builtin_module_all() {
+        let mut sorted: Vec<&str> = ALL_MODULES.to_vec();
+        sorted.sort_unstable();
+        assert_eq!(sorted, ALL_MODULES);
+        assert_eq!(BuiltinModule::ALL.len(), ALL_MODULES.len());
+    }
+
+    /// Every [`BuiltinModule`] round-trips through its name — the property
+    /// [`ModuleId::parse`] leans on to recognise a builtin at all.
+    #[test]
+    fn every_builtin_round_trips_through_its_name() {
+        for &module in BuiltinModule::ALL {
+            assert_eq!(
+                Some(module),
+                BuiltinModule::from_name(module.name()),
+                "{module:?} does not round-trip through its own name {:?}",
+                module.name()
+            );
+        }
+    }
+
+    #[test]
+    fn module_id_parses_every_builtin() {
+        for &module in BuiltinModule::ALL {
+            assert_eq!(
+                Some(ModuleId::Builtin(module)),
+                ModuleId::parse(module.name())
+            );
+        }
+    }
+
+    #[test]
+    fn module_id_parses_the_prefixed_families() {
+        assert_eq!(Some(ModuleId::EnvVar(None)), ModuleId::parse("env_var"));
+        assert_eq!(
+            Some(ModuleId::EnvVar(Some("SHELL"))),
+            ModuleId::parse("env_var.SHELL")
+        );
+        assert_eq!(
+            Some(ModuleId::Custom("git_hash")),
+            ModuleId::parse("custom.git_hash")
+        );
+    }
+
+    /// The crux of `ModuleId`: nothing that merely *looks* like a builtin, a
+    /// dotted family member, or a bare prefix parses as one.
+    #[test]
+    fn module_id_rejects_everything_else() {
+        for unrecognised in [
+            "not_a_module",
+            // Bare `custom` never dispatched to anything before `ModuleId`
+            // existed either; it must not gain a meaning now.
+            "custom",
+            // A string that merely starts with a builtin's name is not that
+            // builtin — this is the "arbitrary string masquerading as a
+            // builtin" case the type exists to rule out.
+            "awsome",
+            "aws2",
+            "",
+        ] {
+            assert_eq!(
+                None,
+                ModuleId::parse(unrecognised),
+                "{unrecognised:?} parsed as a module, but is not one"
+            );
+        }
+    }
+
+    #[test]
+    fn cadence_and_description_agree_with_entry_for() {
+        for &module in BuiltinModule::ALL {
+            let entry = entry_for(module);
+            assert_eq!(Some(entry.cadence), cadence(module.name()));
+            assert_eq!(entry.description, description(module.name()));
+        }
+    }
+}

--- a/src/modules/registry.rs
+++ b/src/modules/registry.rs
@@ -5,10 +5,6 @@ use std::sync::LazyLock;
 use crate::context::Context;
 use crate::module::Module;
 
-#[cfg(feature = "battery")]
-use super::BATTERY_PERIOD;
-use super::{Cadence, LOCALIP_PERIOD, MEMORY_USAGE_PERIOD, TIME_PERIOD};
-
 /// Declares [`BuiltinModule`] and everything that can be generated from
 /// enumerating it alone: its name in each direction, and the array of every
 /// variant. See the module-level doc comment for why this is a macro.
@@ -168,7 +164,6 @@ builtin_modules! {
 /// What the table says about a module, beyond what [`BuiltinModule`] already
 /// carries (its name).
 pub struct ModuleEntry {
-    pub cadence: Cadence,
     pub description: &'static str,
     /// This module's place in [`PROMPT_ORDER`], or `None` for a module that is
     /// not part of the default ordering — a profile-only module such as
@@ -190,109 +185,88 @@ pub const fn entry_for(module: BuiltinModule) -> ModuleEntry {
     match module {
         // Instant — a cheap system call, or reading shell-supplied or environment state. No file system traversal and no subprocess.
         M::Character => ModuleEntry {
-            cadence: Cadence::Instant,
             description: "A character (usually an arrow) beside where the text is entered in your terminal",
             prompt_position: Some(100),
         },
         M::ClaudeContext => ModuleEntry {
-            cadence: Cadence::Instant,
             description: "Context window usage for Claude Code session",
             prompt_position: None,
         },
         M::ClaudeCost => ModuleEntry {
-            cadence: Cadence::Instant,
             description: "Cost info for Claude Code session",
             prompt_position: None,
         },
         M::ClaudeModel => ModuleEntry {
-            cadence: Cadence::Instant,
             description: "AI model name for Claude Code session",
             prompt_position: None,
         },
         M::CmdDuration => ModuleEntry {
-            cadence: Cadence::Instant,
             description: "How long the last command took to execute",
             prompt_position: Some(90),
         },
         M::Conda => ModuleEntry {
-            cadence: Cadence::Instant,
             description: "The current conda environment, if $CONDA_DEFAULT_ENV is set",
             prompt_position: Some(75),
         },
         M::Fill => ModuleEntry {
-            cadence: Cadence::Instant,
             description: "Fills the remaining space on the line with a pad string",
             prompt_position: None,
         },
         M::GuixShell => ModuleEntry {
-            cadence: Cadence::Instant,
             description: "The guix-shell environment",
             prompt_position: Some(73),
         },
         M::Hostname => ModuleEntry {
-            cadence: Cadence::Instant,
             description: "The system hostname",
             prompt_position: Some(1),
         },
         M::Jobs => ModuleEntry {
-            cadence: Cadence::Instant,
             description: "The current number of jobs running",
             prompt_position: Some(92),
         },
         M::LineBreak => ModuleEntry {
-            cadence: Cadence::Instant,
             description: "Separates the prompt into two lines",
             prompt_position: Some(91),
         },
         M::Meson => ModuleEntry {
-            cadence: Cadence::Instant,
             description: "The current Meson environment, if $MESON_DEVENV and $MESON_PROJECT_NAME are set",
             prompt_position: Some(77),
         },
         M::NixShell => ModuleEntry {
-            cadence: Cadence::Instant,
             description: "The nix-shell environment",
             prompt_position: Some(74),
         },
         M::Shell => ModuleEntry {
-            cadence: Cadence::Instant,
             description: "The currently used shell indicator",
             prompt_position: Some(99),
         },
         M::Shlvl => ModuleEntry {
-            cadence: Cadence::Instant,
             description: "The current value of SHLVL",
             prompt_position: Some(3),
         },
         M::Singularity => ModuleEntry {
-            cadence: Cadence::Instant,
             description: "The currently used Singularity image",
             prompt_position: Some(4),
         },
         M::Spack => ModuleEntry {
-            cadence: Cadence::Instant,
             description: "The current spack environment, if $SPACK_ENV is set",
             prompt_position: Some(78),
         },
         M::Status => ModuleEntry {
-            cadence: Cadence::Instant,
             description: "The status of the last command",
             prompt_position: Some(95),
         },
         M::Username => ModuleEntry {
-            cadence: Cadence::Instant,
             description: "The active user's username",
             prompt_position: Some(0),
         },
         M::Vcsh => ModuleEntry {
-            cadence: Cadence::Instant,
             description: "The currently active VCSH repository",
             prompt_position: Some(8),
         },
 
         // Instant — a container marker under `/run`, a virtual filesystem backed by memory rather than a disk or a network mount: the `stat` or `open` against it cannot stall the way one against a real filesystem can.
         M::Container => ModuleEntry {
-            cadence: Cadence::Instant,
             description: "The container indicator, if inside a container.",
             prompt_position: Some(96),
         },
@@ -300,437 +274,346 @@ pub const fn entry_for(module: BuiltinModule) -> ModuleEntry {
         // Dynamic — intrinsically time-varying values, re-polled on their own period.
         #[cfg(feature = "battery")]
         M::Battery => ModuleEntry {
-            cadence: Cadence::Dynamic {
-                period: BATTERY_PERIOD,
-            },
             description: "The current charge of the device's battery and its current charging status",
             prompt_position: Some(93),
         },
         M::Localip => ModuleEntry {
-            cadence: Cadence::Dynamic {
-                period: LOCALIP_PERIOD,
-            },
             description: "The currently assigned ipv4 address",
             prompt_position: Some(2),
         },
         M::MemoryUsage => ModuleEntry {
-            cadence: Cadence::Dynamic {
-                period: MEMORY_USAGE_PERIOD,
-            },
             description: "Current system memory and swap usage",
             prompt_position: Some(79),
         },
         M::Time => ModuleEntry {
-            cadence: Cadence::Dynamic {
-                period: TIME_PERIOD,
-            },
             description: "The current local time",
             prompt_position: Some(94),
         },
 
         // Deferred — read one or more credentials or profile files under the user's home directory: `~/.aws/{config,credentials}`, `~/.azure/azureProfile.json`, `~/.config/gcloud/...`, `~/.config/openstack/clouds.yaml`. Each path is known up front, but "known up front" does not mean bounded — the directory it lives under may be a slow or network mount, and these are full file reads (parsed as INI or JSON), not a single cheap `stat`.
         M::Aws => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The current AWS region and profile",
             prompt_position: Some(80),
         },
         M::Azure => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The current Azure subscription",
             prompt_position: Some(83),
         },
         M::Gcloud => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The current GCP client configuration",
             prompt_position: Some(81),
         },
         M::Openstack => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The current OpenStack cloud and project",
             prompt_position: Some(82),
         },
 
         // Deferred — discover a repository, either by opening it through `Context::get_repo` or by walking the ancestors of the working directory looking for a control directory.
         M::Directory => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The current working directory",
             prompt_position: Some(7),
         },
         M::GitCommit => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The active commit (and tag if any) of the current Git repo",
             prompt_position: Some(12),
         },
         M::GitState => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The current Git operation and its progress",
             prompt_position: Some(13),
         },
         M::HgBranch => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The active branch and topic of the repo in your current directory",
             prompt_position: Some(16),
         },
         M::HgState => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The current hg operation",
             prompt_position: Some(17),
         },
         M::Vcs => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The currently active VCS repository (first one matching)",
             prompt_position: None,
         },
 
         // Deferred — repository discovery followed by a `git` subprocess.
         M::GitBranch => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The active branch of the current Git repo",
             prompt_position: Some(11),
         },
         M::GitMetrics => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The currently added/deleted lines in your Git repo",
             prompt_position: Some(14),
         },
         M::GitStatus => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "Symbols representing the state of the current Git repo, filtered to your current directory",
             prompt_position: Some(15),
         },
 
         // Deferred — scan the working directory for marker files. No subprocess, but the scan itself is unbounded: its cost is set by the directory it lands in, not by the module.
         M::Daml => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The Daml SDK version of your project",
             prompt_position: Some(26),
         },
         M::DockerContext => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The current docker context",
             prompt_position: Some(19),
         },
         M::Gradle => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The currently installed version of Gradle",
             prompt_position: Some(37),
         },
         M::Kubernetes => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The current Kubernetes context name and, if set, the namespace",
             prompt_position: Some(5),
         },
         M::Maven => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The Maven Wrapper version of the current project",
             prompt_position: Some(45),
         },
 
         // Deferred — `os_info` inspects the running system, which on several platforms means spawning a helper such as `sw_vers` or `lsb_release`.
         M::Os => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The current operating system",
             prompt_position: Some(98),
         },
 
         // Deferred — spawn a subprocess to ask a tool for its version or its state. Most of these gate the subprocess behind a directory scan first, which makes them cheap in an unrelated directory but does not make them bounded: the scan is itself unbounded input/output.
         M::Buf => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The currently installed version of the Buf CLI",
             prompt_position: Some(72),
         },
         M::Bun => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The currently installed version of the Bun",
             prompt_position: Some(21),
         },
         M::C => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "Your C compiler type",
             prompt_position: Some(22),
         },
         M::Cmake => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The currently installed version of CMake",
             prompt_position: Some(23),
         },
         M::Cobol => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The currently installed version of COBOL/GNUCOBOL",
             prompt_position: Some(24),
         },
         M::Cpp => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "Your C++ compiler type",
             prompt_position: Some(25),
         },
         M::Crystal => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The currently installed version of Crystal",
             prompt_position: Some(87),
         },
         M::Dart => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The currently installed version of Dart",
             prompt_position: Some(27),
         },
         M::Deno => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The currently installed version of Deno",
             prompt_position: Some(28),
         },
         M::Direnv => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The currently applied direnv file",
             prompt_position: Some(84),
         },
         M::Dotnet => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The relevant version of the .NET Core SDK for the current directory",
             prompt_position: Some(29),
         },
         M::Elixir => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The currently installed versions of Elixir and OTP",
             prompt_position: Some(30),
         },
         M::Elm => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The currently installed version of Elm",
             prompt_position: Some(31),
         },
         M::Erlang => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "Current OTP version",
             prompt_position: Some(32),
         },
         M::Fennel => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The currently installed version of Fennel",
             prompt_position: Some(33),
         },
         M::Fortran => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The currently used version of Fortran",
             prompt_position: Some(34),
         },
         M::FossilBranch => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The active branch of the check-out in your current directory",
             prompt_position: Some(9),
         },
         M::FossilMetrics => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The currently added/deleted lines in your check-out",
             prompt_position: Some(10),
         },
         M::Gleam => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The currently installed version of Gleam",
             prompt_position: Some(35),
         },
         M::Golang => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The currently installed version of Golang",
             prompt_position: Some(36),
         },
         M::Haskell => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The selected version of the Haskell toolchain",
             prompt_position: Some(38),
         },
         M::Haxe => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The currently installed version of Haxe",
             prompt_position: Some(39),
         },
         M::Helm => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The currently installed version of Helm",
             prompt_position: Some(40),
         },
         M::Java => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The currently installed version of Java",
             prompt_position: Some(41),
         },
         M::Julia => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The currently installed version of Julia",
             prompt_position: Some(42),
         },
         M::Kotlin => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The currently installed version of Kotlin",
             prompt_position: Some(43),
         },
         M::Lua => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The currently installed version of Lua",
             prompt_position: Some(44),
         },
         M::Mise => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The current mise status",
             prompt_position: Some(86),
         },
         M::Mojo => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The currently installed version of Mojo",
             prompt_position: Some(46),
         },
         M::Nats => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The current NATS context",
             prompt_position: Some(6),
         },
         M::Netns => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The current network namespace",
             prompt_position: Some(97),
         },
         M::Nim => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The currently installed version of Nim",
             prompt_position: Some(47),
         },
         M::Nodejs => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The currently installed version of NodeJS",
             prompt_position: Some(48),
         },
         M::Ocaml => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The currently installed version of OCaml",
             prompt_position: Some(49),
         },
         M::Odin => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The currently installed version of Odin",
             prompt_position: Some(50),
         },
         M::Opa => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The currently installed version of Open Platform Agent",
             prompt_position: Some(51),
         },
         M::Package => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The package version of the current directory's project",
             prompt_position: Some(20),
         },
         M::Perl => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The currently installed version of Perl",
             prompt_position: Some(52),
         },
         M::Php => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The currently installed version of PHP",
             prompt_position: Some(53),
         },
         M::PijulChannel => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The current channel of the repo in the current directory",
             prompt_position: Some(18),
         },
         M::Pixi => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The currently installed version of Pixi, and the active environment if $PIXI_ENVIRONMENT_NAME is set",
             prompt_position: Some(76),
         },
         M::Pulumi => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The current username, stack, and installed version of Pulumi",
             prompt_position: Some(54),
         },
         M::Purescript => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The currently installed version of PureScript",
             prompt_position: Some(55),
         },
         M::Python => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The currently installed version of Python",
             prompt_position: Some(56),
         },
         M::Quarto => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The currently installed version of Quarto",
             prompt_position: Some(57),
         },
         M::Raku => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The currently installed version of Raku",
             prompt_position: Some(58),
         },
         M::Red => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The currently installed version of Red",
             prompt_position: Some(60),
         },
         M::Rlang => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The currently installed version of R",
             prompt_position: Some(59),
         },
         M::Ruby => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The currently installed version of Ruby",
             prompt_position: Some(61),
         },
         M::Rust => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The currently installed version of Rust",
             prompt_position: Some(62),
         },
         M::Scala => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The currently installed version of Scala",
             prompt_position: Some(63),
         },
         M::Solidity => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The current installed version of Solidity",
             prompt_position: Some(64),
         },
         M::Sudo => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The sudo credentials are currently cached",
             prompt_position: Some(89),
         },
         M::Swift => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The currently installed version of Swift",
             prompt_position: Some(65),
         },
         M::Terraform => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The currently selected terraform workspace and version",
             prompt_position: Some(66),
         },
         M::Typst => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The currently installed version of Typst",
             prompt_position: Some(67),
         },
         M::Vagrant => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The currently installed version of Vagrant",
             prompt_position: Some(69),
         },
         M::Vlang => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The currently installed version of V",
             prompt_position: Some(68),
         },
         M::Xmake => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The currently installed version of XMake",
             prompt_position: Some(70),
         },
         M::Zig => ModuleEntry {
-            cadence: Cadence::Deferred,
             description: "The currently installed version of Zig",
             prompt_position: Some(71),
         },
@@ -894,18 +777,6 @@ impl<'a> ModuleId<'a> {
             return Some(Self::Custom(suffix));
         }
         None
-    }
-}
-
-/// The [`Cadence`] of `module`, or `None` if it is not recognised at all.
-#[must_use]
-pub fn cadence(module: &str) -> Option<Cadence> {
-    match ModuleId::parse(module)? {
-        ModuleId::Builtin(builtin) => Some(entry_for(builtin).cadence),
-        // A single environment variable lookup, whichever variable was named.
-        ModuleId::EnvVar(_) => Some(Cadence::Instant),
-        // A user-supplied command line, run through a shell.
-        ModuleId::Custom(_) => Some(Cadence::Deferred),
     }
 }
 
@@ -1174,10 +1045,9 @@ mod tests {
     }
 
     #[test]
-    fn cadence_and_description_agree_with_entry_for() {
+    fn description_agrees_with_entry_for() {
         for &module in BuiltinModule::ALL {
             let entry = entry_for(module);
-            assert_eq!(Some(entry.cadence), cadence(module.name()));
             assert_eq!(entry.description, description(module.name()));
         }
     }

--- a/src/modules/registry.rs
+++ b/src/modules/registry.rs
@@ -556,6 +556,7 @@ pub const fn entry_for(module: BuiltinModule) -> ModuleEntry {
             prompt_position: Some(41),
         },
         M::JjBookmark => ModuleEntry {
+            cadence: Cadence::Deferred,
             description: "The closest ancestor bookmark in Jujutsu",
             prompt_position: None,
         },

--- a/src/plan/mod.rs
+++ b/src/plan/mod.rs
@@ -60,6 +60,12 @@ impl fmt::Display for ModuleName {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct ModuleSlot(usize);
 
+impl ModuleSlot {
+    pub(crate) fn index(self) -> usize {
+        self.0
+    }
+}
+
 /// The modules that can make a conditional visible.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 struct Predicate(Vec<ModuleSlot>);
@@ -175,6 +181,12 @@ pub struct ModuleUse {
     /// The module to run.
     pub module: ModuleName,
     slot: ModuleSlot,
+}
+
+impl ModuleUse {
+    pub(crate) fn slot(&self) -> ModuleSlot {
+        self.slot
+    }
 }
 
 /// The prompt, built from configuration alone.

--- a/src/plan/mod.rs
+++ b/src/plan/mod.rs
@@ -1,0 +1,1240 @@
+//! A prompt plan derived from configuration.
+
+use std::borrow::Cow;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
+
+use crate::config::{
+    ModuleConfig, StarshipConfig, Style, get_palette, parse_style_string_with_palette,
+};
+use crate::configs::fill::FillConfig;
+use crate::configs::{PROMPT_ORDER, Palette, StarshipRootConfig};
+use crate::context::Target;
+use crate::escaping::Destination;
+use crate::formatter::model::{FormatElement, StyleElement, VariableHolder};
+use crate::formatter::parse_format_string;
+use crate::segment::Segment;
+
+/// The format string used when the configured one cannot be used at all.
+const FALLBACK_FORMAT: &str = ">";
+
+/// The variable that stands for "every module the format string does not name".
+const ALL_MODULES_VARIABLE: &str = "all";
+
+/// The module that emits a stretchable run of padding.
+const FILL_MODULE: &str = "fill";
+
+/// The module that emits nothing but a line break.
+const LINE_BREAK_MODULE: &str = "line_break";
+
+/// The name of a module as it may appear in a format string.
+///
+/// Not every name is a module that exists — a format string may name anything —
+/// so this is a name that prompt rendering will *try* to turn into segments,
+/// not a proof that it can.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ModuleName(String);
+
+impl ModuleName {
+    /// Wraps a name taken from a format string or from the default ordering.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self(name.into())
+    }
+
+    /// The name as it is spelled in a format string.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for ModuleName {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.0)
+    }
+}
+
+/// The position of one distinct module in a [`Plan`].
+///
+/// This is deliberately not a module name: the plan interns every name once,
+/// so rendering can update a slot in constant time without a second lookup.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct ModuleSlot(usize);
+
+impl ModuleSlot {
+    pub(crate) fn index(self) -> usize {
+        self.0
+    }
+}
+
+/// The modules that can make a conditional visible.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+struct Predicate(Vec<ModuleSlot>);
+
+impl Predicate {
+    fn of(module: ModuleSlot) -> Self {
+        Self(vec![module])
+    }
+
+    fn union(&mut self, other: Self) {
+        for module in other.0 {
+            if !self.0.contains(&module) {
+                self.0.push(module);
+            }
+        }
+    }
+}
+
+/// Literal text together with the style that configuration gives it.
+///
+/// The text never contains a line break: line breaks are structural and are
+/// held by [`Node::LineBreak`] instead.
+#[derive(Clone, Debug, PartialEq)]
+pub struct StaticText {
+    text: String,
+    style: Option<Style>,
+}
+
+/// The characters a fill repeats, and the style it is drawn with.
+#[derive(Clone, Debug, PartialEq)]
+pub struct FillTemplate {
+    symbol: String,
+    style: Option<Style>,
+}
+
+/// One piece of a [`Plan`].
+#[derive(Clone, Debug, PartialEq)]
+enum Node {
+    /// Literal text with the style configuration gives it.
+    Static(StaticText),
+    /// A module's output, to be supplied per render.
+    Slot {
+        /// The module whose segments fill the slot.
+        slot: ModuleSlot,
+        /// The style of the enclosing text group, which the module's segments
+        /// take on wherever they carry no style of their own.
+        inherited_style: Option<Style>,
+    },
+    /// Padding that stretches to whatever width the line has left over.
+    ///
+    /// A fill's characters come from configuration; only how many of them are
+    /// painted is decided per render, and that is decided by the width of
+    /// everything around it rather than by anything a module produces. So a
+    /// fill has no per-render value of its own and contributes nothing to any
+    /// predicate.
+    Fill {
+        /// What to repeat, and in which style.
+        template: FillTemplate,
+    },
+    /// A body that shows only when at least one module in `predicate` renders
+    /// something non-empty.
+    ///
+    /// The predicate is never empty: a body that no module can ever bring into
+    /// view is dropped at build time instead, and one that always shows is
+    /// inlined.
+    Conditional {
+        /// The modules whose emptiness decides whether the body shows.
+        predicate: Predicate,
+        /// What to render when it does.
+        body: Vec<Self>,
+    },
+    /// The end of a visual line.
+    LineBreak,
+}
+
+/// Everything [`Plan::build`] is allowed to look at.
+///
+/// There is deliberately no way to reach a [`crate::context::Context`] from
+/// here: the fields are the parsed configuration, the destination whose escaping
+/// rules apply, and which of the prompts is being built. That is what makes "a
+/// plan is a function of configuration" a fact about the types rather than a
+/// promise in a comment.
+pub struct PromptConfiguration<'configuration> {
+    starship_configuration: &'configuration StarshipConfig,
+    root_configuration: &'configuration StarshipRootConfig,
+    destination: Destination,
+    target: &'configuration Target,
+}
+
+impl<'configuration> PromptConfiguration<'configuration> {
+    /// Bundles the configuration a plan is built from.
+    pub fn new(
+        starship_configuration: &'configuration StarshipConfig,
+        root_configuration: &'configuration StarshipRootConfig,
+        destination: Destination,
+        target: &'configuration Target,
+    ) -> Self {
+        Self {
+            starship_configuration,
+            root_configuration,
+            destination,
+            target,
+        }
+    }
+}
+
+/// A distinct module in a plan, in first-paint order.
+///
+/// A module named multiple times is represented once. Its private slot keeps
+/// the rendered value tied to that one plan.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ModuleUse {
+    /// The module to run.
+    pub module: ModuleName,
+    slot: ModuleSlot,
+}
+
+impl ModuleUse {
+    pub(crate) fn slot(&self) -> ModuleSlot {
+        self.slot
+    }
+}
+
+/// The prompt, built from configuration alone.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Plan {
+    nodes: Vec<Node>,
+    modules: Vec<ModuleUse>,
+    referenced_modules: BTreeSet<ModuleName>,
+}
+
+impl Plan {
+    /// Builds the plan for one prompt.
+    ///
+    /// Everything this reads is configuration; nothing it reads can vary between
+    /// two renders of the same prompt.
+    pub fn build(configuration: &PromptConfiguration<'_>) -> Self {
+        // Palette resolution: the one configuration-dependent input to style
+        // resolution. Read once, then threaded through every style in the plan.
+        let palette = get_palette(
+            &configuration.root_configuration.palettes,
+            configuration.root_configuration.palette.as_deref(),
+        );
+
+        let (elements, referenced_modules) = select_format(configuration);
+        let modules_expanded_by_all = modules_expanded_by_all(&referenced_modules);
+
+        let mut builder = Builder {
+            starship_configuration: configuration.starship_configuration,
+            palette,
+            destination: configuration.destination,
+            modules_expanded_by_all: &modules_expanded_by_all,
+            slots: BTreeMap::new(),
+            modules: Vec::new(),
+        };
+
+        let mut nodes = Vec::new();
+        builder.build_elements(&elements, None, &mut nodes);
+
+        Self {
+            nodes,
+            modules: builder.modules,
+            referenced_modules,
+        }
+    }
+
+    /// The modules the format strings name, including `all` if they name it.
+    ///
+    /// Both the main and the right format contribute, because a module named by
+    /// either one is not one that `$all` should supply again.
+    pub fn referenced_modules(&self) -> &BTreeSet<ModuleName> {
+        &self.referenced_modules
+    }
+
+    /// Every module the plan renders, distinct, in first-paint order.
+    ///
+    /// See [`ModuleUse`] for what that order guarantees.
+    pub fn module_uses(&self) -> &[ModuleUse] {
+        &self.modules
+    }
+
+    fn nodes(&self) -> &[Node] {
+        &self.nodes
+    }
+}
+
+/// What each module of one plan resolved to, for one render.
+///
+/// The state is keyed by *what a value is about* rather than by where it goes,
+/// and it can only be made from the plan it belongs to — [`PromptState::empty`]
+/// is the sole constructor and the sole place the two are ever associated. So
+/// there is no way to hand one plan's values to another plan's structure: no
+/// function takes a plan and a state as two arguments, because a state already
+/// holds its own.
+///
+/// A module with no value renders nothing, which is also what a module that is
+/// disabled or produced nothing renders — the three are indistinguishable by
+/// design. A module that produced an *empty* segment is a different thing
+/// again: the segment is still there, still carries a style, and a following
+/// `prev_fg` or `prev_bg` can still see it.
+#[derive(Clone)]
+pub struct PromptState<'plan> {
+    plan: &'plan Plan,
+    resolved: Vec<Vec<Segment>>,
+}
+
+impl<'plan> PromptState<'plan> {
+    /// A render of `plan` in which no module has resolved yet.
+    pub fn empty(plan: &'plan Plan) -> Self {
+        Self {
+            plan,
+            resolved: vec![Vec::new(); plan.modules.len()],
+        }
+    }
+
+    /// Takes what a module resolved to into this render.
+    ///
+    /// The module is named by a borrow of the plan's own copy of the name, so
+    /// what is recorded cannot be about a prompt other than the one being
+    /// rendered.
+    pub fn record(&mut self, module: &ModuleUse, segments: Vec<Segment>) {
+        self.resolved[module.slot.0] = segments;
+    }
+
+    /// What a module resolved to, or nothing if it has not resolved.
+    fn resolved_segments(&self, slot: ModuleSlot) -> &[Segment] {
+        &self.resolved[slot.0]
+    }
+
+    /// Fills the plan in, producing the segments the prompt is painted from.
+    pub fn render(&self) -> Vec<Segment> {
+        let mut segments = Vec::new();
+        self.render_nodes(self.plan.nodes(), &mut segments);
+        segments
+    }
+
+    fn render_nodes(&self, nodes: &[Node], segments: &mut Vec<Segment>) {
+        for node in nodes {
+            match node {
+                Node::Static(text) => {
+                    segments.push(Segment::text(text.style, text.text.clone()));
+                }
+                Node::LineBreak => segments.push(Segment::LineTerm),
+                Node::Slot {
+                    slot,
+                    inherited_style,
+                    ..
+                } => segments.extend(self.resolved_segments(*slot).iter().cloned().map(
+                    |mut segment| {
+                        segment.set_style_if_empty(*inherited_style);
+                        segment
+                    },
+                )),
+                Node::Fill { template } => {
+                    segments.push(Segment::fill(template.style, template.symbol.clone()));
+                }
+                Node::Conditional { predicate, body } => {
+                    if predicate.0.iter().any(|slot| self.is_filled(*slot)) {
+                        self.render_nodes(body, segments);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Whether a module rendered anything a conditional would count as present.
+    fn is_filled(&self, slot: ModuleSlot) -> bool {
+        self.resolved_segments(slot)
+            .iter()
+            .any(|segment| !segment.value().is_empty())
+    }
+}
+
+/// The modules `$all` stands for: every module in the default ordering that the
+/// format strings do not already name.
+pub fn modules_expanded_by_all(referenced_modules: &BTreeSet<ModuleName>) -> Vec<ModuleName> {
+    PROMPT_ORDER
+        .iter()
+        .map(|module| ModuleName::new(*module))
+        .filter(|module| !referenced_modules.contains(module))
+        .collect()
+}
+
+/// What a part of the plan contributes to the visibility of a conditional that
+/// contains it.
+///
+/// This mirrors, at build time, the question the renderer used to ask at render
+/// time: does any variable inside this conditional have a non-empty value?
+/// Literal text answers "no" — it never brings a conditional into view — and a
+/// module answers "only if it rendered something". A fill and a line break
+/// answer from configuration alone, which is why neither is ever named in a
+/// predicate.
+enum Presence {
+    /// Nothing here can bring a conditional into view.
+    Never,
+    /// A conditional shows exactly when one of these modules is filled.
+    WhenAnyFilled(Predicate),
+    /// A conditional containing this always shows.
+    Always,
+}
+
+impl Presence {
+    fn merge(self, other: Self) -> Self {
+        match (self, other) {
+            (Self::Always, _) | (_, Self::Always) => Self::Always,
+            (Self::Never, only) | (only, Self::Never) => only,
+            (Self::WhenAnyFilled(mut left), Self::WhenAnyFilled(right)) => {
+                left.union(right);
+                Self::WhenAnyFilled(left)
+            }
+        }
+    }
+}
+
+/// Turns format elements into plan nodes.
+struct Builder<'build> {
+    starship_configuration: &'build StarshipConfig,
+    palette: Option<&'build Palette>,
+    destination: Destination,
+    modules_expanded_by_all: &'build [ModuleName],
+    slots: BTreeMap<ModuleName, ModuleSlot>,
+    modules: Vec<ModuleUse>,
+}
+
+impl Builder<'_> {
+    fn build_elements(
+        &mut self,
+        elements: &[FormatElement<'_>],
+        inherited_style: Option<Style>,
+        nodes: &mut Vec<Node>,
+    ) -> Presence {
+        let mut presence = Presence::Never;
+
+        for element in elements {
+            match element {
+                FormatElement::Text(text) => {
+                    let escaped = self.destination.escape(text.clone());
+                    push_literal(&escaped, inherited_style, nodes);
+                }
+                FormatElement::TextGroup(group) => {
+                    let style = self.resolve_style(&group.style);
+                    if group.format.is_empty() {
+                        // An empty text group still produces a segment, so that a
+                        // later `prev_fg` or `prev_bg` can read its style.
+                        nodes.push(Node::Static(StaticText {
+                            text: String::new(),
+                            style,
+                        }));
+                    } else {
+                        presence = presence.merge(self.build_elements(&group.format, style, nodes));
+                    }
+                }
+                FormatElement::Variable(name) => {
+                    presence = presence.merge(self.build_variable(name, inherited_style, nodes));
+                }
+                FormatElement::Conditional(body) => {
+                    presence = presence.merge(self.build_conditional(body, inherited_style, nodes));
+                }
+            }
+        }
+
+        presence
+    }
+
+    fn build_conditional(
+        &mut self,
+        elements: &[FormatElement<'_>],
+        inherited_style: Option<Style>,
+        nodes: &mut Vec<Node>,
+    ) -> Presence {
+        let mut body = Vec::new();
+        let presence = self.build_elements(elements, inherited_style, &mut body);
+
+        match presence {
+            Presence::Always => {
+                // Configuration proves this always shows, so there is nothing
+                // left to decide per render.
+                nodes.append(&mut body);
+                Presence::Always
+            }
+            Presence::WhenAnyFilled(predicate) => {
+                nodes.push(Node::Conditional {
+                    predicate: predicate.clone(),
+                    body,
+                });
+                Presence::WhenAnyFilled(predicate)
+            }
+            Presence::Never => {
+                // No module inside, and nothing statically present: the body
+                // could never have shown, so it goes and takes whatever it
+                // contained with it.
+                Presence::Never
+            }
+        }
+    }
+
+    fn build_variable(
+        &mut self,
+        name: &str,
+        inherited_style: Option<Style>,
+        nodes: &mut Vec<Node>,
+    ) -> Presence {
+        if name == ALL_MODULES_VARIABLE {
+            let expanded = self.modules_expanded_by_all;
+            return expanded.iter().fold(Presence::Never, |presence, module| {
+                presence.merge(self.build_module(module, inherited_style, nodes))
+            });
+        }
+
+        let module = ModuleName::new(name);
+        if self.is_disabled(module.as_str()) {
+            return Presence::Never;
+        }
+        self.build_module(&module, inherited_style, nodes)
+    }
+
+    fn build_module(
+        &mut self,
+        module: &ModuleName,
+        inherited_style: Option<Style>,
+        nodes: &mut Vec<Node>,
+    ) -> Presence {
+        match module.as_str() {
+            // A line break has no data behind it: configuration alone says
+            // whether it is there, and it is never empty when it is.
+            LINE_BREAK_MODULE => {
+                if self.is_disabled(LINE_BREAK_MODULE) {
+                    return Presence::Never;
+                }
+                nodes.push(Node::LineBreak);
+                Presence::Always
+            }
+            // A fill's characters and style are configuration too; only its
+            // width is decided per render.
+            FILL_MODULE => {
+                let Some(template) = self.fill_template(inherited_style) else {
+                    return Presence::Never;
+                };
+                let presence = if template.symbol.is_empty() {
+                    Presence::Never
+                } else {
+                    Presence::Always
+                };
+                nodes.push(Node::Fill { template });
+                presence
+            }
+            _ => {
+                let slot = self.intern(module);
+                nodes.push(Node::Slot {
+                    slot,
+                    inherited_style,
+                });
+                Presence::WhenAnyFilled(Predicate::of(slot))
+            }
+        }
+    }
+
+    fn intern(&mut self, module: &ModuleName) -> ModuleSlot {
+        if let Some(&slot) = self.slots.get(module) {
+            return slot;
+        }
+
+        let slot = ModuleSlot(self.modules.len());
+        self.slots.insert(module.clone(), slot);
+        self.modules.push(ModuleUse {
+            module: module.clone(),
+            slot,
+        });
+        slot
+    }
+
+    /// The fill module's configuration, or `None` if it will not render.
+    fn fill_template(&self, inherited_style: Option<Style>) -> Option<FillTemplate> {
+        if self.is_disabled(FILL_MODULE) {
+            return None;
+        }
+
+        let configuration =
+            FillConfig::try_load(self.starship_configuration.get_module_config(FILL_MODULE));
+        if configuration.disabled {
+            return None;
+        }
+
+        Some(FillTemplate {
+            symbol: configuration.symbol.to_owned(),
+            // A fill with no style of its own takes on the enclosing text
+            // group's style, exactly as any other module's segments would.
+            style: parse_style_string_with_palette(configuration.style, self.palette)
+                .or(inherited_style),
+        })
+    }
+
+    /// Whether a module is switched off by `disabled = true`.
+    fn is_disabled(&self, module: &str) -> bool {
+        self.starship_configuration
+            .get_module_config(module)
+            .and_then(|value| value.as_table()?.get("disabled")?.as_bool())
+            == Some(true)
+    }
+
+    /// Resolves a style specification into a style.
+    ///
+    /// A root format string has no style variables to substitute — only modules
+    /// map those, and a prompt's own format string is not a module — so a style
+    /// variable contributes the empty string, which is what the formatter did
+    /// with an unmapped one too.
+    fn resolve_style(&self, elements: &[StyleElement<'_>]) -> Option<Style> {
+        let style_string: String = elements
+            .iter()
+            .map(|element| match element {
+                StyleElement::Text(text) => text.as_ref(),
+                StyleElement::Variable(_) => "",
+            })
+            .collect();
+
+        parse_style_string_with_palette(&style_string, self.palette)
+    }
+}
+
+/// Splits literal text on line breaks, which are structural rather than textual.
+fn push_literal(text: &str, style: Option<Style>, nodes: &mut Vec<Node>) {
+    for (index, piece) in text.split('\n').enumerate() {
+        if index > 0 {
+            nodes.push(Node::LineBreak);
+        }
+        nodes.push(Node::Static(StaticText {
+            text: piece.to_owned(),
+            style,
+        }));
+    }
+}
+
+/// Picks the format string this prompt is built from, and collects every module
+/// the configured format strings name.
+///
+/// The module set is deliberately taken from *both* the main and the right
+/// format even when only one of them is being built: a module named by either
+/// is one that `$all` must not supply again.
+fn select_format<'configuration>(
+    configuration: &PromptConfiguration<'configuration>,
+) -> (Vec<FormatElement<'configuration>>, BTreeSet<ModuleName>) {
+    let root = configuration.root_configuration;
+
+    if *configuration.target == Target::Continuation {
+        return match parse_format_string(&root.continuation_prompt) {
+            Ok(elements) => {
+                let modules = named_modules(&elements);
+                (elements, modules)
+            }
+            Err(error) => {
+                log::error!("Error parsing continuation prompt: {error}");
+                (fallback_format(), BTreeSet::new())
+            }
+        };
+    }
+
+    let (left_format, right_format): (&'configuration str, &'configuration str) =
+        match configuration.target {
+            Target::Main | Target::Right => (&root.format, &root.right_format),
+            Target::Profile(name) => {
+                match root
+                    .user_profiles
+                    .get(name)
+                    .or_else(|| root.internal_profiles.get(name))
+                {
+                    Some(format) => (format, ""),
+                    None => {
+                        log::error!("Profile {name:?} not found");
+                        return (fallback_format(), BTreeSet::new());
+                    }
+                }
+            }
+            Target::Continuation => {
+                unreachable!("Continuation prompt should have been handled above")
+            }
+        };
+
+    let left_elements = parse_format_string(left_format);
+    let right_elements = parse_format_string(right_format);
+
+    if let Err(ref error) = left_elements {
+        let name = if let Target::Profile(profile_name) = configuration.target {
+            format!("profile.{profile_name}")
+        } else {
+            "format".to_string()
+        };
+        log::error!("Error parsing {name:?}: {error}");
+    }
+
+    if let Err(ref error) = right_elements {
+        log::error!("Error parsing right_format: {error}");
+    }
+
+    let modules: BTreeSet<ModuleName> = [&left_elements, &right_elements]
+        .into_iter()
+        .flatten()
+        .flat_map(|elements| named_modules(elements))
+        .collect();
+
+    let selected = match configuration.target {
+        Target::Main | Target::Profile(_) => left_elements,
+        Target::Right => right_elements,
+        Target::Continuation => {
+            unreachable!("Continuation prompt should have been handled above")
+        }
+    };
+
+    match selected {
+        Ok(elements) => (elements, modules),
+        Err(_) => (fallback_format(), BTreeSet::new()),
+    }
+}
+
+fn fallback_format() -> Vec<FormatElement<'static>> {
+    vec![FormatElement::Text(Cow::Borrowed(FALLBACK_FORMAT))]
+}
+
+fn named_modules(elements: &[FormatElement<'_>]) -> BTreeSet<ModuleName> {
+    elements
+        .get_variables()
+        .into_iter()
+        .map(|name| ModuleName::new(name.into_owned()))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::parse_style_string;
+    use crate::formatter::StringFormatter;
+    use crate::module::painted::Painted;
+    use crate::segment::Segment;
+    use std::collections::HashMap;
+
+    /// A root configuration whose main format is `format`.
+    ///
+    /// `StarshipRootConfig` keeps a private field, so it cannot be built with
+    /// struct update syntax from another module.
+    fn root_configuration(format: &str) -> StarshipRootConfig {
+        set_format(StarshipRootConfig::default(), format)
+    }
+
+    fn set_format(mut root: StarshipRootConfig, format: &str) -> StarshipRootConfig {
+        root.format = format.to_owned();
+        root
+    }
+
+    /// Builds the main prompt's plan, the way a prompt would.
+    fn plan_with(root: &StarshipRootConfig, starship: &StarshipConfig) -> Plan {
+        plan_for(root, starship, &Target::Main)
+    }
+
+    fn plan_for(root: &StarshipRootConfig, starship: &StarshipConfig, target: &Target) -> Plan {
+        Plan::build(&PromptConfiguration::new(
+            starship,
+            root,
+            Destination::RawTerminal,
+            target,
+        ))
+    }
+
+    fn default_plan(format: &str) -> Plan {
+        plan_with(&root_configuration(format), &StarshipConfig::default())
+    }
+
+    /// The segments a render resolved so far renders to, described as markup.
+    fn render_markup(state: &PromptState<'_>) -> String {
+        Painted::paint(&state.render(), None).to_markup()
+    }
+
+    /// Resolves every module of a plan from a lookup table of name to segments.
+    fn fill_from<'plan>(
+        plan: &'plan Plan,
+        table: &HashMap<&str, Vec<Segment>>,
+    ) -> PromptState<'plan> {
+        let mut state = PromptState::empty(plan);
+        for module_use in plan.module_uses() {
+            if let Some(segments) = table.get(module_use.module.as_str()) {
+                state.record(module_use, segments.clone());
+            }
+        }
+        state
+    }
+
+    fn module<'plan>(plan: &'plan Plan, name: &str) -> &'plan ModuleUse {
+        plan.module_uses()
+            .iter()
+            .find(|module| module.module.as_str() == name)
+            .expect("module is part of the plan")
+    }
+
+    fn styled(style: &str, text: &str) -> Vec<Segment> {
+        Segment::from_text(parse_style_string(style, None), text)
+    }
+
+    // ---------------------------------------------------------------- equivalence
+
+    /// The format strings the plan has to agree with the formatter on.
+    const EQUIVALENT_FORMATS: &[&str] = &[
+        "",
+        "text only",
+        "$alpha",
+        "$alpha$beta",
+        "$alpha $beta",
+        "[$alpha](red bold)",
+        "[$alpha](bg:blue)[$beta](fg:prev_bg)",
+        "[](bg:#9A348E)[X](bg:prev_bg)",
+        "[]()",
+        "($alpha) between ($empty)",
+        "($alpha ($empty)) and ($empty ($alpha))",
+        "(literal only)",
+        "[($empty)](red bold)",
+        "[(@$empty)](red bold)",
+        "line one\nline two",
+        "[a\nb](green)",
+        "$line_break",
+        "a$line_break b",
+        "($line_break)",
+        "$fill",
+        "left$fill right",
+        "[$fill](red)",
+        "($fill)",
+        r"\\\[\$text\]\(red bold\)",
+        "${custom.thing}",
+        "$alpha[$beta](bold $style_variable)$alpha",
+        "[[$alpha](red)](blue)",
+        "(($alpha))",
+        "$alpha$alpha",
+    ];
+
+    /// The values every variable takes, for both implementations.
+    fn equivalence_table() -> HashMap<&'static str, Vec<Segment>> {
+        HashMap::from([
+            ("alpha", Segment::from_text(None, "A")),
+            ("beta", styled("green", "B")),
+            ("empty", Vec::new()),
+            ("custom.thing", styled("italic", "C")),
+            ("line_break", vec![Segment::LineTerm]),
+            (
+                "fill",
+                vec![Segment::fill(parse_style_string("bold black", None), ".")],
+            ),
+        ])
+    }
+
+    #[test]
+    fn a_plan_renders_what_the_formatter_renders() {
+        let table = equivalence_table();
+
+        for format in EQUIVALENT_FORMATS {
+            let formatter_segments = StringFormatter::new(format)
+                .expect("format string should parse")
+                .map_variables_to_segments(|variable| {
+                    table
+                        .get(variable)
+                        .cloned()
+                        .map(Ok)
+                        .or(Some(Ok(Vec::new())))
+                })
+                .parse(None, None)
+                .expect("format string should evaluate");
+            let expected = Painted::paint(&formatter_segments, None).to_markup();
+
+            let plan = default_plan(format);
+            let actual = render_markup(&fill_from(&plan, &table));
+
+            assert_eq!(expected, actual, "rendering {format:?}");
+        }
+    }
+
+    #[test]
+    fn a_plan_renders_what_the_formatter_renders_for_every_terminal_width() {
+        use crate::module::painted::TerminalWidth;
+
+        let table = equivalence_table();
+        let format = "left$fill middle$fill right";
+
+        let formatter_segments = StringFormatter::new(format)
+            .expect("format string should parse")
+            .map_variables_to_segments(|variable| {
+                table
+                    .get(variable)
+                    .cloned()
+                    .map(Ok)
+                    .or(Some(Ok(Vec::new())))
+            })
+            .parse(None, None)
+            .expect("format string should evaluate");
+
+        let plan = default_plan(format);
+        let plan_segments = fill_from(&plan, &table).render();
+
+        for width in [0, 1, 2, 10, 41, 80, 200] {
+            assert_eq!(
+                Painted::paint(&formatter_segments, Some(TerminalWidth(width))).to_string(),
+                Painted::paint(&plan_segments, Some(TerminalWidth(width))).to_string(),
+                "at width {width}"
+            );
+        }
+    }
+
+    // ---------------------------------------------------------------- modules
+
+    /// The names of the modules a plan uses, in the order it reports them.
+    fn used_modules(plan: &Plan) -> Vec<&str> {
+        plan.module_uses()
+            .iter()
+            .map(|module_use| module_use.module.as_str())
+            .collect()
+    }
+
+    #[test]
+    fn module_uses_are_reported_in_first_paint_order() {
+        let plan = default_plan("$alpha[$beta]($style)($gamma$delta)");
+
+        assert_eq!(vec!["alpha", "beta", "gamma", "delta"], used_modules(&plan));
+    }
+
+    #[test]
+    fn the_same_configuration_always_yields_the_same_plan() {
+        let format = "$alpha($beta$fill)[$gamma](red)$all";
+        assert_eq!(default_plan(format), default_plan(format));
+    }
+
+    #[test]
+    fn each_distinct_module_has_one_plan_slot() {
+        let plan = default_plan("$alpha($beta)$fill[$gamma](red)($delta$fill)$alpha");
+
+        assert_eq!(vec!["alpha", "beta", "gamma", "delta"], used_modules(&plan));
+    }
+
+    #[test]
+    fn a_module_named_twice_is_one_use_that_renders_in_every_position() {
+        let plan = default_plan("$alpha$beta$alpha");
+
+        assert_eq!(vec!["alpha", "beta"], used_modules(&plan));
+        assert_eq!(
+            "ABA",
+            render_markup(&fill_from(
+                &plan,
+                &HashMap::from([
+                    ("alpha", Segment::from_text(None, "A")),
+                    ("beta", Segment::from_text(None, "B")),
+                ])
+            ))
+        );
+    }
+
+    #[test]
+    fn a_later_resolution_replaces_an_earlier_one() {
+        let plan = default_plan("$alpha");
+        let mut state = PromptState::empty(&plan);
+        let alpha = module(&plan, "alpha");
+
+        state.record(alpha, Segment::from_text(None, "first"));
+        state.record(alpha, Segment::from_text(None, "second"));
+
+        assert_eq!("second", render_markup(&state));
+    }
+
+    // ---------------------------------------------------------------- conditionals
+
+    #[test]
+    fn a_conditional_keeps_its_literal_with_its_module() {
+        let plan = default_plan("($alpha literal)");
+        let mut state = PromptState::empty(&plan);
+        state.record(module(&plan, "alpha"), Segment::from_text(None, "A"));
+
+        assert_eq!("A literal", render_markup(&state));
+    }
+
+    #[test]
+    fn a_literal_inside_a_conditional_is_not_static() {
+        let plan = default_plan("($alpha literal)");
+
+        assert_eq!("", render_markup(&PromptState::empty(&plan)));
+    }
+
+    #[test]
+    fn a_conditional_nothing_can_fill_is_dropped() {
+        let plan = default_plan("(just literal text)");
+
+        assert_eq!(&[] as &[Node], plan.nodes());
+        assert!(plan.module_uses().is_empty());
+    }
+
+    #[test]
+    fn a_dropped_conditional_takes_its_contents_with_it() {
+        // A fill with nothing to repeat renders an empty segment, and a fill
+        // never names a module in a predicate anyway, so nothing inside this
+        // conditional can bring it into view and the whole thing goes — the
+        // fill included, leaving the plan with only what followed it.
+        let starship = StarshipConfig {
+            config: Some(toml::toml! {
+                [fill]
+                symbol = ""
+            }),
+        };
+        let plan = plan_with(&root_configuration("($fill)$alpha"), &starship);
+
+        assert!(matches!(plan.nodes(), [Node::Slot { .. }]));
+        assert_eq!(vec!["alpha"], used_modules(&plan));
+    }
+
+    #[test]
+    fn a_conditional_configuration_always_shows_is_inlined() {
+        assert_eq!(&[Node::LineBreak], default_plan("($line_break)").nodes());
+
+        // A fill always renders its symbol, so a conditional holding one is
+        // decided by configuration too.
+        let plan = default_plan("($fill)");
+        assert!(matches!(plan.nodes(), [Node::Fill { .. }]));
+    }
+
+    #[test]
+    fn a_nested_conditional_is_visible_when_its_module_is_filled() {
+        let plan = default_plan("(literal ($alpha))");
+        let mut state = PromptState::empty(&plan);
+        state.record(module(&plan, "alpha"), Segment::from_text(None, "A"));
+
+        assert_eq!("literal A", render_markup(&state));
+    }
+
+    #[test]
+    fn a_conditional_shows_when_any_of_its_modules_is_filled() {
+        let plan = default_plan("($alpha$beta)");
+        let mut state = PromptState::empty(&plan);
+
+        assert_eq!("", render_markup(&state));
+
+        state.record(module(&plan, "beta"), Segment::from_text(None, "B"));
+        assert_eq!("B", render_markup(&state));
+    }
+
+    #[test]
+    fn an_empty_segment_does_not_fill_a_module() {
+        let plan = default_plan("($alpha)");
+        let mut state = PromptState::empty(&plan);
+        state.record(module(&plan, "alpha"), Segment::from_text(None, ""));
+
+        assert_eq!("", render_markup(&state));
+    }
+
+    // ---------------------------------------------------------------- text
+
+    #[test]
+    fn literal_line_breaks_become_structure() {
+        let plan = default_plan("a\nb");
+
+        assert_eq!(
+            vec![
+                Node::Static(StaticText {
+                    text: "a".to_owned(),
+                    style: None
+                }),
+                Node::LineBreak,
+                Node::Static(StaticText {
+                    text: "b".to_owned(),
+                    style: None
+                }),
+            ],
+            plan.nodes()
+        );
+    }
+
+    #[test]
+    fn literal_text_is_escaped_for_the_destination_the_plan_was_built_for() {
+        // `\$` is the format string's way of writing a literal dollar sign.
+        let root = root_configuration(r"10% \$");
+        let starship = StarshipConfig::default();
+
+        for (destination, expected) in [
+            (Destination::RawTerminal, "10% $"),
+            (
+                Destination::shell_prompt_variable(crate::context::Shell::Zsh),
+                "10%% $",
+            ),
+            (
+                Destination::shell_prompt_variable(crate::context::Shell::Bash),
+                r"10% \$",
+            ),
+        ] {
+            let plan = Plan::build(&PromptConfiguration::new(
+                &starship,
+                &root,
+                destination,
+                &Target::Main,
+            ));
+            let rendered = Painted::paint(&PromptState::empty(&plan).render(), None).to_string();
+            assert_eq!(expected, rendered, "for {destination:?}");
+        }
+    }
+
+    // ---------------------------------------------------------------- styles
+
+    #[test]
+    fn a_palette_is_applied_when_styles_are_resolved() {
+        let mut root = root_configuration("[x](love)");
+        root.palette = Some("rose".to_owned());
+        root.palettes = HashMap::from([(
+            "rose".to_owned(),
+            HashMap::from([("love".to_owned(), "#EB6F92".to_owned())]),
+        )]);
+        let plan = plan_with(&root, &StarshipConfig::default());
+
+        assert_eq!("[x](#EB6F92)", render_markup(&PromptState::empty(&plan)));
+    }
+
+    #[test]
+    fn without_the_palette_the_same_style_string_means_something_else() {
+        // The point of resolving palettes during plan construction: `love` is
+        // not a colour on its own, so a style resolved without the palette is
+        // not merely differently coloured, it is a different style.
+        let plan = default_plan("[x](love)");
+
+        assert_eq!("x", render_markup(&PromptState::empty(&plan)));
+    }
+
+    #[test]
+    fn a_prev_reference_survives_into_the_plan_for_painting_to_resolve() {
+        let plan = default_plan("[a](fg:red bg:blue)[b](fg:prev_bg)");
+
+        assert_eq!(
+            "[a](red bg:blue)[b](blue)",
+            render_markup(&PromptState::empty(&plan))
+        );
+    }
+
+    #[test]
+    fn a_module_inherits_the_style_of_its_text_group() {
+        let plan = default_plan("[$alpha](red bold)");
+        let mut state = PromptState::empty(&plan);
+        state.record(module(&plan, "alpha"), Segment::from_text(None, "A"));
+
+        assert_eq!("[A](red bold)", render_markup(&state));
+    }
+
+    // ---------------------------------------------------------------- fill
+
+    #[test]
+    fn a_fill_takes_its_characters_and_style_from_configuration() {
+        let starship = StarshipConfig {
+            config: Some(toml::toml! {
+                [fill]
+                symbol = "*-"
+                style = "bold green"
+            }),
+        };
+        let plan = plan_with(&root_configuration("$fill"), &starship);
+
+        assert_eq!(
+            vec![Node::Fill {
+                template: FillTemplate {
+                    symbol: "*-".to_owned(),
+                    style: parse_style_string("bold green", None),
+                },
+            }],
+            plan.nodes()
+        );
+    }
+
+    #[test]
+    fn a_disabled_fill_leaves_nothing_behind() {
+        let starship = StarshipConfig {
+            config: Some(toml::toml! {
+                [fill]
+                disabled = true
+            }),
+        };
+        let plan = plan_with(&root_configuration("$fill"), &starship);
+
+        assert_eq!(&[] as &[Node], plan.nodes());
+        assert!(plan.module_uses().is_empty());
+    }
+
+    #[test]
+    fn a_disabled_line_break_leaves_nothing_behind() {
+        let starship = StarshipConfig {
+            config: Some(toml::toml! {
+                [line_break]
+                disabled = true
+            }),
+        };
+        let plan = plan_with(&root_configuration("$line_break"), &starship);
+
+        assert_eq!(&[] as &[Node], plan.nodes());
+    }
+
+    // ---------------------------------------------------------------- $all
+
+    #[test]
+    fn all_expands_to_the_modules_the_format_does_not_name() {
+        let plan = default_plan("$directory$all");
+        let uses = plan.module_uses();
+
+        assert_eq!("directory", uses[0].module.as_str());
+        assert_eq!(
+            1,
+            uses.iter()
+                .filter(|module_use| module_use.module.as_str() == "directory")
+                .count()
+        );
+    }
+
+    #[test]
+    fn all_expands_in_the_default_ordering() {
+        let plan = default_plan("$all");
+        let expanded = used_modules(&plan);
+
+        // `line_break` and any module without data of its own are structural,
+        // so they are not modules the plan runs; the rest keep the default
+        // order.
+        let mut remaining = expanded.iter();
+        for module in PROMPT_ORDER.iter() {
+            if *module == LINE_BREAK_MODULE {
+                continue;
+            }
+            assert_eq!(
+                Some(&module),
+                remaining.next().as_ref(),
+                "{module} out of order"
+            );
+        }
+        assert_eq!(None, remaining.next());
+    }
+
+    #[test]
+    fn the_right_format_also_claims_modules_from_all() {
+        let mut root = root_configuration("$all");
+        root.right_format = "$directory".to_owned();
+        let plan = plan_with(&root, &StarshipConfig::default());
+
+        assert!(!used_modules(&plan).contains(&"directory"));
+    }
+
+    // ---------------------------------------------------------------- targets
+
+    #[test]
+    fn each_target_selects_its_own_format() {
+        let mut root = root_configuration("main");
+        root.right_format = "right".to_owned();
+        root.continuation_prompt = "continuation".to_owned();
+        root.user_profiles = [("chosen".to_owned(), "profile".to_owned())]
+            .into_iter()
+            .collect();
+        let starship = StarshipConfig::default();
+
+        for (target, expected) in [
+            (Target::Main, "main"),
+            (Target::Right, "right"),
+            (Target::Continuation, "continuation"),
+            (Target::Profile("chosen".to_owned()), "profile"),
+            // An unknown profile falls back to a bare prompt character.
+            (Target::Profile("missing".to_owned()), ">"),
+        ] {
+            let plan = plan_for(&root, &starship, &target);
+            assert_eq!(
+                expected,
+                render_markup(&PromptState::empty(&plan)),
+                "for {target:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn an_unparsable_format_falls_back_to_a_bare_prompt_character() {
+        let plan = default_plan("[unclosed");
+
+        assert_eq!(">", render_markup(&PromptState::empty(&plan)));
+        assert!(plan.referenced_modules().is_empty());
+    }
+}

--- a/src/plan/mod.rs
+++ b/src/plan/mod.rs
@@ -27,21 +27,17 @@ const FILL_MODULE: &str = "fill";
 /// The module that emits nothing but a line break.
 const LINE_BREAK_MODULE: &str = "line_break";
 
+const ESTIMATED_STYLE_STRING_LENGTH: usize = 16;
+
 /// The name of a module as it may appear in a format string.
-///
-/// Not every name is a module that exists — a format string may name anything —
-/// so this is a name that prompt rendering will *try* to turn into segments,
-/// not a proof that it can.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ModuleName(String);
 
 impl ModuleName {
-    /// Wraps a name taken from a format string or from the default ordering.
     pub fn new(name: impl Into<String>) -> Self {
         Self(name.into())
     }
 
-    /// The name as it is spelled in a format string.
     pub fn as_str(&self) -> &str {
         &self.0
     }
@@ -54,10 +50,7 @@ impl fmt::Display for ModuleName {
 }
 
 /// The position of one distinct module in a [`Plan`].
-///
-/// This is deliberately not a module name: the plan interns every name once,
-/// so rendering can update a slot in constant time without a second lookup.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) struct ModuleSlot(usize);
 
 impl ModuleSlot {
@@ -76,18 +69,13 @@ impl Predicate {
     }
 
     fn union(&mut self, other: Self) {
-        for module in other.0 {
-            if !self.0.contains(&module) {
-                self.0.push(module);
-            }
-        }
+        self.0.extend(other.0);
+        self.0.sort_unstable();
+        self.0.dedup();
     }
 }
 
 /// Literal text together with the style that configuration gives it.
-///
-/// The text never contains a line break: line breaks are structural and are
-/// held by [`Node::LineBreak`] instead.
 #[derive(Clone, Debug, PartialEq)]
 pub struct StaticText {
     text: String,
@@ -104,50 +92,21 @@ pub struct FillTemplate {
 /// One piece of a [`Plan`].
 #[derive(Clone, Debug, PartialEq)]
 enum Node {
-    /// Literal text with the style configuration gives it.
     Static(StaticText),
-    /// A module's output, to be supplied per render.
     Slot {
-        /// The module whose segments fill the slot.
         slot: ModuleSlot,
-        /// The style of the enclosing text group, which the module's segments
-        /// take on wherever they carry no style of their own.
         inherited_style: Option<Style>,
     },
-    /// Padding that stretches to whatever width the line has left over.
-    ///
-    /// A fill's characters come from configuration; only how many of them are
-    /// painted is decided per render, and that is decided by the width of
-    /// everything around it rather than by anything a module produces. So a
-    /// fill has no per-render value of its own and contributes nothing to any
-    /// predicate.
     Fill {
-        /// What to repeat, and in which style.
         template: FillTemplate,
     },
-    /// A body that shows only when at least one module in `predicate` renders
-    /// something non-empty.
-    ///
-    /// The predicate is never empty: a body that no module can ever bring into
-    /// view is dropped at build time instead, and one that always shows is
-    /// inlined.
     Conditional {
-        /// The modules whose emptiness decides whether the body shows.
         predicate: Predicate,
-        /// What to render when it does.
         body: Vec<Self>,
     },
-    /// The end of a visual line.
     LineBreak,
 }
 
-/// Everything [`Plan::build`] is allowed to look at.
-///
-/// There is deliberately no way to reach a [`crate::context::Context`] from
-/// here: the fields are the parsed configuration, the destination whose escaping
-/// rules apply, and which of the prompts is being built. That is what makes "a
-/// plan is a function of configuration" a fact about the types rather than a
-/// promise in a comment.
 pub struct PromptConfiguration<'configuration> {
     starship_configuration: &'configuration StarshipConfig,
     root_configuration: &'configuration StarshipRootConfig,
@@ -156,7 +115,6 @@ pub struct PromptConfiguration<'configuration> {
 }
 
 impl<'configuration> PromptConfiguration<'configuration> {
-    /// Bundles the configuration a plan is built from.
     pub fn new(
         starship_configuration: &'configuration StarshipConfig,
         root_configuration: &'configuration StarshipRootConfig,
@@ -172,13 +130,8 @@ impl<'configuration> PromptConfiguration<'configuration> {
     }
 }
 
-/// A distinct module in a plan, in first-paint order.
-///
-/// A module named multiple times is represented once. Its private slot keeps
-/// the rendered value tied to that one plan.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ModuleUse {
-    /// The module to run.
     pub module: ModuleName,
     slot: ModuleSlot,
 }
@@ -189,7 +142,6 @@ impl ModuleUse {
     }
 }
 
-/// The prompt, built from configuration alone.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Plan {
     nodes: Vec<Node>,
@@ -198,26 +150,19 @@ pub struct Plan {
 }
 
 impl Plan {
-    /// Builds the plan for one prompt.
-    ///
-    /// Everything this reads is configuration; nothing it reads can vary between
-    /// two renders of the same prompt.
     pub fn build(configuration: &PromptConfiguration<'_>) -> Self {
-        // Palette resolution: the one configuration-dependent input to style
-        // resolution. Read once, then threaded through every style in the plan.
         let palette = get_palette(
             &configuration.root_configuration.palettes,
             configuration.root_configuration.palette.as_deref(),
         );
 
         let (elements, referenced_modules) = select_format(configuration);
-        let modules_expanded_by_all = modules_expanded_by_all(&referenced_modules);
 
         let mut builder = Builder {
             starship_configuration: configuration.starship_configuration,
             palette,
             destination: configuration.destination,
-            modules_expanded_by_all: &modules_expanded_by_all,
+            referenced_modules: &referenced_modules,
             slots: BTreeMap::new(),
             modules: Vec::new(),
         };
@@ -232,17 +177,10 @@ impl Plan {
         }
     }
 
-    /// The modules the format strings name, including `all` if they name it.
-    ///
-    /// Both the main and the right format contribute, because a module named by
-    /// either one is not one that `$all` should supply again.
     pub fn referenced_modules(&self) -> &BTreeSet<ModuleName> {
         &self.referenced_modules
     }
 
-    /// Every module the plan renders, distinct, in first-paint order.
-    ///
-    /// See [`ModuleUse`] for what that order guarantees.
     pub fn module_uses(&self) -> &[ModuleUse] {
         &self.modules
     }
@@ -252,20 +190,6 @@ impl Plan {
     }
 }
 
-/// What each module of one plan resolved to, for one render.
-///
-/// The state is keyed by *what a value is about* rather than by where it goes,
-/// and it can only be made from the plan it belongs to — [`PromptState::empty`]
-/// is the sole constructor and the sole place the two are ever associated. So
-/// there is no way to hand one plan's values to another plan's structure: no
-/// function takes a plan and a state as two arguments, because a state already
-/// holds its own.
-///
-/// A module with no value renders nothing, which is also what a module that is
-/// disabled or produced nothing renders — the three are indistinguishable by
-/// design. A module that produced an *empty* segment is a different thing
-/// again: the segment is still there, still carries a style, and a following
-/// `prev_fg` or `prev_bg` can still see it.
 #[derive(Clone)]
 pub struct PromptState<'plan> {
     plan: &'plan Plan,
@@ -287,7 +211,6 @@ impl fmt::Display for RecordError {
 impl std::error::Error for RecordError {}
 
 impl<'plan> PromptState<'plan> {
-    /// A render of `plan` in which no module has resolved yet.
     pub fn empty(plan: &'plan Plan) -> Self {
         Self {
             plan,
@@ -318,12 +241,10 @@ impl<'plan> PromptState<'plan> {
         Ok(())
     }
 
-    /// What a module resolved to, or nothing if it has not resolved.
     fn resolved_segments(&self, slot: ModuleSlot) -> &[Segment] {
         &self.resolved[slot.0]
     }
 
-    /// Fills the plan in, producing the segments the prompt is painted from.
     pub fn render(&self) -> Vec<Segment> {
         let mut segments = Vec::new();
         self.render_nodes(self.plan.nodes(), &mut segments);
@@ -340,13 +261,14 @@ impl<'plan> PromptState<'plan> {
                 Node::Slot {
                     slot,
                     inherited_style,
-                    ..
-                } => segments.extend(self.resolved_segments(*slot).iter().cloned().map(
-                    |mut segment| {
-                        segment.set_style_if_empty(*inherited_style);
-                        segment
-                    },
-                )),
+                } => {
+                    segments.extend(self.resolved_segments(*slot).iter().cloned().map(
+                        |mut segment| {
+                            segment.set_style_if_empty(*inherited_style);
+                            segment
+                        },
+                    ));
+                }
                 Node::Fill { template } => {
                     segments.push(Segment::fill(template.style, template.symbol.clone()));
                 }
@@ -359,7 +281,6 @@ impl<'plan> PromptState<'plan> {
         }
     }
 
-    /// Whether a module rendered anything a conditional would count as present.
     fn is_filled(&self, slot: ModuleSlot) -> bool {
         self.resolved_segments(slot)
             .iter()
@@ -367,31 +288,9 @@ impl<'plan> PromptState<'plan> {
     }
 }
 
-/// The modules `$all` stands for: every module in the default ordering that the
-/// format strings do not already name.
-pub fn modules_expanded_by_all(referenced_modules: &BTreeSet<ModuleName>) -> Vec<ModuleName> {
-    PROMPT_ORDER
-        .iter()
-        .map(|module| ModuleName::new(*module))
-        .filter(|module| !referenced_modules.contains(module))
-        .collect()
-}
-
-/// What a part of the plan contributes to the visibility of a conditional that
-/// contains it.
-///
-/// This mirrors, at build time, the question the renderer used to ask at render
-/// time: does any variable inside this conditional have a non-empty value?
-/// Literal text answers "no" — it never brings a conditional into view — and a
-/// module answers "only if it rendered something". A fill and a line break
-/// answer from configuration alone, which is why neither is ever named in a
-/// predicate.
 enum Presence {
-    /// Nothing here can bring a conditional into view.
     Never,
-    /// A conditional shows exactly when one of these modules is filled.
     WhenAnyFilled(Predicate),
-    /// A conditional containing this always shows.
     Always,
 }
 
@@ -408,12 +307,11 @@ impl Presence {
     }
 }
 
-/// Turns format elements into plan nodes.
 struct Builder<'build> {
     starship_configuration: &'build StarshipConfig,
     palette: Option<&'build Palette>,
     destination: Destination,
-    modules_expanded_by_all: &'build [ModuleName],
+    referenced_modules: &'build BTreeSet<ModuleName>,
     slots: BTreeMap<ModuleName, ModuleSlot>,
     modules: Vec<ModuleUse>,
 }
@@ -430,14 +328,12 @@ impl Builder<'_> {
         for element in elements {
             match element {
                 FormatElement::Text(text) => {
-                    let escaped = self.destination.escape(text.clone());
-                    push_literal(&escaped, inherited_style, nodes);
+                    let escaped_text = self.destination.escape(text.clone());
+                    push_literal(&escaped_text, inherited_style, nodes);
                 }
                 FormatElement::TextGroup(group) => {
                     let style = self.resolve_style(&group.style);
                     if group.format.is_empty() {
-                        // An empty text group still produces a segment, so that a
-                        // later `prev_fg` or `prev_bg` can read its style.
                         nodes.push(Node::Static(StaticText {
                             text: String::new(),
                             style,
@@ -469,8 +365,6 @@ impl Builder<'_> {
 
         match presence {
             Presence::Always => {
-                // Configuration proves this always shows, so there is nothing
-                // left to decide per render.
                 nodes.append(&mut body);
                 Presence::Always
             }
@@ -481,12 +375,7 @@ impl Builder<'_> {
                 });
                 Presence::WhenAnyFilled(predicate)
             }
-            Presence::Never => {
-                // No module inside, and nothing statically present: the body
-                // could never have shown, so it goes and takes whatever it
-                // contained with it.
-                Presence::Never
-            }
+            Presence::Never => Presence::Never,
         }
     }
 
@@ -497,16 +386,18 @@ impl Builder<'_> {
         nodes: &mut Vec<Node>,
     ) -> Presence {
         if name == ALL_MODULES_VARIABLE {
-            let expanded = self.modules_expanded_by_all;
-            return expanded.iter().fold(Presence::Never, |presence, module| {
-                presence.merge(self.build_module(module, inherited_style, nodes))
-            });
+            return modules_expanded_by_all(self.referenced_modules)
+                .into_iter()
+                .fold(Presence::Never, |presence, module_name| {
+                    presence.merge(self.build_module(&module_name, inherited_style, nodes))
+                });
         }
 
         let module = ModuleName::new(name);
         if self.is_disabled(module.as_str()) {
             return Presence::Never;
         }
+
         self.build_module(&module, inherited_style, nodes)
     }
 
@@ -517,8 +408,6 @@ impl Builder<'_> {
         nodes: &mut Vec<Node>,
     ) -> Presence {
         match module.as_str() {
-            // A line break has no data behind it: configuration alone says
-            // whether it is there, and it is never empty when it is.
             LINE_BREAK_MODULE => {
                 if self.is_disabled(LINE_BREAK_MODULE) {
                     return Presence::Never;
@@ -526,17 +415,17 @@ impl Builder<'_> {
                 nodes.push(Node::LineBreak);
                 Presence::Always
             }
-            // A fill's characters and style are configuration too; only its
-            // width is decided per render.
             FILL_MODULE => {
                 let Some(template) = self.fill_template(inherited_style) else {
                     return Presence::Never;
                 };
+
                 let presence = if template.symbol.is_empty() {
                     Presence::Never
                 } else {
                     Presence::Always
                 };
+
                 nodes.push(Node::Fill { template });
                 presence
             }
@@ -565,145 +454,133 @@ impl Builder<'_> {
         slot
     }
 
-    /// The fill module's configuration, or `None` if it will not render.
     fn fill_template(&self, inherited_style: Option<Style>) -> Option<FillTemplate> {
         if self.is_disabled(FILL_MODULE) {
             return None;
         }
 
-        let configuration =
-            FillConfig::try_load(self.starship_configuration.get_module_config(FILL_MODULE));
+        let module_configuration = self.starship_configuration.get_module_config(FILL_MODULE);
+        let configuration = FillConfig::try_load(module_configuration);
+
         if configuration.disabled {
             return None;
         }
 
+        let resolved_style =
+            parse_style_string_with_palette(configuration.style, self.palette).or(inherited_style);
+
         Some(FillTemplate {
             symbol: configuration.symbol.to_owned(),
-            // A fill with no style of its own takes on the enclosing text
-            // group's style, exactly as any other module's segments would.
-            style: parse_style_string_with_palette(configuration.style, self.palette)
-                .or(inherited_style),
+            style: resolved_style,
         })
     }
 
-    /// Whether a module is switched off by `disabled = true`.
-    fn is_disabled(&self, module: &str) -> bool {
+    fn is_disabled(&self, module_name: &str) -> bool {
         self.starship_configuration
-            .get_module_config(module)
-            .and_then(|value| value.as_table()?.get("disabled")?.as_bool())
-            == Some(true)
+            .get_module_config(module_name)
+            .and_then(|configuration_value| configuration_value.as_table())
+            .and_then(|module_table| module_table.get("disabled"))
+            .and_then(|disabled_flag| disabled_flag.as_bool())
+            .unwrap_or(false)
     }
 
-    /// Resolves a style specification into a style.
-    ///
-    /// A root format string has no style variables to substitute — only modules
-    /// map those, and a prompt's own format string is not a module — so a style
-    /// variable contributes the empty string, which is what the formatter did
-    /// with an unmapped one too.
     fn resolve_style(&self, elements: &[StyleElement<'_>]) -> Option<Style> {
-        let style_string: String = elements
-            .iter()
-            .map(|element| match element {
-                StyleElement::Text(text) => text.as_ref(),
-                StyleElement::Variable(_) => "",
-            })
-            .collect();
+        let mut style_string = String::with_capacity(ESTIMATED_STYLE_STRING_LENGTH);
+
+        for element in elements {
+            match element {
+                StyleElement::Text(text) => style_string.push_str(text.as_ref()),
+                StyleElement::Variable(_) => {}
+            }
+        }
 
         parse_style_string_with_palette(&style_string, self.palette)
     }
 }
 
-/// Splits literal text on line breaks, which are structural rather than textual.
+/// Every module `$all` stands for, in prompt order, that the format string
+/// did not already name explicitly.
+#[must_use]
+pub fn modules_expanded_by_all(referenced_modules: &BTreeSet<ModuleName>) -> Vec<ModuleName> {
+    PROMPT_ORDER
+        .iter()
+        .map(|module_name| ModuleName::new(*module_name))
+        .filter(|module_name| !referenced_modules.contains(module_name))
+        .collect()
+}
+
 fn push_literal(text: &str, style: Option<Style>, nodes: &mut Vec<Node>) {
-    for (index, piece) in text.split('\n').enumerate() {
-        if index > 0 {
-            nodes.push(Node::LineBreak);
-        }
+    let mut lines = text.split('\n');
+
+    if let Some(first_line) = lines.next() {
         nodes.push(Node::Static(StaticText {
-            text: piece.to_owned(),
+            text: first_line.to_owned(),
+            style,
+        }));
+    }
+
+    for subsequent_line in lines {
+        nodes.push(Node::LineBreak);
+        nodes.push(Node::Static(StaticText {
+            text: subsequent_line.to_owned(),
             style,
         }));
     }
 }
 
-/// Picks the format string this prompt is built from, and collects every module
-/// the configured format strings name.
-///
-/// The module set is deliberately taken from *both* the main and the right
-/// format even when only one of them is being built: a module named by either
-/// is one that `$all` must not supply again.
 fn select_format<'configuration>(
     configuration: &PromptConfiguration<'configuration>,
 ) -> (Vec<FormatElement<'configuration>>, BTreeSet<ModuleName>) {
     let root = configuration.root_configuration;
 
-    if *configuration.target == Target::Continuation {
-        return match parse_format_string(&root.continuation_prompt) {
-            Ok(elements) => {
-                let modules = named_modules(&elements);
-                (elements, modules)
-            }
-            Err(error) => {
-                log::error!("Error parsing continuation prompt: {error}");
-                (fallback_format(), BTreeSet::new())
-            }
-        };
-    }
+    let (left_format, right_format, fallback_name) = match configuration.target {
+        Target::Continuation => (&root.continuation_prompt[..], "", "continuation_prompt"),
+        Target::Main => (&root.format[..], &root.right_format[..], "format"),
+        Target::Right => (&root.format[..], &root.right_format[..], "right_format"),
+        Target::Profile(profile_name) => {
+            let profile = root
+                .user_profiles
+                .get(profile_name)
+                .or_else(|| root.internal_profiles.get(profile_name));
 
-    let (left_format, right_format): (&'configuration str, &'configuration str) =
-        match configuration.target {
-            Target::Main | Target::Right => (&root.format, &root.right_format),
-            Target::Profile(name) => {
-                match root
-                    .user_profiles
-                    .get(name)
-                    .or_else(|| root.internal_profiles.get(name))
-                {
-                    Some(format) => (format, ""),
-                    None => {
-                        log::error!("Profile {name:?} not found");
-                        return (fallback_format(), BTreeSet::new());
-                    }
+            match profile {
+                Some(format_string) => (format_string.as_str(), "", "profile"),
+                None => {
+                    log::error!("Profile {profile_name:?} not found");
+                    return (fallback_format(), BTreeSet::new());
                 }
             }
-            Target::Continuation => {
-                unreachable!("Continuation prompt should have been handled above")
-            }
-        };
-
-    let left_elements = parse_format_string(left_format);
-    let right_elements = parse_format_string(right_format);
-
-    if let Err(ref error) = left_elements {
-        let name = if let Target::Profile(profile_name) = configuration.target {
-            format!("profile.{profile_name}")
-        } else {
-            "format".to_string()
-        };
-        log::error!("Error parsing {name:?}: {error}");
-    }
-
-    if let Err(ref error) = right_elements {
-        log::error!("Error parsing right_format: {error}");
-    }
-
-    let modules: BTreeSet<ModuleName> = [&left_elements, &right_elements]
-        .into_iter()
-        .flatten()
-        .flat_map(|elements| named_modules(elements))
-        .collect();
-
-    let selected = match configuration.target {
-        Target::Main | Target::Profile(_) => left_elements,
-        Target::Right => right_elements,
-        Target::Continuation => {
-            unreachable!("Continuation prompt should have been handled above")
         }
     };
 
-    match selected {
-        Ok(elements) => (elements, modules),
-        Err(_) => (fallback_format(), BTreeSet::new()),
+    let left_elements = parse_and_log(left_format, fallback_name);
+    let right_elements = parse_and_log(right_format, "right_format");
+
+    let mut referenced_modules = named_modules(&left_elements);
+    referenced_modules.extend(named_modules(&right_elements));
+
+    let selected_elements = match configuration.target {
+        Target::Main | Target::Profile(_) | Target::Continuation => left_elements,
+        Target::Right => right_elements,
+    };
+
+    (selected_elements, referenced_modules)
+}
+
+fn parse_and_log<'configuration>(
+    format_string: &'configuration str,
+    name: &str,
+) -> Vec<FormatElement<'configuration>> {
+    if format_string.is_empty() {
+        return Vec::new();
+    }
+
+    match parse_format_string(format_string) {
+        Ok(elements) => elements,
+        Err(error) => {
+            log::error!("Error parsing {name}: {error}");
+            fallback_format()
+        }
     }
 }
 

--- a/src/plan/mod.rs
+++ b/src/plan/mod.rs
@@ -389,7 +389,11 @@ impl Builder<'_> {
             return modules_expanded_by_all(self.referenced_modules)
                 .into_iter()
                 .fold(Presence::Never, |presence, module_name| {
-                    presence.merge(self.build_module(&module_name, inherited_style, nodes))
+                    if self.is_disabled(module_name.as_str()) {
+                        presence
+                    } else {
+                        presence.merge(self.build_module(&module_name, inherited_style, nodes))
+                    }
                 });
         }
 
@@ -470,7 +474,7 @@ impl Builder<'_> {
             parse_style_string_with_palette(configuration.style, self.palette).or(inherited_style);
 
         Some(FillTemplate {
-            symbol: configuration.symbol.to_owned(),
+            symbol: self.destination.escape(configuration.symbol),
             style: resolved_style,
         })
     }

--- a/src/plan/mod.rs
+++ b/src/plan/mod.rs
@@ -936,8 +936,12 @@ mod tests {
         let mut state = PromptState::empty(&plan);
         let alpha = module(&plan, "alpha");
 
-        state.record(alpha, Segment::from_text(None, "first")).unwrap();
-        state.record(alpha, Segment::from_text(None, "second")).unwrap();
+        state
+            .record(alpha, Segment::from_text(None, "first"))
+            .unwrap();
+        state
+            .record(alpha, Segment::from_text(None, "second"))
+            .unwrap();
 
         assert_eq!("second", render_markup(&state));
     }
@@ -948,7 +952,9 @@ mod tests {
     fn a_conditional_keeps_its_literal_with_its_module() {
         let plan = default_plan("($alpha literal)");
         let mut state = PromptState::empty(&plan);
-        state.record(module(&plan, "alpha"), Segment::from_text(None, "A")).unwrap();
+        state
+            .record(module(&plan, "alpha"), Segment::from_text(None, "A"))
+            .unwrap();
 
         assert_eq!("A literal", render_markup(&state));
     }
@@ -1000,7 +1006,9 @@ mod tests {
     fn a_nested_conditional_is_visible_when_its_module_is_filled() {
         let plan = default_plan("(literal ($alpha))");
         let mut state = PromptState::empty(&plan);
-        state.record(module(&plan, "alpha"), Segment::from_text(None, "A")).unwrap();
+        state
+            .record(module(&plan, "alpha"), Segment::from_text(None, "A"))
+            .unwrap();
 
         assert_eq!("literal A", render_markup(&state));
     }
@@ -1012,7 +1020,9 @@ mod tests {
 
         assert_eq!("", render_markup(&state));
 
-        state.record(module(&plan, "beta"), Segment::from_text(None, "B")).unwrap();
+        state
+            .record(module(&plan, "beta"), Segment::from_text(None, "B"))
+            .unwrap();
         assert_eq!("B", render_markup(&state));
     }
 
@@ -1020,7 +1030,9 @@ mod tests {
     fn an_empty_segment_does_not_fill_a_module() {
         let plan = default_plan("($alpha)");
         let mut state = PromptState::empty(&plan);
-        state.record(module(&plan, "alpha"), Segment::from_text(None, "")).unwrap();
+        state
+            .record(module(&plan, "alpha"), Segment::from_text(None, ""))
+            .unwrap();
 
         assert_eq!("", render_markup(&state));
     }
@@ -1114,7 +1126,9 @@ mod tests {
     fn a_module_inherits_the_style_of_its_text_group() {
         let plan = default_plan("[$alpha](red bold)");
         let mut state = PromptState::empty(&plan);
-        state.record(module(&plan, "alpha"), Segment::from_text(None, "A")).unwrap();
+        state
+            .record(module(&plan, "alpha"), Segment::from_text(None, "A"))
+            .unwrap();
 
         assert_eq!("[A](red bold)", render_markup(&state));
     }

--- a/src/plan/mod.rs
+++ b/src/plan/mod.rs
@@ -60,12 +60,6 @@ impl fmt::Display for ModuleName {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct ModuleSlot(usize);
 
-impl ModuleSlot {
-    pub(crate) fn index(self) -> usize {
-        self.0
-    }
-}
-
 /// The modules that can make a conditional visible.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 struct Predicate(Vec<ModuleSlot>);
@@ -183,12 +177,6 @@ pub struct ModuleUse {
     slot: ModuleSlot,
 }
 
-impl ModuleUse {
-    pub(crate) fn slot(&self) -> ModuleSlot {
-        self.slot
-    }
-}
-
 /// The prompt, built from configuration alone.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Plan {
@@ -272,6 +260,20 @@ pub struct PromptState<'plan> {
     resolved: Vec<Vec<Segment>>,
 }
 
+/// An attempt to record a module result in a state for another plan.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RecordError {
+    ForeignModuleUse,
+}
+
+impl fmt::Display for RecordError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("module use does not belong to this prompt plan")
+    }
+}
+
+impl std::error::Error for RecordError {}
+
 impl<'plan> PromptState<'plan> {
     /// A render of `plan` in which no module has resolved yet.
     pub fn empty(plan: &'plan Plan) -> Self {
@@ -286,8 +288,22 @@ impl<'plan> PromptState<'plan> {
     /// The module is named by a borrow of the plan's own copy of the name, so
     /// what is recorded cannot be about a prompt other than the one being
     /// rendered.
-    pub fn record(&mut self, module: &ModuleUse, segments: Vec<Segment>) {
+    pub fn record(
+        &mut self,
+        module: &ModuleUse,
+        segments: Vec<Segment>,
+    ) -> Result<(), RecordError> {
+        if !self
+            .plan
+            .module_uses()
+            .iter()
+            .any(|candidate| std::ptr::eq(candidate, module))
+        {
+            return Err(RecordError::ForeignModuleUse);
+        }
+
         self.resolved[module.slot.0] = segments;
+        Ok(())
     }
 
     /// What a module resolved to, or nothing if it has not resolved.
@@ -744,7 +760,7 @@ mod tests {
         let mut state = PromptState::empty(plan);
         for module_use in plan.module_uses() {
             if let Some(segments) = table.get(module_use.module.as_str()) {
-                state.record(module_use, segments.clone());
+                state.record(module_use, segments.clone()).unwrap();
             }
         }
         state
@@ -920,8 +936,8 @@ mod tests {
         let mut state = PromptState::empty(&plan);
         let alpha = module(&plan, "alpha");
 
-        state.record(alpha, Segment::from_text(None, "first"));
-        state.record(alpha, Segment::from_text(None, "second"));
+        state.record(alpha, Segment::from_text(None, "first")).unwrap();
+        state.record(alpha, Segment::from_text(None, "second")).unwrap();
 
         assert_eq!("second", render_markup(&state));
     }
@@ -932,7 +948,7 @@ mod tests {
     fn a_conditional_keeps_its_literal_with_its_module() {
         let plan = default_plan("($alpha literal)");
         let mut state = PromptState::empty(&plan);
-        state.record(module(&plan, "alpha"), Segment::from_text(None, "A"));
+        state.record(module(&plan, "alpha"), Segment::from_text(None, "A")).unwrap();
 
         assert_eq!("A literal", render_markup(&state));
     }
@@ -984,7 +1000,7 @@ mod tests {
     fn a_nested_conditional_is_visible_when_its_module_is_filled() {
         let plan = default_plan("(literal ($alpha))");
         let mut state = PromptState::empty(&plan);
-        state.record(module(&plan, "alpha"), Segment::from_text(None, "A"));
+        state.record(module(&plan, "alpha"), Segment::from_text(None, "A")).unwrap();
 
         assert_eq!("literal A", render_markup(&state));
     }
@@ -996,7 +1012,7 @@ mod tests {
 
         assert_eq!("", render_markup(&state));
 
-        state.record(module(&plan, "beta"), Segment::from_text(None, "B"));
+        state.record(module(&plan, "beta"), Segment::from_text(None, "B")).unwrap();
         assert_eq!("B", render_markup(&state));
     }
 
@@ -1004,7 +1020,7 @@ mod tests {
     fn an_empty_segment_does_not_fill_a_module() {
         let plan = default_plan("($alpha)");
         let mut state = PromptState::empty(&plan);
-        state.record(module(&plan, "alpha"), Segment::from_text(None, ""));
+        state.record(module(&plan, "alpha"), Segment::from_text(None, "")).unwrap();
 
         assert_eq!("", render_markup(&state));
     }
@@ -1098,7 +1114,7 @@ mod tests {
     fn a_module_inherits_the_style_of_its_text_group() {
         let plan = default_plan("[$alpha](red bold)");
         let mut state = PromptState::empty(&plan);
-        state.record(module(&plan, "alpha"), Segment::from_text(None, "A"));
+        state.record(module(&plan, "alpha"), Segment::from_text(None, "A")).unwrap();
 
         assert_eq!("[A](red bold)", render_markup(&state));
     }

--- a/src/print.rs
+++ b/src/print.rs
@@ -1,5 +1,4 @@
 use clap::{ValueEnum, builder::PossibleValue};
-use nu_ansi_term::AnsiStrings;
 use rayon::prelude::*;
 use regex::Regex;
 use std::collections::BTreeSet;
@@ -12,13 +11,12 @@ use terminal_size::terminal_size;
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthChar;
 
-use crate::configs::PROMPT_ORDER;
 use crate::context::{Context, Properties, Shell, Target};
-use crate::formatter::{StringFormatter, VariableHolder};
 use crate::module::ALL_MODULES;
 use crate::module::Module;
+use crate::module::painted::TerminalWidth;
 use crate::modules;
-use crate::segment::Segment;
+use crate::plan::{ModuleName, Plan, PromptConfiguration, modules_expanded_by_all};
 use crate::shadow;
 use crate::utils::wrap_colorseq_for_shell;
 
@@ -90,17 +88,26 @@ pub fn prompt_with_claude_code(args: Properties, target: Target) {
     write!(handle, "{}", get_prompt(&context)).unwrap();
 }
 
+/// What starship shows instead of a prompt under a terminal that cannot render
+/// one.
+pub const DUMB_TERMINAL_PROMPT: &str = "Starship disabled due to TERM=dumb > ";
+
+/// Whether the terminal starship is running under can render a prompt at all.
+///
+/// A `dumb` terminal has no cursor addressing or rendition, so neither a
+/// styled prompt nor an incremental repaint means anything there.
+pub fn is_dumb_terminal() -> bool {
+    std::env::var_os("TERM").is_some_and(|term| term == "dumb")
+}
+
 pub fn get_prompt(context: &Context) -> String {
     let config = &context.root_config;
     let mut buf = String::new();
 
-    match std::env::var_os("TERM") {
-        Some(term) if term == "dumb" => {
-            log::error!("Under a 'dumb' terminal (TERM=dumb).");
-            buf.push_str("Starship disabled due to TERM=dumb > ");
-            return buf;
-        }
-        _ => {}
+    if is_dumb_terminal() {
+        log::error!("Under a 'dumb' terminal (TERM=dumb).");
+        buf.push_str(DUMB_TERMINAL_PROMPT);
+        return buf;
     }
 
     // A workaround for a fish bug (see #739,#279). Applying it to all shells
@@ -109,48 +116,23 @@ pub fn get_prompt(context: &Context) -> String {
         buf.push_str("\x1b[J"); // An ASCII control code to clear screen
     }
 
-    let (formatter, modules) = load_formatter_and_modules(context);
-
-    let formatter = formatter.map_variables_to_segments(|module| {
-        // Make $all display all modules not explicitly referenced
-        if module == "all" {
-            Some(Ok(all_modules_uniq(&modules)
-                .par_iter()
-                .flat_map(|module| {
-                    handle_module(module, context, &modules)
-                        .into_iter()
-                        .flat_map(|module| module.segments)
-                        .collect::<Vec<Segment>>()
-                })
-                .collect::<Vec<_>>()))
-        } else if context.is_module_disabled_in_config(module) {
-            None
-        } else {
-            // Get segments from module
-            Some(Ok(handle_module(module, context, &modules)
-                .into_iter()
-                .flat_map(|module| module.segments)
-                .collect::<Vec<Segment>>()))
-        }
-    });
+    // The prompt is built in two steps: a plan, which follows from
+    // configuration alone, and then the module output that fills its slots.
+    let plan = Plan::build(&prompt_configuration(context));
+    let state = crate::render::fill_slots(&plan, context);
 
     // Creates a root module and prints it.
     let mut root_module = Module::new("Starship Root", "The root module", None);
-    root_module.set_segments(
-        formatter
-            .parse(None, Some(context))
-            .expect("Unexpected error returned in root format variables"),
-    );
+    root_module.set_segments(state.render());
 
-    let module_strings = root_module.ansi_strings_for_width(Some(context.width));
+    let painted = root_module.paint_for_width(Some(TerminalWidth(context.width)));
     if config.add_newline && context.target != Target::Continuation {
         // continuation prompts normally do not include newlines, but they can
         writeln!(buf).unwrap();
     }
-    // AnsiStrings strips redundant ANSI color sequences, so apply it before modifying the ANSI
+    // Painting strips redundant ANSI color sequences, so apply it before modifying the ANSI
     // color sequences for this specific shell
-    let shell_wrapped_output =
-        wrap_colorseq_for_shell(AnsiStrings(&module_strings).to_string(), context.shell);
+    let shell_wrapped_output = wrap_colorseq_for_shell(painted.to_string(), context.shell);
     write!(buf, "{shell_wrapped_output}").unwrap();
 
     if context.target == Target::Right {
@@ -195,9 +177,7 @@ pub fn timings(args: Properties) {
         .map(|module| ModuleTiming {
             name: String::from(module.get_name().as_str()),
             name_len: module.get_name().width_graphemes(),
-            value: nu_ansi_term::AnsiStrings(&module.ansi_strings())
-                .to_string()
-                .replace('\n', "\\n"),
+            value: module.paint().to_string().replace('\n', "\\n"),
             duration: module.duration,
             duration_len: format_duration(&module.duration).width_graphemes(),
         })
@@ -244,7 +224,7 @@ pub fn explain(args: Properties) {
         .map(|module| {
             let value = module.get_segments().join("");
             ModuleInfo {
-                value: nu_ansi_term::AnsiStrings(&module.ansi_strings()).to_string(),
+                value: module.paint().to_string(),
                 value_len: value.width_graphemes()
                     + format_duration(&module.duration).width_graphemes(),
                 desc: module.get_description().clone(),
@@ -319,20 +299,36 @@ pub fn explain(args: Properties) {
     }
 }
 
+/// The configuration a prompt's [`Plan`] is built from.
+///
+/// This is the only place a [`Context`] is taken apart into the configuration a
+/// plan is allowed to see; [`Plan::build`] itself has no way back to one.
+pub fn prompt_configuration<'context>(
+    context: &'context Context<'_>,
+) -> PromptConfiguration<'context> {
+    PromptConfiguration::new(
+        &context.config,
+        &context.root_config,
+        context.destination(),
+        &context.target,
+    )
+}
+
 fn compute_modules<'a>(context: &'a Context) -> Vec<Module<'a>> {
     let mut prompt_order: Vec<Module<'a>> = Vec::new();
 
-    let (_formatter, modules) = load_formatter_and_modules(context);
+    let plan = Plan::build(&prompt_configuration(context));
+    let modules = plan.referenced_modules();
 
-    for module in &modules {
+    for module in modules {
         // Manually add all modules if `$all` is encountered
-        if module == "all" {
-            for module in all_modules_uniq(&modules) {
-                let modules = handle_module(&module, context, &modules);
+        if module.as_str() == "all" {
+            for module in modules_expanded_by_all(modules) {
+                let modules = handle_module(module.as_str(), context, modules);
                 prompt_order.extend(modules);
             }
         } else {
-            let modules = handle_module(module, context, &modules);
+            let modules = handle_module(module.as_str(), context, modules);
             prompt_order.extend(modules);
         }
     }
@@ -340,10 +336,10 @@ fn compute_modules<'a>(context: &'a Context) -> Vec<Module<'a>> {
     prompt_order
 }
 
-fn handle_module<'a>(
+pub fn handle_module<'a>(
     module: &str,
     context: &'a Context,
-    module_list: &BTreeSet<String>,
+    module_list: &BTreeSet<ModuleName>,
 ) -> Vec<Module<'a>> {
     let mut modules: Vec<Module> = Vec::new();
 
@@ -397,9 +393,9 @@ fn should_add_implicit_module(
     parent_module: &str,
     child_module: &str,
     config: &toml::Value,
-    module_list: &BTreeSet<String>,
+    module_list: &BTreeSet<ModuleName>,
 ) -> bool {
-    let explicit_module_name = format!("{parent_module}.{child_module}");
+    let explicit_module_name = ModuleName::new(format!("{parent_module}.{child_module}"));
     let is_explicitly_specified = module_list.contains(&explicit_module_name);
 
     if is_explicitly_specified {
@@ -422,89 +418,6 @@ pub fn format_duration(duration: &Duration) -> String {
         "<1ms".to_string()
     } else {
         format!("{milis:?}ms")
-    }
-}
-
-/// Return the modules from $all that are not already in the list
-fn all_modules_uniq(module_list: &BTreeSet<String>) -> Vec<String> {
-    let mut prompt_order: Vec<String> = Vec::new();
-    for module in PROMPT_ORDER {
-        if !module_list.contains(*module) {
-            prompt_order.push(String::from(*module));
-        }
-    }
-
-    prompt_order
-}
-
-/// Load the correct formatter for the context (ie left prompt or right prompt)
-/// and the list of all modules used in a format string
-fn load_formatter_and_modules<'a>(context: &'a Context) -> (StringFormatter<'a>, BTreeSet<String>) {
-    let config = &context.root_config;
-
-    if context.target == Target::Continuation {
-        let cf = &config.continuation_prompt;
-        let formatter = StringFormatter::new(cf);
-        return match formatter {
-            Ok(f) => {
-                let modules = f.get_variables().into_iter().collect();
-                (f, modules)
-            }
-            Err(e) => {
-                log::error!("Error parsing continuation prompt: {e}");
-                (StringFormatter::raw(">"), BTreeSet::new())
-            }
-        };
-    }
-
-    let (left_format_str, right_format_str): (&str, &str) = match context.target {
-        Target::Main | Target::Right => (&config.format, &config.right_format),
-        Target::Profile(ref name) => {
-            if let Some(lf) = config
-                .user_profiles
-                .get(name)
-                .or_else(|| config.internal_profiles.get(name))
-            {
-                (lf, "")
-            } else {
-                log::error!("Profile {name:?} not found");
-                return (StringFormatter::raw(">"), BTreeSet::new());
-            }
-        }
-        Target::Continuation => unreachable!("Continuation prompt should have been handled above"),
-    };
-
-    let lf = StringFormatter::new(left_format_str);
-    let rf = StringFormatter::new(right_format_str);
-
-    if let Err(ref e) = lf {
-        let name = if let Target::Profile(ref profile_name) = context.target {
-            format!("profile.{profile_name}")
-        } else {
-            "format".to_string()
-        };
-        log::error!("Error parsing {name:?}: {e}");
-    }
-
-    if let Err(ref e) = rf {
-        log::error!("Error parsing right_format: {e}");
-    }
-
-    let modules = [&lf, &rf]
-        .into_iter()
-        .flatten()
-        .flat_map(VariableHolder::get_variables)
-        .collect();
-
-    let main_formatter = match context.target {
-        Target::Main | Target::Profile(_) => lf,
-        Target::Right => rf,
-        Target::Continuation => unreachable!("Continuation prompt should have been handled above"),
-    };
-
-    match main_formatter {
-        Ok(f) => (f, modules),
-        _ => (StringFormatter::raw(">"), BTreeSet::new()),
     }
 }
 
@@ -599,6 +512,10 @@ mod test {
                 format="$all"
                 [character]
                 format=">"
+                // `battery` reads real hardware; disable it so this doesn't
+                // depend on the developer's laptop charge level.
+                [battery]
+                disabled = true
         });
         context.env.insert("HOME", NULL_DEVICE.to_string());
         let dir = tempfile::tempdir().unwrap();
@@ -617,6 +534,9 @@ mod test {
             right_format="$all"
             [character]
             format=">"
+            // See `prompt_with_all`: `battery` reads real hardware.
+            [battery]
+            disabled = true
         });
         context.env.insert("HOME", NULL_DEVICE.to_string());
         let dir = tempfile::tempdir().unwrap();

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,0 +1,611 @@
+//! Prompt module rendering.
+
+use std::collections::BTreeSet;
+use std::fmt;
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+use crate::context::Context;
+use crate::module::{ALL_MODULES, Module};
+use crate::modules::{Cadence, cadence};
+use crate::plan::{ModuleName, ModuleSlot, ModuleUse, Plan, PromptState};
+use crate::segment::Segment;
+
+/// Whether a resolution belongs to the first render or a later poll.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ResolutionKind {
+    Initial,
+    Refresh,
+}
+
+/// One resolved module.
+pub struct Resolution<'plan> {
+    module: &'plan ModuleUse,
+    segments: Vec<Segment>,
+    elapsed: Duration,
+    kind: ResolutionKind,
+}
+
+impl fmt::Debug for Resolution<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let value: String = self.segments.iter().map(Segment::value).collect();
+        formatter
+            .debug_struct("Resolution")
+            .field("module", &self.module.module.as_str())
+            .field("value", &value)
+            .field("elapsed", &self.elapsed)
+            .field("kind", &self.kind)
+            .finish()
+    }
+}
+
+impl<'plan> Resolution<'plan> {
+    fn initial(module: &'plan ModuleUse, segments: Vec<Segment>, elapsed: Duration) -> Self {
+        Self {
+            module,
+            segments,
+            elapsed,
+            kind: ResolutionKind::Initial,
+        }
+    }
+
+    pub fn module(&self) -> &'plan ModuleName {
+        &self.module.module
+    }
+
+    pub fn elapsed(&self) -> Duration {
+        self.elapsed
+    }
+
+    pub(crate) fn kind(&self) -> ResolutionKind {
+        self.kind
+    }
+
+    pub(crate) fn slot(&self) -> ModuleSlot {
+        self.module.slot()
+    }
+
+    pub fn store_in(self, state: &mut PromptState<'plan>) {
+        state.record(self.module, self.segments);
+    }
+}
+
+/// A module subset.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Selection {
+    EveryModule,
+    InstantOnly,
+    DeferredOnly,
+}
+
+impl Selection {
+    fn admits(self, module: &str) -> bool {
+        let is_instant = cadence(module) == Some(Cadence::Instant);
+        match self {
+            Self::EveryModule => true,
+            Self::InstantOnly => is_instant,
+            Self::DeferredOnly => !is_instant,
+        }
+    }
+}
+
+pub fn modules(plan: &Plan, selection: Selection) -> impl Iterator<Item = &ModuleName> {
+    selected_modules(plan, selection).map(|module_use| &module_use.module)
+}
+
+/// A dynamic module and its refresh period.
+#[derive(Clone)]
+pub struct DynamicModule<'plan> {
+    module: &'plan ModuleUse,
+    referenced_modules: &'plan BTreeSet<ModuleName>,
+    period: Duration,
+}
+
+impl<'plan> DynamicModule<'plan> {
+    pub fn name(&self) -> &'plan ModuleName {
+        &self.module.module
+    }
+
+    pub fn period(&self) -> Duration {
+        self.period
+    }
+
+    pub(crate) fn slot(&self) -> ModuleSlot {
+        self.module.slot()
+    }
+
+    #[must_use]
+    pub fn every(mut self, period: Duration) -> Self {
+        self.period = period;
+        self
+    }
+
+    pub fn resolve(&self, context: &Context) -> Resolution<'plan> {
+        let started = Instant::now();
+        let segments = render_module(self.module, context, self.referenced_modules);
+        Resolution {
+            module: self.module,
+            segments,
+            elapsed: started.elapsed(),
+            kind: ResolutionKind::Refresh,
+        }
+    }
+}
+
+/// Returns enabled dynamic modules in prompt order.
+pub fn dynamic_modules<'plan>(plan: &'plan Plan, context: &Context) -> Vec<DynamicModule<'plan>> {
+    selected_modules(plan, Selection::DeferredOnly)
+        .filter(|module_use| !is_switched_off(&module_use.module, context))
+        .filter_map(|module_use| match cadence(module_use.module.as_str()) {
+            Some(Cadence::Dynamic { period }) => Some(DynamicModule {
+                module: module_use,
+                referenced_modules: plan.referenced_modules(),
+                period,
+            }),
+            _ => None,
+        })
+        .collect()
+}
+
+// Use effective defaults: disabled dynamic modules must not keep streams alive.
+fn is_switched_off(module: &ModuleName, context: &Context) -> bool {
+    use crate::config::ModuleConfig;
+
+    let table = context.config.get_module_config(module.as_str());
+    match module.as_str() {
+        "battery" => crate::configs::battery::BatteryConfig::try_load(table).disabled,
+        "localip" => crate::configs::localip::LocalipConfig::try_load(table).disabled,
+        "memory_usage" => crate::configs::memory_usage::MemoryConfig::try_load(table).disabled,
+        "time" => crate::configs::time::TimeConfig::try_load(table).disabled,
+        other => context.is_module_disabled_in_config(other),
+    }
+}
+
+/// The modules of `plan` that `selection` covers, in first-paint order.
+///
+/// The plan already reports each of its modules exactly once, however many
+/// positions name it — see [`Plan::module_uses`] — so a module is run once and
+/// its value stands in all of them, which is what the formatter did when it
+/// cached one value per variable name.
+fn selected_modules(plan: &Plan, selection: Selection) -> impl Iterator<Item = &ModuleUse> {
+    plan.module_uses()
+        .iter()
+        .filter(move |module_use| selection.admits(module_use.module.as_str()))
+}
+
+/// What taking from a [`Resolutions`] produced.
+#[derive(Debug)]
+pub enum Arrival<'plan> {
+    /// A module finished.
+    Resolved(Resolution<'plan>),
+    /// Every module has finished; there will be no further arrivals.
+    Finished,
+}
+
+/// Modules that are running, whose output can be taken as it arrives.
+///
+/// A caller wanting a *time-based* draw policy — collecting several results
+/// that land close together rather than drawing each the instant it lands —
+/// does not go through this type. [`crate::stream`]'s event loop owns its own
+/// channel and calls `recv_timeout` on it directly instead, which is what lets
+/// it wait on a module arriving *or* a repaint deadline expiring *or* a
+/// dynamic module falling due, all at once.
+pub struct Resolutions<'plan> {
+    receiver: mpsc::Receiver<Resolution<'plan>>,
+}
+
+impl<'plan> Resolutions<'plan> {
+    /// Waits for the next module to finish, however long that takes.
+    pub fn next_arrival(&self) -> Arrival<'plan> {
+        match self.receiver.recv() {
+            Ok(resolution) => Arrival::Resolved(resolution),
+            Err(mpsc::RecvError) => Arrival::Finished,
+        }
+    }
+}
+
+/// Somewhere to start a module rendering that is not on the calling thread.
+///
+/// Handed to the body of [`while_running`] so that a caller draining
+/// resolutions can start *more* work without waiting for what is already
+/// running to finish. That is what a dynamic module needs: its period expires
+/// while the prompt's slow modules are still resolving, and re-rendering it on
+/// the draining thread would stall every other refinement behind it.
+pub struct Spawner<'borrow, 'scope, 'context> {
+    scope: &'borrow rayon::Scope<'scope>,
+    sender: mpsc::Sender<Resolution<'scope>>,
+    context: &'scope Context<'context>,
+}
+
+impl<'scope, 'context> Spawner<'_, 'scope, 'context> {
+    /// Renders `module` again, off this thread, delivering the result to the
+    /// same stream of arrivals as everything else.
+    ///
+    /// Several of these run at once, which is the point: a battery service that
+    /// takes half a second to answer must not hold up a clock that only wants
+    /// to tick.
+    pub fn poll(&self, module: DynamicModule<'scope>) {
+        let sender = self.sender.clone();
+        let context = self.context;
+        self.scope.spawn(move |_| {
+            // The receiver outlives this scope, so a failed send would mean the
+            // caller had stopped draining — in which case there is nobody left
+            // to tell.
+            let _ = sender.send(module.resolve(context));
+        });
+    }
+}
+
+/// Runs the selected modules, delivering each one's output to `arrivals` as it
+/// finishes, while `body` runs on the calling thread.
+///
+/// Unlike [`with_resolutions`] the channel is the caller's, so it stays open
+/// after the last selected module has finished and the caller can keep using it
+/// for work it starts itself through the [`Spawner`]. A caller that works this
+/// way cannot learn that everything has finished by watching the channel
+/// disconnect, and must count what it is waiting for instead.
+pub fn while_running<'scope, 'context, T>(
+    plan: &'scope Plan,
+    context: &'scope Context<'context>,
+    selection: Selection,
+    arrivals: &mpsc::Sender<Resolution<'scope>>,
+    body: impl FnOnce(&Spawner<'_, 'scope, 'context>) -> T,
+) -> T {
+    let selected = selected_modules(plan, selection);
+    let referenced_modules = plan.referenced_modules();
+
+    rayon::in_place_scope(|scope| {
+        for module_use in selected {
+            let sender = arrivals.clone();
+            scope.spawn(move |_| {
+                let started = Instant::now();
+                let segments = render_module(module_use, context, referenced_modules);
+                let _ = sender.send(Resolution::initial(module_use, segments, started.elapsed()));
+            });
+        }
+
+        body(&Spawner {
+            scope,
+            sender: arrivals.clone(),
+            context,
+        })
+    })
+}
+
+/// Runs the selected modules and lets `consume` take their output as it
+/// arrives.
+///
+/// Every selected module produces exactly one arrival, including one that
+/// produced nothing: "this module resolved to nothing" is information a caller
+/// repainting a prompt needs just as much as a value is.
+///
+/// `consume` runs on the calling thread and returns when it stops taking; the
+/// modules still running are waited for before this returns, so nothing outlives
+/// the call.
+pub fn with_resolutions<'plan, T>(
+    plan: &'plan Plan,
+    context: &Context,
+    selection: Selection,
+    consume: impl FnOnce(&Resolutions<'plan>) -> T,
+) -> T {
+    let selected = selected_modules(plan, selection);
+    let referenced_modules = plan.referenced_modules();
+    let (sender, receiver) = mpsc::channel::<Resolution<'plan>>();
+
+    // `in_place_scope` rather than `scope`: the body runs on the calling thread
+    // instead of being migrated into the pool, which is what lets `consume` be
+    // an ordinary closure borrowing whatever the caller is filling in. `scope`
+    // would demand a `Send` closure and a shared, locked accumulator for no
+    // benefit — the receiving side is not the work.
+    rayon::in_place_scope(|scope| {
+        for module_use in selected {
+            let sender = sender.clone();
+            scope.spawn(move |_| {
+                let started = Instant::now();
+                let segments = render_module(module_use, context, referenced_modules);
+                // The receiver lives as long as this scope, so a send can only
+                // fail once `consume` has returned — in which case there is
+                // nothing left to report the result to.
+                let _ = sender.send(Resolution::initial(module_use, segments, started.elapsed()));
+            });
+        }
+        // Every remaining sender is owned by a spawned worker, so the channel
+        // disconnects — and [`Arrival::Finished`] appears — exactly when the
+        // last of them has finished. Dropping this one is what makes that true.
+        drop(sender);
+
+        consume(&Resolutions { receiver })
+    })
+}
+
+/// Runs the selected modules, handing each one's output to `receive` as soon as
+/// that module finishes.
+pub fn stream<'plan>(
+    plan: &'plan Plan,
+    context: &Context,
+    selection: Selection,
+    mut receive: impl FnMut(Resolution<'plan>),
+) {
+    with_resolutions(plan, context, selection, |resolutions| {
+        while let Arrival::Resolved(resolution) = resolutions.next_arrival() {
+            receive(resolution);
+        }
+    });
+}
+
+/// Runs everything the very first paint of a prompt may show, handing each
+/// result to `receive` as it becomes available.
+///
+/// That is two things:
+///
+/// * the instant approximation of every module that has one
+///   ([`crate::modules::Render::instant`]), run on this thread, in paint order.
+///   An approximation is by definition too cheap to be worth handing to a
+///   thread, and running them here keeps the pool free for the work that is
+///   not;
+/// * every [`Cadence::Instant`] module, run for real and in parallel.
+///
+/// Both are bounded, so this returns in the time the slowest *instant* module
+/// takes rather than the time the slowest module takes.
+pub fn stream_instant<'plan>(
+    plan: &'plan Plan,
+    context: &Context,
+    mut receive: impl FnMut(Resolution<'plan>),
+) {
+    for module_use in selected_modules(plan, Selection::DeferredOnly) {
+        let started = Instant::now();
+        let Some(module) = approximate_module(&module_use.module, context) else {
+            continue;
+        };
+        receive(Resolution::initial(
+            module_use,
+            module.segments,
+            started.elapsed(),
+        ));
+    }
+
+    stream(plan, context, Selection::InstantOnly, receive);
+}
+
+/// Runs every module the plan asks for and takes their output into one render.
+pub fn fill_slots<'plan>(plan: &'plan Plan, context: &Context) -> PromptState<'plan> {
+    let mut state = PromptState::empty(plan);
+    stream(plan, context, Selection::EveryModule, |resolution| {
+        resolution.store_in(&mut state);
+    });
+    state
+}
+
+/// The segments one module contributes to the prompt.
+fn render_module(
+    module: &ModuleUse,
+    context: &Context,
+    referenced_modules: &BTreeSet<ModuleName>,
+) -> Vec<Segment> {
+    crate::print::handle_module(module.module.as_str(), context, referenced_modules)
+        .into_iter()
+        .flat_map(|module| module.segments)
+        .collect()
+}
+
+/// The instant approximation of one module, if it has one.
+///
+/// Unlike [`render_module`] this never expands `custom` or `env_var` into their
+/// children: those are dispatched by prefix and have no approximation, so there
+/// would be nothing to expand them for.
+fn approximate_module<'context>(
+    module: &ModuleName,
+    context: &'context Context<'_>,
+) -> Option<Module<'context>> {
+    // Only a module that exists can have an approximation, and a disabled
+    // module has nothing to approximate. Both are checks `handle_module`
+    // applies to the full render whichever origin the slot has, so the first
+    // paint and the refinement agree about which modules are in the prompt at
+    // all.
+    if !ALL_MODULES.contains(&module.as_str())
+        || context.is_module_disabled_in_config(module.as_str())
+    {
+        return None;
+    }
+
+    crate::modules::instant(module.as_str(), context)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::plan::PromptConfiguration;
+    use crate::test::default_context;
+
+    /// The plan a context's main prompt would be built from.
+    fn plan_of(context: &Context) -> Plan {
+        Plan::build(&PromptConfiguration::new(
+            &context.config,
+            &context.root_config,
+            context.destination(),
+            &context.target,
+        ))
+    }
+
+    /// The names of the modules a selection runs, in completion order.
+    fn resolved_modules(context: &Context, selection: Selection) -> Vec<String> {
+        let plan = plan_of(context);
+        let mut resolved = Vec::new();
+        stream(&plan, context, selection, |resolution| {
+            resolved.push(resolution.module().as_str().to_owned());
+        });
+        resolved
+    }
+
+    #[test]
+    fn every_module_of_the_plan_is_reported_exactly_once() {
+        let context = default_context().set_config(toml::toml! {
+            format = "$character$character$status$hostname"
+        });
+        let mut resolved = resolved_modules(&context, Selection::EveryModule);
+        resolved.sort_unstable();
+
+        // `character` fills two slots but is run once.
+        assert_eq!(vec!["character", "hostname", "status"], resolved);
+    }
+
+    #[test]
+    fn a_module_named_more_than_once_fills_every_position() {
+        let context = default_context().set_config(toml::toml! {
+            add_newline = false
+            format = "$character$character"
+            [character]
+            format = ">"
+        });
+        let plan = plan_of(&context);
+        let state = fill_slots(&plan, &context);
+
+        assert_eq!(
+            ">>",
+            crate::module::painted::Painted::paint(&state.render(), None).to_string()
+        );
+    }
+
+    #[test]
+    fn distinct_custom_modules_fill_their_own_slots() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let mut context = default_context().set_config(toml::toml! {
+            add_newline = false
+            format = "${custom.fast}${custom.slow}$character"
+            [custom.fast]
+            command = "printf fast"
+            when = true
+            format = "$output"
+            shell = ["/bin/sh"]
+            [custom.slow]
+            command = "printf slow"
+            when = true
+            format = "$output"
+            shell = ["/bin/sh"]
+            [character]
+            format = ">"
+        });
+        context.current_dir = directory.path().to_path_buf();
+        context.logical_dir = directory.path().to_path_buf();
+        let plan = plan_of(&context);
+        let state = fill_slots(&plan, &context);
+
+        assert_eq!(
+            "fastslow>",
+            crate::module::painted::Painted::paint(&state.render(), None).to_string()
+        );
+    }
+
+    #[test]
+    fn the_instant_selection_and_its_complement_partition_the_plan() {
+        let context = default_context().set_config(toml::toml! {
+            format = "$character$directory$status$git_branch"
+        });
+
+        let mut instant = resolved_modules(&context, Selection::InstantOnly);
+        let mut deferred = resolved_modules(&context, Selection::DeferredOnly);
+        instant.sort_unstable();
+        deferred.sort_unstable();
+
+        assert_eq!(vec!["character", "status"], instant);
+        assert_eq!(vec!["directory", "git_branch"], deferred);
+    }
+
+    #[test]
+    fn an_empty_selection_runs_nothing() {
+        let context = default_context().set_config(toml::toml! {
+            format = "$directory"
+        });
+        assert!(resolved_modules(&context, Selection::InstantOnly).is_empty());
+    }
+
+    #[test]
+    fn streaming_and_filling_agree() {
+        let context = default_context().set_config(toml::toml! {
+            add_newline = false
+            format = "$status$character"
+            [character]
+            format = "[>](green)"
+        });
+        let plan = plan_of(&context);
+
+        let filled = fill_slots(&plan, &context);
+        let mut streamed = PromptState::empty(&plan);
+        stream(&plan, &context, Selection::EveryModule, |resolution| {
+            resolution.store_in(&mut streamed);
+        });
+
+        assert_eq!(
+            crate::module::painted::Painted::paint(&filled.render(), None).to_markup(),
+            crate::module::painted::Painted::paint(&streamed.render(), None).to_markup(),
+        );
+    }
+
+    #[test]
+    fn a_dynamic_module_is_found_among_the_deferred_ones() {
+        let context = default_context().set_config(toml::toml! {
+            format = "$time$character"
+            [time]
+            disabled = false
+            format = "$time"
+        });
+        let plan = plan_of(&context);
+
+        let found = dynamic_modules(&plan, &context);
+        assert_eq!(1, found.len());
+        assert_eq!("time", found[0].name().as_str());
+        assert_eq!(Duration::from_secs(1), found[0].period());
+    }
+
+    #[test]
+    fn a_prompt_with_nothing_dynamic_in_it_has_no_dynamic_modules() {
+        let context = default_context().set_config(toml::toml! {
+            format = "$character$directory$git_branch"
+        });
+        assert!(dynamic_modules(&plan_of(&context), &context).is_empty());
+    }
+
+    #[test]
+    fn a_dynamic_module_can_be_given_a_different_period() {
+        let context = default_context().set_config(toml::toml! {
+            format = "$time"
+            [time]
+            disabled = false
+        });
+        let plan = plan_of(&context);
+        let module = dynamic_modules(&plan, &context)
+            .into_iter()
+            .next()
+            .expect("time is dynamic")
+            .every(Duration::from_millis(250));
+
+        assert_eq!(Duration::from_millis(250), module.period());
+    }
+
+    #[test]
+    fn resolving_a_dynamic_module_produces_a_value_the_prompt_renders() {
+        let context = default_context().set_config(toml::toml! {
+            add_newline = false
+            format = "$time"
+            [time]
+            disabled = false
+            format = "the-time"
+        });
+        let plan = plan_of(&context);
+        let module = dynamic_modules(&plan, &context)
+            .into_iter()
+            .next()
+            .expect("time is dynamic");
+
+        let resolution = module.resolve(&context);
+        assert_eq!("time", resolution.module().as_str());
+        assert_eq!(ResolutionKind::Refresh, resolution.kind());
+        let mut state = PromptState::empty(&plan);
+        resolution.store_in(&mut state);
+
+        assert_eq!(
+            "the-time",
+            crate::module::painted::Painted::paint(&state.render(), None).to_string()
+        );
+    }
+}

--- a/src/render.rs
+++ b/src/render.rs
@@ -71,6 +71,11 @@ impl<'plan> Resolution<'plan> {
     }
 
     #[inline]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.segments.is_empty()
+    }
+
+    #[inline]
     pub fn store_in(self, state: &mut PromptState<'plan>) {
         state
             .record(self.module, self.segments)

--- a/src/render.rs
+++ b/src/render.rs
@@ -228,19 +228,31 @@ mod tests {
     #[test]
     fn distinct_custom_modules_fill_their_own_slots() {
         let directory = tempfile::tempdir().expect("temporary directory");
+        let shell = if cfg!(windows) {
+            vec![
+                "powershell".to_owned(),
+                "-NoProfile".to_owned(),
+                "-Command".to_owned(),
+                "-".to_owned(),
+            ]
+        } else {
+            vec!["/bin/sh".to_owned()]
+        };
         let mut context = default_context().set_config(toml::toml! {
             add_newline = false
             format = "${custom.fast}${custom.slow}$character"
             [custom.fast]
-            command = "printf fast"
+            command = "echo fast"
             when = true
             format = "$output"
-            shell = ["/bin/sh"]
+            use_stdin = true
+            shell = (shell.clone())
             [custom.slow]
-            command = "printf slow"
+            command = "echo slow"
             when = true
             format = "$output"
-            shell = ["/bin/sh"]
+            use_stdin = true
+            shell = shell
             [character]
             format = ">"
         });

--- a/src/render.rs
+++ b/src/render.rs
@@ -6,13 +6,16 @@ use std::sync::mpsc;
 use std::time::{Duration, Instant};
 
 use crate::context::Context;
-use crate::plan::{ModuleName, ModuleUse, Plan, PromptState};
+use crate::module::{ALL_MODULES, Module};
+use crate::modules::{Cadence, cadence};
+use crate::plan::{ModuleName, ModuleSlot, ModuleUse, Plan, PromptState};
 use crate::segment::Segment;
 
 /// Whether a resolution belongs to the first render or a later poll.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum ResolutionKind {
     Initial,
+    Refresh,
 }
 
 /// One resolved module.
@@ -46,6 +49,22 @@ impl<'plan> Resolution<'plan> {
         }
     }
 
+    pub fn module(&self) -> &'plan ModuleName {
+        &self.module.module
+    }
+
+    pub fn elapsed(&self) -> Duration {
+        self.elapsed
+    }
+
+    pub(crate) fn kind(&self) -> ResolutionKind {
+        self.kind
+    }
+
+    pub(crate) fn slot(&self) -> ModuleSlot {
+        self.module.slot()
+    }
+
     pub fn store_in(self, state: &mut PromptState<'plan>) {
         state
             .record(self.module, self.segments)
@@ -57,13 +76,90 @@ impl<'plan> Resolution<'plan> {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Selection {
     EveryModule,
+    InstantOnly,
+    DeferredOnly,
 }
 
 impl Selection {
-    fn admits(self, _module: &str) -> bool {
+    fn admits(self, module: &str) -> bool {
+        let is_instant = cadence(module) == Some(Cadence::Instant);
         match self {
             Self::EveryModule => true,
+            Self::InstantOnly => is_instant,
+            Self::DeferredOnly => !is_instant,
         }
+    }
+}
+
+pub fn modules(plan: &Plan, selection: Selection) -> impl Iterator<Item = &ModuleName> {
+    selected_modules(plan, selection).map(|module_use| &module_use.module)
+}
+
+/// A dynamic module and its refresh period.
+#[derive(Clone)]
+pub struct DynamicModule<'plan> {
+    module: &'plan ModuleUse,
+    referenced_modules: &'plan BTreeSet<ModuleName>,
+    period: Duration,
+}
+
+impl<'plan> DynamicModule<'plan> {
+    pub fn name(&self) -> &'plan ModuleName {
+        &self.module.module
+    }
+
+    pub fn period(&self) -> Duration {
+        self.period
+    }
+
+    pub(crate) fn slot(&self) -> ModuleSlot {
+        self.module.slot()
+    }
+
+    #[must_use]
+    pub fn every(mut self, period: Duration) -> Self {
+        self.period = period;
+        self
+    }
+
+    pub fn resolve(&self, context: &Context) -> Resolution<'plan> {
+        let started = Instant::now();
+        let segments = render_module(self.module, context, self.referenced_modules);
+        Resolution {
+            module: self.module,
+            segments,
+            elapsed: started.elapsed(),
+            kind: ResolutionKind::Refresh,
+        }
+    }
+}
+
+/// Returns enabled dynamic modules in prompt order.
+pub fn dynamic_modules<'plan>(plan: &'plan Plan, context: &Context) -> Vec<DynamicModule<'plan>> {
+    selected_modules(plan, Selection::DeferredOnly)
+        .filter(|module_use| !is_switched_off(&module_use.module, context))
+        .filter_map(|module_use| match cadence(module_use.module.as_str()) {
+            Some(Cadence::Dynamic { period }) => Some(DynamicModule {
+                module: module_use,
+                referenced_modules: plan.referenced_modules(),
+                period,
+            }),
+            _ => None,
+        })
+        .collect()
+}
+
+// Use effective defaults: disabled dynamic modules must not keep streams alive.
+fn is_switched_off(module: &ModuleName, context: &Context) -> bool {
+    use crate::config::ModuleConfig;
+
+    let table = context.config.get_module_config(module.as_str());
+    match module.as_str() {
+        "battery" => crate::configs::battery::BatteryConfig::try_load(table).disabled,
+        "localip" => crate::configs::localip::LocalipConfig::try_load(table).disabled,
+        "memory_usage" => crate::configs::memory_usage::MemoryConfig::try_load(table).disabled,
+        "time" => crate::configs::time::TimeConfig::try_load(table).disabled,
+        other => context.is_module_disabled_in_config(other),
     }
 }
 
@@ -108,6 +204,74 @@ impl<'plan> Resolutions<'plan> {
             Err(mpsc::RecvError) => Arrival::Finished,
         }
     }
+}
+
+/// Somewhere to start a module rendering that is not on the calling thread.
+///
+/// Handed to the body of [`while_running`] so that a caller draining
+/// resolutions can start *more* work without waiting for what is already
+/// running to finish. That is what a dynamic module needs: its period expires
+/// while the prompt's slow modules are still resolving, and re-rendering it on
+/// the draining thread would stall every other refinement behind it.
+pub struct Spawner<'borrow, 'scope, 'context> {
+    scope: &'borrow rayon::Scope<'scope>,
+    sender: mpsc::Sender<Resolution<'scope>>,
+    context: &'scope Context<'context>,
+}
+
+impl<'scope, 'context> Spawner<'_, 'scope, 'context> {
+    /// Renders `module` again, off this thread, delivering the result to the
+    /// same stream of arrivals as everything else.
+    ///
+    /// Several of these run at once, which is the point: a battery service that
+    /// takes half a second to answer must not hold up a clock that only wants
+    /// to tick.
+    pub fn poll(&self, module: DynamicModule<'scope>) {
+        let sender = self.sender.clone();
+        let context = self.context;
+        self.scope.spawn(move |_| {
+            // The receiver outlives this scope, so a failed send would mean the
+            // caller had stopped draining — in which case there is nobody left
+            // to tell.
+            let _ = sender.send(module.resolve(context));
+        });
+    }
+}
+
+/// Runs the selected modules, delivering each one's output to `arrivals` as it
+/// finishes, while `body` runs on the calling thread.
+///
+/// Unlike [`with_resolutions`] the channel is the caller's, so it stays open
+/// after the last selected module has finished and the caller can keep using it
+/// for work it starts itself through the [`Spawner`]. A caller that works this
+/// way cannot learn that everything has finished by watching the channel
+/// disconnect, and must count what it is waiting for instead.
+pub fn while_running<'scope, 'context, T>(
+    plan: &'scope Plan,
+    context: &'scope Context<'context>,
+    selection: Selection,
+    arrivals: &mpsc::Sender<Resolution<'scope>>,
+    body: impl FnOnce(&Spawner<'_, 'scope, 'context>) -> T,
+) -> T {
+    let selected = selected_modules(plan, selection);
+    let referenced_modules = plan.referenced_modules();
+
+    rayon::in_place_scope(|scope| {
+        for module_use in selected {
+            let sender = arrivals.clone();
+            scope.spawn(move |_| {
+                let started = Instant::now();
+                let segments = render_module(module_use, context, referenced_modules);
+                let _ = sender.send(Resolution::initial(module_use, segments, started.elapsed()));
+            });
+        }
+
+        body(&Spawner {
+            scope,
+            sender: arrivals.clone(),
+            context,
+        })
+    })
 }
 
 /// Runs the selected modules and lets `consume` take their output as it
@@ -171,6 +335,40 @@ pub fn stream<'plan>(
     });
 }
 
+/// Runs everything the very first paint of a prompt may show, handing each
+/// result to `receive` as it becomes available.
+///
+/// That is two things:
+///
+/// * the instant approximation of every module that has one
+///   ([`crate::modules::Render::instant`]), run on this thread, in paint order.
+///   An approximation is by definition too cheap to be worth handing to a
+///   thread, and running them here keeps the pool free for the work that is
+///   not;
+/// * every [`Cadence::Instant`] module, run for real and in parallel.
+///
+/// Both are bounded, so this returns in the time the slowest *instant* module
+/// takes rather than the time the slowest module takes.
+pub fn stream_instant<'plan>(
+    plan: &'plan Plan,
+    context: &Context,
+    mut receive: impl FnMut(Resolution<'plan>),
+) {
+    for module_use in selected_modules(plan, Selection::DeferredOnly) {
+        let started = Instant::now();
+        let Some(module) = approximate_module(&module_use.module, context) else {
+            continue;
+        };
+        receive(Resolution::initial(
+            module_use,
+            module.segments,
+            started.elapsed(),
+        ));
+    }
+
+    stream(plan, context, Selection::InstantOnly, receive);
+}
+
 /// Runs every module the plan asks for and takes their output into one render.
 pub fn fill_slots<'plan>(plan: &'plan Plan, context: &Context) -> PromptState<'plan> {
     let mut state = PromptState::empty(plan);
@@ -192,6 +390,29 @@ fn render_module(
         .collect()
 }
 
+/// The instant approximation of one module, if it has one.
+///
+/// Unlike [`render_module`] this never expands `custom` or `env_var` into their
+/// children: those are dispatched by prefix and have no approximation, so there
+/// would be nothing to expand them for.
+fn approximate_module<'context>(
+    module: &ModuleName,
+    context: &'context Context<'_>,
+) -> Option<Module<'context>> {
+    // Only a module that exists can have an approximation, and a disabled
+    // module has nothing to approximate. Both are checks `handle_module`
+    // applies to the full render whichever origin the slot has, so the first
+    // paint and the refinement agree about which modules are in the prompt at
+    // all.
+    if !ALL_MODULES.contains(&module.as_str())
+        || context.is_module_disabled_in_config(module.as_str())
+    {
+        return None;
+    }
+
+    crate::modules::instant(module.as_str(), context)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -206,6 +427,28 @@ mod tests {
             context.destination(),
             &context.target,
         ))
+    }
+
+    /// The names of the modules a selection runs, in completion order.
+    fn resolved_modules(context: &Context, selection: Selection) -> Vec<String> {
+        let plan = plan_of(context);
+        let mut resolved = Vec::new();
+        stream(&plan, context, selection, |resolution| {
+            resolved.push(resolution.module().as_str().to_owned());
+        });
+        resolved
+    }
+
+    #[test]
+    fn every_module_of_the_plan_is_reported_exactly_once() {
+        let context = default_context().set_config(toml::toml! {
+            format = "$character$character$status$hostname"
+        });
+        let mut resolved = resolved_modules(&context, Selection::EveryModule);
+        resolved.sort_unstable();
+
+        // `character` fills two slots but is run once.
+        assert_eq!(vec!["character", "hostname", "status"], resolved);
     }
 
     #[test]
@@ -270,6 +513,29 @@ mod tests {
     }
 
     #[test]
+    fn the_instant_selection_and_its_complement_partition_the_plan() {
+        let context = default_context().set_config(toml::toml! {
+            format = "$character$directory$status$git_branch"
+        });
+
+        let mut instant = resolved_modules(&context, Selection::InstantOnly);
+        let mut deferred = resolved_modules(&context, Selection::DeferredOnly);
+        instant.sort_unstable();
+        deferred.sort_unstable();
+
+        assert_eq!(vec!["character", "status"], instant);
+        assert_eq!(vec!["directory", "git_branch"], deferred);
+    }
+
+    #[test]
+    fn an_empty_selection_runs_nothing() {
+        let context = default_context().set_config(toml::toml! {
+            format = "$directory"
+        });
+        assert!(resolved_modules(&context, Selection::InstantOnly).is_empty());
+    }
+
+    #[test]
     fn streaming_and_filling_agree() {
         let context = default_context().set_config(toml::toml! {
             add_newline = false
@@ -288,6 +554,74 @@ mod tests {
         assert_eq!(
             crate::module::painted::Painted::paint(&filled.render(), None).to_markup(),
             crate::module::painted::Painted::paint(&streamed.render(), None).to_markup(),
+        );
+    }
+
+    #[test]
+    fn a_dynamic_module_is_found_among_the_deferred_ones() {
+        let context = default_context().set_config(toml::toml! {
+            format = "$time$character"
+            [time]
+            disabled = false
+            format = "$time"
+        });
+        let plan = plan_of(&context);
+
+        let found = dynamic_modules(&plan, &context);
+        assert_eq!(1, found.len());
+        assert_eq!("time", found[0].name().as_str());
+        assert_eq!(Duration::from_secs(1), found[0].period());
+    }
+
+    #[test]
+    fn a_prompt_with_nothing_dynamic_in_it_has_no_dynamic_modules() {
+        let context = default_context().set_config(toml::toml! {
+            format = "$character$directory$git_branch"
+        });
+        assert!(dynamic_modules(&plan_of(&context), &context).is_empty());
+    }
+
+    #[test]
+    fn a_dynamic_module_can_be_given_a_different_period() {
+        let context = default_context().set_config(toml::toml! {
+            format = "$time"
+            [time]
+            disabled = false
+        });
+        let plan = plan_of(&context);
+        let module = dynamic_modules(&plan, &context)
+            .into_iter()
+            .next()
+            .expect("time is dynamic")
+            .every(Duration::from_millis(250));
+
+        assert_eq!(Duration::from_millis(250), module.period());
+    }
+
+    #[test]
+    fn resolving_a_dynamic_module_produces_a_value_the_prompt_renders() {
+        let context = default_context().set_config(toml::toml! {
+            add_newline = false
+            format = "$time"
+            [time]
+            disabled = false
+            format = "the-time"
+        });
+        let plan = plan_of(&context);
+        let module = dynamic_modules(&plan, &context)
+            .into_iter()
+            .next()
+            .expect("time is dynamic");
+
+        let resolution = module.resolve(&context);
+        assert_eq!("time", resolution.module().as_str());
+        assert_eq!(ResolutionKind::Refresh, resolution.kind());
+        let mut state = PromptState::empty(&plan);
+        resolution.store_in(&mut state);
+
+        assert_eq!(
+            "the-time",
+            crate::module::painted::Painted::paint(&state.render(), None).to_string()
         );
     }
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -28,11 +28,11 @@ pub struct Resolution<'plan> {
 
 impl fmt::Debug for Resolution<'_> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let value: String = self.segments.iter().map(Segment::value).collect();
+        let stringified_value: String = self.segments.iter().map(Segment::value).collect();
         formatter
             .debug_struct("Resolution")
             .field("module", &self.module.module.as_str())
-            .field("value", &value)
+            .field("value", &stringified_value)
             .field("elapsed", &self.elapsed)
             .field("kind", &self.kind)
             .finish()
@@ -40,6 +40,7 @@ impl fmt::Debug for Resolution<'_> {
 }
 
 impl<'plan> Resolution<'plan> {
+    #[inline]
     fn initial(module: &'plan ModuleUse, segments: Vec<Segment>, elapsed: Duration) -> Self {
         Self {
             module,
@@ -49,22 +50,27 @@ impl<'plan> Resolution<'plan> {
         }
     }
 
+    #[inline]
     pub fn module(&self) -> &'plan ModuleName {
         &self.module.module
     }
 
+    #[inline]
     pub fn elapsed(&self) -> Duration {
         self.elapsed
     }
 
+    #[inline]
     pub(crate) fn kind(&self) -> ResolutionKind {
         self.kind
     }
 
+    #[inline]
     pub(crate) fn slot(&self) -> ModuleSlot {
         self.module.slot()
     }
 
+    #[inline]
     pub fn store_in(self, state: &mut PromptState<'plan>) {
         state
             .record(self.module, self.segments)
@@ -81,13 +87,12 @@ pub enum Selection {
 }
 
 impl Selection {
-    fn admits(self, module: &str) -> bool {
-        let is_instant = cadence(module) == Some(Cadence::Instant);
-        match self {
-            Self::EveryModule => true,
-            Self::InstantOnly => is_instant,
-            Self::DeferredOnly => !is_instant,
-        }
+    fn admits(self, module_name: &str) -> bool {
+        let is_instant = cadence(module_name) == Some(Cadence::Instant);
+        matches!(
+            (self, is_instant),
+            (Self::EveryModule, _) | (Self::InstantOnly, true) | (Self::DeferredOnly, false)
+        )
     }
 }
 
@@ -104,14 +109,17 @@ pub struct DynamicModule<'plan> {
 }
 
 impl<'plan> DynamicModule<'plan> {
+    #[inline]
     pub fn name(&self) -> &'plan ModuleName {
         &self.module.module
     }
 
+    #[inline]
     pub fn period(&self) -> Duration {
         self.period
     }
 
+    #[inline]
     pub(crate) fn slot(&self) -> ModuleSlot {
         self.module.slot()
     }
@@ -123,52 +131,56 @@ impl<'plan> DynamicModule<'plan> {
     }
 
     pub fn resolve(&self, context: &Context) -> Resolution<'plan> {
-        let started = Instant::now();
+        let start_time = Instant::now();
         let segments = render_module(self.module, context, self.referenced_modules);
+
         Resolution {
             module: self.module,
             segments,
-            elapsed: started.elapsed(),
+            elapsed: start_time.elapsed(),
             kind: ResolutionKind::Refresh,
         }
     }
 }
 
-/// Returns enabled dynamic modules in prompt order.
+/// The plan's dynamic modules, in prompt order, skipping any that are disabled.
 pub fn dynamic_modules<'plan>(plan: &'plan Plan, context: &Context) -> Vec<DynamicModule<'plan>> {
+    let referenced_modules = plan.referenced_modules();
+
     selected_modules(plan, Selection::DeferredOnly)
         .filter(|module_use| !is_switched_off(&module_use.module, context))
-        .filter_map(|module_use| match cadence(module_use.module.as_str()) {
-            Some(Cadence::Dynamic { period }) => Some(DynamicModule {
+        .filter_map(|module_use| {
+            let Some(Cadence::Dynamic { period }) = cadence(module_use.module.as_str()) else {
+                return None;
+            };
+            Some(DynamicModule {
                 module: module_use,
-                referenced_modules: plan.referenced_modules(),
+                referenced_modules,
                 period,
-            }),
-            _ => None,
+            })
         })
         .collect()
 }
 
-// Use effective defaults: disabled dynamic modules must not keep streams alive.
-fn is_switched_off(module: &ModuleName, context: &Context) -> bool {
+// A disabled dynamic module must not be polled forever.
+fn is_switched_off(module_name: &ModuleName, context: &Context) -> bool {
     use crate::config::ModuleConfig;
 
-    let table = context.config.get_module_config(module.as_str());
-    match module.as_str() {
-        "battery" => crate::configs::battery::BatteryConfig::try_load(table).disabled,
-        "localip" => crate::configs::localip::LocalipConfig::try_load(table).disabled,
-        "memory_usage" => crate::configs::memory_usage::MemoryConfig::try_load(table).disabled,
-        "time" => crate::configs::time::TimeConfig::try_load(table).disabled,
-        other => context.is_module_disabled_in_config(other),
+    let string_name = module_name.as_str();
+    let configuration_table = context.config.get_module_config(string_name);
+
+    match string_name {
+        "battery" => crate::configs::battery::BatteryConfig::try_load(configuration_table).disabled,
+        "localip" => crate::configs::localip::LocalipConfig::try_load(configuration_table).disabled,
+        "memory_usage" => {
+            crate::configs::memory_usage::MemoryConfig::try_load(configuration_table).disabled
+        }
+        "time" => crate::configs::time::TimeConfig::try_load(configuration_table).disabled,
+        other_name => context.is_module_disabled_in_config(other_name),
     }
 }
 
 /// The modules of `plan` that `selection` covers, in first-paint order.
-///
-/// The plan already reports each of its modules exactly once, however many
-/// positions name it — see [`Plan::module_uses`] — so a module is run once and
-/// its value stands in all of them, which is what the formatter did when it
-/// cached one value per variable name.
 fn selected_modules(plan: &Plan, selection: Selection) -> impl Iterator<Item = &ModuleUse> {
     plan.module_uses()
         .iter()
@@ -178,9 +190,7 @@ fn selected_modules(plan: &Plan, selection: Selection) -> impl Iterator<Item = &
 /// What taking from a [`Resolutions`] produced.
 #[derive(Debug)]
 pub enum Arrival<'plan> {
-    /// A module finished.
     Resolved(Resolution<'plan>),
-    /// Every module has finished; there will be no further arrivals.
     Finished,
 }
 
@@ -197,22 +207,13 @@ pub struct Resolutions<'plan> {
 }
 
 impl<'plan> Resolutions<'plan> {
-    /// Waits for the next module to finish, however long that takes.
     pub fn next_arrival(&self) -> Arrival<'plan> {
-        match self.receiver.recv() {
-            Ok(resolution) => Arrival::Resolved(resolution),
-            Err(mpsc::RecvError) => Arrival::Finished,
-        }
+        self.receiver
+            .recv()
+            .map_or(Arrival::Finished, Arrival::Resolved)
     }
 }
 
-/// Somewhere to start a module rendering that is not on the calling thread.
-///
-/// Handed to the body of [`while_running`] so that a caller draining
-/// resolutions can start *more* work without waiting for what is already
-/// running to finish. That is what a dynamic module needs: its period expires
-/// while the prompt's slow modules are still resolving, and re-rendering it on
-/// the draining thread would stall every other refinement behind it.
 pub struct Spawner<'borrow, 'scope, 'context> {
     scope: &'borrow rayon::Scope<'scope>,
     sender: mpsc::Sender<Resolution<'scope>>,
@@ -220,32 +221,36 @@ pub struct Spawner<'borrow, 'scope, 'context> {
 }
 
 impl<'scope, 'context> Spawner<'_, 'scope, 'context> {
-    /// Renders `module` again, off this thread, delivering the result to the
-    /// same stream of arrivals as everything else.
-    ///
-    /// Several of these run at once, which is the point: a battery service that
-    /// takes half a second to answer must not hold up a clock that only wants
-    /// to tick.
     pub fn poll(&self, module: DynamicModule<'scope>) {
         let sender = self.sender.clone();
         let context = self.context;
+
         self.scope.spawn(move |_| {
-            // The receiver outlives this scope, so a failed send would mean the
-            // caller had stopped draining — in which case there is nobody left
-            // to tell.
             let _ = sender.send(module.resolve(context));
         });
     }
 }
 
-/// Runs the selected modules, delivering each one's output to `arrivals` as it
-/// finishes, while `body` runs on the calling thread.
-///
-/// Unlike [`with_resolutions`] the channel is the caller's, so it stays open
-/// after the last selected module has finished and the caller can keep using it
-/// for work it starts itself through the [`Spawner`]. A caller that works this
-/// way cannot learn that everything has finished by watching the channel
-/// disconnect, and must count what it is waiting for instead.
+/// Spawns `module_use`'s render on `scope`, sending the result through `sender`.
+fn spawn_resolution<'scope, 'context>(
+    scope: &rayon::Scope<'scope>,
+    sender: mpsc::Sender<Resolution<'scope>>,
+    module_use: &'scope ModuleUse,
+    context: &'scope Context<'context>,
+    referenced_modules: &'scope BTreeSet<ModuleName>,
+) {
+    scope.spawn(move |_| {
+        let start_time = Instant::now();
+        let segments = render_module(module_use, context, referenced_modules);
+        let _ = sender.send(Resolution::initial(
+            module_use,
+            segments,
+            start_time.elapsed(),
+        ));
+    });
+}
+
+/// Runs the selected modules, delivering each one's output to `arrivals` as it finishes.
 pub fn while_running<'scope, 'context, T>(
     plan: &'scope Plan,
     context: &'scope Context<'context>,
@@ -253,17 +258,17 @@ pub fn while_running<'scope, 'context, T>(
     arrivals: &mpsc::Sender<Resolution<'scope>>,
     body: impl FnOnce(&Spawner<'_, 'scope, 'context>) -> T,
 ) -> T {
-    let selected = selected_modules(plan, selection);
     let referenced_modules = plan.referenced_modules();
 
     rayon::in_place_scope(|scope| {
-        for module_use in selected {
-            let sender = arrivals.clone();
-            scope.spawn(move |_| {
-                let started = Instant::now();
-                let segments = render_module(module_use, context, referenced_modules);
-                let _ = sender.send(Resolution::initial(module_use, segments, started.elapsed()));
-            });
+        for module_use in selected_modules(plan, selection) {
+            spawn_resolution(
+                scope,
+                arrivals.clone(),
+                module_use,
+                context,
+                referenced_modules,
+            );
         }
 
         body(&Spawner {
@@ -274,57 +279,38 @@ pub fn while_running<'scope, 'context, T>(
     })
 }
 
-/// Runs the selected modules and lets `consume` take their output as it
-/// arrives.
-///
-/// Every selected module produces exactly one arrival, including one that
-/// produced nothing: "this module resolved to nothing" is information a caller
-/// repainting a prompt needs just as much as a value is.
-///
-/// `consume` runs on the calling thread and returns when it stops taking; the
-/// modules still running are waited for before this returns, so nothing outlives
-/// the call.
+/// Runs the selected modules and lets `consume` take their output as it arrives.
 pub fn with_resolutions<'plan, T>(
     plan: &'plan Plan,
-    context: &Context,
+    context: &'plan Context<'_>,
     selection: Selection,
     consume: impl FnOnce(&Resolutions<'plan>) -> T,
 ) -> T {
-    let selected = selected_modules(plan, selection);
     let referenced_modules = plan.referenced_modules();
     let (sender, receiver) = mpsc::channel::<Resolution<'plan>>();
 
-    // `in_place_scope` rather than `scope`: the body runs on the calling thread
-    // instead of being migrated into the pool, which is what lets `consume` be
-    // an ordinary closure borrowing whatever the caller is filling in. `scope`
-    // would demand a `Send` closure and a shared, locked accumulator for no
-    // benefit — the receiving side is not the work.
     rayon::in_place_scope(|scope| {
-        for module_use in selected {
-            let sender = sender.clone();
-            scope.spawn(move |_| {
-                let started = Instant::now();
-                let segments = render_module(module_use, context, referenced_modules);
-                // The receiver lives as long as this scope, so a send can only
-                // fail once `consume` has returned — in which case there is
-                // nothing left to report the result to.
-                let _ = sender.send(Resolution::initial(module_use, segments, started.elapsed()));
-            });
+        for module_use in selected_modules(plan, selection) {
+            spawn_resolution(
+                scope,
+                sender.clone(),
+                module_use,
+                context,
+                referenced_modules,
+            );
         }
-        // Every remaining sender is owned by a spawned worker, so the channel
-        // disconnects — and [`Arrival::Finished`] appears — exactly when the
-        // last of them has finished. Dropping this one is what makes that true.
+
+        // Drop our sender so the receiver ends once every worker's clone is dropped too.
         drop(sender);
 
         consume(&Resolutions { receiver })
     })
 }
 
-/// Runs the selected modules, handing each one's output to `receive` as soon as
-/// that module finishes.
+/// Runs the selected modules, handing each one's output to `receive` as soon as it finishes.
 pub fn stream<'plan>(
     plan: &'plan Plan,
-    context: &Context,
+    context: &'plan Context<'_>,
     selection: Selection,
     mut receive: impl FnMut(Resolution<'plan>),
 ) {
@@ -335,42 +321,31 @@ pub fn stream<'plan>(
     });
 }
 
-/// Runs everything the very first paint of a prompt may show, handing each
-/// result to `receive` as it becomes available.
-///
-/// That is two things:
-///
-/// * the instant approximation of every module that has one
-///   ([`crate::modules::Render::instant`]), run on this thread, in paint order.
-///   An approximation is by definition too cheap to be worth handing to a
-///   thread, and running them here keeps the pool free for the work that is
-///   not;
-/// * every [`Cadence::Instant`] module, run for real and in parallel.
-///
-/// Both are bounded, so this returns in the time the slowest *instant* module
-/// takes rather than the time the slowest module takes.
+/// Runs everything the very first paint of a prompt may show.
 pub fn stream_instant<'plan>(
     plan: &'plan Plan,
-    context: &Context,
+    context: &'plan Context<'_>,
     mut receive: impl FnMut(Resolution<'plan>),
 ) {
-    for module_use in selected_modules(plan, Selection::DeferredOnly) {
-        let started = Instant::now();
-        let Some(module) = approximate_module(&module_use.module, context) else {
-            continue;
-        };
-        receive(Resolution::initial(
-            module_use,
-            module.segments,
-            started.elapsed(),
-        ));
-    }
+    // Approximations are Instant by contract, so they run synchronously rather
+    // than paying for a rayon task each.
+    selected_modules(plan, Selection::DeferredOnly)
+        .filter_map(|module_use| {
+            let start_time = Instant::now();
+            let approximation = approximate_module(&module_use.module, context)?;
+            Some(Resolution::initial(
+                module_use,
+                approximation.segments,
+                start_time.elapsed(),
+            ))
+        })
+        .for_each(&mut receive);
 
     stream(plan, context, Selection::InstantOnly, receive);
 }
 
 /// Runs every module the plan asks for and takes their output into one render.
-pub fn fill_slots<'plan>(plan: &'plan Plan, context: &Context) -> PromptState<'plan> {
+pub fn fill_slots<'plan>(plan: &'plan Plan, context: &'plan Context<'_>) -> PromptState<'plan> {
     let mut state = PromptState::empty(plan);
     stream(plan, context, Selection::EveryModule, |resolution| {
         resolution.store_in(&mut state);
@@ -380,39 +355,31 @@ pub fn fill_slots<'plan>(plan: &'plan Plan, context: &Context) -> PromptState<'p
 
 /// The segments one module contributes to the prompt.
 fn render_module(
-    module: &ModuleUse,
+    module_use: &ModuleUse,
     context: &Context,
     referenced_modules: &BTreeSet<ModuleName>,
 ) -> Vec<Segment> {
-    crate::print::handle_module(module.module.as_str(), context, referenced_modules)
+    crate::print::handle_module(module_use.module.as_str(), context, referenced_modules)
         .into_iter()
         .flat_map(|module| module.segments)
         .collect()
 }
 
-/// The instant approximation of one module, if it has one.
-///
-/// Unlike [`render_module`] this never expands `custom` or `env_var` into their
-/// children: those are dispatched by prefix and have no approximation, so there
-/// would be nothing to expand them for.
+/// The instant approximation of one module, or `None` if it has none, is
+/// unrecognised, or is disabled.
 fn approximate_module<'context>(
-    module: &ModuleName,
+    module_name: &ModuleName,
     context: &'context Context<'_>,
 ) -> Option<Module<'context>> {
-    // Only a module that exists can have an approximation, and a disabled
-    // module has nothing to approximate. Both are checks `handle_module`
-    // applies to the full render whichever origin the slot has, so the first
-    // paint and the refinement agree about which modules are in the prompt at
-    // all.
-    if !ALL_MODULES.contains(&module.as_str())
-        || context.is_module_disabled_in_config(module.as_str())
-    {
-        return None;
-    }
+    let string_name = module_name.as_str();
 
-    crate::modules::instant(module.as_str(), context)
+    let is_enabled =
+        ALL_MODULES.contains(&string_name) && !context.is_module_disabled_in_config(string_name);
+
+    is_enabled
+        .then(|| crate::modules::instant(string_name, context))
+        .flatten()
 }
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/render.rs
+++ b/src/render.rs
@@ -164,20 +164,8 @@ pub fn dynamic_modules<'plan>(plan: &'plan Plan, context: &Context) -> Vec<Dynam
 
 // A disabled dynamic module must not be polled forever.
 fn is_switched_off(module_name: &ModuleName, context: &Context) -> bool {
-    use crate::config::ModuleConfig;
-
     let string_name = module_name.as_str();
-    let configuration_table = context.config.get_module_config(string_name);
-
-    match string_name {
-        "battery" => crate::configs::battery::BatteryConfig::try_load(configuration_table).disabled,
-        "localip" => crate::configs::localip::LocalipConfig::try_load(configuration_table).disabled,
-        "memory_usage" => {
-            crate::configs::memory_usage::MemoryConfig::try_load(configuration_table).disabled
-        }
-        "time" => crate::configs::time::TimeConfig::try_load(configuration_table).disabled,
-        other_name => context.is_module_disabled_in_config(other_name),
-    }
+    context.is_module_disabled_in_config(string_name)
 }
 
 /// The modules of `plan` that `selection` covers, in first-paint order.

--- a/src/render.rs
+++ b/src/render.rs
@@ -246,12 +246,14 @@ mod tests {
             when = true
             format = "$output"
             use_stdin = true
+            ignore_timeout = true
             shell = (shell.clone())
             [custom.slow]
             command = "echo slow"
             when = true
             format = "$output"
             use_stdin = true
+            ignore_timeout = true
             shell = shell
             [character]
             format = ">"

--- a/src/render.rs
+++ b/src/render.rs
@@ -6,16 +6,13 @@ use std::sync::mpsc;
 use std::time::{Duration, Instant};
 
 use crate::context::Context;
-use crate::module::{ALL_MODULES, Module};
-use crate::modules::{Cadence, cadence};
-use crate::plan::{ModuleName, ModuleSlot, ModuleUse, Plan, PromptState};
+use crate::plan::{ModuleName, ModuleUse, Plan, PromptState};
 use crate::segment::Segment;
 
 /// Whether a resolution belongs to the first render or a later poll.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum ResolutionKind {
     Initial,
-    Refresh,
 }
 
 /// One resolved module.
@@ -49,24 +46,10 @@ impl<'plan> Resolution<'plan> {
         }
     }
 
-    pub fn module(&self) -> &'plan ModuleName {
-        &self.module.module
-    }
-
-    pub fn elapsed(&self) -> Duration {
-        self.elapsed
-    }
-
-    pub(crate) fn kind(&self) -> ResolutionKind {
-        self.kind
-    }
-
-    pub(crate) fn slot(&self) -> ModuleSlot {
-        self.module.slot()
-    }
-
     pub fn store_in(self, state: &mut PromptState<'plan>) {
-        state.record(self.module, self.segments);
+        state
+            .record(self.module, self.segments)
+            .expect("a resolution always belongs to its prompt state");
     }
 }
 
@@ -74,90 +57,13 @@ impl<'plan> Resolution<'plan> {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Selection {
     EveryModule,
-    InstantOnly,
-    DeferredOnly,
 }
 
 impl Selection {
-    fn admits(self, module: &str) -> bool {
-        let is_instant = cadence(module) == Some(Cadence::Instant);
+    fn admits(self, _module: &str) -> bool {
         match self {
             Self::EveryModule => true,
-            Self::InstantOnly => is_instant,
-            Self::DeferredOnly => !is_instant,
         }
-    }
-}
-
-pub fn modules(plan: &Plan, selection: Selection) -> impl Iterator<Item = &ModuleName> {
-    selected_modules(plan, selection).map(|module_use| &module_use.module)
-}
-
-/// A dynamic module and its refresh period.
-#[derive(Clone)]
-pub struct DynamicModule<'plan> {
-    module: &'plan ModuleUse,
-    referenced_modules: &'plan BTreeSet<ModuleName>,
-    period: Duration,
-}
-
-impl<'plan> DynamicModule<'plan> {
-    pub fn name(&self) -> &'plan ModuleName {
-        &self.module.module
-    }
-
-    pub fn period(&self) -> Duration {
-        self.period
-    }
-
-    pub(crate) fn slot(&self) -> ModuleSlot {
-        self.module.slot()
-    }
-
-    #[must_use]
-    pub fn every(mut self, period: Duration) -> Self {
-        self.period = period;
-        self
-    }
-
-    pub fn resolve(&self, context: &Context) -> Resolution<'plan> {
-        let started = Instant::now();
-        let segments = render_module(self.module, context, self.referenced_modules);
-        Resolution {
-            module: self.module,
-            segments,
-            elapsed: started.elapsed(),
-            kind: ResolutionKind::Refresh,
-        }
-    }
-}
-
-/// Returns enabled dynamic modules in prompt order.
-pub fn dynamic_modules<'plan>(plan: &'plan Plan, context: &Context) -> Vec<DynamicModule<'plan>> {
-    selected_modules(plan, Selection::DeferredOnly)
-        .filter(|module_use| !is_switched_off(&module_use.module, context))
-        .filter_map(|module_use| match cadence(module_use.module.as_str()) {
-            Some(Cadence::Dynamic { period }) => Some(DynamicModule {
-                module: module_use,
-                referenced_modules: plan.referenced_modules(),
-                period,
-            }),
-            _ => None,
-        })
-        .collect()
-}
-
-// Use effective defaults: disabled dynamic modules must not keep streams alive.
-fn is_switched_off(module: &ModuleName, context: &Context) -> bool {
-    use crate::config::ModuleConfig;
-
-    let table = context.config.get_module_config(module.as_str());
-    match module.as_str() {
-        "battery" => crate::configs::battery::BatteryConfig::try_load(table).disabled,
-        "localip" => crate::configs::localip::LocalipConfig::try_load(table).disabled,
-        "memory_usage" => crate::configs::memory_usage::MemoryConfig::try_load(table).disabled,
-        "time" => crate::configs::time::TimeConfig::try_load(table).disabled,
-        other => context.is_module_disabled_in_config(other),
     }
 }
 
@@ -186,7 +92,7 @@ pub enum Arrival<'plan> {
 ///
 /// A caller wanting a *time-based* draw policy — collecting several results
 /// that land close together rather than drawing each the instant it lands —
-/// does not go through this type. [`crate::stream`]'s event loop owns its own
+/// does not go through this type. [`stream`]'s event loop owns its own
 /// channel and calls `recv_timeout` on it directly instead, which is what lets
 /// it wait on a module arriving *or* a repaint deadline expiring *or* a
 /// dynamic module falling due, all at once.
@@ -202,74 +108,6 @@ impl<'plan> Resolutions<'plan> {
             Err(mpsc::RecvError) => Arrival::Finished,
         }
     }
-}
-
-/// Somewhere to start a module rendering that is not on the calling thread.
-///
-/// Handed to the body of [`while_running`] so that a caller draining
-/// resolutions can start *more* work without waiting for what is already
-/// running to finish. That is what a dynamic module needs: its period expires
-/// while the prompt's slow modules are still resolving, and re-rendering it on
-/// the draining thread would stall every other refinement behind it.
-pub struct Spawner<'borrow, 'scope, 'context> {
-    scope: &'borrow rayon::Scope<'scope>,
-    sender: mpsc::Sender<Resolution<'scope>>,
-    context: &'scope Context<'context>,
-}
-
-impl<'scope, 'context> Spawner<'_, 'scope, 'context> {
-    /// Renders `module` again, off this thread, delivering the result to the
-    /// same stream of arrivals as everything else.
-    ///
-    /// Several of these run at once, which is the point: a battery service that
-    /// takes half a second to answer must not hold up a clock that only wants
-    /// to tick.
-    pub fn poll(&self, module: DynamicModule<'scope>) {
-        let sender = self.sender.clone();
-        let context = self.context;
-        self.scope.spawn(move |_| {
-            // The receiver outlives this scope, so a failed send would mean the
-            // caller had stopped draining — in which case there is nobody left
-            // to tell.
-            let _ = sender.send(module.resolve(context));
-        });
-    }
-}
-
-/// Runs the selected modules, delivering each one's output to `arrivals` as it
-/// finishes, while `body` runs on the calling thread.
-///
-/// Unlike [`with_resolutions`] the channel is the caller's, so it stays open
-/// after the last selected module has finished and the caller can keep using it
-/// for work it starts itself through the [`Spawner`]. A caller that works this
-/// way cannot learn that everything has finished by watching the channel
-/// disconnect, and must count what it is waiting for instead.
-pub fn while_running<'scope, 'context, T>(
-    plan: &'scope Plan,
-    context: &'scope Context<'context>,
-    selection: Selection,
-    arrivals: &mpsc::Sender<Resolution<'scope>>,
-    body: impl FnOnce(&Spawner<'_, 'scope, 'context>) -> T,
-) -> T {
-    let selected = selected_modules(plan, selection);
-    let referenced_modules = plan.referenced_modules();
-
-    rayon::in_place_scope(|scope| {
-        for module_use in selected {
-            let sender = arrivals.clone();
-            scope.spawn(move |_| {
-                let started = Instant::now();
-                let segments = render_module(module_use, context, referenced_modules);
-                let _ = sender.send(Resolution::initial(module_use, segments, started.elapsed()));
-            });
-        }
-
-        body(&Spawner {
-            scope,
-            sender: arrivals.clone(),
-            context,
-        })
-    })
 }
 
 /// Runs the selected modules and lets `consume` take their output as it
@@ -333,40 +171,6 @@ pub fn stream<'plan>(
     });
 }
 
-/// Runs everything the very first paint of a prompt may show, handing each
-/// result to `receive` as it becomes available.
-///
-/// That is two things:
-///
-/// * the instant approximation of every module that has one
-///   ([`crate::modules::Render::instant`]), run on this thread, in paint order.
-///   An approximation is by definition too cheap to be worth handing to a
-///   thread, and running them here keeps the pool free for the work that is
-///   not;
-/// * every [`Cadence::Instant`] module, run for real and in parallel.
-///
-/// Both are bounded, so this returns in the time the slowest *instant* module
-/// takes rather than the time the slowest module takes.
-pub fn stream_instant<'plan>(
-    plan: &'plan Plan,
-    context: &Context,
-    mut receive: impl FnMut(Resolution<'plan>),
-) {
-    for module_use in selected_modules(plan, Selection::DeferredOnly) {
-        let started = Instant::now();
-        let Some(module) = approximate_module(&module_use.module, context) else {
-            continue;
-        };
-        receive(Resolution::initial(
-            module_use,
-            module.segments,
-            started.elapsed(),
-        ));
-    }
-
-    stream(plan, context, Selection::InstantOnly, receive);
-}
-
 /// Runs every module the plan asks for and takes their output into one render.
 pub fn fill_slots<'plan>(plan: &'plan Plan, context: &Context) -> PromptState<'plan> {
     let mut state = PromptState::empty(plan);
@@ -388,29 +192,6 @@ fn render_module(
         .collect()
 }
 
-/// The instant approximation of one module, if it has one.
-///
-/// Unlike [`render_module`] this never expands `custom` or `env_var` into their
-/// children: those are dispatched by prefix and have no approximation, so there
-/// would be nothing to expand them for.
-fn approximate_module<'context>(
-    module: &ModuleName,
-    context: &'context Context<'_>,
-) -> Option<Module<'context>> {
-    // Only a module that exists can have an approximation, and a disabled
-    // module has nothing to approximate. Both are checks `handle_module`
-    // applies to the full render whichever origin the slot has, so the first
-    // paint and the refinement agree about which modules are in the prompt at
-    // all.
-    if !ALL_MODULES.contains(&module.as_str())
-        || context.is_module_disabled_in_config(module.as_str())
-    {
-        return None;
-    }
-
-    crate::modules::instant(module.as_str(), context)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -425,28 +206,6 @@ mod tests {
             context.destination(),
             &context.target,
         ))
-    }
-
-    /// The names of the modules a selection runs, in completion order.
-    fn resolved_modules(context: &Context, selection: Selection) -> Vec<String> {
-        let plan = plan_of(context);
-        let mut resolved = Vec::new();
-        stream(&plan, context, selection, |resolution| {
-            resolved.push(resolution.module().as_str().to_owned());
-        });
-        resolved
-    }
-
-    #[test]
-    fn every_module_of_the_plan_is_reported_exactly_once() {
-        let context = default_context().set_config(toml::toml! {
-            format = "$character$character$status$hostname"
-        });
-        let mut resolved = resolved_modules(&context, Selection::EveryModule);
-        resolved.sort_unstable();
-
-        // `character` fills two slots but is run once.
-        assert_eq!(vec!["character", "hostname", "status"], resolved);
     }
 
     #[test]
@@ -497,29 +256,6 @@ mod tests {
     }
 
     #[test]
-    fn the_instant_selection_and_its_complement_partition_the_plan() {
-        let context = default_context().set_config(toml::toml! {
-            format = "$character$directory$status$git_branch"
-        });
-
-        let mut instant = resolved_modules(&context, Selection::InstantOnly);
-        let mut deferred = resolved_modules(&context, Selection::DeferredOnly);
-        instant.sort_unstable();
-        deferred.sort_unstable();
-
-        assert_eq!(vec!["character", "status"], instant);
-        assert_eq!(vec!["directory", "git_branch"], deferred);
-    }
-
-    #[test]
-    fn an_empty_selection_runs_nothing() {
-        let context = default_context().set_config(toml::toml! {
-            format = "$directory"
-        });
-        assert!(resolved_modules(&context, Selection::InstantOnly).is_empty());
-    }
-
-    #[test]
     fn streaming_and_filling_agree() {
         let context = default_context().set_config(toml::toml! {
             add_newline = false
@@ -538,74 +274,6 @@ mod tests {
         assert_eq!(
             crate::module::painted::Painted::paint(&filled.render(), None).to_markup(),
             crate::module::painted::Painted::paint(&streamed.render(), None).to_markup(),
-        );
-    }
-
-    #[test]
-    fn a_dynamic_module_is_found_among_the_deferred_ones() {
-        let context = default_context().set_config(toml::toml! {
-            format = "$time$character"
-            [time]
-            disabled = false
-            format = "$time"
-        });
-        let plan = plan_of(&context);
-
-        let found = dynamic_modules(&plan, &context);
-        assert_eq!(1, found.len());
-        assert_eq!("time", found[0].name().as_str());
-        assert_eq!(Duration::from_secs(1), found[0].period());
-    }
-
-    #[test]
-    fn a_prompt_with_nothing_dynamic_in_it_has_no_dynamic_modules() {
-        let context = default_context().set_config(toml::toml! {
-            format = "$character$directory$git_branch"
-        });
-        assert!(dynamic_modules(&plan_of(&context), &context).is_empty());
-    }
-
-    #[test]
-    fn a_dynamic_module_can_be_given_a_different_period() {
-        let context = default_context().set_config(toml::toml! {
-            format = "$time"
-            [time]
-            disabled = false
-        });
-        let plan = plan_of(&context);
-        let module = dynamic_modules(&plan, &context)
-            .into_iter()
-            .next()
-            .expect("time is dynamic")
-            .every(Duration::from_millis(250));
-
-        assert_eq!(Duration::from_millis(250), module.period());
-    }
-
-    #[test]
-    fn resolving_a_dynamic_module_produces_a_value_the_prompt_renders() {
-        let context = default_context().set_config(toml::toml! {
-            add_newline = false
-            format = "$time"
-            [time]
-            disabled = false
-            format = "the-time"
-        });
-        let plan = plan_of(&context);
-        let module = dynamic_modules(&plan, &context)
-            .into_iter()
-            .next()
-            .expect("time is dynamic");
-
-        let resolution = module.resolve(&context);
-        assert_eq!("time", resolution.module().as_str());
-        assert_eq!(ResolutionKind::Refresh, resolution.kind());
-        let mut state = PromptState::empty(&plan);
-        resolution.store_in(&mut state);
-
-        assert_eq!(
-            "the-time",
-            crate::module::painted::Painted::paint(&state.render(), None).to_string()
         );
     }
 }

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -16,12 +16,17 @@ pub struct TextSegment {
 }
 
 impl TextSegment {
-    // Returns the AnsiString of the segment value
-    fn ansi_string(&self, prev: Option<&AnsiStyle>) -> AnsiString<'_> {
-        match self.style {
-            Some(style) => style.to_ansi_style(prev).paint(&self.value),
-            None => AnsiString::from(&self.value),
-        }
+    /// The segment's style before any `prev_fg`/`prev_bg` reference in it has
+    /// been resolved.
+    pub(crate) fn symbolic_style(&self) -> Option<Style> {
+        self.style
+    }
+
+    fn ansi_string(&self, previous: Option<&AnsiStyle>) -> AnsiString<'_> {
+        self.style.map_or_else(
+            || AnsiString::from(&self.value),
+            |style| style.to_ansi_style(previous).paint(&self.value),
+        )
     }
 }
 
@@ -36,23 +41,39 @@ pub struct FillSegment {
 }
 
 impl FillSegment {
-    // Returns the AnsiString of the segment value, not including its prefix and suffix
-    pub fn ansi_string(&self, width: Option<usize>, prev: Option<&AnsiStyle>) -> AnsiString<'_> {
-        let s = match width {
-            Some(w) => self
+    /// The segment's style before any `prev_fg`/`prev_bg` reference in it has
+    /// been resolved.
+    pub(crate) fn symbolic_style(&self) -> Option<Style> {
+        self.style
+    }
+
+    /// Repeats the fill's value until it occupies `width` terminal cells,
+    /// stopping before any grapheme that would overshoot. Without a width the
+    /// value is used as it stands.
+    pub(crate) fn expand(&self, width: Option<usize>) -> String {
+        match width {
+            Some(width) => self
                 .value
                 .graphemes(true)
                 .cycle()
-                .scan(0usize, |len, g| {
-                    *len += Grapheme(g).width();
-                    if *len <= w { Some(g) } else { None }
+                .scan(0usize, |used, grapheme| {
+                    *used += Grapheme(grapheme).width();
+                    if *used <= width { Some(grapheme) } else { None }
                 })
-                .collect::<String>(),
+                .collect(),
             None => String::from(&self.value),
-        };
+        }
+    }
+
+    pub fn ansi_string(
+        &self,
+        width: Option<usize>,
+        previous: Option<&AnsiStyle>,
+    ) -> AnsiString<'_> {
+        let text = self.expand(width);
         match self.style {
-            Some(style) => style.to_ansi_style(prev).paint(s),
-            None => AnsiString::from(s),
+            Some(style) => style.to_ansi_style(previous).paint(text),
+            None => AnsiString::from(text),
         }
     }
 }
@@ -60,12 +81,9 @@ impl FillSegment {
 #[cfg(test)]
 mod fill_seg_tests {
     use super::FillSegment;
-    use nu_ansi_term::Color;
-
     #[test]
-    fn ansi_string_width() {
+    fn expansion_respects_terminal_width() {
         let width: usize = 10;
-        let style = Color::Blue.bold();
 
         let inputs = vec![
             (".", ".........."),
@@ -78,10 +96,9 @@ mod fill_seg_tests {
         for (text, expected) in &inputs {
             let f = FillSegment {
                 value: String::from(*text),
-                style: Some(style.into()),
+                style: None,
             };
-            let actual = f.ansi_string(Some(width), None);
-            assert_eq!(style.paint(*expected), actual);
+            assert_eq!(*expected, f.expand(Some(width)));
         }
     }
 }
@@ -95,6 +112,13 @@ pub enum Segment {
 }
 
 impl Segment {
+    pub(crate) fn text(style: Option<Style>, value: impl Into<String>) -> Self {
+        Self::Text(TextSegment {
+            style,
+            value: value.into(),
+        })
+    }
+
     /// Creates new segments from a text with a style; breaking out `LineTerminators`.
     pub fn from_text<T>(style: Option<Style>, value: T) -> Vec<Self>
     where
@@ -105,10 +129,7 @@ impl Segment {
             if !segs.is_empty() {
                 segs.push(Self::LineTerm);
             }
-            segs.push(Self::Text(TextSegment {
-                value: String::from(s),
-                style,
-            }));
+            segs.push(Self::text(style, s));
         });
         segs
     }
@@ -126,13 +147,13 @@ impl Segment {
 
     pub fn style(&self) -> Option<AnsiStyle> {
         match self {
-            Self::Fill(fs) => fs.style.map(|cs| cs.to_ansi_style(None)),
-            Self::Text(ts) => ts.style.map(|cs| cs.to_ansi_style(None)),
+            Self::Text(text) => text.style.map(|style| style.to_ansi_style(None)),
+            Self::Fill(fill) => fill.style.map(|style| style.to_ansi_style(None)),
             Self::LineTerm => None,
         }
     }
 
-    pub fn set_style_if_empty(&mut self, style: Option<Style>) {
+    pub(crate) fn set_style_if_empty(&mut self, style: Option<Style>) {
         match self {
             Self::Fill(fs) => {
                 if fs.style.is_none() {
@@ -148,7 +169,7 @@ impl Segment {
         }
     }
 
-    pub fn value(&self) -> &str {
+    pub(crate) fn value(&self) -> &str {
         match self {
             Self::Fill(fs) => &fs.value,
             Self::Text(ts) => &ts.value,
@@ -156,16 +177,15 @@ impl Segment {
         }
     }
 
-    // Returns the AnsiString of the segment value, not including its prefix and suffix
-    pub fn ansi_string(&self, prev: Option<&AnsiStyle>) -> AnsiString<'_> {
+    pub fn ansi_string(&self, previous: Option<&AnsiStyle>) -> AnsiString<'_> {
         match self {
-            Self::Fill(fs) => fs.ansi_string(None, prev),
-            Self::Text(ts) => ts.ansi_string(prev),
+            Self::Text(text) => text.ansi_string(previous),
+            Self::Fill(fill) => fill.ansi_string(None, previous),
             Self::LineTerm => AnsiString::from(LINE_TERMINATOR_STRING),
         }
     }
 
-    pub fn width_graphemes(&self) -> usize {
+    pub(crate) fn width_graphemes(&self) -> usize {
         match self {
             Self::Fill(fs) => fs.value.width_graphemes(),
             Self::Text(ts) => ts.value.width_graphemes(),

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -16,6 +16,10 @@ pub struct TextSegment {
 }
 
 impl TextSegment {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.value.is_empty()
+    }
+
     /// The segment's style before any `prev_fg`/`prev_bg` reference in it has
     /// been resolved.
     pub(crate) fn symbolic_style(&self) -> Option<Style> {

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -56,15 +56,22 @@ impl FillSegment {
     /// value is used as it stands.
     pub(crate) fn expand(&self, width: Option<usize>) -> String {
         match width {
-            Some(width) => self
-                .value
-                .graphemes(true)
-                .cycle()
+            Some(width) => {
+                if !self
+                    .value
+                    .graphemes(true)
+                    .any(|grapheme| Grapheme(grapheme).width() > 0)
+                {
+                    return String::new();
+                }
+
+                self.value.graphemes(true).cycle()
                 .scan(0usize, |used, grapheme| {
                     *used += Grapheme(grapheme).width();
                     if *used <= width { Some(grapheme) } else { None }
                 })
-                .collect(),
+                .collect()
+            }
             None => String::from(&self.value),
         }
     }

--- a/src/segment.rs
+++ b/src/segment.rs
@@ -65,12 +65,14 @@ impl FillSegment {
                     return String::new();
                 }
 
-                self.value.graphemes(true).cycle()
-                .scan(0usize, |used, grapheme| {
-                    *used += Grapheme(grapheme).width();
-                    if *used <= width { Some(grapheme) } else { None }
-                })
-                .collect()
+                self.value
+                    .graphemes(true)
+                    .cycle()
+                    .scan(0usize, |used, grapheme| {
+                        *used += Grapheme(grapheme).width();
+                        if *used <= width { Some(grapheme) } else { None }
+                    })
+                    .collect()
             }
             None => String::from(&self.value),
         }

--- a/src/stream/bus.rs
+++ b/src/stream/bus.rs
@@ -1,0 +1,233 @@
+//! The pure batching policy for prompt refinements.
+
+use std::time::{Duration, Instant};
+
+use crate::module::painted::{Painted, Run, RunKind, TerminalWidth};
+use crate::print::UnicodeWidthGraphemes;
+
+use super::schedule::ArrivalSchedule;
+
+/// The maximum delay a batch may add to a refinement.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct BusWindow(Duration);
+
+impl BusWindow {
+    #[must_use]
+    pub const fn from_milliseconds(milliseconds: u64) -> Self {
+        Self(Duration::from_millis(milliseconds))
+    }
+
+    #[must_use]
+    pub const fn duration(self) -> Duration {
+        self.0
+    }
+}
+
+/// Whether a refinement moves cells that follow it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Reflow {
+    None,
+    Shifts,
+}
+
+impl Reflow {
+    pub fn between(previous: &Painted, next: &Painted) -> Self {
+        if previous.line_count() != next.line_count()
+            || previous
+                .lines()
+                .zip(next.lines())
+                .any(|(previous, next)| line_width(previous) != line_width(next))
+        {
+            Self::Shifts
+        } else {
+            Self::None
+        }
+    }
+}
+
+fn line_width(line: &[Run]) -> TerminalWidth {
+    TerminalWidth(
+        line.iter()
+            .filter(|run| run.kind() != RunKind::LineTerminator)
+            .map(|run| run.text().width_graphemes())
+            .sum(),
+    )
+}
+
+/// What the caller should do with an arriving refinement.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Verdict {
+    DrawNow,
+    Hold,
+}
+
+#[derive(Clone, Debug)]
+enum Policy {
+    Reactive,
+    Predicted {
+        schedule: ArrivalSchedule,
+        started: Instant,
+    },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Holding {
+    Nothing,
+    Until(Instant),
+}
+
+/// A state machine that batches arriving refinements without knowing their text.
+#[derive(Clone, Debug)]
+pub struct Bus {
+    window: BusWindow,
+    policy: Policy,
+    holding: Holding,
+}
+
+impl Bus {
+    #[must_use]
+    pub fn fixed(window: BusWindow) -> Self {
+        Self {
+            window,
+            policy: Policy::Reactive,
+            holding: Holding::Nothing,
+        }
+    }
+
+    #[must_use]
+    pub fn scheduled(window: BusWindow, schedule: ArrivalSchedule, started: Instant) -> Self {
+        Self {
+            window,
+            policy: Policy::Predicted { schedule, started },
+            holding: Holding::Nothing,
+        }
+    }
+
+    /// Admits one refinement. An open batch accepts everything until `release`.
+    pub fn admit(&mut self, reflow: Reflow, now: Instant) -> Verdict {
+        if self.holding != Holding::Nothing {
+            return Verdict::Hold;
+        }
+
+        let Some(deadline) = self.deadline_for(reflow, now) else {
+            return Verdict::DrawNow;
+        };
+        self.holding = Holding::Until(deadline);
+        Verdict::Hold
+    }
+
+    fn deadline_for(&self, reflow: Reflow, now: Instant) -> Option<Instant> {
+        let window_deadline = || now.checked_add(self.window.duration()).unwrap_or(now);
+        match &self.policy {
+            Policy::Reactive => (reflow == Reflow::Shifts && !self.window.duration().is_zero())
+                .then(window_deadline),
+            Policy::Predicted { schedule, started } => {
+                let elapsed = now.saturating_duration_since(*started);
+                let batch = schedule.expected_batch_at(elapsed)?;
+                batch.has_later_arrival.then(|| {
+                    now.checked_add(
+                        batch
+                            .closes
+                            .saturating_sub(elapsed)
+                            .min(self.window.duration()),
+                    )
+                    .unwrap_or(now)
+                })
+            }
+        }
+    }
+
+    /// The time an open batch must be emitted, if any.
+    pub fn deadline(&self) -> Option<Instant> {
+        match self.holding {
+            Holding::Nothing => None,
+            Holding::Until(deadline) => Some(deadline),
+        }
+    }
+
+    /// Releases the held batch exactly once.
+    pub fn release(&mut self) -> bool {
+        let held = std::mem::replace(&mut self.holding, Holding::Nothing);
+        held != Holding::Nothing
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::schedule::PredictedArrival;
+    use super::*;
+    use crate::segment::Segment;
+
+    const WINDOW: BusWindow = BusWindow::from_milliseconds(100);
+
+    fn painted(text: &str) -> Painted {
+        Painted::paint(&Segment::from_text(None, text), Some(TerminalWidth(40)))
+    }
+
+    #[test]
+    fn fills_make_a_width_change_screen_stable() {
+        let before = Painted::paint(
+            &[
+                Segment::from_text(None, "a").remove(0),
+                Segment::fill(None, "."),
+            ],
+            Some(TerminalWidth(20)),
+        );
+        let after = Painted::paint(
+            &[
+                Segment::from_text(None, "long").remove(0),
+                Segment::fill(None, "."),
+            ],
+            Some(TerminalWidth(20)),
+        );
+        assert_eq!(Reflow::None, Reflow::between(&before, &after));
+    }
+
+    #[test]
+    fn an_unknown_reflow_opens_one_bounded_batch() {
+        let now = Instant::now();
+        let mut bus = Bus::fixed(WINDOW);
+        assert_eq!(Verdict::Hold, bus.admit(Reflow::Shifts, now));
+        assert_eq!(Some(now + WINDOW.duration()), bus.deadline());
+        assert!(bus.release());
+        assert!(!bus.release());
+    }
+
+    #[test]
+    fn zero_window_draws_immediately() {
+        assert_eq!(
+            Verdict::DrawNow,
+            Bus::fixed(BusWindow::from_milliseconds(0)).admit(Reflow::Shifts, Instant::now())
+        );
+    }
+
+    #[test]
+    fn a_prediction_holds_only_while_another_arrival_is_expected() {
+        let now = Instant::now();
+        let schedule = ArrivalSchedule::of(
+            [
+                PredictedArrival::after(Duration::from_millis(10)),
+                PredictedArrival::after(Duration::from_millis(40)),
+            ],
+            WINDOW,
+        );
+        let mut bus = Bus::scheduled(WINDOW, schedule, now);
+        assert_eq!(
+            Verdict::Hold,
+            bus.admit(Reflow::None, now + Duration::from_millis(10))
+        );
+        assert!(bus.release());
+        assert_eq!(
+            Verdict::DrawNow,
+            bus.admit(Reflow::None, now + Duration::from_millis(40))
+        );
+    }
+
+    #[test]
+    fn changing_a_line_width_is_a_reflow() {
+        assert_eq!(
+            Reflow::Shifts,
+            Reflow::between(&painted("a"), &painted("long"))
+        );
+    }
+}

--- a/src/stream/bus.rs
+++ b/src/stream/bus.rs
@@ -33,33 +33,16 @@ pub enum Reflow {
 impl Reflow {
     pub fn between(previous: &Painted, next: &Painted) -> Self {
         if previous.line_count() != next.line_count()
-            || previous.lines().zip(next.lines()).any(|(previous, next)| {
-                line_width(previous) != line_width(next)
-                    || fill_layout(previous) != fill_layout(next)
-            })
+            || previous
+                .lines()
+                .zip(next.lines())
+                .any(|(previous, next)| line_width(previous) != line_width(next))
         {
             Self::Shifts
         } else {
             Self::None
         }
     }
-}
-
-fn fill_layout(line: &[Run]) -> Vec<(usize, &str)> {
-    let mut column = 0;
-    let mut fills = Vec::new();
-
-    for run in line {
-        if run.kind() == RunKind::LineTerminator {
-            continue;
-        }
-        if run.kind() == RunKind::Fill {
-            fills.push((column, run.text()));
-        }
-        column += run.text().width_graphemes();
-    }
-
-    fills
 }
 
 fn line_width(line: &[Run]) -> TerminalWidth {
@@ -190,7 +173,7 @@ mod tests {
     }
 
     #[test]
-    fn moving_a_fill_is_a_reflow() {
+    fn fills_make_a_width_change_screen_stable() {
         let before = Painted::paint(
             &[
                 Segment::from_text(None, "a").remove(0),
@@ -205,7 +188,7 @@ mod tests {
             ],
             Some(TerminalWidth(20)),
         );
-        assert_eq!(Reflow::Shifts, Reflow::between(&before, &after));
+        assert_eq!(Reflow::None, Reflow::between(&before, &after));
     }
 
     #[test]

--- a/src/stream/bus.rs
+++ b/src/stream/bus.rs
@@ -190,7 +190,7 @@ mod tests {
     }
 
     #[test]
-    fn fills_make_a_width_change_screen_stable() {
+    fn moving_a_fill_is_a_reflow() {
         let before = Painted::paint(
             &[
                 Segment::from_text(None, "a").remove(0),
@@ -205,7 +205,7 @@ mod tests {
             ],
             Some(TerminalWidth(20)),
         );
-        assert_eq!(Reflow::None, Reflow::between(&before, &after));
+        assert_eq!(Reflow::Shifts, Reflow::between(&before, &after));
     }
 
     #[test]

--- a/src/stream/bus.rs
+++ b/src/stream/bus.rs
@@ -36,13 +36,33 @@ impl Reflow {
             || previous
                 .lines()
                 .zip(next.lines())
-                .any(|(previous, next)| line_width(previous) != line_width(next))
+                .any(|(previous, next)| {
+                    line_width(previous) != line_width(next)
+                        || fill_layout(previous) != fill_layout(next)
+                })
         {
             Self::Shifts
         } else {
             Self::None
         }
     }
+}
+
+fn fill_layout(line: &[Run]) -> Vec<(usize, &str)> {
+    let mut column = 0;
+    let mut fills = Vec::new();
+
+    for run in line {
+        if run.kind() == RunKind::LineTerminator {
+            continue;
+        }
+        if run.kind() == RunKind::Fill {
+            fills.push((column, run.text()));
+        }
+        column += run.text().width_graphemes();
+    }
+
+    fills
 }
 
 fn line_width(line: &[Run]) -> TerminalWidth {
@@ -105,8 +125,12 @@ impl Bus {
 
     /// Admits one refinement. An open batch accepts everything until `release`.
     pub fn admit(&mut self, reflow: Reflow, now: Instant) -> Verdict {
-        if self.holding != Holding::Nothing {
-            return Verdict::Hold;
+        if let Holding::Until(deadline) = self.holding {
+            if deadline > now {
+                return Verdict::Hold;
+            }
+            self.holding = Holding::Nothing;
+            return Verdict::DrawNow;
         }
 
         let Some(deadline) = self.deadline_for(reflow, now) else {
@@ -123,7 +147,10 @@ impl Bus {
                 .then(window_deadline),
             Policy::Predicted { schedule, started } => {
                 let elapsed = now.saturating_duration_since(*started);
-                let batch = schedule.expected_batch_at(elapsed)?;
+                let Some(batch) = schedule.expected_batch_at(elapsed) else {
+                    return (reflow == Reflow::Shifts && !self.window.duration().is_zero())
+                        .then(window_deadline);
+                };
                 batch.has_later_arrival.then(|| {
                     now.checked_add(
                         batch
@@ -132,6 +159,7 @@ impl Bus {
                             .min(self.window.duration()),
                     )
                     .unwrap_or(now)
+                    .max(now)
                 })
             }
         }

--- a/src/stream/bus.rs
+++ b/src/stream/bus.rs
@@ -33,13 +33,10 @@ pub enum Reflow {
 impl Reflow {
     pub fn between(previous: &Painted, next: &Painted) -> Self {
         if previous.line_count() != next.line_count()
-            || previous
-                .lines()
-                .zip(next.lines())
-                .any(|(previous, next)| {
-                    line_width(previous) != line_width(next)
-                        || fill_layout(previous) != fill_layout(next)
-                })
+            || previous.lines().zip(next.lines()).any(|(previous, next)| {
+                line_width(previous) != line_width(next)
+                    || fill_layout(previous) != fill_layout(next)
+            })
         {
             Self::Shifts
         } else {

--- a/src/stream/bus.rs
+++ b/src/stream/bus.rs
@@ -33,10 +33,9 @@ pub enum Reflow {
 impl Reflow {
     pub fn between(previous: &Painted, next: &Painted) -> Self {
         if previous.line_count() != next.line_count()
-            || previous
-                .lines()
-                .zip(next.lines())
-                .any(|(previous, next)| line_width(previous) != line_width(next))
+            || previous.lines().zip(next.lines()).any(|(previous, next)| {
+                line_width(previous) != line_width(next) || unchanged_literals_shift(previous, next)
+            })
         {
             Self::Shifts
         } else {
@@ -52,6 +51,81 @@ fn line_width(line: &[Run]) -> TerminalWidth {
             .map(|run| run.text().width_graphemes())
             .sum(),
     )
+}
+
+/// Whether literal content surviving the update has changed columns.
+///
+/// A fill may move when a preceding module changes without causing a visible
+/// jump: it simply absorbs the change in width. New literal output is not a
+/// moved cell either. The longest common subsequence identifies literal runs
+/// that survived the update; only a changed column of one of those runs is a
+/// reflow.
+fn unchanged_literals_shift(previous: &[Run], next: &[Run]) -> bool {
+    let previous = literal_runs(previous);
+    let next = literal_runs(next);
+    let columns = longest_common_subsequence_lengths(&previous, &next);
+    let width = next.len() + 1;
+    let mut previous_index = 0;
+    let mut next_index = 0;
+
+    while previous_index < previous.len() && next_index < next.len() {
+        if previous[previous_index].0 == next[next_index].0
+            && columns[previous_index * width + next_index]
+                == 1 + columns[(previous_index + 1) * width + next_index + 1]
+        {
+            if previous[previous_index].1 != next[next_index].1 {
+                return true;
+            }
+            previous_index += 1;
+            next_index += 1;
+        } else if columns[(previous_index + 1) * width + next_index]
+            >= columns[previous_index * width + next_index + 1]
+        {
+            previous_index += 1;
+        } else {
+            next_index += 1;
+        }
+    }
+
+    false
+}
+
+fn literal_runs(line: &[Run]) -> Vec<(&str, TerminalWidth)> {
+    let mut column = TerminalWidth(0);
+    let mut literals = Vec::new();
+
+    for run in line {
+        if run.kind() == RunKind::Text {
+            literals.push((run.text(), column));
+        }
+        if run.kind() != RunKind::LineTerminator {
+            column.0 += run.text().width_graphemes();
+        }
+    }
+
+    literals
+}
+
+fn longest_common_subsequence_lengths(
+    previous: &[(&str, TerminalWidth)],
+    next: &[(&str, TerminalWidth)],
+) -> Vec<usize> {
+    let width = next.len() + 1;
+    let mut lengths = vec![0; (previous.len() + 1) * width];
+
+    for previous_index in (0..previous.len()).rev() {
+        for next_index in (0..next.len()).rev() {
+            lengths[previous_index * width + next_index] =
+                if previous[previous_index].0 == next[next_index].0 {
+                    1 + lengths[(previous_index + 1) * width + next_index + 1]
+                } else {
+                    lengths[(previous_index + 1) * width + next_index]
+                        .max(lengths[previous_index * width + next_index + 1])
+                };
+        }
+    }
+
+    lengths
 }
 
 /// What the caller should do with an arriving refinement.
@@ -164,6 +238,7 @@ impl Bus {
 mod tests {
     use super::super::schedule::PredictedArrival;
     use super::*;
+    use crate::module::painted::LineIndex;
     use crate::segment::Segment;
 
     const WINDOW: BusWindow = BusWindow::from_milliseconds(100);
@@ -189,6 +264,34 @@ mod tests {
             Some(TerminalWidth(20)),
         );
         assert_eq!(Reflow::None, Reflow::between(&before, &after));
+    }
+
+    #[test]
+    fn a_fill_cannot_hide_a_shifted_literal_run() {
+        let before = Painted::paint(
+            &[
+                Segment::from_text(None, "a").remove(0),
+                Segment::from_text(None, " middle").remove(0),
+                Segment::fill(None, "."),
+                Segment::from_text(None, "right").remove(0),
+            ],
+            Some(TerminalWidth(20)),
+        );
+        let after = Painted::paint(
+            &[
+                Segment::from_text(None, "long").remove(0),
+                Segment::from_text(None, " middle").remove(0),
+                Segment::fill(None, "."),
+                Segment::from_text(None, "right").remove(0),
+            ],
+            Some(TerminalWidth(20)),
+        );
+
+        assert_eq!(
+            line_width(before.line(LineIndex(0)).unwrap()),
+            line_width(after.line(LineIndex(0)).unwrap())
+        );
+        assert_eq!(Reflow::Shifts, Reflow::between(&before, &after));
     }
 
     #[test]

--- a/src/stream/latency.rs
+++ b/src/stream/latency.rs
@@ -8,7 +8,10 @@ use std::convert::Infallible;
 use std::num::NonZeroU64;
 use std::time::Duration;
 
-use crate::frame::{Microseconds, Timings};
+use crate::frame::Timings;
+
+const DEFAULT_SMOOTHING_PARTS: u64 = 4;
+const ESTIMATE_WEIGHT_OFFSET: u64 = 1;
 
 /// Integer weight (one part in `parts`) so blending never needs float rounding.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -20,64 +23,45 @@ impl SmoothingWeight {
         Self(parts)
     }
 
-    /// `estimate` moved one step towards `measured`.
-    fn blend(self, estimate: Microseconds, measured: Microseconds) -> Microseconds {
-        let parts = u128::from(self.0.get());
-        // In `u128` because a `u64` of microseconds is over half a million
-        // years and multiplying two of them is not: the arithmetic below cannot
-        // overflow, so it needs no saturating behaviour to reason about.
-        let blended = (u128::from(measured.0) + u128::from(estimate.0) * (parts - 1)) / parts;
-        Microseconds(u64::try_from(blended).unwrap_or(u64::MAX))
+    #[must_use]
+    fn blend(self, estimate: u64, measured: u64) -> u64 {
+        let total_parts = u128::from(self.0.get());
+        let previous_estimate_weight = total_parts - u128::from(ESTIMATE_WEIGHT_OFFSET);
+
+        // u128 avoids overflow without saturating.
+        let blended_microseconds =
+            (u128::from(measured) + u128::from(estimate) * previous_estimate_weight) / total_parts;
+        u64::try_from(blended_microseconds).unwrap_or(u64::MAX)
     }
 }
 
-/// The weight the newest measurement carries.
-///
-/// A quarter. Three prompts of a genuinely slower machine move the estimate
-/// most of the way there, which is fast enough to follow a change of working
-/// directory into a large repository, while one anomalous prompt moves it by a
-/// quarter and is undone by the next ordinary one.
-const NEWEST_MEASUREMENT_WEIGHT: SmoothingWeight =
-    SmoothingWeight::one_part_in(NonZeroU64::new(4).expect("four is not zero"));
+const NEWEST_MEASUREMENT_WEIGHT: SmoothingWeight = SmoothingWeight::one_part_in(
+    NonZeroU64::new(DEFAULT_SMOOTHING_PARTS).expect("smoothing parts must be non-zero"),
+);
 
 /// The session's running estimate of what each module costs.
-///
-/// Empty on the first prompt of a session, and empty for a shell whose
-/// transport does not carry the estimates back. Both are ordinary: see
-/// [`Self::is_empty`], whose callers fall back to a fixed bus window.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct LatencyEstimates(Timings);
 
 impl LatencyEstimates {
     /// No estimates at all: the first prompt of a session.
     #[must_use]
-    pub fn none() -> Self {
-        Self::default()
+    pub const fn none() -> Self {
+        Self(Timings::empty())
     }
 
-    /// The estimates a `--timings` argument carries.
-    ///
-    /// Never fails. The argument is a value this process wrote itself and a
-    /// shell handed back, so anything malformed in it is a bug in the transport
-    /// — but the estimates are advisory, and refusing to draw a prompt because
-    /// an advisory input was truncated would turn a slightly worse repaint
-    /// schedule into no prompt at all.
-    ///
-    /// # Errors
-    ///
-    /// None ever; the signature exists so that this can be a `clap` value
-    /// parser.
+    /// Parses the argument provided via the `--timings` command line flag.
     pub fn parse_argument(argument: &str) -> Result<Self, Infallible> {
         if argument.trim().is_empty() {
             return Ok(Self::none());
         }
-        match Timings::from_json(argument.as_bytes()) {
-            Some(timings) => Ok(Self(timings)),
-            None => {
-                log::warn!("Ignoring a --timings argument that is not a timing payload");
-                Ok(Self::none())
-            }
-        }
+
+        let parsed_timings = Timings::from_json(argument.as_bytes()).unwrap_or_else(|| {
+            log::warn!("Ignoring a --timings argument that is not a timing payload");
+            Timings::default()
+        });
+
+        Ok(Self(parsed_timings))
     }
 
     #[must_use]
@@ -85,37 +69,33 @@ impl LatencyEstimates {
         self.0.is_empty()
     }
 
-    /// How long `module` is expected to take, if it has ever been measured.
+    /// How long a specific module is expected to take, if recorded.
     #[must_use]
-    pub fn of(&self, module: &str) -> Option<Duration> {
-        self.0.get(module).map(Microseconds::duration)
+    pub fn of(&self, module_name: &str) -> Option<Duration> {
+        self.0.get(module_name).map(Duration::from_micros)
     }
 
-    /// These estimates brought up to date with what this prompt measured.
-    ///
-    /// A module measured this time moves a quarter of the way towards what it
-    /// cost; a module that was not measured — one this prompt does not show, or
-    /// one whose slot the format string dropped — keeps the estimate it had.
-    /// Keeping it is what makes a prompt in a repository still remember what
-    /// `git_status` costs after a few prompts spent outside one.
+    /// Folds `measured_timings` in; a module missing from it keeps its prior estimate.
     #[must_use]
-    pub fn updated_with(&self, measured: &Timings) -> Self {
-        let mut updated = self.0.clone();
-        for (module, cost) in measured.iter() {
-            let blended = match self.0.get(module) {
-                Some(estimate) => NEWEST_MEASUREMENT_WEIGHT.blend(estimate, cost),
-                // Nothing to smooth against: the first measurement *is* the
-                // estimate.
-                None => cost,
-            };
-            updated.set(module, blended);
+    pub fn updated_with(&self, measured_timings: &Timings) -> Self {
+        let mut updated_timings = self.0.clone();
+
+        for (module_name, measurement_cost) in measured_timings.iter() {
+            let resolved_cost = self
+                .0
+                .get(module_name)
+                .map_or(measurement_cost, |existing| {
+                    NEWEST_MEASUREMENT_WEIGHT.blend(existing, measurement_cost)
+                });
+            updated_timings.set(module_name, resolved_cost);
         }
-        Self(updated)
+
+        Self(updated_timings)
     }
 
-    /// The payload to hand back to the shell.
+    /// The timings to hand back to the shell.
     #[must_use]
-    pub fn timings(&self) -> &Timings {
+    pub const fn timings(&self) -> &Timings {
         &self.0
     }
 }
@@ -147,7 +127,7 @@ mod tests {
     fn measured(measurements: &[(&str, u64)]) -> Timings {
         let mut timings = Timings::default();
         for (module, microseconds) in measurements {
-            timings.set(module, Microseconds(*microseconds));
+            timings.set(module, *microseconds);
         }
         timings
     }
@@ -239,9 +219,6 @@ mod tests {
     fn no_smoothing_at_all_takes_the_newest_measurement() {
         let weight = SmoothingWeight::one_part_in(NonZeroU64::new(1).expect("one is not zero"));
 
-        assert_eq!(
-            Microseconds(400),
-            weight.blend(Microseconds(100), Microseconds(400))
-        );
+        assert_eq!(400, weight.blend(100, 400));
     }
 }

--- a/src/stream/latency.rs
+++ b/src/stream/latency.rs
@@ -1,0 +1,247 @@
+//! What each module has been costing, remembered by the shell between prompts.
+//!
+//! Kept in a shell variable, not a file: these estimates only ever affect when
+//! refinements are batched, never what is drawn, so a stale one costs nothing
+//! but extra repaints and needs no invalidation story.
+
+use std::convert::Infallible;
+use std::num::NonZeroU64;
+use std::time::Duration;
+
+use crate::frame::{Microseconds, Timings};
+
+/// Integer weight (one part in `parts`) so blending never needs float rounding.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SmoothingWeight(NonZeroU64);
+
+impl SmoothingWeight {
+    #[must_use]
+    pub const fn one_part_in(parts: NonZeroU64) -> Self {
+        Self(parts)
+    }
+
+    /// `estimate` moved one step towards `measured`.
+    fn blend(self, estimate: Microseconds, measured: Microseconds) -> Microseconds {
+        let parts = u128::from(self.0.get());
+        // In `u128` because a `u64` of microseconds is over half a million
+        // years and multiplying two of them is not: the arithmetic below cannot
+        // overflow, so it needs no saturating behaviour to reason about.
+        let blended = (u128::from(measured.0) + u128::from(estimate.0) * (parts - 1)) / parts;
+        Microseconds(u64::try_from(blended).unwrap_or(u64::MAX))
+    }
+}
+
+/// The weight the newest measurement carries.
+///
+/// A quarter. Three prompts of a genuinely slower machine move the estimate
+/// most of the way there, which is fast enough to follow a change of working
+/// directory into a large repository, while one anomalous prompt moves it by a
+/// quarter and is undone by the next ordinary one.
+const NEWEST_MEASUREMENT_WEIGHT: SmoothingWeight =
+    SmoothingWeight::one_part_in(NonZeroU64::new(4).expect("four is not zero"));
+
+/// The session's running estimate of what each module costs.
+///
+/// Empty on the first prompt of a session, and empty for a shell whose
+/// transport does not carry the estimates back. Both are ordinary: see
+/// [`Self::is_empty`], whose callers fall back to a fixed bus window.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct LatencyEstimates(Timings);
+
+impl LatencyEstimates {
+    /// No estimates at all: the first prompt of a session.
+    #[must_use]
+    pub fn none() -> Self {
+        Self::default()
+    }
+
+    /// The estimates a `--timings` argument carries.
+    ///
+    /// Never fails. The argument is a value this process wrote itself and a
+    /// shell handed back, so anything malformed in it is a bug in the transport
+    /// — but the estimates are advisory, and refusing to draw a prompt because
+    /// an advisory input was truncated would turn a slightly worse repaint
+    /// schedule into no prompt at all.
+    ///
+    /// # Errors
+    ///
+    /// None ever; the signature exists so that this can be a `clap` value
+    /// parser.
+    pub fn parse_argument(argument: &str) -> Result<Self, Infallible> {
+        if argument.trim().is_empty() {
+            return Ok(Self::none());
+        }
+        match Timings::from_json(argument.as_bytes()) {
+            Some(timings) => Ok(Self(timings)),
+            None => {
+                log::warn!("Ignoring a --timings argument that is not a timing payload");
+                Ok(Self::none())
+            }
+        }
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// How long `module` is expected to take, if it has ever been measured.
+    #[must_use]
+    pub fn of(&self, module: &str) -> Option<Duration> {
+        self.0.get(module).map(Microseconds::duration)
+    }
+
+    /// These estimates brought up to date with what this prompt measured.
+    ///
+    /// A module measured this time moves a quarter of the way towards what it
+    /// cost; a module that was not measured — one this prompt does not show, or
+    /// one whose slot the format string dropped — keeps the estimate it had.
+    /// Keeping it is what makes a prompt in a repository still remember what
+    /// `git_status` costs after a few prompts spent outside one.
+    #[must_use]
+    pub fn updated_with(&self, measured: &Timings) -> Self {
+        let mut updated = self.0.clone();
+        for (module, cost) in measured.iter() {
+            let blended = match self.0.get(module) {
+                Some(estimate) => NEWEST_MEASUREMENT_WEIGHT.blend(estimate, cost),
+                // Nothing to smooth against: the first measurement *is* the
+                // estimate.
+                None => cost,
+            };
+            updated.set(module, blended);
+        }
+        Self(updated)
+    }
+
+    /// The payload to hand back to the shell.
+    #[must_use]
+    pub fn timings(&self) -> &Timings {
+        &self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::frame::ServerEvent;
+
+    /// The `timings` payload bytes of a `ServerEvent::Complete` frame, as handed back as `--timings=<this>`.
+    fn complete_payload(timings: &Timings) -> Vec<u8> {
+        let mut written = Vec::new();
+        ServerEvent::Complete(timings.clone())
+            .write_to(&mut written)
+            .expect("writing to a vector cannot fail");
+        let keyword_length = written
+            .iter()
+            .position(|&byte| byte == 0)
+            .expect("a NUL-terminated keyword field")
+            + 1;
+        let payload_length = written[keyword_length..]
+            .iter()
+            .position(|&byte| byte == 0)
+            .expect("a NUL-terminated timings field");
+        written[keyword_length..keyword_length + payload_length].to_vec()
+    }
+
+    /// Timings holding one measurement per named module.
+    fn measured(measurements: &[(&str, u64)]) -> Timings {
+        let mut timings = Timings::default();
+        for (module, microseconds) in measurements {
+            timings.set(module, Microseconds(*microseconds));
+        }
+        timings
+    }
+
+    #[test]
+    fn a_session_with_nothing_measured_yet_has_no_estimates() {
+        let estimates = LatencyEstimates::none();
+
+        assert!(estimates.is_empty());
+        assert_eq!(None, estimates.of("git_status"));
+    }
+
+    #[test]
+    fn the_first_measurement_of_a_module_becomes_its_estimate() {
+        let estimates = LatencyEstimates::none().updated_with(&measured(&[("git_status", 40_000)]));
+
+        assert_eq!(Some(Duration::from_millis(40)), estimates.of("git_status"));
+    }
+
+    #[test]
+    fn one_slow_prompt_does_not_take_the_estimate_with_it() {
+        let settled = LatencyEstimates::none().updated_with(&measured(&[("git_status", 40_000)]));
+        // Ten times as slow, once.
+        let disturbed = settled.updated_with(&measured(&[("git_status", 400_000)]));
+
+        let estimate = disturbed.of("git_status").expect("the module was measured");
+        assert!(
+            estimate < Duration::from_millis(140),
+            "one outlier moved the estimate to {estimate:?}"
+        );
+        assert!(
+            estimate > Duration::from_millis(40),
+            "the outlier must still move the estimate at all, but it is {estimate:?}"
+        );
+    }
+
+    #[test]
+    fn a_machine_that_really_did_get_slower_is_followed() {
+        let mut estimates =
+            LatencyEstimates::none().updated_with(&measured(&[("git_status", 10_000)]));
+        for _ in 0..8 {
+            estimates = estimates.updated_with(&measured(&[("git_status", 200_000)]));
+        }
+
+        let estimate = estimates.of("git_status").expect("the module was measured");
+        assert!(
+            estimate > Duration::from_millis(150),
+            "eight slow prompts should have moved the estimate, but it is {estimate:?}"
+        );
+    }
+
+    #[test]
+    fn a_module_this_prompt_did_not_run_keeps_its_estimate() {
+        let estimates = LatencyEstimates::none()
+            .updated_with(&measured(&[("git_status", 40_000), ("rust", 8_000)]))
+            .updated_with(&measured(&[("rust", 8_000)]));
+
+        assert_eq!(Some(Duration::from_millis(40)), estimates.of("git_status"));
+    }
+
+    #[test]
+    fn the_estimates_survive_a_round_trip_through_the_shell() {
+        let estimates = LatencyEstimates::none().updated_with(&measured(&[
+            ("git_status", 40_000),
+            ("custom.slow", 900_000),
+        ]));
+
+        // Mirrors the shell: keep the completion payload, hand it back as the next argument.
+        let payload = complete_payload(estimates.timings());
+        let variable = String::from_utf8(payload).expect("the payload is text");
+        let handed_back = LatencyEstimates::parse_argument(&variable).expect("parsing never fails");
+
+        assert_eq!(estimates, handed_back);
+    }
+
+    #[test]
+    fn an_argument_that_is_not_a_payload_leaves_the_prompt_with_no_estimates() {
+        for argument in ["", "   ", "not json", "{", "[1, 2, 3]"] {
+            let estimates =
+                LatencyEstimates::parse_argument(argument).expect("parsing never fails");
+            assert!(
+                estimates.is_empty(),
+                "{argument:?} should have produced no estimates"
+            );
+        }
+    }
+
+    #[test]
+    fn no_smoothing_at_all_takes_the_newest_measurement() {
+        let weight = SmoothingWeight::one_part_in(NonZeroU64::new(1).expect("one is not zero"));
+
+        assert_eq!(
+            Microseconds(400),
+            weight.blend(Microseconds(100), Microseconds(400))
+        );
+    }
+}

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -1,0 +1,1414 @@
+//! Streaming prompt execution.
+
+pub(crate) mod bus;
+pub(crate) mod latency;
+pub(crate) mod schedule;
+
+pub use latency::LatencyEstimates;
+
+use std::fmt;
+use std::io::{self, Write};
+use std::num::NonZeroUsize;
+use std::sync::mpsc;
+use std::time::{Duration, Instant};
+
+use crate::context::{Context, Properties, Target};
+#[cfg(test)]
+use crate::frame::Patch;
+use crate::frame::{
+    FrameEncoding, ProcessId, PromptVariablePayload, RawTerminalPayload, ServerEvent, Timings,
+};
+use crate::module::painted::{Painted, TerminalWidth};
+use crate::plan::{Plan, PromptState};
+use crate::print::prompt_configuration;
+use crate::render::{self, DynamicModule, Resolution, ResolutionKind, Selection, Spawner};
+use crate::segment::Segment;
+use crate::transport::{RefinementTier, StreamingTransport, Tier, TransportMismatch};
+
+use bus::{Bus, BusWindow, Reflow, Verdict};
+use schedule::{ArrivalSchedule, PredictedArrival};
+
+// Detect abandoned pipes while no modules are due.
+const HEARTBEAT: Duration = Duration::from_secs(1);
+
+fn beyond_any_command_line() -> Instant {
+    Instant::now() + Duration::from_secs(60 * 60 * 24)
+}
+
+/// Writes one streamed prompt.
+pub fn stream(
+    properties: Properties,
+    target: Target,
+    estimates: &LatencyEstimates,
+    transport: StreamingTransport,
+    frames: FrameEncoding,
+) -> Result<(), StreamError> {
+    let context = Context::new(properties, target).rendering_for_the_terminal();
+    let standard_output = io::stdout();
+    let mut output = standard_output.lock();
+    let tier = transport.tier(context.shell, &context.target)?;
+    run_at_tier(&context, estimates, tier, frames, &mut output).map_err(StreamError::Io)
+}
+
+#[derive(Debug)]
+pub enum StreamError {
+    Transport(TransportMismatch),
+    Io(io::Error),
+}
+
+impl StreamError {
+    pub fn is_broken_pipe(&self) -> bool {
+        matches!(self, Self::Io(error) if error.kind() == io::ErrorKind::BrokenPipe)
+    }
+}
+
+impl fmt::Display for StreamError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Transport(error) => error.fmt(formatter),
+            Self::Io(error) => error.fmt(formatter),
+        }
+    }
+}
+
+impl std::error::Error for StreamError {}
+
+impl From<TransportMismatch> for StreamError {
+    fn from(error: TransportMismatch) -> Self {
+        Self::Transport(error)
+    }
+}
+
+#[cfg(test)]
+fn run(context: &Context, estimates: &LatencyEstimates, output: &mut impl Write) -> io::Result<()> {
+    let tier = StreamingTransport::Auto
+        .tier(context.shell, &context.target)
+        .expect("the automatic transport accepts every shell");
+    run_at_tier(context, estimates, tier, FrameEncoding::Compact, output)
+}
+
+fn run_at_tier(
+    context: &Context,
+    estimates: &LatencyEstimates,
+    tier: Tier,
+    frames: FrameEncoding,
+    output: &mut impl Write,
+) -> io::Result<()> {
+    if crate::print::is_dumb_terminal() {
+        log::error!("Under a 'dumb' terminal (TERM=dumb).");
+        let notice = Painted::paint(
+            &Segment::from_text(None, crate::print::DUMB_TERMINAL_PROMPT),
+            None,
+        );
+        ready(&notice, context).write(frames, output)?;
+        return ServerEvent::Complete(Timings::default()).write(frames, output);
+    }
+
+    let plan = Plan::build(&prompt_configuration(context));
+    let asynchronous = &context.root_config.asynchronous;
+
+    let refinement = tier.refinement();
+    if !asynchronous.enabled || refinement.is_none() {
+        let mut timings = Timings::default();
+        let mut state = PromptState::empty(&plan);
+        render::stream(&plan, context, Selection::EveryModule, |resolution| {
+            record(&mut timings, &resolution);
+            resolution.store_in(&mut state);
+        });
+
+        let finished = paint(&state, context);
+        ready(&finished, context).write(frames, output)?;
+        return ServerEvent::Complete(estimates.updated_with(&timings).timings().clone())
+            .write(frames, output);
+    }
+
+    let mut timings = Timings::default();
+    let mut state = PromptState::empty(&plan);
+    render::stream_instant(&plan, context, |resolution| {
+        record(&mut timings, &resolution);
+        resolution.store_in(&mut state);
+    });
+
+    let drawn = paint(&state, context);
+    ready(&drawn, context).write(frames, output)?;
+
+    let window = BusWindow::from_milliseconds(asynchronous.bus);
+    let mut session = Session {
+        context,
+        refinement: refinement.expect("a static tier returns before opening a session"),
+        terminal_width: TerminalWidth(context.width),
+        state,
+        drawn,
+        bus: opened_bus(&plan, estimates, asynchronous.adaptive, window),
+        timings,
+        estimates,
+        completion: Completion::new(render::modules(&plan, Selection::DeferredOnly).count()),
+        polls: scheduled_polls(&plan, context, asynchronous),
+        frames,
+        last_written: Instant::now(),
+    };
+
+    let (arrivals, resolutions) = mpsc::channel::<Resolution>();
+    render::while_running(
+        &plan,
+        context,
+        Selection::DeferredOnly,
+        &arrivals,
+        |spawner| session.serve(&resolutions, spawner, output),
+    )
+}
+
+fn opened_bus(plan: &Plan, estimates: &LatencyEstimates, adaptive: bool, window: BusWindow) -> Bus {
+    if !adaptive {
+        return Bus::fixed(window);
+    }
+    match expected_arrivals(plan, estimates, window) {
+        schedule if schedule.is_empty() => Bus::fixed(window),
+        schedule => Bus::scheduled(window, schedule, Instant::now()),
+    }
+}
+
+struct Session<'plan, 'context> {
+    context: &'plan Context<'context>,
+    refinement: RefinementTier,
+    terminal_width: TerminalWidth,
+    state: PromptState<'plan>,
+    drawn: Painted,
+    bus: Bus,
+    timings: Timings,
+    estimates: &'plan LatencyEstimates,
+    completion: Completion,
+    polls: Vec<Option<ScheduledPoll<'plan>>>,
+    frames: FrameEncoding,
+    last_written: Instant,
+}
+
+enum Completion {
+    AwaitingInitial(NonZeroUsize),
+    Ready,
+    Reported,
+}
+
+impl Completion {
+    fn new(initial_resolutions: usize) -> Self {
+        NonZeroUsize::new(initial_resolutions).map_or(Self::Ready, Self::AwaitingInitial)
+    }
+
+    fn initial_resolved(&mut self) {
+        match self {
+            Self::AwaitingInitial(remaining) => {
+                *self = NonZeroUsize::new(remaining.get() - 1)
+                    .map_or(Self::Ready, Self::AwaitingInitial);
+            }
+            Self::Ready | Self::Reported => {
+                unreachable!("every deferred module has exactly one initial resolution")
+            }
+        }
+    }
+
+    fn take_ready(&mut self) -> bool {
+        if !matches!(self, Self::Ready) {
+            return false;
+        }
+        *self = Self::Reported;
+        true
+    }
+
+    fn is_reported(&self) -> bool {
+        matches!(self, Self::Reported)
+    }
+}
+
+/// A dynamic module and its mutually exclusive polling state.
+struct ScheduledPoll<'plan> {
+    module: DynamicModule<'plan>,
+    state: PollState,
+}
+
+enum PollState {
+    AwaitingInitial,
+    Due(Instant),
+    Running,
+}
+
+impl<'plan> ScheduledPoll<'plan> {
+    fn due(&self) -> Option<Instant> {
+        match self.state {
+            PollState::AwaitingInitial | PollState::Running => None,
+            PollState::Due(due) => Some(due),
+        }
+    }
+
+    fn start<'context>(&mut self, now: Instant, spawner: &Spawner<'_, 'plan, 'context>) {
+        if self.due().is_none_or(|due| due > now) {
+            return;
+        }
+        spawner.poll(self.module.clone());
+        self.state = PollState::Running;
+    }
+
+    fn initial_resolved(&mut self) {
+        assert!(matches!(self.state, PollState::AwaitingInitial));
+        self.state = PollState::Due(next_due(self.module.period()));
+    }
+
+    fn refresh_resolved(&mut self) {
+        assert!(matches!(self.state, PollState::Running));
+        self.state = PollState::Due(next_due(self.module.period()));
+    }
+}
+
+impl<'plan, 'context> Session<'plan, 'context> {
+    /// Runs until the shell stops reading, or until there is nothing left that
+    /// could ever change the prompt.
+    fn serve(
+        &mut self,
+        resolutions: &mpsc::Receiver<Resolution<'plan>>,
+        spawner: &Spawner<'_, 'plan, 'context>,
+        output: &mut impl Write,
+    ) -> io::Result<()> {
+        loop {
+            // Everything the session owes is settled before it waits, not
+            // after. A prompt whose modules are all instant has nothing
+            // outstanding the moment it starts, and checking after the wait
+            // made it sit through a whole heartbeat before saying so.
+
+            // The estimates are handed over as soon as every module has
+            // resolved once, rather than as the process exits: a prompt with a
+            // clock in it goes on writing for as long as the command line lives
+            // and would otherwise never hand them over at all.
+            if self.completion.take_ready() {
+                // Nothing is left to group a held refinement with, so holding it
+                // buys nothing — and returning below without drawing it would
+                // announce a finished prompt that is missing whichever module
+                // resolved last. The bus collects *future* arrivals; once there
+                // are none it has to let go.
+                self.release(output)?;
+
+                let measured = self.estimates.updated_with(&self.timings).timings().clone();
+                self.write(ServerEvent::Complete(measured), output)?;
+            }
+
+            // A finished prompt with nothing that goes stale can never change
+            // again, so the process has no further reason to exist.
+            if self.completion.is_reported() && self.polls.iter().all(Option::is_none) {
+                return Ok(());
+            }
+
+            self.start_due_polls(spawner);
+
+            if self.last_written.elapsed() >= HEARTBEAT {
+                self.write(ServerEvent::Heartbeat, output)?;
+            }
+
+            let now = Instant::now();
+            match resolutions.recv_timeout(self.next_wakeup().saturating_duration_since(now)) {
+                Ok(resolution) => {
+                    self.absorb(resolution);
+                    // The bus decides whether this refinement is drawn now or
+                    // held back to be drawn with whatever lands next.
+                    let next = paint(&self.state, self.context);
+                    if self
+                        .bus
+                        .admit(Reflow::between(&self.drawn, &next), Instant::now())
+                        == Verdict::DrawNow
+                    {
+                        self.draw(next, output)?;
+                    }
+                }
+                Err(mpsc::RecvTimeoutError::Timeout) => {
+                    self.release_if_due(Instant::now(), output)?;
+                }
+                // The session holds a sender of its own for the polls it
+                // starts, so the channel cannot disconnect while it is running.
+                Err(mpsc::RecvTimeoutError::Disconnected) => {
+                    unreachable!("the session holds a sender, so its channel cannot disconnect")
+                }
+            }
+        }
+    }
+
+    /// The next moment the loop has to be awake, whatever happens in between.
+    fn next_wakeup(&self) -> Instant {
+        let heartbeat = self.last_written + HEARTBEAT;
+        let bus = self.bus.deadline();
+        let polls = self.polls.iter().flatten().filter_map(ScheduledPoll::due);
+
+        [heartbeat]
+            .into_iter()
+            .chain(bus)
+            .chain(polls)
+            .min()
+            .unwrap_or(heartbeat)
+    }
+
+    /// Takes one module's output into the prompt.
+    fn absorb(&mut self, resolution: Resolution<'plan>) {
+        record(&mut self.timings, &resolution);
+        match resolution.kind() {
+            ResolutionKind::Initial => {
+                self.completion.initial_resolved();
+                if let Some(poll) = self.polls[resolution.slot().index()].as_mut() {
+                    poll.initial_resolved();
+                }
+            }
+            ResolutionKind::Refresh => {
+                self.polls[resolution.slot().index()]
+                    .as_mut()
+                    .expect("only a dynamic module can refresh")
+                    .refresh_resolved();
+            }
+        }
+
+        resolution.store_in(&mut self.state);
+    }
+
+    /// Starts a rendering of every dynamic module that has fallen due.
+    fn start_due_polls(&mut self, spawner: &Spawner<'_, 'plan, 'context>) {
+        let now = Instant::now();
+        for poll in self.polls.iter_mut().flatten() {
+            poll.start(now, spawner);
+        }
+    }
+
+    /// Draws whatever the bus is holding back, if it is holding anything.
+    fn release(&mut self, output: &mut impl Write) -> io::Result<()> {
+        if !self.bus.release() {
+            return Ok(());
+        }
+        let next = paint(&self.state, self.context);
+        self.draw(next, output)?;
+        Ok(())
+    }
+
+    fn release_if_due(&mut self, now: Instant, output: &mut impl Write) -> io::Result<()> {
+        if self.bus.deadline().is_some_and(|deadline| deadline <= now) {
+            self.release(output)?;
+        }
+        Ok(())
+    }
+
+    /// Writes whatever turns the prompt on screen into `next`.
+    fn draw(&mut self, next: Painted, output: &mut impl Write) -> io::Result<()> {
+        let patch = crate::transport::patch(
+            &self.drawn,
+            &next,
+            self.terminal_width,
+            self.refinement,
+            self.context.shell,
+        );
+        self.drawn = next;
+        let Some(patch) = patch else {
+            return Ok(());
+        };
+        self.write(ServerEvent::Patch(patch), output)
+    }
+
+    /// Writes one event and remembers when, so the heartbeat only fires when
+    /// nothing else has.
+    fn write(&mut self, event: ServerEvent, output: &mut impl Write) -> io::Result<()> {
+        event.write(self.frames, output)?;
+        self.last_written = Instant::now();
+        Ok(())
+    }
+}
+
+/// When a module polled now falls due again.
+fn next_due(period: Duration) -> Instant {
+    Instant::now()
+        .checked_add(period)
+        .unwrap_or_else(beyond_any_command_line)
+}
+
+/// Every dynamic module of `plan`, at the period `[async.dynamic]` configures
+/// for it rather than the one it declares for itself, ready to be polled.
+///
+/// The cadence table's own period is what a module is classified with — see
+/// [`crate::modules::cadence`] — and `[async.dynamic]` covers exactly the same
+/// modules by name, so every one of them has a configured period to fall back
+/// on if the two ever disagreed about which modules those are.
+fn scheduled_polls<'plan>(
+    plan: &'plan Plan,
+    context: &Context,
+    asynchronous: &crate::configs::asynchronous::AsynchronousConfig,
+) -> Vec<Option<ScheduledPoll<'plan>>> {
+    let mut polls = (0..plan.module_uses().len())
+        .map(|_| None)
+        .collect::<Vec<_>>();
+    for module in configured_dynamic_modules(plan, context, asynchronous) {
+        let slot = module.slot().index();
+        polls[slot] = Some(ScheduledPoll {
+            module,
+            state: PollState::AwaitingInitial,
+        });
+    }
+    polls
+}
+
+/// The dynamic modules this prompt actually has, at their configured periods.
+fn configured_dynamic_modules<'plan>(
+    plan: &'plan Plan,
+    context: &Context,
+    asynchronous: &crate::configs::asynchronous::AsynchronousConfig,
+) -> Vec<DynamicModule<'plan>> {
+    render::dynamic_modules(plan, context)
+        .into_iter()
+        .map(
+            |module| match asynchronous.dynamic.period_for(module.name().as_str()) {
+                Some(period) => module.every(period),
+                None => module,
+            },
+        )
+        .collect()
+}
+
+/// When each of this prompt's deferred modules is expected to resolve, grouped
+/// into the fewest repaints that adds no more than `window` of latency to any
+/// of them.
+///
+/// Only the modules this prompt actually runs, and only those that have ever
+/// been measured: a module nobody has timed yet is left out of the prediction
+/// rather than guessed at, so it simply falls through to the fixed window.
+fn expected_arrivals(
+    plan: &Plan,
+    estimates: &LatencyEstimates,
+    window: BusWindow,
+) -> ArrivalSchedule {
+    let arrivals = render::modules(plan, Selection::DeferredOnly)
+        .filter_map(|module| estimates.of(module.as_str()))
+        .map(PredictedArrival::after);
+
+    ArrivalSchedule::of(arrivals, window)
+}
+
+/// The opening event of a stream: the prompt as first drawn, and the process
+/// drawing it.
+fn ready(painted: &Painted, context: &Context) -> ServerEvent {
+    ServerEvent::Ready {
+        prompt: PromptVariablePayload::escaped_for(
+            &RawTerminalPayload::prompt(painted),
+            context.shell,
+        ),
+        process_id: ProcessId::of_this_process(),
+    }
+}
+
+/// Records what a resolution cost, under the module's own name.
+fn record(timings: &mut Timings, resolution: &Resolution<'_>) {
+    timings.record(resolution.module().as_str(), resolution.elapsed());
+}
+
+/// The prompt as it would appear on the terminal for what has resolved so far.
+///
+/// The leading blank line that `add_newline` asks for is part of the painted
+/// prompt rather than something written around it, because every repaint is
+/// positioned relative to the row the prompt starts on: a newline the painted
+/// representation does not know about would put every repaint one row out.
+fn paint(state: &PromptState<'_>, context: &Context) -> Painted {
+    let mut segments = Vec::new();
+    if leads_with_a_blank_line(context) {
+        segments.push(Segment::LineTerm);
+    }
+    segments.extend(state.render());
+
+    Painted::paint(&segments, Some(TerminalWidth(context.width)))
+}
+
+/// Whether this prompt is preceded by a blank line.
+///
+/// The right prompt shares a row with the main one and a continuation prompt
+/// continues a line already begun, so neither may introduce a line of its own,
+/// whatever `add_newline` says.
+fn leads_with_a_blank_line(context: &Context) -> bool {
+    context.root_config.add_newline && context.target == Target::Main
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::context::Shell;
+    use crate::test::default_context;
+    use std::collections::BTreeSet;
+    use std::io::Cursor;
+    use std::time::Duration;
+
+    /// zsh: the only shell at [`Tier::CellPrecise`], so a stream built for it produces every event kind.
+    fn refinable(mut context: Context<'static>) -> Context<'static> {
+        context.shell = Shell::Zsh;
+        context
+    }
+
+    /// Every event one streaming prompt writes, for a session with nothing measured yet.
+    fn events_of(context: &Context) -> Vec<ServerEvent> {
+        events_of_a_session(context, &LatencyEstimates::none())
+    }
+
+    /// Every event one streaming prompt writes; only for a session that finishes (this writes into
+    /// an unbounded buffer) — use [`ClosesAfter`] for one that keeps re-polling forever.
+    fn events_of_a_session(context: &Context, estimates: &LatencyEstimates) -> Vec<ServerEvent> {
+        let mut written: Vec<u8> = Vec::new();
+        run(context, estimates, &mut written).expect("writing to a vector cannot fail");
+
+        let mut reader = Cursor::new(written);
+        let mut events = Vec::new();
+        while let Some(event) =
+            ServerEvent::read_from(&mut reader).expect("the engine writes well-formed events")
+        {
+            events.push(event);
+        }
+        events
+    }
+
+    /// Event kind, ignoring payload — the protocol itself has no `kind()`; only tests want this.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum EventKind {
+        Ready,
+        Patch,
+        Complete,
+        Heartbeat,
+    }
+
+    fn kind_of(event: &ServerEvent) -> EventKind {
+        match event {
+            ServerEvent::Ready { .. } => EventKind::Ready,
+            ServerEvent::Patch(_) => EventKind::Patch,
+            ServerEvent::Complete(_) => EventKind::Complete,
+            ServerEvent::Heartbeat => EventKind::Heartbeat,
+        }
+    }
+
+    fn kinds_of(events: &[ServerEvent]) -> Vec<EventKind> {
+        events.iter().map(kind_of).collect()
+    }
+
+    /// The prompt-variable bytes of `event`, as text.
+    fn prompt_text(event: &ServerEvent) -> String {
+        let bytes = match event {
+            ServerEvent::Ready { prompt, .. } => prompt.as_bytes(),
+            ServerEvent::Patch(patch) => patch.prompt().as_bytes(),
+            other => panic!("{other:?} carries no prompt"),
+        };
+        String::from_utf8(bytes.to_vec()).expect("prompt bytes are text")
+    }
+
+    /// A writer that fails every write once `deadline` passes, standing in for a reader that
+    /// has gone away — a deadline rather than a write count so a test need not predict how
+    /// many writes one poll cycle costs.
+    struct ClosesAfter {
+        buffer: Vec<u8>,
+        deadline: Instant,
+    }
+
+    impl Write for ClosesAfter {
+        fn write(&mut self, data: &[u8]) -> io::Result<usize> {
+            if Instant::now() >= self.deadline {
+                return Err(io::Error::from(io::ErrorKind::BrokenPipe));
+            }
+            self.buffer.extend_from_slice(data);
+            Ok(data.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn the_first_event_is_always_ready() {
+        let context = default_context().set_config(toml::toml! {
+            add_newline = false
+            format = "$character"
+            [character]
+            format = ">"
+        });
+        let events = events_of(&context);
+
+        assert_eq!(Some(EventKind::Ready), events.first().map(kind_of));
+        assert_eq!(">", prompt_text(&events[0]));
+    }
+
+    #[test]
+    fn the_last_event_is_always_complete_when_nothing_dynamic_is_running() {
+        let context = default_context().set_config(toml::toml! {
+            add_newline = false
+            format = "$character"
+        });
+        let events = events_of(&context);
+
+        assert_eq!(Some(EventKind::Complete), events.last().map(kind_of));
+        let timings = match events.last().expect("there is an event") {
+            ServerEvent::Complete(timings) => timings,
+            other => panic!("the last event was {other:?}, not a completion"),
+        };
+        assert!(timings.get("character").is_some());
+    }
+
+    /// A shell that can't be refined must get its prompt already complete, or it keeps a
+    /// stale one for the command line's life.
+    #[test]
+    fn a_shell_that_cannot_be_refined_is_sent_one_finished_prompt() {
+        let directory = tempfile::tempdir().expect("a temporary directory");
+        let mut context = default_context().set_config(toml::toml! {
+            add_newline = false
+            format = "${custom.slow}$character"
+            [character]
+            format = ">"
+            [custom.slow]
+            when = true
+            command = "echo refined"
+            format = "[$output](cyan)"
+        });
+        context.current_dir = directory.path().to_path_buf();
+        context.logical_dir = directory.path().to_path_buf();
+        // The default context's shell is `Unknown`, which is `Tier::Static`.
+        assert!(!Tier::of(context.shell).can_refine());
+
+        let events = events_of(&context);
+        assert_eq!(
+            vec![EventKind::Ready, EventKind::Complete],
+            kinds_of(&events),
+            "a static shell must be sent nothing after its prompt"
+        );
+        assert!(
+            prompt_text(&events[0]).contains("refined"),
+            "the one prompt a static shell is sent must be the finished one, \
+             but was {:?}",
+            prompt_text(&events[0])
+        );
+        assert!(
+            match &events[1] {
+                ServerEvent::Complete(timings) => timings.get("custom.slow").is_some(),
+                other => panic!("the last event was {other:?}, not a completion"),
+            },
+            "a static stream still reports what each module cost"
+        );
+    }
+
+    #[test]
+    fn a_prompt_of_instant_modules_alone_needs_no_refinement() {
+        let context = default_context().set_config(toml::toml! {
+            add_newline = false
+            format = "$status$character"
+            [character]
+            format = ">"
+        });
+
+        // Nothing deferred, so nothing can change after the paint (deliberately
+        // `Shell::Unknown`, not a refinable shell).
+        assert_eq!(
+            vec![EventKind::Ready, EventKind::Complete],
+            kinds_of(&events_of(&context))
+        );
+    }
+
+    #[test]
+    fn a_deferred_module_that_resolves_to_nothing_changes_nothing() {
+        let directory = tempfile::tempdir().expect("a temporary directory");
+        let mut context = refinable(default_context()).set_config(toml::toml! {
+            add_newline = false
+            format = "$rust$character"
+            [character]
+            format = ">"
+        });
+        context.current_dir = directory.path().to_path_buf();
+
+        // `rust` is deferred and resolves to nothing here, so the paint was already
+        // right — no refinement follows.
+        assert_eq!(
+            vec![EventKind::Ready, EventKind::Complete],
+            kinds_of(&events_of(&context))
+        );
+    }
+
+    #[test]
+    fn the_paint_leaves_deferred_slots_empty() {
+        let directory = tempfile::tempdir().expect("a temporary directory");
+        let mut context = refinable(default_context()).set_config(toml::toml! {
+            add_newline = false
+            format = "[$git_branch](red)$character"
+            [character]
+            format = ">"
+        });
+        context.current_dir = directory.path().to_path_buf();
+
+        let events = events_of(&context);
+        assert_eq!(">", prompt_text(&events[0]));
+    }
+
+    #[test]
+    fn add_newline_puts_the_blank_line_inside_the_painted_prompt() {
+        let context = default_context().set_config(toml::toml! {
+            add_newline = true
+            format = "$character"
+            [character]
+            format = ">"
+        });
+        let events = events_of(&context);
+
+        assert_eq!("\n>", prompt_text(&events[0]));
+    }
+
+    #[test]
+    fn a_right_prompt_never_leads_with_a_blank_line() {
+        let mut context = default_context().set_config(toml::toml! {
+            add_newline = true
+            right_format = "$character"
+            [character]
+            format = ">"
+        });
+        context.target = Target::Right;
+
+        assert_eq!(">", prompt_text(&events_of(&context)[0]));
+    }
+
+    /// A prompt whose deferred `custom` modules genuinely resolve to something controllable,
+    /// so its stream carries real refinements rather than only a paint.
+    fn context_with_deferred_modules(shell_command: &str) -> (Context<'static>, tempfile::TempDir) {
+        // A `custom` module runs in the working directory, so it needs one that exists.
+        let directory = tempfile::tempdir().expect("a temporary directory");
+        let mut context = refinable(default_context()).set_config(toml::toml! {
+            add_newline = false
+            format = "${custom.first} ${custom.second}$line_break$character"
+            [async]
+            bus = GENEROUS_WINDOW
+            [character]
+            format = "[>](green) "
+            [custom.first]
+            when = true
+            command = shell_command
+            format = "[$output](bold cyan)"
+            [custom.second]
+            when = true
+            command = shell_command
+            format = "[$output](yellow)"
+        });
+        context.current_dir = directory.path().to_path_buf();
+        context.logical_dir = directory.path().to_path_buf();
+        (context, directory)
+    }
+
+    /// Replays `events` into a live terminal emulator, kept live so a caller can keep feeding
+    /// it (see `a_patch_that_carries_a_repaint_carries_the_prompt_that_matches_it`). Mirrors the
+    /// shell: `Ready` and a prompt-only `Patch` are expanded and redrawn; a `Patch` with a
+    /// repaint is fed the repaint alone, never also redrawn from its prompt.
+    fn terminal_after(
+        events: &[ServerEvent],
+        width: TerminalWidth,
+        shell: Shell,
+    ) -> crate::damage::terminal::EmulatedTerminal {
+        let mut terminal = crate::damage::terminal::EmulatedTerminal::blank(width);
+        for event in events {
+            match event {
+                ServerEvent::Ready { prompt, .. } => {
+                    terminal.redraw(prompt.as_terminal_bytes_under(shell).as_bytes());
+                }
+                ServerEvent::Patch(patch) => match patch.repaint() {
+                    Some(repaint) => terminal.feed(repaint.as_bytes()),
+                    None => {
+                        terminal.redraw(patch.prompt().as_terminal_bytes_under(shell).as_bytes());
+                    }
+                },
+                ServerEvent::Complete(_) | ServerEvent::Heartbeat => {}
+            }
+        }
+        terminal
+    }
+
+    /// Replays a whole event stream and returns the resulting screen; expanding (rather than
+    /// feeding raw escaped bytes) means this also tests the escaping, not just the repaints.
+    fn replay(
+        events: &[ServerEvent],
+        width: TerminalWidth,
+        shell: Shell,
+    ) -> crate::damage::terminal::Screen {
+        terminal_after(events, width, shell).screen()
+    }
+
+    #[test]
+    fn replaying_the_events_reproduces_a_full_render() {
+        let (context, _directory) = context_with_deferred_modules("echo refined");
+        let width = TerminalWidth(context.width);
+
+        let events = events_of(&context);
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event, ServerEvent::Patch(_))),
+            "the stream refined nothing, so replaying it proves nothing: {events:?}"
+        );
+
+        // What a plain synchronous `starship prompt` would have put on screen.
+        let plan = Plan::build(&prompt_configuration(&context));
+        let expected = paint(&render::fill_slots(&plan, &context), &context);
+
+        assert_eq!(
+            crate::damage::terminal::fully_rendered(&expected, width),
+            replay(&events, width, context.shell),
+            "replaying the event stream must leave the terminal exactly as a \
+             synchronous render would"
+        );
+    }
+
+    #[test]
+    fn replaying_a_multi_line_prompt_reproduces_a_full_render() {
+        // Modules resolve to multi-line text — the case the length prefix exists for, and
+        // where a repaint's row arithmetic can get it wrong.
+        let (context, _directory) = context_with_deferred_modules("printf 'one\\ntwo'");
+        let width = TerminalWidth(context.width);
+
+        let events = events_of(&context);
+        let plan = Plan::build(&prompt_configuration(&context));
+        let expected = paint(&render::fill_slots(&plan, &context), &context);
+
+        assert_eq!(
+            crate::damage::terminal::fully_rendered(&expected, width),
+            replay(&events, width, context.shell)
+        );
+    }
+
+    /// Long enough that two `echo`s can't straddle it, so this tests the bus, not machine load.
+    const GENEROUS_WINDOW: u64 = 5_000;
+
+    /// The patches between the paint and the completion: the refinements.
+    fn refinements(events: &[ServerEvent]) -> Vec<&Patch> {
+        events
+            .iter()
+            .filter_map(|event| match event {
+                ServerEvent::Patch(patch) => Some(patch),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn width_stable_refinements_are_drawn_as_they_land() {
+        // A fill absorbs both modules' growth, so neither changes line width or has reason
+        // to wait, despite the long window.
+        let directory = tempfile::tempdir().expect("a temporary directory");
+        let mut context = refinable(default_context()).set_config(toml::toml! {
+            add_newline = false
+            format = "${custom.first}$fill${custom.second}$line_break$character"
+            [async]
+            bus = GENEROUS_WINDOW
+            [character]
+            format = "[>](green) "
+            [fill]
+            symbol = "."
+            [custom.first]
+            when = true
+            command = "echo one"
+            format = "[$output](cyan)"
+            [custom.second]
+            when = true
+            command = "echo two"
+            format = "[$output](yellow)"
+        });
+        context.current_dir = directory.path().to_path_buf();
+        context.logical_dir = directory.path().to_path_buf();
+
+        let events = events_of(&context);
+        let refinements = refinements(&events);
+        assert_eq!(
+            2,
+            refinements.len(),
+            "a refinement that moves nothing sideways must not wait for the \
+             bus, but got {refinements:?}"
+        );
+        assert!(
+            refinements.iter().all(|patch| patch.repaint().is_some()),
+            "a width-stable refinement must repaint cells rather than redraw \
+             the whole prompt: {refinements:?}"
+        );
+    }
+
+    #[test]
+    fn width_changing_refinements_are_collapsed_into_one_reflow() {
+        // No fill this time, so each module's output shifts everything after it and both
+        // join one window.
+        let (context, _directory) = context_with_deferred_modules("echo refined");
+
+        assert_eq!(
+            1,
+            refinements(&events_of(&context)).len(),
+            "two reflows landing in one window must be drawn once"
+        );
+    }
+
+    /// A patch is atomic (see `crate::frame`); this asserts the substance behind that shape —
+    /// the prompt a patch carries actually describes the screen its repaint draws.
+    #[test]
+    fn a_patch_that_carries_a_repaint_carries_the_prompt_that_matches_it() {
+        let directory = tempfile::tempdir().expect("a temporary directory");
+        let mut context = refinable(default_context()).set_config(toml::toml! {
+            add_newline = false
+            format = "${custom.first}$fill${custom.second}$line_break$character"
+            [async]
+            bus = GENEROUS_WINDOW
+            [character]
+            format = "[>](green) "
+            [fill]
+            symbol = "."
+            [custom.first]
+            when = true
+            command = "echo one"
+            format = "[$output](cyan)"
+            [custom.second]
+            when = true
+            command = "echo two"
+            format = "[$output](yellow)"
+        });
+        context.current_dir = directory.path().to_path_buf();
+        context.logical_dir = directory.path().to_path_buf();
+        let width = TerminalWidth(context.width);
+
+        let events = events_of(&context);
+        let repainting_indices: Vec<usize> = events
+            .iter()
+            .enumerate()
+            .filter_map(|(index, event)| match event {
+                ServerEvent::Patch(patch) if patch.repaint().is_some() => Some(index),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            !repainting_indices.is_empty(),
+            "the fixture must produce at least one repainting patch or it \
+             proves nothing: {events:?}"
+        );
+
+        for index in repainting_indices {
+            let ServerEvent::Patch(patch) = &events[index] else {
+                unreachable!("filtered to patch events with a repaint above");
+            };
+
+            // What was on screen right before this patch, with only its own repaint applied.
+            let mut terminal = terminal_after(&events[..index], width, context.shell);
+            terminal.feed(patch.repaint().expect("filtered above").as_bytes());
+            let screen_from_repaint = terminal.screen();
+
+            // What the patch's own prompt says the whole screen should be.
+            let mut fresh = crate::damage::terminal::EmulatedTerminal::blank(width);
+            fresh.redraw(
+                patch
+                    .prompt()
+                    .as_terminal_bytes_under(context.shell)
+                    .as_bytes(),
+            );
+
+            assert_eq!(
+                fresh.screen(),
+                screen_from_repaint,
+                "the patch at event {index} carries a prompt that disagrees \
+                 with its own repaint"
+            );
+        }
+    }
+
+    /// Three slow modules separated by `$fill`, sleeps spaced to land in one group without
+    /// depending on scheduler noise; the fill keeps every refinement width-stable.
+    fn context_with_three_width_stable_modules() -> (Context<'static>, tempfile::TempDir) {
+        let directory = tempfile::tempdir().expect("a temporary directory");
+        let mut context = refinable(default_context()).set_config(toml::toml! {
+            add_newline = false
+            format = "${custom.first}$fill${custom.second} ${custom.third}$line_break$character"
+            [async]
+            bus = GENEROUS_WINDOW
+            [character]
+            format = "[>](green) "
+            [fill]
+            symbol = "."
+            [custom.first]
+            when = true
+            command = "sleep 0.10 && echo one"
+            format = "[$output](cyan)"
+            [custom.second]
+            when = true
+            command = "sleep 0.12 && echo two"
+            format = "[$output](yellow)"
+            [custom.third]
+            when = true
+            command = "sleep 0.14 && echo three"
+            format = "[$output](red)"
+        });
+        context.current_dir = directory.path().to_path_buf();
+        context.logical_dir = directory.path().to_path_buf();
+        (context, directory)
+    }
+
+    /// What the shell hands to the next prompt: the completion payload's actual round-tripped
+    /// text, not the engine's in-memory value.
+    fn estimates_from(events: &[ServerEvent]) -> LatencyEstimates {
+        let completion = events
+            .iter()
+            .find(|event| matches!(event, ServerEvent::Complete(_)))
+            .expect("every stream reports what its modules cost");
+
+        let mut written: Vec<u8> = Vec::new();
+        completion
+            .write_to(&mut written)
+            .expect("writing to a vector cannot fail");
+        let mut fields = written.split(|&byte| byte == 0);
+        assert_eq!(Some(b"COMPLETE".as_slice()), fields.next());
+        let payload =
+            String::from_utf8_lossy(fields.next().expect("a timing payload")).into_owned();
+
+        LatencyEstimates::parse_argument(&payload).expect("parsing never fails")
+    }
+
+    /// The same prompt drawn twice, the second time knowing what the first measured.
+    #[test]
+    fn measured_latencies_collapse_repaints_a_fixed_window_draws_one_at_a_time() {
+        let (context, _directory) = context_with_three_width_stable_modules();
+
+        // First prompt of the session: nothing measured, so every width-stable refinement
+        // draws immediately.
+        let unaided = events_of(&context);
+        assert_eq!(
+            3,
+            refinements(&unaided).len(),
+            "three width-stable refinements should be three repaints without a \
+             prediction, but were {:?}",
+            refinements(&unaided)
+        );
+
+        // The next prompt of the same session, handed what the first measured.
+        let estimates = estimates_from(&unaided);
+        let informed = events_of_a_session(&context, &estimates);
+
+        assert!(
+            refinements(&informed).len() < refinements(&unaided).len(),
+            "knowing when the modules resolve must group their repaints: \
+             {:?} against {:?}",
+            refinements(&informed),
+            refinements(&unaided)
+        );
+    }
+
+    /// Fewer repaints are only worth having if the screen ends up the same.
+    #[test]
+    fn scheduling_repaints_does_not_change_what_is_finally_on_screen() {
+        let (context, _directory) = context_with_three_width_stable_modules();
+        let width = TerminalWidth(context.width);
+
+        let estimates = estimates_from(&events_of(&context));
+        let informed = events_of_a_session(&context, &estimates);
+
+        let plan = Plan::build(&prompt_configuration(&context));
+        let expected = paint(&render::fill_slots(&plan, &context), &context);
+
+        assert_eq!(
+            crate::damage::terminal::fully_rendered(&expected, width),
+            replay(&informed, width, context.shell),
+            "a scheduled stream must leave the terminal exactly as a \
+             synchronous render would"
+        );
+    }
+
+    #[test]
+    fn a_prompt_whose_modules_have_never_been_measured_draws_to_the_fixed_window() {
+        // Estimates for modules this prompt lacks predict nothing about it, so it behaves
+        // as if it had none.
+        let (context, _directory) = context_with_three_width_stable_modules();
+        let mut unrelated = Timings::default();
+        unrelated.record("git_status", Duration::from_millis(80));
+        let estimates = LatencyEstimates::none().updated_with(&unrelated);
+
+        assert_eq!(
+            3,
+            refinements(&events_of_a_session(&context, &estimates)).len()
+        );
+    }
+
+    #[test]
+    fn the_timing_frame_carries_the_session_estimate_rather_than_one_measurement() {
+        let (context, _directory) = context_with_deferred_modules("echo refined");
+        let measured = estimates_from(&events_of(&context));
+
+        // A second prompt folds its own measurement into what it was handed; what comes
+        // back is neither run alone.
+        let mut inflated = Timings::default();
+        inflated.record("custom.first", Duration::from_secs(10));
+        let handed_in = measured.updated_with(&inflated);
+        let handed_back = estimates_from(&events_of_a_session(&context, &handed_in));
+
+        let estimate = handed_back
+            .of("custom.first")
+            .expect("the module was measured");
+        assert!(
+            estimate < handed_in.of("custom.first").expect("it was handed in"),
+            "a fast prompt must pull the estimate down, but it stayed at {estimate:?}"
+        );
+        assert!(
+            estimate > measured.of("custom.first").expect("it was measured"),
+            "one fast prompt must not erase the history either, but it fell to {estimate:?}"
+        );
+    }
+
+    #[test]
+    fn disabling_async_renders_one_finished_prompt_even_for_a_refinable_shell() {
+        let (context, _directory) = context_with_deferred_modules("echo refined");
+        let mut disabled = context;
+        disabled = disabled.set_config(toml::toml! {
+            add_newline = false
+            format = "${custom.first} ${custom.second}$line_break$character"
+            [async]
+            enabled = false
+            [character]
+            format = "[>](green) "
+            [custom.first]
+            when = true
+            command = "echo refined"
+            format = "[$output](bold cyan)"
+            [custom.second]
+            when = true
+            command = "echo refined"
+            format = "[$output](yellow)"
+        });
+
+        let events = events_of(&disabled);
+        assert_eq!(
+            vec![EventKind::Ready, EventKind::Complete],
+            kinds_of(&events),
+            "a shell that could otherwise be refined must be sent one finished \
+             prompt when [async] is disabled, but was {:?}",
+            kinds_of(&events)
+        );
+        assert!(
+            prompt_text(&events[0]).contains("refined"),
+            "the one prompt sent must already be the finished one, but was {:?}",
+            prompt_text(&events[0])
+        );
+    }
+
+    #[test]
+    fn disabling_adaptive_ignores_measured_latencies_and_keeps_the_fixed_window() {
+        let (context, _directory) = context_with_three_width_stable_modules();
+        let estimates = estimates_from(&events_of(&context));
+
+        let mut not_adaptive = context;
+        not_adaptive.root_config.asynchronous.adaptive = false;
+
+        assert_eq!(
+            3,
+            refinements(&events_of_a_session(&not_adaptive, &estimates)).len(),
+            "with adaptive off, measured latencies must not change how repaints \
+             are grouped"
+        );
+    }
+
+    #[test]
+    fn async_dynamic_configuration_overrides_a_module_own_period() {
+        let context = refinable(default_context()).set_config(toml::toml! {
+            format = "$time"
+            [time]
+            disabled = false
+        });
+        let plan = Plan::build(&prompt_configuration(&context));
+
+        let mut configured = context.root_config.asynchronous.dynamic.clone();
+        configured.time = crate::configs::asynchronous::RefreshPeriod::try_from(250)
+            .expect("250ms is within range");
+        let mut asynchronous = context.root_config.asynchronous.clone();
+        asynchronous.dynamic = configured;
+
+        let modules = configured_dynamic_modules(&plan, &context, &asynchronous);
+        assert_eq!(1, modules.len());
+        assert_eq!(Duration::from_millis(250), modules[0].period());
+    }
+
+    #[test]
+    fn a_dynamic_slot_is_not_due_until_its_initial_arrival() {
+        let context = refinable(default_context()).set_config(toml::toml! {
+            format = "$time"
+            [time]
+            disabled = false
+        });
+        let plan = Plan::build(&prompt_configuration(&context));
+        let mut polls = scheduled_polls(&plan, &context, &context.root_config.asynchronous);
+        let poll = polls.iter_mut().flatten().next().expect("time is dynamic");
+
+        assert_eq!(None, poll.due());
+        poll.initial_resolved();
+        assert!(poll.due().is_some());
+    }
+
+    #[test]
+    fn the_directory_module_is_painted_before_it_has_really_resolved() {
+        // The whole reason `Render::instant` exists: `directory` is deferred, so without
+        // it the first paint shows no path.
+        let home = tempfile::tempdir().expect("a temporary directory");
+        let working = home.path().join("code");
+        std::fs::create_dir_all(&working).expect("a working directory");
+
+        let mut context = refinable(default_context()).set_config(toml::toml! {
+            add_newline = false
+            format = "$directory"
+            [directory]
+            format = "[$path]($style)"
+            truncate_to_repo = true
+        });
+        context.current_dir = working.clone();
+        context.logical_dir = working;
+        context
+            .env
+            .insert("HOME", home.path().display().to_string());
+
+        let events = events_of(&context);
+        assert!(
+            prompt_text(&events[0]).contains("code"),
+            "the first paint should already show a path, but was {:?}",
+            prompt_text(&events[0])
+        );
+    }
+
+    // Guards the process-leak regression: `render::dynamic_modules` must skip switched-off
+    // modules, or the streaming process never exits (see its doc comment in `src/render.rs`).
+
+    /// The untouched default `$all` prompt must reach `Complete` with nothing left running;
+    /// `battery` alone defaults to enabled, so it's pinned off here to keep that unrelated
+    /// default from failing this test.
+    #[test]
+    fn the_default_configuration_leaves_nothing_running() {
+        let context = refinable(default_context()).set_config(toml::toml! {
+            [battery]
+            disabled = true
+        });
+
+        let mut writer = ClosesAfter {
+            buffer: Vec::new(),
+            deadline: Instant::now() + Duration::from_secs(2),
+        };
+        let result = run(&context, &LatencyEstimates::none(), &mut writer);
+
+        assert!(
+            result.is_ok(),
+            "a default prompt must run to completion rather than still be \
+             writing when the deadline arrives, but got {result:?}"
+        );
+
+        let mut reader = Cursor::new(writer.buffer);
+        let mut saw_complete = false;
+        while let Some(event) = ServerEvent::read_from(&mut reader).expect("a well-formed event") {
+            if matches!(event, ServerEvent::Complete(_)) {
+                saw_complete = true;
+            }
+        }
+        assert!(saw_complete, "a default prompt must report completion");
+    }
+
+    /// `time` defaults to `disabled = true`; naming it in `format` alone must not schedule
+    /// re-polling, since a switched-off module can never change the screen.
+    #[test]
+    fn a_statically_disabled_dynamic_module_does_not_keep_the_session_alive() {
+        let context = refinable(default_context()).set_config(toml::toml! {
+            add_newline = false
+            format = "$time"
+        });
+
+        let mut writer = ClosesAfter {
+            buffer: Vec::new(),
+            deadline: Instant::now() + Duration::from_secs(2),
+        };
+        let result = run(&context, &LatencyEstimates::none(), &mut writer);
+
+        assert!(
+            result.is_ok(),
+            "a disabled `time` module must not keep the session alive, but \
+             the stream was still writing when the deadline arrived: {result:?}"
+        );
+    }
+
+    /// An enabled dynamic module is genuinely re-rendered while live, and its on-screen
+    /// value actually changes between polls.
+    #[test]
+    fn an_enabled_dynamic_module_is_repolled_and_its_value_advances_on_screen() {
+        let context = refinable(default_context()).set_config(toml::toml! {
+            add_newline = false
+            format = "$time"
+            [time]
+            disabled = false
+            // Nanosecond precision so polls a few milliseconds apart are certain to disagree,
+            // without waiting out a real clock second.
+            time_format = "%N"
+            [async.dynamic]
+            time = 5
+        });
+
+        let mut writer = ClosesAfter {
+            buffer: Vec::new(),
+            deadline: Instant::now() + Duration::from_millis(200),
+        };
+        let result = run(&context, &LatencyEstimates::none(), &mut writer);
+
+        assert!(
+            matches!(&result, Err(error) if error.kind() == io::ErrorKind::BrokenPipe),
+            "an enabled clock must keep the session alive past the deadline, \
+             but the stream returned {result:?}"
+        );
+
+        let mut reader = Cursor::new(writer.buffer);
+        let mut values = Vec::new();
+        while let Ok(Some(event)) = ServerEvent::read_from(&mut reader) {
+            match event {
+                ServerEvent::Ready { prompt, .. } => {
+                    values.push(String::from_utf8_lossy(prompt.as_bytes()).into_owned());
+                }
+                ServerEvent::Patch(patch) => {
+                    values.push(String::from_utf8_lossy(patch.prompt().as_bytes()).into_owned());
+                }
+                ServerEvent::Complete(_) | ServerEvent::Heartbeat => {}
+            }
+        }
+
+        assert!(
+            values.len() >= 2,
+            "expected at least two prompts in 200 milliseconds of 5-millisecond \
+             polling, got {}",
+            values.len()
+        );
+        let distinct: BTreeSet<&String> = values.iter().collect();
+        assert!(
+            distinct.len() > 1,
+            "the time module's value never changed across repaints: {values:?}"
+        );
+    }
+
+    /// A quiet poll cycle still writes a heartbeat before `HEARTBEAT` is up — the only way
+    /// to notice a closed pipe with nothing else due. Takes just over one second to run;
+    /// there is no faster way to observe it.
+    #[test]
+    fn a_quiet_interval_still_produces_a_heartbeat() {
+        let context = refinable(default_context()).set_config(toml::toml! {
+            add_newline = false
+            format = "$time"
+            [time]
+            disabled = false
+            [async.dynamic]
+            time = 30_000
+        });
+
+        let mut writer = ClosesAfter {
+            buffer: Vec::new(),
+            deadline: Instant::now() + HEARTBEAT + Duration::from_millis(200),
+        };
+        let result = run(&context, &LatencyEstimates::none(), &mut writer);
+
+        assert!(
+            matches!(&result, Err(error) if error.kind() == io::ErrorKind::BrokenPipe),
+            "the session must still be running past one heartbeat for this to \
+             prove anything, but returned {result:?}"
+        );
+
+        let mut reader = Cursor::new(writer.buffer);
+        let mut saw_a_heartbeat = false;
+        while let Ok(Some(event)) = ServerEvent::read_from(&mut reader) {
+            if matches!(event, ServerEvent::Heartbeat) {
+                saw_a_heartbeat = true;
+            }
+        }
+        assert!(
+            saw_a_heartbeat,
+            "waiting past a whole HEARTBEAT produced no heartbeat event at all"
+        );
+    }
+}

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -1006,11 +1006,21 @@ mod tests {
 
     /// Three slow modules separated by `$fill`, sleeps spaced to land in one group without
     /// depending on scheduler noise; the fill keeps every refinement width-stable.
+    ///
+    /// The gaps between sleeps (300ms) are wide relative to process-spawn and
+    /// scheduling jitter under a loaded CI runner — narrower gaps (previously
+    /// 20ms) let that jitter push the "informed" run's predicted arrivals far
+    /// enough off the "unaided" run's actual ones that they landed in
+    /// different repaint groups, intermittently failing a test whose whole
+    /// point is that they group. `command_timeout` is raised well past the
+    /// longest sleep since the default (500ms) would otherwise kill these
+    /// modules before they resolve.
     fn context_with_three_width_stable_modules() -> (Context<'static>, tempfile::TempDir) {
         let directory = tempfile::tempdir().expect("a temporary directory");
         let mut context = refinable(default_context()).set_config(toml::toml! {
             add_newline = false
             format = "${custom.first}$fill${custom.second} ${custom.third}$line_break$character"
+            command_timeout = 10_000
             [async]
             bus = GENEROUS_WINDOW
             [character]
@@ -1019,15 +1029,15 @@ mod tests {
             symbol = "."
             [custom.first]
             when = true
-            command = "sleep 0.10 && echo one"
+            command = "sleep 0.30 && echo one"
             format = "[$output](cyan)"
             [custom.second]
             when = true
-            command = "sleep 0.12 && echo two"
+            command = "sleep 0.60 && echo two"
             format = "[$output](yellow)"
             [custom.third]
             when = true
-            command = "sleep 0.14 && echo three"
+            command = "sleep 0.90 && echo three"
             format = "[$output](red)"
         });
         context.current_dir = directory.path().to_path_buf();

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -8,7 +8,6 @@ pub use latency::LatencyEstimates;
 
 use std::fmt;
 use std::io::{self, Write};
-use std::num::NonZeroUsize;
 use std::sync::mpsc;
 use std::time::{Duration, Instant};
 
@@ -28,198 +27,444 @@ use crate::transport::{RefinementTier, StreamingTransport, Tier, TransportMismat
 use bus::{Bus, BusWindow, Reflow, Verdict};
 use schedule::{ArrivalSchedule, PredictedArrival};
 
-// Detect abandoned pipes while no modules are due.
-const HEARTBEAT: Duration = Duration::from_secs(1);
+const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(1);
+const FAR_FUTURE_DELAY: Duration = Duration::from_secs(24 * 60 * 60);
 
-fn beyond_any_command_line() -> Instant {
-    Instant::now() + Duration::from_secs(60 * 60 * 24)
-}
-
-/// Writes one streamed prompt.
+/// Streams a prompt to the terminal output.
 pub fn stream(
     properties: Properties,
     target: Target,
-    estimates: &LatencyEstimates,
-    transport: StreamingTransport,
-    frames: FrameEncoding,
+    latency_estimates: &LatencyEstimates,
+    streaming_transport: StreamingTransport,
+    frame_encoding: FrameEncoding,
 ) -> Result<(), StreamError> {
     let context = Context::new(properties, target).rendering_for_the_terminal();
     let standard_output = io::stdout();
-    let mut output = standard_output.lock();
-    let tier = transport.tier(context.shell, &context.target)?;
-    run_at_tier(&context, estimates, tier, frames, &mut output).map_err(StreamError::Io)
+    let mut output_writer = standard_output.lock();
+
+    let transport_tier = streaming_transport.tier(context.shell, &context.target)?;
+    run_at_tier(
+        &context,
+        latency_estimates,
+        transport_tier,
+        frame_encoding,
+        &mut output_writer,
+    )
+    .map_err(StreamError::InputOutput)
 }
 
 #[derive(Debug)]
 pub enum StreamError {
-    Transport(TransportMismatch),
-    Io(io::Error),
+    TransportMismatch(TransportMismatch),
+    InputOutput(io::Error),
 }
 
 impl StreamError {
     pub fn is_broken_pipe(&self) -> bool {
-        matches!(self, Self::Io(error) if error.kind() == io::ErrorKind::BrokenPipe)
+        matches!(self, Self::InputOutput(error) if error.kind() == io::ErrorKind::BrokenPipe)
     }
 }
 
 impl fmt::Display for StreamError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Transport(error) => error.fmt(formatter),
-            Self::Io(error) => error.fmt(formatter),
+            Self::TransportMismatch(error) => error.fmt(formatter),
+            Self::InputOutput(error) => error.fmt(formatter),
         }
     }
 }
 
-impl std::error::Error for StreamError {}
+impl std::error::Error for StreamError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::TransportMismatch(error) => Some(error),
+            Self::InputOutput(error) => Some(error),
+        }
+    }
+}
 
 impl From<TransportMismatch> for StreamError {
     fn from(error: TransportMismatch) -> Self {
-        Self::Transport(error)
+        Self::TransportMismatch(error)
     }
 }
 
 #[cfg(test)]
-fn run(context: &Context, estimates: &LatencyEstimates, output: &mut impl Write) -> io::Result<()> {
-    let tier = StreamingTransport::Auto
+fn run(
+    context: &Context,
+    latency_estimates: &LatencyEstimates,
+    output_writer: &mut impl Write,
+) -> io::Result<()> {
+    let transport_tier = StreamingTransport::Auto
         .tier(context.shell, &context.target)
-        .expect("the automatic transport accepts every shell");
-    run_at_tier(context, estimates, tier, FrameEncoding::Compact, output)
+        .expect("The automatic transport accepts every shell environment.");
+    run_at_tier(
+        context,
+        latency_estimates,
+        transport_tier,
+        FrameEncoding::Compact,
+        output_writer,
+    )
 }
 
 fn run_at_tier(
     context: &Context,
-    estimates: &LatencyEstimates,
-    tier: Tier,
-    frames: FrameEncoding,
-    output: &mut impl Write,
+    latency_estimates: &LatencyEstimates,
+    transport_tier: Tier,
+    frame_encoding: FrameEncoding,
+    output_writer: &mut impl Write,
 ) -> io::Result<()> {
     if crate::print::is_dumb_terminal() {
-        log::error!("Under a 'dumb' terminal (TERM=dumb).");
-        let notice = Painted::paint(
-            &Segment::from_text(None, crate::print::DUMB_TERMINAL_PROMPT),
-            None,
+        return handle_dumb_terminal(context, frame_encoding, output_writer);
+    }
+
+    let prompt_config = prompt_configuration(context);
+    let execution_plan = Plan::build(&prompt_config);
+    let asynchronous_config = &context.root_config.asynchronous;
+    let optional_refinement = transport_tier.refinement();
+
+    let mut measured_timings = Timings::default();
+    let mut prompt_state = PromptState::empty(&execution_plan);
+
+    let is_asynchronous = asynchronous_config.enabled && optional_refinement.is_some();
+
+    if !is_asynchronous {
+        render::stream(
+            &execution_plan,
+            context,
+            Selection::EveryModule,
+            |resolution| {
+                measured_timings.record(resolution.module().as_str(), resolution.elapsed());
+                resolution.store_in(&mut prompt_state);
+            },
         );
-        ready(&notice, context).write(frames, output)?;
-        return ServerEvent::Complete(Timings::default()).write(frames, output);
+
+        let final_painted_prompt = paint_prompt(&prompt_state, context);
+        write_server_event(
+            create_ready_event(&final_painted_prompt, context),
+            frame_encoding,
+            output_writer,
+        )?;
+
+        let final_timings = latency_estimates
+            .updated_with(&measured_timings)
+            .timings()
+            .clone();
+        return write_server_event(
+            ServerEvent::Complete(final_timings),
+            frame_encoding,
+            output_writer,
+        );
     }
 
-    let plan = Plan::build(&prompt_configuration(context));
-    let asynchronous = &context.root_config.asynchronous;
-
-    let refinement = tier.refinement();
-    if !asynchronous.enabled || refinement.is_none() {
-        let mut timings = Timings::default();
-        let mut state = PromptState::empty(&plan);
-        render::stream(&plan, context, Selection::EveryModule, |resolution| {
-            record(&mut timings, &resolution);
-            resolution.store_in(&mut state);
-        });
-
-        let finished = paint(&state, context);
-        ready(&finished, context).write(frames, output)?;
-        return ServerEvent::Complete(estimates.updated_with(&timings).timings().clone())
-            .write(frames, output);
-    }
-
-    let mut timings = Timings::default();
-    let mut state = PromptState::empty(&plan);
-    render::stream_instant(&plan, context, |resolution| {
-        record(&mut timings, &resolution);
-        resolution.store_in(&mut state);
+    render::stream_instant(&execution_plan, context, |resolution| {
+        measured_timings.record(resolution.module().as_str(), resolution.elapsed());
+        resolution.store_in(&mut prompt_state);
     });
 
-    let drawn = paint(&state, context);
-    ready(&drawn, context).write(frames, output)?;
+    let initial_painted_prompt = paint_prompt(&prompt_state, context);
+    write_server_event(
+        create_ready_event(&initial_painted_prompt, context),
+        frame_encoding,
+        output_writer,
+    )?;
 
-    let window = BusWindow::from_milliseconds(asynchronous.bus);
-    let mut session = Session {
-        context,
-        refinement: refinement.expect("a static tier returns before opening a session"),
+    let refinement_tier = optional_refinement
+        .expect("A static transport tier returns early; async logic requires a refinement tier.");
+
+    let terminal_canvas = TerminalCanvas {
+        prompt_state,
+        painted_output: initial_painted_prompt,
         terminal_width: TerminalWidth(context.width),
-        state,
-        drawn,
-        bus: opened_bus(&plan, estimates, asynchronous.adaptive, window),
-        timings,
-        estimates,
-        completion: Completion::new(render::modules(&plan, Selection::DeferredOnly).count()),
-        polls: scheduled_polls(&plan, context, asynchronous),
-        frames,
-        last_written: Instant::now(),
+        refinement_tier,
     };
 
-    let (arrivals, resolutions) = mpsc::channel::<Resolution>();
+    let bus_window = BusWindow::from_milliseconds(asynchronous_config.bus);
+    let active_scheduler = Scheduler::new(&execution_plan, context, asynchronous_config);
+    let active_progress =
+        ProgressTracker::new(render::modules(&execution_plan, Selection::DeferredOnly).count());
+    let active_bus = initialize_bus(
+        &execution_plan,
+        latency_estimates,
+        asynchronous_config.adaptive,
+        bus_window,
+    );
+
+    let mut streaming_session = StreamingSession {
+        context,
+        canvas: terminal_canvas,
+        bus: active_bus,
+        measured_timings,
+        latency_estimates,
+        progress: active_progress,
+        scheduler: active_scheduler,
+        frame_encoding,
+        last_written_timestamp: Instant::now(),
+    };
+
+    let (arrival_sender, arrival_receiver) = mpsc::channel::<Resolution>();
     render::while_running(
-        &plan,
+        &execution_plan,
         context,
         Selection::DeferredOnly,
-        &arrivals,
-        |spawner| session.serve(&resolutions, spawner, output),
+        &arrival_sender,
+        |process_spawner| {
+            streaming_session.serve(&arrival_receiver, process_spawner, output_writer)
+        },
     )
 }
 
-fn opened_bus(plan: &Plan, estimates: &LatencyEstimates, adaptive: bool, window: BusWindow) -> Bus {
-    if !adaptive {
-        return Bus::fixed(window);
-    }
-    match expected_arrivals(plan, estimates, window) {
-        schedule if schedule.is_empty() => Bus::fixed(window),
-        schedule => Bus::scheduled(window, schedule, Instant::now()),
-    }
-}
-
-struct Session<'plan, 'context> {
+struct StreamingSession<'plan, 'context> {
     context: &'plan Context<'context>,
-    refinement: RefinementTier,
-    terminal_width: TerminalWidth,
-    state: PromptState<'plan>,
-    drawn: Painted,
+    canvas: TerminalCanvas<'plan>,
     bus: Bus,
-    timings: Timings,
-    estimates: &'plan LatencyEstimates,
-    completion: Completion,
+    measured_timings: Timings,
+    latency_estimates: &'plan LatencyEstimates,
+    progress: ProgressTracker,
+    scheduler: Scheduler<'plan>,
+    frame_encoding: FrameEncoding,
+    last_written_timestamp: Instant,
+}
+
+impl<'plan, 'context> StreamingSession<'plan, 'context> {
+    fn serve(
+        &mut self,
+        resolutions_receiver: &mpsc::Receiver<Resolution<'plan>>,
+        process_spawner: &Spawner<'_, 'plan, 'context>,
+        output_writer: &mut impl Write,
+    ) -> io::Result<()> {
+        loop {
+            if self.progress.check_and_take_ready() {
+                self.flush_held_bus_events(output_writer)?;
+                let final_timings = self
+                    .latency_estimates
+                    .updated_with(&self.measured_timings)
+                    .timings()
+                    .clone();
+                self.write_server_event(ServerEvent::Complete(final_timings), output_writer)?;
+            }
+
+            if self.progress.is_completed() && !self.scheduler.has_active_polls() {
+                return Ok(());
+            }
+
+            self.scheduler
+                .spawn_due_tasks(Instant::now(), process_spawner);
+
+            if self.last_written_timestamp.elapsed() >= HEARTBEAT_INTERVAL {
+                self.write_server_event(ServerEvent::Heartbeat, output_writer)?;
+            }
+
+            let next_wakeup_time = self.calculate_next_wakeup();
+            let timeout_duration = next_wakeup_time.saturating_duration_since(Instant::now());
+
+            match resolutions_receiver.recv_timeout(timeout_duration) {
+                Ok(resolution) => self.process_resolution(resolution, output_writer)?,
+                Err(mpsc::RecvTimeoutError::Timeout) => {
+                    let current_time = Instant::now();
+                    if self
+                        .bus
+                        .deadline()
+                        .is_some_and(|deadline| deadline <= current_time)
+                    {
+                        self.flush_held_bus_events(output_writer)?;
+                    }
+                }
+                Err(mpsc::RecvTimeoutError::Disconnected) => {
+                    unreachable!(
+                        "The streaming session holds a channel sender, so the receiver cannot disconnect."
+                    )
+                }
+            }
+        }
+    }
+
+    fn process_resolution(
+        &mut self,
+        resolution: Resolution<'plan>,
+        output_writer: &mut impl Write,
+    ) -> io::Result<()> {
+        self.measured_timings
+            .record(resolution.module().as_str(), resolution.elapsed());
+        self.scheduler.register_resolution(&resolution);
+        self.progress.register_resolution(&resolution);
+
+        resolution.store_in(&mut self.canvas.prompt_state);
+
+        let next_painted_prompt = paint_prompt(&self.canvas.prompt_state, self.context);
+        let reflow = Reflow::between(&self.canvas.painted_output, &next_painted_prompt);
+
+        if self.bus.admit(reflow, Instant::now()) == Verdict::DrawNow {
+            self.draw_and_transmit(next_painted_prompt, output_writer)?;
+        }
+        Ok(())
+    }
+
+    fn flush_held_bus_events(&mut self, output_writer: &mut impl Write) -> io::Result<()> {
+        if !self.bus.release() {
+            return Ok(());
+        }
+        let next_painted_prompt = paint_prompt(&self.canvas.prompt_state, self.context);
+        self.draw_and_transmit(next_painted_prompt, output_writer)
+    }
+
+    fn draw_and_transmit(
+        &mut self,
+        next_painted_prompt: Painted,
+        output_writer: &mut impl Write,
+    ) -> io::Result<()> {
+        let patch_payload = crate::transport::patch(
+            &self.canvas.painted_output,
+            &next_painted_prompt,
+            self.canvas.terminal_width,
+            self.canvas.refinement_tier,
+            self.context.shell,
+        );
+
+        self.canvas.painted_output = next_painted_prompt;
+
+        if let Some(payload) = patch_payload {
+            self.write_server_event(ServerEvent::Patch(payload), output_writer)?;
+        }
+        Ok(())
+    }
+
+    fn write_server_event(
+        &mut self,
+        event: ServerEvent,
+        output_writer: &mut impl Write,
+    ) -> io::Result<()> {
+        event.write(self.frame_encoding, output_writer)?;
+        self.last_written_timestamp = Instant::now();
+        Ok(())
+    }
+
+    fn calculate_next_wakeup(&self) -> Instant {
+        let heartbeat_deadline = self.last_written_timestamp + HEARTBEAT_INTERVAL;
+        let bus_deadline = self.bus.deadline();
+        let scheduler_deadline = self.scheduler.next_wakeup();
+
+        [Some(heartbeat_deadline), bus_deadline, scheduler_deadline]
+            .into_iter()
+            .flatten()
+            .min()
+            .unwrap_or(heartbeat_deadline)
+    }
+}
+
+struct TerminalCanvas<'plan> {
+    prompt_state: PromptState<'plan>,
+    painted_output: Painted,
+    terminal_width: TerminalWidth,
+    refinement_tier: RefinementTier,
+}
+
+struct ProgressTracker {
+    pending_initial_resolutions: usize,
+    is_reported: bool,
+}
+
+impl ProgressTracker {
+    fn new(total_deferred_modules: usize) -> Self {
+        Self {
+            pending_initial_resolutions: total_deferred_modules,
+            is_reported: false,
+        }
+    }
+
+    fn register_resolution(&mut self, resolution: &Resolution) {
+        if matches!(resolution.kind(), ResolutionKind::Initial) {
+            assert!(
+                self.pending_initial_resolutions > 0,
+                "Every deferred module must have exactly one initial resolution."
+            );
+            self.pending_initial_resolutions -= 1;
+        }
+    }
+
+    fn check_and_take_ready(&mut self) -> bool {
+        if self.pending_initial_resolutions == 0 && !self.is_reported {
+            self.is_reported = true;
+            true
+        } else {
+            false
+        }
+    }
+
+    fn is_completed(&self) -> bool {
+        self.is_reported
+    }
+}
+
+struct Scheduler<'plan> {
     polls: Vec<Option<ScheduledPoll<'plan>>>,
-    frames: FrameEncoding,
-    last_written: Instant,
 }
 
-enum Completion {
-    AwaitingInitial(NonZeroUsize),
-    Ready,
-    Reported,
-}
+impl<'plan> Scheduler<'plan> {
+    fn new(
+        plan: &'plan Plan,
+        context: &Context,
+        asynchronous_config: &crate::configs::asynchronous::AsynchronousConfig,
+    ) -> Self {
+        let mut polls = std::iter::repeat_with(|| None)
+            .take(plan.module_uses().len())
+            .collect::<Vec<_>>();
 
-impl Completion {
-    fn new(initial_resolutions: usize) -> Self {
-        NonZeroUsize::new(initial_resolutions).map_or(Self::Ready, Self::AwaitingInitial)
+        for module in configured_dynamic_modules(plan, context, asynchronous_config) {
+            let slot_index = module.slot().index();
+            polls[slot_index] = Some(ScheduledPoll {
+                module,
+                state: PollState::AwaitingInitial,
+            });
+        }
+        Self { polls }
     }
 
-    fn initial_resolved(&mut self) {
-        match self {
-            Self::AwaitingInitial(remaining) => {
-                *self = NonZeroUsize::new(remaining.get() - 1)
-                    .map_or(Self::Ready, Self::AwaitingInitial);
-            }
-            Self::Ready | Self::Reported => {
-                unreachable!("every deferred module has exactly one initial resolution")
+    fn register_resolution(&mut self, resolution: &Resolution) {
+        let slot_index = resolution.slot().index();
+        let optional_poll = self.polls[slot_index].as_mut();
+
+        let poll = match resolution.kind() {
+            ResolutionKind::Initial => optional_poll,
+            ResolutionKind::Refresh => Some(
+                optional_poll.expect("A refresh resolution was received for a non-dynamic module."),
+            ),
+        };
+        if let Some(poll) = poll {
+            poll.state = PollState::Due(calculate_next_due_time(poll.module.period()));
+        }
+    }
+
+    fn spawn_due_tasks(&mut self, current_time: Instant, process_spawner: &Spawner<'_, 'plan, '_>) {
+        for poll in self.polls.iter_mut().flatten() {
+            if let PollState::Due(due_time) = poll.state
+                && due_time <= current_time
+            {
+                process_spawner.poll(poll.module.clone());
+                poll.state = PollState::Running;
             }
         }
     }
 
-    fn take_ready(&mut self) -> bool {
-        if !matches!(self, Self::Ready) {
-            return false;
-        }
-        *self = Self::Reported;
-        true
+    fn next_wakeup(&self) -> Option<Instant> {
+        self.polls
+            .iter()
+            .flatten()
+            .filter_map(|poll| {
+                if let PollState::Due(due_time) = poll.state {
+                    Some(due_time)
+                } else {
+                    None
+                }
+            })
+            .min()
     }
 
-    fn is_reported(&self) -> bool {
-        matches!(self, Self::Reported)
+    fn has_active_polls(&self) -> bool {
+        self.polls.iter().any(Option::is_some)
     }
 }
 
-/// A dynamic module and its mutually exclusive polling state.
 struct ScheduledPoll<'plan> {
     module: DynamicModule<'plan>,
     state: PollState,
@@ -231,296 +476,119 @@ enum PollState {
     Running,
 }
 
-impl<'plan> ScheduledPoll<'plan> {
-    fn due(&self) -> Option<Instant> {
-        match self.state {
-            PollState::AwaitingInitial | PollState::Running => None,
-            PollState::Due(due) => Some(due),
-        }
-    }
-
-    fn start<'context>(&mut self, now: Instant, spawner: &Spawner<'_, 'plan, 'context>) {
-        if self.due().is_none_or(|due| due > now) {
-            return;
-        }
-        spawner.poll(self.module.clone());
-        self.state = PollState::Running;
-    }
-
-    fn initial_resolved(&mut self) {
-        assert!(matches!(self.state, PollState::AwaitingInitial));
-        self.state = PollState::Due(next_due(self.module.period()));
-    }
-
-    fn refresh_resolved(&mut self) {
-        assert!(matches!(self.state, PollState::Running));
-        self.state = PollState::Due(next_due(self.module.period()));
-    }
-}
-
-impl<'plan, 'context> Session<'plan, 'context> {
-    /// Runs until the shell stops reading, or until there is nothing left that
-    /// could ever change the prompt.
-    fn serve(
-        &mut self,
-        resolutions: &mpsc::Receiver<Resolution<'plan>>,
-        spawner: &Spawner<'_, 'plan, 'context>,
-        output: &mut impl Write,
-    ) -> io::Result<()> {
-        loop {
-            // Everything the session owes is settled before it waits, not
-            // after. A prompt whose modules are all instant has nothing
-            // outstanding the moment it starts, and checking after the wait
-            // made it sit through a whole heartbeat before saying so.
-
-            // The estimates are handed over as soon as every module has
-            // resolved once, rather than as the process exits: a prompt with a
-            // clock in it goes on writing for as long as the command line lives
-            // and would otherwise never hand them over at all.
-            if self.completion.take_ready() {
-                // Nothing is left to group a held refinement with, so holding it
-                // buys nothing — and returning below without drawing it would
-                // announce a finished prompt that is missing whichever module
-                // resolved last. The bus collects *future* arrivals; once there
-                // are none it has to let go.
-                self.release(output)?;
-
-                let measured = self.estimates.updated_with(&self.timings).timings().clone();
-                self.write(ServerEvent::Complete(measured), output)?;
-            }
-
-            // A finished prompt with nothing that goes stale can never change
-            // again, so the process has no further reason to exist.
-            if self.completion.is_reported() && self.polls.iter().all(Option::is_none) {
-                return Ok(());
-            }
-
-            self.start_due_polls(spawner);
-
-            if self.last_written.elapsed() >= HEARTBEAT {
-                self.write(ServerEvent::Heartbeat, output)?;
-            }
-
-            let now = Instant::now();
-            match resolutions.recv_timeout(self.next_wakeup().saturating_duration_since(now)) {
-                Ok(resolution) => {
-                    self.absorb(resolution);
-                    // The bus decides whether this refinement is drawn now or
-                    // held back to be drawn with whatever lands next.
-                    let next = paint(&self.state, self.context);
-                    if self
-                        .bus
-                        .admit(Reflow::between(&self.drawn, &next), Instant::now())
-                        == Verdict::DrawNow
-                    {
-                        self.draw(next, output)?;
-                    }
-                }
-                Err(mpsc::RecvTimeoutError::Timeout) => {
-                    self.release_if_due(Instant::now(), output)?;
-                }
-                // The session holds a sender of its own for the polls it
-                // starts, so the channel cannot disconnect while it is running.
-                Err(mpsc::RecvTimeoutError::Disconnected) => {
-                    unreachable!("the session holds a sender, so its channel cannot disconnect")
-                }
-            }
-        }
-    }
-
-    /// The next moment the loop has to be awake, whatever happens in between.
-    fn next_wakeup(&self) -> Instant {
-        let heartbeat = self.last_written + HEARTBEAT;
-        let bus = self.bus.deadline();
-        let polls = self.polls.iter().flatten().filter_map(ScheduledPoll::due);
-
-        [heartbeat]
-            .into_iter()
-            .chain(bus)
-            .chain(polls)
-            .min()
-            .unwrap_or(heartbeat)
-    }
-
-    /// Takes one module's output into the prompt.
-    fn absorb(&mut self, resolution: Resolution<'plan>) {
-        record(&mut self.timings, &resolution);
-        match resolution.kind() {
-            ResolutionKind::Initial => {
-                self.completion.initial_resolved();
-                if let Some(poll) = self.polls[resolution.slot().index()].as_mut() {
-                    poll.initial_resolved();
-                }
-            }
-            ResolutionKind::Refresh => {
-                self.polls[resolution.slot().index()]
-                    .as_mut()
-                    .expect("only a dynamic module can refresh")
-                    .refresh_resolved();
-            }
-        }
-
-        resolution.store_in(&mut self.state);
-    }
-
-    /// Starts a rendering of every dynamic module that has fallen due.
-    fn start_due_polls(&mut self, spawner: &Spawner<'_, 'plan, 'context>) {
-        let now = Instant::now();
-        for poll in self.polls.iter_mut().flatten() {
-            poll.start(now, spawner);
-        }
-    }
-
-    /// Draws whatever the bus is holding back, if it is holding anything.
-    fn release(&mut self, output: &mut impl Write) -> io::Result<()> {
-        if !self.bus.release() {
-            return Ok(());
-        }
-        let next = paint(&self.state, self.context);
-        self.draw(next, output)?;
-        Ok(())
-    }
-
-    fn release_if_due(&mut self, now: Instant, output: &mut impl Write) -> io::Result<()> {
-        if self.bus.deadline().is_some_and(|deadline| deadline <= now) {
-            self.release(output)?;
-        }
-        Ok(())
-    }
-
-    /// Writes whatever turns the prompt on screen into `next`.
-    fn draw(&mut self, next: Painted, output: &mut impl Write) -> io::Result<()> {
-        let patch = crate::transport::patch(
-            &self.drawn,
-            &next,
-            self.terminal_width,
-            self.refinement,
-            self.context.shell,
-        );
-        self.drawn = next;
-        let Some(patch) = patch else {
-            return Ok(());
-        };
-        self.write(ServerEvent::Patch(patch), output)
-    }
-
-    /// Writes one event and remembers when, so the heartbeat only fires when
-    /// nothing else has.
-    fn write(&mut self, event: ServerEvent, output: &mut impl Write) -> io::Result<()> {
-        event.write(self.frames, output)?;
-        self.last_written = Instant::now();
-        Ok(())
-    }
-}
-
-/// When a module polled now falls due again.
-fn next_due(period: Duration) -> Instant {
-    Instant::now()
-        .checked_add(period)
-        .unwrap_or_else(beyond_any_command_line)
-}
-
-/// Every dynamic module of `plan`, at the period `[async.dynamic]` configures
-/// for it rather than the one it declares for itself, ready to be polled.
-///
-/// The cadence table's own period is what a module is classified with — see
-/// [`crate::modules::cadence`] — and `[async.dynamic]` covers exactly the same
-/// modules by name, so every one of them has a configured period to fall back
-/// on if the two ever disagreed about which modules those are.
-fn scheduled_polls<'plan>(
-    plan: &'plan Plan,
-    context: &Context,
-    asynchronous: &crate::configs::asynchronous::AsynchronousConfig,
-) -> Vec<Option<ScheduledPoll<'plan>>> {
-    let mut polls = (0..plan.module_uses().len())
-        .map(|_| None)
-        .collect::<Vec<_>>();
-    for module in configured_dynamic_modules(plan, context, asynchronous) {
-        let slot = module.slot().index();
-        polls[slot] = Some(ScheduledPoll {
-            module,
-            state: PollState::AwaitingInitial,
-        });
-    }
-    polls
-}
-
-/// The dynamic modules this prompt actually has, at their configured periods.
-fn configured_dynamic_modules<'plan>(
-    plan: &'plan Plan,
-    context: &Context,
-    asynchronous: &crate::configs::asynchronous::AsynchronousConfig,
-) -> Vec<DynamicModule<'plan>> {
-    render::dynamic_modules(plan, context)
-        .into_iter()
-        .map(
-            |module| match asynchronous.dynamic.period_for(module.name().as_str()) {
-                Some(period) => module.every(period),
-                None => module,
-            },
-        )
-        .collect()
-}
-
-/// When each of this prompt's deferred modules is expected to resolve, grouped
-/// into the fewest repaints that adds no more than `window` of latency to any
-/// of them.
-///
-/// Only the modules this prompt actually runs, and only those that have ever
-/// been measured: a module nobody has timed yet is left out of the prediction
-/// rather than guessed at, so it simply falls through to the fixed window.
-fn expected_arrivals(
+fn initialize_bus(
     plan: &Plan,
-    estimates: &LatencyEstimates,
+    latency_estimates: &LatencyEstimates,
+    is_adaptive: bool,
+    window: BusWindow,
+) -> Bus {
+    if !is_adaptive {
+        return Bus::fixed(window);
+    }
+
+    let schedule = calculate_expected_arrivals(plan, latency_estimates, window);
+    if schedule.is_empty() {
+        Bus::fixed(window)
+    } else {
+        Bus::scheduled(window, schedule, Instant::now())
+    }
+}
+
+fn calculate_expected_arrivals(
+    plan: &Plan,
+    latency_estimates: &LatencyEstimates,
     window: BusWindow,
 ) -> ArrivalSchedule {
-    let arrivals = render::modules(plan, Selection::DeferredOnly)
-        .filter_map(|module| estimates.of(module.as_str()))
+    let predicted_arrivals = render::modules(plan, Selection::DeferredOnly)
+        .filter_map(|module| latency_estimates.of(module.as_str()))
         .map(PredictedArrival::after);
 
-    ArrivalSchedule::of(arrivals, window)
+    ArrivalSchedule::of(predicted_arrivals, window)
 }
 
-/// The opening event of a stream: the prompt as first drawn, and the process
-/// drawing it.
-fn ready(painted: &Painted, context: &Context) -> ServerEvent {
+fn handle_dumb_terminal(
+    context: &Context,
+    frame_encoding: FrameEncoding,
+    output_writer: &mut impl Write,
+) -> io::Result<()> {
+    log::error!("Environment configured as a 'dumb' terminal (TERM=dumb).");
+
+    let text_segment = Segment::from_text(None, crate::print::DUMB_TERMINAL_PROMPT);
+    let notice_painted = Painted::paint(&text_segment, None);
+
+    write_server_event(
+        create_ready_event(&notice_painted, context),
+        frame_encoding,
+        output_writer,
+    )?;
+    write_server_event(
+        ServerEvent::Complete(Timings::default()),
+        frame_encoding,
+        output_writer,
+    )
+}
+
+fn paint_prompt(state: &PromptState<'_>, context: &Context) -> Painted {
+    let rendered_state = state.render();
+    let mut segments = Vec::with_capacity(rendered_state.len() + 1);
+
+    if has_leading_blank_line(context) {
+        segments.push(Segment::LineTerm);
+    }
+
+    segments.extend(rendered_state);
+    Painted::paint(&segments, Some(TerminalWidth(context.width)))
+}
+
+fn has_leading_blank_line(context: &Context) -> bool {
+    context.root_config.add_newline && context.target == Target::Main
+}
+
+fn create_ready_event(painted_output: &Painted, context: &Context) -> ServerEvent {
+    let terminal_payload = RawTerminalPayload::prompt(painted_output);
+    let escaped_payload = PromptVariablePayload::escaped_for(&terminal_payload, context.shell);
+
     ServerEvent::Ready {
-        prompt: PromptVariablePayload::escaped_for(
-            &RawTerminalPayload::prompt(painted),
-            context.shell,
-        ),
+        prompt: escaped_payload,
         process_id: ProcessId::of_this_process(),
     }
 }
 
-/// Records what a resolution cost, under the module's own name.
-fn record(timings: &mut Timings, resolution: &Resolution<'_>) {
-    timings.record(resolution.module().as_str(), resolution.elapsed());
+fn write_server_event(
+    event: ServerEvent,
+    frame_encoding: FrameEncoding,
+    output_writer: &mut impl Write,
+) -> io::Result<()> {
+    event.write(frame_encoding, output_writer)
 }
 
-/// The prompt as it would appear on the terminal for what has resolved so far.
-///
-/// The leading blank line that `add_newline` asks for is part of the painted
-/// prompt rather than something written around it, because every repaint is
-/// positioned relative to the row the prompt starts on: a newline the painted
-/// representation does not know about would put every repaint one row out.
-fn paint(state: &PromptState<'_>, context: &Context) -> Painted {
-    let mut segments = Vec::new();
-    if leads_with_a_blank_line(context) {
-        segments.push(Segment::LineTerm);
-    }
-    segments.extend(state.render());
-
-    Painted::paint(&segments, Some(TerminalWidth(context.width)))
+fn calculate_next_due_time(period: Duration) -> Instant {
+    Instant::now()
+        .checked_add(period)
+        .unwrap_or_else(calculate_far_future_fallback)
 }
 
-/// Whether this prompt is preceded by a blank line.
-///
-/// The right prompt shares a row with the main one and a continuation prompt
-/// continues a line already begun, so neither may introduce a line of its own,
-/// whatever `add_newline` says.
-fn leads_with_a_blank_line(context: &Context) -> bool {
-    context.root_config.add_newline && context.target == Target::Main
+fn calculate_far_future_fallback() -> Instant {
+    Instant::now() + FAR_FUTURE_DELAY
+}
+
+fn configured_dynamic_modules<'plan>(
+    plan: &'plan Plan,
+    context: &Context,
+    asynchronous_config: &crate::configs::asynchronous::AsynchronousConfig,
+) -> Vec<DynamicModule<'plan>> {
+    render::dynamic_modules(plan, context)
+        .into_iter()
+        .map(|module| {
+            let override_period = asynchronous_config
+                .dynamic
+                .period_for(module.name().as_str());
+            match override_period {
+                Some(period) => module.every(period),
+                None => module,
+            }
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -839,7 +907,7 @@ mod tests {
 
         // What a plain synchronous `starship prompt` would have put on screen.
         let plan = Plan::build(&prompt_configuration(&context));
-        let expected = paint(&render::fill_slots(&plan, &context), &context);
+        let expected = paint_prompt(&render::fill_slots(&plan, &context), &context);
 
         assert_eq!(
             crate::damage::terminal::fully_rendered(&expected, width),
@@ -858,7 +926,7 @@ mod tests {
 
         let events = events_of(&context);
         let plan = Plan::build(&prompt_configuration(&context));
-        let expected = paint(&render::fill_slots(&plan, &context), &context);
+        let expected = paint_prompt(&render::fill_slots(&plan, &context), &context);
 
         assert_eq!(
             crate::damage::terminal::fully_rendered(&expected, width),
@@ -1104,7 +1172,7 @@ mod tests {
         let informed = events_of_a_session(&context, &estimates);
 
         let plan = Plan::build(&prompt_configuration(&context));
-        let expected = paint(&render::fill_slots(&plan, &context), &context);
+        let expected = paint_prompt(&render::fill_slots(&plan, &context), &context);
 
         assert_eq!(
             crate::damage::terminal::fully_rendered(&expected, width),
@@ -1234,12 +1302,36 @@ mod tests {
             disabled = false
         });
         let plan = Plan::build(&prompt_configuration(&context));
-        let mut polls = scheduled_polls(&plan, &context, &context.root_config.asynchronous);
-        let poll = polls.iter_mut().flatten().next().expect("time is dynamic");
+        let asynchronous = &context.root_config.asynchronous;
+        let mut scheduler = Scheduler::new(&plan, &context, asynchronous);
 
-        assert_eq!(None, poll.due());
-        poll.initial_resolved();
-        assert!(poll.due().is_some());
+        let slot_index = scheduler
+            .polls
+            .iter()
+            .position(Option::is_some)
+            .expect("time is dynamic");
+        assert!(matches!(
+            scheduler.polls[slot_index]
+                .as_ref()
+                .expect("time is dynamic")
+                .state,
+            PollState::AwaitingInitial
+        ));
+
+        let dynamic_module = configured_dynamic_modules(&plan, &context, asynchronous)
+            .into_iter()
+            .next()
+            .expect("time is dynamic");
+        let resolution = dynamic_module.resolve(&context);
+        scheduler.register_resolution(&resolution);
+
+        assert!(matches!(
+            scheduler.polls[slot_index]
+                .as_ref()
+                .expect("time is dynamic")
+                .state,
+            PollState::Due(_)
+        ));
     }
 
     #[test]
@@ -1399,7 +1491,7 @@ mod tests {
 
         let mut writer = ClosesAfter {
             buffer: Vec::new(),
-            deadline: Instant::now() + HEARTBEAT + Duration::from_millis(200),
+            deadline: Instant::now() + HEARTBEAT_INTERVAL + Duration::from_millis(200),
         };
         let result = run(&context, &LatencyEstimates::none(), &mut writer);
 

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -425,6 +425,13 @@ impl<'plan> Scheduler<'plan> {
         let optional_poll = self.polls[slot_index].as_mut();
 
         let poll = match resolution.kind() {
+            ResolutionKind::Initial if resolution.is_empty() => {
+                // A dynamic module that rendered nothing on its first pass is disabled. It
+                // cannot change the prompt until the next invocation, so do not keep this
+                // streaming session alive polling it.
+                self.polls[slot_index] = None;
+                None
+            }
             ResolutionKind::Initial => optional_poll,
             ResolutionKind::Refresh => Some(
                 optional_poll.expect("A refresh resolution was received for a non-dynamic module."),

--- a/src/stream/schedule.rs
+++ b/src/stream/schedule.rs
@@ -1,0 +1,116 @@
+//! Predicted refinement batches.
+
+use std::time::Duration;
+
+use super::bus::BusWindow;
+
+/// A module expected to finish after this much elapsed time.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct PredictedArrival(Duration);
+
+impl PredictedArrival {
+    #[must_use]
+    pub const fn after(elapsed: Duration) -> Self {
+        Self(elapsed)
+    }
+
+    const fn elapsed(self) -> Duration {
+        self.0
+    }
+}
+
+/// The portion of a prediction relevant to the next actual arrival.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct ExpectedBatch {
+    pub(crate) closes: Duration,
+    pub(crate) has_later_arrival: bool,
+}
+
+/// The minimal partition of predicted arrivals into latency-bounded batches.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ArrivalSchedule(Vec<Batch>);
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct Batch {
+    closes: Duration,
+    arrivals: Vec<PredictedArrival>,
+}
+
+impl ArrivalSchedule {
+    #[must_use]
+    pub fn of(arrivals: impl IntoIterator<Item = PredictedArrival>, window: BusWindow) -> Self {
+        let mut arrivals: Vec<_> = arrivals.into_iter().collect();
+        arrivals.sort_unstable();
+
+        let mut batches: Vec<Batch> = Vec::new();
+        for arrival in arrivals {
+            match batches.last_mut() {
+                Some(batch) if arrival.elapsed() <= batch.closes => batch.arrivals.push(arrival),
+                _ => batches.push(Batch {
+                    closes: arrival.elapsed().saturating_add(window.duration()),
+                    arrivals: vec![arrival],
+                }),
+            }
+        }
+        Self(batches)
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub(crate) fn expected_batch_at(&self, elapsed: Duration) -> Option<ExpectedBatch> {
+        let batch = self.0.iter().find(|batch| batch.closes >= elapsed)?;
+        Some(ExpectedBatch {
+            closes: batch.closes,
+            has_later_arrival: batch
+                .arrivals
+                .iter()
+                .any(|arrival| arrival.elapsed() > elapsed),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const WINDOW: BusWindow = BusWindow::from_milliseconds(100);
+
+    fn schedule(milliseconds: &[u64]) -> ArrivalSchedule {
+        ArrivalSchedule::of(
+            milliseconds
+                .iter()
+                .map(|milliseconds| PredictedArrival::after(Duration::from_millis(*milliseconds))),
+            WINDOW,
+        )
+    }
+
+    #[test]
+    fn greedily_groups_every_arrival_within_the_latency_budget() {
+        let schedule = schedule(&[150, 10, 40, 111]);
+        assert_eq!(
+            Some(ExpectedBatch {
+                closes: Duration::from_millis(110),
+                has_later_arrival: true,
+            }),
+            schedule.expected_batch_at(Duration::from_millis(10))
+        );
+        assert_eq!(
+            Some(ExpectedBatch {
+                closes: Duration::from_millis(211),
+                has_later_arrival: false,
+            }),
+            schedule.expected_batch_at(Duration::from_millis(150))
+        );
+    }
+
+    #[test]
+    fn expired_predictions_are_ignored() {
+        assert_eq!(
+            None,
+            schedule(&[10]).expected_batch_at(Duration::from_millis(111))
+        );
+    }
+}

--- a/src/stream/schedule.rs
+++ b/src/stream/schedule.rs
@@ -67,7 +67,9 @@ impl ArrivalSchedule {
             has_later_arrival: batch
                 .arrivals
                 .iter()
-                .any(|arrival| arrival.elapsed() > elapsed),
+                .filter(|arrival| arrival.elapsed() >= elapsed)
+                .nth(1)
+                .is_some(),
         })
     }
 }

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -8,11 +8,10 @@ use log::{Level, LevelFilter};
 use rstest::fixture;
 use std::fmt;
 use std::fs;
-use std::io;
+use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::sync::LazyLock;
-use std::sync::Once;
+use std::sync::{LazyLock, Once};
 use tempfile::TempDir;
 
 mod jj_tester;
@@ -29,45 +28,25 @@ static HG_FIXTURE: LazyLock<PathBuf> = LazyLock::new(|| FIXTURE_DIR.join("hg-rep
 static LOGGER: Once = Once::new();
 
 static TEST_GIT_CONFIG: &[(&str, &str)] = &[
-    // Dummy user
     ("user.email", "starship@example.com"),
     ("user.name", "starship"),
-    // Prevent intermittent test failures and ensure that the result of git commands
-    // are available during I/O-contentious tests, by having git run `fsync`.
-    // This is especially important on Windows.
-    // Newer, more far-reaching git setting for `fsync`, that's not yet widely supported:
-    ("core.fsync", "all"),
-    // Older git setting for `fsync` for compatibility with older git versions:
-    ("core.fsyncObjectFiles", "true"),
-    // Disable signing
+    ("core.fsync", "all"),             // Prevent intermittent I/O test failures
+    ("core.fsyncObjectFiles", "true"), // Fallback for older git versions
     ("commit.gpgsign", "false"),
     ("tag.gpgsign", "false"),
 ];
 
 fn init_logger() {
     let mut logger = StarshipLogger::default();
+    let null_path = PathBuf::from(if cfg!(windows) { "nul" } else { "/dev/null" });
 
-    // Don't log to files during tests
-    let nul = if cfg!(windows) { "nul" } else { "/dev/null" };
-    let nul = PathBuf::from(nul);
-
-    // Maximum log level
     log::set_max_level(LevelFilter::Trace);
     logger.set_log_level(Level::Trace);
-    logger.set_log_file_path(nul);
-
+    logger.set_log_file_path(null_path);
     log::set_boxed_logger(Box::new(logger)).unwrap();
 }
 
-/// A context rendering against starship's defaults and nothing else.
-///
-/// Built through [`Context::new_with_config`], the constructor that demands a
-/// configuration, rather than through the one that loads whatever the ambient
-/// environment points at. That is what makes a test's result independent of the
-/// developer's own `starship.toml`: everything the context derives from
-/// configuration — `root_config` today, whatever is added later — is derived
-/// from the empty configuration supplied here, so there is no field left
-/// carrying a value the test never asked for.
+/// A clean context built purely from starship's defaults, isolated from the ambient environment.
 pub fn default_context() -> Context<'static> {
     Context::new_with_config(
         Properties::default(),
@@ -80,35 +59,28 @@ pub fn default_context() -> Context<'static> {
     )
 }
 
-/// Render a specific starship module by name
 pub struct ModuleRenderer<'a> {
     name: &'a str,
     context: Context<'a>,
 }
 
 impl<'a> ModuleRenderer<'a> {
-    /// Creates a new `ModuleRenderer`
     pub fn new(name: &'a str) -> Self {
-        // Start logger
         LOGGER.call_once(init_logger);
-
-        let context = default_context();
-
-        Self { name, context }
+        Self {
+            name,
+            context: default_context(),
+        }
     }
 
-    /// Creates a new `ModuleRenderer` with `HOME` set to a `TempDir`
-    pub fn new_with_home(name: &'a str) -> io::Result<(Self, tempfile::TempDir)> {
-        let module_renderer = ModuleRenderer::new(name);
+    pub fn new_with_home(name: &'a str) -> io::Result<(Self, TempDir)> {
         let homedir = tempfile::tempdir()?;
         let home = dunce::canonicalize(homedir.path())?;
-        Ok((module_renderer.env("HOME", home.to_str().unwrap()), homedir))
+        let renderer = Self::new(name).env("HOME", home.to_str().unwrap());
+        Ok((renderer, homedir))
     }
 
-    pub fn path<T>(mut self, path: T) -> Self
-    where
-        T: Into<PathBuf>,
-    {
+    pub fn path<T: Into<PathBuf>>(mut self, path: T) -> Self {
         self.context.current_dir = path.into();
         self.context
             .logical_dir
@@ -116,18 +88,10 @@ impl<'a> ModuleRenderer<'a> {
         self
     }
 
-    pub fn root_path(&self) -> &Path {
-        self.context.root_dir.path()
-    }
-
-    pub fn logical_path<T>(mut self, path: T) -> Self
-    where
-        T: Into<PathBuf>,
-    {
+    pub fn logical_path<T: Into<PathBuf>>(mut self, path: T) -> Self {
         self.context.logical_dir = path.into();
         self
     }
-
     /// Init at `JJRepo` with a mocked path, allowing to test JJ modules in several situations:
     /// valid repo, invalid repo, no repo at all.
     pub fn jj_repo<T>(mut self, path: T) -> Self
@@ -143,84 +107,63 @@ impl<'a> ModuleRenderer<'a> {
         self.context = self.context.set_config(config);
         self
     }
-
-    /// Adds the variable to the `env_mocks` of the underlying context
     pub fn env<V: Into<String>>(mut self, key: &'a str, val: V) -> Self {
         self.context.env.insert(key, val.into());
         self
     }
-
-    /// Adds the command to the `command_mocks` of the underlying context
     pub fn cmd(mut self, key: &'a str, val: Option<CommandOutput>) -> Self {
         self.context.cmd.insert(key, val);
         self
     }
-
     pub fn shell(mut self, shell: Shell) -> Self {
         self.context.shell = shell;
         self
     }
-
     pub fn jobs(mut self, jobs: i64) -> Self {
         self.context.properties.jobs = jobs;
         self
     }
-
     pub fn cmd_duration(mut self, duration: u64) -> Self {
         self.context.properties.cmd_duration = Some(duration.to_string());
         self
     }
-
-    pub fn keymap<T>(mut self, keymap: T) -> Self
-    where
-        T: Into<String>,
-    {
+    pub fn keymap<T: Into<String>>(mut self, keymap: T) -> Self {
         self.context.properties.keymap = keymap.into();
         self
     }
-
     pub fn status(mut self, status: i64) -> Self {
         self.context.properties.status_code = Some(status.to_string());
         self
     }
-
     pub fn width(mut self, width: usize) -> Self {
         self.context.width = width;
         self
     }
-
     pub fn claude_code_data(mut self, data: crate::context::ClaudeCodeData) -> Self {
         self.context.claude_code_data = Some(Box::new(data));
+        self
+    }
+    pub fn pipestatus(mut self, status: &[i64]) -> Self {
+        self.context.properties.pipestatus = Some(status.iter().map(ToString::to_string).collect());
         self
     }
 
     #[cfg(feature = "battery")]
     pub fn battery_info_provider(
         mut self,
-        battery_info_provider: &'a (dyn crate::modules::BatteryInfoProvider + Send + Sync),
+        provider: &'a (dyn crate::modules::BatteryInfoProvider + Send + Sync),
     ) -> Self {
-        self.context.battery_info_provider = battery_info_provider;
+        self.context.battery_info_provider = provider;
         self
     }
 
-    pub fn pipestatus(mut self, status: &[i64]) -> Self {
-        self.context.properties.pipestatus = Some(
-            status
-                .iter()
-                .map(std::string::ToString::to_string)
-                .collect(),
-        );
-        self
+    pub fn root_path(&self) -> &Path {
+        self.context.root_dir.path()
     }
 
-    /// Renders the module returning its output
+    /// Renders the module, returning its output (if any).
     pub fn collect(self) -> Option<String> {
-        let ret = crate::print::get_module(self.name, &self.context);
-        // all tests rely on the fact that an empty module produces None as output as the
-        // convention was that there would be no module but None. This is nowadays not anymore
-        // the case (to get durations for all modules). So here we make it so, that an empty
-        // module returns None in the tests...
-        ret.filter(|s| !s.is_empty())
+        crate::print::get_module(self.name, &self.context).filter(|s| !s.is_empty())
     }
 }
 
@@ -230,171 +173,92 @@ impl<'a> From<ModuleRenderer<'a>> for Context<'a> {
     }
 }
 
-/// What a starship module produced when rendered.
-///
-/// This exists so a rendered module can be compared and snapshotted as a value
-/// with an explicit "the module rendered nothing" case, rather than as an
-/// `Option<String>` whose `None` and `Some("")` cases both mean "nothing" in
-/// different places.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum RenderedModule {
-    /// The module declined to render, or rendered nothing at all.
     Empty,
-    /// The module rendered the contained text, ANSI styling escape sequences
-    /// included. The styling is part of what module tests assert on, so it is
-    /// never stripped.
     Styled(String),
 }
 
 impl From<Option<String>> for RenderedModule {
     fn from(collected: Option<String>) -> Self {
-        match collected {
-            None => Self::Empty,
-            Some(text) => Self::Styled(text),
-        }
+        collected.map_or(Self::Empty, Self::Styled)
     }
 }
 
 impl fmt::Display for RenderedModule {
-    /// Renders the module output in a form that is safe and reviewable inside a
-    /// snapshot.
-    ///
-    /// Rendered output is written as a quoted, escaped Rust string literal, for
-    /// two reasons. Control characters — above all the ANSI escape sequences
-    /// that carry the styling contract — become visible `\u{1b}` text instead
-    /// of raw bytes a reviewer cannot see in a diff. And the surrounding quotes
-    /// pin down the exact extent of the output: snapshot files are stored with
-    /// trailing whitespace trimmed, so an unquoted rendering would silently
-    /// discard the trailing space that most module formats end with, and a
-    /// regression that dropped it would go unnoticed.
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+    /// Renders output safely for snapshotting (escaped strings reveal ANSI codes).
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Empty => formatter.write_str("<no output>"),
-            Self::Styled(text) => write!(formatter, "{text:?}"),
+            Self::Empty => f.write_str("<no output>"),
+            Self::Styled(text) => write!(f, "{text:?}"),
         }
     }
 }
 
-/// A throwaway project directory that owns the temporary directory backing it
-/// and renders starship modules against itself.
-///
-/// This replaces the `tempfile::tempdir()?` / `File::create(..)?.sync_all()?` /
-/// `directory.close()` preamble that otherwise forces every module test to
-/// return `io::Result<()>` purely as plumbing. The temporary directory is
-/// removed when the `Project` is dropped, and a set-up failure panics
-/// immediately, naming the path that failed, instead of being threaded through
-/// a `Result` that says nothing about which step broke.
+/// A throwaway project directory that owns its temporary backing path.
 pub struct Project {
     directory: TempDir,
 }
 
 impl Project {
-    /// Creates a project in a fresh temporary directory under the platform's
-    /// temporary-file root.
     pub fn new() -> Self {
         Self {
-            directory: TempDir::new().expect("failed to create a temporary project directory"),
+            directory: TempDir::new().expect("failed to create temporary project directory"),
         }
     }
 
-    /// Creates a project in a fresh temporary directory nested inside
-    /// `parent_directory`, for tests whose expectations depend on where the
-    /// project lives (under the user's home directory, under a known root, ...).
-    pub fn inside(parent_directory: &Path) -> Self {
-        fs::create_dir_all(parent_directory).unwrap_or_else(|error| {
-            panic!(
-                "failed to create parent directory {}: {error}",
-                parent_directory.display()
-            )
-        });
+    pub fn inside(parent: &Path) -> Self {
+        fs::create_dir_all(parent).expect("failed to create parent directory");
         Self {
-            directory: TempDir::new_in(parent_directory).unwrap_or_else(|error| {
-                panic!(
-                    "failed to create a temporary project directory inside {}: {error}",
-                    parent_directory.display()
-                )
-            }),
+            directory: TempDir::new_in(parent)
+                .expect("failed to create temporary project directory"),
         }
     }
 
-    /// Creates a project whose directory is a freshly materialized version
-    /// control checkout, as produced by [`fixture_repo`].
-    ///
-    /// Pair this with `#[rstest]`'s `#[values(..)]` over [`FixtureProvider`] to
-    /// get one independently named, independently reported test per backend.
     pub fn from_repository_fixture(provider: FixtureProvider) -> Self {
         Self {
-            directory: fixture_repo(provider)
-                .unwrap_or_else(|error| panic!("failed to create a {provider:?} fixture: {error}")),
+            directory: fixture_repo(provider).expect("failed to create fixture"),
         }
     }
 
-    /// The absolute path of this project's directory.
     pub fn path(&self) -> &Path {
         self.directory.path()
     }
 
-    /// The final component of this project's directory name.
-    ///
-    /// Temporary directories are randomly named, so tests whose expected output
-    /// embeds the project's own name have to read it back rather than hardcode
-    /// it.
     pub fn directory_name(&self) -> String {
         self.path()
             .file_name()
-            .expect("a temporary project directory always has a final component")
+            .unwrap()
             .to_string_lossy()
             .into_owned()
     }
 
-    /// Creates an empty file at `relative_path`, together with any missing
-    /// parent directories, and flushes it to disk before returning.
-    ///
-    /// The flush matters: several modules detect a project by reading the
-    /// directory, and an unflushed file has been observed to be invisible to
-    /// the freshly spawned processes some modules use.
     pub fn create_file(&self, relative_path: impl AsRef<Path>) -> &Self {
         self.write_file(relative_path, "")
     }
 
-    /// Creates a file at `relative_path` holding `contents`, together with any
-    /// missing parent directories, and flushes it to disk before returning.
     pub fn write_file(&self, relative_path: impl AsRef<Path>, contents: &str) -> &Self {
-        use std::io::Write;
-
         let path = self.path().join(relative_path);
         if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent).unwrap_or_else(|error| {
-                panic!("failed to create directory {}: {error}", parent.display())
-            });
+            fs::create_dir_all(parent).expect("failed to create parent directory");
         }
-        let mut file = fs::File::create(&path)
-            .unwrap_or_else(|error| panic!("failed to create file {}: {error}", path.display()));
+
+        let mut file = fs::File::create(&path).expect("failed to create file");
         file.write_all(contents.as_bytes())
-            .unwrap_or_else(|error| panic!("failed to write file {}: {error}", path.display()));
-        file.sync_all()
-            .unwrap_or_else(|error| panic!("failed to flush file {}: {error}", path.display()));
+            .expect("failed to write file");
+        file.sync_all().expect("failed to flush file");
         self
     }
 
-    /// Creates a directory at `relative_path`, together with any missing parent
-    /// directories.
     pub fn create_directory(&self, relative_path: impl AsRef<Path>) -> &Self {
-        let path = self.path().join(relative_path);
-        fs::create_dir_all(&path).unwrap_or_else(|error| {
-            panic!("failed to create directory {}: {error}", path.display())
-        });
+        fs::create_dir_all(self.path().join(relative_path)).expect("failed to create directory");
         self
     }
 
-    /// A [`ModuleRenderer`] already pointed at this project's directory, for
-    /// tests that need to configure the render further before collecting it.
     pub fn renderer<'a>(&self, module_name: &'a str) -> ModuleRenderer<'a> {
         ModuleRenderer::new(module_name).path(self.path())
     }
 
-    /// Renders `module_name` with this project's directory as the current
-    /// directory.
     pub fn render(&self, module_name: &str) -> RenderedModule {
         self.renderer(module_name).collect().into()
     }
@@ -406,22 +270,14 @@ impl Default for Project {
     }
 }
 
-/// An `rstest` fixture supplying a fresh, empty [`Project`].
 #[fixture]
 pub fn project() -> Project {
     Project::new()
 }
 
-/// An `rstest` fixture supplying a fresh [`Project`] nested inside the current
-/// user's home directory, for the modules whose output depends on the rendered
-/// path lying under `~`.
 #[fixture]
 pub fn home_project() -> Project {
-    Project::inside(
-        crate::utils::home_dir()
-            .expect("tests require a resolvable home directory")
-            .as_path(),
-    )
+    Project::inside(&crate::utils::home_dir().expect("tests require a resolvable home directory"))
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -433,22 +289,18 @@ pub enum FixtureProvider {
 }
 
 impl FixtureProvider {
-    /// A working git checkout using the classic loose/packed reference files.
     pub const GIT: Self = Self::Git {
         reftable: false,
         bare: false,
     };
-    /// A working git checkout using the newer `reftable` reference backend.
     pub const GIT_REFTABLE: Self = Self::Git {
         reftable: true,
         bare: false,
     };
-    /// A bare git repository using the classic loose/packed reference files.
     pub const BARE_GIT: Self = Self::Git {
         reftable: false,
         bare: true,
     };
-    /// A bare git repository using the newer `reftable` reference backend.
     pub const BARE_GIT_REFTABLE: Self = Self::Git {
         reftable: true,
         bare: true,
@@ -457,7 +309,6 @@ impl FixtureProvider {
 
 pub const COMMON_GIT_PROVIDERS: &[FixtureProvider] =
     &[FixtureProvider::GIT, FixtureProvider::GIT_REFTABLE];
-
 pub const BARE_GIT_PROVIDERS: &[FixtureProvider] = &[
     FixtureProvider::BARE_GIT,
     FixtureProvider::BARE_GIT_REFTABLE,
@@ -484,91 +335,66 @@ pub fn fixture_repo(provider: FixtureProvider) -> io::Result<TempDir> {
 }
 
 pub fn fixture_repo_with_hash(provider: FixtureProvider, sha256: bool) -> io::Result<TempDir> {
+    let dir = tempfile::tempdir()?;
+    let path = dir.path();
+
     match provider {
         FixtureProvider::Fossil => {
-            let checkout_db = if cfg!(windows) {
+            let db = if cfg!(windows) {
                 "_FOSSIL_"
             } else {
                 ".fslckout"
             };
-            let path = tempfile::tempdir()?;
-            fs::create_dir(path.path().join("subdir"))?;
+            fs::create_dir(path.join("subdir"))?;
             fs::OpenOptions::new()
                 .create(true)
+                .truncate(true)
                 .write(true)
-                .truncate(false)
-                .open(path.path().join(checkout_db))?
+                .open(path.join(db))?
                 .sync_all()?;
-            Ok(path)
         }
         FixtureProvider::Git { reftable, bare } => {
-            let path = tempfile::tempdir()?;
-
             let fixture = if sha256 {
-                &GIT_SHA256_FIXTURE
+                &*GIT_SHA256_FIXTURE
             } else {
-                &GIT_FIXTURE
+                &*GIT_FIXTURE
             };
+            let mut cmd = create_command("git")?;
 
-            let mut command = create_command("git")?;
-            command
-                .current_dir(path.path())
+            cmd.current_dir(path)
                 .arg("clone")
                 .args(reftable.then_some("--ref-format=reftable"))
                 .args(["-b", "master"]);
 
             if bare {
-                command.arg("--bare");
+                cmd.arg("--bare");
             }
+            config_cmd_for_tests(&mut cmd);
+            cmd.arg(fixture.as_os_str()).arg(path).output()?;
+            config_git_repo_for_tests(path)?;
 
-            config_cmd_for_tests(&mut command);
-
-            command.arg(fixture.as_os_str()).arg(path.path()).output()?;
-
-            config_git_repo_for_tests(path.path())?;
             if !bare {
                 create_command("git")?
                     .args(["reset", "--hard", "HEAD"])
-                    .current_dir(path.path())
+                    .current_dir(path)
                     .output()?;
             }
-
-            Ok(path)
         }
         FixtureProvider::Hg => {
-            let path = tempfile::tempdir()?;
-
             create_command("hg")?
-                .current_dir(path.path())
-                .arg("clone")
-                .arg(HG_FIXTURE.as_os_str())
-                .arg(path.path())
+                .current_dir(path)
+                .args(["clone", HG_FIXTURE.to_str().unwrap()])
+                .arg(path)
                 .output()?;
-
-            Ok(path)
         }
         FixtureProvider::Pijul => {
-            let path = tempfile::tempdir()?;
-            fs::create_dir(path.path().join(".pijul"))?;
-            Ok(path)
+            fs::create_dir(path.join(".pijul"))?;
         }
     }
+    Ok(dir)
 }
 
 /// The regression net for test-suite hermeticity.
-///
-/// A suite that reads the developer's own `~/.config/starship.toml` verifies
-/// nothing: it passes in continuous integration, where no such file exists, and
-/// fails on any machine that has one — and a personal configuration can just as
-/// easily make a genuinely broken module render the expected output. Everything
-/// derived from configuration is affected, not only `config` itself:
-/// `root_config` carries `palette`/`palettes`, which rewrite every named color
-/// a module renders.
-///
-/// The structural fix lives in `Context::ambient_config`, which compiles the
-/// filesystem read out of test builds entirely. These checks exist so that
-/// removing it fails loudly and immediately, on every machine, rather than
-/// silently rearming the trap.
 #[cfg(test)]
 mod hermeticity {
     use super::{ModuleRenderer, default_context};
@@ -577,10 +403,7 @@ mod hermeticity {
     use std::ffi::OsString;
     use std::path::PathBuf;
 
-    /// A configuration that would be impossible to miss if it were ever read:
-    /// it redefines the palette every styled module resolves its colors
-    /// through, and overrides a module format outright.
-    const LOUD_CONFIGURATION: &str = r##"
+    const LOUD_CONFIG: &str = r##"
 add_newline = false
 palette = "planted"
 
@@ -592,26 +415,14 @@ red = "#00ff00"
 format = "PLANTED"
 "##;
 
-    /// Plants a configuration exactly where the ambient loader would look for
-    /// one, points the environment at it, and builds a context the ordinary
-    /// way. The context must agree that this is the file it would load — and
-    /// must still not have loaded it.
-    ///
-    /// This is deliberately not a check on a temporary directory being ignored:
-    /// it asserts on `get_config_path_os`, the very function the ambient loader
-    /// consults, so the file really is reachable and really is the one that
-    /// would be read.
     #[test]
-    fn a_test_build_never_reads_the_configuration_the_environment_points_at() {
-        let directory =
-            tempfile::tempdir().expect("failed to create a temporary configuration directory");
-        let configuration_path = directory.path().join("starship.toml");
-        std::fs::write(&configuration_path, LOUD_CONFIGURATION)
-            .expect("failed to plant the configuration file");
-        let configuration_path_text = configuration_path.display().to_string();
+    fn test_build_ignores_ambient_config() {
+        let dir = tempfile::tempdir().expect("failed to create temp dir");
+        let config_path = dir.path().join("starship.toml");
+        std::fs::write(&config_path, LOUD_CONFIG).expect("failed to plant config");
 
-        let mut environment = Env::default();
-        environment.insert("STARSHIP_CONFIG", configuration_path_text.clone());
+        let mut env = Env::default();
+        env.insert("STARSHIP_CONFIG", config_path.display().to_string());
 
         let context = Context::new_with_shell_and_path(
             Properties::default(),
@@ -619,59 +430,38 @@ format = "PLANTED"
             Target::Main,
             PathBuf::new(),
             PathBuf::new(),
-            environment,
+            env,
         );
 
         assert_eq!(
             context.get_config_path_os(),
-            Some(OsString::from(&configuration_path_text)),
-            "the planted configuration is not where the ambient loader would look, so this check \
-             would pass for the wrong reason"
+            Some(OsString::from(config_path.display().to_string()))
         );
         assert!(
             context.config.config.is_none(),
-            "a test build read the configuration file the environment points at"
+            "Test leaked hermeticity and read the planted config!"
         );
         assert_eq!(
-            root_configuration_text(&context.root_config),
-            root_configuration_text(&StarshipRootConfig::default()),
-            "a test build derived its root configuration from the file the environment points at"
+            root_config_text(&context.root_config),
+            root_config_text(&StarshipRootConfig::default())
         );
     }
 
-    /// The harness every module test renders through carries no configuration,
-    /// and nothing derived from one.
-    ///
-    /// Compared by serializing the whole root configuration rather than by
-    /// checking the fields that are known to matter today: a field added later
-    /// and populated from a leftover configuration is caught without anyone
-    /// remembering to extend this check.
     #[test]
-    fn the_test_harness_context_carries_no_configuration() {
+    fn test_harness_carries_no_config() {
         let context = default_context();
-
         assert!(
             context.config.config.is_none(),
-            "default_context() carries a configuration it was never given"
+            "default_context() carries a configuration"
         );
         assert_eq!(
-            root_configuration_text(&context.root_config),
-            root_configuration_text(&StarshipRootConfig::default()),
-            "default_context() carries a root configuration that is not starship's default; some \
-             field derived from configuration is not being derived from the configuration the \
-             context was constructed with"
+            root_config_text(&context.root_config),
+            root_config_text(&StarshipRootConfig::default())
         );
     }
 
-    /// A module rendered through the harness resolves its colors against
-    /// starship's own definitions.
-    ///
-    /// This is the symptom the hermeticity bug actually presented as: with a
-    /// developer palette in effect, a module styled `green` renders as that
-    /// palette's truecolor green (`ESC[38;2;R;G;Bm`) rather than as ANSI green
-    /// (`ESC[32m`), and every assertion on rendered output fails.
     #[test]
-    fn rendered_modules_resolve_colors_against_starship_defaults() {
+    fn test_rendered_modules_use_defaults() {
         let rendered = ModuleRenderer::new("character")
             .config(toml::toml! {
                 [character]
@@ -682,13 +472,11 @@ format = "PLANTED"
 
         assert!(
             rendered.contains("\u{1b}[32m"),
-            "expected ANSI green in {rendered:?}; a palette from outside the test redefined it"
+            "Expected ANSI green, found overridden palette color: {rendered:?}"
         );
     }
 
-    /// `StarshipRootConfig` has no `PartialEq`, so compare the whole thing by
-    /// its serialized form.
-    fn root_configuration_text(root_config: &StarshipRootConfig) -> String {
-        toml::to_string(root_config).expect("the root configuration always serializes")
+    fn root_config_text(config: &StarshipRootConfig) -> String {
+        toml::to_string(config).expect("root configuration must serialize")
     }
 }

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -317,9 +317,34 @@ impl Project {
         }
     }
 
+    /// Creates a project whose directory is a freshly materialized version
+    /// control checkout, as produced by [`fixture_repo`].
+    ///
+    /// Pair this with `#[rstest]`'s `#[values(..)]` over [`FixtureProvider`] to
+    /// get one independently named, independently reported test per backend.
+    pub fn from_repository_fixture(provider: FixtureProvider) -> Self {
+        Self {
+            directory: fixture_repo(provider)
+                .unwrap_or_else(|error| panic!("failed to create a {provider:?} fixture: {error}")),
+        }
+    }
+
     /// The absolute path of this project's directory.
     pub fn path(&self) -> &Path {
         self.directory.path()
+    }
+
+    /// The final component of this project's directory name.
+    ///
+    /// Temporary directories are randomly named, so tests whose expected output
+    /// embeds the project's own name have to read it back rather than hardcode
+    /// it.
+    pub fn directory_name(&self) -> String {
+        self.path()
+            .file_name()
+            .expect("a temporary project directory always has a final component")
+            .to_string_lossy()
+            .into_owned()
     }
 
     /// Creates an empty file at `relative_path`, together with any missing

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -59,17 +59,25 @@ fn init_logger() {
     log::set_boxed_logger(Box::new(logger)).unwrap();
 }
 
+/// A context rendering against starship's defaults and nothing else.
+///
+/// Built through [`Context::new_with_config`], the constructor that demands a
+/// configuration, rather than through the one that loads whatever the ambient
+/// environment points at. That is what makes a test's result independent of the
+/// developer's own `starship.toml`: everything the context derives from
+/// configuration — `root_config` today, whatever is added later — is derived
+/// from the empty configuration supplied here, so there is no field left
+/// carrying a value the test never asked for.
 pub fn default_context() -> Context<'static> {
-    let mut context = Context::new_with_shell_and_path(
+    Context::new_with_config(
         Properties::default(),
         Shell::Unknown,
         Target::Main,
         PathBuf::new(),
         PathBuf::new(),
         Env::default(),
-    );
-    context.config = StarshipConfig { config: None };
-    context
+        StarshipConfig { config: None },
+    )
 }
 
 /// Render a specific starship module by name

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -5,6 +5,8 @@ use crate::{
     utils::{CommandOutput, create_command},
 };
 use log::{Level, LevelFilter};
+use rstest::fixture;
+use std::fmt;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -220,6 +222,175 @@ impl<'a> From<ModuleRenderer<'a>> for Context<'a> {
     }
 }
 
+/// What a starship module produced when rendered.
+///
+/// This exists so a rendered module can be compared and snapshotted as a value
+/// with an explicit "the module rendered nothing" case, rather than as an
+/// `Option<String>` whose `None` and `Some("")` cases both mean "nothing" in
+/// different places.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RenderedModule {
+    /// The module declined to render, or rendered nothing at all.
+    Empty,
+    /// The module rendered the contained text, ANSI styling escape sequences
+    /// included. The styling is part of what module tests assert on, so it is
+    /// never stripped.
+    Styled(String),
+}
+
+impl From<Option<String>> for RenderedModule {
+    fn from(collected: Option<String>) -> Self {
+        match collected {
+            None => Self::Empty,
+            Some(text) => Self::Styled(text),
+        }
+    }
+}
+
+impl fmt::Display for RenderedModule {
+    /// Renders the module output in a form that is safe and reviewable inside a
+    /// snapshot.
+    ///
+    /// Rendered output is written as a quoted, escaped Rust string literal, for
+    /// two reasons. Control characters — above all the ANSI escape sequences
+    /// that carry the styling contract — become visible `\u{1b}` text instead
+    /// of raw bytes a reviewer cannot see in a diff. And the surrounding quotes
+    /// pin down the exact extent of the output: snapshot files are stored with
+    /// trailing whitespace trimmed, so an unquoted rendering would silently
+    /// discard the trailing space that most module formats end with, and a
+    /// regression that dropped it would go unnoticed.
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Empty => formatter.write_str("<no output>"),
+            Self::Styled(text) => write!(formatter, "{text:?}"),
+        }
+    }
+}
+
+/// A throwaway project directory that owns the temporary directory backing it
+/// and renders starship modules against itself.
+///
+/// This replaces the `tempfile::tempdir()?` / `File::create(..)?.sync_all()?` /
+/// `directory.close()` preamble that otherwise forces every module test to
+/// return `io::Result<()>` purely as plumbing. The temporary directory is
+/// removed when the `Project` is dropped, and a set-up failure panics
+/// immediately, naming the path that failed, instead of being threaded through
+/// a `Result` that says nothing about which step broke.
+pub struct Project {
+    directory: TempDir,
+}
+
+impl Project {
+    /// Creates a project in a fresh temporary directory under the platform's
+    /// temporary-file root.
+    pub fn new() -> Self {
+        Self {
+            directory: TempDir::new().expect("failed to create a temporary project directory"),
+        }
+    }
+
+    /// Creates a project in a fresh temporary directory nested inside
+    /// `parent_directory`, for tests whose expectations depend on where the
+    /// project lives (under the user's home directory, under a known root, ...).
+    pub fn inside(parent_directory: &Path) -> Self {
+        fs::create_dir_all(parent_directory).unwrap_or_else(|error| {
+            panic!(
+                "failed to create parent directory {}: {error}",
+                parent_directory.display()
+            )
+        });
+        Self {
+            directory: TempDir::new_in(parent_directory).unwrap_or_else(|error| {
+                panic!(
+                    "failed to create a temporary project directory inside {}: {error}",
+                    parent_directory.display()
+                )
+            }),
+        }
+    }
+
+    /// The absolute path of this project's directory.
+    pub fn path(&self) -> &Path {
+        self.directory.path()
+    }
+
+    /// Creates an empty file at `relative_path`, together with any missing
+    /// parent directories, and flushes it to disk before returning.
+    ///
+    /// The flush matters: several modules detect a project by reading the
+    /// directory, and an unflushed file has been observed to be invisible to
+    /// the freshly spawned processes some modules use.
+    pub fn create_file(&self, relative_path: impl AsRef<Path>) -> &Self {
+        self.write_file(relative_path, "")
+    }
+
+    /// Creates a file at `relative_path` holding `contents`, together with any
+    /// missing parent directories, and flushes it to disk before returning.
+    pub fn write_file(&self, relative_path: impl AsRef<Path>, contents: &str) -> &Self {
+        use std::io::Write;
+
+        let path = self.path().join(relative_path);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap_or_else(|error| {
+                panic!("failed to create directory {}: {error}", parent.display())
+            });
+        }
+        let mut file = fs::File::create(&path)
+            .unwrap_or_else(|error| panic!("failed to create file {}: {error}", path.display()));
+        file.write_all(contents.as_bytes())
+            .unwrap_or_else(|error| panic!("failed to write file {}: {error}", path.display()));
+        file.sync_all()
+            .unwrap_or_else(|error| panic!("failed to flush file {}: {error}", path.display()));
+        self
+    }
+
+    /// Creates a directory at `relative_path`, together with any missing parent
+    /// directories.
+    pub fn create_directory(&self, relative_path: impl AsRef<Path>) -> &Self {
+        let path = self.path().join(relative_path);
+        fs::create_dir_all(&path).unwrap_or_else(|error| {
+            panic!("failed to create directory {}: {error}", path.display())
+        });
+        self
+    }
+
+    /// A [`ModuleRenderer`] already pointed at this project's directory, for
+    /// tests that need to configure the render further before collecting it.
+    pub fn renderer<'a>(&self, module_name: &'a str) -> ModuleRenderer<'a> {
+        ModuleRenderer::new(module_name).path(self.path())
+    }
+
+    /// Renders `module_name` with this project's directory as the current
+    /// directory.
+    pub fn render(&self, module_name: &str) -> RenderedModule {
+        self.renderer(module_name).collect().into()
+    }
+}
+
+impl Default for Project {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// An `rstest` fixture supplying a fresh, empty [`Project`].
+#[fixture]
+pub fn project() -> Project {
+    Project::new()
+}
+
+/// An `rstest` fixture supplying a fresh [`Project`] nested inside the current
+/// user's home directory, for the modules whose output depends on the rendered
+/// path lying under `~`.
+#[fixture]
+pub fn home_project() -> Project {
+    Project::inside(
+        crate::utils::home_dir()
+            .expect("tests require a resolvable home directory")
+            .as_path(),
+    )
+}
+
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum FixtureProvider {
     Fossil,
@@ -228,26 +399,35 @@ pub enum FixtureProvider {
     Pijul,
 }
 
-pub const COMMON_GIT_PROVIDERS: &[FixtureProvider] = &[
-    FixtureProvider::Git {
+impl FixtureProvider {
+    /// A working git checkout using the classic loose/packed reference files.
+    pub const GIT: Self = Self::Git {
         reftable: false,
         bare: false,
-    },
-    FixtureProvider::Git {
+    };
+    /// A working git checkout using the newer `reftable` reference backend.
+    pub const GIT_REFTABLE: Self = Self::Git {
         reftable: true,
         bare: false,
-    },
-];
+    };
+    /// A bare git repository using the classic loose/packed reference files.
+    pub const BARE_GIT: Self = Self::Git {
+        reftable: false,
+        bare: true,
+    };
+    /// A bare git repository using the newer `reftable` reference backend.
+    pub const BARE_GIT_REFTABLE: Self = Self::Git {
+        reftable: true,
+        bare: true,
+    };
+}
+
+pub const COMMON_GIT_PROVIDERS: &[FixtureProvider] =
+    &[FixtureProvider::GIT, FixtureProvider::GIT_REFTABLE];
 
 pub const BARE_GIT_PROVIDERS: &[FixtureProvider] = &[
-    FixtureProvider::Git {
-        reftable: false,
-        bare: true,
-    },
-    FixtureProvider::Git {
-        reftable: true,
-        bare: true,
-    },
+    FixtureProvider::BARE_GIT,
+    FixtureProvider::BARE_GIT_REFTABLE,
 ];
 
 pub fn config_cmd_for_tests(cmd: &mut Command) {

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -529,3 +529,141 @@ pub fn fixture_repo_with_hash(provider: FixtureProvider, sha256: bool) -> io::Re
         }
     }
 }
+
+/// The regression net for test-suite hermeticity.
+///
+/// A suite that reads the developer's own `~/.config/starship.toml` verifies
+/// nothing: it passes in continuous integration, where no such file exists, and
+/// fails on any machine that has one — and a personal configuration can just as
+/// easily make a genuinely broken module render the expected output. Everything
+/// derived from configuration is affected, not only `config` itself:
+/// `root_config` carries `palette`/`palettes`, which rewrite every named color
+/// a module renders.
+///
+/// The structural fix lives in `Context::ambient_config`, which compiles the
+/// filesystem read out of test builds entirely. These checks exist so that
+/// removing it fails loudly and immediately, on every machine, rather than
+/// silently rearming the trap.
+#[cfg(test)]
+mod hermeticity {
+    use super::{ModuleRenderer, default_context};
+    use crate::configs::StarshipRootConfig;
+    use crate::context::{Context, Env, Properties, Shell, Target};
+    use std::ffi::OsString;
+    use std::path::PathBuf;
+
+    /// A configuration that would be impossible to miss if it were ever read:
+    /// it redefines the palette every styled module resolves its colors
+    /// through, and overrides a module format outright.
+    const LOUD_CONFIGURATION: &str = r##"
+add_newline = false
+palette = "planted"
+
+[palettes.planted]
+green = "#ff0000"
+red = "#00ff00"
+
+[nodejs]
+format = "PLANTED"
+"##;
+
+    /// Plants a configuration exactly where the ambient loader would look for
+    /// one, points the environment at it, and builds a context the ordinary
+    /// way. The context must agree that this is the file it would load — and
+    /// must still not have loaded it.
+    ///
+    /// This is deliberately not a check on a temporary directory being ignored:
+    /// it asserts on `get_config_path_os`, the very function the ambient loader
+    /// consults, so the file really is reachable and really is the one that
+    /// would be read.
+    #[test]
+    fn a_test_build_never_reads_the_configuration_the_environment_points_at() {
+        let directory =
+            tempfile::tempdir().expect("failed to create a temporary configuration directory");
+        let configuration_path = directory.path().join("starship.toml");
+        std::fs::write(&configuration_path, LOUD_CONFIGURATION)
+            .expect("failed to plant the configuration file");
+        let configuration_path_text = configuration_path.display().to_string();
+
+        let mut environment = Env::default();
+        environment.insert("STARSHIP_CONFIG", configuration_path_text.clone());
+
+        let context = Context::new_with_shell_and_path(
+            Properties::default(),
+            Shell::Unknown,
+            Target::Main,
+            PathBuf::new(),
+            PathBuf::new(),
+            environment,
+        );
+
+        assert_eq!(
+            context.get_config_path_os(),
+            Some(OsString::from(&configuration_path_text)),
+            "the planted configuration is not where the ambient loader would look, so this check \
+             would pass for the wrong reason"
+        );
+        assert!(
+            context.config.config.is_none(),
+            "a test build read the configuration file the environment points at"
+        );
+        assert_eq!(
+            root_configuration_text(&context.root_config),
+            root_configuration_text(&StarshipRootConfig::default()),
+            "a test build derived its root configuration from the file the environment points at"
+        );
+    }
+
+    /// The harness every module test renders through carries no configuration,
+    /// and nothing derived from one.
+    ///
+    /// Compared by serializing the whole root configuration rather than by
+    /// checking the fields that are known to matter today: a field added later
+    /// and populated from a leftover configuration is caught without anyone
+    /// remembering to extend this check.
+    #[test]
+    fn the_test_harness_context_carries_no_configuration() {
+        let context = default_context();
+
+        assert!(
+            context.config.config.is_none(),
+            "default_context() carries a configuration it was never given"
+        );
+        assert_eq!(
+            root_configuration_text(&context.root_config),
+            root_configuration_text(&StarshipRootConfig::default()),
+            "default_context() carries a root configuration that is not starship's default; some \
+             field derived from configuration is not being derived from the configuration the \
+             context was constructed with"
+        );
+    }
+
+    /// A module rendered through the harness resolves its colors against
+    /// starship's own definitions.
+    ///
+    /// This is the symptom the hermeticity bug actually presented as: with a
+    /// developer palette in effect, a module styled `green` renders as that
+    /// palette's truecolor green (`ESC[38;2;R;G;Bm`) rather than as ANSI green
+    /// (`ESC[32m`), and every assertion on rendered output fails.
+    #[test]
+    fn rendered_modules_resolve_colors_against_starship_defaults() {
+        let rendered = ModuleRenderer::new("character")
+            .config(toml::toml! {
+                [character]
+                success_symbol = "[>](green)"
+            })
+            .collect()
+            .expect("the character module always renders");
+
+        assert!(
+            rendered.contains("\u{1b}[32m"),
+            "expected ANSI green in {rendered:?}; a palette from outside the test redefined it"
+        );
+    }
+
+    /// `StarshipRootConfig` has no `PartialEq`, so compare the whole thing by
+    /// its serialized form.
+    fn root_configuration_text(root_config: &StarshipRootConfig) -> String {
+        toml::to_string(root_config).expect("the root configuration always serializes")
+    }
+}

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -1,0 +1,478 @@
+//! Shell capabilities for streamed prompts.
+
+use std::fmt;
+
+use clap::ValueEnum;
+
+use crate::context::{Shell, Target};
+use crate::damage::Damage;
+use crate::frame::{Patch, PromptVariablePayload, RawTerminalPayload};
+use crate::module::painted::{Painted, TerminalWidth};
+
+/// A shell's streaming capability.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Tier {
+    Static,
+    PromptReplace,
+    CellPrecise,
+}
+
+impl Tier {
+    pub fn of(shell: Shell) -> Self {
+        match shell {
+            Shell::Zsh => Self::CellPrecise,
+
+            Shell::Fish => Self::PromptReplace,
+
+            Shell::Nu => Self::PromptReplace,
+
+            Shell::Elvish | Shell::Xonsh => Self::Static,
+
+            Shell::Bash
+            | Shell::Pwsh
+            | Shell::PowerShell
+            | Shell::Ion
+            | Shell::Tcsh
+            | Shell::Cmd
+            | Shell::Unknown => Self::Static,
+        }
+    }
+
+    #[cfg(test)]
+    pub fn for_prompt(shell: Shell, target: &Target) -> Self {
+        Self::of(shell).for_target(target)
+    }
+
+    fn for_target(self, target: &Target) -> Self {
+        match target {
+            Target::Main => self,
+            Target::Right | Target::Continuation | Target::Profile(_) => {
+                self.min(Self::PromptReplace)
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn can_refine(self) -> bool {
+        self.refinement().is_some()
+    }
+
+    pub(crate) fn refinement(self) -> Option<RefinementTier> {
+        match self {
+            Self::Static => None,
+            Self::PromptReplace => Some(RefinementTier::PromptReplace),
+            Self::CellPrecise => Some(RefinementTier::CellPrecise),
+        }
+    }
+}
+
+/// The capabilities available once a stream has committed to refining.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum RefinementTier {
+    PromptReplace,
+    CellPrecise,
+}
+
+/// Requested stream transport.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, ValueEnum)]
+pub enum StreamingTransport {
+    #[default]
+    Auto,
+    Ble,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TransportMismatch {
+    requested: StreamingTransport,
+    shell: Shell,
+}
+
+impl fmt::Display for TransportMismatch {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.requested {
+            StreamingTransport::Auto => unreachable!("automatic transport accepts every shell"),
+            StreamingTransport::Ble => write!(
+                formatter,
+                "--transport=ble requires STARSHIP_SHELL=bash, found {:#?}",
+                self.shell
+            ),
+        }
+    }
+}
+
+impl std::error::Error for TransportMismatch {}
+
+impl StreamingTransport {
+    pub(crate) fn tier(self, shell: Shell, target: &Target) -> Result<Tier, TransportMismatch> {
+        let capability = match self {
+            Self::Auto => Tier::of(shell),
+            Self::Ble if shell == Shell::Bash => Tier::PromptReplace,
+            Self::Ble => {
+                return Err(TransportMismatch {
+                    requested: self,
+                    shell,
+                });
+            }
+        };
+        Ok(capability.for_target(target))
+    }
+}
+
+/// The refinement that turns `previous` into `next`, if anything changed.
+pub(crate) fn patch(
+    previous: &Painted,
+    next: &Painted,
+    terminal_width: TerminalWidth,
+    tier: RefinementTier,
+    shell: Shell,
+) -> Option<Patch> {
+    let prompt = || PromptVariablePayload::escaped_for(&RawTerminalPayload::prompt(next), shell);
+
+    match Damage::between(previous, next, terminal_width) {
+        Damage::None => None,
+        Damage::Full => Some(Patch::whole_prompt(prompt())),
+        Damage::Repaint(bytes) => Some(match tier {
+            RefinementTier::PromptReplace => Patch::whole_prompt(prompt()),
+            RefinementTier::CellPrecise => {
+                Patch::repainting_cells(prompt(), RawTerminalPayload::repaint(&bytes))
+            }
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::damage::tests::{painted, segments, text};
+    use crate::segment::Segment;
+
+    const EVERY_SHELL: &[Shell] = &[
+        Shell::Bash,
+        Shell::Fish,
+        Shell::Ion,
+        Shell::Pwsh,
+        Shell::PowerShell,
+        Shell::Zsh,
+        Shell::Elvish,
+        Shell::Tcsh,
+        Shell::Nu,
+        Shell::Xonsh,
+        Shell::Cmd,
+        Shell::Unknown,
+    ];
+
+    #[test]
+    fn the_ladder_is_strictly_ordered() {
+        assert!(Tier::Static < Tier::PromptReplace);
+        assert!(Tier::PromptReplace < Tier::CellPrecise);
+        assert!(!Tier::Static.can_refine());
+        assert!(Tier::PromptReplace.can_refine());
+        assert!(Tier::CellPrecise.can_refine());
+    }
+
+    #[test]
+    fn every_shell_has_a_tier() {
+        for &shell in EVERY_SHELL {
+            let _ = Tier::of(shell);
+        }
+        assert_eq!(Tier::CellPrecise, Tier::of(Shell::Zsh));
+    }
+
+    /// The shells whose output this change must not alter at all.
+    #[test]
+    fn the_shells_that_cannot_be_refined_are_exactly_the_expected_ones() {
+        let unrefinable: Vec<Shell> = EVERY_SHELL
+            .iter()
+            .copied()
+            .filter(|shell| !Tier::of(*shell).can_refine())
+            .collect();
+
+        assert_eq!(
+            vec![
+                Shell::Bash,
+                Shell::Ion,
+                Shell::Pwsh,
+                Shell::PowerShell,
+                Shell::Elvish,
+                Shell::Tcsh,
+                Shell::Xonsh,
+                Shell::Cmd,
+                Shell::Unknown,
+            ],
+            unrefinable,
+            "every shell but zsh, fish and nu is drawn synchronously today"
+        );
+    }
+
+    /// A right prompt is placed by the shell, so it is never repainted cell by cell.
+    #[test]
+    fn only_the_main_prompt_is_ever_repainted_cell_by_cell() {
+        assert_eq!(
+            Tier::CellPrecise,
+            Tier::for_prompt(Shell::Zsh, &Target::Main)
+        );
+        for target in [
+            Target::Right,
+            Target::Continuation,
+            Target::Profile("anything".to_owned()),
+        ] {
+            assert_eq!(
+                Tier::PromptReplace,
+                Tier::for_prompt(Shell::Zsh, &target),
+                "for {target:?}"
+            );
+        }
+
+        // A shell that could not be refined at all is not promoted by this.
+        for target in [Target::Main, Target::Right] {
+            assert_eq!(Tier::Static, Tier::for_prompt(Shell::Bash, &target));
+        }
+    }
+
+    #[test]
+    fn ble_is_an_explicit_bash_prompt_replace_transport() {
+        assert_eq!(
+            Tier::PromptReplace,
+            StreamingTransport::Ble
+                .tier(Shell::Bash, &Target::Main)
+                .unwrap()
+        );
+        assert_eq!(
+            Tier::PromptReplace,
+            StreamingTransport::Ble
+                .tier(Shell::Bash, &Target::Right)
+                .unwrap()
+        );
+        assert!(
+            StreamingTransport::Ble
+                .tier(Shell::Zsh, &Target::Main)
+                .is_err()
+        );
+        assert_eq!(
+            Tier::Static,
+            StreamingTransport::Auto
+                .tier(Shell::Bash, &Target::Main)
+                .unwrap()
+        );
+    }
+
+    const WIDTH: TerminalWidth = TerminalWidth(80);
+
+    fn refine(previous: &Painted, next: &Painted, tier: RefinementTier, shell: Shell) -> Patch {
+        patch(previous, next, WIDTH, tier, shell).expect("the prompts differ")
+    }
+
+    /// Two prompts of the same shape differing in one word: a run of damage.
+    fn a_run_of_damage() -> (Painted, Painted) {
+        (
+            painted(&segments("[main](red) >"), WIDTH.0),
+            painted(&segments("[work](red) >"), WIDTH.0),
+        )
+    }
+
+    /// Two prompts of different shapes: nothing incremental expresses it.
+    fn full_damage() -> (Painted, Painted) {
+        (
+            painted(&segments("one"), WIDTH.0),
+            painted(&segments("a much longer prompt\nover two lines"), WIDTH.0),
+        )
+    }
+
+    #[test]
+    fn a_cell_precise_shell_is_sent_the_incremental_repaint() {
+        let (previous, next) = a_run_of_damage();
+        assert!(matches!(
+            refine(&previous, &next, RefinementTier::CellPrecise, Shell::Zsh),
+            Patch::Repaint { .. }
+        ));
+    }
+
+    #[test]
+    fn a_prompt_replace_shell_is_sent_a_whole_prompt_for_the_same_change() {
+        let (previous, next) = a_run_of_damage();
+        assert!(matches!(
+            refine(&previous, &next, RefinementTier::PromptReplace, Shell::Fish),
+            Patch::Replace(_)
+        ));
+    }
+
+    /// Separate from the table above so promoting a shell to a higher tier doesn't change this test's meaning.
+    #[test]
+    fn the_rung_rather_than_the_shell_decides_what_is_sent() {
+        let (previous, next) = a_run_of_damage();
+        for shell in EVERY_SHELL {
+            assert!(
+                matches!(
+                    refine(&previous, &next, RefinementTier::PromptReplace, *shell),
+                    Patch::Replace(_)
+                ),
+                "for {shell:?}"
+            );
+            assert!(
+                matches!(
+                    refine(&previous, &next, RefinementTier::CellPrecise, *shell),
+                    Patch::Repaint { .. }
+                ),
+                "for {shell:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn full_damage_degrades_to_a_whole_prompt_on_every_tier() {
+        let (previous, next) = full_damage();
+        for tier in [RefinementTier::PromptReplace, RefinementTier::CellPrecise] {
+            assert!(
+                matches!(
+                    refine(&previous, &next, tier, Shell::Zsh),
+                    Patch::Replace(_)
+                ),
+                "a full repaint must be a whole prompt at {tier:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_prompt_that_did_not_change_is_not_delivered_at_all() {
+        let prompt = painted(&segments("[main](red) >"), WIDTH.0);
+        for tier in [RefinementTier::PromptReplace, RefinementTier::CellPrecise] {
+            assert_eq!(None, patch(&prompt, &prompt, WIDTH, tier, Shell::Zsh));
+        }
+    }
+
+    /// Guards the doubled-percent-sign bug: a repaint is raw terminal bytes, never escaped.
+    #[test]
+    fn an_incremental_repaint_is_never_escaped_for_the_shell() {
+        // Differ from the first character so the repaint's run covers the percent sign.
+        let previous = painted(&segments("10% off >"), WIDTH.0);
+        let next = painted(&segments("25% bad >"), WIDTH.0);
+
+        let Some(Patch::Repaint { repaint, prompt }) = patch(
+            &previous,
+            &next,
+            WIDTH,
+            RefinementTier::CellPrecise,
+            Shell::Zsh,
+        ) else {
+            panic!("a same-width change under zsh is an incremental repaint");
+        };
+
+        let bytes = String::from_utf8(repaint.as_bytes().to_vec()).expect("a repaint is text");
+        assert!(
+            bytes.contains("25%") && !bytes.contains("%%"),
+            "a repaint under zsh must carry a single percent sign, but was {bytes:?}"
+        );
+
+        // Same bytes, opposite treatment: this prompt is for zsh to expand, so it is escaped.
+        let variable = String::from_utf8(prompt.as_bytes().to_vec()).expect("a prompt is text");
+        assert!(
+            variable.contains("25%% bad"),
+            "the prompt beside a repaint must be escaped for zsh, but was {variable:?}"
+        );
+        assert_eq!(
+            RawTerminalPayload::prompt(&next),
+            prompt.as_terminal_bytes_under(Shell::Zsh)
+        );
+    }
+
+    /// A repaint always ships with its prompt, or the shell's prompt variable would describe a stale screen.
+    #[test]
+    fn a_repaint_always_arrives_with_the_prompt_the_screen_now_shows() {
+        let (previous, next) = a_run_of_damage();
+        let Some(Patch::Repaint { prompt, .. }) = patch(
+            &previous,
+            &next,
+            WIDTH,
+            RefinementTier::CellPrecise,
+            Shell::Zsh,
+        ) else {
+            panic!("a same-width change under zsh is an incremental repaint");
+        };
+
+        assert_eq!(
+            RawTerminalPayload::prompt(&next),
+            prompt.as_terminal_bytes_under(Shell::Zsh),
+            "the prompt beside a repaint must describe exactly what was painted"
+        );
+    }
+
+    /// Guards zsh eating a percent sign: a whole prompt is assigned into `PROMPT`, which zsh re-expands, so it must be escaped.
+    #[test]
+    fn a_whole_prompt_is_always_escaped_for_the_shell() {
+        let previous = painted(&segments("one"), WIDTH.0);
+        let next = painted(&segments("10% off\nover two lines"), WIDTH.0);
+
+        let Some(Patch::Replace(prompt)) = patch(
+            &previous,
+            &next,
+            WIDTH,
+            RefinementTier::CellPrecise,
+            Shell::Zsh,
+        ) else {
+            panic!("a change of shape is a whole prompt");
+        };
+
+        let bytes = String::from_utf8(prompt.as_bytes().to_vec()).expect("a prompt is text");
+        assert!(
+            bytes.contains("10%% off"),
+            "a whole prompt under zsh must double its percent signs, but was {bytes:?}"
+        );
+
+        // What zsh draws from this is exactly what the terminal would have shown directly.
+        assert_eq!(
+            RawTerminalPayload::prompt(&next),
+            prompt.as_terminal_bytes_under(Shell::Zsh)
+        );
+    }
+
+    /// Same pair of failures for bash, whose expansion eats backslashes and dollar signs instead.
+    #[test]
+    fn a_whole_prompt_survives_bash_prompt_expansion_unchanged() {
+        let previous = painted(&segments("one"), WIDTH.0);
+        let next = painted(
+            &[
+                text("", r"cost $5 `now` back\slash"),
+                Segment::LineTerm,
+                text("", "over two lines"),
+            ],
+            WIDTH.0,
+        );
+
+        let Some(Patch::Replace(prompt)) = patch(
+            &previous,
+            &next,
+            WIDTH,
+            RefinementTier::PromptReplace,
+            Shell::Bash,
+        ) else {
+            panic!("a change of shape is a whole prompt");
+        };
+
+        assert_eq!(
+            RawTerminalPayload::prompt(&next),
+            prompt.as_terminal_bytes_under(Shell::Bash)
+        );
+    }
+
+    /// A shell that expands nothing gets the rendered bytes untouched.
+    #[test]
+    fn a_shell_that_expands_nothing_gets_the_bytes_it_would_have_drawn() {
+        let previous = painted(&segments("one"), WIDTH.0);
+        let next = painted(&segments("10% off\nover two lines"), WIDTH.0);
+
+        let Some(Patch::Replace(prompt)) = patch(
+            &previous,
+            &next,
+            WIDTH,
+            RefinementTier::PromptReplace,
+            Shell::Fish,
+        ) else {
+            panic!("a change of shape is a whole prompt");
+        };
+
+        assert_eq!(
+            RawTerminalPayload::prompt(&next).as_bytes(),
+            prompt.as_bytes()
+        );
+    }
+}

--- a/tests/init_async.rs
+++ b/tests/init_async.rs
@@ -113,6 +113,13 @@ impl Pty {
                 Err(error) if error.kind() == ErrorKind::WouldBlock => {
                     thread::sleep(Duration::from_millis(10))
                 }
+                // Linux, unlike macOS, answers a read on the master with EIO
+                // rather than EOF once the shell has exited and closed its
+                // side of the pty -- the same "nothing more is coming" signal
+                // as `Ok(0)`, not a real failure.
+                Err(error) if error.raw_os_error() == Some(nix::errno::Errno::EIO as i32) => {
+                    return true;
+                }
                 Err(error) => panic!("failed to read shell output: {error}"),
             }
         }

--- a/tests/init_async.rs
+++ b/tests/init_async.rs
@@ -1,0 +1,475 @@
+#![cfg(unix)]
+#![allow(clippy::disallowed_methods)] // Integration tests must launch real shells.
+
+use alacritty_terminal::event::{Event, EventListener, WindowSize};
+use alacritty_terminal::grid::Dimensions;
+use alacritty_terminal::index::Line;
+use alacritty_terminal::term::{Config, Term};
+use alacritty_terminal::tty::{self, EventedReadWrite, Options, Shell as PtyShell};
+use alacritty_terminal::vte::ansi::Processor;
+use std::collections::HashMap;
+use std::env;
+use std::ffi::OsString;
+use std::fs;
+use std::io::{ErrorKind, Read, Write};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::mpsc;
+use std::thread;
+use std::time::{Duration, Instant};
+use tempfile::TempDir;
+
+const TIMEOUT: Duration = Duration::from_secs(15);
+const COLUMNS: usize = 160;
+const LINES: usize = 24;
+
+#[derive(Clone)]
+struct Listener(mpsc::Sender<Event>);
+
+impl EventListener for Listener {
+    fn send_event(&self, event: Event) {
+        let _ = self.0.send(event);
+    }
+}
+
+struct Size;
+
+impl Dimensions for Size {
+    fn total_lines(&self) -> usize {
+        LINES
+    }
+
+    fn screen_lines(&self) -> usize {
+        LINES
+    }
+
+    fn columns(&self) -> usize {
+        COLUMNS
+    }
+}
+
+struct Pty {
+    pty: tty::Pty,
+    parser: Processor,
+    terminal: Term<Listener>,
+    events: mpsc::Receiver<Event>,
+}
+
+impl Pty {
+    fn spawn(launch: Launch, cwd: &Path) -> Self {
+        let pty = tty::new(
+            &Options {
+                shell: Some(PtyShell::new(
+                    launch.program.to_str().expect("shell path is UTF-8").into(),
+                    launch.args,
+                )),
+                working_directory: Some(cwd.into()),
+                drain_on_exit: false,
+                env: launch.environment,
+            },
+            WindowSize {
+                num_lines: LINES as u16,
+                num_cols: COLUMNS as u16,
+                cell_width: 8,
+                cell_height: 16,
+            },
+            0,
+        )
+        .unwrap_or_else(|error| panic!("failed to start {}: {error}", launch.program.display()));
+        let (sender, events) = mpsc::channel();
+
+        Self {
+            pty,
+            parser: Processor::new(),
+            terminal: Term::new(Config::default(), &Size, Listener(sender)),
+            events,
+        }
+    }
+
+    fn send(&mut self, input: &str) {
+        self.pty
+            .writer()
+            .write_all(input.as_bytes())
+            .unwrap_or_else(|error| panic!("failed to write to shell: {error}"));
+        self.pty
+            .writer()
+            .flush()
+            .expect("failed to flush shell input");
+    }
+
+    fn pump(&mut self, timeout: Duration) -> bool {
+        let deadline = Instant::now() + timeout;
+        let mut bytes = [0; 4096];
+
+        while Instant::now() < deadline {
+            match self.pty.reader().read(&mut bytes) {
+                Ok(0) => return true,
+                Ok(read) => {
+                    self.parser.advance(&mut self.terminal, &bytes[..read]);
+                    while let Ok(Event::PtyWrite(reply)) = self.events.try_recv() {
+                        let _ = self.pty.writer().write_all(reply.as_bytes());
+                    }
+                }
+                Err(error) if error.kind() == ErrorKind::WouldBlock => {
+                    thread::sleep(Duration::from_millis(10))
+                }
+                Err(error) => panic!("failed to read shell output: {error}"),
+            }
+        }
+
+        false
+    }
+
+    fn screen(&self) -> String {
+        let grid = self.terminal.grid();
+        (0..grid.screen_lines())
+            .map(|row| {
+                let line = grid[Line(row as i32)]
+                    .into_iter()
+                    .map(|cell| cell.c)
+                    .collect::<String>();
+                line.trim_end().to_owned()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    fn wait_for(&mut self, needle: &str) -> String {
+        let deadline = Instant::now() + TIMEOUT;
+        loop {
+            let screen = self.screen();
+            if screen.contains(needle) {
+                return screen;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "never saw {needle:?}; screen was:\n{screen}"
+            );
+            self.pump(Duration::from_millis(25));
+        }
+    }
+
+    fn close(&mut self) {
+        self.send("exit\n");
+        let deadline = Instant::now() + TIMEOUT;
+        while !self.pump(Duration::from_millis(25)) {
+            assert!(
+                Instant::now() < deadline,
+                "shell did not exit; screen was:\n{}",
+                self.screen(),
+            );
+        }
+    }
+
+    fn abandon(&mut self) {
+        let _ = self.pty.writer().write_all(b"exit\n");
+    }
+}
+
+#[derive(Clone, Copy)]
+enum Shell {
+    Zsh,
+    Fish,
+    Bash,
+    Nushell,
+}
+
+impl Shell {
+    const fn name(self) -> &'static str {
+        match self {
+            Self::Zsh => "zsh",
+            Self::Fish => "fish",
+            Self::Bash => "bash",
+            Self::Nushell => "nu",
+        }
+    }
+
+    const fn input(self) -> &'static str {
+        match self {
+            Self::Nushell => "print (['RESULT', 'typing-survived'] | str join ':')",
+            Self::Zsh | Self::Fish | Self::Bash => "printf 'RESULT:%s\\n' typing-survived",
+        }
+    }
+
+    fn launch(self, fixture: &Fixture) -> Launch {
+        let mut environment = fixture.environment();
+        let (program, args, startup) = match self {
+            Self::Zsh => (
+                PathBuf::from("zsh"),
+                vec!["-f".into(), "-i".into()],
+                Startup::Source("source \"$STARSHIP_INIT\"\n"),
+            ),
+            Self::Fish => (
+                PathBuf::from("fish"),
+                vec!["--interactive".into()],
+                Startup::Source("source \"$STARSHIP_INIT\"\n"),
+            ),
+            Self::Bash => {
+                environment.insert("BLE_SH".into(), ble().display().to_string());
+                (
+                    bash(),
+                    vec![
+                        "--noprofile".into(),
+                        "--rcfile".into(),
+                        fixture.bashrc().display().to_string(),
+                        "-i".into(),
+                    ],
+                    Startup::Ready,
+                )
+            }
+            Self::Nushell => (
+                nushell(),
+                vec!["--config".into(), fixture.init.display().to_string()],
+                Startup::Ready,
+            ),
+        };
+
+        Launch {
+            program,
+            args,
+            startup,
+            environment,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum Startup {
+    Source(&'static str),
+    Ready,
+}
+
+struct Launch {
+    program: PathBuf,
+    args: Vec<String>,
+    startup: Startup,
+    environment: HashMap<String, String>,
+}
+
+fn bash() -> PathBuf {
+    let path = env::var_os("BASH")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("/bin/bash"));
+    let output = Command::new(&path)
+        .arg("--version")
+        .output()
+        .unwrap_or_else(|error| panic!("BASH must name Bash 4+: {}: {error}", path.display()));
+    let major = String::from_utf8_lossy(&output.stdout)
+        .split(|character: char| !character.is_ascii_digit())
+        .find_map(|number| number.parse::<u32>().ok());
+    assert!(
+        output.status.success() && major.is_some_and(|major| major >= 4),
+        "BASH must name Bash 4+: {}",
+        path.display()
+    );
+    path
+}
+
+fn ble() -> PathBuf {
+    let path = env::var_os("BLE_SH")
+        .map(PathBuf::from)
+        .expect("BLE_SH must name ble.sh");
+    assert!(path.is_file(), "BLE_SH is not a file: {}", path.display());
+    path
+}
+
+fn nushell() -> PathBuf {
+    let path = env::var_os("NUSHELL_MAIN")
+        .map(PathBuf::from)
+        .expect("NUSHELL_MAIN must name the Nushell main binary");
+    assert!(
+        path.is_file(),
+        "NUSHELL_MAIN is not a file: {}",
+        path.display()
+    );
+    path
+}
+
+struct Fixture {
+    directory: TempDir,
+    init: PathBuf,
+}
+
+impl Fixture {
+    fn new(shell: Shell) -> Self {
+        let directory = tempfile::tempdir().expect("failed to create scratch directory");
+        fs::write(
+            directory.path().join("starship.toml"),
+            r#"
+format = "${custom.fast}${custom.slow}$character"
+add_newline = false
+
+[custom.fast]
+command = "printf FAST"
+when = true
+format = "[$output]($style) "
+style = "red"
+shell = ["/bin/sh"]
+
+[custom.slow]
+command = "sleep 2; printf SLOW"
+when = true
+format = "[$output]($style) "
+style = "red"
+shell = ["/bin/sh"]
+ignore_timeout = true
+
+[character]
+success_symbol = ">"
+"#,
+        )
+        .expect("failed to write config");
+
+        let init = directory.path().join("starship-init");
+        let mut command = Command::new(starship());
+        command
+            .args(["init", shell.name(), "--print-full-init"])
+            .env("PATH", path_with_starship_first());
+        let output = command
+            .output()
+            .unwrap_or_else(|error| panic!("failed to emit {} init: {error}", shell.name()));
+        assert!(
+            output.status.success(),
+            "failed to emit {} init: {}",
+            shell.name(),
+            String::from_utf8_lossy(&output.stderr),
+        );
+        fs::write(&init, output.stdout).expect("failed to write shell init");
+
+        Self { directory, init }
+    }
+
+    fn bashrc(&self) -> PathBuf {
+        let bashrc = self.directory.path().join("bashrc");
+        fs::write(&bashrc, "source \"$BLE_SH\"\nsource \"$STARSHIP_INIT\"\n")
+            .expect("failed to write Bash rcfile");
+        bashrc
+    }
+
+    fn environment(&self) -> HashMap<String, String> {
+        let xdg = self.directory.path().join("xdg");
+        fs::create_dir_all(xdg.join("fish")).expect("failed to create fish XDG directory");
+
+        let mut environment = HashMap::from([
+            (
+                "STARSHIP_CONFIG".into(),
+                self.directory
+                    .path()
+                    .join("starship.toml")
+                    .display()
+                    .to_string(),
+            ),
+            ("STARSHIP_INIT".into(), self.init.display().to_string()),
+            ("TERM".into(), "xterm-256color".into()),
+            ("PS1".into(), "$ ".into()),
+            ("HOME".into(), self.directory.path().display().to_string()),
+            ("XDG_CONFIG_HOME".into(), xdg.display().to_string()),
+            ("XDG_DATA_HOME".into(), xdg.display().to_string()),
+        ]);
+        if let Some(path) = env::var_os("PATH") {
+            environment.insert("PATH".into(), path.display().to_string());
+        }
+        environment
+    }
+}
+
+fn starship() -> &'static Path {
+    Path::new(env!("CARGO_BIN_EXE_starship"))
+}
+
+fn path_with_starship_first() -> OsString {
+    let bin_directory = starship()
+        .parent()
+        .expect("the Starship test binary has a parent directory");
+    let inherited = env::var_os("PATH")
+        .map(|path| env::split_paths(&path).collect::<Vec<_>>())
+        .unwrap_or_default();
+    env::join_paths(std::iter::once(bin_directory.to_path_buf()).chain(inherited))
+        .expect("PATH entries contain no path separator")
+}
+
+struct Session {
+    pty: Pty,
+    _fixture: Fixture,
+    closed: bool,
+}
+
+impl Session {
+    fn start(shell: Shell) -> Self {
+        let fixture = Fixture::new(shell);
+        let launch = shell.launch(&fixture);
+        let startup = launch.startup;
+        let mut pty = Pty::spawn(launch, fixture.directory.path());
+        if let Startup::Source(command) = startup {
+            pty.send(command);
+        }
+        Self {
+            pty,
+            _fixture: fixture,
+            closed: false,
+        }
+    }
+
+    fn close(&mut self) {
+        self.pty.close();
+        self.closed = true;
+    }
+}
+
+impl Drop for Session {
+    fn drop(&mut self) {
+        if self.closed {
+            return;
+        }
+        self.pty.abandon();
+        self.pty.pump(Duration::from_millis(100));
+    }
+}
+
+fn streams(shell: Shell) {
+    let mut session = Session::start(shell);
+    let first = session.pty.wait_for("FAST");
+    assert!(
+        !first.contains("SLOW"),
+        "first paint waited for SLOW:\n{first}"
+    );
+
+    let input = shell.input();
+    session.pty.send(input);
+    let refined = session.pty.wait_for("SLOW");
+    assert!(refined.contains(input), "refinement lost input:\n{refined}");
+
+    session.pty.send("\n");
+    session.pty.wait_for("RESULT:typing-survived");
+    if matches!(shell, Shell::Nushell) {
+        session
+            .pty
+            .send("let count = job list | where description == starship-stream | length; print $\"JOB_COUNT:($count)\"\n");
+        session.pty.wait_for("JOB_COUNT:0");
+    }
+    session.close();
+}
+
+#[test]
+#[ignore = "requires zsh"]
+fn zsh_streams_a_live_prompt() {
+    streams(Shell::Zsh);
+}
+
+#[test]
+#[ignore = "requires fish"]
+fn fish_streams_a_live_prompt() {
+    streams(Shell::Fish);
+}
+
+#[test]
+#[ignore = "requires BLE_SH and Bash 4+"]
+fn bash_ble_streams_a_live_prompt() {
+    streams(Shell::Bash);
+}
+
+#[test]
+#[ignore = "requires NUSHELL_MAIN"]
+fn nushell_streams_a_live_prompt() {
+    streams(Shell::Nushell);
+}

--- a/tests/init_async.rs
+++ b/tests/init_async.rs
@@ -292,9 +292,8 @@ struct Fixture {
 
 impl Fixture {
     fn new(shell: Shell) -> Self {
-        let directory = tempfile::tempdir().expect("failed to create scratch directory");
-        fs::write(
-            directory.path().join("starship.toml"),
+        Self::with_config(
+            shell,
             r#"
 format = "${custom.fast}${custom.slow}$character"
 add_newline = false
@@ -318,7 +317,11 @@ ignore_timeout = true
 success_symbol = ">"
 "#,
         )
-        .expect("failed to write config");
+    }
+
+    fn with_config(shell: Shell, config: &str) -> Self {
+        let directory = tempfile::tempdir().expect("failed to create scratch directory");
+        fs::write(directory.path().join("starship.toml"), config).expect("failed to write config");
 
         let init = directory.path().join("starship-init");
         let mut command = Command::new(starship());
@@ -396,7 +399,14 @@ struct Session {
 
 impl Session {
     fn start(shell: Shell) -> Self {
-        let fixture = Fixture::new(shell);
+        Self::start_with_fixture(shell, Fixture::new(shell))
+    }
+
+    fn start_with_config(shell: Shell, config: &str) -> Self {
+        Self::start_with_fixture(shell, Fixture::with_config(shell, config))
+    }
+
+    fn start_with_fixture(shell: Shell, fixture: Fixture) -> Self {
         let launch = shell.launch(&fixture);
         let startup = launch.startup;
         let mut pty = Pty::spawn(launch, fixture.directory.path());
@@ -454,6 +464,73 @@ fn streams(shell: Shell) {
 #[ignore = "requires zsh"]
 fn zsh_streams_a_live_prompt() {
     streams(Shell::Zsh);
+}
+
+/// Regression test: `right_format` must stream and repaint on its own, the
+/// same as `format` does — never recomputed once per prompt draw via a
+/// blocking synchronous `starship prompt --right` call. Each shell that can
+/// refine the right prompt (zsh, fish, and bash through ble.sh) drives its
+/// own independent right-prompt stream. A live clock placed in the right
+/// prompt advances with no input sent, proving the stream is running.
+fn right_prompt_ticks_on_its_own(shell: Shell) {
+    let mut session = Session::start_with_config(
+        shell,
+        r#"
+format = "MARK$character"
+add_newline = false
+
+right_format = "$time"
+
+[character]
+success_symbol = ">"
+
+[time]
+disabled = false
+format = "[$time]($style)"
+style = ""
+time_format = "%S%.6f"
+
+[async.dynamic]
+time = 30
+"#,
+    );
+
+    session.pty.wait_for("MARK");
+    session.pty.pump(Duration::from_millis(50));
+    let first = session.pty.screen();
+
+    let deadline = Instant::now() + TIMEOUT;
+    loop {
+        session.pty.pump(Duration::from_millis(25));
+        let later = session.pty.screen();
+        if later != first {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "right prompt never changed on its own, with no input sent:\n{first}"
+        );
+    }
+
+    session.close();
+}
+
+#[test]
+#[ignore = "requires zsh"]
+fn zsh_right_prompt_ticks_on_its_own() {
+    right_prompt_ticks_on_its_own(Shell::Zsh);
+}
+
+#[test]
+#[ignore = "requires fish"]
+fn fish_right_prompt_ticks_on_its_own() {
+    right_prompt_ticks_on_its_own(Shell::Fish);
+}
+
+#[test]
+#[ignore = "requires BLE_SH and Bash 4+"]
+fn bash_ble_right_prompt_ticks_on_its_own() {
+    right_prompt_ticks_on_its_own(Shell::Bash);
 }
 
 #[test]

--- a/typos.toml
+++ b/typos.toml
@@ -10,5 +10,6 @@ typ = "typ"
 extentions = "extentions" # TODO: should be extensions
 worl = "worl" # typo on purpose
 rela = "rela"
+awsome = "awsome" # typo on purpose: an aws-lookalike module name that must not parse
 [files]
 extend-exclude = ["CHANGELOG.md", "docs/*"]


### PR DESCRIPTION
**Stack:** [#7705](https://github.com/starship/starship/pull/7705) --> [#7706](https://github.com/starship/starship/pull/7706) --> [#7707](https://github.com/starship/starship/pull/7707) --> **#7708 (this PR)** --> [#7709](https://github.com/starship/starship/pull/7709)

### Summary

Add asynchronous prompt refinement for bash with ble.sh, and validate the integrations against real interactive shells in pseudo-terminals.

### Changes

- Stream bash refinements through ble.sh and retain synchronous behavior for ordinary bash.
- Render left and right prompts through one renderer process, avoiding an unnecessary second render.
- Add a pseudo-terminal test harness for real shell integrations.
- Run the streaming-shell tests in CI.
- Add a runnable streaming demonstration configuration and launcher.

### Requirements

Bash streaming requires ble.sh 4.0 or later. Without ble.sh, Starship renders the completed prompt synchronously.
