### PR TITLE
docs: fix Catppuccin spelling in the preset guide

### DIFF
--- a/docs/presets/catppuccin-powerline.md
+++ b/docs/presets/catppuccin-powerline.md
@@ -16,7 +16,7 @@ This preset is a minimally modified version of [Gruvbox Rainbow](./gruvbox-rainb
 starship preset catppuccin-powerline -o ~/.config/starship.toml
 ```
 
-By default this preset uses the Mocha flavour of Catppucin, but you can specify any of the flavours by modifying the value of `palette`:
+By default this preset uses the Mocha flavour of Catppuccin, but you can specify any of the flavours by modifying the value of `palette`:
 
 - `catppuccin_mocha`
 - `catppuccin_frappe`


### PR DESCRIPTION
The Catppuccin Powerline preset guide misspells the theme name as "Catppucin" once:

> By default this preset uses the Mocha flavour of Catppucin

The same file already uses the correct spelling "Catppuccin" in its heading and in the link to [github.com/catppuccin/catppuccin](https://github.com/catppuccin/catppuccin), so this aligns that one occurrence.
