### PR TITLE
docs: correct documented defaults for direnv style and fortran

### DIFF
--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -1303,7 +1303,7 @@ The `direnv` module shows the status of the current rc file if one is present. T
 | ------------------- | -------------------------------------- | ------------------------------------------------------- |
 | `format`            | `'[$symbol$loaded/$allowed]($style) '` | The format for the module.                              |
 | `symbol`            | `'direnv '`                            | The symbol used before displaying the direnv context.   |
-| `style`             | `'bold orange'`                        | The style for the module.                               |
+| `style`             | `'bold bright-yellow'`                 | The style for the module.                               |
 | `disabled`          | `true`                                 | Disables the `direnv` module.                           |
 | `detect_extensions` | `[]`                                   | Which extensions should trigger this module.            |
 | `detect_files`      | `['.envrc']`                           | Which filenames should trigger this module.             |
@@ -1712,8 +1712,8 @@ The `fortran` module shows the current compiler version of Fortran.
 
 | Option              | Default                                                                                                                     | Description                                                               |
 | ------------------- | --------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| `symbol`            | `' '`                                                                                                                      | The symbol used before displaying the version of Fortran.                 |
-| `format`            | `'via [$symbol($version )]($style)'`                                                                                        | The format for the module.                                                |
+| `symbol`            | `'🅵  '`                                                                                                                     | The symbol used before displaying the version of Fortran.                 |
+| `format`            | `'via [$symbol($version(-$name) )]($style)'`                                                                                | The format for the module.                                                |
 | `version_format`    | `'${raw}'`                                                                                                                  | The version format. Available vars are `raw`, `major`, `minor`, & `patch` |
 | `style`             | `'bold purple'`                                                                                                             | The style for the module.                                                 |
 | `detect_extensions` | `['f', 'F', 'for', 'FOR', 'ftn', 'FTN', 'f77', 'F77', 'f90', 'F90', 'f95', 'F95','f03', 'F03', 'f08', 'F08', 'f18', 'F18']` | Which extensions should trigger this module.                              |


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- To help with semantic versioning the PR title should start with one of the conventional commit types. -->
<!--- The conventional commit types for Semantic PR are: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert -->

#### Description
<!--- Describe your changes in detail -->

Three default values in the configuration reference do not match what the modules use.

`direnv.style` is documented as `'bold orange'`. #5969 changed the source to `bright-yellow` ("replace nonexistent 'orange' color with 'bright-yellow'") and the docs table kept the old value. `orange` is not one of the sixteen names `parse_color_string` accepts, and `parse_style` folds the tokens with an `Option`, so an unparseable colour discards the whole style rather than just that token.

`fortran.symbol` is documented as U+E7DE, which is what `nerd-font-symbols.toml` sets for the module, not its default.

`fortran.format` is documented without the `(-$name)` group, which is the only reason the `$name` variable listed below it renders.

`.github/config-schema.json` agrees with the source on all three, so the reference is the lone outlier.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #

No open issue. Found by comparing every default in `docs/config/README.md` against `src/configs/`.

#### Screenshots (if appropriate):

N/A, the change is three cells in the docs tables.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
<!--- Most changes do not need to be tested on multiple operating systems. -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

Docs-only, so nothing here is platform-specific and the other two boxes are left unticked rather than claimed.

`dprint check` and `typos` pass on the changed file. The `orange` claim was checked against the parser rather than inferred: a temporary test asserting `<StyleWrapper>::from_config(&Value::from("bold orange")).is_err()` passed, and `"bold bright-yellow"` parsed to bold + `Color::LightYellow`. That test was reverted and is not in this diff.

#### AI-Assistance
<!-- Per our AI Policy (AI_POLICY.md), all AI usage must be declared. -->
Have you used AI-assistance to author this PR?

- [x] Yes
- [ ] No

If **yes**, describe the scope of assistance:
<!--- Describe how you used AI-Assistance -->
<!--- Disclosure is required if you have used AI-assistance -->
<!--- For example: answering project questions, writing tests, implementation, or documentation -->

Full scope: the audit that found these three values, the diff, this description, and the commit message were all written by Claude Opus 5 running in Claude Code, on my machine and under my direction. Not an unattended loop.

To be accurate about the human-in-the-loop requirement rather than just ticking the box: I have not yet read the diff line by line myself. It is three table cells, and I will confirm on this thread before you spend review time on it. I would rather say that than assert a review I have not done.

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
- [ ] I understand and have read the code I contribute and can answer questions about it.
