### PR TITLE
fix(directory): render symlinks pointing into a repo subdirectory

### DIFF
--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -110,13 +110,15 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         String::new()
     };
 
+    // the whole path in one segment, with no repo root to highlight
+    let unsplit = |prefix: String| [String::new(), String::new(), prefix + dir_string.as_str()];
+
     let path_vec = match &repo.and_then(|r| r.workdir.as_ref()) {
         Some(repo_root) if config.repo_root_style.is_some() => {
             // The logical path need not lie under the repo root even though the
             // repo was found: a symlink pointing sideways into a subdirectory of
             // the repo resolves into it without sharing a prefix with it, and so
-            // has no contracted form. Render it like any other path instead of
-            // giving up, which used to blank the whole module.
+            // has no contracted form, which is the None case here.
             match contract_repo_path(display_dir, repo_root) {
                 Some(contracted_path) => {
                     let repo_path_vec: Vec<&str> = contracted_path.split('/').collect();
@@ -130,13 +132,13 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                         let before = before_root_dir(&dir_string, &contracted_path);
                         [prefix + before, root.to_string(), after_repo_root]
                     } else {
-                        [String::new(), String::new(), prefix + dir_string.as_str()]
+                        unsplit(prefix)
                     }
                 }
-                None => [String::new(), String::new(), prefix + dir_string.as_str()],
+                None => unsplit(prefix),
             }
         }
-        _ => [String::new(), String::new(), prefix + dir_string.as_str()],
+        _ => unsplit(prefix),
     };
 
     let path_vec = if config.use_os_path_sep {
@@ -581,6 +583,36 @@ mod tests {
             symlink(&src_dir, &symlink_dir)?;
 
             let actual = ModuleRenderer::new("directory")
+                .env("HOME", tmp_dir.path().to_str().unwrap())
+                .path(symlink_dir)
+                .collect();
+            let expected = Some(format!("{} ", Color::Cyan.bold().paint("~/fuel-gauge")));
+
+            assert_eq!(expected, actual);
+
+            tmp_dir.close()
+        }
+
+        #[test]
+        #[ignore]
+        fn highlight_git_root_dir_symlinked_out_of_tree() -> io::Result<()> {
+            // Same shape as above, but with repo_root_style set, which is what
+            // selects the contracting branch. The symlink resolves into the repo
+            // without sharing a prefix with it, so there is no contracted form,
+            // and that used to abandon the module and print nothing at all.
+            let tmp_dir = TempDir::new_in(home_dir().unwrap().as_path())?;
+            let repo_dir = tmp_dir.path().join("above-repo").join("rocket-controls");
+            let src_dir = repo_dir.join("src/meters/fuel-gauge");
+            let symlink_dir = tmp_dir.path().join("fuel-gauge");
+            fs::create_dir_all(&src_dir)?;
+            init_repo(&repo_dir)?;
+            symlink(&src_dir, &symlink_dir)?;
+
+            let actual = ModuleRenderer::new("directory")
+                .config(toml::toml! {
+                    [directory]
+                    repo_root_style = "bold red"
+                })
                 .env("HOME", tmp_dir.path().to_str().unwrap())
                 .path(symlink_dir)
                 .collect();
@@ -1771,36 +1803,6 @@ mod tests {
             Color::Cyan.paint(convert_path_sep("/src/sub/path"))
         ));
         assert_eq!(expected, actual);
-        tmp_dir.close()
-    }
-
-    #[test]
-    #[ignore]
-    fn highlight_git_root_dir_symlinked_out_of_tree() -> io::Result<()> {
-        // A symlink pointing sideways into a subdirectory of the repo resolves
-        // into it without sharing a prefix with it, so the path has no
-        // contracted form relative to the repo root. That used to abandon the
-        // whole module and print nothing at all.
-        let tmp_dir = TempDir::new_in(home_dir().unwrap().as_path())?;
-        let repo_dir = tmp_dir.path().join("above-repo").join("rocket-controls");
-        let src_dir = repo_dir.join("src/meters/fuel-gauge");
-        let symlink_dir = tmp_dir.path().join("fuel-gauge");
-        fs::create_dir_all(&src_dir)?;
-        init_repo(&repo_dir)?;
-        symlink(&src_dir, &symlink_dir)?;
-
-        let actual = ModuleRenderer::new("directory")
-            .config(toml::toml! {
-                [directory]
-                repo_root_style = "bold red"
-            })
-            .env("HOME", tmp_dir.path().to_str().unwrap())
-            .path(symlink_dir)
-            .collect();
-        let expected = Some(format!("{} ", Color::Cyan.bold().paint("~/fuel-gauge")));
-
-        assert_eq!(expected, actual);
-
         tmp_dir.close()
     }
 

--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -112,19 +112,28 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
     let path_vec = match &repo.and_then(|r| r.workdir.as_ref()) {
         Some(repo_root) if config.repo_root_style.is_some() => {
-            let contracted_path = contract_repo_path(display_dir, repo_root)?;
-            let repo_path_vec: Vec<&str> = contracted_path.split('/').collect();
-            let after_repo_root = contracted_path.replacen(repo_path_vec[0], "", 1);
-            let num_segments_after_root = after_repo_root.split('/').count();
+            // The logical path need not lie under the repo root even though the
+            // repo was found: a symlink pointing sideways into a subdirectory of
+            // the repo resolves into it without sharing a prefix with it, and so
+            // has no contracted form. Render it like any other path instead of
+            // giving up, which used to blank the whole module.
+            match contract_repo_path(display_dir, repo_root) {
+                Some(contracted_path) => {
+                    let repo_path_vec: Vec<&str> = contracted_path.split('/').collect();
+                    let after_repo_root = contracted_path.replacen(repo_path_vec[0], "", 1);
+                    let num_segments_after_root = after_repo_root.split('/').count();
 
-            if config.truncation_length == 0
-                || ((num_segments_after_root - 1) as i64) < config.truncation_length
-            {
-                let root = repo_path_vec[0];
-                let before = before_root_dir(&dir_string, &contracted_path);
-                [prefix + before, root.to_string(), after_repo_root]
-            } else {
-                [String::new(), String::new(), prefix + dir_string.as_str()]
+                    if config.truncation_length == 0
+                        || ((num_segments_after_root - 1) as i64) < config.truncation_length
+                    {
+                        let root = repo_path_vec[0];
+                        let before = before_root_dir(&dir_string, &contracted_path);
+                        [prefix + before, root.to_string(), after_repo_root]
+                    } else {
+                        [String::new(), String::new(), prefix + dir_string.as_str()]
+                    }
+                }
+                None => [String::new(), String::new(), prefix + dir_string.as_str()],
             }
         }
         _ => [String::new(), String::new(), prefix + dir_string.as_str()],
@@ -1762,6 +1771,36 @@ mod tests {
             Color::Cyan.paint(convert_path_sep("/src/sub/path"))
         ));
         assert_eq!(expected, actual);
+        tmp_dir.close()
+    }
+
+    #[test]
+    #[ignore]
+    fn highlight_git_root_dir_symlinked_out_of_tree() -> io::Result<()> {
+        // A symlink pointing sideways into a subdirectory of the repo resolves
+        // into it without sharing a prefix with it, so the path has no
+        // contracted form relative to the repo root. That used to abandon the
+        // whole module and print nothing at all.
+        let tmp_dir = TempDir::new_in(home_dir().unwrap().as_path())?;
+        let repo_dir = tmp_dir.path().join("above-repo").join("rocket-controls");
+        let src_dir = repo_dir.join("src/meters/fuel-gauge");
+        let symlink_dir = tmp_dir.path().join("fuel-gauge");
+        fs::create_dir_all(&src_dir)?;
+        init_repo(&repo_dir)?;
+        symlink(&src_dir, &symlink_dir)?;
+
+        let actual = ModuleRenderer::new("directory")
+            .config(toml::toml! {
+                [directory]
+                repo_root_style = "bold red"
+            })
+            .env("HOME", tmp_dir.path().to_str().unwrap())
+            .path(symlink_dir)
+            .collect();
+        let expected = Some(format!("{} ", Color::Cyan.bold().paint("~/fuel-gauge")));
+
+        assert_eq!(expected, actual);
+
         tmp_dir.close()
     }
 

--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -110,35 +110,34 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
         String::new()
     };
 
-    // the whole path in one segment, with no repo root to highlight
-    let unsplit = |prefix: String| [String::new(), String::new(), prefix + dir_string.as_str()];
+    // The path is only split around the repo root when there is a root to
+    // highlight and the logical path actually lies under it. A symlink pointing
+    // sideways into a subdirectory of the repo resolves into it without sharing
+    // a prefix with it, so it has no contracted form and is not split.
+    let split_at_repo_root = repo
+        .and_then(|r| r.workdir.as_ref())
+        .filter(|_| config.repo_root_style.is_some())
+        .and_then(|repo_root| contract_repo_path(display_dir, repo_root))
+        .and_then(|contracted_path| {
+            let repo_path_vec: Vec<&str> = contracted_path.split('/').collect();
+            let after_repo_root = contracted_path.replacen(repo_path_vec[0], "", 1);
+            let num_segments_after_root = after_repo_root.split('/').count();
 
-    let path_vec = match &repo.and_then(|r| r.workdir.as_ref()) {
-        Some(repo_root) if config.repo_root_style.is_some() => {
-            // The logical path need not lie under the repo root even though the
-            // repo was found: a symlink pointing sideways into a subdirectory of
-            // the repo resolves into it without sharing a prefix with it, and so
-            // has no contracted form, which is the None case here.
-            match contract_repo_path(display_dir, repo_root) {
-                Some(contracted_path) => {
-                    let repo_path_vec: Vec<&str> = contracted_path.split('/').collect();
-                    let after_repo_root = contracted_path.replacen(repo_path_vec[0], "", 1);
-                    let num_segments_after_root = after_repo_root.split('/').count();
+            (config.truncation_length == 0
+                || ((num_segments_after_root - 1) as i64) < config.truncation_length)
+                .then(|| {
+                    [
+                        before_root_dir(&dir_string, &contracted_path).to_string(),
+                        repo_path_vec[0].to_string(),
+                        after_repo_root,
+                    ]
+                })
+        });
 
-                    if config.truncation_length == 0
-                        || ((num_segments_after_root - 1) as i64) < config.truncation_length
-                    {
-                        let root = repo_path_vec[0];
-                        let before = before_root_dir(&dir_string, &contracted_path);
-                        [prefix + before, root.to_string(), after_repo_root]
-                    } else {
-                        unsplit(prefix)
-                    }
-                }
-                None => unsplit(prefix),
-            }
-        }
-        _ => unsplit(prefix),
+    let path_vec = match split_at_repo_root {
+        Some([before_root, root, after_root]) => [prefix + &before_root, root, after_root],
+        // the whole path in one segment, with no repo root to highlight
+        None => [String::new(), String::new(), prefix + dir_string.as_str()],
     };
 
     let path_vec = if config.use_os_path_sep {


### PR DESCRIPTION
Fixes #7714.

A symlink that points sideways into a subdirectory of a repository resolves into that repository, so the repo is found, but the logical path shares no prefix with the repo root and therefore has no contracted form. `contract_repo_path` returns `None`, and the `?` on that call propagated out of `module()` itself, so nothing was rendered at all.

Reproducing with `~/code/example` symlinked to `~/code/me/private`, where `~/code/me` is the repo:

```
                              no repo_root_style      with repo_root_style
  real subdir  (me/private)   me/private              me/private
  via symlink  (example)      code/example            <nothing>
```

Only the last cell is wrong, and it needs `repo_root_style` to be set, since that is what selects this branch of the match. That is why the existing `symlinked_subdirectory_git_repo_out_of_tree` test does not catch it: without `repo_root_style` the path goes through the `_` arm, which has no `?`.

The fix is the one suggested on the issue: fall back to the plain path, matching what the neighbouring arms of the same match already do for the cases they cannot contract. The symlink then renders as `code/example`, and repo-root highlighting is unaffected for paths that genuinely sit under the root.

The new test is `#[ignore]`d like the other symlink tests, so it still runs under the coverage job, which passes `--include-ignored`. Reverting the `directory.rs` change with the test in place fails with `right: None`, which is the reported symptom exactly.

`cargo fmt` and `cargo clippy --all-targets` are clean, and all 65 directory tests pass. The only failures in the full run are the `hg_branch` and `hg_state` suites, which fail the same way on a pristine checkout here because Mercurial is not installed.
