### PR TITLE
fix(pulumi): read the per-backend stack selection

### DIFF
--- a/src/modules/pulumi.rs
+++ b/src/modules/pulumi.rs
@@ -14,6 +14,7 @@ use crate::configs::pulumi::PulumiConfig;
 use crate::formatter::{StringFormatter, VersionFormatter};
 
 static PULUMI_HOME: &str = "PULUMI_HOME";
+static PULUMI_BACKEND_URL: &str = "PULUMI_BACKEND_URL";
 
 #[derive(Deserialize)]
 struct Credentials {
@@ -24,6 +25,15 @@ struct Credentials {
 #[derive(Deserialize)]
 struct Account {
     username: Option<String>,
+}
+
+/// Since v3.256.0 Pulumi records a stack per backend in `stacks`.
+/// It still reads the older `stack`, and so do we, but it no longer writes it.
+#[derive(Debug, Deserialize)]
+struct Workspace {
+    stack: Option<String>,
+    #[serde(default)]
+    stacks: HashMap<String, String>,
 }
 
 /// Creates a module with the current Pulumi version and stack name.
@@ -130,23 +140,28 @@ fn stack_name(project_file: &Path, context: &Context) -> Option<String> {
 
     let mut contents = String::new();
     file.read_to_string(&mut contents).ok()?;
-    let name = YamlLoader::load_from_str(&contents).ok().and_then(
-        |yaml| -> Option<Option<String>> {
-            log::trace!("Parsed {project_file:?} into yaml");
-            let yaml = yaml.into_iter().next()?;
-            yaml.into_hash().map(|mut hash| -> Option<String> {
-                hash.remove(&Yaml::String("name".to_string()))?
-                    .into_string()
-            })
-        },
-    )??;
+    let mut project = YamlLoader::load_from_str(&contents)
+        .ok()
+        .and_then(|yaml| yaml.into_iter().next())
+        .and_then(Yaml::into_hash)?;
+    log::trace!("Parsed {project_file:?} into yaml");
+
+    let name = project
+        .remove(&Yaml::String("name".to_string()))?
+        .into_string()?;
     log::trace!("Found project name: {name:?}");
+
+    let project_backend = project
+        .remove(&Yaml::String("backend".to_string()))
+        .and_then(Yaml::into_hash)
+        .and_then(|mut backend| backend.remove(&Yaml::String("url".to_string())))
+        .and_then(Yaml::into_string);
 
     let workspace_file = get_pulumi_workspace(context, &name, project_file)
         .map(File::open)?
         .ok()?;
     log::trace!("Trying to read workspace_file: {workspace_file:?}");
-    let workspace: serde_json::Value = match serde_json::from_reader(workspace_file) {
+    let workspace: Workspace = match serde_json::from_reader(workspace_file) {
         Ok(k) => k,
         Err(e) => {
             log::debug!("Failed to parse workspace file: {e}");
@@ -154,11 +169,42 @@ fn stack_name(project_file: &Path, context: &Context) -> Option<String> {
         }
     };
     log::trace!("Read workspace_file: {workspace:?}");
-    workspace
-        .as_object()?
-        .get("stack")?
-        .as_str()
-        .map(ToString::to_string)
+
+    let backend = current_backend_url(context, project_backend);
+    log::trace!("Looking for a stack selected for backend {backend:?}");
+
+    selected_stack(workspace, backend.as_deref())
+}
+
+/// Pick the stack Pulumi considers selected, newest file format first.
+fn selected_stack(workspace: Workspace, backend: Option<&str>) -> Option<String> {
+    let Workspace { stack, mut stacks } = workspace;
+
+    if let Some(stack) = backend.and_then(|backend| stacks.remove(backend)) {
+        return Some(stack);
+    }
+
+    if stack.is_some() {
+        return stack;
+    }
+
+    // Only when the backend could not be determined at all: a lone selection
+    // is the one Pulumi would pick too. With a known backend, a selection for
+    // a different one is not ours to report.
+    if backend.is_none() && stacks.len() == 1 {
+        return stacks.into_values().next();
+    }
+
+    None
+}
+
+/// The backend Pulumi is pointed at, in the order the CLI resolves it.
+fn current_backend_url(context: &Context, project_backend: Option<String>) -> Option<String> {
+    if let Some(url) = context.get_env(PULUMI_BACKEND_URL) {
+        return Some(url);
+    }
+
+    project_backend.or_else(|| read_credentials(context)?.current)
 }
 
 /// Calculates the path of the workspace settings file for a given pulumi stack.
@@ -189,15 +235,18 @@ fn pulumi_home_dir(context: &Context) -> Option<PathBuf> {
     }
 }
 
-fn get_pulumi_username(context: &Context) -> Option<String> {
+fn read_credentials(context: &Context) -> Option<Credentials> {
     let home_dir = pulumi_home_dir(context)?;
     let creds_path = home_dir.join("credentials.json");
 
     let file = File::open(creds_path).ok()?;
     let reader = BufReader::new(file);
 
-    // Read the JSON contents of the file as an instance of `User`.
-    let creds: Credentials = serde_json::from_reader(reader).ok()?;
+    serde_json::from_reader(reader).ok()
+}
+
+fn get_pulumi_username(context: &Context) -> Option<String> {
+    let creds = read_credentials(context)?;
 
     let current_api_provider = creds.current?;
 
@@ -290,6 +339,99 @@ mod tests {
         );
     }
 
+    fn workspace(stack: Option<&str>, stacks: &[(&str, &str)]) -> Workspace {
+        Workspace {
+            stack: stack.map(ToString::to_string),
+            stacks: stacks
+                .iter()
+                .map(|(backend, stack)| ((*backend).to_string(), (*stack).to_string()))
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn stack_of_the_current_backend_wins() {
+        let workspace = workspace(
+            Some("stale"),
+            &[
+                ("https://api.pulumi.com", "starship/dev"),
+                ("file:///tmp/state", "local"),
+            ],
+        );
+        assert_eq!(
+            selected_stack(workspace, Some("https://api.pulumi.com")),
+            Some("starship/dev".to_string())
+        );
+    }
+
+    #[test]
+    fn legacy_stack_is_used_when_the_backend_has_no_selection() {
+        let workspace = workspace(Some("launch"), &[("file:///tmp/state", "local")]);
+        assert_eq!(
+            selected_stack(workspace, Some("https://api.pulumi.com")),
+            Some("launch".to_string())
+        );
+    }
+
+    #[test]
+    fn legacy_stack_is_still_read() {
+        assert_eq!(
+            selected_stack(workspace(Some("launch"), &[]), None),
+            Some("launch".to_string())
+        );
+    }
+
+    #[test]
+    fn single_stack_is_used_when_the_backend_is_unknown() {
+        let workspace = workspace(None, &[("https://api.pulumi.com", "starship/dev")]);
+        assert_eq!(
+            selected_stack(workspace, None),
+            Some("starship/dev".to_string())
+        );
+    }
+
+    #[test]
+    fn stack_of_another_backend_is_not_reported() {
+        let workspace = workspace(None, &[("file:///tmp/state", "local")]);
+        assert_eq!(
+            selected_stack(workspace, Some("https://api.pulumi.com")),
+            None
+        );
+    }
+
+    #[test]
+    fn ambiguous_stacks_render_nothing() {
+        let workspace = workspace(
+            None,
+            &[
+                ("https://api.pulumi.com", "starship/dev"),
+                ("file:///tmp/state", "local"),
+            ],
+        );
+        assert_eq!(selected_stack(workspace, None), None);
+    }
+
+    #[test]
+    fn backend_url_prefers_the_environment() {
+        let mut context = Context::new(Properties::default(), Target::Main);
+        context
+            .env
+            .insert("PULUMI_BACKEND_URL", "https://api.pulumi.com".to_string());
+        assert_eq!(
+            current_backend_url(&context, Some("file:///tmp/state".to_string())),
+            Some("https://api.pulumi.com".to_string())
+        );
+    }
+
+    #[test]
+    fn backend_url_falls_back_to_the_project() {
+        let context = Context::new(Properties::default(), Target::Main);
+        assert_eq!(
+            current_backend_url(&context, Some("file:///tmp/state".to_string())),
+            Some("file:///tmp/state".to_string())
+        );
+    }
+
     #[test]
     fn version_render() -> io::Result<()> {
         let dir = tempfile::tempdir()?;
@@ -330,6 +472,73 @@ mod tests {
             &serde_json::json!(
                 {
                     "stack": "launch"
+                }
+            ),
+        )?;
+        workspace.sync_all()?;
+
+        let credential_path = root.join(".pulumi");
+        std::fs::create_dir_all(&credential_path)?;
+        let credential_path = &credential_path.join("credentials.json");
+        let mut credential = File::create(credential_path)?;
+        serde_json::to_writer_pretty(
+            &mut credential,
+            &serde_json::json!(
+                {
+                    "current": "https://api.example.com",
+                    "accessTokens": {
+                        "https://api.example.com": "redacted",
+                        "https://api.pulumi.com": "redacted"
+                    },
+                    "accounts": {
+                        "https://api.example.com": {
+                            "accessToken": "redacted",
+                            "username": "test-user",
+                            "lastValidatedAt": "2022-01-12T00:00:00.000000000-08:00"
+                        }
+                    }
+                }
+            ),
+        )?;
+        credential.sync_all()?;
+        let rendered = module_renderer
+            .path(root.clone())
+            .logical_path(root)
+            .config(toml::toml! {
+                [pulumi]
+                format = "via [$symbol($username@)$stack]($style) "
+            })
+            .collect();
+        let expected = format!(
+            "via {} ",
+            Color::Fixed(5).bold().paint(" test-user@launch")
+        );
+        assert_eq!(expected, rendered.expect("a result"));
+        dir.close()
+    }
+
+    #[test]
+    /// `render_valid_paths` with the file format written since Pulumi v3.256.0.
+    fn render_valid_paths_with_per_backend_stacks() -> io::Result<()> {
+        use io::Write;
+        let (module_renderer, dir) = ModuleRenderer::new_with_home("pulumi")?;
+        let root = dunce::canonicalize(dir.path())?;
+        let mut yaml = File::create(root.join("Pulumi.yml"))?;
+        yaml.write_all("name: starship\nruntime: nodejs\ndescription: A thing\n".as_bytes())?;
+        yaml.sync_all()?;
+
+        let workspace_path = root.join(".pulumi").join("workspaces");
+        std::fs::create_dir_all(&workspace_path)?;
+        let workspace_path = &workspace_path.join("starship-test-workspace.json");
+        let mut workspace = File::create(workspace_path)?;
+        serde_json::to_writer_pretty(
+            &mut workspace,
+            &serde_json::json!(
+                {
+                    "stacks": {
+                        "https://api.example.com": "launch",
+                        "https://api.pulumi.com": "other"
+                    }
                 }
             ),
         )?;


### PR DESCRIPTION
## Description

Fixes #7723

Pulumi v3.256.0 ([pulumi/pulumi#23974](https://github.com/pulumi/pulumi/pull/23974)) scoped the selected stack to the active backend, changing the workspace settings file:

```jsonc
// ~/.pulumi/workspaces/<project>-<sha1>-workspace.json, before
{
    "stack": "acme/infra/dev"
}

// after
{
    "stacks": {
        "https://api.pulumi.com": "acme/infra/dev"
    }
}
```

Pulumi still reads the old `stack` key, but no longer writes it, so `$stack` silently goes empty after the first `pulumi stack select` on a new enough CLI.

This reads the new map, picking the entry for the backend in use. The backend is resolved the same way the CLI resolves it in `GetCurrentCloudURLWithSource`:

1. `PULUMI_BACKEND_URL`
2. the project's `backend.url` in `Pulumi.yaml`
3. `current` in `credentials.json` (already parsed by this module for `$username`)

with two fallbacks after that: the legacy `stack` key, and — when the backend cannot be determined at all — the single entry in `stacks` if there is only one. Both orderings match `Settings.StackForBackend` on the Pulumi side, so we render what `pulumi stack` would print.

One known approximation: when the backend resolves but only the legacy `stack` is set, it is reported even if it names a stack belonging to another backend. Pulumi parses the stack reference and treats an unparseable legacy name as unset (the `fromLegacy` branch in `CurrentStackAt`); this module does not parse references, so it follows `StackForBackend` and reports it. That only affects workspace files still on the old format, which is what they rendered before this change too.

Verified against a real `~/.pulumi`: for a project whose workspace file uses the new format `$stack` was empty before and shows the stack after, and a project whose workspace file still uses the old key keeps rendering.

Left out deliberately: `PULUMI_STACK`, which overrides the workspace selection entirely. That was never supported by this module, so it is not part of this regression — happy to add it in a follow-up if wanted.

## Motivation and Context

The `pulumi` module has been showing no stack for everyone on Pulumi v3.256.0 (2026-08-04) or later.

## How Has This Been Tested?

- [x] macOS
- [ ] Linux
- [ ] Windows

`selected_stack` is a pure function, so its tests are plain assertions: the backend-scoped lookup, the legacy key with and without a resolvable backend, the single-entry fallback, and the ambiguous case. Two more cover the backend resolution order. A new render test exercises the whole path with the new file format, alongside the existing one that still uses the old format.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
