### PR TITLE
feat: add `jj_status` module

### DIFF
--- a/.github/config-schema.json
+++ b/.github/config-schema.json
@@ -1002,6 +1002,24 @@
         "disabled": false
       }
     },
+    "jj_status": {
+      "$ref": "#/$defs/JJStatusConfig",
+      "default": {
+        "format": "([\\[$all\\]]($style) )",
+        "style": "bold red",
+        "conflicted": "!",
+        "description_empty": "◌",
+        "description_present": "",
+        "hidden": "",
+        "immutable": "◆",
+        "added": "+",
+        "copied": "=",
+        "deleted": "✘",
+        "modified": "~",
+        "renamed": "»",
+        "disabled": false
+      }
+    },
     "jobs": {
       "$ref": "#/$defs/JobsConfig",
       "default": {
@@ -4630,7 +4648,78 @@
           "default": "([+$added]($added_style) )([-$deleted]($deleted_style) )"
         },
         "disabled": {
-          "description": "Disable the `jj_metrics`",
+          "description": "Disable the module",
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "JJStatusConfig": {
+      "type": "object",
+      "properties": {
+        "format": {
+          "description": "The default format for `jj_status`.",
+          "type": "string",
+          "default": "([\\[$all\\]]($style) )"
+        },
+        "style": {
+          "description": "The style for the module.",
+          "type": "string",
+          "default": "bold red"
+        },
+        "conflicted": {
+          "description": "The format shown when the current change or a parent has merge conflicts.",
+          "type": "string",
+          "default": "!"
+        },
+        "description_empty": {
+          "description": "The format shown when the current change has no description.",
+          "type": "string",
+          "default": "◌"
+        },
+        "description_present": {
+          "description": "The format shown when the current change has a description.",
+          "type": "string",
+          "default": ""
+        },
+        "hidden": {
+          "description": "The format shown when the current change is hidden.",
+          "type": "string",
+          "default": ""
+        },
+        "immutable": {
+          "description": "The format shown when the current change is immutable.",
+          "type": "string",
+          "default": "◆"
+        },
+        "added": {
+          "description": "The format shown when a new file has been added in the working directory.",
+          "type": "string",
+          "default": "+"
+        },
+        "copied": {
+          "description": "The format shown when a new file has been copied in the working directory.",
+          "type": "string",
+          "default": "="
+        },
+        "deleted": {
+          "description": "The format shown when a file has been deleted in the working directory.",
+          "type": "string",
+          "default": "✘"
+        },
+        "modified": {
+          "description": "The format shown when a file has been modified in the working directory.",
+          "type": "string",
+          "default": "~"
+        },
+        "renamed": {
+          "description": "The format shown when a file has been renamed in the working directory.",
+          "type": "string",
+          "default": "»"
+        },
+        "disabled": {
+          "description": "Disables the `jj_status` module.",
           "type": "boolean",
           "default": false
         }

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -2690,6 +2690,85 @@ added_style = 'bold blue'
 format = '[+$added]($added_style)/[-$deleted]($deleted_style) '
 ```
 
+## JJ Status
+
+The `jj_status` module shows symbols representing the state of the [Jujutsu](https://docs.jj-vcs.dev/) repo in your current directory.
+
+### Options
+
+| Option                | Default                   | Description                                                                |
+| --------------------- | ------------------------- | -------------------------------------------------------------------------- |
+| `format`              | `'([\[$all\]]($style) )'` | The default format for `jj_status`.                                        |
+| `conflicted`          | `'!'`                     | The format shown when the current change or a parent has merge conflicts.  |
+| `description_empty`   | `'◌'`                     | The format shown when the current change has no description.               |
+| `description_present` | `''`                      | The format shown when the current change has a description.                |
+| `hidden`              | `''`                      | The format shown when the current change is hidden.                        |
+| `immutable`           | `'◆'`                     | The format shown when the current change is immutable.                     |
+| `added`               | `'+'`                     | The format shown when a new file has been added in the working directory.  |
+| `copied`              | `'='`                     | The format shown when a new file has been copied in the working directory. |
+| `deleted`             | `'✘'`                     | The format shown when a file has been deleted in the working directory.    |
+| `modified`            | `'~'`                     | The format shown when a file has been modified in the working directory.   |
+| `renamed`             | `'»'`                     | The format shown when a file has been renamed in the working directory.    |
+| `style`               | `'bold red'`              | The style for the module.                                                  |
+| `disabled`            | `false`                   | Disables the `jj_status` module.                                           |
+
+### Variables
+
+The following variables can be used in `format`:
+
+| Variable      | Description                                                                                    |
+| ------------- | ---------------------------------------------------------------------------------------------- |
+| `all`         | Shortcut for `$conflicted$description$hidden$immutable$added$copied$deleted$modified$renamed`. |
+| `conflicted`  | Displays `conflicted` when the current change or a parent has merge conflicts.                 |
+| `description` | Displays `description_empty` or `description_present` accordingly.                             |
+| `hidden`      | Displays `hidden` when the current change is hidden.                                           |
+| `immutable`   | Displays `immutable` when the current change is immutable.                                     |
+| `added`       | Displays `added` when a file has been added in the working directory.                          |
+| `copied`      | Displays `copied` when a file has been copied in the working directory.                        |
+| `deleted`     | Displays `deleted` when a file has been deleted in the working directory.                      |
+| `modified`    | Displays `modified` when a file has been modified in the working directory.                    |
+| `renamed`     | Displays `renamed` when a file has been renamed in the working directory.                      |
+| style\*       | Mirrors the value of option `style`.                                                           |
+
+*: This variable can only be used as a part of a style string
+
+The following variable can be used in `added`, `copied`, `deleted`, `modified` and `renamed`:
+
+| Variable | Description              |
+| -------- | ------------------------ |
+| `count`  | Show the number of files |
+
+### Example
+
+Show symbols:
+
+```toml
+# ~/.config/starship.toml
+
+[jj_status]
+conflicted = '🏳'
+description_present = ""
+hidden = '🥷'
+immutable = '🔒'
+added = '📦'
+deleted = '🗑'
+modified = '📝'
+renamed = '👅'
+```
+
+Add `count` to symbols supporting it:
+
+```toml
+# ~/.config/starship.toml
+
+[jj_status]
+added = "+$count"
+copied = "=$count"
+deleted = "✘$count"
+modified = "~$count"
+renamed = "»$count"
+```
+
 ## Jobs
 
 The `jobs` module shows the current number of jobs running.

--- a/docs/public/presets/toml/bracketed-segments.toml
+++ b/docs/public/presets/toml/bracketed-segments.toml
@@ -135,6 +135,9 @@ format = '\[[\($change\)]($style)\]'
 [jj_metrics]
 format = '(\[[+$added]($added_style)\])(\[[-$deleted]($deleted_style)\])'
 
+[jj_status]
+format = '([\[$all\]]($style))'
+
 [jobs]
 format = '\[[$symbol$number]($style)\]'
 

--- a/docs/public/presets/toml/catppuccin-powerline.toml
+++ b/docs/public/presets/toml/catppuccin-powerline.toml
@@ -125,6 +125,10 @@ symbol = ""
 style = "bg:yellow"
 format = '[[ $symbol $bookmark(@$remote)$diverged( \\(+$overflow_count others\\)) ](fg:crust bg:yellow)]($style)'
 
+[jj_status]
+style = "bg:yellow"
+format = '[[($all )](fg:crust bg:yellow)]($style)'
+
 [kotlin]
 symbol = ""
 style = "bg:green"

--- a/docs/public/presets/toml/gruvbox-rainbow.toml
+++ b/docs/public/presets/toml/gruvbox-rainbow.toml
@@ -145,6 +145,10 @@ symbol = ""
 style = "bg:color_aqua"
 format = '[[ $symbol $bookmark(@$remote)$diverged( \\(+$overflow_count others\\)) ](fg:color_fg0 bg:color_aqua)]($style)'
 
+[jj_status]
+style = "bg:color_aqua"
+format = '[[($all )](fg:color_fg0 bg:color_aqua)]($style)'
+
 [kotlin]
 symbol = ""
 style = "bg:color_blue"

--- a/docs/public/presets/toml/jetpack.toml
+++ b/docs/public/presets/toml/jetpack.toml
@@ -322,6 +322,20 @@ format = '([▴$added]($added_style))([▿$deleted]($deleted_style))'
 added_style = 'italic dimmed green'
 deleted_style = 'italic dimmed red'
 
+[jj_status]
+format = "([⎪$all⎥]($style))"
+style = "bold italic bright-blue"
+conflicted = "[◪◦](italic bright-magenta)"
+description_empty = "[◌◦](italic bright-magenta)"
+description_present = "[◦](italic bright-magenta)"
+hidden = "[󰘓◦](italic bright-magenta)"
+immutable = "[◦](italic bright-magenta)"
+added = "[▪](italic bright-cyan)"
+copied = "[◃◈](italic white)"
+deleted = "[✕](italic red)"
+modified = "[●◦](italic yellow)"
+renamed = "[◎◦](italic bright-blue)"
+
 [julia]
 symbol = "◎ "
 format = " jl [$symbol($version )]($style)"

--- a/docs/public/presets/toml/pastel-powerline.toml
+++ b/docs/public/presets/toml/pastel-powerline.toml
@@ -126,6 +126,10 @@ symbol = ""
 style = "bg:#FCA17D"
 format = '[ $symbol $bookmark(@$remote)$diverged( \\(+$overflow_count others\\)) ]($style)'
 
+[jj_status]
+style = "bg:#FCA17D"
+format = '[$all ]($style)'
+
 [julia]
 symbol = " "
 style = "bg:#86BBD8"

--- a/docs/public/presets/toml/plain-text-symbols.toml
+++ b/docs/public/presets/toml/plain-text-symbols.toml
@@ -140,6 +140,12 @@ symbol = "java "
 symbol = "jj "
 truncation_symbol = "..."
 
+[jj_status]
+description_empty = "e"
+immutable = "i"
+deleted = "x"
+renamed = "r"
+
 [jobs]
 symbol = "*"
 

--- a/docs/public/presets/toml/pure-preset.toml
+++ b/docs/public/presets/toml/pure-preset.toml
@@ -47,6 +47,20 @@ style = "yellow"
 format = "[$bookmark(@$remote)$diverged( \\(+$overflow_count others\\))]($style)"
 style = "bright-black"
 
+[jj_status]
+format = "[[(*$all)](218)]($style)"
+style = "cyan"
+conflicted = "​"
+description_empty = ""
+description_present = ""
+hidden = "​"
+immutable = "​"
+added = "​"
+copied = ""
+deleted = "​"
+modified = "​"
+renamed = "​"
+
 [python]
 format = "[$virtualenv]($style) "
 style = "bright-black"

--- a/docs/public/presets/toml/tokyo-night.toml
+++ b/docs/public/presets/toml/tokyo-night.toml
@@ -45,6 +45,10 @@ symbol = ""
 style = "bg:#394260"
 format = '[[ $symbol $bookmark(@$remote)$diverged( \\(+$overflow_count others\\)) ](fg:#769ff0 bg:#394260)]($style)'
 
+[jj_status]
+style = "bg:#394260"
+format = '[[($all )](fg:#769ff0 bg:#394260)]($style)'
+
 [nodejs]
 symbol = ""
 style = "bg:#212736"

--- a/src/configs/jj_metrics.rs
+++ b/src/configs/jj_metrics.rs
@@ -16,7 +16,7 @@ pub struct JJMetricsConfig<'a> {
     pub only_nonzero_diffs: bool,
     /// Format string for the module
     pub format: &'a str,
-    /// Disable the `jj_metrics`
+    /// Disable the module
     pub disabled: bool,
 }
 

--- a/src/configs/jj_status.rs
+++ b/src/configs/jj_status.rs
@@ -1,0 +1,62 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Deserialize, Serialize)]
+#[cfg_attr(
+    feature = "config-schema",
+    derive(schemars::JsonSchema),
+    schemars(deny_unknown_fields)
+)]
+#[serde(default)]
+pub struct JJStatusConfig<'a> {
+    /// The default format for `jj_status`.
+    pub format: &'a str,
+    /// The style for the module.
+    pub style: &'a str,
+
+    /// The format shown when the current change or a parent has merge conflicts.
+    pub conflicted: &'a str,
+
+    /// The format shown when the current change has no description.
+    pub description_empty: &'a str,
+    /// The format shown when the current change has a description.
+    pub description_present: &'a str,
+
+    /// The format shown when the current change is hidden.
+    pub hidden: &'a str,
+    /// The format shown when the current change is immutable.
+    pub immutable: &'a str,
+
+    /// The format shown when a new file has been added in the working directory.
+    pub added: &'a str,
+    /// The format shown when a new file has been copied in the working directory.
+    pub copied: &'a str,
+    /// The format shown when a file has been deleted in the working directory.
+    pub deleted: &'a str,
+    /// The format shown when a file has been modified in the working directory.
+    pub modified: &'a str,
+    /// The format shown when a file has been renamed in the working directory.
+    pub renamed: &'a str,
+
+    /// Disables the `jj_status` module.
+    pub disabled: bool,
+}
+
+impl Default for JJStatusConfig<'_> {
+    fn default() -> Self {
+        Self {
+            format: "([\\[$all\\]]($style) )",
+            style: "bold red",
+            conflicted: "!",
+            description_empty: "◌",
+            description_present: "",
+            hidden: "",
+            immutable: "◆",
+            added: "+",
+            copied: "=",
+            deleted: "✘",
+            modified: "~",
+            renamed: "»",
+            disabled: false,
+        }
+    }
+}

--- a/src/configs/mod.rs
+++ b/src/configs/mod.rs
@@ -56,6 +56,7 @@ pub mod java;
 pub mod jj_bookmark;
 pub mod jj_change;
 pub mod jj_metrics;
+pub mod jj_status;
 pub mod jobs;
 pub mod julia;
 pub mod kotlin;
@@ -236,6 +237,8 @@ pub struct FullConfig<'a> {
     jj_change: jj_change::JJChangeConfig<'a>,
     #[serde(borrow)]
     jj_metrics: jj_metrics::JJMetricsConfig<'a>,
+    #[serde(borrow)]
+    jj_status: jj_status::JJStatusConfig<'a>,
     #[serde(borrow)]
     jobs: jobs::JobsConfig<'a>,
     #[serde(borrow)]

--- a/src/context/jj_repo.rs
+++ b/src/context/jj_repo.rs
@@ -299,6 +299,19 @@ impl JJRepo {
     pub const METRIC_DELETED: &str = "/jj/metrics-deleted";
     pub const METRIC_ZERO: &str = "/jj/metrics-zero";
 
+    pub const STATUS_IMMEDIATE_CONFLICT: &str = "/jj/status/immediate-conflict";
+    pub const STATUS_NO_CONFLICT: &str = "/jj/status/no-conflict";
+    pub const STATUS_DESCRIPTION: &str = "/jj/status/description";
+    pub const STATUS_HIDDEN: &str = "/jj/status/hidden";
+    pub const STATUS_IMMUTABLE: &str = "/jj/status/immutable";
+
+    pub const STATUS_ADDED: &str = "/jj/status/added";
+    pub const STATUS_COPIED: &str = "/jj/status/copied";
+    pub const STATUS_DELETED: &str = "/jj/status/deleted";
+    pub const STATUS_MODIFIED: &str = "/jj/status/modified";
+    pub const STATUS_RENAMED: &str = "/jj/status/renamed";
+    pub const STATUS_NO_CHANGES: &str = "/jj/status/no-changes";
+
     pub const NONE: &str = "/jj/no-repo";
 }
 
@@ -439,6 +452,73 @@ pub fn mock_jj_cmd(s: &str) -> Option<crate::utils::CommandOutput> {
             || output([
                 (LINES_A, "0"),
                 (LINES_D, "0"),
+            ]),
+        ),
+        // Repos testing jj_status rendering
+        (
+            JJRepo::STATUS_IMMEDIATE_CONFLICT,
+            || output([
+                (CONFLICT, "true"),
+            ]),
+        ),
+        (
+            JJRepo::STATUS_NO_CONFLICT,
+            || output([
+                (CONFLICT, "false"),
+            ]),
+        ),
+        (
+            JJRepo::STATUS_DESCRIPTION,
+            || output([
+                (DESC, "true"),
+            ]),
+        ),
+        (
+            JJRepo::STATUS_HIDDEN,
+            || output([
+                (HIDDEN, "true"),
+            ]),
+        ),
+        (
+            JJRepo::STATUS_IMMUTABLE,
+            || output([
+                (IMMUTABLE, "true"),
+            ]),
+        ),
+        (
+            JJRepo::STATUS_ADDED,
+            || output([
+                (FILES, "AA"),
+            ]),
+        ),
+        (
+            JJRepo::STATUS_COPIED,
+            || output([
+                (FILES, "CCC"),
+            ]),
+        ),
+        (
+            JJRepo::STATUS_DELETED,
+            || output([
+                (FILES, "DDDD"),
+            ]),
+        ),
+        (
+            JJRepo::STATUS_MODIFIED,
+            || output([
+                (FILES, "MMMMM"),
+            ]),
+        ),
+        (
+            JJRepo::STATUS_RENAMED,
+            || output([
+                (FILES, "RRRRRR"),
+            ]),
+        ),
+        (
+            JJRepo::STATUS_NO_CHANGES,
+            || output([
+                (FILES, ""),
             ]),
         ),
         // Used to test the parsing will correctly fail on empty stdout

--- a/src/context/jj_repo.rs
+++ b/src/context/jj_repo.rs
@@ -38,8 +38,24 @@ pub struct CurrentChange {
     /// Total lines removed in this change
     pub lines_removed: u32,
 
+    pub status: Status,
+}
+
+#[derive(Debug, Default)]
+pub struct Status {
     /// See `impl CurrentChange` below
-    flags: u32,
+    flags: u8,
+
+    /// Count of added files
+    pub added: usize,
+    /// Count of copied files
+    pub copied: usize,
+    /// Count of deleted files
+    pub deleted: usize,
+    /// Count of modified files
+    pub modified: usize,
+    /// Count of renamed files
+    pub renamed: usize,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -164,42 +180,34 @@ impl JJRepo {
                     bookmarks: parse_bookmark_lines(lines.next()?, lines.next()?),
                     lines_added: lines.next()?.parse().ok()?,
                     lines_removed: lines.next()?.parse().ok()?,
-                    flags: {
-                        let mut flags = 0;
+                    status: {
+                        let mut status = Status::default();
 
                         if has_conflict {
-                            flags |= CurrentChange::CONFLICTED;
+                            status.flags |= CurrentChange::CONFLICTED;
                         }
                         if description {
-                            flags |= CurrentChange::DESCRIPTION;
+                            status.flags |= CurrentChange::DESCRIPTION;
                         }
                         if hidden {
-                            flags |= CurrentChange::HIDDEN;
+                            status.flags |= CurrentChange::HIDDEN;
                         }
                         if immutable {
-                            flags |= CurrentChange::IMMUTABLE;
+                            status.flags |= CurrentChange::IMMUTABLE;
                         }
 
-                        if let Some(statuses) = lines.next() {
-                            if statuses.contains('A') {
-                                flags |= CurrentChange::STATUS_ADDED;
-                            }
-                            if statuses.contains('C') {
-                                flags |= CurrentChange::STATUS_COPIED;
-                            }
-                            if statuses.contains('D') {
-                                flags |= CurrentChange::STATUS_DELETED;
-                            }
-                            if statuses.contains('M') {
-                                flags |= CurrentChange::STATUS_MODIFIED;
-                            }
-                            if statuses.contains('R') {
-                                flags |= CurrentChange::STATUS_RENAMED;
-                            }
+                        // JJ documents the characters it will return, those that interest us are
+                        // all single bytes so we don't need to do the u8 -> char conversion
+                        for byte in lines.next().unwrap_or("").bytes() {
+                            status.added += usize::from(byte == b'A');
+                            status.copied += usize::from(byte == b'C');
+                            status.deleted += usize::from(byte == b'D');
+                            status.modified += usize::from(byte == b'M');
+                            status.renamed += usize::from(byte == b'R');
                         }
 
-                        flags
-                    },
+                        status
+                    }
                 })
             })
             .as_ref()
@@ -207,60 +215,29 @@ impl JJRepo {
 }
 
 impl CurrentChange {
-    const CONFLICTED: u32 = 1 << 0;
-    const DESCRIPTION: u32 = 1 << 1;
-    const HIDDEN: u32 = 1 << 2;
-    const IMMUTABLE: u32 = 1 << 3;
-
-    const STATUS_ADDED: u32 = 1 << 4;
-    const STATUS_COPIED: u32 = 1 << 5;
-    const STATUS_DELETED: u32 = 1 << 6;
-    const STATUS_MODIFIED: u32 = 1 << 7;
-    const STATUS_RENAMED: u32 = 1 << 8;
+    const CONFLICTED: u8 = 1 << 0;
+    const DESCRIPTION: u8 = 1 << 1;
+    const HIDDEN: u8 = 1 << 2;
+    const IMMUTABLE: u8 = 1 << 3;
 
     /// True if any mutable change up to the current one is conflicted
     pub fn conflicted(&self) -> bool {
-        self.flags & Self::CONFLICTED == Self::CONFLICTED
+        self.status.flags & Self::CONFLICTED == Self::CONFLICTED
     }
 
     /// True if the current change has a non-empty description
     pub fn description(&self) -> bool {
-        self.flags & Self::DESCRIPTION == Self::DESCRIPTION
+        self.status.flags & Self::DESCRIPTION == Self::DESCRIPTION
     }
 
     /// True if the current change is hidden
     pub fn hidden(&self) -> bool {
-        self.flags & Self::HIDDEN == Self::HIDDEN
+        self.status.flags & Self::HIDDEN == Self::HIDDEN
     }
 
     /// True if the current change is immutable
     pub fn immutable(&self) -> bool {
-        self.flags & Self::IMMUTABLE == Self::IMMUTABLE
-    }
-
-    /// True if the current change includes at least one added file
-    pub fn status_added(&self) -> bool {
-        self.flags & Self::STATUS_ADDED == Self::STATUS_ADDED
-    }
-
-    /// True if the current change includes at least one copied file
-    pub fn status_copied(&self) -> bool {
-        self.flags & Self::STATUS_COPIED == Self::STATUS_COPIED
-    }
-
-    /// True if the current change includes at least one deleted file
-    pub fn status_deleted(&self) -> bool {
-        self.flags & Self::STATUS_DELETED == Self::STATUS_DELETED
-    }
-
-    /// True if the current change includes at least one modified file
-    pub fn status_modified(&self) -> bool {
-        self.flags & Self::STATUS_MODIFIED == Self::STATUS_MODIFIED
-    }
-
-    /// True if the current change includes at least one renamed file
-    pub fn status_renamed(&self) -> bool {
-        self.flags & Self::STATUS_RENAMED == Self::STATUS_RENAMED
+        self.status.flags & Self::IMMUTABLE == Self::IMMUTABLE
     }
 }
 

--- a/src/module.rs
+++ b/src/module.rs
@@ -60,6 +60,7 @@ pub const ALL_MODULES: &[&str] = &[
     "jj_bookmark",
     "jj_change",
     "jj_metrics",
+    "jj_status",
     "jobs",
     "julia",
     "kotlin",

--- a/src/modules/git_status.rs
+++ b/src/modules/git_status.rs
@@ -1,3 +1,4 @@
+use super::utils::format;
 use super::{Context, Module, ModuleConfig};
 use crate::configs::git_status::GitStatusConfig;
 use crate::formatter::StringFormatter;
@@ -63,12 +64,12 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
             .map_variables_to_segments(|variable: &str| {
                 let segments = match variable {
                     "stashed" => info.get_stashed().and_then(|count| {
-                        format_count(config.stashed, "git_status.stashed", context, count)
+                        format::count(config.stashed, "git_status.stashed", context, count)
                     }),
                     "ahead_behind" => info.get_ahead_behind().and_then(|(ahead, behind)| {
                         let (ahead, behind) = (ahead?, behind?);
                         if ahead > 0 && behind > 0 {
-                            format_text(
+                            format::text(
                                 config.diverged,
                                 "git_status.diverged",
                                 context,
@@ -79,36 +80,36 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                                 },
                             )
                         } else if ahead > 0 && behind == 0 {
-                            format_count(config.ahead, "git_status.ahead", context, ahead)
+                            format::count(config.ahead, "git_status.ahead", context, ahead)
                         } else if behind > 0 && ahead == 0 {
-                            format_count(config.behind, "git_status.behind", context, behind)
+                            format::count(config.behind, "git_status.behind", context, behind)
                         } else {
-                            format_symbol(config.up_to_date, "git_status.up_to_date", context)
+                            format::symbol(config.up_to_date, "git_status.up_to_date", context)
                         }
                     }),
                     "conflicted" => info.get_conflicted().and_then(|count| {
-                        format_count(config.conflicted, "git_status.conflicted", context, count)
+                        format::count(config.conflicted, "git_status.conflicted", context, count)
                     }),
                     "deleted" => info.get_deleted().and_then(|count| {
-                        format_count(config.deleted, "git_status.deleted", context, count)
+                        format::count(config.deleted, "git_status.deleted", context, count)
                     }),
                     "renamed" => info.get_renamed().and_then(|count| {
-                        format_count(config.renamed, "git_status.renamed", context, count)
+                        format::count(config.renamed, "git_status.renamed", context, count)
                     }),
                     "modified" => info.get_modified().and_then(|count| {
-                        format_count(config.modified, "git_status.modified", context, count)
+                        format::count(config.modified, "git_status.modified", context, count)
                     }),
                     "staged" => info.get_staged().and_then(|count| {
-                        format_count(config.staged, "git_status.staged", context, count)
+                        format::count(config.staged, "git_status.staged", context, count)
                     }),
                     "untracked" => info.get_untracked().and_then(|count| {
-                        format_count(config.untracked, "git_status.untracked", context, count)
+                        format::count(config.untracked, "git_status.untracked", context, count)
                     }),
                     "typechanged" => info.get_typechanged().and_then(|count| {
-                        format_count(config.typechanged, "git_status.typechanged", context, count)
+                        format::count(config.typechanged, "git_status.typechanged", context, count)
                     }),
                     "worktree_added" => info.get_worktree_added().and_then(|count| {
-                        format_count(
+                        format::count(
                             config.worktree_added,
                             "git_status.worktree_added",
                             context,
@@ -116,7 +117,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                         )
                     }),
                     "worktree_deleted" => info.get_worktree_deleted().and_then(|count| {
-                        format_count(
+                        format::count(
                             config.worktree_deleted,
                             "git_status.worktree_deleted",
                             context,
@@ -124,7 +125,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                         )
                     }),
                     "worktree_modified" => info.get_worktree_modified().and_then(|count| {
-                        format_count(
+                        format::count(
                             config.worktree_modified,
                             "git_status.worktree_modified",
                             context,
@@ -132,7 +133,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                         )
                     }),
                     "worktree_typechanged" => info.get_worktree_typechanged().and_then(|count| {
-                        format_count(
+                        format::count(
                             config.worktree_typechanged,
                             "git_status.worktree_typechanged",
                             context,
@@ -140,10 +141,10 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                         )
                     }),
                     "index_added" => info.get_index_added().and_then(|count| {
-                        format_count(config.index_added, "git_status.index_added", context, count)
+                        format::count(config.index_added, "git_status.index_added", context, count)
                     }),
                     "index_deleted" => info.get_index_deleted().and_then(|count| {
-                        format_count(
+                        format::count(
                             config.index_deleted,
                             "git_status.index_deleted",
                             context,
@@ -151,7 +152,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                         )
                     }),
                     "index_modified" => info.get_index_modified().and_then(|count| {
-                        format_count(
+                        format::count(
                             config.index_modified,
                             "git_status.index_modified",
                             context,
@@ -159,7 +160,7 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
                         )
                     }),
                     "index_typechanged" => info.get_index_typechanged().and_then(|count| {
-                        format_count(
+                        format::count(
                             config.index_typechanged,
                             "git_status.index_typechanged",
                             context,
@@ -750,51 +751,6 @@ impl RepoStatus {
             }
         }
     }
-}
-
-fn format_text<F>(
-    format_str: &str,
-    config_path: &str,
-    context: &Context,
-    mapper: F,
-) -> Option<Vec<Segment>>
-where
-    F: Fn(&str) -> Option<String> + Send + Sync,
-{
-    if let Ok(formatter) = StringFormatter::new(format_str) {
-        formatter
-            .map(|variable| mapper(variable).map(Ok))
-            .parse(None, Some(context))
-            .ok()
-    } else {
-        log::warn!("Error parsing format string `{config_path}`");
-        None
-    }
-}
-
-fn format_count(
-    format_str: &str,
-    config_path: &str,
-    context: &Context,
-    count: usize,
-) -> Option<Vec<Segment>> {
-    if count == 0 {
-        return None;
-    }
-
-    format_text(
-        format_str,
-        config_path,
-        context,
-        |variable| match variable {
-            "count" => Some(count.to_string()),
-            _ => None,
-        },
-    )
-}
-
-fn format_symbol(format_str: &str, config_path: &str, context: &Context) -> Option<Vec<Segment>> {
-    format_text(format_str, config_path, context, |_variable| None)
 }
 
 #[cfg(target_os = "linux")]

--- a/src/modules/jj_status.rs
+++ b/src/modules/jj_status.rs
@@ -57,3 +57,238 @@ pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
 
     Some(module)
 }
+
+#[cfg(test)]
+mod tests {
+    use nu_ansi_term::Color;
+    use toml::toml;
+
+    use crate::context::JJRepo;
+    use crate::test::JJTester;
+
+    fn tester(repo: &'static str) -> JJTester {
+        JJTester::new("jj_status").repo(repo)
+    }
+
+    #[test]
+    fn test_render_basics() {
+        JJTester::basic_tests("jj_status");
+    }
+
+    #[test]
+    fn test_render_default_config() {
+        tester(JJRepo::BASE)
+            .expected(format!("{} ", Color::Red.bold().paint("[!◌+=✘~»]")))
+            .render();
+    }
+
+    #[test]
+    fn test_render_style() {
+        tester(JJRepo::BASE)
+            .options(toml! {
+                style = "italic blue"
+            })
+            .expected(format!("{} ", Color::Blue.italic().paint("[!◌+=✘~»]")))
+            .render();
+    }
+
+    #[test]
+    fn test_render_format() {
+        tester(JJRepo::BASE)
+            .options(toml! {
+                format = "$all"
+            })
+            .expected("!◌+=✘~»")
+            .render();
+    }
+
+    #[test]
+    fn test_render_format_status_immediate_conflict() {
+        tester(JJRepo::STATUS_IMMEDIATE_CONFLICT)
+            .options(toml! { format = "$all" })
+            .expected("!◌+=✘~»")
+            .render();
+        tester(JJRepo::STATUS_IMMEDIATE_CONFLICT)
+            .options(toml! { format = "$conflicted" })
+            .expected("!")
+            .render();
+    }
+
+    #[test]
+    fn test_render_format_status_no_conflict() {
+        tester(JJRepo::STATUS_NO_CONFLICT)
+            .options(toml! { format = "$all" })
+            .expected("◌+=✘~»")
+            .render();
+        tester(JJRepo::STATUS_NO_CONFLICT)
+            .options(toml! { format = "$conflicted" })
+            .render();
+    }
+
+    #[test]
+    fn test_render_format_status_description() {
+        tester(JJRepo::STATUS_DESCRIPTION)
+            .options(toml! {
+                format = "$description"
+                description_present = "d"
+            })
+            .expected("d")
+            .render();
+    }
+
+    #[test]
+    fn test_render_format_status_hidden() {
+        tester(JJRepo::STATUS_HIDDEN)
+            .options(toml! {
+                format = "$hidden"
+                hidden = "h"
+            })
+            .expected("h")
+            .render();
+    }
+
+    #[test]
+    fn test_render_format_status_immutable() {
+        tester(JJRepo::STATUS_IMMUTABLE)
+            .options(toml! {
+                format = "$immutable"
+            })
+            .expected("◆")
+            .render();
+    }
+
+    #[test]
+    fn test_render_format_status_added() {
+        tester(JJRepo::STATUS_ADDED)
+            .options(toml! {
+                format = "$added"
+            })
+            .expected("+")
+            .render();
+
+        tester(JJRepo::STATUS_NO_CHANGES)
+            .options(toml! {
+                format = "$added"
+            })
+            .render();
+    }
+
+    #[test]
+    fn test_render_format_status_copied() {
+        tester(JJRepo::STATUS_COPIED)
+            .options(toml! {
+                format = "$copied"
+            })
+            .expected("=")
+            .render();
+
+        tester(JJRepo::STATUS_NO_CHANGES)
+            .options(toml! {
+                format = "$copied"
+            })
+            .render();
+    }
+
+    #[test]
+    fn test_render_format_status_deleted() {
+        tester(JJRepo::STATUS_DELETED)
+            .options(toml! {
+                format = "$deleted"
+            })
+            .expected("✘")
+            .render();
+
+        tester(JJRepo::STATUS_NO_CHANGES)
+            .options(toml! {
+                format = "$deleted"
+            })
+            .render();
+    }
+
+    #[test]
+    fn test_render_format_status_modified() {
+        tester(JJRepo::STATUS_MODIFIED)
+            .options(toml! {
+                format = "$modified"
+            })
+            .expected("~")
+            .render();
+
+        tester(JJRepo::STATUS_NO_CHANGES)
+            .options(toml! {
+                format = "$modified"
+            })
+            .render();
+    }
+
+    #[test]
+    fn test_render_format_status_renamed() {
+        tester(JJRepo::STATUS_RENAMED)
+            .options(toml! {
+                format = "$renamed"
+            })
+            .expected("»")
+            .render();
+
+        tester(JJRepo::STATUS_NO_CHANGES)
+            .options(toml! {
+                format = "$renamed"
+            })
+            .render();
+    }
+
+    #[test]
+    fn test_render_format_status_added_with_count() {
+        tester(JJRepo::STATUS_ADDED)
+            .options(toml! {
+                format = "$added"
+                added = "+$count"
+            })
+            .expected("+2")
+            .render();
+    }
+
+    #[test]
+    fn test_render_format_status_copied_with_count() {
+        tester(JJRepo::STATUS_COPIED)
+            .options(toml! {
+                format = "$copied"
+                copied = "=$count"
+            })
+            .expected("=3")
+            .render();
+    }
+
+    #[test]
+    fn test_render_format_status_deleted_with_count() {
+        tester(JJRepo::STATUS_DELETED)
+            .options(toml! {
+                format = "$deleted"
+                deleted = "✘$count"
+            })
+            .expected("✘4")
+            .render();
+    }
+
+    #[test]
+    fn test_render_format_status_modified_with_count() {
+        tester(JJRepo::STATUS_MODIFIED)
+            .options(toml! {
+                format = "$modified"
+                modified = "~$count"
+            })
+            .expected("~5")
+            .render();
+    }
+
+    #[test]
+    fn test_render_format_status_renamed_with_count() {
+        tester(JJRepo::STATUS_RENAMED)
+            .options(toml! {
+                format = "$renamed"
+                renamed = "»$count"
+            })
+            .expected("»6")
+            .render();
+    }
+}

--- a/src/modules/jj_status.rs
+++ b/src/modules/jj_status.rs
@@ -1,0 +1,59 @@
+use super::utils::format;
+use super::{Context, Module, ModuleConfig};
+
+use crate::configs::jj_status::JJStatusConfig;
+use crate::formatter::StringFormatter;
+
+/// Creates a module with the JJ status in the current working directory
+pub fn module<'a>(context: &'a Context) -> Option<Module<'a>> {
+    let mut module = context.new_module("jj_status");
+    let config = JJStatusConfig::try_load(module.config);
+
+    if config.disabled {
+        return None;
+    }
+
+    let current_change = context.get_jj_repo()?.current_change(context)?;
+
+    let parsed = StringFormatter::new(config.format).and_then(|formatter| {
+        formatter
+            .map_meta(|variable, _| match variable {
+                "all" => Some("$conflicted$description$hidden$immutable$added$copied$deleted$modified$renamed"),
+                _ => None,
+            })
+            .map_style(|variable| match variable {
+                "style" => Some(Ok(config.style)),
+                _ => None,
+            })
+            .map_variables_to_segments(|variable| {
+                let segments = match variable {
+                    "added" => format::count(config.added, "jj_status.added", context, current_change.status.added),
+                    "copied" => format::count(config.copied, "jj_status.copied", context, current_change.status.copied),
+                    "deleted" => format::count(config.deleted, "jj_status.deleted", context, current_change.status.deleted),
+                    "modified" => format::count(config.modified, "jj_status.modified", context, current_change.status.modified),
+                    "renamed" => format::count(config.renamed, "jj_status.renamed", context, current_change.status.renamed),
+                    "conflicted" => current_change.conflicted().then(|| format::symbol(config.conflicted, "jj_status.conflicted", context)).flatten(),
+                    "description" => match current_change.description() {
+                        true => format::symbol(config.description_present, "jj_status.description_present", context),
+                        false => format::symbol(config.description_empty, "jj_status.description_empty", context),
+                    },
+                    "hidden" => current_change.hidden().then(|| format::symbol(config.hidden, "jj_status.hidden", context)).flatten(),
+                    "immutable" => current_change.immutable().then(|| format::symbol(config.immutable, "jj_status.immutable", context)).flatten(),
+                    _ => None,
+                };
+
+            segments.map(Ok)
+        })
+            .parse(None, Some(context))
+    });
+
+    module.set_segments(match parsed {
+        Ok(segments) => segments,
+        Err(error) => {
+            log::warn!("Error in module `jj_status`:\n{error}");
+            return None;
+        }
+    });
+
+    Some(module)
+}

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -53,6 +53,7 @@ mod java;
 mod jj_bookmark;
 mod jj_change;
 mod jj_metrics;
+mod jj_status;
 mod jobs;
 mod julia;
 mod kotlin;
@@ -180,6 +181,7 @@ pub fn handle<'a>(module: &str, context: &'a Context) -> Option<Module<'a>> {
             "jj_bookmark" => jj_bookmark::module(context),
             "jj_change" => jj_change::module(context),
             "jj_metrics" => jj_metrics::module(context),
+            "jj_status" => jj_status::module(context),
             "jobs" => jobs::module(context),
             "julia" => julia::module(context),
             "kotlin" => kotlin::module(context),
@@ -322,6 +324,7 @@ pub fn description(module: &str) -> &'static str {
         "jj_bookmark" => "The closest ancestor bookmark in Jujutsu",
         "jj_change" => "The current change in Jujutsu",
         "jj_metrics" => "The number of added and deleted lines in Jujutsu",
+        "jj_status" => "Current status in Jujutsu represented via symbols",
         "jobs" => "The current number of jobs running",
         "julia" => "The currently installed version of Julia",
         "kotlin" => "The currently installed version of Kotlin",

--- a/src/modules/utils/format.rs
+++ b/src/modules/utils/format.rs
@@ -1,0 +1,52 @@
+//! Helper module to format values with a custom mapper
+//!
+//! Intended for usage inside a [`StringFormatter::map_variables_to_segments()`] call.
+
+use super::super::Context;
+use crate::formatter::StringFormatter;
+use crate::segment::Segment;
+
+pub fn text<F>(
+    format_str: &str,
+    config_path: &str,
+    context: &Context,
+    mapper: F,
+) -> Option<Vec<Segment>>
+where
+    F: Fn(&str) -> Option<String> + Send + Sync,
+{
+    if let Ok(formatter) = StringFormatter::new(format_str) {
+        formatter
+            .map(|variable| mapper(variable).map(Ok))
+            .parse(None, Some(context))
+            .ok()
+    } else {
+        log::warn!("Error parsing format string `{config_path}`");
+        None
+    }
+}
+
+pub fn count(
+    format_str: &str,
+    config_path: &str,
+    context: &Context,
+    count: usize,
+) -> Option<Vec<Segment>> {
+    if count == 0 {
+        return None;
+    }
+
+    text(
+        format_str,
+        config_path,
+        context,
+        |variable| match variable {
+            "count" => Some(count.to_string()),
+            _ => None,
+        },
+    )
+}
+
+pub fn symbol(format_str: &str, config_path: &str, context: &Context) -> Option<Vec<Segment>> {
+    text(format_str, config_path, context, |_variable| None)
+}

--- a/src/modules/utils/mod.rs
+++ b/src/modules/utils/mod.rs
@@ -6,6 +6,8 @@ pub mod directory_win;
 #[cfg(not(target_os = "windows"))]
 pub mod directory_nix;
 
+pub mod format;
+
 pub mod path;
 
 pub mod truncate;


### PR DESCRIPTION
**See https://github.com/starship/starship/pull/7612 for the full MR with every changes, this MR has been extracted from it to make review easier.**

- First commit prepares the addition of `jj_status` by extracting functions from `git_status` to `utils::format`
- Second keeps track of counts for added/copied/deleted/modified/renamed files to address https://github.com/starship/starship/pull/7643#discussion_r3740771615
- Third and fourth commit add `jj_status`, starting with the module implementation and then the rendering tests

Each commit can be reviewed on its own, they all pass tests and formatting.