### PR TITLE
feat: add `jj_metrics` module

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -991,6 +991,16 @@
         "disabled": false
       }
     },
+    "jj_metrics": {
+      "$ref": "#/$defs/JJMetricsConfig",
+      "default": {
+        "added_style": "bold green",
+        "deleted_style": "bold red",
+        "only_nonzero_diffs": true,
+        "format": "([+$added]($added_style) )([-$deleted]($deleted_style) )",
+        "disabled": false
+      }
+    },
     "jobs": {
       "$ref": "#/$defs/JobsConfig",
       "default": {
@@ -4582,6 +4592,37 @@
         },
         "disabled": {
           "description": "Disable the module",
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "JJMetricsConfig": {
+      "type": "object",
+      "properties": {
+        "added_style": {
+          "description": "Value of the `$added_style` variable in the format string",
+          "type": "string",
+          "default": "bold green"
+        },
+        "deleted_style": {
+          "description": "Value of the `$deleted_style` variable in the format string",
+          "type": "string",
+          "default": "bold red"
+        },
+        "only_nonzero_diffs": {
+          "description": "Render only for changed items",
+          "type": "boolean",
+          "default": true
+        },
+        "format": {
+          "description": "Format string for the module",
+          "type": "string",
+          "default": "([+$added]($added_style) )([-$deleted]($deleted_style) )"
+        },
+        "disabled": {
+          "description": "Disable the `jj_metrics`",
           "type": "boolean",
           "default": false
         }

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2653,6 +2653,41 @@ prefix is always correctly displayed
 format = "($change:$commit) "
 ```
 
+## JJ Metrics
+
+The `jj_metrics` module shows the number of added and deleted lines in the current [Jujutsu](https://docs.jj-vcs.dev/) repository.
+
+### Options
+
+| Option               | Default                                                      | Description                           |
+| -------------------- | ------------------------------------------------------------ | ------------------------------------- |
+| `added_style`        | `'bold green'`                                               | The style for the added count.        |
+| `deleted_style`      | `'bold red'`                                                 | The style for the deleted count.      |
+| `only_nonzero_diffs` | `true`                                                       | Render status only for changed items. |
+| `format`             | `'([+$added]($added_style) )([-$deleted]($deleted_style) )'` | The format for the module.            |
+| `disabled`           | `false`                                                      | Disables the `jj_metrics` module.     |
+
+### Variables
+
+| Variable        | Example | Description                                 |
+| --------------- | ------- | ------------------------------------------- |
+| added           | `1`     | The current number of added lines           |
+| deleted         | `2`     | The current number of deleted lines         |
+| added_style\*   |         | Mirrors the value of option `added_style`   |
+| deleted_style\* |         | Mirrors the value of option `deleted_style` |
+
+*: This variable can only be used as a part of a style string
+
+### Example
+
+```toml
+# ~/.config/starship.toml
+
+[jj_metrics]
+added_style = 'bold blue'
+format = '[+$added]($added_style)/[-$deleted]($deleted_style) '
+```
+
 ## Jobs
 
 The `jobs` module shows the current number of jobs running.

--- a/docs/public/presets/toml/bracketed-segments.toml
+++ b/docs/public/presets/toml/bracketed-segments.toml
@@ -132,6 +132,9 @@ format = '\[[$symbol$bookmark(@$remote)$diverged( \(+$overflow_count others\))](
 [jj_change]
 format = '\[[\($change\)]($style)\]'
 
+[jj_metrics]
+format = '(\[[+$added]($added_style)\])(\[[-$deleted]($deleted_style)\])'
+
 [jobs]
 format = '\[[$symbol$number]($style)\]'
 

--- a/docs/public/presets/toml/jetpack.toml
+++ b/docs/public/presets/toml/jetpack.toml
@@ -317,6 +317,11 @@ truncation_symbol = "⋯"
 truncation_length = 11
 ignore_names = ["main", "master"]
 
+[jj_metrics]
+format = '([▴$added]($added_style))([▿$deleted]($deleted_style))'
+added_style = 'italic dimmed green'
+deleted_style = 'italic dimmed red'
+
 [julia]
 symbol = "◎ "
 format = " jl [$symbol($version )]($style)"

--- a/src/configs/jj_metrics.rs
+++ b/src/configs/jj_metrics.rs
@@ -1,0 +1,33 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(
+    feature = "config-schema",
+    derive(schemars::JsonSchema),
+    schemars(deny_unknown_fields)
+)]
+#[serde(default)]
+pub struct JJMetricsConfig<'a> {
+    /// Value of the `$added_style` variable in the format string
+    pub added_style: &'a str,
+    /// Value of the `$deleted_style` variable in the format string
+    pub deleted_style: &'a str,
+    /// Render only for changed items
+    pub only_nonzero_diffs: bool,
+    /// Format string for the module
+    pub format: &'a str,
+    /// Disable the `jj_metrics`
+    pub disabled: bool,
+}
+
+impl Default for JJMetricsConfig<'_> {
+    fn default() -> Self {
+        Self {
+            added_style: "bold green",
+            deleted_style: "bold red",
+            only_nonzero_diffs: true,
+            format: "([+$added]($added_style) )([-$deleted]($deleted_style) )",
+            disabled: false,
+        }
+    }
+}

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -55,6 +55,7 @@ pub mod hostname;
 pub mod java;
 pub mod jj_bookmark;
 pub mod jj_change;
+pub mod jj_metrics;
 pub mod jobs;
 pub mod julia;
 pub mod kotlin;
@@ -233,6 +234,8 @@ pub struct FullConfig<'a> {
     jj_bookmark: jj_bookmark::JJBookmarkConfig<'a>,
     #[serde(borrow)]
     jj_change: jj_change::JJChangeConfig<'a>,
+    #[serde(borrow)]
+    jj_metrics: jj_metrics::JJMetricsConfig<'a>,
     #[serde(borrow)]
     jobs: jobs::JobsConfig<'a>,
     #[serde(borrow)]

--- a/src/context/jj_repo.rs
+++ b/src/context/jj_repo.rs
@@ -318,6 +318,10 @@ impl JJRepo {
     pub const CHANGE_DIVERGENT: &str = "/jj/change/divergent";
     pub const CHANGE_NOT_ASCII: &str = "/jj/change/not-ascii";
 
+    pub const METRIC_ADDED: &str = "/jj/metrics-added";
+    pub const METRIC_DELETED: &str = "/jj/metrics-deleted";
+    pub const METRIC_ZERO: &str = "/jj/metrics-zero";
+
     pub const NONE: &str = "/jj/no-repo";
 }
 
@@ -438,6 +442,26 @@ pub fn mock_jj_cmd(s: &str) -> Option<crate::utils::CommandOutput> {
             JJRepo::CHANGE_NOT_ASCII,
             || output([
                 (CHANGE, "Étxwmvtttmrkkoqkutlystlnozssmnk"),
+            ]),
+        ),
+        // Repos testing jj_metrics rendering
+        (
+            JJRepo::METRIC_ADDED,
+            || output([
+                (LINES_D, "0"),
+            ]),
+        ),
+        (
+            JJRepo::METRIC_DELETED,
+            || output([
+                (LINES_A, "0")
+            ]),
+        ),
+        (
+            JJRepo::METRIC_ZERO,
+            || output([
+                (LINES_A, "0"),
+                (LINES_D, "0"),
             ]),
         ),
         // Used to test the parsing will correctly fail on empty stdout

--- a/src/module.rs
+++ b/src/module.rs
@@ -59,6 +59,7 @@ pub const ALL_MODULES: &[&str] = &[
     "java",
     "jj_bookmark",
     "jj_change",
+    "jj_metrics",
     "jobs",
     "julia",
     "kotlin",

--- a/src/modules/jj_metrics.rs
+++ b/src/modules/jj_metrics.rs
@@ -1,0 +1,49 @@
+use super::{Context, Module, ModuleConfig};
+
+use crate::configs::jj_metrics::JJMetricsConfig;
+use crate::formatter::StringFormatter;
+
+/// Creates a module with the JJ metrics in the current repository
+pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let mut module = context.new_module("jj_metrics");
+    let config = JJMetricsConfig::try_load(module.config);
+
+    if config.disabled {
+        return None;
+    }
+
+    let current_change = context.get_jj_repo()?.current_change(context)?;
+
+    let render_value = |value: u32| {
+        if config.only_nonzero_diffs && value == 0 {
+            return None;
+        }
+
+        Some(Ok(value.to_string()))
+    };
+
+    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
+        formatter
+            .map_style(|variable| match variable {
+                "added_style" => Some(Ok(config.added_style)),
+                "deleted_style" => Some(Ok(config.deleted_style)),
+                _ => None,
+            })
+            .map(|variable| match variable {
+                "added" => render_value(current_change.lines_added),
+                "deleted" => render_value(current_change.lines_removed),
+                _ => None,
+            })
+            .parse(None, Some(context))
+    });
+
+    module.set_segments(match parsed {
+        Ok(segments) => segments,
+        Err(error) => {
+            log::warn!("Error in module `jj_metrics`:\n{error}");
+            return None;
+        }
+    });
+
+    Some(module)
+}

--- a/src/modules/jj_metrics.rs
+++ b/src/modules/jj_metrics.rs
@@ -47,3 +47,106 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
     Some(module)
 }
+
+#[cfg(test)]
+mod tests {
+    use nu_ansi_term::Color;
+    use toml::toml;
+
+    use crate::context::JJRepo;
+    use crate::test::JJTester;
+
+    fn tester(repo: &'static str) -> JJTester {
+        JJTester::new("jj_metrics").repo(repo)
+    }
+
+    #[test]
+    fn test_render_basics() {
+        JJTester::basic_tests("jj_metrics");
+    }
+
+    #[test]
+    fn test_render_default_config() {
+        tester(JJRepo::BASE)
+            .expected(format!(
+                "{} {} ",
+                Color::Green.bold().paint("+100"),
+                Color::Red.bold().paint("-90")
+            ))
+            .render();
+    }
+
+    #[test]
+    fn test_render_style() {
+        tester(JJRepo::BASE)
+            .options(toml! {
+                added_style = "italic blue"
+                deleted_style = "italic yellow"
+            })
+            .expected(format!(
+                "{} {} ",
+                Color::Blue.italic().paint("+100"),
+                Color::Yellow.italic().paint("-90")
+            ))
+            .render();
+    }
+
+    #[test]
+    fn test_render_format() {
+        tester(JJRepo::BASE)
+            .options(toml! {
+                format = "(-$deleted)/(+$added)"
+            })
+            .expected("-90/+100")
+            .render();
+    }
+
+    #[test]
+    fn test_render_only_added() {
+        tester(JJRepo::METRIC_ADDED)
+            .options(toml! {
+                format = "(+$added )(-$deleted )"
+            })
+            .expected("+100 ")
+            .render();
+
+        tester(JJRepo::METRIC_ADDED)
+            .options(toml! {
+                format = "(+$added )(-$deleted )"
+                only_nonzero_diffs = false
+            })
+            .expected("+100 -0 ")
+            .render();
+    }
+
+    #[test]
+    fn test_render_only_deleted() {
+        tester(JJRepo::METRIC_DELETED)
+            .options(toml! {
+                format = "(+$added )(-$deleted )"
+            })
+            .expected("-90 ")
+            .render();
+
+        tester(JJRepo::METRIC_DELETED)
+            .options(toml! {
+                format = "(+$added )(-$deleted )"
+                only_nonzero_diffs = false
+            })
+            .expected("+0 -90 ")
+            .render();
+    }
+
+    #[test]
+    fn test_render_zero_diffs() {
+        tester(JJRepo::METRIC_ZERO)
+            .options(toml! {
+                format = "(+$added )(-$deleted )"
+                only_nonzero_diffs = false
+            })
+            .expected("+0 -0 ")
+            .render();
+
+        tester(JJRepo::METRIC_ZERO).render();
+    }
+}

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -52,6 +52,7 @@ mod hostname;
 mod java;
 mod jj_bookmark;
 mod jj_change;
+mod jj_metrics;
 mod jobs;
 mod julia;
 mod kotlin;
@@ -178,6 +179,7 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
             "java" => java::module(context),
             "jj_bookmark" => jj_bookmark::module(context),
             "jj_change" => jj_change::module(context),
+            "jj_metrics" => jj_metrics::module(context),
             "jobs" => jobs::module(context),
             "julia" => julia::module(context),
             "kotlin" => kotlin::module(context),
@@ -319,6 +321,7 @@ pub fn description(module: &str) -> &'static str {
         "java" => "The currently installed version of Java",
         "jj_bookmark" => "The closest ancestor bookmark in Jujutsu",
         "jj_change" => "The current change in Jujutsu",
+        "jj_metrics" => "The number of added and deleted lines in Jujutsu",
         "jobs" => "The current number of jobs running",
         "julia" => "The currently installed version of Julia",
         "kotlin" => "The currently installed version of Kotlin",


### PR DESCRIPTION
**See https://github.com/starship/starship/pull/7612 for the full MR with every changes, this MR has been extracted from it to make review easier.**

Adds `jj_metrics` in two commits, one for the module implementation and one for the rendering tests

Each commit can be reviewed on its own, they all pass tests and formatting.