### PR TITLE
docs: add Lumesh to supported shells list (#7680)

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ eval $(starship init ion)
 
 Add the following to `~/.config/lumesh/config.lm`:
 
-```bash
+```sh
 set LUME_PROMPT_SETTINGS = {
     starship: 1,
     lazy: 0,

--- a/README.md
+++ b/README.md
@@ -351,6 +351,20 @@ eval $(starship init ion)
 </details>
 
 <details>
+<summary>Lumesh</summary>
+
+Add the following to `~/.config/lumesh/config.lm`:
+
+```bash
+set LUME_PROMPT_SETTINGS = {
+    starship: 1,
+    lazy: 0,
+}
+```
+
+</details>
+
+<details>
 <summary>Nushell</summary>
 
 Add the following to the end of your Nushell configuration (find it by running `$nu.config-path` in Nushell):

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,10 +16,9 @@ features:
   - title: Customizable
     details: Every little detail is customizable to your liking, to make this prompt as minimal or feature-rich as you'd like it to be.
 footer: ISC Licensed | Copyright © 2019-present Starship Contributors
-
 # Used for the description meta tag, for SEO
 metaTitle: "Starship: Cross-Shell Prompt"
-description: Starship is the minimal, blazing fast, and extremely customizable prompt for any shell! Shows the information you need, while staying sleek and minimal. Quick installation available for Bash, Fish, ZSH, Ion, Tcsh, Elvish, Nu, Xonsh, Cmd, and PowerShell.
+description: Starship is the minimal, blazing fast, and extremely customizable prompt for any shell! Shows the information you need, while staying sleek and minimal. Quick installation available for Bash, Fish, ZSH, Ion, Tcsh, Elvish, Nu, Xonsh, Cmd, Lumesh, and PowerShell.
 ---
 
 <script setup>
@@ -176,4 +175,17 @@ onMounted(() => {
    -- starship.lua
 
    load(io.popen('starship init cmd'):read("*a"))()
+   ```
+
+   #### Lumesh
+
+   Add the following to `~/.config/lumesh/config.lm`:
+
+   ```sh
+   # ~/.config/lumesh/config.lm
+
+   set LUME_PROMPT_SETTINGS = {
+       starship: 1,
+       lazy: 0,
+   }
    ```


### PR DESCRIPTION
#### Description
Adds Lumesh configuration instructions to the supported shell list in `README.md` and `docs/README.md`.

#### Motivation and Context
Lumesh has native built-in support for Starship prompts via `~/.config/lumesh/config.lm`. Adding it to the supported shells documentation allows Lumesh users to easily find setup instructions.
Closes #7680

#### How Has This Been Tested?
- [x] I have tested using **Windows**
- Formatted and verified with `dprint` and tested the VitePress docs build.

#### AI-Assistance
Have you used AI-assistance to author this PR?
- [x] Yes
- [ ] No

If **yes**, describe the scope of assistance:
Assisted in identifying documentation locations, formatting files with dprint, and drafting PR text.

#### Checklist:
- [x] I have updated the documentation accordingly.
- [x] I have updated the tests accordingly.
- [x] I understand and have read the code I contribute and can answer questions about it.
