### PR TITLE
fix(directory): fallback to uncontracted path for symlink into repo subdir

### DIFF
--- a/src/modules/directory.rs
+++ b/src/modules/directory.rs
@@ -112,17 +112,20 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
     let path_vec = match &repo.and_then(|r| r.workdir.as_ref()) {
         Some(repo_root) if config.repo_root_style.is_some() => {
-            let contracted_path = contract_repo_path(display_dir, repo_root)?;
-            let repo_path_vec: Vec<&str> = contracted_path.split('/').collect();
-            let after_repo_root = contracted_path.replacen(repo_path_vec[0], "", 1);
-            let num_segments_after_root = after_repo_root.split('/').count();
+            if let Some(contracted_path) = contract_repo_path(display_dir, repo_root) {
+                let repo_path_vec: Vec<&str> = contracted_path.split('/').collect();
+                let after_repo_root = contracted_path.replacen(repo_path_vec[0], "", 1);
+                let num_segments_after_root = after_repo_root.split('/').count();
 
-            if config.truncation_length == 0
-                || ((num_segments_after_root - 1) as i64) < config.truncation_length
-            {
-                let root = repo_path_vec[0];
-                let before = before_root_dir(&dir_string, &contracted_path);
-                [prefix + before, root.to_string(), after_repo_root]
+                if config.truncation_length == 0
+                    || ((num_segments_after_root - 1) as i64) < config.truncation_length
+                {
+                    let root = repo_path_vec[0];
+                    let before = before_root_dir(&dir_string, &contracted_path);
+                    [prefix + before, root.to_string(), after_repo_root]
+                } else {
+                    [String::new(), String::new(), prefix + dir_string.as_str()]
+                }
             } else {
                 [String::new(), String::new(), prefix + dir_string.as_str()]
             }
@@ -1819,6 +1822,66 @@ mod tests {
             )),
             Color::Green.prefix(),
             Color::Cyan.bold().paint(convert_path_sep("/src/sub/path"))
+        ));
+        assert_eq!(expected, actual);
+        tmp_dir.close()
+    }
+
+    #[test]
+    fn highlight_git_root_dir_symlink_into_repo_subdir() -> io::Result<()> {
+        let (tmp_dir, _) = make_known_tempdir(Path::new("/tmp"))?;
+        let repo_dir = tmp_dir.path().join("above").join("repo");
+        let dir = repo_dir.join("src/sub/path");
+        fs::create_dir_all(&dir)?;
+        init_repo(&repo_dir).unwrap();
+
+        let symlink_dir = tmp_dir.path().join("symlink_dir");
+        symlink(&dir, &symlink_dir)?;
+
+        let actual = ModuleRenderer::new("directory")
+            .config(toml::toml! {
+                [directory]
+                truncation_length = 0
+                truncate_to_repo = false
+                repo_root_style = "bold red"
+            })
+            .path(&symlink_dir)
+            .collect();
+        let expected = Some(format!(
+            "{} ",
+            Color::Cyan
+                .bold()
+                .paint(convert_path_sep(symlink_dir.to_str().unwrap()))
+        ));
+        assert_eq!(expected, actual);
+        tmp_dir.close()
+    }
+
+    #[test]
+    fn highlight_git_root_dir_symlink_into_repo_subdir_truncate_to_repo() -> io::Result<()> {
+        let (tmp_dir, _) = make_known_tempdir(Path::new("/tmp"))?;
+        let repo_dir = tmp_dir.path().join("above").join("repo");
+        let dir = repo_dir.join("src/sub/path");
+        fs::create_dir_all(&dir)?;
+        init_repo(&repo_dir).unwrap();
+
+        let symlink_dir = tmp_dir.path().join("symlink_dir");
+        symlink(&dir, &symlink_dir)?;
+
+        let actual = ModuleRenderer::new("directory")
+            .config(toml::toml! {
+                [directory]
+                truncation_length = 0
+                truncate_to_repo = true
+                repo_root_style = "bold red"
+            })
+            .path(&symlink_dir)
+            .collect();
+        let expected = Some(format!(
+            "{} ",
+            Color::Cyan
+                .bold()
+                .paint(convert_path_sep(symlink_dir.to_str().unwrap()))
         ));
         assert_eq!(expected, actual);
         tmp_dir.close()


### PR DESCRIPTION
#### Description
When `repo_root_style` is configured, Starship attempts to contract the display path relative to the git repo root via `contract_repo_path`. If the user navigates into a symlink pointing sideways into a subdirectory of a repository (e.g. `~/code/example` -> `~/code/me/private`), the logical directory ancestors do not match the repository top-level root, causing `contract_repo_path` to return `None`.

Previously, this was unwrapped using the `?` operator, causing the entire `directory` module to return `None` and fail to display any path in the prompt.

This PR replaces the early return with a fallback to the uncontracted directory string formatting, matching the behavior of the other fallback paths when repo root contraction is not possible.

#### Motivation and Context
Closes #7714

#### Screenshots (if appropriate):
N/A

#### How Has This Been Tested?
- Added unit test `highlight_git_root_dir_symlink_into_repo_subdir` reproducing the case from #7714 and asserting the path renders instead of returning `None`.
- Added unit test `highlight_git_root_dir_symlink_into_repo_subdir_truncate_to_repo` testing with `truncate_to_repo = true`.
- Ran `cargo test --lib` (1,267 passed, 0 failed).
- Ran `cargo clippy --all-targets` and `cargo fmt --check`.

- [ ] I have tested using **MacOS**
- [x] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### AI-Assistance
Have you used AI-assistance to author this PR?

- [x] Yes
- [ ] No

If **yes**, describe the scope of assistance:
Used AI-assisted tooling (Antigravity) to locate the `?` early-return code path in `src/modules/directory.rs` and author the regression test cases.

#### Checklist:
- [x] I have updated the documentation accordingly (N/A — bug fix, no new configuration options or syntax changes).
- [x] I have updated the tests accordingly.
- [x] I understand and have read the code I contribute and can answer questions about it.